### PR TITLE
search: Add zoekt querying to searcher

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -211,7 +211,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 				CombyRule:                    p.CombyRule,
 				IsWordMatch:                  p.IsWordMatch,
 				IsCaseSensitive:              p.IsCaseSensitive,
-				FileMatchLimit:               int32(p.FileMatchLimit),
+				FileMatchLimit:               int32(fileMatchLimit),
 				ExcludePattern:               p.ExcludePattern,
 				PathPatternsAreCaseSensitive: p.PathPatternsAreCaseSensitive,
 				PatternMatchesContent:        p.PatternMatchesContent,

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -218,7 +218,13 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 				PatternMatchesPath:           p.PatternMatchesPath,
 				Languages:                    p.Languages,
 			},
-			Zoekt: search.Indexed(),
+			Zoekt: nil,
+		}
+
+		if args.Zoekt == nil {
+			// TODO(@camdencheek): remove this once the zoekt endpoints are sent with the request:
+			// https://github.com/sourcegraph/sourcegraph/pull/17387#pullrequestreview-571951086
+			return nil, false, false, fmt.Errorf("cannot do indexed search because Zoekt client is unset")
 		}
 
 		zoektMatches, limitHit, _, err := zoektSearch(ctx, args, repoBranches, time.Since, nil)

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -208,12 +208,10 @@ func writeZip(path string, fileMatches []zoekt.FileMatch) (err error) {
 		return err
 	}
 
-	// TODO is this handled outside of here?
 	defer func() {
 		if err != nil {
 			rmErr := os.Remove(path)
 			if rmErr != nil {
-				// TODO is there a conventional way to handle errors during cleanup?
 				err = fmt.Errorf("error1: %s, error2: %s", err, rmErr)
 			}
 		}

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -201,7 +201,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repoBranches 
 	return resp.Files, limitHit, partial, nil
 }
 
-func writeZip(f *os.File, fileMatches []zoekt.FileMatch) (err error) {
+func writeZip(f *io.Writer, fileMatches []zoekt.FileMatch) (err error) {
 	zw := zip.NewWriter(f)
 	defer zw.Close()
 

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -187,7 +187,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repoBranches 
 	}
 
 	limitHit, files, _ := zoektutil.LimitMatches(limitHit, int(args.PatternInfo.FileMatchLimit), resp.Files, func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
-		return repo, revs, true
+		return repo, revs, false
 	})
 	resp.Files = files
 

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"regexp/syntax"
 	"time"
@@ -202,22 +201,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repoBranches 
 	return resp.Files, limitHit, partial, nil
 }
 
