### PR TITLE
codeintel: Filter out dumps associated with force pushed-away commits

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/api/cursor.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/cursor.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 )
 
@@ -50,7 +51,7 @@ func decodeCursor(rawEncoded string) (Cursor, error) {
 
 // DecodeOrCreateCursor decodes and returns the raw cursor, or creates a new initial page cursor
 // if a raw cursor is not supplied.
-func DecodeOrCreateCursor(path string, line, character, uploadID int, rawCursor string, dbStore DBStore, lsifStore LSIFStore) (Cursor, error) {
+func DecodeOrCreateCursor(ctx context.Context, path string, line, character, uploadID int, rawCursor string, dbStore DBStore, lsifStore LSIFStore) (Cursor, error) {
 	if rawCursor != "" {
 		cursor, err := decodeCursor(rawCursor)
 		if err != nil {
@@ -60,7 +61,7 @@ func DecodeOrCreateCursor(path string, line, character, uploadID int, rawCursor 
 		return cursor, nil
 	}
 
-	dump, exists, err := dbStore.GetDumpByID(context.Background(), uploadID)
+	dump, exists, err := dbStore.GetDumpByID(ctx, uploadID)
 	if err != nil {
 		return Cursor{}, errors.Wrap(err, "store.GetDumpByID")
 	}
@@ -69,7 +70,7 @@ func DecodeOrCreateCursor(path string, line, character, uploadID int, rawCursor 
 	}
 
 	pathInBundle := strings.TrimPrefix(path, dump.Root)
-	rangeMonikers, err := lsifStore.MonikersByPosition(context.Background(), dump.ID, pathInBundle, line, character)
+	rangeMonikers, err := lsifStore.MonikersByPosition(ctx, dump.ID, pathInBundle, line, character)
 	if err != nil {
 		return Cursor{}, errors.Wrap(err, "bundleClient.MonikersByPosition")
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/api/cursor_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/cursor_test.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 )
@@ -58,7 +60,7 @@ func TestDecodeOrCreateCursor(t *testing.T) {
 		Monikers:  []lsifstore.MonikerData{testMoniker1, testMoniker2},
 	}
 
-	if cursor, err := DecodeOrCreateCursor("sub1/main.go", 10, 20, 42, "", mockDBStore, mockLSIFStore); err != nil {
+	if cursor, err := DecodeOrCreateCursor(context.Background(), "sub1/main.go", 10, 20, 42, "", mockDBStore, mockLSIFStore); err != nil {
 		t.Fatalf("unexpected error decoding cursor: %s", err)
 	} else if diff := cmp.Diff(expectedCursor, cursor); diff != "" {
 		t.Errorf("unexpected cursor (-want +got):\n%s", diff)
@@ -70,7 +72,7 @@ func TestDecodeOrCreateCursorUnknownDump(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	setMockDBStoreGetDumpByID(t, mockDBStore, nil)
 
-	if _, err := DecodeOrCreateCursor("sub1/main.go", 10, 20, 42, "", mockDBStore, mockLSIFStore); err != ErrMissingDump {
+	if _, err := DecodeOrCreateCursor(context.Background(), "sub1/main.go", 10, 20, 42, "", mockDBStore, mockLSIFStore); err != ErrMissingDump {
 		t.Fatalf("unexpected error decoding cursor. want=%q have =%q", ErrMissingDump, err)
 	}
 }
@@ -102,7 +104,7 @@ func TestDecodeOrCreateCursorExisting(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
 
-	if cursor, err := DecodeOrCreateCursor("", 0, 0, 0, EncodeCursor(expectedCursor), mockDBStore, mockLSIFStore); err != nil {
+	if cursor, err := DecodeOrCreateCursor(context.Background(), "", 0, 0, 0, EncodeCursor(expectedCursor), mockDBStore, mockLSIFStore); err != nil {
 		t.Fatalf("unexpected error decoding cursor: %s", err)
 	} else if diff := cmp.Diff(expectedCursor, cursor); diff != "" {
 		t.Errorf("unexpected cursor (-want +got):\n%s", diff)

--- a/enterprise/cmd/frontend/internal/codeintel/api/definitions_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/definitions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -21,6 +22,7 @@ func TestDefinitions(t *testing.T) {
 		{DumpID: 42, Path: "bar.go", Range: testRange2},
 		{DumpID: 42, Path: "baz.go", Range: testRange3},
 	})
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	definitions, err := api.Definitions(context.Background(), "sub1/main.go", 10, 50, 42)
@@ -43,6 +45,7 @@ func TestDefinitionsUnknownDump(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 	setMockDBStoreGetDumpByID(t, mockDBStore, nil)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	if _, err := api.Definitions(context.Background(), "sub1/main.go", 10, 50, 25); err != ErrMissingDump {
@@ -63,6 +66,7 @@ func TestDefinitionViaSameDumpMoniker(t *testing.T) {
 		{DumpID: 42, Path: "bar.go", Range: testRange2},
 		{DumpID: 42, Path: "baz.go", Range: testRange3},
 	}, 3)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	definitions, err := api.Definitions(context.Background(), "sub1/main.go", 10, 50, 42)
@@ -95,6 +99,7 @@ func TestDefinitionViaRemoteDumpMoniker(t *testing.T) {
 		{DumpID: 50, Path: "bar.go", Range: testRange2},
 		{DumpID: 50, Path: "baz.go", Range: testRange3},
 	}, 15)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	definitions, err := api.Definitions(context.Background(), "sub1/main.go", 10, 50, 42)

--- a/enterprise/cmd/frontend/internal/codeintel/api/helpers_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"

--- a/enterprise/cmd/frontend/internal/codeintel/api/hover_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/hover_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -17,6 +18,7 @@ func TestHover(t *testing.T) {
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1})
 	setmockLSIFStoreHover(t, mockLSIFStore, 42, "main.go", 10, 50, "text", testRange1, true)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	text, r, exists, err := api.Hover(context.Background(), "sub1/main.go", 10, 50, 42)
@@ -40,6 +42,7 @@ func TestHoverUnknownDump(t *testing.T) {
 	mockLSIFStore := NewMockLSIFStore()
 	mockGitserverClient := NewMockGitserverClient()
 	setMockDBStoreGetDumpByID(t, mockDBStore, nil)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	if _, _, _, err := api.Hover(context.Background(), "sub1/main.go", 10, 50, 42); err != ErrMissingDump {
@@ -68,6 +71,7 @@ func TestHoverRemoteDefinitionHoverText(t *testing.T) {
 		hoverSpec{42, "main.go", 10, 50, "", lsifstore.Range{}, false},
 		hoverSpec{50, "foo.go", 10, 50, "text", testRange4, true},
 	)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	text, r, exists, err := api.Hover(context.Background(), "sub1/main.go", 10, 50, 42)
@@ -97,6 +101,7 @@ func TestHoverUnknownDefinition(t *testing.T) {
 	setmockLSIFStoreMonikersByPosition(t, mockLSIFStore, 42, "main.go", 10, 50, [][]lsifstore.MonikerData{{testMoniker1}})
 	setmockLSIFStorePackageInformation(t, mockLSIFStore, 42, "main.go", "1234", testPackageInformation)
 	setMockDBStoreGetPackage(t, mockDBStore, "gomod", "leftpad", "0.1.0", store.Dump{}, false)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	_, _, exists, err := api.Hover(context.Background(), "sub1/main.go", 10, 50, 42)

--- a/enterprise/cmd/frontend/internal/codeintel/api/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/iface.go
@@ -64,5 +64,6 @@ type LSIFStore interface {
 }
 
 type GitserverClient interface {
+	CommitExists(ctx context.Context, repositoryID int, commit string) (bool, error)
 	CommitGraph(ctx context.Context, repositoryID int, options gitserver.CommitGraphOptions) (*gitserver.CommitGraph, error)
 }

--- a/enterprise/cmd/frontend/internal/codeintel/api/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/mock_iface_test.go
@@ -1556,6 +1556,9 @@ func (c DBStoreSameRepoPagerFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/api)
 // used for unit testing.
 type MockGitserverClient struct {
+	// CommitExistsFunc is an instance of a mock function object controlling
+	// the behavior of the method CommitExists.
+	CommitExistsFunc *GitserverClientCommitExistsFunc
 	// CommitGraphFunc is an instance of a mock function object controlling
 	// the behavior of the method CommitGraph.
 	CommitGraphFunc *GitserverClientCommitGraphFunc
@@ -1566,6 +1569,11 @@ type MockGitserverClient struct {
 // overwritten.
 func NewMockGitserverClient() *MockGitserverClient {
 	return &MockGitserverClient{
+		CommitExistsFunc: &GitserverClientCommitExistsFunc{
+			defaultHook: func(context.Context, int, string) (bool, error) {
+				return false, nil
+			},
+		},
 		CommitGraphFunc: &GitserverClientCommitGraphFunc{
 			defaultHook: func(context.Context, int, gitserver.CommitGraphOptions) (*gitserver.CommitGraph, error) {
 				return nil, nil
@@ -1579,10 +1587,126 @@ func NewMockGitserverClient() *MockGitserverClient {
 // overwritten.
 func NewMockGitserverClientFrom(i GitserverClient) *MockGitserverClient {
 	return &MockGitserverClient{
+		CommitExistsFunc: &GitserverClientCommitExistsFunc{
+			defaultHook: i.CommitExists,
+		},
 		CommitGraphFunc: &GitserverClientCommitGraphFunc{
 			defaultHook: i.CommitGraph,
 		},
 	}
+}
+
+// GitserverClientCommitExistsFunc describes the behavior when the
+// CommitExists method of the parent MockGitserverClient instance is
+// invoked.
+type GitserverClientCommitExistsFunc struct {
+	defaultHook func(context.Context, int, string) (bool, error)
+	hooks       []func(context.Context, int, string) (bool, error)
+	history     []GitserverClientCommitExistsFuncCall
+	mutex       sync.Mutex
+}
+
+// CommitExists delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockGitserverClient) CommitExists(v0 context.Context, v1 int, v2 string) (bool, error) {
+	r0, r1 := m.CommitExistsFunc.nextHook()(v0, v1, v2)
+	m.CommitExistsFunc.appendCall(GitserverClientCommitExistsFuncCall{v0, v1, v2, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CommitExists method
+// of the parent MockGitserverClient instance is invoked and the hook queue
+// is empty.
+func (f *GitserverClientCommitExistsFunc) SetDefaultHook(hook func(context.Context, int, string) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CommitExists method of the parent MockGitserverClient instance inovkes
+// the hook at the front of the queue and discards it. After the queue is
+// empty, the default hook function is invoked for any future action.
+func (f *GitserverClientCommitExistsFunc) PushHook(hook func(context.Context, int, string) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *GitserverClientCommitExistsFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *GitserverClientCommitExistsFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int, string) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *GitserverClientCommitExistsFunc) nextHook() func(context.Context, int, string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *GitserverClientCommitExistsFunc) appendCall(r0 GitserverClientCommitExistsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of GitserverClientCommitExistsFuncCall objects
+// describing the invocations of this function.
+func (f *GitserverClientCommitExistsFunc) History() []GitserverClientCommitExistsFuncCall {
+	f.mutex.Lock()
+	history := make([]GitserverClientCommitExistsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// GitserverClientCommitExistsFuncCall is an object that describes an
+// invocation of method CommitExists on an instance of MockGitserverClient.
+type GitserverClientCommitExistsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Arg2 is the value of the 3rd argument passed to this method
+	// invocation.
+	Arg2 string
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c GitserverClientCommitExistsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c GitserverClientCommitExistsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // GitserverClientCommitGraphFunc describes the behavior when the

--- a/enterprise/cmd/frontend/internal/codeintel/api/monikers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/monikers.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 )
 
 func lookupMoniker(
+	ctx context.Context,
 	dbStore DBStore,
 	lsifStore LSIFStore,
+	gitserverClient GitserverClient,
 	dumpID int,
 	path string,
 	modelType string,
@@ -22,7 +25,7 @@ func lookupMoniker(
 		return nil, 0, nil
 	}
 
-	pid, _, err := lsifStore.PackageInformation(context.Background(), dumpID, path, string(moniker.PackageInformationID))
+	pid, _, err := lsifStore.PackageInformation(ctx, dumpID, path, string(moniker.PackageInformationID))
 	if err != nil {
 		if err == lsifstore.ErrNotFound {
 			log15.Warn("Bundle does not exist")
@@ -31,12 +34,21 @@ func lookupMoniker(
 		return nil, 0, errors.Wrap(err, "lsifStore.BundleClient")
 	}
 
-	dump, exists, err := dbStore.GetPackage(context.Background(), moniker.Scheme, pid.Name, pid.Version)
+	dump, exists, err := dbStore.GetPackage(ctx, moniker.Scheme, pid.Name, pid.Version)
 	if err != nil || !exists {
 		return nil, 0, errors.Wrap(err, "store.GetPackage")
 	}
 
-	locations, count, err := lsifStore.MonikerResults(context.Background(), dump.ID, modelType, moniker.Scheme, moniker.Identifier, skip, take)
+	// TODO - cache
+	commitExists, err := gitserverClient.CommitExists(ctx, dump.RepositoryID, dump.Commit)
+	if err != nil {
+		return nil, 0, errors.Wrap(err, "gitserverClient.CommitExists")
+	}
+	if !commitExists {
+		return nil, 0, nil
+	}
+
+	locations, count, err := lsifStore.MonikerResults(ctx, dump.ID, modelType, moniker.Scheme, moniker.Identifier, skip, take)
 	if err != nil {
 		if err == lsifstore.ErrNotFound {
 			log15.Warn("Bundle does not exist")

--- a/enterprise/cmd/frontend/internal/codeintel/api/monikers.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/monikers.go
@@ -39,7 +39,6 @@ func lookupMoniker(
 		return nil, 0, errors.Wrap(err, "store.GetPackage")
 	}
 
-	// TODO - cache
 	commitExists, err := gitserverClient.CommitExists(ctx, dump.RepositoryID, dump.Commit)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "gitserverClient.CommitExists")

--- a/enterprise/cmd/frontend/internal/codeintel/api/references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/references.go
@@ -8,6 +8,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	pkgerrors "github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/bloomfilter"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
@@ -37,6 +38,7 @@ func (api *CodeIntelAPI) References(ctx context.Context, repositoryID int, commi
 	rpr := &ReferencePageResolver{
 		dbStore:         api.dbStore,
 		lsifStore:       api.lsifStore,
+		gitserverClient: api.gitserverClient,
 		repositoryID:    repositoryID,
 		commit:          commit,
 		remoteDumpLimit: RemoteDumpLimit,
@@ -49,6 +51,7 @@ func (api *CodeIntelAPI) References(ctx context.Context, repositoryID int, commi
 type ReferencePageResolver struct {
 	dbStore         DBStore
 	lsifStore       LSIFStore
+	gitserverClient GitserverClient
 	repositoryID    int
 	commit          string
 	remoteDumpLimit int
@@ -329,6 +332,7 @@ func (s *ReferencePageResolver) resolveLocationsViaReferencePager(ctx context.Co
 	scheme := cursor.Scheme
 	identifier := cursor.Identifier
 	limit := s.limit
+	commitExistenceCache := map[int]map[string]bool{}
 
 	if len(cursor.DumpIDs) == 0 {
 		totalCount, pager, err := createPager(ctx)
@@ -385,6 +389,28 @@ func (s *ReferencePageResolver) resolveLocationsViaReferencePager(ctx context.Co
 			return nil, Cursor{}, false, pkgerrors.Wrap(err, "store.GetDumpByID")
 		}
 		if !exists {
+			continue
+		}
+
+		if _, ok := commitExistenceCache[dump.RepositoryID]; !ok {
+			commitExistenceCache[dump.RepositoryID] = map[string]struct{}{}
+		}
+
+		// We've already determined the target commit doesn't exist
+		if exists, ok := commitExistenceCache[dump.RepositoryID][dump.Commit]; ok && !exists {
+			continue
+		}
+
+		commitExists, err := s.gitserverClient.CommitExists(ctx, dump.RepositoryID, dump.Commit)
+		if err != nil {
+			return nil, Cursor{}, false, pkgerrors.Wrap(err, "gitserverClient.CommitExists")
+		}
+
+		// Cache result as we're likely to have multiple
+		// dumps per commit if there are overlapping roots.
+		commitExistenceCache[dump.RepositoryID][dump.Commit] = exists
+
+		if !commitExists {
 			continue
 		}
 

--- a/enterprise/cmd/frontend/internal/codeintel/api/references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/references.go
@@ -263,7 +263,7 @@ func (s *ReferencePageResolver) handleDefinitionMonikersCursor(ctx context.Conte
 			continue
 		}
 
-		locations, count, err := lookupMoniker(s.dbStore, s.lsifStore, cursor.DumpID, cursor.Path, "references", moniker, cursor.SkipResults, s.limit)
+		locations, count, err := lookupMoniker(ctx, s.dbStore, s.lsifStore, s.gitserverClient, cursor.DumpID, cursor.Path, "references", moniker, cursor.SkipResults, s.limit)
 		if err != nil {
 			return nil, Cursor{}, false, err
 		}
@@ -393,7 +393,7 @@ func (s *ReferencePageResolver) resolveLocationsViaReferencePager(ctx context.Co
 		}
 
 		if _, ok := commitExistenceCache[dump.RepositoryID]; !ok {
-			commitExistenceCache[dump.RepositoryID] = map[string]struct{}{}
+			commitExistenceCache[dump.RepositoryID] = map[string]bool{}
 		}
 
 		// We've already determined the target commit doesn't exist

--- a/enterprise/cmd/frontend/internal/codeintel/api/references_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/references_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 )
@@ -13,6 +14,7 @@ import (
 func TestHandleSameDumpCursor(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1})
 	setmockLSIFStoreReferences(t, mockLSIFStore, 42, "main.go", 23, 34, []lsifstore.Location{
@@ -26,13 +28,15 @@ func TestHandleSameDumpCursor(t *testing.T) {
 		{DumpID: 42, Path: "bar.go", Range: testRange3},
 		{DumpID: 42, Path: "bar.go", Range: testRange4},
 	})
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	rpr := &ReferencePageResolver{
-		dbStore:      mockDBStore,
-		lsifStore:    mockLSIFStore,
-		repositoryID: 100,
-		commit:       testCommit,
-		limit:        5,
+		dbStore:         mockDBStore,
+		lsifStore:       mockLSIFStore,
+		gitserverClient: mockGitserverClient,
+		repositoryID:    100,
+		commit:          testCommit,
+		limit:           5,
 	}
 
 	t.Run("partial results", func(t *testing.T) {
@@ -120,6 +124,7 @@ func TestHandleSameDumpCursor(t *testing.T) {
 func TestHandleSameDumpMonikersCursor(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1})
 	setmockLSIFStoreReferences(t, mockLSIFStore, 42, "main.go", 23, 34, []lsifstore.Location{
@@ -127,13 +132,15 @@ func TestHandleSameDumpMonikersCursor(t *testing.T) {
 		{DumpID: 42, Path: "foo.go", Range: testRange2},
 		{DumpID: 42, Path: "foo.go", Range: testRange3},
 	})
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	rpr := &ReferencePageResolver{
-		dbStore:      mockDBStore,
-		lsifStore:    mockLSIFStore,
-		repositoryID: 100,
-		commit:       testCommit,
-		limit:        5,
+		dbStore:         mockDBStore,
+		lsifStore:       mockLSIFStore,
+		gitserverClient: mockGitserverClient,
+		repositoryID:    100,
+		commit:          testCommit,
+		limit:           5,
 	}
 
 	t.Run("partial results", func(t *testing.T) {
@@ -228,17 +235,20 @@ func TestHandleSameDumpMonikersCursor(t *testing.T) {
 func TestHandleDefinitionMonikersCursor(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1, 50: testDump2})
 	setmockLSIFStorePackageInformation(t, mockLSIFStore, 42, "main.go", "1234", testPackageInformation)
 	setMockDBStoreGetPackage(t, mockDBStore, "gomod", "leftpad", "0.1.0", testDump2, true)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	rpr := &ReferencePageResolver{
-		dbStore:      mockDBStore,
-		lsifStore:    mockLSIFStore,
-		repositoryID: 100,
-		commit:       testCommit,
-		limit:        5,
+		dbStore:         mockDBStore,
+		lsifStore:       mockLSIFStore,
+		gitserverClient: mockGitserverClient,
+		repositoryID:    100,
+		commit:          testCommit,
+		limit:           5,
 	}
 
 	t.Run("partial results", func(t *testing.T) {
@@ -336,6 +346,7 @@ func TestHandleDefinitionMonikersCursor(t *testing.T) {
 func TestHandleSameRepoCursor(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
 	mockReferencePager := NewMockReferencePager()
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1, 50: testDump2, 51: testDump3, 52: testDump4})
@@ -345,6 +356,7 @@ func TestHandleSameRepoCursor(t *testing.T) {
 		{DumpID: 51, Filter: readTestFilter(t, "normal", "1")},
 		{DumpID: 52, Filter: readTestFilter(t, "normal", "1")},
 	})
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	t.Run("partial results", func(t *testing.T) {
 		setmockLSIFStoreMonikerResults(t, mockLSIFStore, 50, "references", "gomod", "bar", 0, 5, []lsifstore.Location{
@@ -358,6 +370,7 @@ func TestHandleSameRepoCursor(t *testing.T) {
 		rpr := &ReferencePageResolver{
 			dbStore:         mockDBStore,
 			lsifStore:       mockLSIFStore,
+			gitserverClient: mockGitserverClient,
 			repositoryID:    100,
 			commit:          testCommit,
 			remoteDumpLimit: 5,
@@ -439,6 +452,7 @@ func TestHandleSameRepoCursor(t *testing.T) {
 		rpr := &ReferencePageResolver{
 			dbStore:         mockDBStore,
 			lsifStore:       mockLSIFStore,
+			gitserverClient: mockGitserverClient,
 			repositoryID:    100,
 			commit:          testCommit,
 			remoteDumpLimit: 5,
@@ -487,6 +501,7 @@ func TestHandleSameRepoCursor(t *testing.T) {
 func TestHandleSameRepoCursorMultipleDumpBatches(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
 	mockReferencePager := NewMockReferencePager()
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1, 50: testDump2, 51: testDump3, 52: testDump4})
@@ -499,10 +514,12 @@ func TestHandleSameRepoCursorMultipleDumpBatches(t *testing.T) {
 		{DumpID: 51, Path: "baz.go", Range: testRange3},
 		{DumpID: 51, Path: "bonk.go", Range: testRange4},
 	}, 2)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	rpr := &ReferencePageResolver{
 		dbStore:         mockDBStore,
 		lsifStore:       mockLSIFStore,
+		gitserverClient: mockGitserverClient,
 		repositoryID:    100,
 		commit:          testCommit,
 		remoteDumpLimit: 2,
@@ -562,6 +579,7 @@ func TestHandleSameRepoCursorMultipleDumpBatches(t *testing.T) {
 func TestHandleRemoteRepoCursor(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
 	mockReferencePager := NewMockReferencePager()
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1, 50: testDump2, 51: testDump3, 52: testDump4})
@@ -571,6 +589,7 @@ func TestHandleRemoteRepoCursor(t *testing.T) {
 		{DumpID: 51, Filter: readTestFilter(t, "normal", "1")},
 		{DumpID: 52, Filter: readTestFilter(t, "normal", "1")},
 	})
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	t.Run("partial results", func(t *testing.T) {
 		setmockLSIFStoreMonikerResults(t, mockLSIFStore, 50, "references", "gomod", "bar", 0, 5, []lsifstore.Location{
@@ -584,6 +603,7 @@ func TestHandleRemoteRepoCursor(t *testing.T) {
 		rpr := &ReferencePageResolver{
 			dbStore:         mockDBStore,
 			lsifStore:       mockLSIFStore,
+			gitserverClient: mockGitserverClient,
 			repositoryID:    100,
 			commit:          testCommit,
 			remoteDumpLimit: 5,
@@ -665,6 +685,7 @@ func TestHandleRemoteRepoCursor(t *testing.T) {
 		rpr := &ReferencePageResolver{
 			dbStore:         mockDBStore,
 			lsifStore:       mockLSIFStore,
+			gitserverClient: mockGitserverClient,
 			repositoryID:    100,
 			commit:          testCommit,
 			remoteDumpLimit: 5,
@@ -702,6 +723,7 @@ func TestHandleRemoteRepoCursor(t *testing.T) {
 func TestHandleRemoteRepoCursorMultipleDumpBatches(t *testing.T) {
 	mockDBStore := NewMockDBStore()
 	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
 	mockReferencePager := NewMockReferencePager()
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1, 50: testDump2, 51: testDump3, 52: testDump4})
@@ -714,10 +736,12 @@ func TestHandleRemoteRepoCursorMultipleDumpBatches(t *testing.T) {
 		{DumpID: 51, Path: "baz.go", Range: testRange3},
 		{DumpID: 51, Path: "bonk.go", Range: testRange4},
 	}, 2)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
 
 	rpr := &ReferencePageResolver{
 		dbStore:         mockDBStore,
 		lsifStore:       mockLSIFStore,
+		gitserverClient: mockGitserverClient,
 		repositoryID:    100,
 		commit:          testCommit,
 		remoteDumpLimit: 2,

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go/log"
+
 	codeintelapi "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/api"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
@@ -252,7 +253,7 @@ func (r *queryResolver) References(ctx context.Context, line, character, limit i
 			continue
 		}
 
-		cursor, err := codeintelapi.DecodeOrCreateCursor(adjustedPath, adjustedPosition.Line, adjustedPosition.Character, r.uploads[i].ID, rawCursor, r.dbStore, r.lsifStore)
+		cursor, err := codeintelapi.DecodeOrCreateCursor(ctx, adjustedPath, adjustedPosition.Line, adjustedPosition.Character, r.uploads[i].ID, rawCursor, r.dbStore, r.lsifStore)
 		if err != nil {
 			return nil, "", err
 		}

--- a/enterprise/internal/codeintel/gitserver/observability.go
+++ b/enterprise/internal/codeintel/gitserver/observability.go
@@ -14,6 +14,7 @@ type operations struct {
 	commitGraph       *observation.Operation
 	directoryChildren *observation.Operation
 	fileExists        *observation.Operation
+	commitExists      *observation.Operation
 	head              *observation.Operation
 	listFiles         *observation.Operation
 	rawContents       *observation.Operation
@@ -49,6 +50,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		commitGraph:       op("CommitGraph"),
 		directoryChildren: op("DirectoryChildren"),
 		fileExists:        op("FileExists"),
+		commitExists:      op("CommitExists"),
 		head:              op("Head"),
 		listFiles:         op("ListFiles"),
 		rawContents:       op("RawContents"),


### PR DESCRIPTION
Ensure that dumps attached to a commit that is not known to gitserver is not returned from either FindClosestDumps or Packages, or References queries in the API layer. Fixes https://github.com/sourcegraph/sourcegraph/issues/12588.