### PR TITLE
Don't check 'select all' with no query hits

### DIFF
--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -370,7 +370,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                     <input
                         className="mr-3"
                         type="checkbox"
-                        checked={selectionState.repos.size === filteredRepos.length}
+                        checked={selectionState.repos.size !== 0 && selectionState.repos.size === filteredRepos.length}
                         onChange={selectAll}
                     />
                     <span


### PR DESCRIPTION

### Description

Tiniest of fixes. When filtering doesn't yield any results - `select all` checkbox was checked.

![Screen Shot 2021-01-14 at 4 52 37 PM](https://user-images.githubusercontent.com/1319181/104653963-60d4d000-5689-11eb-98fb-9017d0c9f291.png)
