### PR TITLE
repo-updater: Don't schedule all repos for update on startup

### DIFF
--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -699,7 +699,7 @@ func (s *RepoStore) ListDefaultRepos(ctx context.Context, opts ListDefaultReposO
 
 	cloneClause := sqlf.Sprintf("TRUE")
 	if opts.OnlyUncloned {
-		cloneClause = sqlf.Sprintf("not r.cloned")
+		cloneClause = sqlf.Sprintf("NOT r.cloned")
 	}
 
 	q := sqlf.Sprintf(`

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -733,7 +733,7 @@ UNION
 	WHERE
 		r.deleted_at IS NULL
 		AND r.id > %s
-        AND %s
+		AND %s
 
 	ORDER BY id ASC
 	LIMIT %s`, opts.AfterID, cloneClause, opts.AfterID, cloneClause, opts.Limit)

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -655,6 +655,8 @@ func (s *RepoStore) list(ctx context.Context, tr *trace.Trace, minimal bool, opt
 type ListDefaultReposOptions struct {
 	Limit   int
 	AfterID int32
+	// If true, will only include uncloned default repos
+	OnlyUncloned bool
 }
 
 // ListAllDefaultRepos returns a list of all default repos. Default repos are a union of
@@ -695,7 +697,12 @@ func (s *RepoStore) ListDefaultRepos(ctx context.Context, opts ListDefaultReposO
 	}()
 	s.ensureStore()
 
-	var q = sqlf.Sprintf(`
+	cloneClause := sqlf.Sprintf("TRUE")
+	if opts.OnlyUncloned {
+		cloneClause = sqlf.Sprintf("not r.cloned")
+	}
+
+	q := sqlf.Sprintf(`
 -- source: internal/db/default_repos.go:defaultRepos.List
 SELECT
     id,
@@ -714,6 +721,7 @@ WHERE
 			AND s.deleted_at IS NULL
 			AND r.id = sr.repo_id
             AND r.deleted_at IS NULL
+            AND %s
     )
 UNION
     SELECT
@@ -725,9 +733,10 @@ UNION
 	WHERE
 		r.deleted_at IS NULL
 		AND r.id > %s
+        AND %s
 
 	ORDER BY id ASC
-	LIMIT %s`, opts.AfterID, opts.AfterID, opts.Limit)
+	LIMIT %s`, opts.AfterID, cloneClause, opts.AfterID, cloneClause, opts.Limit)
 
 	var repos []*types.RepoName
 


### PR DESCRIPTION
With the recent change, fdc8858eb, to ensure that all indexed repos
are known to the scheduler we inadvertently caused all indexed repos
to be scheduled for update whenever `repo-updater` started.

Our old logic was that every 30 seconds we fetch all indexed repos and
add them to the scheduler if they're not already known to it. The
intention here is that the scheduler should know about all repos that
need to be indexed so that it'll update them occasionally and ensure
they are cloned, even after a gitserver rebalance.

The issue is that when this first runs all ~400k default repos are unknown
to the scheduler and therefore added with the minimum update interval of
45 seconds.

Instead, we now first fetch the list of known cloned repos from gitserver
and only add indexed repos to the scheduler if they are NOT in the
cloned list.