-func writeZip(path string, fileMatches []zoekt.FileMatch) (err error) {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		if err != nil {
-			rmErr := os.Remove(path)
-			if rmErr != nil {
-				err = fmt.Errorf("error1: %s, error2: %s", err, rmErr)
-			}
-		}
-	}()
-	defer f.Close()
-
+func writeZip(f *os.File, fileMatches []zoekt.FileMatch) (err error) {
 	zw := zip.NewWriter(f)
 	defer zw.Close()
 

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -4,7 +4,7 @@ import (
 	"archive/zip"
 	"context"
 	"errors"
-	"os"
+	"io"
 	"regexp/syntax"
 	"time"
 
@@ -201,8 +201,8 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repoBranches 
 	return resp.Files, limitHit, partial, nil
 }
 
-func writeZip(f *io.Writer, fileMatches []zoekt.FileMatch) (err error) {
-	zw := zip.NewWriter(f)
+func writeZip(w io.Writer, fileMatches []zoekt.FileMatch) (err error) {
+	zw := zip.NewWriter(w)
 	defer zw.Close()
 
 	for _, match := range fileMatches {

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -1,10 +1,23 @@
 package search
 
 import (
+	"archive/zip"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"regexp/syntax"
+	"time"
+
+	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func HandleFilePathPatterns(query *search.TextPatternInfo) (zoektquery.Q, error) {
@@ -49,4 +62,202 @@ func HandleFilePathPatterns(query *search.TextPatternInfo) (zoektquery.Q, error)
 	}
 
 	return zoektquery.NewAnd(and...), nil
+}
+
+func buildQuery(args *search.TextParameters, repoBranches map[string][]string, filePathPatterns zoektquery.Q, shortcircuit bool) (zoektquery.Q, error) {
+	regexString := comby.StructuralPatToRegexpQuery(args.PatternInfo.Pattern, shortcircuit)
+	if len(regexString) == 0 {
+		return &zoektquery.Const{Value: true}, nil
+	}
+	re, err := syntax.Parse(regexString, syntax.ClassNL|syntax.PerlX|syntax.UnicodeGroups)
+	if err != nil {
+		return nil, err
+	}
+	return zoektquery.NewAnd(
+		&zoektquery.RepoBranches{Set: repoBranches},
+		filePathPatterns,
+		&zoektquery.Regexp{
+			Regexp:        re,
+			CaseSensitive: true,
+			Content:       true,
+		},
+	), nil
+}
+
+type zoektSearchStreamEvent struct {
+	fm       []zoekt.FileMatch
+	limitHit bool
+	partial  map[api.RepoID]struct{}
+	err      error
+}
+
+func zoektSearchStream(ctx context.Context, args *search.TextParameters, repoBranches map[string][]string, since func(t time.Time) time.Duration) <-chan zoektSearchStreamEvent {
+	c := make(chan zoektSearchStreamEvent)
+	go func() {
+		defer close(c)
+		_, _, _, _ = zoektSearch(ctx, args, repoBranches, since, c)
+	}()
+
+	return c
+}
+
+const defaultMaxSearchResults = 30
+
+// zoektSearch searches repositories using zoekt, returning only the file paths containing
+// content matching the given pattern.
+//
+// Timeouts are reported through the context, and as a special case errNoResultsInTimeout
+// is returned if no results are found in the given timeout (instead of the more common
+// case of finding partial or full results in the given timeout).
+func zoektSearch(ctx context.Context, args *search.TextParameters, repoBranches map[string][]string, since func(t time.Time) time.Duration, c chan<- zoektSearchStreamEvent) (fm []zoekt.FileMatch, limitHit bool, partial map[api.RepoID]struct{}, err error) {
+	defer func() {
+		if c != nil {
+			c <- zoektSearchStreamEvent{
+				fm:       fm,
+				limitHit: limitHit,
+				partial:  partial,
+				err:      err,
+			}
+		}
+	}()
+	if len(repoBranches) == 0 {
+		return nil, false, nil, nil
+	}
+
+	k := zoektutil.ResultCountFactor(len(repoBranches), args.PatternInfo.FileMatchLimit, args.Mode == search.ZoektGlobalSearch)
+	searchOpts := zoektutil.SearchOpts(ctx, k, args.PatternInfo)
+	searchOpts.Whole = true
+
+	if args.UseFullDeadline {
+		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
+		deadline, _ := ctx.Deadline()
+		searchOpts.MaxWallTime = time.Until(deadline)
+
+		// We don't want our context's deadline to cut off zoekt so that we can get the results
+		// found before the deadline.
+		//
+		// We'll create a new context that gets cancelled if the other context is cancelled for any
+		// reason other than the deadline being exceeded. This essentially means the deadline for the new context
+		// will be `deadline + time for zoekt to cancel + network latency`.
+		var cancel context.CancelFunc
+		ctx, cancel = contextWithoutDeadline(ctx)
+		defer cancel()
+	}
+
+	filePathPatterns, err := HandleFilePathPatterns(args.PatternInfo)
+	if err != nil {
+		return nil, false, nil, err
+	}
+
+	t0 := time.Now()
+	q, err := buildQuery(args, repoBranches, filePathPatterns, true)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	resp, err := args.Zoekt.Client.Search(ctx, q, &searchOpts)
+	if err != nil {
+		return nil, false, nil, err
+	}
+	if since(t0) >= searchOpts.MaxWallTime {
+		return nil, false, nil, errNoResultsInTimeout
+	}
+
+	// We always return approximate results (limitHit true) unless we run the branch to perform a more complete search.
+	limitHit = true
+	// If the previous indexed search did not return a substantial number of matching file candidates or count was
+	// manually specified, run a more complete and expensive search.
+	if resp.FileCount < 10 || args.PatternInfo.FileMatchLimit != defaultMaxSearchResults {
+		q, err = buildQuery(args, repoBranches, filePathPatterns, false)
+		if err != nil {
+			return nil, false, nil, err
+		}
+		resp, err = args.Zoekt.Client.Search(ctx, q, &searchOpts)
+		if err != nil {
+			return nil, false, nil, err
+		}
+		if since(t0) >= searchOpts.MaxWallTime {
+			return nil, false, nil, errNoResultsInTimeout
+		}
+		// This is the only place limitHit can be set false, meaning we covered everything.
+		limitHit = resp.FilesSkipped+resp.ShardsSkipped > 0
+	}
+
+	if len(resp.Files) == 0 {
+		return nil, false, nil, nil
+	}
+
+	limitHit, files, _ := zoektutil.LimitMatches(limitHit, int(args.PatternInfo.FileMatchLimit), resp.Files, func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
+		return repo, revs, true
+	})
+	resp.Files = files
+
+	maxLineMatches := 25 + k
+	for _, file := range resp.Files {
+		if len(file.LineMatches) > maxLineMatches {
+			file.LineMatches = file.LineMatches[:maxLineMatches]
+			limitHit = true
+		}
+	}
+
+	return resp.Files, limitHit, partial, nil
+}
+
+func writeZip(path string, fileMatches []zoekt.FileMatch) (err error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	// TODO is this handled outside of here?
+	defer func() {
+		if err != nil {
+			rmErr := os.Remove(path)
+			if rmErr != nil {
+				// TODO is there a conventional way to handle errors during cleanup?
+				err = fmt.Errorf("error1: %s, error2: %s", err, rmErr)
+			}
+		}
+	}()
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	defer zw.Close()
+
+	for _, match := range fileMatches {
+		mw, err := zw.Create(match.FileName)
+		if err != nil {
+			return err
+		}
+
+		_, err = mw.Write(match.Content)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var errNoResultsInTimeout = errors.New("no results found in specified timeout")
+
+// contextWithoutDeadline returns a context which will cancel if the cOld is
+// canceled.
+func contextWithoutDeadline(cOld context.Context) (context.Context, context.CancelFunc) {
+	cNew, cancel := context.WithCancel(context.Background())
+
+	// Set trace context so we still get spans propagated
+	cNew = trace.CopyContext(cNew, cOld)
+
+	go func() {
+		select {
+		case <-cOld.Done():
+			// cancel the new context if the old one is done for some reason other than the deadline passing.
+			if cOld.Err() != context.DeadlineExceeded {
+				cancel()
+			}
+		case <-cNew.Done():
+		}
+	}()
+
+	return cNew, cancel
 }


### PR DESCRIPTION
Adds the ability of searcher to query zoekt directly for the file list
and contents that it should perform structural search on.

To activate that code path, a temporary special comby rule
(`rule:'where "zoekt" == "zoekt"'`) needs to be added to the query.

There are no frontend changes included here, so the frontend will still
query zoekt to get the list of files, but searcher will ignore that file
list if the special rule is set.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
