### PR TITLE
search: Move zoektSearchOpts to internal/search/zoekt

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -9,10 +9,10 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 
 	searcherzoekt "github.com/sourcegraph/sourcegraph/cmd/searcher/search"
-	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -9,6 +9,7 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 
 	searcherzoekt "github.com/sourcegraph/sourcegraph/cmd/searcher/search"
+	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -67,7 +68,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	}
 
 	k := zoektResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, args.Mode == search.ZoektGlobalSearch)
-	searchOpts := zoektSearchOpts(ctx, k, args.PatternInfo)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.PatternInfo)
 
 	if args.UseFullDeadline {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 	"github.com/inconshreveable/log15"
-	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
@@ -23,7 +22,6 @@ import (
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -339,48 +337,6 @@ func zoektResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch boo
 	return k
 }
 
-func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[string]string) {
-	if !ot.ShouldTrace(ctx) {
-		return false, nil
-	}
-
-	spanContext = make(map[string]string)
-	if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err != nil {
-		log15.Warn("Error injecting span context into map: %s", err)
-		return true, nil
-	}
-	return true, spanContext
-}
-
-func zoektSearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt.SearchOptions {
-	shouldTrace, spanContext := getSpanContext(ctx)
-	searchOpts := zoekt.SearchOptions{
-		Trace:                  shouldTrace,
-		SpanContext:            spanContext,
-		MaxWallTime:            defaultTimeout,
-		ShardMaxMatchCount:     100 * k,
-		TotalMaxMatchCount:     100 * k,
-		ShardMaxImportantMatch: 15 * k,
-		TotalMaxImportantMatch: 25 * k,
-		MaxDocDisplayCount:     2 * defaultMaxSearchResults,
-	}
-
-	// We want zoekt to return more than FileMatchLimit results since we use
-	// the extra results to populate reposLimitHit. Additionally the defaults
-	// are very low, so we always want to return at least 2000.
-	if query.FileMatchLimit > defaultMaxSearchResults {
-		searchOpts.MaxDocDisplayCount = 2 * int(query.FileMatchLimit)
-	}
-	if searchOpts.MaxDocDisplayCount < 2000 {
-		searchOpts.MaxDocDisplayCount = 2000
-	}
-
-	if userProbablyWantsToWaitLonger := query.FileMatchLimit > defaultMaxSearchResults; userProbablyWantsToWaitLonger {
-		searchOpts.MaxWallTime *= time.Duration(3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
-	}
-
-	return searchOpts
-}
 
 var errNoResultsInTimeout = errors.New("no results found in specified timeout")
 
@@ -441,7 +397,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	}
 
 	k := zoektResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, args.Mode == search.ZoektGlobalSearch)
-	searchOpts := zoektSearchOpts(ctx, k, args.PatternInfo)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.PatternInfo)
 
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -337,7 +337,6 @@ func zoektResultCountFactor(numRepos int, fileMatchLimit int32, globalSearch boo
 	return k
 }
 
-
 var errNoResultsInTimeout = errors.New("no results found in specified timeout")
 
 type zoektSearchStreamEvent struct {

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -1,20 +1,21 @@
 package zoekt
 
 import (
-  "context"
+	"context"
 	"regexp/syntax"
-  "time"
+	"time"
 
-  "github.com/google/zoekt"
+	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
-  "github.com/opentracing/opentracing-go"
-  "github.com/inconshreveable/log15"
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
 
-  "github.com/sourcegraph/sourcegraph/internal/trace/ot"
-  "github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 const defaultMaxSearchResults = 30
+
 var defaultTimeout = 20 * time.Second
 
 func FileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {

--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -1,10 +1,21 @@
 package zoekt
 
 import (
+  "context"
 	"regexp/syntax"
+  "time"
 
+  "github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
+  "github.com/opentracing/opentracing-go"
+  "github.com/inconshreveable/log15"
+
+  "github.com/sourcegraph/sourcegraph/internal/trace/ot"
+  "github.com/sourcegraph/sourcegraph/internal/search"
 )
+
+const defaultMaxSearchResults = 30
+var defaultTimeout = 20 * time.Second
 
 func FileRe(pattern string, queryIsCaseSensitive bool) (zoektquery.Q, error) {
 	return ParseRe(pattern, true, false, queryIsCaseSensitive)
@@ -42,4 +53,47 @@ func ParseRe(pattern string, filenameOnly bool, contentOnly bool, queryIsCaseSen
 		Content:       contentOnly,
 		FileName:      filenameOnly,
 	}, nil
+}
+
+func getSpanContext(ctx context.Context) (shouldTrace bool, spanContext map[string]string) {
+	if !ot.ShouldTrace(ctx) {
+		return false, nil
+	}
+
+	spanContext = make(map[string]string)
+	if err := ot.GetTracer(ctx).Inject(opentracing.SpanFromContext(ctx).Context(), opentracing.TextMap, opentracing.TextMapCarrier(spanContext)); err != nil {
+		log15.Warn("Error injecting span context into map: %s", err)
+		return true, nil
+	}
+	return true, spanContext
+}
+
+func SearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt.SearchOptions {
+	shouldTrace, spanContext := getSpanContext(ctx)
+	searchOpts := zoekt.SearchOptions{
+		Trace:                  shouldTrace,
+		SpanContext:            spanContext,
+		MaxWallTime:            defaultTimeout,
+		ShardMaxMatchCount:     100 * k,
+		TotalMaxMatchCount:     100 * k,
+		ShardMaxImportantMatch: 15 * k,
+		TotalMaxImportantMatch: 25 * k,
+		MaxDocDisplayCount:     2 * defaultMaxSearchResults,
+	}
+
+	// We want zoekt to return more than FileMatchLimit results since we use
+	// the extra results to populate reposLimitHit. Additionally the defaults
+	// are very low, so we always want to return at least 2000.
+	if query.FileMatchLimit > defaultMaxSearchResults {
+		searchOpts.MaxDocDisplayCount = 2 * int(query.FileMatchLimit)
+	}
+	if searchOpts.MaxDocDisplayCount < 2000 {
+		searchOpts.MaxDocDisplayCount = 2000
+	}
+
+	if userProbablyWantsToWaitLonger := query.FileMatchLimit > defaultMaxSearchResults; userProbablyWantsToWaitLonger {
+		searchOpts.MaxWallTime *= time.Duration(3 * float64(query.FileMatchLimit) / float64(defaultMaxSearchResults))
+	}
+
+	return searchOpts
 }


### PR DESCRIPTION
This moves a couple more things to internal/sesarch/zoekt to make them
available for searcher to use.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
