### PR TITLE
sentry: allow specify a DSN for backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- New site config option `"log": { "sentry": { "backendDSN": "<REDACTED>" } }` to use a separate Sentry project for backend errors. [#17363](https://github.com/sourcegraph/sourcegraph/pull/17363)
 
 ### Changed
 

--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -60,12 +60,21 @@ func Init() {
 				return
 			}
 
-			if conf.Get().Log.Sentry == nil {
+			sentryConfig := conf.Get().Log.Sentry
+			if sentryConfig == nil {
 				return
 			}
 
+			// Create a local variable to not mutate the original config object
+			backendDSN := sentryConfig.BackendDSN
+
+			// Fallback to default DSN if the backend DSN is not specified separately
+			if backendDSN == "" {
+				backendDSN = sentryConfig.Dsn
+			}
+
 			// An empty dsn value is ignored: not an error.
-			if err := initClient(conf.Get().Log.Sentry.Dsn); err != nil {
+			if err := initClient(backendDSN); err != nil {
 				log15.Error("sentry.initClient", "error", err)
 			}
 		})

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1049,6 +1049,8 @@ type SearchScope struct {
 
 // Sentry description: Configuration for Sentry
 type Sentry struct {
+	// BackendDSN description: Sentry Data Source Name (DSN) for backend errors. Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.
+	BackendDSN string `json:"backendDSN,omitempty"`
 	// Dsn description: Sentry Data Source Name (DSN). Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.
 	Dsn string `json:"dsn,omitempty"`
 }

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -656,6 +656,11 @@
               "description": "Sentry Data Source Name (DSN). Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.",
               "type": "string",
               "pattern": "^https?://"
+            },
+            "backendDSN": {
+              "description": "Sentry Data Source Name (DSN) for backend errors. Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.",
+              "type": "string",
+              "pattern": "^https?://"
             }
           }
         }

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -661,6 +661,11 @@ const SiteSchemaJSON = `{
               "description": "Sentry Data Source Name (DSN). Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.",
               "type": "string",
               "pattern": "^https?://"
+            },
+            "backendDSN": {
+              "description": "Sentry Data Source Name (DSN) for backend errors. Per the Sentry docs (https://docs.sentry.io/quickstart/#about-the-dsn), it should match the following pattern: '{PROTOCOL}://{PUBLIC_KEY}@{HOST}/{PATH}{PROJECT_ID}'.",
+              "type": "string",
+              "pattern": "^https?://"
             }
           }
         }


### PR DESCRIPTION
Adds a new site config option `"log": { "sentry": { "backendDSN": "<REDACTED>" } }` to set a separate Sentry DSN only for backend errors.

Part of #16109