### PR TITLE
Adopt proper changeset backdrop highlight

### DIFF
--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -104,7 +104,7 @@ const queryChangesets: typeof _queryChangesets = () =>
                 __typename: 'HiddenExternalChangeset',
                 createdAt: subDays(now, 5).toISOString(),
                 state: ChangesetState.FAILED,
-                id: 'someh3',
+                id: 'someh5',
                 nextSyncAt: null,
                 updatedAt: subDays(now, 5).toISOString(),
             },

--- a/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.scss
+++ b/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.scss
@@ -2,12 +2,6 @@
     &__grid {
         display: grid;
         grid-template-columns: [caret] min-content [status] min-content [info] minmax(auto, 1fr) [checkstate] min-content [reviewstate] min-content [diffstat] min-content [end];
-        row-gap: 1rem;
-        column-gap: 1rem;
         align-items: center;
-        @include media-breakpoint-down(sm) {
-            row-gap: 0.5rem;
-            column-gap: 0.5rem;
-        }
     }
 }

--- a/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesetsHeader.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesetsHeader.tsx
@@ -7,10 +7,10 @@ export interface CampaignChangesetsHeaderProps {
 export const CampaignChangesetsHeader: React.FunctionComponent<CampaignChangesetsHeaderProps> = () => (
     <>
         <span className="d-none d-md-block" />
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
-        <h5 className="d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
-        <h5 className="d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
     </>
 )

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.scss
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.scss
@@ -9,6 +9,11 @@
             grid-column: 2 / -1;
         }
     }
+    &__bg-expanded {
+        @include media-breakpoint-up(sm) {
+            background-color: rgba($oc-blue-0, 0.5);
+        }
+    }
     &__expanded-section {
         background-color: rgba($oc-blue-0, 0.5);
         // Make it full width in the current row.

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.scss
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.scss
@@ -10,12 +10,9 @@
         }
     }
     &__bg-expanded {
-        @include media-breakpoint-up(sm) {
-            background-color: rgba($oc-blue-0, 0.5);
-        }
+        background-color: rgba($oc-blue-0, 0.5);
     }
     &__expanded-section {
-        background-color: rgba($oc-blue-0, 0.5);
         // Make it full width in the current row.
         grid-column: 2 / -1;
         @include media-breakpoint-down(xs) {

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -18,6 +18,7 @@ import { ErrorAlert } from '../../../../components/alerts'
 import { ChangesetFileDiff } from './ChangesetFileDiff'
 import { ExternalChangesetInfoCell } from './ExternalChangesetInfoCell'
 import { DownloadDiffButton } from './DownloadDiffButton'
+import classNames from 'classnames'
 
 export interface ExternalChangesetNodeProps extends ThemeProps {
     node: ExternalChangesetFields
@@ -66,24 +67,57 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                     <ChevronRightIcon className="icon-inline" aria-label="Expand section" />
                 )}
             </button>
-            <ChangesetStatusCell changeset={node} className="external-changeset-node__state d-block d-sm-flex" />
+            <ChangesetStatusCell
+                changeset={node}
+                className={classNames(
+                    'p-2 align-self-stretch external-changeset-node__state d-block d-sm-flex',
+                    isExpanded && 'external-changeset-node__bg-expanded'
+                )}
+            />
             <ExternalChangesetInfoCell
                 node={node}
                 viewerCanAdminister={viewerCanAdminister}
-                className="external-changeset-node__information"
+                className={classNames(
+                    'p-2 align-self-stretch external-changeset-node__information',
+                    isExpanded && 'external-changeset-node__bg-expanded'
+                )}
             />
-            <div className="d-flex d-md-none justify-content-start external-changeset-node__statuses">
+            <div
+                className={classNames(
+                    'd-flex d-md-none justify-content-start external-changeset-node__statuses',
+                    isExpanded && 'external-changeset-node__bg-expanded',
+                    (node.checkState || node.reviewState || node.diffStat) && 'p-2'
+                )}
+            >
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} className="mr-3" />}
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
                 {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
             </div>
-            <span className="d-none d-md-inline">
+            <span
+                className={classNames(
+                    'align-self-stretch d-none d-md-flex',
+                    isExpanded && 'external-changeset-node__bg-expanded',
+                    node.checkState && 'p-2'
+                )}
+            >
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}
             </span>
