### PR TITLE
campaigns: add UI to text search on preview lists

### DIFF
--- a/client/web/src/enterprise/campaigns/preview/list/PreviewFilterRow.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewFilterRow.tsx
@@ -1,0 +1,67 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import * as H from 'history'
+import { Form } from 'reactstrap'
+
+export interface PreviewFilters {
+    search: string | null
+}
+
+export interface PreviewFilterRowProps {
+    history: H.History
+    location: H.Location
+    onFiltersChange: (newFilters: PreviewFilters) => void
+}
+
+export const PreviewFilterRow: React.FunctionComponent<PreviewFilterRowProps> = ({
+    history,
+    location,
+    onFiltersChange,
+}) => {
+    const urlParameters = new URLSearchParams(location.search)
+
+    const searchElement = useRef<HTMLInputElement | null>(null)
+    const [search, setSearch] = useState<string | undefined>(() => urlParameters.get('search') ?? undefined)
+    useEffect(() => {
+        const urlParameters = new URLSearchParams(location.search)
+
+        if (search) {
+            urlParameters.set('search', search)
+        } else {
+            urlParameters.delete('search')
+        }
+
+        if (location.search !== urlParameters.toString()) {
+            history.replace({ ...location, search: urlParameters.toString() })
+        }
+
+        // Update the filters in the parent component.
+        onFiltersChange({ search: search || null })
+
+        // We cannot depend on the history, since it's modified by this hook and that would cause an infinite render loop.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [search])
+
+    const onSubmit = useCallback(
+        (event?: React.FormEvent<HTMLFormElement>): void => {
+            event?.preventDefault()
+            setSearch(searchElement.current?.value)
+        },
+        [setSearch, searchElement]
+    )
+
+    return (
+        <div className="row no-gutters">
+            <div className="m-0 col">
+                <Form className="form-inline d-flex my-2" onSubmit={onSubmit}>
+                    <input
+                        className="form-control flex-grow-1 changeset-filter__search"
+                        type="search"
+                        ref={searchElement}
+                        defaultValue={search}
+                        placeholder="Search title and repository name"
+                    />
+                </Form>
+            </div>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewList.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import * as H from 'history'
 import { ThemeProps } from '../../../../../../shared/src/theme'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
@@ -7,6 +7,7 @@ import { queryChangesetApplyPreview as _queryChangesetApplyPreview, queryChanges
 import { ChangesetApplyPreviewNode, ChangesetApplyPreviewNodeProps } from './ChangesetApplyPreviewNode'
 import { PreviewListHeader } from './PreviewListHeader'
 import { EmptyPreviewListElement } from './EmptyPreviewListElement'
+import { PreviewFilterRow, PreviewFilters } from './PreviewFilterRow'
 
 interface Props extends ThemeProps {
     campaignSpecID: Scalars['ID']
@@ -34,20 +35,26 @@ export const PreviewList: React.FunctionComponent<Props> = ({
     queryChangesetSpecFileDiffs,
     expandChangesetDescriptions,
 }) => {
+    const [filters, setFilters] = useState<PreviewFilters>({
+        search: null,
+    })
+
     const queryChangesetApplyPreviewConnection = useCallback(
         (args: FilteredConnectionQueryArguments) =>
             queryChangesetApplyPreview({
                 first: args.first ?? null,
                 after: args.after ?? null,
                 campaignSpec: campaignSpecID,
+                search: filters.search,
             }),
-        [campaignSpecID, queryChangesetApplyPreview]
+        [campaignSpecID, filters.search, queryChangesetApplyPreview]
     )
 
     return (
         <>
             <h3>Preview</h3>
             <hr className="mb-3" />
+            <PreviewFilterRow history={history} location={location} onFiltersChange={setFilters} />
             <FilteredConnection<ChangesetApplyPreviewFields, Omit<ChangesetApplyPreviewNodeProps, 'node'>>
                 className="mt-2"
                 nodeComponent={ChangesetApplyPreviewNode}

--- a/client/web/src/enterprise/campaigns/preview/list/backend.ts
+++ b/client/web/src/enterprise/campaigns/preview/list/backend.ts
@@ -181,14 +181,15 @@ export const queryChangesetApplyPreview = ({
     campaignSpec,
     first,
     after,
+    search,
 }: CampaignSpecApplyPreviewVariables): Observable<CampaignSpecApplyPreviewConnectionFields> =>
     requestGraphQL<CampaignSpecApplyPreviewResult, CampaignSpecApplyPreviewVariables>(
         gql`
-            query CampaignSpecApplyPreview($campaignSpec: ID!, $first: Int, $after: String) {
+            query CampaignSpecApplyPreview($campaignSpec: ID!, $first: Int, $after: String, $search: String) {
                 node(id: $campaignSpec) {
                     __typename
                     ... on CampaignSpec {
-                        applyPreview(first: $first, after: $after) {
+                        applyPreview(first: $first, after: $after, search: $search) {
                             ...CampaignSpecApplyPreviewConnectionFields
                         }
                     }
@@ -197,7 +198,7 @@ export const queryChangesetApplyPreview = ({
 
             ${campaignSpecApplyPreviewConnectionFieldsFragment}
         `,
-        { campaignSpec, first, after }
+        { campaignSpec, first, after, search }
     ).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {


### PR DESCRIPTION
This is just straight up ~stolen~ lovingly reproduced from the search box we have on the changeset list. I chose not to refactor the text input into its own component because it just doesn't feel worth it.

When we add dropdowns in a future PR, I anticipate we'll reuse `ChangesetFilter`.

Here's how it looks:

![image](https://user-images.githubusercontent.com/229984/104662517-dd62b100-567f-11eb-9528-eff3da220fdc.png)

Closes #15829.