### PR TITLE
db: Convert db/users to basestore

### DIFF
--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -40,6 +40,9 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 	t.Run("authenticated as user", func(t *testing.T) {
 		resetMocks()
 		mockAccessTokensCreate(t, 1, []string{authz.ScopeUserAll})
+		db.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+			return &types.User{ID: 1, SiteAdmin: false}, nil
+		}
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
@@ -82,7 +85,6 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		db.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
 			return &types.User{ID: 1, SiteAdmin: false}, nil
 		}
-		defer func() { db.Mocks.Users.GetByCurrentAuthUser = nil }()
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
 		result, err := (&schemaResolver{}).CreateAccessToken(ctx, &createAccessTokenInput{
@@ -228,6 +230,9 @@ func TestMutation_DeleteAccessToken(t *testing.T) {
 	t.Run("authenticated as user", func(t *testing.T) {
 		resetMocks()
 		mockAccessTokens(t)
+		db.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+			return &types.User{ID: 1, SiteAdmin: false}, nil
+		}
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
 				Context: actor.WithActor(context.Background(), &actor.Actor{UID: 2}),

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -149,6 +149,9 @@ func TestAffiliatedRepositories(t *testing.T) {
 			SiteAdmin: userID == 1,
 		}, nil
 	}
+	db.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+		return &types.User{ID: 1, SiteAdmin: true}, nil
+	}
 	cf = httpcli.NewFactory(
 		nil,
 		func(c *http.Client) error {

--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -38,6 +38,9 @@ func TestSetExternalServiceRepos(t *testing.T) {
 			SiteAdmin: userID == 1,
 		}, nil
 	}
+	db.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+		return &types.User{ID: 1, SiteAdmin: true}, nil
+	}
 	var called bool
 	db.Mocks.ExternalServices.Upsert = func(ctx context.Context, services ...*types.ExternalService) error {
 		called = true

--- a/cmd/frontend/graphqlbackend/settings_mutation_test.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation_test.go
@@ -17,6 +17,9 @@ func TestSettingsMutation_EditSettings(t *testing.T) {
 	db.Mocks.Users.GetByID = func(context.Context, int32) (*types.User, error) {
 		return &types.User{ID: 1}, nil
 	}
+	db.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+		return &types.User{ID: 1, SiteAdmin: false}, nil
+	}
 	db.Mocks.Settings.GetLatest = func(context.Context, api.SettingsSubject) (*api.Settings, error) {
 		return &api.Settings{ID: 1, Contents: "{}"}, nil
 	}
@@ -64,6 +67,9 @@ func TestSettingsMutation_OverwriteSettings(t *testing.T) {
 	resetMocks()
 	db.Mocks.Users.GetByID = func(context.Context, int32) (*types.User, error) {
 		return &types.User{ID: 1}, nil
+	}
+	db.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+		return &types.User{ID: 1, SiteAdmin: false}, nil
 	}
 	db.Mocks.Settings.GetLatest = func(context.Context, api.SettingsSubject) (*api.Settings, error) {
 		return &api.Settings{ID: 1, Contents: "{}"}, nil

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users_test.go
@@ -169,9 +169,10 @@ func TestEnforcement_AfterCreateUser(t *testing.T) {
 			}
 
 			if test.wantCalledExecContext != calledExecContext {
-				t.Fatalf("calledExecContext: want %v but got %v", test.wantCalledExecContext, calledExecContext)
-			} else if test.wantSiteAdmin != user.SiteAdmin {
-				t.Fatalf("siteAdmin: want %v but got %v", test.wantSiteAdmin, user.SiteAdmin)
+				t.Errorf("calledExecContext: want %v but got %v", test.wantCalledExecContext, calledExecContext)
+			}
+			if test.wantSiteAdmin != user.SiteAdmin {
+				t.Errorf("siteAdmin: want %v but got %v", test.wantSiteAdmin, user.SiteAdmin)
 			}
 		})
 	}

--- a/internal/db/external_accounts.go
+++ b/internal/db/external_accounts.go
@@ -6,10 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/keegancsmith/sqlf"
 	otlog "github.com/opentracing/opentracing-go/log"
 
+	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -87,35 +87,29 @@ func (s *userExternalAccounts) AssociateUserAndSave(ctx context.Context, userID 
 
 	// This "upsert" may cause us to return an ephemeral failure due to a race condition, but it
 	// won't result in inconsistent data.  Wrap in transaction.
-	tx, err := dbconn.Global.BeginTx(ctx, nil)
+
+	// Temporarily use basestore here until we've migrated all of userExternalAccounts
+	bs := basestore.NewWithDB(dbconn.Global, sql.TxOptions{})
+	tx, err := bs.Transact(ctx)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err != nil {
-			rollErr := tx.Rollback()
-			if rollErr != nil {
-				err = multierror.Append(err, rollErr)
-			}
-			return
-		}
-		err = tx.Commit()
-	}()
+	defer tx.Done(err)
 
 	// Find whether the account exists and, if so, which user ID the account is associated with.
 	var exists bool
 	var existingID, associatedUserID int32
-	err = tx.QueryRowContext(ctx, `
+	err = tx.QueryRow(ctx, sqlf.Sprintf(`
 -- source: internal/db/external_accounts.go:userExternalAccounts.AssociateUserAndSave
 SELECT id, user_id
 FROM user_external_accounts
 WHERE
-	service_type = $1
-AND service_id = $2
-AND client_id = $3
-AND account_id = $4
+	service_type = %s
+AND service_id = %s
+AND client_id = %s
+AND account_id = %s
 AND deleted_at IS NULL
-`, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID).Scan(&existingID, &associatedUserID)
+`, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID)).Scan(&existingID, &associatedUserID)
 	if err != nil && err != sql.ErrNoRows {
 		return err
 	}
