### PR TITLE
Remove old version warning from campaigns docs

### DIFF
--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -45,10 +45,7 @@ Create a campaign by specifying a search query to get a list of repositories and
 <a class="btn" href="references/requirements">Requirements</a>
 </div>
 
-> NOTE: This documentation describes the campaign functionality shipped in Sourcegraph 3.19 and src-cli 3.18, and later versions of both. [Click here](https://docs.sourcegraph.com/@3.18/user/campaigns) to read the documentation for campaigns in older versions of Sourcegraph and src-cli.
->
->
-> We highly recommend using the latest versions of Sourcegraph and src-cli with campaigns, since we're steadily shipping new features and improvements.
+> NOTE: We highly recommend using the latest versions of Sourcegraph and src-cli with campaigns, since we're steadily shipping new features and improvements.
 
 ## Getting started
 


### PR DESCRIPTION
It's been a few months now and I don't think it makes sense to link back to the old documentation _on the front page of the docs_. Old docs are always available.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
