### PR TITLE
streaming search: run AND expressions in batch mode

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -287,7 +287,9 @@ type searchResolver struct {
 	// searchResolver.SetResultChannel
 	resultChannel chan<- []SearchResultResolver
 
-	// Cached resolveRepositories results.
+	// Cached resolveRepositories results. We use a pointer to the mutex so that we
+	// can copy the resolver, while sharing the mutex. If we didn't use a pointer,
+	// the mutex would lead to unexpected behaviour.
 	reposMu  *sync.Mutex
 	resolved *searchrepos.Resolved
 	repoErr  error

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -915,8 +915,8 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 	start := time.Now()
 
 	// For streaming search we want to run the evaluation of AND expressions in batch
-	// mode. We copy r to r2 and replace the channel with a sink. Before we return we
-	// send the (batch) result down r's result channel.
+	// mode. We copy r to r2 and replace the result channel with a sink. Before we
+	// return we send the (batch) result down r's result channel.
 	r2 := *r
 	sink := make(chan []SearchResultResolver)
 	defer close(sink)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -852,7 +853,7 @@ func TestSearchResultsHydration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}}
+	resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}, reposMu: &sync.Mutex{}, resolved: &searchrepos.Resolved{}}
 	results, err := resolver.Results(ctx)
 	if err != nil {
 		t.Fatal("Results:", err)
@@ -1301,7 +1302,7 @@ func TestEvaluateAnd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}}
+			resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}, reposMu: &sync.Mutex{}, resolved: &searchrepos.Resolved{}}
 			results, err := resolver.Results(ctx)
 			if err != nil {
 				t.Fatal("Results:", err)

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -3,12 +3,14 @@ package graphqlbackend
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	searchzoekt "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -96,6 +98,8 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 		zoekt:        z,
 		searcherURLs: endpoint.Static("test"),
 		userSettings: &schema.Settings{},
+		reposMu:      &sync.Mutex{},
+		resolved:     &repos.Resolved{},
 	}
 	results, err := resolver.Results(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/graph-gophers/graphql-go"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	searchrepos "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -549,6 +551,8 @@ func TestVersionContext(t *testing.T) {
 				query:          qinfo,
 				versionContext: &tc.versionContext,
 				userSettings:   &schema.Settings{},
+				reposMu:        &sync.Mutex{},
+				resolved:       &repos.Resolved{},
 			}
 
 			db.Mocks.Repos.ListRepoNames = func(ctx context.Context, opts db.ReposListOptions) ([]*types.RepoName, error) {

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/graph-gophers/graphql-go"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	searchrepos "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -552,7 +551,7 @@ func TestVersionContext(t *testing.T) {
 				versionContext: &tc.versionContext,
 				userSettings:   &schema.Settings{},
 				reposMu:        &sync.Mutex{},
-				resolved:       &repos.Resolved{},
+				resolved:       &searchrepos.Resolved{},
 			}
 
 			db.Mocks.Repos.ListRepoNames = func(ctx context.Context, opts db.ReposListOptions) ([]*types.RepoName, error) {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/16423

streaming search was broken for expressions because we streamed back results of individual terms. While this is desirable for OR expressions, it breaks AND expressions because we are only interested in the intersection of their term results. With this change, we fall back to batch mode for AND expressions, streaming back results only after we calculated the intersection of all term results.

In the future, we might want to handle this more efficiently by calculating the intersection on the fly.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
