### PR TITLE
Fail if trying to push to a repository via SSH

### DIFF
--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -535,10 +535,24 @@ func buildCommitOpts(repo *types.Repo, extSvc *types.ExternalService, spec *camp
 	return opts, nil
 }
 
+// ErrNoSSHPush is returned by buildPushConfig if the clone URL of the
+// repository uses the ssh:// scheme, which is currently not supported by campaigns.
+type ErrNoSSHPush struct{}
+
+func (e ErrNoSSHPush) Error() string {
+	return "campaigns currently do not support pushing commits via SSH, only HTTP(s) is supported right now"
+}
+
+func (e ErrNoSSHPush) NonRetryable() bool { return true }
+
 func buildPushConfig(extSvcType, cloneURL string, a auth.Authenticator) (*protocol.PushConfig, error) {
 	u, err := url.Parse(cloneURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing repository clone URL")
+	}
+
+	if u.Scheme == "ssh" {
+		return nil, ErrNoSSHPush{}
 	}
 
 	switch av := a.(type) {

--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -540,7 +540,7 @@ func buildCommitOpts(repo *types.Repo, extSvc *types.ExternalService, spec *camp
 type ErrNoSSHPush struct{}
 
 func (e ErrNoSSHPush) Error() string {
-	return "campaigns currently do not support pushing commits via SSH, only HTTP(s) is supported right now"
+	return "campaigns currently do not support pushing commits via SSH, only HTTP(s) is supported. See https://docs.sourcegraph.com/admin/repo/auth for information on which settings can cause SSH to be used."
 }
 
 func (e ErrNoSSHPush) NonRetryable() bool { return true }

--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -730,6 +730,9 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 	bbsRepo := bbsRepos[0]
 	bbsRepoCloneURL := bbsRepo.Sources[bbsExtSvc.URN()].CloneURL
 
+	bbsSSHRepos, _ := ct.CreateBbsSSHTestRepos(t, ctx, dbconn.Global, 1)
+	bbsSSHRepo := bbsSSHRepos[0]
+
 	gitClient := &ct.FakeGitserverClient{ResponseErr: nil}
 	fakeSource := &ct.FakeChangesetSource{Svc: extSvc}
 	sourcer := repos.NewFakeSourcer(nil, fakeSource)
@@ -813,6 +816,12 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			wantPushConfig: &gitprotocol.PushConfig{
 				RemoteURL: bbsRepoCloneURL,
 			},
+		},
+		{
+			name:    "ssh clone URL",
+			user:    admin,
+			repo:    bbsSSHRepo,
+			wantErr: true,
 		},
 	}
 


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/17050 by returning a (non-retryable) error to say that we don't support SSH support, _for now_, until https://github.com/sourcegraph/sourcegraph/issues/16888 is implemented.

Screenshot:

<img width="1152" alt="screenshot_2021-01-18_16 30 57@2x" src="https://user-images.githubusercontent.com/1185253/104938827-e7522000-59af-11eb-987a-c99470a5206e.png">
