### PR TITLE
Fix links to 404 page

### DIFF
--- a/client/shared/src/components/BadgeAttachment.test.tsx
+++ b/client/shared/src/components/BadgeAttachment.test.tsx
@@ -11,7 +11,7 @@ export const base64ImageBadge: Omit<BadgeAttachmentRenderOptions, 'kind'> = {
     light: { icon: base64icon },
     hoverMessage:
         'Search-based results - click to see how these results are calculated and how to get precise intelligence with LSIF.',
-    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence',
+    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/search_based_code_intelligence',
 }
 
 export const badgeWithKind: BadgeAttachmentRenderOptions = {

--- a/client/shared/src/components/__snapshots__/BadgeAttachment.test.tsx.snap
+++ b/client/shared/src/components/__snapshots__/BadgeAttachment.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`BadgeAttachment renders an img element with a base64 icon 1`] = `
     class=""
     data-placement="left"
     data-tooltip="Search-based results - click to see how these results are calculated and how to get precise intelligence with LSIF."
-    href="https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence"
+    href="https://docs.sourcegraph.com/code_intelligence/explanations/search_based_code_intelligence"
     rel="noreferrer noopener"
     target="_blank"
   >
@@ -23,7 +23,7 @@ exports[`BadgeAttachment renders an svg element with a predefined icon 1`] = `
     class=""
     data-placement="left"
     data-tooltip="Search-based results - click to see how these results are calculated and how to get precise intelligence with LSIF."
-    href="https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence"
+    href="https://docs.sourcegraph.com/code_intelligence/explanations/search_based_code_intelligence"
     rel="noreferrer noopener"
     target="_blank"
   >

--- a/client/shared/src/hover/HoverOverlay.story.tsx
+++ b/client/shared/src/hover/HoverOverlay.story.tsx
@@ -58,7 +58,7 @@ const FIXTURE_BADGE: BadgeAttachmentRenderOptions = {
     kind: 'info',
     hoverMessage:
         'Search-based results - click to see how these results are calculated and how to get precise intelligence with LSIF.',
-    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence',
+    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/search_based_code_intelligence',
 }
 
 const LEGACY_FIXTURE_BADGE = {
@@ -70,7 +70,7 @@ const LEGACY_FIXTURE_BADGE = {
     },
     hoverMessage:
         'Search-based results - click to see how these results are calculated and how to get precise intelligence with LSIF.',
-    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/basic_code_intelligence',
+    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/search_based_code_intelligence',
 } as BadgeAttachmentRenderOptions
 
 const FIXTURE_CONTENT: Badged<MarkupContent> = {

--- a/doc/dev/background-information/codeintel/extensions.md
+++ b/doc/dev/background-information/codeintel/extensions.md
@@ -4,7 +4,7 @@ Definition, reference, and hover providers are invoked from the extension host w
 
 These providers receive the current text document (denoting a repository, commit, and path) and the position the user is hovering (a line and column offset within the file). The providers return results as an asynchronous iterator, which allows additional results to be streamed into the UI as they are received from the backend.
 
-Code intelligence queries are resolved favoring [precise](http://localhost:5080/code_intelligence/explanations/precise_code_intelligence) code intelligence, if available, then falling back to [search-based](http://localhost:5080/code_intelligence/explanations/basic_code_intelligence).
+Code intelligence queries are resolved favoring [precise](http://localhost:5080/code_intelligence/explanations/precise_code_intelligence) code intelligence, if available, then falling back to [search-based](http://localhost:5080/code_intelligence/explanations/search_based_code_intelligence).
 
 ## Definitions
 


### PR DESCRIPTION
Previously, Sourcegraph linked to a non-existent page on "basic code
intelligence" when hovering over a tooltip about code intel. Now, the
link points to the page on "search-based code intelligence".

Identical to #17366 except this PR does not come from my personal fork.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