-            <span className="d-none d-md-inline">
+            <span
+                className={classNames(
+                    'align-self-stretch d-none d-md-flex',
+                    isExpanded && 'external-changeset-node__bg-expanded',
+                    node.reviewState && 'p-2'
+                )}
+            >
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}
             </span>
-            <div className="d-none d-md-flex justify-content-center">
+            <div
+                className={classNames(
+                    'align-self-stretch d-none d-md-flex',
+                    isExpanded && 'external-changeset-node__bg-expanded',
+                    node.diffStat && 'p-2'
+                )}
+            >
                 {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
             </div>
             {/* The button for expanding the information used on xs devices. */}

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -69,23 +69,16 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
             </button>
             <ChangesetStatusCell
                 changeset={node}
-                className={classNames(
-                    'p-2 align-self-stretch external-changeset-node__state d-block d-sm-flex',
-                    isExpanded && 'external-changeset-node__bg-expanded'
-                )}
+                className="p-2 align-self-stretch external-changeset-node__state d-block d-sm-flex"
             />
             <ExternalChangesetInfoCell
                 node={node}
                 viewerCanAdminister={viewerCanAdminister}
-                className={classNames(
-                    'p-2 align-self-stretch external-changeset-node__information',
-                    isExpanded && 'external-changeset-node__bg-expanded'
-                )}
+                className="p-2 align-self-stretch external-changeset-node__information"
             />
             <div
                 className={classNames(
                     'd-flex d-md-none justify-content-start external-changeset-node__statuses',
-                    isExpanded && 'external-changeset-node__bg-expanded',
                     (node.checkState || node.reviewState || node.diffStat) && 'p-2'
                 )}
             >
@@ -93,31 +86,13 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
                 {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
             </div>
-            <span
-                className={classNames(
-                    'align-self-stretch d-none d-md-flex',
-                    isExpanded && 'external-changeset-node__bg-expanded',
-                    node.checkState && 'p-2'
-                )}
-            >
+            <span className={classNames('align-self-stretch d-none d-md-flex', node.checkState && 'p-2')}>
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}
             </span>
-            <span
-                className={classNames(
-                    'align-self-stretch d-none d-md-flex',
-                    isExpanded && 'external-changeset-node__bg-expanded',
-                    node.reviewState && 'p-2'
-                )}
-            >
+            <span className={classNames('align-self-stretch d-none d-md-flex', node.reviewState && 'p-2')}>
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}
             </span>
