### PR TITLE
symbols: compute correct symbol offsets on indexed search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixed queries like `(type:commit or type:diff)` so that if the query matches both the commit message and the diff, both are returned as results. [#16899](https://github.com/sourcegraph/sourcegraph/issues/16899)
 - Fixed container monitoring and provisioning dashboard panels not displaying metrics in certain deployment types and environments. If you continue to have issues with these panels not displaying any metrics after upgrading, please [open an issue](https://github.com/sourcegraph/sourcegraph/issues/new).
 - Fixed a nonexistent field in site configuration being marked as "required" when configuring PagerDuty alert notifications. [#17277](https://github.com/sourcegraph/sourcegraph/pull/17277)
+- Fixed cases of incorrect highlighting for symbol definitions in the definitions panel. [#17258](https://github.com/sourcegraph/sourcegraph/pull/17258)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
+	"github.com/sourcegraph/go-langserver/pkg/lsp"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -255,6 +255,19 @@ func TestLimitingSymbolResults(t *testing.T) {
 					t.Error(cmp.Diff(res2, tc.want))
 				}
 			})
+		}
+	})
+}
+
+func TestSymbolRange(t *testing.T) {
+	t.Run("unescaped pattern", func(t *testing.T) {
+		want := lsp.Range{
+			Start: lsp.Position{Line: 0, Character: 37},
+			End:   lsp.Position{Line: 0, Character: 40},
+		}
+		got := symbolRange(protocol.Symbol{Line: 1, Name: "baz", Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`})
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatal(diff)
 		}
 	})
 }

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -631,6 +631,38 @@ func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMat
 	return lines, matchCount
 }
 
+func escape(s string) string {
+	isSpecial := func(c rune) bool {
+		switch c {
+		case '\\', '/':
+			return true
+		default:
+			return false
+		}
+	}
+
+	// Avoid extra work by counting additions. regexp.QuoteMeta does the same,
+	// but is more efficient since it does it via bytes.
+	count := 0
+	for _, c := range s {
+		if isSpecial(c) {
+			count++
+		}
+	}
+	if count == 0 {
+		return string(s)
+	}
+
+	escaped := make([]rune, 0, len(s)+count)
+	for _, c := range s {
+		if isSpecial(c) {
+			escaped = append(escaped, '\\')
+		}
+		escaped = append(escaped, c)
+	}
+	return string(escaped)
+}
+
 func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*searchSymbolResult {
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
@@ -662,6 +694,11 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 					ParentKind: m.SymbolInfo.ParentKind,
 					Path:       file.FileName,
 					Line:       l.LineNumber,
+					// symbolRange requires a Pattern /^...$/ containing the line of the symbol to compute the symbol's offsets.
+					// This Pattern is directly accessible on the unindexed code path. But on the indexed code path, we need to
+					// populate it, or we will always compute a 0 offset, which messes up API use (e.g., highlighting).
+					// It must escape `/` or `\` in the line.
+					Pattern: fmt.Sprintf("/^%s$/", escape(string(l.Line))),
 				},
 				lang:    lang,
 				baseURI: baseURI,

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -999,9 +999,11 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		Version:    "deadbeef",
 		LineMatches: []zoekt.LineMatch{{
 			// Skips missing symbol info (shouldn't happen in practice).
+			Line:          []byte(""),
 			LineNumber:    5,
 			LineFragments: []zoekt.LineFragmentMatch{{}},
 		}, {
+			Line:       []byte("symbol a symbol b"),
 			LineNumber: 10,
 			LineFragments: []zoekt.LineFragmentMatch{{
 				SymbolInfo: symbolInfo("a"),
@@ -1009,9 +1011,16 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 				SymbolInfo: symbolInfo("b"),
 			}},
 		}, {
+			Line:       []byte("symbol c"),
 			LineNumber: 15,
 			LineFragments: []zoekt.LineFragmentMatch{{
 				SymbolInfo: symbolInfo("c"),
+			}},
+		}, {
+			Line:       []byte(`bar() { var regex = /.*\//; function baz() { }  } `),
+			LineNumber: 20,
+			LineFragments: []zoekt.LineFragmentMatch{{
+				SymbolInfo: symbolInfo("baz"),
 			}},
 		}},
 	}
@@ -1042,15 +1051,23 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 	}
 
 	want := []protocol.Symbol{{
-		Name: "a",
-		Line: 10,
+		Name:    "a",
+		Line:    10,
+		Pattern: "/^symbol a symbol b$/",
 	}, {
-		Name: "b",
-		Line: 10,
+		Name:    "b",
+		Line:    10,
+		Pattern: "/^symbol a symbol b$/",
 	}, {
-		Name: "c",
-		Line: 15,
-	}}
+		Name:    "c",
+		Line:    15,
+		Pattern: "/^symbol c$/",
+	}, {
+		Name:    "baz",
+		Line:    20,
+		Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`,
+	},
+	}
 	for i := range want {
 		want[i].Kind = "kind"
 		want[i].Parent = "parent"


### PR DESCRIPTION
Previously:

<img width="481" alt="Screen Shot 2021-01-13 at 7 12 33 PM" src="https://user-images.githubusercontent.com/888624/104535578-b058c480-55d3-11eb-9794-4b8793811847.png">

Now:

<img width="493" alt="Screen Shot 2021-01-13 at 6 58 07 PM" src="https://user-images.githubusercontent.com/888624/104534928-6ae7c780-55d2-11eb-96b9-3862b61e093b.png">

Fixes https://github.com/sourcegraph/sourcegraph/issues/12500 and part of customer issue https://github.com/sourcegraph/customer/issues/153. @efritz and I thought we needed to pass some other pattern info to this, but actually the fix is something different. Took a while to figure out what's going on in this code.

I'm just going to copy the inline comment, because the way symbols work is convoluted.

> [symbolRange](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_symbols.go#L300-306) requires a Pattern /^...$/ containing the line of the symbol to compute the symbol's offsets.
> This Pattern is directly accessible on the unindexed code path. But on the indexed code path, we need to
> populate it, or we will always compute a 0 offset, which messes up API use (e.g., highlighting).

We really shouldn't be relying on this `symbol.Pattern` member to compute the offsets, but here we are. I fear that being smart and calculating the offset/range inside the `zoekt.go` code will only fragment where computation is done (i.e., on the unindexed path, we do it in this one place, and then in another place on the indexed path, seems like madness.  On the whole though, probably not a whole lot worse than this fix).  

As much as symbols code needs attention, my appetite for rewriting parts of this is super low compared to a lot of other things. As I understand we basically don't have anyone who owns the symbols code right now and it would be nice if we did....