### PR TITLE
Add "create code monitor" button to search results page

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -177,6 +177,11 @@ interface SourcegraphWebAppState extends SettingsCascadeProps {
      * Wether to enable enable contextual syntax highlighting and hovers for search queries
      */
     enableSmartQuery: boolean
+
+    /**
+     * Whether the code monitoring feature flag is enabled.
+     */
+    enableCodeMonitoring: boolean
 }
 
 const notificationClassNames = {
@@ -260,6 +265,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             showMultilineSearchConsole: false,
             showQueryBuilder: false,
             enableSmartQuery: false,
+            enableCodeMonitoring: false,
         }
     }
 
@@ -410,6 +416,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                     showMultilineSearchConsole={this.state.showMultilineSearchConsole}
                                     showQueryBuilder={this.state.showQueryBuilder}
                                     enableSmartQuery={this.state.enableSmartQuery}
+                                    enableCodeMonitoring={this.state.enableCodeMonitoring}
                                     fetchSavedSearches={fetchSavedSearches}
                                     fetchRecentSearches={fetchRecentSearches}
                                     fetchRecentFileViews={fetchRecentFileViews}

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { createMemoryHistory, createLocation } from 'history'
+import { CodeMonitorForm, CodeMonitorFormProps } from './CodeMonitorForm'
+import { NEVER } from 'rxjs'
+import { AuthenticatedUser } from '../../../auth'
+
+const PROPS: CodeMonitorFormProps = {
+    history: createMemoryHistory(),
+    location: createLocation('/code-monitoring/new'),
+    onSubmit: () => NEVER,
+    submitButtonLabel: '',
+    authenticatedUser: {
+        id: 'userID',
+        username: 'username',
+        email: 'user@me.com',
+        siteAdmin: true,
+    } as AuthenticatedUser,
+}
+
+describe('CodeMonitorForm', () => {
+    test('Uses trigger-query when present in URL search params', () => {
+        const component = mount(
+            <CodeMonitorForm {...PROPS} location={createLocation('/code-monitoring/new?trigger-query=foo')} />
+        )
+        const triggerQuery = component.find('[data-testid="trigger-query-edit"]')
+        expect(triggerQuery.length).toStrictEqual(1)
+        expect(triggerQuery.at(0).prop('value')).toStrictEqual('foo')
+    })
+})

--- a/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/CodeMonitorForm.tsx
@@ -45,15 +45,21 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
     codeMonitor,
     showDeleteButton,
     deleteCodeMonitor,