-            <div
-                className={classNames(
-                    'align-self-stretch d-none d-md-flex',
-                    isExpanded && 'external-changeset-node__bg-expanded',
-                    node.diffStat && 'p-2'
-                )}
-            >
+            <div className={classNames('align-self-stretch d-none d-md-flex', node.diffStat && 'p-2')}>
                 {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
             </div>
             {/* The button for expanding the information used on xs devices. */}
@@ -136,8 +111,8 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
             </button>
             {isExpanded && (
                 <>
-                    <div />
-                    <div className="external-changeset-node__expanded-section p-2">
+                    <div className="external-changeset-node__bg-expanded align-self-stretch" />
+                    <div className="external-changeset-node__expanded-section external-changeset-node__bg-expanded p-2">
                         {node.currentSpec?.type === ChangesetSpecType.BRANCH && (
                             <DownloadDiffButton changesetID={node.id} />
                         )}

--- a/client/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/HiddenExternalChangesetNode.tsx
@@ -10,8 +10,11 @@ export interface HiddenExternalChangesetNodeProps {
 export const HiddenExternalChangesetNode: React.FunctionComponent<HiddenExternalChangesetNodeProps> = ({ node }) => (
     <>
         <span className="d-none d-sm-block" />
-        <ChangesetStatusCell changeset={node} className="hidden-external-changeset-node__status d-block d-sm-flex" />
-        <HiddenExternalChangesetInfoCell node={node} className="hidden-external-changeset-node__information" />
+        <ChangesetStatusCell
+            changeset={node}
+            className="p-2 hidden-external-changeset-node__status d-block d-sm-flex"
+        />
+        <HiddenExternalChangesetInfoCell node={node} className="p-2 hidden-external-changeset-node__information" />
         <span className="d-none d-sm-block" />
         <span className="d-none d-sm-block" />
         <span className="d-none d-sm-block" />

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.scss
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.scss
@@ -15,7 +15,7 @@
     }
     &__status-cell {
         @include media-breakpoint-up(sm) {
-            background-color: $oc-blue-0;
+            background-color: var(--oc-blue-0);
         }
     }
     &__list-cell {
@@ -28,12 +28,24 @@
         }
     }
     &__expanded-section {
-        background-color: rgba($oc-blue-0, 0.5);
+        // Make it full width in the current row.
+        grid-column: 2 / -1;
         @include media-breakpoint-down(xs) {
             // Make it full width in the current row.
             grid-column: 1 / -1;
         }
-        // Make it full width in the current row.
-        grid-column: 2 / -1;
+    }
+}
+
+.theme-dark {
+    .visible-changeset-apply-preview-node {
+        &__status-cell {
+            @include media-breakpoint-up(sm) {
+                background-color: var(--oc-gray-7);
+            }
+        }
+        &__bg-expanded {
+            background-color: rgba($oc-gray-7, 0.5);
+        }
     }
 }

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -17,7 +17,6 @@ import { FileDiffNode } from '../../../../components/diff/FileDiffNode'
 import { FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
 import { GitBranchChangesetDescriptionInfo } from './GitBranchChangesetDescriptionInfo'
 import { ChangesetStatusCell } from '../../detail/changesets/ChangesetStatusCell'
-import classNames from 'classnames'
 
 export interface VisibleChangesetApplyPreviewNodeProps extends ThemeProps {
     node: VisibleChangesetApplyPreviewFields
@@ -64,24 +63,13 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<VisibleCh
             </button>
             <VisibleChangesetApplyPreviewNodeStatusCell
                 node={node}
-                className={classNames(
-                    'visible-changeset-apply-preview-node__list-cell d-block d-sm-flex visible-changeset-apply-preview-node__current-state align-self-stretch visible-changeset-apply-preview-node__status-cell',
-                    isExpanded && 'visible-changeset-apply-preview-node__bg-expanded'
-                )}
+                className="visible-changeset-apply-preview-node__list-cell d-block d-sm-flex visible-changeset-apply-preview-node__current-state align-self-stretch visible-changeset-apply-preview-node__status-cell"
             />
             <PreviewActions
                 node={node}
-                className={classNames(
-                    'visible-changeset-apply-preview-node__list-cell visible-changeset-apply-preview-node__action align-self-stretch',
-                    isExpanded && 'visible-changeset-apply-preview-node__bg-expanded'
-                )}
+                className="visible-changeset-apply-preview-node__list-cell visible-changeset-apply-preview-node__action align-self-stretch"
             />
-            <div
-                className={classNames(
-                    'visible-changeset-apply-preview-node__list-cell visible-changeset-apply-preview-node__information align-self-stretch',
-                    isExpanded && 'visible-changeset-apply-preview-node__bg-expanded'
-                )}
-            >
+            <div className="visible-changeset-apply-preview-node__list-cell visible-changeset-apply-preview-node__information align-self-stretch">
                 <div className="d-flex flex-column">
                     <ChangesetSpecTitle spec={node} />
                     <div className="mr-2">
@@ -89,12 +77,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<VisibleCh
                     </div>
                 </div>
             </div>
-            <div
-                className={classNames(
-                    'visible-changeset-apply-preview-node__list-cell d-flex justify-content-center align-content-center align-self-stretch',
-                    isExpanded && 'visible-changeset-apply-preview-node__bg-expanded'
-                )}
-            >
+            <div className="visible-changeset-apply-preview-node__list-cell d-flex justify-content-center align-content-center align-self-stretch">
                 <ApplyDiffStat spec={node} />
             </div>
             {/* The button for expanding the information used on xs devices. */}
@@ -113,8 +96,8 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<VisibleCh
             </button>
             {isExpanded && (
                 <>
-                    <div />
-                    <div className="visible-changeset-apply-preview-node__expanded-section p-2">
+                    <div className="visible-changeset-apply-preview-node__bg-expanded align-self-stretch" />
+                    <div className="visible-changeset-apply-preview-node__expanded-section visible-changeset-apply-preview-node__bg-expanded p-2">
                         <ExpandedSection
                             node={node}
                             history={history}


### PR DESCRIPTION
As already implemented previously on preview nodes, this new pattern is now also used for changeset nodes, which finally makes the backdrop work properly.
