### PR TITLE
Implement base ref changed indicator in preview UI

### DIFF
--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -65,6 +65,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.IMPORT],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
@@ -85,6 +86,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.PUSH, ChangesetSpecOperation.PUBLISH],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
@@ -96,6 +98,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.PUSH, ChangesetSpecOperation.PUBLISH_DRAFT],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
@@ -107,6 +110,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsAttach',
@@ -118,6 +122,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.UPDATE],
         delta: {
             titleChanged: true,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
@@ -126,6 +131,12 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'the old title',
                 state: ChangesetState.OPEN,
+                currentSpec: {
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        baseRef: 'main',
+                    },
+                },
             },
         },
     },
@@ -134,6 +145,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.UNDRAFT],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
@@ -142,6 +154,12 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'Le draft changeset',
                 state: ChangesetState.OPEN,
+                currentSpec: {
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        baseRef: 'main',
+                    },
+                },
             },
         },
     },
@@ -150,6 +168,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.REOPEN, ChangesetSpecOperation.UPDATE],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsUpdate',
@@ -158,6 +177,12 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'Le closed changeset',
                 state: ChangesetState.OPEN,
+                currentSpec: {
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        baseRef: 'main',
+                    },
+                },
             },
         },
     },
@@ -166,6 +191,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.CLOSE, ChangesetSpecOperation.DETACH],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsDetach',
@@ -187,6 +213,7 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
         operations: [ChangesetSpecOperation.DETACH],
         delta: {
             titleChanged: false,
+            baseRefChanged: false,
         },
         targets: {
             __typename: 'VisibleApplyPreviewTargetsDetach',
@@ -199,6 +226,29 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                     added: 2,
                     changed: 8,
                     deleted: 10,
+                },
+            },
+        },
+    },
+    'Change base ref': {
+        __typename: 'VisibleChangesetApplyPreview',
+        operations: [ChangesetSpecOperation.UPDATE],
+        delta: {
+            titleChanged: false,
+            baseRefChanged: true,
+        },
+        targets: {
+            __typename: 'VisibleApplyPreviewTargetsUpdate',
+            changesetSpec: baseChangesetSpec(true),
+            changeset: {
+                id: '123123',
+                title: 'Change base ref',
+                state: ChangesetState.OPEN,
+                currentSpec: {
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        baseRef: 'main',
+                    },
                 },
             },
         },

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -274,6 +274,13 @@ const References: React.FunctionComponent<{ spec: VisibleChangesetApplyPreviewFi
     }
     return (
         <div className="d-block d-sm-inline-block">
+            {spec.delta.baseRefChanged &&
+                spec.targets.__typename === 'VisibleApplyPreviewTargetsUpdate' &&
+                spec.targets.changeset.currentSpec?.description.__typename === 'GitBranchChangesetDescription' && (
+                    <del className="badge badge-danger mr-2">
+                        {spec.targets.changeset.currentSpec?.description.baseRef}
+                    </del>
+                )}
             <span className="badge badge-primary">{spec.targets.changesetSpec.description.baseRef}</span> &larr;{' '}
             <span className="badge badge-primary">{spec.targets.changesetSpec.description.headRef}</span>
         </div>

--- a/client/web/src/enterprise/campaigns/preview/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/preview/list/backend.ts
@@ -128,6 +128,7 @@ const campaignSpecApplyPreviewConnectionFieldsFragment = gql`
         operations
         delta {
             titleChanged
+            baseRefChanged
         }
         targets {
             __typename
@@ -144,6 +145,14 @@ const campaignSpecApplyPreviewConnectionFieldsFragment = gql`
                     id
                     title
                     state
+                    currentSpec {
+                        description {
+                            __typename
+                            ... on GitBranchChangesetDescription {
+                                baseRef
+                            }
+                        }
+                    }
                 }
             }
             ... on VisibleApplyPreviewTargetsDetach {

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -570,6 +570,7 @@ describe('Campaigns', () => {
                                         operations: [ChangesetSpecOperation.PUSH, ChangesetSpecOperation.PUBLISH],
                                         delta: {
                                             titleChanged: false,
+                                            baseRefChanged: false,
                                         },
                                         targets: {
                                             __typename: 'VisibleApplyPreviewTargetsAttach',


### PR DESCRIPTION
This adds a little indicator when a base ref changed, as per the designs.

![image](https://user-images.githubusercontent.com/19534377/104631218-3fc9aa80-569c-11eb-840a-86d056084ace.png)
