### PR TITLE
Recheck changeset syncer preconditions

### DIFF
--- a/enterprise/internal/campaigns/store/changesets.go
+++ b/enterprise/internal/campaigns/store/changesets.go
@@ -265,6 +265,8 @@ type GetChangesetOpts struct {
 	ExternalID          string
 	ExternalServiceType string
 	ExternalBranch      string
+	ReconcilerState     campaigns.ReconcilerState
+	PublicationState    campaigns.ChangesetPublicationState
 }
 
 // GetChangeset gets a changeset matching the given options.
@@ -312,6 +314,12 @@ func getChangesetQuery(opts *GetChangesetOpts) *sqlf.Query {
 	}
 	if opts.ExternalBranch != "" {
 		preds = append(preds, sqlf.Sprintf("changesets.external_branch = %s", opts.ExternalBranch))
+	}
+	if opts.ReconcilerState != "" {
+		preds = append(preds, sqlf.Sprintf("changesets.reconciler_state = %s", opts.ReconcilerState.ToDB()))
+	}
+	if opts.PublicationState != "" {
+		preds = append(preds, sqlf.Sprintf("changesets.publication_state = %s", opts.PublicationState))
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/campaigns/store/changesets_test.go
+++ b/enterprise/internal/campaigns/store/changesets_test.go
@@ -755,6 +755,60 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 				}
 			}
 		})
+
+		t.Run("ReconcilerState", func(t *testing.T) {
+			for _, c := range changesets {
+				opts := GetChangesetOpts{ID: c.ID, ReconcilerState: c.ReconcilerState}
+
+				have, err := s.GetChangeset(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := c
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatal(diff)
+				}
+
+				if c.ReconcilerState == campaigns.ReconcilerStateErrored {
+					c.ReconcilerState = campaigns.ReconcilerStateCompleted
+				} else {
+					opts.ReconcilerState = campaigns.ReconcilerStateErrored
+				}
+				_, err = s.GetChangeset(ctx, opts)
+				if err != ErrNoResults {
+					t.Fatalf("unexpected error, want=%q have=%q", ErrNoResults, err)
+				}
+			}
+		})
+
+		t.Run("PublicationState", func(t *testing.T) {
+			for _, c := range changesets {
+				opts := GetChangesetOpts{ID: c.ID, PublicationState: c.PublicationState}
+
+				have, err := s.GetChangeset(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := c
+
+				if diff := cmp.Diff(have, want); diff != "" {
+					t.Fatal(diff)
+				}
+
+				// Toggle publication state
+				if c.PublicationState == campaigns.ChangesetPublicationStateUnpublished {
+					opts.PublicationState = campaigns.ChangesetPublicationStatePublished
+				} else {
+					opts.PublicationState = campaigns.ChangesetPublicationStateUnpublished
+				}
+
+				_, err = s.GetChangeset(ctx, opts)
+				if err != ErrNoResults {
+					t.Fatalf("unexpected error, want=%q have=%q", ErrNoResults, err)
+				}
+			}
+		})
 	})
 
 	t.Run("Update", func(t *testing.T) {


### PR DESCRIPTION
Between the time when the schedule is computed and the time when the sync is happening the changeset might have changed. If that's the case, we don't need to sync it currently anymore and should skip it.
