### PR TITLE
monitoring: disable versioning for services w/o debugserver

### DIFF
--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -122,5 +122,8 @@ func Postgres() *monitoring.Container {
 				},
 			},
 		},
+
+		// This is third-party service
+		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -146,5 +146,8 @@ func Prometheus() *monitoring.Container {
 				},
 			},
 		},
+
+		// This is third-party service
+		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -93,5 +93,6 @@ func SyntectServer() *monitoring.Container {
 				},
 			},
 		},
+		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -78,5 +78,7 @@ func ZoektIndexServer() *monitoring.Container {
 				},
 			},
 		},
+
+		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/definitions/zoekt_web_server.go
+++ b/monitoring/definitions/zoekt_web_server.go
@@ -67,5 +67,7 @@ func ZoektWebServer() *monitoring.Container {
 			// kubernetes monitoring for zoekt-web-server is provided by zoekt-index-server,
 			// since both services are deployed together
 		},
+
+		NoSourcegraphDebugServer: true,
 	}
 }

--- a/monitoring/monitoring/README.md
+++ b/monitoring/monitoring/README.md
@@ -50,7 +50,7 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Containe
 
 Generate is the main Sourcegraph monitoring generator entrypoint\.
 
-## type [Container](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L17-L30>)
+## type [Container](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L17-L37>)
 
 Container describes a Docker container to be observed\.
 
@@ -70,6 +70,13 @@ type Container struct {
 
     // Groups of observable information about the container.
     Groups []Group
+
+    // NoSourcegraphDebugServer indicates if this container does not export the standard
+    // Sourcegraph debug server (package `internal/debugserver`).
+    //
+    // This is used to configure monitoring features that depend on information exported
+    // by the standard Sourcegraph debug server.
+    NoSourcegraphDebugServer bool
 }
 ```
 
@@ -93,7 +100,7 @@ type GenerateOptions struct {
 }
 ```
 
-## type [Group](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L348-L363>)
+## type [Group](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L359-L374>)
 
 Group describes a group of observable information about a container\.
 
@@ -118,7 +125,7 @@ type Group struct {
 }
 ```
 
-## type [Observable](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L411-L523>)
+## type [Observable](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L422-L534>)
 
 Observable describes a metric about a container that can be observed\. For example\, memory usage\.
 
@@ -240,7 +247,7 @@ type Observable struct {
 }
 ```
 
-## type [ObservableAlertDefinition](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L587-L593>)
+## type [ObservableAlertDefinition](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L598-L604>)
 
 ObservableAlertDefinition defines when an alert would be considered firing\.
 
@@ -250,7 +257,7 @@ type ObservableAlertDefinition struct {
 }
 ```
 
-### func [Alert](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L582>)
+### func [Alert](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L593>)
 
 ```go
 func Alert() *ObservableAlertDefinition
@@ -258,7 +265,7 @@ func Alert() *ObservableAlertDefinition
 
 Alert provides a builder for defining alerting on an Observable\.
 
-### func \(\*ObservableAlertDefinition\) [For](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L625>)
+### func \(\*ObservableAlertDefinition\) [For](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L636>)
 
 ```go
 func (a *ObservableAlertDefinition) For(d time.Duration) *ObservableAlertDefinition
@@ -266,7 +273,7 @@ func (a *ObservableAlertDefinition) For(d time.Duration) *ObservableAlertDefinit
 
 For indicates how long the given thresholds must be exceeded for this alert to be considered firing\. Defaults to 0s \(immediately alerts when threshold is exceeded\)\.
 
-### func \(\*ObservableAlertDefinition\) [Greater](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L610>)
+### func \(\*ObservableAlertDefinition\) [Greater](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L621>)
 
 ```go
 func (a *ObservableAlertDefinition) Greater(f float64) *ObservableAlertDefinition
@@ -274,7 +281,7 @@ func (a *ObservableAlertDefinition) Greater(f float64) *ObservableAlertDefinitio
 
 Greater indicates the alert should fire when strictly greater to this value\.
 
-### func \(\*ObservableAlertDefinition\) [GreaterOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L596>)
+### func \(\*ObservableAlertDefinition\) [GreaterOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L607>)
 
 ```go
 func (a *ObservableAlertDefinition) GreaterOrEqual(f float64) *ObservableAlertDefinition
@@ -282,7 +289,7 @@ func (a *ObservableAlertDefinition) GreaterOrEqual(f float64) *ObservableAlertDe
 
 GreaterOrEqual indicates the alert should fire when greater or equal the given value\.
 
-### func \(\*ObservableAlertDefinition\) [Less](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L617>)
+### func \(\*ObservableAlertDefinition\) [Less](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L628>)
 
 ```go
 func (a *ObservableAlertDefinition) Less(f float64) *ObservableAlertDefinition
@@ -290,7 +297,7 @@ func (a *ObservableAlertDefinition) Less(f float64) *ObservableAlertDefinition
 
 Less indicates the alert should fire when strictly less than this value\.
 
-### func \(\*ObservableAlertDefinition\) [LessOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L603>)
+### func \(\*ObservableAlertDefinition\) [LessOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L614>)
 
 ```go
 func (a *ObservableAlertDefinition) LessOrEqual(f float64) *ObservableAlertDefinition
@@ -298,7 +305,7 @@ func (a *ObservableAlertDefinition) LessOrEqual(f float64) *ObservableAlertDefin
 
 LessOrEqual indicates the alert should fire when less than or equal to the given value\.
 
-## type [ObservableOwner](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L396>)
+## type [ObservableOwner](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L407>)
 
 ObservableOwner denotes a team that owns an Observable\. The current teams are described in the handbook: https://about.sourcegraph.com/company/team/org_chart#engineering
 
@@ -440,7 +447,7 @@ Using a shared prefix helps with discoverability of available options\.
 type ObservablePanelOption func(Observable, *sdk.GraphPanel)
 ```
 
-## type [Row](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L380>)
+## type [Row](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L391>)
 
 Row of observable metrics\.
 

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -27,6 +27,13 @@ type Container struct {
 
 	// Groups of observable information about the container.
 	Groups []Group
+
+	// NoSourcegraphDebugServer indicates if this container does not export the standard
+	// Sourcegraph debug server (package `internal/debugserver`).
+	//
+	// This is used to configure monitoring features that depend on information exported
+	// by the standard Sourcegraph debug server.
+	NoSourcegraphDebugServer bool
 }
 
 func (c *Container) validate() error {
@@ -89,7 +96,11 @@ func (c *Container) renderDashboard() *sdk.Board {
 			Enable:      false, // disable by default for now
 			Type:        "tags",
 		},
-		{
+	}
+	// Annotation layers that require a service to export information required by the
+	// Sourcegraph debug server - see the `NoSourcegraphDebugServer` docstring.
+	if !c.NoSourcegraphDebugServer {
+		board.Annotations.List = append(board.Annotations.List, sdk.Annotation{
 			Name:       "Version changes",
 			Datasource: stringPtr("Prometheus"),
 			// Per version, instance generate an annotation whenever labels change
@@ -102,7 +113,7 @@ func (c *Container) renderDashboard() *sdk.Board {
 			IconColor:   "rgb(255, 255, 255)",
 			Enable:      false, // disable by default for now
 			Type:        "tags",
-		},
+		})
 	}
 
 	description := sdk.NewText("")


### PR DESCRIPTION
The `src_service_metadata` metric used for version annotations is only exported by services that use `debugserver`