### PR TITLE
Document dynamic changesetTemplates and steps.outputs

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -28,6 +28,7 @@ The document content can set class names and IDs on elements (for example, Markd
     --warning-badge-color: #f59f00;
     --critical-badge-color: #f03e3e;
     --experimental-color: #b200f8;
+    --feature-color: #38757F;
 
     --table-row-bg-1: var(--body-bg);
 }
@@ -432,6 +433,16 @@ body > #page > main > #content {
     background-color: var(--experimental-color);
 }
 
+.badge-feature {
+    color: var(--feature-color);
+    background-color: var(--note-color);
+}
+
+.badge-note {
+    color: #000000;
+    background-color: var(--note-color);
+}
+
 .badge-warning {
     color: #ffffff;
     background-color: var(--warning-badge-color);
@@ -564,6 +575,7 @@ body > #page > main > #content {
 .markdown-body aside.experimental {
     border-color: var(--experimental-color);
 }
+
 .markdown-body table {
     display: block;
     width: 100%;

--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -99,5 +99,5 @@ Create a campaign by specifying a search query to get a list of repositories and
 
 - [Requirements](references/requirements.md)
 - [Campaign spec YAML reference](references/campaign_spec_yaml_reference.md)
-- <span class="badge badge-experimental">Experimental</span> [Campaign spec templating](references/campaign_spec_templating.md)
+- [Campaign spec templating](references/campaign_spec_templating.md)
 - [Troubleshooting](references/troubleshooting.md)

--- a/doc/campaigns/references/campaign_spec_templating.md
+++ b/doc/campaigns/references/campaign_spec_templating.md
@@ -6,7 +6,7 @@
 </style>
 
 <aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change in the future. It's available in Sourcegraph 3.22 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5 and later.
+<span class="badge badge-experimental">Experimental</span> This feature is experimental and might change in the future. It's available in Sourcegraph 3.22 with <a href="../../cli">Sourcegraph CLI</a> 3.21.5 and later.
 </aside>
 
 ## Overview
@@ -51,7 +51,7 @@ Template variables are supported in the following fields:
 - [`steps.files`](campaign_spec_yaml_reference.md#steps-run) values
 - [`steps.outputs.<name>.value`](campaign_spec_yaml_reference.md#steps-outputs)
 
-Additionally, with Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later:
+Additionally, with Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later:
 
 - [`changesetTemplate.title`](campaign_spec_yaml_reference.md#changesettemplate-title)
 - [`changesetTemplate.body`](campaign_spec_yaml_reference.md#changesettemplate-body)
@@ -94,23 +94,23 @@ The following template variables are available in the fields under `steps`:
 
 - `${{ step.modified_files }}`
 
-    Only in `steps.outputs`: List of files that have been modified by the just-executed step. Empty list if no files have been modified. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+    Only in `steps.outputs`: List of files that have been modified by the just-executed step. Empty list if no files have been modified. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later)
 - `${{ step.added_files }}`
 
-    Only in `steps.outputs`: List of files that have been added by the just-executed step. Empty list if no files have been added. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+    Only in `steps.outputs`: List of files that have been added by the just-executed step. Empty list if no files have been added. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later)
 - `${{ step.deleted_files }}`
 
-    Only in `steps.outputs`: List of files that have been deleted by the just-executed step. Empty list if no files have been deleted. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+    Only in `steps.outputs`: List of files that have been deleted by the just-executed step. Empty list if no files have been deleted. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later)
 - `${{ step.stdout }}`
 
-    Only in `steps.outputs`: The complete output of the just-executed step on standard output. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+    Only in `steps.outputs`: The complete output of the just-executed step on standard output. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later)
 - `${{ step.stderr }}`
 
-    Only in `steps.outputs`: The complete output of the just-executed step on standard error. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+    Only in `steps.outputs`: The complete output of the just-executed step on standard error. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later)
 
 ### `changesetTemplate` context
 
-**Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later**.
+**Requires Sourcegraph 3.24 and [Sourcegraph CLI](../../cli/index.md) 3.24 or later**.
 
 The following template variables are available in the fields under `changesetTemplate`:
 

--- a/doc/campaigns/references/campaign_spec_templating.md
+++ b/doc/campaigns/references/campaign_spec_templating.md
@@ -49,10 +49,26 @@ Template variables are supported in the following fields:
 - [`steps.run`](campaign_spec_yaml_reference.md#steps-run)
 - [`steps.env`](campaign_spec_yaml_reference.md#steps-run) values
 - [`steps.files`](campaign_spec_yaml_reference.md#steps-run) values
+- [`steps.outputs.<name>.value`](campaign_spec_yaml_reference.md#steps-outputs)
+
+Additionally, with Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later:
+
+- [`changesetTemplate.title`](campaign_spec_yaml_reference.md#changesettemplate-title)
+- [`changesetTemplate.body`](campaign_spec_yaml_reference.md#changesettemplate-body)
+- [`changesetTemplate.branch`](campaign_spec_yaml_reference.md#changesettemplate-branch)
+- [`changesetTemplate.commit.message`](campaign_spec_yaml_reference.md#changesettemplate-commit-message)
+- [`changesetTemplate.commit.author.name`](campaign_spec_yaml_reference.md#changesettemplate-commit-author)
+- [`changesetTemplate.commit.author.email`](campaign_spec_yaml_reference.md#changesettemplate-commit-author)
 
 ## Template variables
 
-The following template variables are available:
+Template variables are the names that are defined and accessible when using templating syntax in a given context.
+
+Depending on the context (i.e. `steps` or `changesetTemplate`), different variables are available. E.g.: in the context of `steps` the template variable `previous_step` is available, but not in the context of `changesetTemplate`.
+
+### `steps` context
+
+The following template variables are available in the fields under `steps`:
 
 - `${{ repository.search_result_paths }}`
 
@@ -62,19 +78,60 @@ The following template variables are available:
     Full name of the repository in which the step is being executed.
 - `${{ previous_step.modified_files }}`
 
-    List of files that have been modified by the previous step in `steps`. Empty if no files have been modified.
+    List of files that have been modified by the previous step in `steps`. Empty list if no files have been modified.
 - `${{ previous_step.added_files }}`
 
-    List of files that have been added by the previous step in `steps`. Empty if no files have been added.
+    List of files that have been added by the previous step in `steps`. Empty list if no files have been added.
 - `${{ previous_step.deleted_files }}`
 
-    List of files that have been deleted by the previous step in `steps`. Empty if no files have been deleted.
+    List of files that have been deleted by the previous step in `steps`. Empty list if no files have been deleted.
 - `${{ previous_step.stdout }}`
 
     The complete output of the previous step on standard output.
 - `${{ previous_step.stderr }}`
 
     The complete output of the previous step on standard error.
+
+- `${{ step.modified_files }}`
+
+    Only in `steps.outputs`: List of files that have been modified by the just-executed step. Empty list if no files have been modified. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+- `${{ step.added_files }}`
+
+    Only in `steps.outputs`: List of files that have been added by the just-executed step. Empty list if no files have been added. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+- `${{ step.deleted_files }}`
+
+    Only in `steps.outputs`: List of files that have been deleted by the just-executed step. Empty list if no files have been deleted. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+- `${{ step.stdout }}`
+
+    Only in `steps.outputs`: The complete output of the just-executed step on standard output. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+- `${{ step.stderr }}`
+
+    Only in `steps.outputs`: The complete output of the just-executed step on standard error. (Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later)
+
+### `changesetTemplate` context
+
+**Requires Sourcegraph 3.24 and [Sourcegraph CLI](../cli/index.md) 3.24 or later**.
+
+The following template variables are available in the fields under `changesetTemplate`:
+
+- `${{ repository.search_result_paths }}`
+
+    Unique list of file paths relative to the repository root directory in which the search results of the `repositoriesMatchingQuery`s have been found.
+- `${{ repository.name }}`
+
+    Full name of the repository in which the step is being executed.
+- `${{ steps.modified_files }}`
+
+    List of files that have been modified by the `steps`. Empty list if no files have been modified.
+- `${{ steps.added_files }}`
+
+    List of files that have been added by the `steps`. Empty list if no files have been added.
+- `${{ steps.deleted_files }}`
+
+    List of files that have been deleted by the `steps`. Empty list if no files have been deleted.
+- `${{ outputs.<name> }}`
+
+    Value of an [`output`](campaign_spec_yaml_reference.md#steps-outputs) set by `steps`. If the [`outputs.<name>.format`](campaign_spec_yaml_reference.md#steps-outputs-format) was `yaml` or `json` and the `value` a data structure (i.e. array, object, ...), then subfields can be accessed too. See "[Examples](#examples)" below.
 
 ## Template helper functions
 
@@ -135,11 +192,32 @@ steps:
 
 If you need to escape the `${{` and `}}` delimiters you can simply render them as string literals:
 
-
 ```yaml
 steps:
   - run: cp /tmp/escaped.txt .
     container: alpine:3
     files:
       /tmp/escaped.txt: ${{ "${{" }} ${{ "}}" }}
+```
+
+Accessing the `outputs` set by `steps` in subsequent `steps` and the `changesetTemplate`:
+
+```yaml
+steps:
+  - run: echo "Hello there!"
+    container: alpine:3
+    outputs:
+      myFriendlyMessage:
+        value: "${{ step.stdout }}"
+  - run: echo "We have access to the output here: ${{ outputs.myFriendlyMessage }}"
+    container: alpine:3
+    outputs:
+      stepTwoOutput:
+        otherMessage: "here too: ${{ outputs.myFriendlyMessage }}"
+
+changesetTemplate:
+  # [...]
+  body: |
+    The first step left us the following message: ${{ outputs.myFriendlyMessage }}
+    The second step left this one: ${{ outputs.otherMessage }}
 ```

--- a/doc/campaigns/references/campaign_spec_templating.md
+++ b/doc/campaigns/references/campaign_spec_templating.md
@@ -28,7 +28,7 @@ steps:
     container: unibeautify/goimports
 ```
 
-Before executing the first `run` command `repository.search_result_paths` will be replaced with the relative-to-root-dir file paths of each search resulted yielded by `repositoriesMatchingQuery`. By using the [template helper function](#template-helper-functions) `join`, an argument list of whitespace-separated values is constructed.
+Before executing the first `run` command, `repository.search_result_paths` will be replaced with the relative-to-root-dir file paths of each search result yielded by `repositoriesMatchingQuery`. By using the [template helper function](#template-helper-functions) `join`, an argument list of whitespace-separated values is constructed.
 
 The final `run` value, that will be executed, will look similar to this:
 
@@ -221,7 +221,7 @@ steps:
 changesetTemplate:
   # [...]
 
-  # Since templating fields use Go's `text/templates` and `goreleaserConfig` was
+  # Since templating fields use Go's `text/template` and `goreleaserConfig` was
   # parsed as YAML we can iterate over every field:
   body: |
     This repository has a `gorelaserConfig`: ${{ outputs.goreleaserConfigExists.exists }}.

--- a/doc/campaigns/references/campaign_spec_yaml_reference.md
+++ b/doc/campaigns/references/campaign_spec_yaml_reference.md
@@ -272,7 +272,7 @@ steps:
 
 > NOTE: This feature is only available in Sourcegraph 3.24 and later.
 
-Output variables that are set after the [`steps.run`](#steps-run) command has been executed. These variables are available as `outputs.<name>` <a href="campaign_spec_templating">template variables</a> in subsequent step's `run`, `env`, and `outputs` properties and the [`changesetTemplate`](#changesettemplate).
+Output variables that are set after the [`steps.run`](#steps-run) command has been executed. These variables are available in the global `outputs` namespace as `outputs.<name>` <a href="campaign_spec_templating">template variables</a> in subsequent step's `run`, `env`, and `outputs` properties and the [`changesetTemplate`](#changesettemplate). Two steps with the same output variable name will overwrite the previous contents.
 
 ### Examples
 

--- a/doc/campaigns/references/campaign_spec_yaml_reference.md
+++ b/doc/campaigns/references/campaign_spec_yaml_reference.md
@@ -272,7 +272,7 @@ steps:
 
 > NOTE: This feature is only available in Sourcegraph 3.24 and later.
 
-Output variables that are set after the [`steps.run`](#steps-run) command has been executed. These variables are available in the global `outputs` namespace as `outputs.<name>` <a href="campaign_spec_templating">template variables</a> in subsequent step's `run`, `env`, and `outputs` properties and the [`changesetTemplate`](#changesettemplate). Two steps with the same output variable name will overwrite the previous contents.
+Output variables that are set after the [`steps.run`](#steps-run) command has been executed. These variables are available in the global `outputs` namespace as `outputs.<name>` <a href="campaign_spec_templating">template variables</a> in the `run`, `env`, and `outputs` properties of subsequent steps, and the [`changesetTemplate`](#changesettemplate). Two steps with the same output variable name will overwrite the previous contents.
 
 ### Examples
 

--- a/doc/campaigns/references/campaign_spec_yaml_reference.md
+++ b/doc/campaigns/references/campaign_spec_yaml_reference.md
@@ -418,7 +418,7 @@ changesetTemplate:
 The title of the changeset on the code host.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
 </aside>
 
 ## [`changesetTemplate.body`](#changesettemplate-body)
@@ -426,7 +426,7 @@ The title of the changeset on the code host.
 The body (description) of the changeset on the code host. If the code supports Markdown you can use it here.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
 </aside>
 
 ## [`changesetTemplate.branch`](#changesettemplate-branch)
@@ -434,7 +434,7 @@ The body (description) of the changeset on the code host. If the code supports M
 The name of the Git branch to create or update on each repository with the changes.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
 </aside>
 
 ## [`changesetTemplate.commit`](#changesettemplate-commit)
@@ -446,7 +446,7 @@ The Git commit to create with the changes.
 The Git commit message.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
 </aside>
 
 ## [`changesetTemplate.commit.author`](#changesettemplate-commit-author)
@@ -454,7 +454,7 @@ The Git commit message.
 The `name` and `email` of the Git commit author.
 
 <aside class="note">
-<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../../cli">Sourcegraph CLI</a> 3.24.
 </aside>
 
 ### Examples

--- a/doc/campaigns/references/campaign_spec_yaml_reference.md
+++ b/doc/campaigns/references/campaign_spec_yaml_reference.md
@@ -157,8 +157,8 @@ steps:
 
 The shell command to run in the container. It can also be a multi-line shell script. The working directory is the root directory of the repository checkout.
 
-<aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> <code>steps.run</code> can include <a href="campaign_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<aside class="note">
+<span class="badge badge-feature">Templating</span> <code>steps.run</code> can include <a href="campaign_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
 </aside>
 
 ## [`steps.container`](#steps-run)
@@ -175,8 +175,8 @@ Environment variables to set in the environment when running this command.
 
 These may be defined either as an [object](#environment-object) or (in Sourcegraph 3.23 and later) as an [array](#environment-array).
 
-<aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> The value for each entry in <code>steps.env</code> can include <a href="campaign_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<aside class="note">
+<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.env</code> can include <a href="campaign_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
 </aside>
 
 ### Environment object
@@ -235,8 +235,8 @@ Files to create on the host machine and mount into the container when running `s
 
 `steps.files` is an object, where the key is the name of the file _inside the container_ and the value is the content of the file.
 
-<aside class="experimental">
-<span class="badge badge-experimental">Experimental</span> The value for each entry in <code>steps.files</code> can include <a href="campaign_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
+<aside class="note">
+<span class="badge badge-feature">Templating</span> The value for each entry in <code>steps.files</code> can include <a href="campaign_spec_templating">template variables</a> in Sourcegraph 3.22 and <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.21.5.
 </aside>
 
 ### Examples
@@ -268,6 +268,81 @@ steps:
         .dir-locals.el
 ```
 
+## [`steps.outputs`](#steps-outputs)
+
+> NOTE: This feature is only available in Sourcegraph 3.24 and later.
+
+Output variables that are set after the [`steps.run`](#steps-run) command has been executed. These variables are available as `outputs.<name>` <a href="campaign_spec_templating">template variables</a> in subsequent step's `run`, `env`, and `outputs` properties and the [`changesetTemplate`](#changesettemplate).
+
+### Examples
+
+```yaml
+steps:
+  - run: yarn upgrade
+    container: alpine:3
+    outputs:
+      # Set output `friendlyMessage`
+      friendlyMessage:
+        value: "Hello there!"
+```
+
+```yaml
+steps:
+  - run: echo "Hello there!" >> message.txt && cat message.txt
+    container: alpine:3
+    outputs:
+      friendlyMessage:
+        # `value` supports templating variables and can access the just-executed
+        # step's stdout/stderr.
+        value: "${{ step.stdout }}"
+```
+
+```yaml
+steps:
+  - run: echo "Hello there!"
+    container: alpine:3
+    outputs:
+      stepOneOutput:
+        value: "${{ step.stdout }}"
+  - run: echo "We have access to the output here: ${{ outputs.stepOneOutput }}"
+    container: alpine:3
+    outputs:
+      stepTwoOutput:
+        value: "here too: ${{ outputs.stepOneOutput }}"
+```
+
+```yaml
+steps:
+  - run: cat .goreleaser.yml >&2
+    container: alpine:3
+    outputs:
+      goreleaserConfig:
+        value: "${{ step.stderr }}"
+        # Specifying a `format` tells Sourcegraph CLI how to parse the value before
+        # making it available as a template variable.
+        format: yaml
+
+changesetTemplate:
+  # [...]
+  body: |
+    The `goreleaser.yml` defines the following `before.hooks`:
+    ${{ outputs.goreleaserConfig.before.hooks }}
+```
+
+## [`steps.outputs.<name>.value`](#steps-outputs-name-value)
+
+The value the output should be set to.
+
+<aside class="note">
+<span class="badge badge-feature">Templating</span> <code>steps.outputs.$name.value</code> can include <a href="campaign_spec_templating">template variables</a>.
+</aside>
+
+## [`steps.outputs.<name>.format`](#steps-outputs-name-format)
+
+The format of the corresponding [`steps.outputs.<name>.value`](#outputs-value). When this is set to something other than `text`, it will be parsed as the given format.
+
+Possible values: `text`, `yaml`, `json`. Default is `text`.
+
 ## [`importChangesets`](#importchangesets)
 
 An array describing which already-existing changesets should be imported from the code host into the campaign.
@@ -281,6 +356,7 @@ importChangesets:
   - repository: github.com/sourcegraph/src-cli
     externalIDs: [260, 271]
 ```
+
 
 ## [`importChangesets.repository`](#importchangesets-repository)
 
@@ -341,13 +417,25 @@ changesetTemplate:
 
 The title of the changeset on the code host.
 
+<aside class="note">
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+</aside>
+
 ## [`changesetTemplate.body`](#changesettemplate-body)
 
 The body (description) of the changeset on the code host. If the code supports Markdown you can use it here.
 
+<aside class="note">
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+</aside>
+
 ## [`changesetTemplate.branch`](#changesettemplate-branch)
 
 The name of the Git branch to create or update on each repository with the changes.
+
+<aside class="note">
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+</aside>
 
 ## [`changesetTemplate.commit`](#changesettemplate-commit)
 
@@ -357,9 +445,17 @@ The Git commit to create with the changes.
 
 The Git commit message.
 
+<aside class="note">
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+</aside>
+
 ## [`changesetTemplate.commit.author`](#changesettemplate-commit-author)
 
 The `name` and `email` of the Git commit author.
+
+<aside class="note">
+<span class="badge badge-feature">Templating</span> <code>changesetTemplate.title</code> can include <a href="campaign_spec_templating">template variables</a> starting with Sourcegraph 3.24 and <a href="../cli/index.md">Sourcegraph CLI</a> 3.24.
+</aside>
 
 ### Examples
 

--- a/doc/campaigns/references/index.md
+++ b/doc/campaigns/references/index.md
@@ -1,6 +1,6 @@
 # References
 
 - [Campaign spec YAML reference](campaign_spec_yaml_reference.md)
-- <span class="badge badge-experimental">Experimental</span> [Campaign spec templating](campaign_spec_templating.md)
+- [Campaign spec templating](campaign_spec_templating.md)
 - [Troubleshooting](troubleshooting.md)
 - [Requirements](requirements.md)


### PR DESCRIPTION
This pull request does multiple things:

- documents `steps.outputs` in campaign spec reference with lots of examples to show how they work
- documents which `changesetTemplate` fields now allow templating in campaign spec reference
- documents which template variables are available in `outputs` in campaign spec templating doc
- documents which template variables are available in `changesetTemplate` in campaign spec templating doc
- change links to Sourcegraph CLI from linking to the github repository to the CLI docs, now that we have them
- switch to using tables to document the available variables in templating fields. That looks like this:

![image](https://user-images.githubusercontent.com/1185253/104922144-971c9300-599a-11eb-8480-ebf1969976f5.png)

I also decided to do the following:

- remove the `Experimental` badge next to "Campaign spec templating"
- change the `Experimental` badge next to fields in campaign spec YAML reference to a `Templating` badge that links to the templating page. That looks like this:

<img width="892" alt="screenshot_2021-01-18_12 59 38@2x" src="https://user-images.githubusercontent.com/1185253/104913329-bcef6b00-598d-11eb-8214-9b4aff740bf7.png">

Why remove the `Experimental` badge? I think templating is here to stay and features (such as dynamic changeset templates) build on top of it. Having the experimental badge might scare users off, which is bad, since a lot of cool things (e.g.: only run commands over matched files) are possible with templating. And while we will surely update it and/or might make drastic changes to it in the future, that's not different to any other features we currently have.