### PR TITLE
Fixes a link from repos to code hosts when no code hosts were active.

### DIFF
--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -134,9 +134,9 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
             <div className="card p-3 m-2">
                 <h3 className="mb-1">You have not added any repositories to Sourcegraph</h3>
                 <p className="text-muted mb-0">
-                    <a className="text-primary" href={routingPrefix + '/external-services'}>
+                    <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
                         Connect a code host
-                    </a>{' '}
+                    </Link>{' '}
                     to start adding your repositories to Sourcegraph.
                 </p>
             </div>


### PR DESCRIPTION

### Description

Fixes a link from repos to code hosts when no code hosts were active. 

![Screen Shot 2021-01-15 at 1 15 50 PM](https://user-images.githubusercontent.com/1319181/104763396-ce3d3b00-5733-11eb-82a8-b27d5b21e3f0.png)