+    location,
 }) => {
     const LOADING = 'loading' as const
+
+    const triggerQueryFromURL = useMemo(
+        () => (codeMonitor ? undefined : new URLSearchParams(location.search).get('trigger-query')),
+        [codeMonitor, location.search]
+    )
 
     const [currentCodeMonitorState, setCodeMonitor] = useState<CodeMonitorFields>(
         codeMonitor ?? {
             id: '',
             description: '',
             enabled: true,
-            trigger: { id: '', query: '' },
+            trigger: { id: '', query: triggerQueryFromURL ?? '' },
             actions: {
                 nodes: [],
             },
@@ -184,6 +190,7 @@ export const CodeMonitorForm: React.FunctionComponent<CodeMonitorFormProps> = ({
                         onQueryChange={onQueryChange}
                         triggerCompleted={formCompletion.triggerCompleted}
                         setTriggerCompleted={setTriggerCompleted}
+                        startExpanded={!!triggerQueryFromURL}
                     />
                 </div>
                 <div

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
@@ -22,6 +22,7 @@ describe('FormTriggerArea', () => {
                 triggerCompleted={false}
                 onQueryChange={sinon.spy()}
                 setTriggerCompleted={sinon.spy()}
+                startExpanded={false}
             />
         )
         act(() => {

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -14,6 +14,7 @@ interface TriggerAreaProps {
     onQueryChange: (query: string) => void
     triggerCompleted: boolean
     setTriggerCompleted: (complete: boolean) => void
+    startExpanded: boolean
 }
 
 const isDiffOrCommit = (value: string): boolean => value === 'diff' || value === 'commit'
@@ -23,8 +24,9 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
     onQueryChange,
     triggerCompleted,
     setTriggerCompleted,
+    startExpanded,
 }) => {
-    const [showQueryForm, setShowQueryForm] = useState(false)
+    const [showQueryForm, setShowQueryForm] = useState(startExpanded)
     const toggleQueryForm: React.FormEventHandler = useCallback(event => {
         event.preventDefault()
         setShowQueryForm(show => !show)
@@ -141,6 +143,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                     autoFocus={true}
                                     ref={queryInputReference}
                                     spellCheck={false}
+                                    data-testid="trigger-query-edit"
                                 />
                                 {queryState.kind === 'INVALID' && (
                                     <small className="trigger-area__query-input-error-message invalid-feedback test-trigger-error">
@@ -193,7 +196,10 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     <div className="d-flex justify-content-between align-items-center">
                         <div>
                             <div className="font-weight-bold">When there are new search results</div>
-                            <code className="trigger-area__query-label text-break text-muted test-existing-query">
+                            <code
+                                className="trigger-area__query-label text-break text-muted test-existing-query"
+                                data-testid="trigger-query-existing"
+                            >
                                 {query}
                             </code>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`FormTriggerArea Error message is shown when query is invalid 1`] = `
   onQueryChange={[Function]}
   query="test"
   setTriggerCompleted={[Function]}
+  startExpanded={false}
   triggerCompleted={false}
 >
   <h3>
@@ -38,6 +39,7 @@ exports[`FormTriggerArea Error message is shown when query is invalid 1`] = `
           <input
             autoFocus={true}
             className="trigger-area__query-input-field form-control my-2 test-trigger-input is-invalid"
+            data-testid="trigger-query-edit"
             onChange={[Function]}
             required={true}
             spellCheck={false}

--- a/client/web/src/enterprise/code-monitoring/index.ts
+++ b/client/web/src/enterprise/code-monitoring/index.ts
@@ -13,6 +13,10 @@ import {
 } from '../../graphql-operations'
 
 export interface CodeMonitoringProps {
+    /**
+     * Whether the code monitoring feature flag is enabled.
+     */
+    enableCodeMonitoring: boolean
     createCodeMonitor: (
         monitorInput: CreateCodeMonitorVariables
     ) => Observable<CreateCodeMonitorResult['createCodeMonitor']>

--- a/client/web/src/search/results/SearchResults.test.tsx
+++ b/client/web/src/search/results/SearchResults.test.tsx
@@ -41,6 +41,7 @@ describe('SearchResults', () => {
         setVersionContext: () => undefined,
         availableVersionContexts: undefined,
         previousVersionContext: 'sg-last-version-context',
+        enableCodeMonitoring: false,
     }
 
     it('calls the search request once', () => {

--- a/client/web/src/search/results/SearchResults.tsx
+++ b/client/web/src/search/results/SearchResults.tsx
@@ -37,6 +37,7 @@ import { AuthenticatedUser } from '../../auth'
 import { SearchPatternType } from '../../../../shared/src/graphql-operations'
 import { shouldDisplayPerformanceWarning } from '../backend'
 import { VersionContextWarning } from './VersionContextWarning'
+import { CodeMonitoringProps } from '../../enterprise/code-monitoring'
 
 export interface SearchResultsProps
     extends ExtensionsControllerProps<'executeCommand' | 'extHostAPI' | 'services'>,
@@ -46,7 +47,8 @@ export interface SearchResultsProps
         ThemeProps,
         PatternTypeProps,
         CaseSensitivityProps,
-        VersionContextProps {
+        VersionContextProps,
+        Pick<CodeMonitoringProps, 'enableCodeMonitoring'> {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History

--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import { createMemoryHistory, createLocation } from 'history'
+import { noop } from 'lodash'
+import { NEVER } from 'rxjs'
+import { SearchResultsInfoBar, SearchResultsInfoBarProps } from './SearchResultsInfoBar'
+import { AuthenticatedUser } from '../../auth'
+import { NOOP_TELEMETRY_SERVICE } from '../../../../shared/src/telemetry/telemetryService'
+import { SearchPatternType } from '../../graphql-operations'
+
+const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
+    extensionsController: { executeCommand: () => Promise.resolve(), services: {} as any },
+    platformContext: { forceUpdateTooltip: noop, settings: NEVER },
+    history: createMemoryHistory(),
+    location: createLocation('/search'),
+    authenticatedUser: {
+        id: 'userID',
+        username: 'username',
+        email: 'user@me.com',
+        siteAdmin: true,
+    } as AuthenticatedUser,
+    resultsFound: true,
+    allExpanded: true,
+    onExpandAllResultsToggle: noop,
+    onSaveQueryClick: noop,
+    stats: <div />,
+    telemetryService: NOOP_TELEMETRY_SERVICE,
+    patternType: SearchPatternType.literal,
+    setPatternType: noop,
+}
+
+describe('SearchResultsInfoBar', () => {
+    test('code monitoring feature flag disabled', () => {
+        expect(
+            renderer
+                .create(<SearchResultsInfoBar {...COMMON_PROPS} enableCodeMonitoring={false} query="foo type:diff" />)
+                .toJSON()
+        ).toMatchSnapshot()
+    })
+
+    test('code monitoring feature flag enabled, cannot create monitor from query', () => {
+        expect(
+            renderer.create(<SearchResultsInfoBar {...COMMON_PROPS} enableCodeMonitoring={true} query="foo" />).toJSON()
+        ).toMatchSnapshot()
+    })
+
+    test('code monitoring feature flag enabled, can create monitor from query', () => {
+        expect(
+            renderer
+                .create(<SearchResultsInfoBar {...COMMON_PROPS} enableCodeMonitoring={true} query="foo type:diff" />)
+                .toJSON()
+        ).toMatchSnapshot()
+    })
+})

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -88,7 +88,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
         }
         const searchParameters = new URLSearchParams(props.location.search)
         searchParameters.set('trigger-query', `${props.query} patterntype:${props.patternType}`)
-        const toURL = canCreateMonitorFromQuery ? `/code-monitoring/new?${searchParameters.toString()}` : ''
+        const toURL = `/code-monitoring/new?${searchParameters.toString()}`
         return (
             <li className="nav-item">
                 <Link to={toURL} className="btn btn-link nav-link text-decoration-none">

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -13,12 +13,15 @@ import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { SearchPatternType } from '../../graphql-operations'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
+import { CodeMonitoringProps } from '../../enterprise/code-monitoring'
 
 interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'services'>,
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
         TelemetryProps,
-        PatternTypeProps {
+        PatternTypeProps,
+        Pick<CodeMonitoringProps, 'enableCodeMonitoring'> {
+    history: H.History
     /** The currently authenticated user or null */
     authenticatedUser: AuthenticatedUser | null
 

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import * as React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import ArrowCollapseVerticalIcon from 'mdi-react/ArrowCollapseVerticalIcon'
 import ArrowExpandVerticalIcon from 'mdi-react/ArrowExpandVerticalIcon'
 import classNames from 'classnames'
@@ -14,8 +14,11 @@ import { SearchPatternType } from '../../graphql-operations'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { CodeMonitoringProps } from '../../enterprise/code-monitoring'
+import { CodeMonitoringLogo } from '../../enterprise/code-monitoring/CodeMonitoringLogo'
+import { FilterKind, findFilter } from '../../../../shared/src/search/query/validate'
+import { Link } from '../../../../shared/src/components/Link'
 
-interface SearchResultsInfoBarProps
+export interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'services'>,
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
         TelemetryProps,
@@ -67,50 +70,84 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
  * The info bar shown over the search results list that displays metadata
  * and a few actions like expand all and save query
  */
-export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => (
-    <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
-        <small className="search-results-info-bar__row">
-            {props.stats}
-            <QuotesInterpretedLiterallyNotice {...props} />
+export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => {
+    const redirectToCodeMonitoringPage = useCallback(() => {
+        const searchParameters = new URLSearchParams(props.location.search)
+        searchParameters.set('trigger-query', props.query ? `${props.query} patterntype:${props.patternType}` : '')
+        props.history.push(`/code-monitoring/new?${searchParameters.toString()}`)
+    }, [props.history, props.query, props.location.search])
+    const CreateCodeMonitorButton = useMemo(() => {
+        if (!props.enableCodeMonitoring || !props.query) {
+            return null
+        }
+        const globalTypeFilterInQuery = findFilter(props.query, 'type', FilterKind.Global)
+        const globalTypeFilterValue =
+            globalTypeFilterInQuery?.value?.type === 'literal'
+                ? globalTypeFilterInQuery.value.value
+                : globalTypeFilterInQuery?.value?.type === 'quoted'
+                ? globalTypeFilterInQuery.value.quotedValue
+                : undefined
+        const canCreateMonitorFromQuery = globalTypeFilterValue === 'diff' || globalTypeFilterValue === 'commit'
+        if (!canCreateMonitorFromQuery) {
+            return null
+        }
+        const searchParameters = new URLSearchParams(props.location.search)
+        searchParameters.set('trigger-query', `${props.query} patterntype:${props.patternType}`)
+        const toURL = canCreateMonitorFromQuery ? `/code-monitoring/new?${searchParameters.toString()}` : ''
+        return (
+            <li className="nav-item">
+                <Link to={toURL} className={'btn btn-link nav-link text-decoration-none'}>
+                    <CodeMonitoringLogo className="icon-inline" />
+                    Create code monitor
+                </Link>
+            </li>
+        )
+    }, [props.enableCodeMonitoring, props.query, redirectToCodeMonitoringPage, props.patternType])
+    return (
+        <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
+            <small className="search-results-info-bar__row">
+                {props.stats}
+                <QuotesInterpretedLiterallyNotice {...props} />
 
-            <ul className="nav align-items-center justify-content-end">
-                <ActionsNavItems
-                    {...props}
-                    extraContext={{ searchQuery: props.query || null }}
-                    menu={ContributableMenu.SearchResultsToolbar}
-                    wrapInList={false}
-                    showLoadingSpinnerDuringExecution={true}
-                    actionItemClass="btn btn-link nav-link text-decoration-none"
-                />
-
-                {props.showSavedQueryButton !== false && props.authenticatedUser && (
-                    <li className="nav-item">
-                        <button
-                            type="button"
-                            onClick={props.onSaveQueryClick}
-                            className="btn btn-link nav-link text-decoration-none"
-                        >
-                            <DownloadIcon className="icon-inline test-save-search-link" /> Save this search query
-                        </button>
-                    </li>
-                )}
-                {props.resultsFound && (
-                    <li className="nav-item">
-                        <button
-                            type="button"
-                            onClick={props.onExpandAllResultsToggle}
-                            className="btn btn-link nav-link text-decoration-none"
-                            data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
-                        >
-                            {props.allExpanded ? (
-                                <ArrowCollapseVerticalIcon className="icon-inline" />
-                            ) : (
-                                <ArrowExpandVerticalIcon className="icon-inline" />
-                            )}
-                        </button>
-                    </li>
-                )}
-            </ul>
-        </small>
-    </div>
-)
+                <ul className="nav align-items-center justify-content-end">
+                    <ActionsNavItems
+                        {...props}
+                        extraContext={{ searchQuery: props.query || null }}
+                        menu={ContributableMenu.SearchResultsToolbar}
+                        wrapInList={false}
+                        showLoadingSpinnerDuringExecution={true}
+                        actionItemClass="btn btn-link nav-link text-decoration-none"
+                    />
+                    {CreateCodeMonitorButton}
+                    {props.showSavedQueryButton !== false && props.authenticatedUser && (
+                        <li className="nav-item">
+                            <button
+                                type="button"
+                                onClick={props.onSaveQueryClick}
+                                className="btn btn-link nav-link text-decoration-none"
+                            >
+                                <DownloadIcon className="icon-inline test-save-search-link" /> Save this search query
+                            </button>
+                        </li>
+                    )}
+                    {props.resultsFound && (
+                        <li className="nav-item">
+                            <button
+                                type="button"
+                                onClick={props.onExpandAllResultsToggle}
+                                className="btn btn-link nav-link text-decoration-none"
+                                data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
+                            >
+                                {props.allExpanded ? (
+                                    <ArrowCollapseVerticalIcon className="icon-inline" />
+                                ) : (
+                                    <ArrowExpandVerticalIcon className="icon-inline" />
+                                )}
+                            </button>
+                        </li>
+                    )}
+                </ul>
+            </small>
+        </div>
+    )
+}

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -121,7 +121,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                                 onClick={props.onSaveQueryClick}
                                 className="btn btn-link nav-link text-decoration-none"
                             >
-                                <DownloadIcon className="icon-inline test-save-search-link" /> Save this search query
+                                <DownloadIcon className="icon-inline test-save-search-link" /> Save search
                             </button>
                         </li>
                     )}

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -80,6 +80,17 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                     actionItemClass="btn btn-link nav-link text-decoration-none"
                 />
 
+                {props.showSavedQueryButton !== false && props.authenticatedUser && (
+                    <li className="nav-item">
+                        <button
+                            type="button"
+                            onClick={props.onSaveQueryClick}
+                            className="btn btn-link nav-link text-decoration-none"
+                        >
+                            <DownloadIcon className="icon-inline test-save-search-link" /> Save this search query
+                        </button>
+                    </li>
+                )}
                 {props.resultsFound && (
                     <li className="nav-item">
                         <button
@@ -93,18 +104,6 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                             ) : (
                                 <ArrowExpandVerticalIcon className="icon-inline" />
                             )}
-                        </button>
-                    </li>
-                )}
-
-                {props.showSavedQueryButton !== false && props.authenticatedUser && (
-                    <li className="nav-item">
-                        <button
-                            type="button"
-                            onClick={props.onSaveQueryClick}
-                            className="btn btn-link nav-link text-decoration-none"
-                        >
-                            <DownloadIcon className="icon-inline test-save-search-link" /> Save this search query
                         </button>
                     </li>
                 )}

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import ArrowCollapseVerticalIcon from 'mdi-react/ArrowCollapseVerticalIcon'
 import ArrowExpandVerticalIcon from 'mdi-react/ArrowExpandVerticalIcon'
 import classNames from 'classnames'
@@ -71,11 +71,6 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => {
-    const redirectToCodeMonitoringPage = useCallback(() => {
-        const searchParameters = new URLSearchParams(props.location.search)
-        searchParameters.set('trigger-query', props.query ? `${props.query} patterntype:${props.patternType}` : '')
-        props.history.push(`/code-monitoring/new?${searchParameters.toString()}`)
-    }, [props.history, props.query, props.location.search])
     const CreateCodeMonitorButton = useMemo(() => {
         if (!props.enableCodeMonitoring || !props.query) {
             return null
@@ -102,7 +97,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 </Link>
             </li>
         )
-    }, [props.enableCodeMonitoring, props.query, redirectToCodeMonitoringPage, props.patternType])
+    }, [props.enableCodeMonitoring, props.query, props.patternType])
     return (
         <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
             <small className="search-results-info-bar__row">

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -91,13 +91,13 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
         const toURL = canCreateMonitorFromQuery ? `/code-monitoring/new?${searchParameters.toString()}` : ''
         return (
             <li className="nav-item">
-                <Link to={toURL} className={'btn btn-link nav-link text-decoration-none'}>
+                <Link to={toURL} className="btn btn-link nav-link text-decoration-none">
                     <CodeMonitoringLogo className="icon-inline" />
                     Create code monitor
                 </Link>
             </li>
         )
-    }, [props.enableCodeMonitoring, props.query, props.patternType])
+    }, [props.enableCodeMonitoring, props.query, props.patternType, props.location.search])
     return (
         <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
             <small className="search-results-info-bar__row">

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -89,13 +89,9 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                             data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
                         >
                             {props.allExpanded ? (
-                                <>
-                                    <ArrowCollapseVerticalIcon className="icon-inline" /> Collapse all
-                                </>
+                                <ArrowCollapseVerticalIcon className="icon-inline" />
                             ) : (
-                                <>
-                                    <ArrowExpandVerticalIcon className="icon-inline" /> Expand all
-                                </>
+                                <ArrowExpandVerticalIcon className="icon-inline" />
                             )}
                         </button>
                     </li>

--- a/client/web/src/search/results/SearchResultsList.story.tsx
+++ b/client/web/src/search/results/SearchResultsList.story.tsx
@@ -59,6 +59,7 @@ const defaultProps: SearchResultsListProps = {
     navbarSearchQueryState: { query: '' },
 
     shouldDisplayPerformanceWarning: () => of(false),
+    enableCodeMonitoring: false,
 }
 
 const { add } = storiesOf('web/search/results/SearchResultsList', module).addParameters({

--- a/client/web/src/search/results/SearchResultsList.test.tsx
+++ b/client/web/src/search/results/SearchResultsList.test.tsx
@@ -121,6 +121,7 @@ describe('SearchResultsList', () => {
         navbarSearchQueryState: { query: '' },
 
         shouldDisplayPerformanceWarning: () => of(false),
+        enableCodeMonitoring: false,
     }
 
     it('displays loading text when results is undefined', () => {

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -34,6 +34,7 @@ import { QueryState } from '../helpers'
 import { PerformanceWarningAlert } from '../../site/PerformanceWarningAlert'
 import { SearchResultsStats } from './SearchResultsStats'
 import { SearchAlert } from './SearchAlert'
+import { CodeMonitoringProps } from '../../enterprise/code-monitoring'
 
 const isSearchResults = (value: unknown): value is GQL.ISearchResults =>
     typeof value === 'object' &&
@@ -49,7 +50,8 @@ export interface SearchResultsListProps
         ThemeProps,
         PatternTypeProps,
         CaseSensitivityProps,
-        VersionContextProps {
+        VersionContextProps,
+        Pick<CodeMonitoringProps, 'enableCodeMonitoring'> {
     location: H.Location
     history: H.History
     authenticatedUser: AuthenticatedUser | null

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -1,0 +1,208 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
+<div
+  className="search-results-info-bar"
+  data-testid="results-info-bar"
+>
+  <small
+    className="search-results-info-bar__row"
+  >
+    <div />
+    <ul
+      className="nav align-items-center justify-content-end"
+    >
+      <li
+        className="nav-item"
+      >
+        <button
+          className="btn btn-link nav-link text-decoration-none"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="mdi-icon icon-inline test-save-search-link"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
+            />
+          </svg>
+           Save this search query
+        </button>
+      </li>
+      <li
+        className="nav-item"
+      >
+        <button
+          className="btn btn-link nav-link text-decoration-none"
+          data-tooltip="Hide more matches on all results"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="mdi-icon icon-inline"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M4,12H20V14H4V12M4,9H20V11H4V9M16,4L12,8L8,4H11V1H13V4H16M8,19L12,15L16,19H13V22H11V19H8Z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </small>
+</div>
+`;
+
+exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create monitor from query 1`] = `
+<div
+  className="search-results-info-bar"
+  data-testid="results-info-bar"
+>
+  <small
+    className="search-results-info-bar__row"
+  >
+    <div />
+    <ul
+      className="nav align-items-center justify-content-end"
+    >
+      <li
+        className="nav-item"
+      >
+        <a
+          className="btn btn-link nav-link text-decoration-none"
+          href="/code-monitoring/new?trigger-query=foo+type%3Adiff+patterntype%3Aliteral"
+        >
+          <svg
+            className="icon-inline"
+            fill="currentColor"
+            height="20"
+            viewBox="0 0 20 20"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
+              fillRule="evenodd"
+            />
+          </svg>
+          Create code monitor
+        </a>
+      </li>
+      <li
+        className="nav-item"
+      >
+        <button
+          className="btn btn-link nav-link text-decoration-none"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="mdi-icon icon-inline test-save-search-link"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
+            />
+          </svg>
+           Save this search query
+        </button>
+      </li>
+      <li
+        className="nav-item"
+      >
+        <button
+          className="btn btn-link nav-link text-decoration-none"
+          data-tooltip="Hide more matches on all results"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="mdi-icon icon-inline"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M4,12H20V14H4V12M4,9H20V11H4V9M16,4L12,8L8,4H11V1H13V4H16M8,19L12,15L16,19H13V22H11V19H8Z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </small>
+</div>
+`;
+
+exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot create monitor from query 1`] = `
+<div
+  className="search-results-info-bar"
+  data-testid="results-info-bar"
+>
+  <small
+    className="search-results-info-bar__row"
+  >
+    <div />
+    <ul
+      className="nav align-items-center justify-content-end"
+    >
+      <li
+        className="nav-item"
+      >
+        <button
+          className="btn btn-link nav-link text-decoration-none"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="mdi-icon icon-inline test-save-search-link"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
+            />
+          </svg>
+           Save this search query
+        </button>
+      </li>
+      <li
+        className="nav-item"
+      >
+        <button
+          className="btn btn-link nav-link text-decoration-none"
+          data-tooltip="Hide more matches on all results"
+          onClick={[Function]}
+          type="button"
+        >
+          <svg
+            className="mdi-icon icon-inline"
+            fill="currentColor"
+            height={24}
+            viewBox="0 0 24 24"
+            width={24}
+          >
+            <path
+              d="M4,12H20V14H4V12M4,9H20V11H4V9M16,4L12,8L8,4H11V1H13V4H16M8,19L12,15L16,19H13V22H11V19H8Z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </small>
+</div>
+`;

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
               d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
             />
           </svg>
-           Save this search query
+           Save search
         </button>
       </li>
       <li
@@ -116,7 +116,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
               d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
             />
           </svg>
-           Save this search query
+           Save search
         </button>
       </li>
       <li
@@ -177,7 +177,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
               d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
             />
           </svg>
-           Save this search query
+           Save search
         </button>
       </li>
       <li

--- a/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
@@ -59,6 +59,7 @@ const defaultProps: StreamingSearchResultsProps = {
     streamSearch: () => of(streamingSearchResult),
 
     fetchHighlightedFileLineRanges: () => of(HIGHLIGHTED_FILE_LINES_LONG),
+    enableCodeMonitoring: false,
 }
 
 const { add } = storiesOf('web/search/results/streaming/StreamingSearchResults', module).addParameters({

--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -70,6 +70,7 @@ describe('StreamingSearchResults', () => {
 
         fetchHighlightedFileLineRanges: HIGHLIGHTED_FILE_LINES_REQUEST,
         isLightTheme: true,
+        enableCodeMonitoring: false,
     }
 
     it('should call streaming search API with the right parameters from URL', () => {

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -42,6 +42,7 @@ import {
     resolveVersionContext,
 } from '../..'
 import { asError } from '../../../../../shared/src/util/errors'
+import { CodeMonitoringProps } from '../../../enterprise/code-monitoring'
 
 export interface StreamingSearchResultsProps
     extends SearchStreamingProps,
@@ -52,7 +53,8 @@ export interface StreamingSearchResultsProps
         ExtensionsControllerProps<'executeCommand' | 'extHostAPI' | 'services'>,
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
         TelemetryProps,
-        ThemeProps {
+        ThemeProps,
+        Pick<CodeMonitoringProps, 'enableCodeMonitoring'> {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -54,6 +54,7 @@ export function experimentalFeaturesFromSettings(
     showMultilineSearchConsole: boolean
     showQueryBuilder: boolean
     enableSmartQuery: boolean
+    enableCodeMonitoring: boolean
 } {
     const experimentalFeatures: SettingsExperimentalFeatures =
         (settingsCascade.final && !isErrorLike(settingsCascade.final) && settingsCascade.final.experimentalFeatures) ||
@@ -67,6 +68,7 @@ export function experimentalFeaturesFromSettings(
         showMultilineSearchConsole = false,
         showQueryBuilder = false,
         enableSmartQuery = true,
+        codeMonitoring = false,
     } = experimentalFeatures
 
     return {
@@ -77,5 +79,6 @@ export function experimentalFeaturesFromSettings(
         showMultilineSearchConsole,
         showQueryBuilder,
         enableSmartQuery,
+        enableCodeMonitoring: codeMonitoring,
     }
 }


### PR DESCRIPTION
Fixes #17267

Review by commit.

Following a slight rearrangement of the search results info bar as per [Figma designs](https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=3700%3A0), adds a "Create code monitor" button to the search results page when the search query contains a top-level `type:diff` or `type:commit` field. This button links to the code monitor creation page, where the query field will be pre-filled through the `trigger-query` URL search parameter.

![image](https://user-images.githubusercontent.com/1741180/104598020-5a892880-5676-11eb-8f78-3e3aa0c67175.png)


https://user-images.githubusercontent.com/1741180/104599435-08e19d80-5678-11eb-870f-adaaf2b15e70.mp4


