### PR TITLE
search: Move FakeClock to timeutil

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	idb "github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -33,6 +32,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -770,7 +770,7 @@ func testServerStatusMessages(t *testing.T, store *repos.Store) func(t *testing.
 					t.Fatal(err)
 				}
 
-				clock := dbtesting.NewFakeClock(time.Now(), 0)
+				clock := timeutil.NewFakeClock(time.Now(), 0)
 				syncer := &repos.Syncer{
 					Store: store,
 					Now:   clock.Now,
@@ -846,7 +846,7 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(
 	return func(t *testing.T, store *repos.Store) func(t *testing.T) {
 		return func(t *testing.T) {
 			ctx := context.Background()
-			clock := dbtesting.NewFakeClock(time.Now(), 0)
+			clock := timeutil.NewFakeClock(time.Now(), 0)
 			now := clock.Now()
 
 			githubSource := types.ExternalService{

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -123,7 +124,7 @@ func parseJSONTime(t testing.TB, ts string) time.Time {
 func newGitHubExternalService(t *testing.T, store *db.ExternalServiceStore) *types.ExternalService {
 	t.Helper()
 
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	svc := types.ExternalService{

--- a/enterprise/internal/campaigns/testing/repos.go
+++ b/enterprise/internal/campaigns/testing/repos.go
@@ -11,8 +11,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	idb "github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -20,7 +20,7 @@ import (
 func TestRepo(t *testing.T, store *idb.ExternalServiceStore, serviceKind string) *types.Repo {
 	t.Helper()
 
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	svc := types.ExternalService{

--- a/internal/db/dbtesting/dbtesting.go
+++ b/internal/db/dbtesting/dbtesting.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
@@ -160,30 +159,4 @@ func initTest(nameSuffix string) error {
 	}
 
 	return nil
-}
-
-// FakeClock provides a controllable clock for use in tests.
-type FakeClock struct {
-	epoch time.Time
-	step  time.Duration
-	steps int
-}
-
-// NewFakeClock returns a FakeClock instance that starts telling time at the given epoch.
-// Every invocation of Now adds step amount of time to the clock.
-func NewFakeClock(epoch time.Time, step time.Duration) FakeClock {
-	return FakeClock{epoch: epoch, step: step}
-}
-
-// Now returns the current fake time and advances the clock "step" amount of time.
-func (c *FakeClock) Now() time.Time {
-	c.steps++
-	return c.Time(c.steps)
-}
-
-// Time tells the time at the given step from the provided epoch.
-func (c FakeClock) Time(step int) time.Time {
-	// We truncate to microsecond precision because Postgres' timestamptz type
-	// doesn't handle nanoseconds.
-	return c.epoch.Add(time.Duration(step) * c.step).UTC().Truncate(time.Microsecond)
 }

--- a/internal/db/external_services_test.go
+++ b/internal/db/external_services_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -950,7 +951,7 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 
 	svcs := types.MakeExternalServices()
 

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	idb "github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -25,12 +24,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func testStoreUpsertRepos(t *testing.T, store *repos.Store) func(*testing.T) {
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	return func(t *testing.T) {
@@ -361,7 +361,7 @@ func testStoreUpsertRepos(t *testing.T, store *repos.Store) func(*testing.T) {
 }
 
 func testStoreUpsertSources(t *testing.T, store *repos.Store) func(*testing.T) {
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	servicesPerKind := createExternalServices(t, store)
@@ -824,7 +824,7 @@ VALUES
 }
 
 func testSyncRateLimiters(t *testing.T, store *repos.Store) func(*testing.T) {
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	return func(t *testing.T) {
@@ -878,7 +878,7 @@ func testStoreEnqueueSyncJobs(db *sql.DB, store *repos.Store) func(t *testing.T,
 	return func(t *testing.T, _ *repos.Store) func(*testing.T) {
 		t.Helper()
 
-		clock := dbtesting.NewFakeClock(time.Now(), 0)
+		clock := timeutil.NewFakeClock(time.Now(), 0)
 		now := clock.Now()
 
 		services := generateExternalServices(10, mkExternalServices(now)...)
@@ -1042,7 +1042,7 @@ func transact(ctx context.Context, s *repos.Store, test func(testing.TB, *repos.
 }
 
 func createExternalServices(t *testing.T, store *repos.Store) map[string]*types.ExternalService {
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	svcs := mkExternalServices(now)

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	idb "github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -27,6 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -87,7 +87,7 @@ func testSyncerSyncWithErrors(t *testing.T, store *repos.Store) func(t *testing.
 		} {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
-				clock := dbtesting.NewFakeClock(time.Now(), time.Second)
+				clock := timeutil.NewFakeClock(time.Now(), time.Second)
 				now := clock.Now
 				ctx := context.Background()
 
@@ -230,7 +230,7 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 		types.Opt.RepoSources(bitbucketCloudService.URN()),
 	)
 
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 
 	svcdup := types.ExternalService{
 		Kind:        extsvc.KindGitHub,
@@ -624,7 +624,7 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 
 				now := tc.now
 				if now == nil {
-					clock := dbtesting.NewFakeClock(time.Now(), time.Second)
+					clock := timeutil.NewFakeClock(time.Now(), time.Second)
 					now = clock.Now
 				}
 
@@ -676,7 +676,7 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 }
 
 func testSyncRepo(t *testing.T, s *repos.Store) func(*testing.T) {
-	clock := dbtesting.NewFakeClock(time.Now(), time.Second)
+	clock := timeutil.NewFakeClock(time.Now(), time.Second)
 
 	servicesPerKind := createExternalServices(t, s)
 

--- a/internal/timeutil/fakeclock.go
+++ b/internal/timeutil/fakeclock.go
@@ -1,0 +1,31 @@
+package timeutil
+
+import (
+	"time"
+)
+
+// FakeClock provides a controllable clock for use in tests.
+type FakeClock struct {
+	epoch time.Time
+	step  time.Duration
+	steps int
+}
+
+// NewFakeClock returns a FakeClock instance that starts telling time at the given epoch.
+// Every invocation of Now adds step amount of time to the clock.
+func NewFakeClock(epoch time.Time, step time.Duration) FakeClock {
+	return FakeClock{epoch: epoch, step: step}
+}
+
+// Now returns the current fake time and advances the clock "step" amount of time.
+func (c *FakeClock) Now() time.Time {
+	c.steps++
+	return c.Time(c.steps)
+}
+
+// Time tells the time at the given step from the provided epoch.
+func (c FakeClock) Time(step int) time.Time {
+	// We truncate to microsecond precision because Postgres' timestamptz type
+	// doesn't handle nanoseconds.
+	return c.epoch.Add(time.Duration(step) * c.step).UTC().Truncate(time.Microsecond)
+}

--- a/internal/types/testing.go
+++ b/internal/types/testing.go
@@ -10,17 +10,17 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func MakeRepo(name, serviceID, serviceType string, services ...*ExternalService) *Repo {
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	repo := Repo{
@@ -105,7 +105,7 @@ func GenerateRepos(n int, base ...*Repo) Repos {
 
 // MakeExternalServices creates one configured external service per kind and returns the list.
 func MakeExternalServices() ExternalServices {
-	clock := dbtesting.NewFakeClock(time.Now(), 0)
+	clock := timeutil.NewFakeClock(time.Now(), 0)
 	now := clock.Now()
 
 	githubSvc := ExternalService{


### PR DESCRIPTION
This moves `FakeClock` from `dbtesting` to `timeutil` so it can used
without introducing a transitive dependency on `dbconn`.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