@@ -133,22 +127,22 @@ AND deleted_at IS NULL
 	}
 
 	// Update the external account (it exists).
-	res, err := tx.ExecContext(ctx, `
+	res, err := tx.ExecResult(ctx, sqlf.Sprintf(`
 -- source: internal/db/external_accounts.go:userExternalAccounts.AssociateUserAndSave
 UPDATE user_external_accounts
 SET
-	auth_data = $6,
-	account_data = $7,
+	auth_data = %s,
+	account_data = %s,
 	updated_at = now(),
 	expired_at = NULL
 WHERE
-	service_type = $1
-AND service_id = $2
-AND client_id = $3
-AND account_id = $4
-AND user_id = $5
+	service_type = %s
+AND service_id = %s
+AND client_id = %s
+AND account_id = %s
+AND user_id = %s
 AND deleted_at IS NULL
-`, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, userID, data.AuthData, data.Data)
+`, data.AuthData, data.Data, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, userID))
 	if err != nil {
 		return err
 	}
@@ -172,38 +166,27 @@ func (s *userExternalAccounts) CreateUserAndSave(ctx context.Context, newUser Ne
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
 
-	// Wrap in transaction.
-	tx, err := dbconn.Global.BeginTx(ctx, nil)
+	tx, err := Users.Transact(ctx)
 	if err != nil {
 		return 0, err
 	}
-	defer func() {
-		if err != nil {
-			rollErr := tx.Rollback()
-			if rollErr != nil {
-				err = multierror.Append(err, rollErr)
-			}
-			return
-		}
-		err = tx.Commit()
-	}()
+	defer tx.Done(err)
 
-	createdUser, err := Users.create(ctx, tx, newUser)
+	createdUser, err := tx.create(ctx, newUser)
 	if err != nil {
 		return 0, err
 	}
 
-	err = s.insert(ctx, tx, createdUser.ID, spec, data)
+	err = s.insert(ctx, tx.Store, createdUser.ID, spec, data)
 	return createdUser.ID, err
 }
 
