### PR TITLE
search: remove old validation code

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -157,11 +157,6 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return nil, &badRequestError{err}
 	}
 
-	err = validateRepoHasFileUsage(r.query)
-	if err != nil {
-		return nil, err
-	}
-
 	resultTypes := r.determineResultTypes(args, "")
 	tr.LazyPrintf("resultTypes: %v", resultTypes)
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1957,11 +1957,6 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return nil, &badRequestError{err}
 	}
 
-	err = validateRepoHasFileUsage(r.query)
-	if err != nil {
-		return nil, err
-	}
-
 	resultTypes := r.determineResultTypes(args, forceOnlyResultType)
 	tr.LazyPrintf("resultTypes: %v", resultTypes)
 	var (
@@ -2276,15 +2271,6 @@ func orderedFuzzyRegexp(pieces []string) string {
 		return pieces[0]
 	}
 	return "(" + strings.Join(pieces, ").*?(") + ")"
-}
-
-// Validates usage of the `repohasfile` filter
-func validateRepoHasFileUsage(q query.QueryInfo) error {
-	// Query only contains "repohasfile:" and "type:symbol"
-	if len(q.Fields()) == 2 && q.Fields()["repohasfile"] != nil && q.Fields()["type"] != nil && len(q.Fields()["type"]) == 1 && q.Fields()["type"][0].Value() == "symbol" {
-		return errors.New("repohasfile does not currently return symbol results. Support for symbol results is coming soon. Subscribe to https://github.com/sourcegraph/sourcegraph/issues/4610 for updates")
-	}
-	return nil
 }
 
 // logSlowSearchesThreshold returns the minimum duration configured in site

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -748,41 +748,6 @@ func TestRoundStr(t *testing.T) {
 	}
 }
 
-func TestValidateRepoHasFileUsage(t *testing.T) {
-	q, err := query.ParseAndCheck("repohasfile:test type:symbol")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = validateRepoHasFileUsage(q)
-	if err == nil {
-		t.Errorf("Expected error but got nil")
-	}
-
-	validQueries := []string{
-		"repohasfile:go",
-		"repohasfile:go error",
-		"repohasfile:test type:repo .",
-		"type:repo",
-		"repohasfile",
-		"foo bar type:repo",
-		"repohasfile:test type:path .",
-		"repohasfile:test type:symbol .",
-		"foo",
-		"bar",
-		"\"repohasfile\"",
-	}
-	for _, validQuery := range validQueries {
-		q, err = query.ParseAndCheck(validQuery)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = validateRepoHasFileUsage(q)
-		if err != nil {
-			t.Errorf("Expected no error, but got %v", err)
-		}
-	}
-}
-
 func TestSearchResultsHydration(t *testing.T) {
 	id := 42
 	repoName := "reponame-foobar"


### PR DESCRIPTION
Stacked on #17344.

This removal was prepped back in https://github.com/sourcegraph/sourcegraph/pull/16047, but it was predicated on removing `migrateParser`.

![trash-it](https://user-images.githubusercontent.com/888624/67820037-de0c2900-fa74-11e9-99e7-a1144172afb9.gif)