### PR TITLE
Fix FilteredConnection input style

### DIFF
--- a/client/web/src/components/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection.scss
@@ -63,8 +63,4 @@
     &__show-more {
         flex: 0 0 auto;
     }
-
-    &__filter {
-        max-width: 30% !important;
-    }
 }

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -24,6 +24,7 @@ import { Form } from '../../../branded/src/components/Form'
 import { ErrorMessage } from './alerts'
 import { hasProperty } from '../../../shared/src/util/types'
 import { Scalars } from '../../../shared/src/graphql-operations'
+import classNames from 'classnames'
 
 /** Checks if the passed value satisfies the GraphQL Node interface */
 const hasID = (value: unknown): value is { id: Scalars['ID'] } =>
@@ -286,7 +287,7 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
             <>
                 {this.props.connectionQuery && summary}
                 {this.props.connection && this.props.connection.nodes.length > 0 && (
-                    <ListComponent className={`filtered-connection__nodes ${this.props.listClassName || ''}`}>
+                    <ListComponent className={classNames('filtered-connection__nodes', this.props.listClassName)}>
                         {HeadComponent && (
                             <HeadComponent
                                 nodes={this.props.connection.nodes}
@@ -301,9 +302,10 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
                 {!this.props.loading && !this.props.noShowMore && this.props.connection && hasNextPage && (
                     <button
                         type="button"
-                        className={`btn btn-secondary btn-sm filtered-connection__show-more ${
-                            this.props.showMoreClassName || ''
-                        }`}
+                        className={classNames(
+                            'btn btn-secondary btn-sm filtered-connection__show-more',
+                            this.props.showMoreClassName
+                        )}
                         onClick={this.onClickShowMore}
                     >
                         Show more
@@ -369,6 +371,9 @@ interface FilteredConnectionDisplayProps extends ConnectionDisplayProps {
 
     /** Called when a filter is selected and on initial render. */
     onValueSelect?: (filter: FilteredConnectionFilter, value: FilterValue) => void
+
+    /** CSS class name for the <input> element */
+    inputClassName?: string
 }
 
 /**
@@ -821,9 +826,11 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
         const compactnessClass = `filtered-connection--${this.props.compact ? 'compact' : 'noncompact'}`
         return (
             <div
-                className={`filtered-connection test-filtered-connection ${compactnessClass} ${
-                    this.props.className || ''
-                }`}
+                className={classNames(
+                    'filtered-connection test-filtered-connection',
+                    compactnessClass,
+                    this.props.className
+                )}
             >
                 {(!this.props.hideSearch || this.props.filters) && (
                     <Form
@@ -841,7 +848,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                         )}
                         {!this.props.hideSearch && (
                             <input
-                                className="form-control filtered-connection__filter"
+                                className={classNames('form-control', this.props.inputClassName)}
                                 type="search"
                                 placeholder={`Search ${this.props.pluralNoun}...`}
                                 name="query"

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -202,7 +202,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
             useURLQuery={true}
           >
             <div
-              className="filtered-connection test-filtered-connection filtered-connection--noncompact "
+              className="filtered-connection test-filtered-connection filtered-connection--noncompact"
             >
               <ConnectionNodes
                 connection={
@@ -499,7 +499,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                 query=""
               >
                 <ul
-                  className="filtered-connection__nodes "
+                  className="filtered-connection__nodes"
                 >
                   <CodeMonitorNode
                     authentictedUser={
@@ -1525,7 +1525,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
             useURLQuery={true}
           >
             <div
-              className="filtered-connection test-filtered-connection filtered-connection--noncompact "
+              className="filtered-connection test-filtered-connection filtered-connection--noncompact"
             >
               <ConnectionNodes
                 connection={
@@ -1640,7 +1640,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                 query=""
               >
                 <ul
-                  className="filtered-connection__nodes "
+                  className="filtered-connection__nodes"
                 >
                   <CodeMonitorNode
                     authentictedUser={
@@ -2106,7 +2106,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
             useURLQuery={true}
           >
             <div
-              className="filtered-connection test-filtered-connection filtered-connection--noncompact "
+              className="filtered-connection test-filtered-connection filtered-connection--noncompact"
             >
               <ConnectionNodes
                 connection={
@@ -2455,7 +2455,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                 query=""
               >
                 <ul
-                  className="filtered-connection__nodes "
+                  className="filtered-connection__nodes"
                 >
                   <CodeMonitorNode
                     authentictedUser={
@@ -3433,7 +3433,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   </small>
                 </p>
                 <button
-                  className="btn btn-secondary btn-sm filtered-connection__show-more "
+                  className="btn btn-secondary btn-sm filtered-connection__show-more"
                   onClick={[Function]}
                   type="button"
                 >

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
@@ -175,7 +175,7 @@ exports[`SiteAdminProductSubscriptionPage renders 1`] = `
     >
       
       <ul
-        className="filtered-connection__nodes "
+        className="filtered-connection__nodes"
       >
         <SiteAdminProductLicenseNode
           node={

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
@@ -70,6 +70,10 @@
             fill: var(--border-color-2);
         }
     }
+
+    &__filter-input {
+        max-width: 30% !important;
+    }
 }
 
 @keyframes shimmer {

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -158,6 +158,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 history={history}
                 location={location}
                 totalCountSummaryComponent={TotalCountSummary}
+                inputClassName="user-settings-repos__filter-input"
             />
         )
     }

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { PageTitle } from '../../../components/PageTitle'
 import { RepositoriesResult, SiteAdminRepositoryFields, UserRepositoriesResult } from '../../../graphql-operations'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
@@ -17,6 +17,8 @@ import { Link } from '../../../../../shared/src/components/Link'
 import { RepositoryNode } from './RepositoryNode'
 import AddIcon from 'mdi-react/AddIcon'
 import { ErrorLike } from '../../../../../shared/src/util/errors'
+import { useObservable } from '../../../../../shared/src/util/useObservable'
+import { map } from 'rxjs/operators'
 
 interface Props extends RouteComponentProps, TelemetryProps {
     userID: string
@@ -37,6 +39,8 @@ const Row: React.FunctionComponent<RowProps> = props => (
     />
 )
 
+const emptyFilters: FilteredConnectionFilter[] = []
+
 /**
  * A page displaying the repositories for this user.
  */
@@ -47,67 +51,65 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
     routingPrefix,
     telemetryService,
 }) => {
-    const emptyFilters: FilteredConnectionFilter[] = []
-    const [state, setState] = useState({ filters: emptyFilters, fetched: false })
     const [hasRepos, setHasRepos] = useState(false)
 
-    if (!state.fetched) {
-        queryExternalServices({ namespace: userID, first: null, after: null })
-            .toPromise()
-            .then(result => {
-                const services: FilterValue[] = [
-                    {
-                        value: 'all',
-                        label: 'All',
-                        args: {},
-                    },
-                ]
-                result.nodes.map(node => {
-                    services.push({
-                        value: node.id,
-                        label: node.displayName,
-                        tooltip: '',
-                        args: { externalServiceID: node.id },
-                    })
-                })
-                const newFilters: FilteredConnectionFilter[] = [
-                    {
-                        label: 'Status',
-                        type: 'select',
-                        id: 'status',
-                        tooltip: 'Repository status',
-                        values: [
-                            {
-                                value: 'all',
-                                label: 'All',
-                                args: {},
-                            },
-                            {
-                                value: 'cloned',
-                                label: 'Cloned',
-                                args: { cloned: true, notCloned: false },
-                            },
-                            {
-                                value: 'not-cloned',
-                                label: 'Not Cloned',
-                                args: { cloned: false, notCloned: true },
-                            },
-                        ],
-                    },
-                    {
-                        label: 'Code host',
-                        type: 'select',
-                        id: 'code-host',
-                        tooltip: 'Code host',
-                        values: services,
-                    },
-                ]
-                setState({ filters: newFilters, fetched: true })
-            })
-            .catch(error => {
-                console.log('ERROR', error)
-            })
-    }
+    const filters =
+        useObservable<FilteredConnectionFilter[]>(
+            useMemo(
+                () =>
+                    queryExternalServices({ namespace: userID, first: null, after: null }).pipe(
+                        map(result => {
+                            const services: FilterValue[] = [
+                                {
+                                    value: 'all',
+                                    label: 'All',
+                                    args: {},
+                                },
+                                ...result.nodes.map(node => ({
+                                    value: node.id,
+                                    label: node.displayName,
+                                    tooltip: '',
+                                    args: { externalServiceID: node.id },
+                                })),
+                            ]
+
+                            return [
+                                {
+                                    label: 'Status',
+                                    type: 'select',
+                                    id: 'status',
+                                    tooltip: 'Repository status',
+                                    values: [
+                                        {
+                                            value: 'all',
+                                            label: 'All',
+                                            args: {},
+                                        },
+                                        {
+                                            value: 'cloned',
+                                            label: 'Cloned',
+                                            args: { cloned: true, notCloned: false },
+                                        },
+                                        {
+                                            value: 'not-cloned',
+                                            label: 'Not Cloned',
+                                            args: { cloned: false, notCloned: true },
+                                        },
+                                    ],
+                                },
+                                {
+                                    label: 'Code host',
+                                    type: 'select',
+                                    id: 'code-host',
+                                    tooltip: 'Code host',
+                                    values: services,
+                                },
+                            ]
+                        })
+                    ),
+                [userID]
+            )
+        ) || emptyFilters
 
     const queryRepositories = useCallback(
         (args: FilteredConnectionQueryArguments): Observable<RepositoriesResult['repositories']> =>
@@ -129,7 +131,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
     }, [telemetryService])
 
     let body: JSX.Element
-    if (state.filters[1] && state.filters[1].values.length === 1) {
+    if (filters[1] && filters[1].values.length === 1) {
         body = (
             <div className="card p-3 m-2">
                 <h3 className="mb-1">You have not added any repositories to Sourcegraph</h3>
@@ -154,7 +156,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 listComponent="table"
                 listClassName="w-100"
                 onUpdate={updated}
-                filters={state.filters}
+                filters={filters}
                 history={history}
                 location={location}
                 totalCountSummaryComponent={TotalCountSummary}
@@ -168,7 +170,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
             <PageTitle title="Repositories" />
             <div className="d-flex justify-content-between align-items-center">
                 <h2 className="mb-2">Repositories</h2>
-                {state.filters[1] && state.filters[1].values.length !== 1 && (
+                {filters[1] && filters[1].values.length !== 1 && (
                     <Link
                         className="btn btn-primary test-goto-add-external-service-page"
                         to={`${routingPrefix}/repositories/manage`}


### PR DESCRIPTION
Fix #16268.

- Add `inputClassName` prop to `FilteredConnection` and remove current max-width 30%, which was only necessary for #16194
- Use `useObservable` for data fetching in `UserSettingsRepositoriesPage`. This ensures that we don't fetch once for each render until the Promise is fulfilled and sets `fetched` state to `true`. [`useObservable` also takes care of cancellation and error handling](https://sourcegraph.com/gitlab.com/sourcegraph/sourcegraph/-/blob/client/shared/src/util/useObservable.ts#L16-40) 

#### After fix 

![Screenshot from 2021-01-18 14-14-49](https://user-images.githubusercontent.com/37420160/104956012-3fc9f300-5999-11eb-8ca9-5dba6a4d5358.png)

![Screenshot from 2021-01-18 14-15-02](https://user-images.githubusercontent.com/37420160/104955998-3b053f00-5999-11eb-8539-0d3d788eae44.png)
