### PR TITLE
search: prepare extraction of SearchResultsCommon from graphqlbackend

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -612,7 +612,7 @@ func sortSearchSuggestions(s []*searchSuggestionResolver) {
 // returning common as to reflect that new information. If searchErr is a fatal error,
 // it returns a non-nil error; otherwise, if searchErr == nil or a non-fatal error, it returns a
 // nil error.
-func handleRepoSearchResult(repoRev *search.RepositoryRevisions, limitHit, timedOut bool, searchErr error) (_ searchResultsCommon, fatalErr error) {
+func handleRepoSearchResult(repoRev *search.RepositoryRevisions, limitHit, timedOut bool, searchErr error) (_ SearchResultsCommon, fatalErr error) {
 	var status search.RepoStatus
 	if limitHit {
 		status |= search.RepoStatusLimitHit
@@ -639,9 +639,9 @@ func handleRepoSearchResult(repoRev *search.RepositoryRevisions, limitHit, timed
 	} else {
 		status |= search.RepoStatusSearched
 	}
-	return searchResultsCommon{
-		status:   search.RepoStatusSingleton(repoRev.Repo.ID, status),
-		limitHit: limitHit,
+	return SearchResultsCommon{
+		Status:     search.RepoStatusSingleton(repoRev.Repo.ID, status),
+		IsLimitHit: limitHit,
 	}, fatalErr
 }
 

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -525,7 +525,7 @@ type searchCommitsInReposParameters struct {
 	ResultChannel chan<- []SearchResultResolver
 }
 
-func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) ([]SearchResultResolver, *SearchResultsCommon, error) {
 	var err error
 	tr, ctx := trace.New(ctx, params.TraceName, fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
 	defer func() {
@@ -559,7 +559,7 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 		wg          sync.WaitGroup
 		mu          sync.Mutex
 		unflattened [][]*CommitSearchResultResolver
-		common      = &searchResultsCommon{}
+		common      = &SearchResultsCommon{}
 	)
 	for _, repoRev := range args.Repos {
 		// Skip the repo if no revisions were resolved for it
@@ -606,7 +606,7 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 }
 
 // searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel chan<- []SearchResultResolver) ([]SearchResultResolver, *searchResultsCommon, error) {
+func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel chan<- []SearchResultResolver) ([]SearchResultResolver, *SearchResultsCommon, error) {
 	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
 		TraceName:     "searchCommitDiffsInRepos",
 		ErrorName:     "diffs",
@@ -620,7 +620,7 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 }
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel chan<- []SearchResultResolver) ([]SearchResultResolver, *searchResultsCommon, error) {
+func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel chan<- []SearchResultResolver) ([]SearchResultResolver, *SearchResultsCommon, error) {
 	var terms []string
 	if args.PatternInfo.Pattern != "" {
 		terms = append(terms, args.PatternInfo.Pattern)

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -180,7 +180,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return repoIsLess(resolved.RepoRevs[i].Repo, resolved.RepoRevs[j].Repo)
 	})
 
-	common := SearchResultsCommon{maxResultsCount: r.maxResults()}
+	common := SearchResultsCommon{}
 	cursor, results, fileCommon, err := paginatedSearchFilesInRepos(ctx, &args, r.pagination)
 	if err != nil {
 		return nil, err
@@ -535,7 +535,6 @@ func sliceSearchResults(results []SearchResultResolver, common *SearchResultsCom
 	// we're returning.
 	seenRepos := map[string]struct{}{}
 	finalResults := make([]SearchResultResolver, 0, limit)
-	finalResultCount := int32(0)
 	for _, r := range results[:limit] {
 		repoName := repoOfResult(r)
 		if _, ok := seenRepos[repoName]; ok {
@@ -548,10 +547,8 @@ func sliceSearchResults(results []SearchResultResolver, common *SearchResultsCom
 
 		// Include the results and copy over metadata from the common structure.
 		finalResults = append(finalResults, results...)
-		finalResultCount += int32(len(results))
 	}
 	final.common = sliceSearchResultsCommon(common, firstRepo, lastResultRepo)
-	final.common.resultCount = finalResultCount
 	final.results = finalResults
 	return
 }
@@ -564,7 +561,6 @@ func sliceSearchResultsCommon(common *SearchResultsCommon, firstResultRepo, last
 		IsLimitHit:         false, // irrelevant in paginated search
 		IsIndexUnavailable: common.IsIndexUnavailable,
 		Repos:              make(map[api.RepoID]*types.RepoName),
-		resultCount:        common.resultCount,
 	}
 
 	for _, r := range common.Repos {

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -579,8 +579,8 @@ func sliceSearchResultsCommon(common *SearchResultsCommon, firstResultRepo, last
 		}
 	})
 
-	final.Excluded.Forks = final.Excluded.Forks + common.Excluded.Forks
-	final.Excluded.Archived = final.Excluded.Archived + common.Excluded.Archived
+	final.ExcludedForks = final.ExcludedForks + common.ExcludedForks
+	final.ExcludedArchived = final.ExcludedArchived + common.ExcludedArchived
 
 	return final
 }

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -180,7 +180,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return repoIsLess(resolved.RepoRevs[i].Repo, resolved.RepoRevs[j].Repo)
 	})
 
-	common := searchResultsCommon{maxResultsCount: r.maxResults()}
+	common := SearchResultsCommon{maxResultsCount: r.maxResults()}
 	cursor, results, fileCommon, err := paginatedSearchFilesInRepos(ctx, &args, r.pagination)
 	if err != nil {
 		return nil, err
@@ -205,7 +205,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 
 	return &SearchResultsResolver{
 		start:               start,
-		searchResultsCommon: common,
+		SearchResultsCommon: common,
 		SearchResults:       results,
 		alert:               alert,
 		cursor:              cursor,
@@ -244,7 +244,7 @@ func repoIsLess(i, j *types.RepoName) bool {
 //    top of the penalty we incur from the larger `count:` mentioned in point
 //    2 above (in the worst case scenario).
 //
-func paginatedSearchFilesInRepos(ctx context.Context, args *search.TextParameters, pagination *searchPaginationInfo) (*searchCursor, []SearchResultResolver, *searchResultsCommon, error) {
+func paginatedSearchFilesInRepos(ctx context.Context, args *search.TextParameters, pagination *searchPaginationInfo) (*searchCursor, []SearchResultResolver, *SearchResultsCommon, error) {
 	repos, err := getRepos(ctx, args.RepoPromise)
 	if err != nil {
 		return nil, nil, nil, err
@@ -257,18 +257,18 @@ func paginatedSearchFilesInRepos(ctx context.Context, args *search.TextParameter
 		searchBucketMin:     10,
 		searchBucketMax:     1000,
 	}
-	return plan.execute(ctx, func(batch []*search.RepositoryRevisions) ([]SearchResultResolver, *searchResultsCommon, error) {
+	return plan.execute(ctx, func(batch []*search.RepositoryRevisions) ([]SearchResultResolver, *SearchResultsCommon, error) {
 		batchArgs := *args
 		batchArgs.RepoPromise = (&search.Promise{}).Resolve(batch)
 		fileResults, fileCommon, err := searchFilesInRepos(ctx, &batchArgs, nil)
-		// Timeouts are reported through searchResultsCommon so don't report an error for them
+		// Timeouts are reported through SearchResultsCommon so don't report an error for them
 		if err != nil && !(err == context.DeadlineExceeded || err == context.Canceled) {
 			return nil, nil, err
 		}
 		if fileCommon == nil {
 			// searchFilesInRepos can return a nil structure, but the executor
 			// requires a non-nil one always (which is more sane).
-			fileCommon = &searchResultsCommon{}
+			fileCommon = &SearchResultsCommon{}
 		}
 		// fileResults is not sorted so we must sort it now. fileCommon may or
 		// may not be sorted, but we do not rely on its order.
@@ -315,9 +315,9 @@ type repoPaginationPlan struct {
 
 // executor is a function which searches a batch of repositories.
 //
-// A non-nil searchResultsCommon must always be returned, even if an error is
+// A non-nil SearchResultsCommon must always be returned, even if an error is
 // returned.
-type executor func(batch []*search.RepositoryRevisions) ([]SearchResultResolver, *searchResultsCommon, error)
+type executor func(batch []*search.RepositoryRevisions) ([]SearchResultResolver, *SearchResultsCommon, error)
 
 // repoOfResult is a helper function to resolve the repo associated with a result type.
 func repoOfResult(result SearchResultResolver) string {
@@ -342,7 +342,7 @@ func repoOfResult(result SearchResultResolver) string {
 //
 // If the executor returns any error, the search will be cancelled and the error
 // returned.
-func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *searchCursor, results []SearchResultResolver, common *searchResultsCommon, err error) {
+func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *searchCursor, results []SearchResultResolver, common *SearchResultsCommon, err error) {
 	// Determine how large the batches of repositories we will search over will be.
 	var totalRepos int
 	if p.mockNumTotalRepos != nil {
@@ -368,7 +368,7 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 		repos = repos[repositoryOffset:]
 	}
 
-	// Search backends don't populate searchResultsCommon.repos, the
+	// Search backends don't populate SearchResultsCommon.repos, the
 	// repository searcher does. We need to do that here.
 	commonRepos := make(map[api.RepoID]*types.RepoName, len(repos))
 	for _, r := range repos {
@@ -376,8 +376,8 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 	}
 
 	// Search over the repos list in batches.
-	common = &searchResultsCommon{
-		repos: commonRepos,
+	common = &SearchResultsCommon{
+		Repos: commonRepos,
 	}
 	for start := 0; start <= len(repos); start += batchSize {
 		if start > len(repos) {
@@ -387,7 +387,7 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 		batch := repos[start:clamp(start+batchSize, 0, len(repos))]
 		batchResults, batchCommon, err := exec(batch)
 		if batchCommon == nil {
-			panic("never here: repoPaginationPlan.executor illegally returned nil searchResultsCommon structure")
+			panic("never here: repoPaginationPlan.executor illegally returned nil SearchResultsCommon structure")
 		}
 		if err != nil {
 			return nil, nil, nil, err
@@ -423,8 +423,8 @@ func (p *repoPaginationPlan) execute(ctx context.Context, exec executor) (c *sea
 		// first in the results and we need to know the position for the cursor
 		// RepositoryOffset.
 		potentialLastRepos := []*types.RepoName{lastRepoConsumed}
-		sliced.common.status.Filter(search.RepoStatusCloning|search.RepoStatusMissing, func(id api.RepoID) {
-			potentialLastRepos = append(potentialLastRepos, sliced.common.repos[id])
+		sliced.common.Status.Filter(search.RepoStatusCloning|search.RepoStatusMissing, func(id api.RepoID) {
+			potentialLastRepos = append(potentialLastRepos, sliced.common.Repos[id])
 		})
 		sort.Slice(potentialLastRepos, func(i, j int) bool {
 			return repoIsLess(potentialLastRepos[i], potentialLastRepos[j])
@@ -452,7 +452,7 @@ type slicedSearchResults struct {
 	results []SearchResultResolver
 
 	// common is the new common results structure, updated to reflect the sliced results only.
-	common *searchResultsCommon
+	common *SearchResultsCommon
 
 	// resultOffset indicates where the search would continue within the last
 	// repository whose results were consumed. For example:
@@ -468,9 +468,9 @@ type slicedSearchResults struct {
 }
 
 // sliceSearchResults effectively slices results[offset:offset+limit] and
-// returns an updated searchResultsCommon structure to reflect that, as well as
+// returns an updated SearchResultsCommon structure to reflect that, as well as
 // information about the slicing that was performed.
-func sliceSearchResults(results []SearchResultResolver, common *searchResultsCommon, offset, limit int) (final slicedSearchResults) {
+func sliceSearchResults(results []SearchResultResolver, common *SearchResultsCommon, offset, limit int) (final slicedSearchResults) {
 	firstRepo := ""
 	if len(results[:offset]) > 0 {
 		firstRepo = repoOfResult(results[offset])
@@ -495,7 +495,7 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 	// Break results into repositories because for each result we need to add
 	// the respective repository to the new common structure.
 	reposByName := map[string]*types.RepoName{}
-	for _, r := range common.repos {
+	for _, r := range common.Repos {
 		reposByName[string(r.Name)] = r
 	}
 	resultsByRepo := map[*types.RepoName][]SearchResultResolver{}
@@ -531,7 +531,7 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 		final.resultOffset++
 	}
 
-	// Construct the new searchResultsCommon structure for just the results
+	// Construct the new SearchResultsCommon structure for just the results
 	// we're returning.
 	seenRepos := map[string]struct{}{}
 	finalResults := make([]SearchResultResolver, 0, limit)
@@ -556,35 +556,35 @@ func sliceSearchResults(results []SearchResultResolver, common *searchResultsCom
 	return
 }
 
-func sliceSearchResultsCommon(common *searchResultsCommon, firstResultRepo, lastResultRepo string) *searchResultsCommon {
-	if common.status.Any(search.RepoStatusLimitHit) {
+func sliceSearchResultsCommon(common *SearchResultsCommon, firstResultRepo, lastResultRepo string) *SearchResultsCommon {
+	if common.Status.Any(search.RepoStatusLimitHit) {
 		panic("never here: partial results should never be present in paginated search")
 	}
-	final := &searchResultsCommon{
-		limitHit:         false, // irrelevant in paginated search
-		indexUnavailable: common.indexUnavailable,
-		repos:            make(map[api.RepoID]*types.RepoName),
-		resultCount:      common.resultCount,
+	final := &SearchResultsCommon{
+		IsLimitHit:         false, // irrelevant in paginated search
+		IsIndexUnavailable: common.IsIndexUnavailable,
+		Repos:              make(map[api.RepoID]*types.RepoName),
+		resultCount:        common.resultCount,
 	}
 
-	for _, r := range common.repos {
+	for _, r := range common.Repos {
 		if lastResultRepo == "" || string(r.Name) > lastResultRepo {
 			continue
 		}
 		if firstResultRepo != "" && string(r.Name) < firstResultRepo {
 			continue
 		}
-		final.repos[r.ID] = r
+		final.Repos[r.ID] = r
 	}
 
-	common.status.Iterate(func(id api.RepoID, status search.RepoStatus) {
-		if _, ok := final.repos[id]; ok {
-			final.status.Update(id, status)
+	common.Status.Iterate(func(id api.RepoID, status search.RepoStatus) {
+		if _, ok := final.Repos[id]; ok {
+			final.Status.Update(id, status)
 		}
 	})
 
-	final.excluded.Forks = final.excluded.Forks + common.excluded.Forks
-	final.excluded.Archived = final.excluded.Archived + common.excluded.Archived
+	final.Excluded.Forks = final.Excluded.Forks + common.Excluded.Forks
+	final.Excluded.Archived = final.Excluded.Archived + common.Excluded.Archived
 
 	return final
 }

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -62,7 +62,6 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		for _, r := range repos {
 			fmt.Fprintf(&b, "	%s\n", r)
 		}
-		fmt.Fprintf(&b, "common.resultCount: %v\n", r.common.resultCount)
 		fmt.Fprintf(&b, "resultOffset: %d\n", r.resultOffset)
 		fmt.Fprintf(&b, "limitHit: %v\n", r.limitHit)
 		return b.String()
@@ -105,8 +104,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 			want: slicedSearchResults{
 				results: []SearchResultResolver{},
 				common: &SearchResultsCommon{
-					resultCount: 0,
-					Repos:       nil,
+					Repos: nil,
 				},
 				resultOffset: 0,
 				limitHit:     false,
@@ -125,8 +123,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo1"), "c.go"),
 				},
 				common: &SearchResultsCommon{
-					resultCount: 3,
-					Repos:       reposMap(repoName("org/repo1")),
+					Repos: reposMap(repoName("org/repo1")),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -144,8 +141,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo1"), "b.go"),
 				},
 				common: &SearchResultsCommon{
-					resultCount: 2,
-					Repos:       reposMap(repoName("org/repo1")),
+					Repos: reposMap(repoName("org/repo1")),
 				},
 				resultOffset: 2,
 				limitHit:     true,
@@ -164,8 +160,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo3"), "a.go"),
 				},
 				common: &SearchResultsCommon{
-					resultCount: 3,
-					Repos:       reposMap(repoName("org/repo2"), repoName("org/repo3")),
+					Repos: reposMap(repoName("org/repo2"), repoName("org/repo3")),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -184,8 +179,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo2"), "b.go"),
 				},
 				common: &SearchResultsCommon{
-					resultCount: 3,
-					Repos:       reposMap(repoName("org/repo1"), repoName("org/repo2")),
+					Repos: reposMap(repoName("org/repo1"), repoName("org/repo2")),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -202,8 +196,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				result(repoName("org/repo2"), "c.go"),
 			},
 			common: &SearchResultsCommon{
-				Repos:       reposMap(repoName("org/repo1"), repoName("org/repo2")),
-				resultCount: 3,
+				Repos: reposMap(repoName("org/repo1"), repoName("org/repo2")),
 			},
 			offset: 3,
 			limit:  3,
@@ -214,8 +207,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo2"), "c.go"),
 				},
 				common: &SearchResultsCommon{
-					resultCount: 3,
-					Repos:       reposMap(repoName("org/repo2")),
+					Repos: reposMap(repoName("org/repo2")),
 				},
 				resultOffset: 0,
 				limitHit:     false,
@@ -232,8 +224,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo1"), "b.go"),
 				},
 				common: &SearchResultsCommon{
-					resultCount: 1,
-					Repos:       reposMap(repoName("org/repo1")),
+					Repos: reposMap(repoName("org/repo1")),
 				},
 				resultOffset: 2,
 				limitHit:     true,
@@ -338,8 +329,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repoName("3"), "some/file0.go", "feature"),
 			},
 			wantCommon: &SearchResultsCommon{
-				Repos:       reposMap(repoName("1"), repoName("2"), repoName("3")),
-				resultCount: 10,
+				Repos: reposMap(repoName("1"), repoName("2"), repoName("3")),
 			},
 		},
 		{
@@ -390,8 +380,6 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCommon: &SearchResultsCommon{
 				Repos: reposMap(repoName("1")),
-
-				resultCount: 1,
 			},
 		},
 		{
@@ -414,8 +402,6 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			},
 			wantCommon: &SearchResultsCommon{
 				Repos: reposMap(repoName("1")),
-
-				resultCount: 1,
 			},
 		},
 		{
@@ -668,8 +654,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 				result(repoName("a"), "a.go"),
 			},
 			wantCommon: &SearchResultsCommon{
-				Repos:       reposMap(repoName("a")),
-				resultCount: 1,
+				Repos: reposMap(repoName("a")),
 			},
 		},
 		{

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -55,7 +55,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		}
 		fmt.Fprintln(&b, "common.repos:")
 		var repos []string
-		for _, r := range r.common.repos {
+		for _, r := range r.common.Repos {
 			repos = append(repos, string(r.Name))
 		}
 		sort.Strings(repos)
@@ -83,30 +83,30 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		result(repoName("org/repo5"), "d.go"),
 		result(repoName("org/repo5"), "e.go"),
 	}
-	sharedCommon := &searchResultsCommon{
+	sharedCommon := &SearchResultsCommon{
 		// Note: this is an intentionally unordered list to ensure we do not
 		// rely on the order of lists in common (which is not guaranteed by
 		// tests).
-		repos: reposMap(repoName("org/repo1"), repoName("org/repo3"), repoName("org/repo2")),
+		Repos: reposMap(repoName("org/repo1"), repoName("org/repo3"), repoName("org/repo2")),
 	}
 	tests := []struct {
 		name          string
 		results       []SearchResultResolver
-		common        *searchResultsCommon
+		common        *SearchResultsCommon
 		offset, limit int
 		want          slicedSearchResults
 	}{
 		{
 			name:    "empty result set",
 			results: []SearchResultResolver{},
-			common:  &searchResultsCommon{},
+			common:  &SearchResultsCommon{},
 			offset:  0,
 			limit:   3,
 			want: slicedSearchResults{
 				results: []SearchResultResolver{},
-				common: &searchResultsCommon{
+				common: &SearchResultsCommon{
 					resultCount: 0,
-					repos:       nil,
+					Repos:       nil,
 				},
 				resultOffset: 0,
 				limitHit:     false,
@@ -124,9 +124,9 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo1"), "b.go"),
 					result(repoName("org/repo1"), "c.go"),
 				},
-				common: &searchResultsCommon{
+				common: &SearchResultsCommon{
 					resultCount: 3,
-					repos:       reposMap(repoName("org/repo1")),
+					Repos:       reposMap(repoName("org/repo1")),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -143,9 +143,9 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo1"), "a.go"),
 					result(repoName("org/repo1"), "b.go"),
 				},
-				common: &searchResultsCommon{
+				common: &SearchResultsCommon{
 					resultCount: 2,
-					repos:       reposMap(repoName("org/repo1")),
+					Repos:       reposMap(repoName("org/repo1")),
 				},
 				resultOffset: 2,
 				limitHit:     true,
@@ -163,9 +163,9 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo2"), "b.go"),
 					result(repoName("org/repo3"), "a.go"),
 				},
-				common: &searchResultsCommon{
+				common: &SearchResultsCommon{
 					resultCount: 3,
-					repos:       reposMap(repoName("org/repo2"), repoName("org/repo3")),
+					Repos:       reposMap(repoName("org/repo2"), repoName("org/repo3")),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -183,9 +183,9 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo2"), "a.go"),
 					result(repoName("org/repo2"), "b.go"),
 				},
-				common: &searchResultsCommon{
+				common: &SearchResultsCommon{
 					resultCount: 3,
-					repos:       reposMap(repoName("org/repo1"), repoName("org/repo2")),
+					Repos:       reposMap(repoName("org/repo1"), repoName("org/repo2")),
 				},
 				resultOffset: 0,
 				limitHit:     true,
@@ -201,8 +201,8 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				result(repoName("org/repo2"), "b.go"),
 				result(repoName("org/repo2"), "c.go"),
 			},
-			common: &searchResultsCommon{
-				repos:       reposMap(repoName("org/repo1"), repoName("org/repo2")),
+			common: &SearchResultsCommon{
+				Repos:       reposMap(repoName("org/repo1"), repoName("org/repo2")),
 				resultCount: 3,
 			},
 			offset: 3,
@@ -213,9 +213,9 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 					result(repoName("org/repo2"), "b.go"),
 					result(repoName("org/repo2"), "c.go"),
 				},
-				common: &searchResultsCommon{
+				common: &SearchResultsCommon{
 					resultCount: 3,
-					repos:       reposMap(repoName("org/repo2")),
+					Repos:       reposMap(repoName("org/repo2")),
 				},
 				resultOffset: 0,
 				limitHit:     false,
@@ -231,9 +231,9 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 				results: []SearchResultResolver{
 					result(repoName("org/repo1"), "b.go"),
 				},
-				common: &searchResultsCommon{
+				common: &SearchResultsCommon{
 					resultCount: 1,
-					repos:       reposMap(repoName("org/repo1")),
+					Repos:       reposMap(repoName("org/repo1")),
 				},
 				resultOffset: 2,
 				limitHit:     true,
@@ -281,9 +281,9 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		repoRevs("5", "master"),
 	}
 	var searchedBatches [][]*search.RepositoryRevisions
-	resultsExecutor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
+	resultsExecutor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *SearchResultsCommon, err error) {
 		searchedBatches = append(searchedBatches, batch)
-		common = &searchResultsCommon{repos: reposMap()}
+		common = &SearchResultsCommon{Repos: reposMap()}
 		for _, repoRev := range batch {
 			for _, rev := range repoRev.Revs {
 				rev := rev.RevSpec
@@ -291,12 +291,12 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 					results = append(results, result(repoRev.Repo, fmt.Sprintf("some/file%d.go", i), rev))
 				}
 			}
-			common.repos[repoRev.Repo.ID] = repoRev.Repo
+			common.Repos[repoRev.Repo.ID] = repoRev.Repo
 		}
 		return
 	}
-	noResultsExecutor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
-		return nil, &searchResultsCommon{}, nil
+	noResultsExecutor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *SearchResultsCommon, err error) {
+		return nil, &SearchResultsCommon{}, nil
 	}
 	ctx := context.Background()
 
@@ -307,7 +307,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		wantSearchedBatches [][]*search.RepositoryRevisions
 		wantCursor          *searchCursor
 		wantResults         []SearchResultResolver
-		wantCommon          *searchResultsCommon
+		wantCommon          *SearchResultsCommon
 		wantErr             error
 	}{
 		{
@@ -337,8 +337,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repoName("3"), "some/file2.go", "master"),
 				result(repoName("3"), "some/file0.go", "feature"),
 			},
-			wantCommon: &searchResultsCommon{
-				repos:       reposMap(repoName("1"), repoName("2"), repoName("3")),
+			wantCommon: &SearchResultsCommon{
+				Repos:       reposMap(repoName("1"), repoName("2"), repoName("3")),
 				resultCount: 10,
 			},
 		},
@@ -366,8 +366,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				result(repoName("5"), "some/file1.go", "master"),
 				result(repoName("5"), "some/file2.go", "master"),
 			},
-			wantCommon: &searchResultsCommon{
-				repos: reposMap(repoName("3"), repoName("4"), repoName("5")),
+			wantCommon: &SearchResultsCommon{
+				Repos: reposMap(repoName("3"), repoName("4"), repoName("5")),
 			},
 		},
 		{
@@ -388,8 +388,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			wantResults: []SearchResultResolver{
 				result(repoName("1"), "some/file0.go", "master"),
 			},
-			wantCommon: &searchResultsCommon{
-				repos: reposMap(repoName("1")),
+			wantCommon: &SearchResultsCommon{
+				Repos: reposMap(repoName("1")),
 
 				resultCount: 1,
 			},
@@ -412,8 +412,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 			wantResults: []SearchResultResolver{
 				result(repoName("1"), "some/file1.go", "master"),
 			},
-			wantCommon: &searchResultsCommon{
-				repos: reposMap(repoName("1")),
+			wantCommon: &SearchResultsCommon{
+				Repos: reposMap(repoName("1")),
 
 				resultCount: 1,
 			},
@@ -426,8 +426,8 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 				limit:  1,
 			},
 			wantCursor: &searchCursor{RepositoryOffset: 1, ResultOffset: 0, Finished: true},
-			wantCommon: &searchResultsCommon{
-				repos: reposMap(),
+			wantCommon: &SearchResultsCommon{
+				Repos: reposMap(),
 			},
 		},
 	}
@@ -502,11 +502,11 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 		repoRevs("1", "master"),
 		repoRevs("2", "master"),
 	}
-	executor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
-		common = &searchResultsCommon{repos: reposMap()}
+	executor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *SearchResultsCommon, err error) {
+		common = &SearchResultsCommon{Repos: reposMap()}
 		for _, repoRev := range batch {
 			results = append(results, repoResults[string(repoRev.Repo.Name)]...)
-			common.repos[repoRev.Repo.ID] = repoRev.Repo
+			common.Repos[repoRev.Repo.ID] = repoRev.Repo
 		}
 		return
 	}
@@ -634,14 +634,14 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 		repoRevs("e", "master"),
 		repoRevs("f", "master"),
 	}
-	executor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *searchResultsCommon, err error) {
-		common = &searchResultsCommon{repos: reposMap()}
+	executor := func(batch []*search.RepositoryRevisions) (results []SearchResultResolver, common *SearchResultsCommon, err error) {
+		common = &SearchResultsCommon{Repos: reposMap()}
 		for _, repoRev := range batch {
 			if res, ok := repoResults[string(repoRev.Repo.Name)]; ok {
 				results = append(results, res...)
 			}
 			if mask := status.Get(repoRev.Repo.ID); mask != 0 {
-				common.status.Update(repoRev.Repo.ID, mask)
+				common.Status.Update(repoRev.Repo.ID, mask)
 			}
 		}
 		return
@@ -654,7 +654,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 		searchRepos []*search.RepositoryRevisions
 		wantCursor  *searchCursor
 		wantResults []SearchResultResolver
-		wantCommon  *searchResultsCommon
+		wantCommon  *SearchResultsCommon
 		wantErr     error
 	}{
 		{
@@ -667,8 +667,8 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			wantResults: []SearchResultResolver{
 				result(repoName("a"), "a.go"),
 			},
-			wantCommon: &searchResultsCommon{
-				repos:       reposMap(repoName("a")),
+			wantCommon: &SearchResultsCommon{
+				Repos:       reposMap(repoName("a")),
 				resultCount: 1,
 			},
 		},
@@ -682,10 +682,10 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 			wantResults: []SearchResultResolver{
 				result(repoName("c"), "a.go"),
 			},
-			wantCommon: &searchResultsCommon{
+			wantCommon: &SearchResultsCommon{
 
-				repos: reposMap(repoName("b"), repoName("c")),
-				status: reposStatus(map[string]search.RepoStatus{
+				Repos: reposMap(repoName("b"), repoName("c")),
+				Status: reposStatus(map[string]search.RepoStatus{
 					"b": search.RepoStatusMissing,
 				}),
 			},
@@ -701,9 +701,9 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 				result(repoName("a"), "a.go"),
 				result(repoName("c"), "a.go"),
 			},
-			wantCommon: &searchResultsCommon{
-				repos: reposMap(repoName("a"), repoName("b"), repoName("c")),
-				status: reposStatus(map[string]search.RepoStatus{
+			wantCommon: &SearchResultsCommon{
+				Repos: reposMap(repoName("a"), repoName("b"), repoName("c")),
+				Status: reposStatus(map[string]search.RepoStatus{
 					"b": search.RepoStatusMissing,
 				}),
 			},
@@ -720,9 +720,9 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 				result(repoName("c"), "a.go"),
 				result(repoName("f"), "a.go"),
 			},
-			wantCommon: &searchResultsCommon{
-				repos: reposMap(repoName("a"), repoName("b"), repoName("c"), repoName("d"), repoName("e"), repoName("f")),
-				status: reposStatus(map[string]search.RepoStatus{
+			wantCommon: &SearchResultsCommon{
+				Repos: reposMap(repoName("a"), repoName("b"), repoName("c"), repoName("d"), repoName("e"), repoName("f")),
+				Status: reposStatus(map[string]search.RepoStatus{
 					"b": search.RepoStatusMissing,
 					"d": search.RepoStatusCloning,
 					"e": search.RepoStatusMissing,

--- a/cmd/frontend/graphqlbackend/search_progress.go
+++ b/cmd/frontend/graphqlbackend/search_progress.go
@@ -96,7 +96,7 @@ func shardMatchLimitHandler(resultsResolver *SearchResultsResolver) (search.Skip
 }
 
 func excludedForkHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
-	forks := resultsResolver.excluded.Forks
+	forks := resultsResolver.Excluded.Forks
 	if forks == 0 {
 		return search.Skipped{}, false
 	}
@@ -115,7 +115,7 @@ func excludedForkHandler(resultsResolver *SearchResultsResolver) (search.Skipped
 }
 
 func excludedArchiveHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
-	archived := resultsResolver.excluded.Archived
+	archived := resultsResolver.Excluded.Archived
 	if archived == 0 {
 		return search.Skipped{}, false
 	}

--- a/cmd/frontend/graphqlbackend/search_progress.go
+++ b/cmd/frontend/graphqlbackend/search_progress.go
@@ -96,7 +96,7 @@ func shardMatchLimitHandler(resultsResolver *SearchResultsResolver) (search.Skip
 }
 
 func excludedForkHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
-	forks := resultsResolver.Excluded.Forks
+	forks := resultsResolver.ExcludedForks
 	if forks == 0 {
 		return search.Skipped{}, false
 	}
@@ -115,7 +115,7 @@ func excludedForkHandler(resultsResolver *SearchResultsResolver) (search.Skipped
 }
 
 func excludedArchiveHandler(resultsResolver *SearchResultsResolver) (search.Skipped, bool) {
-	archived := resultsResolver.Excluded.Archived
+	archived := resultsResolver.ExcludedArchived
 	if archived == 0 {
 		return search.Skipped{}, false
 	}

--- a/cmd/frontend/graphqlbackend/search_progress_test.go
+++ b/cmd/frontend/graphqlbackend/search_progress_test.go
@@ -25,23 +25,23 @@ func TestSearchProgress(t *testing.T) {
 	cases := map[string]*SearchResultsResolver{
 		"empty": {},
 		"timedout100": {
-			searchResultsCommon: searchResultsCommon{
-				repos:  reposMap(timedout100...),
-				status: timedout100Status,
+			SearchResultsCommon: SearchResultsCommon{
+				Repos:  reposMap(timedout100...),
+				Status: timedout100Status,
 			},
 		},
 		"all": {
 			SearchResults: []SearchResultResolver{mkFileMatch(&types.RepoName{Name: "found-1"}, "dir/file", 123)},
-			searchResultsCommon: searchResultsCommon{
-				limitHit: true,
-				repos:    reposMap(mkRepos("found-1", "missing-1", "missing-2", "cloning-1", "timedout-1")...),
-				status: mkStatusMap(map[string]search.RepoStatus{
+			SearchResultsCommon: SearchResultsCommon{
+				IsLimitHit: true,
+				Repos:      reposMap(mkRepos("found-1", "missing-1", "missing-2", "cloning-1", "timedout-1")...),
+				Status: mkStatusMap(map[string]search.RepoStatus{
 					"missing-1":  search.RepoStatusMissing,
 					"missing-2":  search.RepoStatusMissing,
 					"cloning-1":  search.RepoStatusCloning,
 					"timedout-1": search.RepoStatusTimedout,
 				}),
-				excluded: repos.ExcludedRepos{
+				Excluded: repos.ExcludedRepos{
 					Forks:    5,
 					Archived: 1,
 				},

--- a/cmd/frontend/graphqlbackend/search_progress_test.go
+++ b/cmd/frontend/graphqlbackend/search_progress_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -41,10 +40,8 @@ func TestSearchProgress(t *testing.T) {
 					"cloning-1":  search.RepoStatusCloning,
 					"timedout-1": search.RepoStatusTimedout,
 				}),
-				Excluded: repos.ExcludedRepos{
-					Forks:    5,
-					Archived: 1,
-				},
+				ExcludedForks:    5,
+				ExcludedArchived: 1,
 			},
 		},
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -11,14 +11,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
 
-var mockSearchRepositories func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error)
+var mockSearchRepositories func(args *search.TextParameters) ([]SearchResultResolver, *SearchResultsCommon, error)
 var repoIcon = "data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K"
 
 // searchRepositories searches for repositories by name.
 //
 // For a repository to match a query, the repository's name must match all of the repo: patterns AND the
 // default patterns (i.e., the patterns that are not prefixed with any search field).
-func searchRepositories(ctx context.Context, args *search.TextParameters, limit int32) (res []SearchResultResolver, common *searchResultsCommon, err error) {
+func searchRepositories(ctx context.Context, args *search.TextParameters, limit int32) (res []SearchResultResolver, common *SearchResultsCommon, err error) {
 	if mockSearchRepositories != nil {
 		return mockSearchRepositories(args)
 	}
@@ -94,8 +94,8 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 		}
 	}
 
-	return results, &searchResultsCommon{
-		limitHit: limitHit,
+	return results, &SearchResultsCommon{
+		IsLimitHit: limitHit,
 	}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -29,7 +29,7 @@ func TestSearchRepositories(t *testing.T) {
 
 	zoekt := &searchbackend.Zoekt{Client: &searchzoekt.FakeSearcher{}}
 
-	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *SearchResultsCommon, err error) {
 		repos, err := getRepos(context.Background(), args.RepoPromise)
 		if err != nil {
 			return nil, nil, err
@@ -42,18 +42,18 @@ func TestSearchRepositories(t *testing.T) {
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		case "bar/one":
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 789}},
 				},
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		case "foo/no-match":
-			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
+			return []*FileMatchResolver{}, &SearchResultsCommon{}, nil
 		default:
-			return nil, &searchResultsCommon{}, errors.New("Unexpected repo")
+			return nil, &SearchResultsCommon{}, errors.New("Unexpected repo")
 		}
 	}
 
@@ -127,7 +127,7 @@ func TestSearchRepositories(t *testing.T) {
 }
 
 func TestRepoShouldBeAdded(t *testing.T) {
-	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+	mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *SearchResultsCommon, err error) {
 		repos, err := getRepos(context.Background(), args.RepoPromise)
 		if err != nil {
 			return nil, nil, err
@@ -140,11 +140,11 @@ func TestRepoShouldBeAdded(t *testing.T) {
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		case "foo/no-match":
-			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
+			return []*FileMatchResolver{}, &SearchResultsCommon{}, nil
 		default:
-			return nil, &searchResultsCommon{}, errors.New("Unexpected repo")
+			return nil, &SearchResultsCommon{}, errors.New("Unexpected repo")
 		}
 	}
 
@@ -152,13 +152,13 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *SearchResultsCommon, err error) {
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustInclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
@@ -172,8 +172,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has repoHasFile filter ", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
+		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *SearchResultsCommon, err error) {
+			return []*FileMatchResolver{}, &SearchResultsCommon{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustInclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
@@ -187,13 +187,13 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo shouldn't be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *SearchResultsCommon, err error) {
 			return []*FileMatchResolver{
 				{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
 				},
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustExclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)
@@ -207,8 +207,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 
 	t.Run("repo should be included in results, query has -repoHasFile filter", func(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{Name: "foo/no-match"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
-		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *searchResultsCommon, err error) {
-			return []*FileMatchResolver{}, &searchResultsCommon{}, nil
+		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *SearchResultsCommon, err error) {
+			return []*FileMatchResolver{}, &SearchResultsCommon{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustExclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
 		shouldBeAdded, err := repoShouldBeAdded(context.Background(), zoekt, repo, pat)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -50,12 +50,14 @@ import (
 // SearchResultsCommon contains fields that should be returned by all funcs
 // that contribute to the overall search result set.
 type SearchResultsCommon struct {
-	IsLimitHit bool // whether the limit on results was hit
+	// IsLimitHit is true if we do not have all results that match the query.
+	IsLimitHit bool
 
 	// Repos that were matched by the repo-related filters. This should only
 	// be set once by search, when we have resolved Repos.
 	Repos map[api.RepoID]*types.RepoName
 
+	// Status is a RepoStatusMap of repository search statuses.
 	Status search.RepoStatusMap
 
 	// ExcludedForks is the count of excluded forked repos because the search
@@ -66,7 +68,8 @@ type SearchResultsCommon struct {
 	// search query doesn't apply to them, but that we want to know about.
 	ExcludedArchived int
 
-	IsIndexUnavailable bool // True if indexed search is enabled but was not available during this search.
+	// IsIndexUnavailable is true if indexed search was unavailable.
+	IsIndexUnavailable bool
 }
 
 // update updates c with the other data, deduping as necessary. It modifies c but

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -93,8 +93,8 @@ func TestSearchResults(t *testing.T) {
 		db.Mocks.Repos.MockGet(t, 1)
 		db.Mocks.Repos.Count = mockCount
 
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
-			return nil, &searchResultsCommon{}, nil
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error) {
+			return nil, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -128,14 +128,14 @@ func TestSearchResults(t *testing.T) {
 		db.Mocks.Repos.Count = mockCount
 
 		calledSearchRepositories := false
-		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *SearchResultsCommon, error) {
 			calledSearchRepositories = true
-			return nil, &searchResultsCommon{}, nil
+			return nil, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchRepositories = nil }()
 
 		calledSearchSymbols := false
-		mockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
+		mockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, common *SearchResultsCommon, err error) {
 			calledSearchSymbols = true
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
@@ -146,14 +146,14 @@ func TestSearchResults(t *testing.T) {
 		defer func() { mockSearchSymbols = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			repo := &types.RepoName{ID: 1, Name: "repo"}
 			fm := mkFileMatch(repo, "dir/file", 123)
-			return []*FileMatchResolver{fm}, &searchResultsCommon{}, nil
+			return []*FileMatchResolver{fm}, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -193,14 +193,14 @@ func TestSearchResults(t *testing.T) {
 		db.Mocks.Repos.Count = mockCount
 
 		calledSearchRepositories := false
-		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *searchResultsCommon, error) {
+		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *SearchResultsCommon, error) {
 			calledSearchRepositories = true
-			return nil, &searchResultsCommon{}, nil
+			return nil, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchRepositories = nil }()
 
 		calledSearchSymbols := false
-		mockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
+		mockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, common *SearchResultsCommon, err error) {
 			calledSearchSymbols = true
 			if want := `"foo\\d \"bar*\""`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
@@ -211,14 +211,14 @@ func TestSearchResults(t *testing.T) {
 		defer func() { mockSearchSymbols = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			repo := &types.RepoName{ID: 1, Name: "repo"}
 			fm := mkFileMatch(repo, "dir/file", 123)
-			return []*FileMatchResolver{fm}, &searchResultsCommon{}, nil
+			return []*FileMatchResolver{fm}, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -972,7 +972,7 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 	type fields struct {
 		results             []SearchResultResolver
-		searchResultsCommon searchResultsCommon
+		searchResultsCommon SearchResultsCommon
 		alert               *searchAlert
 		start               time.Time
 	}
@@ -999,7 +999,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 			name: "file matches limit hit",
 			fields: fields{
 				results:             []SearchResultResolver{&FileMatchResolver{}},
-				searchResultsCommon: searchResultsCommon{limitHit: true},
+				searchResultsCommon: SearchResultsCommon{IsLimitHit: true},
 			},
 			want: "1+",
 		},
@@ -1034,7 +1034,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 						},
 					},
 				},
-				searchResultsCommon: searchResultsCommon{limitHit: true},
+				searchResultsCommon: SearchResultsCommon{IsLimitHit: true},
 			},
 			want: "2+",
 		},
@@ -1043,7 +1043,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &SearchResultsResolver{
 				SearchResults:       tt.fields.results,
-				searchResultsCommon: tt.fields.searchResultsCommon,
+				SearchResultsCommon: tt.fields.searchResultsCommon,
 				alert:               tt.fields.alert,
 				start:               tt.fields.start,
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -47,7 +47,7 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 	}
 
-	mockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, common *searchResultsCommon, err error) {
+	mockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, common *SearchResultsCommon, err error) {
 		// TODO test symbol suggestions
 		return nil, nil, nil
 	}
@@ -103,7 +103,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer git.ResetMocks()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := "foo"; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
@@ -111,7 +111,7 @@ func TestSearchSuggestions(t *testing.T) {
 			fm := mkFileMatch(&types.RepoName{Name: "repo"}, "dir/file")
 			fm.uri = "git://repo?rev#dir/file"
 			fm.CommitID = "rev"
-			return []*FileMatchResolver{fm}, &searchResultsCommon{}, nil
+			return []*FileMatchResolver{fm}, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 		for _, v := range searchVersions {
@@ -160,7 +160,7 @@ func TestSearchSuggestions(t *testing.T) {
 		backend.Mocks.Repos.MockResolveRev_NoCheck(t, api.CommitID("deadbeef"))
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
@@ -177,7 +177,7 @@ func TestSearchSuggestions(t *testing.T) {
 				mk("repo3", "dir/foo-repo3-file-name-match"),
 				mk("repo1", "dir/foo-repo1-file-name-match"),
 				mk("repo", "dir/file-content-match"),
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -240,7 +240,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
@@ -253,7 +253,7 @@ func TestSearchSuggestions(t *testing.T) {
 			}
 			return []*FileMatchResolver{
 				mkFileMatch(&types.RepoName{Name: "foo-repo"}, "dir/file"),
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -361,7 +361,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
@@ -374,7 +374,7 @@ func TestSearchSuggestions(t *testing.T) {
 			}
 			return []*FileMatchResolver{
 				mkFileMatch(&types.RepoName{Name: "foo-repo"}, "dir/bar-file"),
-			}, &searchResultsCommon{}, nil
+			}, &SearchResultsCommon{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -108,7 +108,6 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 
 	addMatches := func(matches []*FileMatchResolver) {
 		if len(matches) > 0 {
-			common.resultCount += int32(len(matches))
 			sort.Slice(matches, func(i, j int) bool {
 				a, b := matches[i].uri, matches[j].uri
 				return a > b

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -283,7 +283,7 @@ func fileMatchURI(name api.RepoName, ref, path string) string {
 	return b.String()
 }
 
-var mockSearchFilesInRepos func(args *search.TextParameters) ([]*FileMatchResolver, *searchResultsCommon, error)
+var mockSearchFilesInRepos func(args *search.TextParameters) ([]*FileMatchResolver, *SearchResultsCommon, error)
 
 func fileMatchResultsToSearchResults(results []*FileMatchResolver) []SearchResultResolver {
 	results2 := make([]SearchResultResolver, len(results))
@@ -295,7 +295,7 @@ func fileMatchResultsToSearchResults(results []*FileMatchResolver) []SearchResul
 
 // searchFilesInRepos searches a set of repos for a pattern.
 // For c != nil searchFilesInRepos will send results down c.
-func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan<- []SearchResultResolver) (res []*FileMatchResolver, common *searchResultsCommon, finalErr error) {
+func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan<- []SearchResultResolver) (res []*FileMatchResolver, common *SearchResultsCommon, finalErr error) {
 	if mockSearchFilesInRepos != nil {
 		return mockSearchFilesInRepos(args)
 	}
@@ -314,7 +314,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	common = &searchResultsCommon{}
+	common = &SearchResultsCommon{}
 
 	indexedTyp := textRequest
 	if args.PatternInfo.IsStructuralPat {
@@ -357,7 +357,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 	if indexed.DisableUnindexedSearch {
 		tr.LazyPrintf("disabling unindexed search")
 		for _, r := range indexed.Unindexed {
-			common.status.Update(r.Repo.ID, search.RepoStatusMissing)
+			common.Status.Update(r.Repo.ID, search.RepoStatusMissing)
 		}
 	} else {
 		// Limit the number of unindexed repositories searched for a single
@@ -368,7 +368,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 		if len(missing) > 0 {
 			tr.LazyPrintf("limiting unindexed repos searched to %d", maxUnindexedRepoRevSearchesPerQuery)
 			for _, r := range missing {
-				common.status.Update(r.ID, search.RepoStatusMissing)
+				common.Status.Update(r.ID, search.RepoStatusMissing)
 			}
 		}
 	}
@@ -406,7 +406,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 			if flattenedSize > int(args.PatternInfo.FileMatchLimit) {
 				tr.LazyPrintf("cancel due to result size: %d > %d", flattenedSize, args.PatternInfo.FileMatchLimit)
 				overLimitCanceled = true
-				common.limitHit = true
+				common.IsLimitHit = true
 				cancel()
 			}
 		}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -386,7 +386,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, c chan
 	// addMatches assumes the caller holds mu.
 	addMatches := func(matches []*FileMatchResolver) {
 		if len(matches) > 0 {
-			common.resultCount += int32(len(matches))
 			sort.Slice(matches, func(i, j int) bool {
 				a, b := matches[i].uri, matches[j].uri
 				return a > b

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -97,7 +97,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 	for _, rr := range repoRevs {
 		repoNames[rr.Repo.ID] = string(rr.Repo.Name)
 	}
-	assertReposStatus(t, repoNames, common.status, map[string]search.RepoStatus{
+	assertReposStatus(t, repoNames, common.Status, map[string]search.RepoStatus{
 		"foo/cloning":    search.RepoStatusCloning,
 		"foo/empty":      search.RepoStatusSearched,
 		"foo/missing":    search.RepoStatusMissing,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -203,7 +203,7 @@ func (s *indexedSearchRequest) Repos() map[string]*search.RepositoryRevisions {
 type streamFunc func(context.Context, *search.TextParameters, *indexedRepoRevs, indexedRequestType, func(t time.Time) time.Duration) <-chan zoektSearchStreamEvent
 
 type indexedSearchEvent struct {
-	common  searchResultsCommon
+	common  SearchResultsCommon
 	results []*FileMatchResolver
 	err     error
 }
@@ -240,7 +240,7 @@ func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- indexedSea
 		zoektStream = zoektSearchHEADOnlyFilesStream
 	default:
 		err := fmt.Errorf("unexpected indexedSearchRequest type: %q", s.typ)
-		c <- indexedSearchEvent{common: searchResultsCommon{}, results: nil, err: err}
+		c <- indexedSearchEvent{common: SearchResultsCommon{}, results: nil, err: err}
 		return
 	}
 
@@ -267,12 +267,12 @@ func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- indexedSea
 
 		if err == errNoResultsInTimeout {
 			err = nil
-			c <- indexedSearchEvent{common: searchResultsCommon{status: mkStatusMap(search.RepoStatusTimedout | search.RepoStatusIndexed)}}
+			c <- indexedSearchEvent{common: SearchResultsCommon{Status: mkStatusMap(search.RepoStatusTimedout | search.RepoStatusIndexed)}}
 			return
 		}
 
 		if err != nil {
-			c <- indexedSearchEvent{common: searchResultsCommon{}, results: nil, err: err}
+			c <- indexedSearchEvent{common: SearchResultsCommon{}, results: nil, err: err}
 			return
 		}
 
@@ -294,9 +294,9 @@ func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- indexedSea
 		}
 
 		c <- indexedSearchEvent{
-			common: searchResultsCommon{
-				status:   statusMap,
-				limitHit: event.limitHit,
+			common: SearchResultsCommon{
+				Status:     statusMap,
+				IsLimitHit: event.limitHit,
 			},
 			results: event.fm,
 			err:     nil,
@@ -305,7 +305,7 @@ func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- indexedSea
 
 	// Successfully searched everything. Communicate every indexed repo was
 	// searched in case it didn't have a result.
-	c <- indexedSearchEvent{common: searchResultsCommon{status: mkStatusMap(search.RepoStatusSearched | search.RepoStatusIndexed)}}
+	c <- indexedSearchEvent{common: SearchResultsCommon{Status: mkStatusMap(search.RepoStatusSearched | search.RepoStatusIndexed)}}
 }
 
 func zoektResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch bool) (k int) {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -67,7 +67,7 @@ func TestIndexedSearch(t *testing.T) {
 		wantMatchURLs      []string
 		wantMatchInputRevs []string
 		wantUnindexed      []*search.RepositoryRevisions
-		wantCommon         searchResultsCommon
+		wantCommon         SearchResultsCommon
 		wantErr            bool
 	}{
 		{
@@ -79,8 +79,8 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: false,
 				since:           func(time.Time) time.Duration { return time.Second - time.Millisecond },
 			},
-			wantCommon: searchResultsCommon{
-				status: mkStatusMap(map[string]search.RepoStatus{
+			wantCommon: SearchResultsCommon{
+				Status: mkStatusMap(map[string]search.RepoStatus{
 					"foo/bar":    search.RepoStatusSearched | search.RepoStatusIndexed,
 					"foo/foobar": search.RepoStatusSearched | search.RepoStatusIndexed,
 				}),
@@ -96,8 +96,8 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: false,
 				since:           func(time.Time) time.Duration { return time.Minute },
 			},
-			wantCommon: searchResultsCommon{
-				status: mkStatusMap(map[string]search.RepoStatus{
+			wantCommon: SearchResultsCommon{
+				Status: mkStatusMap(map[string]search.RepoStatus{
 					"foo/bar":    search.RepoStatusIndexed | search.RepoStatusTimedout,
 					"foo/foobar": search.RepoStatusIndexed | search.RepoStatusTimedout,
 				}),
@@ -112,8 +112,8 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: true,
 				since:           func(time.Time) time.Duration { return 0 },
 			},
-			wantCommon: searchResultsCommon{
-				status: mkStatusMap(map[string]search.RepoStatus{
+			wantCommon: SearchResultsCommon{
+				Status: mkStatusMap(map[string]search.RepoStatus{
 					"foo/bar":    search.RepoStatusIndexed | search.RepoStatusTimedout,
 					"foo/foobar": search.RepoStatusIndexed | search.RepoStatusTimedout,
 				}),
@@ -173,8 +173,8 @@ func TestIndexedSearch(t *testing.T) {
 				"",
 				"",
 			},
-			wantCommon: searchResultsCommon{
-				status: mkStatusMap(map[string]search.RepoStatus{
+			wantCommon: SearchResultsCommon{
+				Status: mkStatusMap(map[string]search.RepoStatus{
 					"foo/bar":    search.RepoStatusSearched | search.RepoStatusIndexed,
 					"foo/foobar": search.RepoStatusSearched | search.RepoStatusIndexed,
 				}),
@@ -203,8 +203,8 @@ func TestIndexedSearch(t *testing.T) {
 				},
 				since: func(time.Time) time.Duration { return 0 },
 			},
-			wantCommon: searchResultsCommon{
-				status: mkStatusMap(map[string]search.RepoStatus{
+			wantCommon: SearchResultsCommon{
+				Status: mkStatusMap(map[string]search.RepoStatus{
 					"foo/bar": search.RepoStatusSearched | search.RepoStatusIndexed,
 				}),
 			},
@@ -238,8 +238,8 @@ func TestIndexedSearch(t *testing.T) {
 					},
 				},
 			},
-			wantCommon: searchResultsCommon{
-				status: mkStatusMap(map[string]search.RepoStatus{
+			wantCommon: SearchResultsCommon{
+				Status: mkStatusMap(map[string]search.RepoStatus{
 					"foo/bar": search.RepoStatusSearched | search.RepoStatusIndexed,
 				}),
 			},
@@ -315,7 +315,7 @@ func TestIndexedSearch(t *testing.T) {
 			// Once we return more than one event we have to account for the proper order of results
 			// in the tests.
 			var (
-				gotCommon searchResultsCommon
+				gotCommon SearchResultsCommon
 				gotFm     []*FileMatchResolver
 			)
 			for event := range indexed.Search(tt.args.ctx) {


### PR DESCRIPTION
We want to extract SearchResultsCommon out of graphqlbackend. This exports everything to allow that. Additionally it disentangles the graphql resolvers from the struct.

Additionally we remove an effectively unused `resultsCount` field. This field was never exposed to a user. Additionally the only read path was in an or condition with `limitHit`. However, it could only be true if `limitHit` is true, so was a codepath that would never return true.