### PR TITLE
Set domain attribute for anonymous user ID cookie

### DIFF
--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -84,7 +84,7 @@ export class EventLogger implements TelemetryService {
             sameSite: 'Strict',
             // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
             // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
-            domain: 'sourcegraph.com',
+            domain: location.hostname,
         })
         localStorage.removeItem(ANONYMOUS_USER_ID_KEY)
         this.anonymousUserId = anonymousUserId

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -82,6 +82,9 @@ export class EventLogger implements TelemetryService {
             secure: true,
             // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
             sameSite: 'Strict',
+            // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
+            domain: 'sourcegraph.com',
         })
         localStorage.removeItem(ANONYMOUS_USER_ID_KEY)
         this.anonymousUserId = anonymousUserId


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/17396.

The anonymous user ID cookie (implemented in https://github.com/sourcegraph/sourcegraph/pull/15912) was not appearing on about.sourcegraph.com. Initially thought it may be because we didn't have a leading `.` in the domain attribute, but it turns out that no longer matters (see https://stackoverflow.com/questions/18492576/share-cookie-between-subdomain-and-domain). 

We actually need to explicitly specify the `Domain` attribute, though, to share the cookies with subdomains. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent. This PR adds the `Domain` attribute.

I haven't tested this because I don't know how to locally. What's the best way to do it? cc @sourcegraph/web 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