-func (s *userExternalAccounts) insert(ctx context.Context, tx *sql.Tx, userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error {
-	_, err := tx.ExecContext(ctx, `
+func (s *userExternalAccounts) insert(ctx context.Context, tx *basestore.Store, userID int32, spec extsvc.AccountSpec, data extsvc.AccountData) error {
+	return tx.Exec(ctx, sqlf.Sprintf(`
 -- source: internal/db/external_accounts.go:userExternalAccounts.insert
 INSERT INTO user_external_accounts (user_id, service_type, service_id, client_id, account_id, auth_data, account_data)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
-`, userID, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, data.AuthData, data.Data)
-	return err
+VALUES (%s, %s, %s, %s, %s, %s, %s)
+`, userID, spec.ServiceType, spec.ServiceID, spec.ClientID, spec.AccountID, data.AuthData, data.Data))
 }
 
 // TouchExpired sets the given user external account to be expired now.

--- a/internal/db/globalstatedb/globalstatedb.go
+++ b/internal/db/globalstatedb/globalstatedb.go
@@ -3,7 +3,6 @@ package globalstatedb
 import (
 	"context"
 	"database/sql"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 
 	"github.com/google/uuid"
 	"github.com/keegancsmith/sqlf"

--- a/internal/db/globalstatedb/globalstatedb.go
+++ b/internal/db/globalstatedb/globalstatedb.go
@@ -3,10 +3,13 @@ package globalstatedb
 import (
 	"context"
 	"database/sql"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 
 	"github.com/google/uuid"
+	"github.com/keegancsmith/sqlf"
 	"github.com/lib/pq"
 
+	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 )
 
@@ -24,7 +27,9 @@ func Get(ctx context.Context) (*State, error) {
 	if err == nil {
 		return configuration, nil
 	}
-	err = tryInsertNew(ctx, dbconn.Global)
+
+	b := basestore.NewWithDB(dbconn.Global, sql.TxOptions{})
+	err = tryInsertNew(ctx, b)
 	if err != nil {
 		return nil, err
 	}
@@ -52,8 +57,8 @@ func SiteInitialized(ctx context.Context) (alreadyInitialized bool, err error) {
 // accidentally deleting all user accounts and opening up their site to any attacker becoming a site
 // admin and (2) a bug in user account creation code letting attackers create site admin accounts.
 func EnsureInitialized(ctx context.Context, dbh interface {
-	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
-	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	QueryRow(ctx context.Context, query *sqlf.Query) *sql.Row
+	Exec(ctx context.Context, query *sqlf.Query) error
 }) (alreadyInitialized bool, err error) {
 	if err := tryInsertNew(ctx, dbh); err != nil {
 		return false, err
@@ -61,12 +66,12 @@ func EnsureInitialized(ctx context.Context, dbh interface {
 
 	// The "SELECT ... FOR UPDATE" prevents a race condition where two calls, each in their own transaction,
 	// would see this initialized value as false and then set it to true below.
-	if err := dbh.QueryRowContext(ctx, `SELECT initialized FROM global_state FOR UPDATE LIMIT 1`).Scan(&alreadyInitialized); err != nil {
+	if err := dbh.QueryRow(ctx, sqlf.Sprintf(`SELECT initialized FROM global_state FOR UPDATE LIMIT 1`)).Scan(&alreadyInitialized); err != nil {
 		return false, err
 	}
 
 	if !alreadyInitialized {
-		_, err = dbh.ExecContext(ctx, "UPDATE global_state SET initialized=true")
+		err = dbh.Exec(ctx, sqlf.Sprintf("UPDATE global_state SET initialized=true"))
 	}
 
 	return alreadyInitialized, err
@@ -82,7 +87,7 @@ func getConfiguration(ctx context.Context) (*State, error) {
 }
 
 func tryInsertNew(ctx context.Context, dbh interface {
-	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	Exec(ctx context.Context, query *sqlf.Query) error
 }) error {
 	siteID, err := uuid.NewRandom()
 	if err != nil {
@@ -97,18 +102,18 @@ func tryInsertNew(ctx context.Context, dbh interface {
 	// because previously global state had a siteID and now we ignore that (or someone ran `DELETE
 	// FROM global_state;` in the PostgreSQL database). In either case, it's safe to generate a new
 	// site ID and set the site as initialized.
-	_, err = dbh.ExecContext(ctx, `
+	err = dbh.Exec(ctx, sqlf.Sprintf(`
 	INSERT INTO global_state(
 		site_id,
 		initialized,
 		mgmt_password_plaintext,
 		mgmt_password_bcrypt
 	) values(
-		$1,
+		%s,
 		EXISTS (SELECT 1 FROM users WHERE deleted_at IS NULL),
 		(SELECT COALESCE((SELECT mgmt_password_plaintext FROM global_state LIMIT 1), '')),
 		(SELECT COALESCE((SELECT mgmt_password_bcrypt FROM global_state LIMIT 1), ''))
-	);`, siteID)
+	);`, siteID))
 	if err != nil {
 		if pqErr, ok := err.(*pq.Error); ok {
 			if pqErr.Constraint == "global_state_pkey" {

--- a/internal/db/stores.go
+++ b/internal/db/stores.go
@@ -12,7 +12,7 @@ var (
 	OrgMembers       = &orgMembers{}
 	SavedSearches    = &savedSearches{}
 	Settings         = &settings{}
-	Users            = &users{}
+	Users            = &UserStore{}
 	UserCredentials  = &userCredentials{}
 	UserEmails       = &userEmails{}
 	EventLogs        = &eventLogs{}

--- a/internal/db/user_tags.go
+++ b/internal/db/user_tags.go
@@ -2,24 +2,35 @@ package db
 
 import (
 	"context"
+	"database/sql"
 
-	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
+	"github.com/keegancsmith/sqlf"
+	"github.com/lib/pq"
+)
+
+const (
+	// If the owner of an external service has this tag, the service is allowed to sync private code
+	TagAllowUserExternalServicePrivate = "AllowUserExternalServicePrivate"
+	// If the owner of an external service has this tag, the service is allowed to sync public code only
+	TagAllowUserExternalServicePublic = "AllowUserExternalServicePublic"
 )
 
 // SetTag adds (present=true) or removes (present=false) a tag from the given user's set of tags. An
 // error occurs if the user does not exist. Adding a duplicate tag or removing a nonexistent tag is
 // not an error.
-func (*UserStore) SetTag(ctx context.Context, userID int32, tag string, present bool) error {
-	var query string
+func (u *UserStore) SetTag(ctx context.Context, userID int32, tag string, present bool) error {
+	u.ensureStore()
+
+	var q *sqlf.Query
 	if present {
 		// Add tag.
-		query = `UPDATE users SET tags=CASE WHEN NOT $2::text = ANY(tags) THEN (tags || $2) ELSE tags END WHERE id=$1`
+		q = sqlf.Sprintf(`UPDATE users SET tags=CASE WHEN NOT %s::text = ANY(tags) THEN (tags || %s::text) ELSE tags END WHERE id=%s`, tag, tag, userID)
 	} else {
 		// Remove tag.
-		query = `UPDATE users SET tags=array_remove(tags, $2) WHERE id=$1`
+		q = sqlf.Sprintf(`UPDATE users SET tags=array_remove(tags, %s::text) WHERE id=%s`, tag, userID)
 	}
 
-	res, err := dbconn.Global.ExecContext(ctx, query, userID, tag)
+	res, err := u.ExecResult(ctx, q)
 	if err != nil {
 		return err
 	}
@@ -31,4 +42,29 @@ func (*UserStore) SetTag(ctx context.Context, userID int32, tag string, present 
 		return userNotFoundErr{args: []interface{}{userID}}
 	}
 	return nil
+}
+
+// HasTag reports whether the context actor has the given tag.
+// If not, it returns false and a nil error.
+func (u *UserStore) HasTag(ctx context.Context, userID int32, tag string) (bool, error) {
+	if Mocks.Users.HasTag != nil {
+		return Mocks.Users.HasTag(ctx, userID, tag)
+	}
+	u.ensureStore()
+
+	var tags []string
+	err := u.QueryRow(ctx, sqlf.Sprintf("SELECT tags FROM users WHERE id = %s", userID)).Scan(pq.Array(&tags))
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, userNotFoundErr{[]interface{}{userID}}
+		}
+		return false, err
+	}
+
+	for _, t := range tags {
+		if t == tag {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/internal/db/user_tags.go
+++ b/internal/db/user_tags.go
@@ -9,7 +9,7 @@ import (
 // SetTag adds (present=true) or removes (present=false) a tag from the given user's set of tags. An
 // error occurs if the user does not exist. Adding a duplicate tag or removing a nonexistent tag is
 // not an error.
-func (*users) SetTag(ctx context.Context, userID int32, tag string, present bool) error {
+func (*UserStore) SetTag(ctx context.Context, userID int32, tag string, present bool) error {
 	var query string
 	if present {
 		// Add tag.

--- a/internal/db/users_builtin_auth.go
+++ b/internal/db/users_builtin_auth.go
@@ -9,16 +9,19 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/randstring"
 	"golang.org/x/crypto/bcrypt"
 )
 
 func (u *UserStore) IsPassword(ctx context.Context, id int32, password string) (bool, error) {
+	u.ensureStore()
+
 	var passwd sql.NullString
-	if err := dbconn.Global.QueryRowContext(ctx, "SELECT passwd FROM users WHERE deleted_at IS NULL AND id=$1", id).Scan(&passwd); err != nil {
+	if err := u.QueryRow(ctx, sqlf.Sprintf("SELECT passwd FROM users WHERE deleted_at IS NULL AND id=%s", id)).Scan(&passwd); err != nil {
 		return false, err
 	}
 	if !passwd.Valid {
@@ -33,6 +36,8 @@ var (
 )
 
 func (u *UserStore) RenewPasswordResetCode(ctx context.Context, id int32) (string, error) {
+	u.ensureStore()
+
 	if _, err := u.GetByID(ctx, id); err != nil {
 		return "", err
 	}
@@ -41,7 +46,7 @@ func (u *UserStore) RenewPasswordResetCode(ctx context.Context, id int32) (strin
 		return "", err
 	}
 	code := base64.StdEncoding.EncodeToString(b[:])
-	res, err := dbconn.Global.ExecContext(ctx, "UPDATE users SET passwd_reset_code=$1, passwd_reset_time=now() WHERE id=$2 AND (passwd_reset_time IS NULL OR passwd_reset_time + interval '"+passwordResetRateLimit+"' < now())", code, id)
+	res, err := u.ExecResult(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_code=%s, passwd_reset_time=now() WHERE id=%s AND (passwd_reset_time IS NULL OR passwd_reset_time + interval '"+passwordResetRateLimit+"' < now())", code, id))
 	if err != nil {
 		return "", err
 	}
@@ -58,6 +63,8 @@ func (u *UserStore) RenewPasswordResetCode(ctx context.Context, id int32) (strin
 
 // SetPassword sets the user's password given a new password and a password reset code
 func (u *UserStore) SetPassword(ctx context.Context, id int32, resetCode, newPassword string) (bool, error) {
+	u.ensureStore()
+
 	// 🚨 SECURITY: no empty passwords
 	if newPassword == "" {
 		return false, errors.New("new password was empty")
@@ -66,7 +73,7 @@ func (u *UserStore) SetPassword(ctx context.Context, id int32, resetCode, newPas
 	resetLinkExpiryDuration := conf.AuthPasswordResetLinkExpiry()
 
 	// 🚨 SECURITY: check resetCode against what's in the DB and that it's not expired
-	r := dbconn.Global.QueryRowContext(ctx, "SELECT count(*) FROM users WHERE id=$1 AND deleted_at IS NULL AND passwd_reset_code=$2 AND passwd_reset_time + interval '"+strconv.Itoa(resetLinkExpiryDuration)+" seconds' > now()", id, resetCode)
+	r := u.QueryRow(ctx, sqlf.Sprintf("SELECT count(*) FROM users WHERE id=%s AND deleted_at IS NULL AND passwd_reset_code=%s AND passwd_reset_time + interval '"+strconv.Itoa(resetLinkExpiryDuration)+" seconds' > now()", id, resetCode))
 
 	var ct int
 	if err := r.Scan(&ct); err != nil {
@@ -83,7 +90,7 @@ func (u *UserStore) SetPassword(ctx context.Context, id int32, resetCode, newPas
 		return false, err
 	}
 	// 🚨 SECURITY: set the new password and clear the reset code and expiry so the same code can't be reused.
-	if _, err := dbconn.Global.ExecContext(ctx, "UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL, passwd=$1 WHERE id=$2", passwd, id); err != nil {
+	if err := u.Exec(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL, passwd=%s WHERE id=%s", passwd, id)); err != nil {
 		return false, err
 	}
 
@@ -91,12 +98,16 @@ func (u *UserStore) SetPassword(ctx context.Context, id int32, resetCode, newPas
 }
 
 func (u *UserStore) DeletePasswordResetCode(ctx context.Context, id int32) error {
-	_, err := dbconn.Global.ExecContext(ctx, "UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL WHERE id=$1", id)
+	u.ensureStore()
+
+	err := u.Exec(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL WHERE id=%s", id))
 	return err
 }
 
 // UpdatePassword updates a user's password given the current password.
 func (u *UserStore) UpdatePassword(ctx context.Context, id int32, oldPassword, newPassword string) error {
+	u.ensureStore()
+
 	// 🚨 SECURITY: No empty passwords.
 	if oldPassword == "" {
 		return errors.New("old password was empty")
@@ -120,7 +131,7 @@ func (u *UserStore) UpdatePassword(ctx context.Context, id int32, oldPassword, n
 		return err
 	}
 	// 🚨 SECURITY: Set the new password
-	if _, err := dbconn.Global.ExecContext(ctx, "UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL, passwd=$1 WHERE id=$2", passwd, id); err != nil {
+	if err := u.Exec(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL, passwd=%s WHERE id=%s", passwd, id)); err != nil {
 		return err
 	}
 
@@ -135,13 +146,15 @@ func (u *UserStore) UpdatePassword(ctx context.Context, id int32, oldPassword, n
 // A randomized password is used (instead of an empty password) to avoid bugs where an empty password
 // is considered to be no password. The random password is expected to be irretrievable.
 func (u *UserStore) RandomizePasswordAndClearPasswordResetRateLimit(ctx context.Context, id int32) error {
+	u.ensureStore()
+
 	passwd, err := hashPassword(randstring.NewLen(36))
 	if err != nil {
 		return err
 	}
 	// 🚨 SECURITY: Set the new random password and clear the reset code/expiry, so the old code
 	// can't be reused, and so a new valid reset code can be generated afterward.
-	_, err = dbconn.Global.ExecContext(ctx, "UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL, passwd=$1 WHERE id=$2", passwd, id)
+	err = u.Exec(ctx, sqlf.Sprintf("UPDATE users SET passwd_reset_code=NULL, passwd_reset_time=NULL, passwd=%s WHERE id=%s", passwd, id))
 	return err
 }
 


### PR DESCRIPTION
Convert the db/users struct to use basestore and rename it to UserStore

`org_members` and `globalstatedb` were also minimally changed and will be fully migrated to basestore in another PR.

Closes: https://github.com/sourcegraph/sourcegraph/issues/15854