### PR TITLE
Fix: permit saving structural searches

### DIFF
--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -284,10 +284,10 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
-var patternTypeRegexp = lazyregexp.New(`(?i)\bpatternType:(literal|regexp)\b`)
+var patternTypeRegexp = lazyregexp.New(`(?i)\bpatternType:(literal|regexp|structural)\b`)
 
 func queryHasPatternType(query string) bool {
 	return patternTypeRegexp.Match([]byte(query))
 }
 
-var errMissingPatternType = errors.New("a `patternType:` filter is required in the query for all saved searches. `patternType` can be \"literal\" or \"regexp\"")
+var errMissingPatternType = errors.New("a `patternType:` filter is required in the query for all saved searches. `patternType` can be \"literal\", \"regexp\" or \"structural\"")


### PR DESCRIPTION
It is currently not possible to save a structural search due to this 
```
var patternTypeRegexp = lazyregexp.New(`(?i)\bpatternType:(literal|regexp|structural)\b`)
```



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
