### PR TITLE
Update language

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
+++ b/client/browser/src/shared/code-hosts/shared/ViewOnSourcegraphButton.tsx
@@ -89,8 +89,8 @@ export const ViewOnSourcegraphButton: React.FunctionComponent<ViewOnSourcegraphB
                 <SourcegraphIconButton
                     {...commonErrorCaseProps}
                     label="Configure Sourcegraph"
-                    title="Setup Sourcegraph for search and code intelligence on private repositories"
-                    ariaLabel="Setup Sourcegraph for search and code intelligence on private repositories"
+                    title="Set up Sourcegraph for search and code intelligence on private repositories"
+                    ariaLabel="Set up Sourcegraph for search and code intelligence on private repositories"
                 />
             )
         }


### PR DESCRIPTION
Quick language fix – "setup" in this context is a noun, while "set up" is an action.