### PR TITLE
search: use rule to activate new structural search path

### DIFF
--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -103,7 +103,11 @@ type PatternInfo struct {
 	// Languages is the languages passed via the lang filters (e.g., "lang:c")
 	Languages []string
 
-	// CombyRule is a rule that constrains matching for structural search. It only applies when IsStructuralPat is true.
+	// CombyRule is a rule that constrains matching for structural search.
+	// It only applies when IsStructuralPat is true.
+	// As a temporary measure, the expression `where "zoekt" == "zoekt"` acts as
+	// a flag to activate a new structural search path to directly query
+	// Zoekt for file contents.
 	CombyRule string
 }
 

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -188,6 +188,11 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		}
 	}(time.Now())
 
+	if p.IsStructuralPat && p.CombyRule == `where "zoekt" == "zoekt"` {
+		// Reserved for calling the new structural search path that directly uses Zoekt.
+		return nil, false, false, badRequestError{"reserved rule, unsupported request"}
+	}
+
 	// Compile pattern before fetching from store incase it is bad.
 	var rg *readerGrep
 	if !p.IsStructuralPat {


### PR DESCRIPTION
Thought about how to communicate using the new path down to searcher. There wasn't an obviously suitable member in the protocol data structure and any change seemed pretty invasive (update arguments in `textsearch.go`, update the protocol type, ... yuck). So instead we're going to use a valid, but meaningless, comby rule to activate the new path. Not invasive, not disruptive, and temporary.

Use a query like `test rule:'where "zoekt" == "zoekt"' patterntype:structural` to activate.