### PR TITLE
search: introduce SearchEvent

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -261,6 +261,14 @@ type searchResolver struct {
 	searcherURLs *endpoint.Map
 }
 
+// SearchEvent is an event on a search stream. It contains fields which can be
+// aggregated up into a final result.
+type SearchEvent struct {
+	Results []SearchResultResolver
+	Stats   streaming.Stats
+	Error   error
+}
+
 // SetResultChannel will send all results down c.
 //
 // This is how our streaming and our batch interface co-exist. When this is


### PR DESCRIPTION
This is the likely shape for search events in streaming. We want to use
this all over our stack. Introducing in its own commit to make it easier
to work on.

In the future we will extract this out of graphqlbackend once we can
detach streaming from needing SearchResultResolver.

Co-authored-by: @stefanhengl 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
