### PR TITLE
opensource redis exporter image, use 64bit binary

### DIFF
--- a/docker-images/redis_exporter/build.sh
+++ b/docker-images/redis_exporter/build.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Retag the v1.15.1 redis-exporter release
+VERSION="v1.15.1@sha256:f3f51453e4261734f08579fe9c812c66ee443626690091401674be4fb724da70"
+docker pull oliver006/redis_exporter:$VERSION
+docker tag oliver006/redis_exporter:$VERSION "$IMAGE"

--- a/enterprise/dev/ci/images/images.go
+++ b/enterprise/dev/ci/images/images.go
@@ -48,6 +48,7 @@ var SourcegraphDockerImages = []string{
 	"indexed-searcher",
 	"postgres-11.4",
 	"redis-cache",
+	"redis_exporter",
 	"redis-store",
 	"search-indexer",
 	"syntax-highlighter",


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/11323