### PR TITLE
search: instant send for first streaming result

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -81,6 +81,8 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	flushTicker := time.NewTicker(100 * time.Millisecond)
 	defer flushTicker.Stop()
 
+	first := true
+
 	for {
 		var results []graphqlbackend.SearchResultResolver
 		var ok bool
@@ -127,6 +129,12 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if len(matchesBuf) == cap(matchesBuf) {
 				flushMatchesBuf()
 			}
+		}
+
+		// Instantly send results if we have not sent any yet.
+		if first && len(matchesBuf) > 0 {
+			first = false
+			flushMatchesBuf()
 		}
 	}
 


### PR DESCRIPTION
Currently the fastest response we will have is 100ms due to the flush
ticker. However, we can avoid buffering in the case of the first results
to improve time to first result.

Co-authored-by: @stefanhengl 