### PR TITLE
monitoring: restart alerts for services w/o 0-downtime deploys

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1530,8 +1530,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Descriptions:**
 
-- <span class="badge badge-warning">warning</span> gitserver: 1+ container restarts
-- <span class="badge badge-critical">critical</span> gitserver: 1+ container restarts for 10m0s
+- <span class="badge badge-warning">warning</span> gitserver: 1+ container restarts for 10m0s
 
 **Possible solutions:**
 
@@ -1546,8 +1545,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ```json
 "observability.silenceAlerts": [
-  "warning_gitserver_container_restarts",
-  "critical_gitserver_container_restarts"
+  "warning_gitserver_container_restarts"
 ]
 ```
 
@@ -4580,8 +4578,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions:**
 
-- <span class="badge badge-warning">warning</span> zoekt-indexserver: 1+ container restarts
-- <span class="badge badge-critical">critical</span> zoekt-indexserver: 1+ container restarts for 10m0s
+- <span class="badge badge-warning">warning</span> zoekt-indexserver: 1+ container restarts for 10m0s
 
 **Possible solutions:**
 
@@ -4596,8 +4593,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 ```json
 "observability.silenceAlerts": [
-  "warning_zoekt-indexserver_container_restarts",
-  "critical_zoekt-indexserver_container_restarts"
+  "warning_zoekt-indexserver_container_restarts"
 ]
 ```
 
@@ -4781,8 +4777,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Descriptions:**
 
-- <span class="badge badge-warning">warning</span> zoekt-webserver: 1+ container restarts
-- <span class="badge badge-critical">critical</span> zoekt-webserver: 1+ container restarts for 10m0s
+- <span class="badge badge-warning">warning</span> zoekt-webserver: 1+ container restarts for 10m0s
 
 **Possible solutions:**
 
@@ -4797,8 +4792,7 @@ with your code hosts connections or networking issues affecting communication wi
 
 ```json
 "observability.silenceAlerts": [
-  "warning_zoekt-webserver_container_restarts",
-  "critical_zoekt-webserver_container_restarts"
+  "warning_zoekt-webserver_container_restarts"
 ]
 ```
 

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -103,7 +103,14 @@ func GitServer() *monitoring.Container {
 						shared.ContainerMemoryUsage("gitserver", monitoring.ObservableOwnerCloud).Observable(),
 					},
 					{
-						shared.ContainerRestarts("gitserver", monitoring.ObservableOwnerCloud).Observable(),
+						// git server does not have 0-downtime deploy, so deploys can
+						// cause extended container restarts. still seta warning alert for
+						// extended periods of container restarts, since this might still
+						// indicate a problem.
+						shared.ContainerRestarts("gitserver", monitoring.ObservableOwnerCloud).
+							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
+							WithCritical(nil).
+							Observable(),
 						shared.ContainerIOUsage("gitserver", monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -1,6 +1,8 @@
 package definitions
 
 import (
+	"time"
+
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -37,7 +39,14 @@ func ZoektIndexServer() *monitoring.Container {
 						shared.ContainerMemoryUsage("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
 					},
 					{
-						shared.ContainerRestarts("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
+						// indexed-search does not have 0-downtime deploy, so deploys can
+						// cause extended container restarts. still seta warning alert for
+						// extended periods of container restarts, since this might still
+						// indicate a problem.
+						shared.ContainerRestarts("zoekt-indexserver", monitoring.ObservableOwnerSearch).
+							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
+							WithCritical(nil).
+							Observable(),
 						shared.ContainerIOUsage("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
 					},
 				},

--- a/monitoring/definitions/zoekt_web_server.go
+++ b/monitoring/definitions/zoekt_web_server.go
@@ -38,7 +38,14 @@ func ZoektWebServer() *monitoring.Container {
 						shared.ContainerMemoryUsage("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
 					},
 					{
-						shared.ContainerRestarts("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
+						// indexed-search does not have 0-downtime deploy, so deploys can
+						// cause extended container restarts. still seta warning alert for
+						// extended periods of container restarts, since this might still
+						// indicate a problem.
+						shared.ContainerRestarts("zoekt-webserver", monitoring.ObservableOwnerSearch).
+							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
+							WithCritical(nil).
+							Observable(),
 						shared.ContainerIOUsage("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
 					},
 				},


### PR DESCRIPTION
Working container restart alerts were recently added for Kubernetes deployments as part of https://github.com/sourcegraph/sourcegraph/pull/17239

However, it seems that periods of container restarts during deployments are expected for certain services. This change removes the critical alert and warn on extended restarts instead.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
