### PR TITLE
Remove container restart alerts

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1181,35 +1181,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## frontend: container_restarts
-
-<p class="subtitle">container restarts (cloud)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> frontend: 1+ container restarts
-- <span class="badge badge-critical">critical</span> frontend: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod (frontend|sourcegraph-frontend)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p (frontend|sourcegraph-frontend)`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' (frontend|sourcegraph-frontend)` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs (frontend|sourcegraph-frontend)` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#frontend-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_frontend_container_restarts",
-  "critical_frontend_container_restarts"
-]
-```
-
-<br />
-
 ## frontend: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
@@ -1524,33 +1495,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## gitserver: container_restarts
-
-<p class="subtitle">container restarts (cloud)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> gitserver: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod gitserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p gitserver`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' gitserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the gitserver container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs gitserver` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#gitserver-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_gitserver_container_restarts"
-]
-```
-
-<br />
-
 ## gitserver: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
@@ -1717,35 +1661,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```json
 "observability.silenceAlerts": [
   "warning_github-proxy_container_memory_usage"
-]
-```
-
-<br />
-
-## github-proxy: container_restarts
-
-<p class="subtitle">container restarts (cloud)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> github-proxy: 1+ container restarts
-- <span class="badge badge-critical">critical</span> github-proxy: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod github-proxy` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p github-proxy`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' github-proxy` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the github-proxy container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs github-proxy` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#github-proxy-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_github-proxy_container_restarts",
-  "critical_github-proxy_container_restarts"
 ]
 ```
 
@@ -2446,35 +2361,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
-## precise-code-intel-worker: container_restarts
-
-<p class="subtitle">container restarts (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> precise-code-intel-worker: 1+ container restarts
-- <span class="badge badge-critical">critical</span> precise-code-intel-worker: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#precise-code-intel-worker-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_precise-code-intel-worker_container_restarts",
-  "critical_precise-code-intel-worker_container_restarts"
-]
-```
-
-<br />
-
 ## precise-code-intel-worker: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (code-intel)</p>
@@ -2690,35 +2576,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ```json
 "observability.silenceAlerts": [
   "warning_query-runner_container_cpu_usage"
-]
-```
-
-<br />
-
-## query-runner: container_restarts
-
-<p class="subtitle">container restarts (search)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> query-runner: 1+ container restarts
-- <span class="badge badge-critical">critical</span> query-runner: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod query-runner` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p query-runner`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' query-runner` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the query-runner container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs query-runner` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#query-runner-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_query-runner_container_restarts",
-  "critical_query-runner_container_restarts"
 ]
 ```
 
@@ -3569,35 +3426,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
-## repo-updater: container_restarts
-
-<p class="subtitle">container restarts (cloud)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> repo-updater: 1+ container restarts
-- <span class="badge badge-critical">critical</span> repo-updater: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod repo-updater` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p repo-updater`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' repo-updater` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the repo-updater container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs repo-updater` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#repo-updater-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_repo-updater_container_restarts",
-  "critical_repo-updater_container_restarts"
-]
-```
-
-<br />
-
 ## repo-updater: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
@@ -3853,35 +3681,6 @@ with your code hosts connections or networking issues affecting communication wi
 ```json
 "observability.silenceAlerts": [
   "warning_searcher_container_memory_usage"
-]
-```
-
-<br />
-
-## searcher: container_restarts
-
-<p class="subtitle">container restarts (search)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> searcher: 1+ container restarts
-- <span class="badge badge-critical">critical</span> searcher: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod searcher` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p searcher`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' searcher` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the searcher container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs searcher` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#searcher-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_searcher_container_restarts",
-  "critical_searcher_container_restarts"
 ]
 ```
 
@@ -4147,35 +3946,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
-## symbols: container_restarts
-
-<p class="subtitle">container restarts (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> symbols: 1+ container restarts
-- <span class="badge badge-critical">critical</span> symbols: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod symbols` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p symbols`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' symbols` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the symbols container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs symbols` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#symbols-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_symbols_container_restarts",
-  "critical_symbols_container_restarts"
-]
-```
-
-<br />
-
 ## symbols: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (code-intel)</p>
@@ -4369,35 +4139,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
-## syntect-server: container_restarts
-
-<p class="subtitle">container restarts (cloud)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> syntect-server: 1+ container restarts
-- <span class="badge badge-critical">critical</span> syntect-server: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod syntect-server` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p syntect-server`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' syntect-server` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the syntect-server container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs syntect-server` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#syntect-server-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_syntect-server_container_restarts",
-  "critical_syntect-server_container_restarts"
-]
-```
-
-<br />
-
 ## syntect-server: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
@@ -4572,33 +4313,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
-## zoekt-indexserver: container_restarts
-
-<p class="subtitle">container restarts (search)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> zoekt-indexserver: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-indexserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-indexserver`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-indexserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-indexserver container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-indexserver` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#zoekt-indexserver-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_zoekt-indexserver_container_restarts"
-]
-```
-
-<br />
-
 ## zoekt-indexserver: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (search)</p>
@@ -4766,33 +4480,6 @@ with your code hosts connections or networking issues affecting communication wi
 ```json
 "observability.silenceAlerts": [
   "warning_zoekt-webserver_container_memory_usage"
-]
-```
-
-<br />
-
-## zoekt-webserver: container_restarts
-
-<p class="subtitle">container restarts (search)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> zoekt-webserver: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-webserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-webserver`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-webserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-webserver container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-webserver` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#zoekt-webserver-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_zoekt-webserver_container_restarts"
 ]
 ```
 
@@ -5081,35 +4768,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 <br />
 
-## prometheus: container_restarts
-
-<p class="subtitle">container restarts (distribution)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> prometheus: 1+ container restarts
-- <span class="badge badge-critical">critical</span> prometheus: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod prometheus` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p prometheus`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' prometheus` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the prometheus container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs prometheus` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#prometheus-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_prometheus_container_restarts",
-  "critical_prometheus_container_restarts"
-]
-```
-
-<br />
-
 ## prometheus: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (distribution)</p>
@@ -5384,35 +5042,6 @@ with your code hosts connections or networking issues affecting communication wi
 ```json
 "observability.silenceAlerts": [
   "warning_executor-queue_container_memory_usage"
-]
-```
-
-<br />
-
-## executor-queue: container_restarts
-
-<p class="subtitle">container restarts (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> executor-queue: 1+ container restarts
-- <span class="badge badge-critical">critical</span> executor-queue: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod executor-queue` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p executor-queue`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' executor-queue` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the executor-queue container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs executor-queue` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#executor-queue-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_executor-queue_container_restarts",
-  "critical_executor-queue_container_restarts"
 ]
 ```
 
@@ -5726,35 +5355,6 @@ with your code hosts connections or networking issues affecting communication wi
 ```json
 "observability.silenceAlerts": [
   "warning_precise-code-intel-indexer_container_memory_usage"
-]
-```
-
-<br />
-
-## precise-code-intel-indexer: container_restarts
-
-<p class="subtitle">container restarts (code-intel)</p>
-
-**Descriptions:**
-
-- <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 1+ container restarts
-- <span class="badge badge-critical">critical</span> precise-code-intel-indexer: 1+ container restarts for 10m0s
-
-**Possible solutions:**
-
-- **Kubernetes:**
-	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
-- **Docker Compose:**
-	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
-	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
-- **Refer to the [dashboards reference](./dashboards.md#precise-code-intel-indexer-container-restarts)** for more help interpreting this alert and metric.
-- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
-
-```json
-"observability.silenceAlerts": [
-  "warning_precise-code-intel-indexer_container_restarts",
-  "critical_precise-code-intel-indexer_container_restarts"
 ]
 ```
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -518,7 +518,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-container
 This cloud panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod (frontend|sourcegraph-frontend)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -678,7 +678,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-containe
 This cloud panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod gitserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -803,7 +803,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-conta
 This cloud panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod github-proxy` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -1143,7 +1143,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 This code-intel panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -1254,7 +1254,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-conta
 This search panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod query-runner` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -1623,7 +1623,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-conta
 This cloud panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod repo-updater` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -1750,7 +1750,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-container
 This search panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod searcher` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -1877,7 +1877,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-
 This code-intel panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod symbols` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -2008,7 +2008,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-con
 This cloud panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod syntect-server` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -2099,7 +2099,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 This search panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-indexserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -2200,7 +2200,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-co
 This search panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-webserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -2352,7 +2352,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-contain
 This distribution panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod prometheus` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -2503,7 +2503,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-con
 This code-intel panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod executor-queue` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
@@ -2695,7 +2695,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 This code-intel panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
-value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 - **Kubernetes:**
 	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -513,13 +513,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-container
 
 <br />
 
-#### frontend: container_restarts
+#### frontend: container_missing
 
-This cloud panel indicates container restarts.
+This cloud panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod (frontend|sourcegraph-frontend)` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p (frontend|sourcegraph-frontend)`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' (frontend|sourcegraph-frontend)` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs (frontend|sourcegraph-frontend)` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -666,13 +673,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-containe
 
 <br />
 
-#### gitserver: container_restarts
+#### gitserver: container_missing
 
-This cloud panel indicates container restarts.
+This cloud panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod gitserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p gitserver`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' gitserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the gitserver container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs gitserver` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -784,13 +798,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-conta
 
 <br />
 
-#### github-proxy: container_restarts
+#### github-proxy: container_missing
 
-This cloud panel indicates container restarts.
+This cloud panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod github-proxy` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p github-proxy`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' github-proxy` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the github-proxy container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs github-proxy` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -1117,13 +1138,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 <br />
 
-#### precise-code-intel-worker: container_restarts
+#### precise-code-intel-worker: container_missing
 
-This code-intel panel indicates container restarts.
+This code-intel panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -1221,13 +1249,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-conta
 
 <br />
 
-#### query-runner: container_restarts
+#### query-runner: container_missing
 
-This search panel indicates container restarts.
+This search panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod query-runner` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p query-runner`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' query-runner` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the query-runner container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs query-runner` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -1583,13 +1618,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-conta
 
 <br />
 
-#### repo-updater: container_restarts
+#### repo-updater: container_missing
 
-This cloud panel indicates container restarts.
+This cloud panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod repo-updater` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p repo-updater`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' repo-updater` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the repo-updater container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs repo-updater` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -1703,13 +1745,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-container
 
 <br />
 
-#### searcher: container_restarts
+#### searcher: container_missing
 
-This search panel indicates container restarts.
+This search panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod searcher` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p searcher`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' searcher` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the searcher container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs searcher` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -1823,13 +1872,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-
 
 <br />
 
-#### symbols: container_restarts
+#### symbols: container_missing
 
-This code-intel panel indicates container restarts.
+This code-intel panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod symbols` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p symbols`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' symbols` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the symbols container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs symbols` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -1947,13 +2003,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-con
 
 <br />
 
-#### syntect-server: container_restarts
+#### syntect-server: container_missing
 
-This cloud panel indicates container restarts.
+This cloud panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod syntect-server` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p syntect-server`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' syntect-server` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the syntect-server container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs syntect-server` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -2031,13 +2094,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 <br />
 
-#### zoekt-indexserver: container_restarts
+#### zoekt-indexserver: container_missing
 
-This search panel indicates container restarts.
+This search panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-indexserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-indexserver`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-indexserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-indexserver container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-indexserver` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -2125,13 +2195,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-co
 
 <br />
 
-#### zoekt-webserver: container_restarts
+#### zoekt-webserver: container_missing
 
-This search panel indicates container restarts.
+This search panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod zoekt-webserver` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p zoekt-webserver`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-webserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-webserver container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-webserver` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -2270,13 +2347,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-contain
 
 <br />
 
-#### prometheus: container_restarts
+#### prometheus: container_missing
 
-This distribution panel indicates container restarts.
+This distribution panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod prometheus` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p prometheus`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' prometheus` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the prometheus container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs prometheus` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -2414,13 +2498,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-con
 
 <br />
 
-#### executor-queue: container_restarts
+#### executor-queue: container_missing
 
-This code-intel panel indicates container restarts.
+This code-intel panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod executor-queue` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p executor-queue`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' executor-queue` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the executor-queue container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs executor-queue` (note this will include logs from the previous and currently running container).
+
 
 <br />
 
@@ -2599,13 +2690,20 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 <br />
 
-#### precise-code-intel-indexer: container_restarts
+#### precise-code-intel-indexer: container_missing
 
-This code-intel panel indicates container restarts.
+This code-intel panel indicates container missing.
 
-This value is based on the number of times a container has not been seen in one minute.
+This value is the number of times a container has not been seen for more than one minute. If you observe this
+value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-restarts) for relevant alerts.
+- **Kubernetes:**
+	- Determine if the pod was OOM killed using `kubectl describe pod precise-code-intel-worker` (look for `OOMKilled: true`) and, if so, consider increasing the memory limit in the relevant `Deployment.yaml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `kubectl logs -p precise-code-intel-worker`.
+- **Docker Compose:**
+	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
+	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
+
 
 <br />
 

--- a/monitoring/definitions/executor_queue.go
+++ b/monitoring/definitions/executor_queue.go
@@ -108,7 +108,7 @@ func ExecutorQueue() *monitoring.Container {
 						shared.ContainerMemoryUsage("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 					{
-						shared.ContainerRestarts("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
+						shared.ContainerMissing("executor-queue", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -728,7 +728,7 @@ func Frontend() *monitoring.Container {
 						shared.ContainerMemoryUsage(containerName, monitoring.ObservableOwnerCloud).Observable(),
 					},
 					{
-						shared.ContainerRestarts(containerName, monitoring.ObservableOwnerCloud).Observable(),
+						shared.ContainerMissing(containerName, monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -103,14 +103,7 @@ func GitServer() *monitoring.Container {
 						shared.ContainerMemoryUsage("gitserver", monitoring.ObservableOwnerCloud).Observable(),
 					},
 					{
-						// git server does not have 0-downtime deploy, so deploys can
-						// cause extended container restarts. still seta warning alert for
-						// extended periods of container restarts, since this might still
-						// indicate a problem.
-						shared.ContainerMissing("gitserver", monitoring.ObservableOwnerCloud).
-							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
-							WithCritical(nil).
-							Observable(),
+						shared.ContainerMissing("gitserver", monitoring.ObservableOwnerCloud).Observable(),
 						shared.ContainerIOUsage("gitserver", monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},

--- a/monitoring/definitions/git_server.go
+++ b/monitoring/definitions/git_server.go
@@ -107,7 +107,7 @@ func GitServer() *monitoring.Container {
 						// cause extended container restarts. still seta warning alert for
 						// extended periods of container restarts, since this might still
 						// indicate a problem.
-						shared.ContainerRestarts("gitserver", monitoring.ObservableOwnerCloud).
+						shared.ContainerMissing("gitserver", monitoring.ObservableOwnerCloud).
 							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
 							WithCritical(nil).
 							Observable(),

--- a/monitoring/definitions/github_proxy.go
+++ b/monitoring/definitions/github_proxy.go
@@ -40,7 +40,7 @@ func GitHubProxy() *monitoring.Container {
 						shared.ContainerMemoryUsage("github-proxy", monitoring.ObservableOwnerCloud).Observable(),
 					},
 					{
-						shared.ContainerRestarts("github-proxy", monitoring.ObservableOwnerCloud).Observable(),
+						shared.ContainerMissing("github-proxy", monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/precise_code_intel_indexer.go
+++ b/monitoring/definitions/precise_code_intel_indexer.go
@@ -144,7 +144,7 @@ func PreciseCodeIntelIndexer() *monitoring.Container {
 						shared.ContainerMemoryUsage("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 					{
-						shared.ContainerRestarts("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
+						shared.ContainerMissing("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/precise_code_intel_worker.go
+++ b/monitoring/definitions/precise_code_intel_worker.go
@@ -204,7 +204,7 @@ func PreciseCodeIntelWorker() *monitoring.Container {
 						shared.ContainerMemoryUsage("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 					{
-						shared.ContainerRestarts("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
+						shared.ContainerMissing("precise-code-intel-worker", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/prometheus.go
+++ b/monitoring/definitions/prometheus.go
@@ -118,7 +118,7 @@ func Prometheus() *monitoring.Container {
 						shared.ContainerMemoryUsage("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
 					},
 					{
-						shared.ContainerRestarts("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
+						shared.ContainerMissing("prometheus", monitoring.ObservableOwnerDistribution).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/query_runner.go
+++ b/monitoring/definitions/query_runner.go
@@ -28,7 +28,7 @@ func QueryRunner() *monitoring.Container {
 						shared.ContainerCPUUsage("query-runner", monitoring.ObservableOwnerSearch).Observable(),
 					},
 					{
-						shared.ContainerRestarts("query-runner", monitoring.ObservableOwnerSearch).Observable(),
+						shared.ContainerMissing("query-runner", monitoring.ObservableOwnerSearch).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/repo_updater.go
+++ b/monitoring/definitions/repo_updater.go
@@ -400,7 +400,7 @@ func RepoUpdater() *monitoring.Container {
 							Observable(),
 					},
 					{
-						shared.ContainerRestarts("repo-updater", monitoring.ObservableOwnerCloud).Observable(),
+						shared.ContainerMissing("repo-updater", monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/searcher.go
+++ b/monitoring/definitions/searcher.go
@@ -48,7 +48,7 @@ func Searcher() *monitoring.Container {
 						shared.ContainerMemoryUsage("searcher", monitoring.ObservableOwnerSearch).Observable(),
 					},
 					{
-						shared.ContainerRestarts("searcher", monitoring.ObservableOwnerSearch).Observable(),
+						shared.ContainerMissing("searcher", monitoring.ObservableOwnerSearch).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/shared/container.go
+++ b/monitoring/definitions/shared/container.go
@@ -28,7 +28,7 @@ var (
 			Owner:   owner,
 			Interpretation: strings.Replace(`
 				This value is the number of times a container has not been seen for more than one minute. If you observe this
-				value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+				value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
 				- **Kubernetes:**
 					- Determine if the pod was OOM killed using 'kubectl describe pod {{CONTAINER_NAME}}' (look for 'OOMKilled: true') and, if so, consider increasing the memory limit in the relevant 'Deployment.yaml'.

--- a/monitoring/definitions/shared/container.go
+++ b/monitoring/definitions/shared/container.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -18,18 +17,19 @@ import (
 const TitleContainerMonitoring = "Container monitoring (not available on server)"
 
 var (
-	ContainerRestarts sharedObservable = func(containerName string, owner monitoring.ObservableOwner) Observable {
+	ContainerMissing sharedObservable = func(containerName string, owner monitoring.ObservableOwner) Observable {
 		return Observable{
-			Name:        "container_restarts",
-			Description: "container restarts",
+			Name:        "container_missing",
+			Description: "container missing",
 			// inspired by https://awesome-prometheus-alerts.grep.to/rules#docker-containers
-			Query:          fmt.Sprintf(`count by(name) ((time() - container_last_seen{%s}) > 60)`, CadvisorNameMatcher(containerName)),
-			Warning:        monitoring.Alert().GreaterOrEqual(1),
-			Critical:       monitoring.Alert().GreaterOrEqual(1).For(10 * time.Minute),
-			Panel:          monitoring.Panel().LegendFormat("{{name}}"),
-			Owner:          owner,
-			Interpretation: "This value is based on the number of times a container has not been seen in one minute.",
-			PossibleSolutions: strings.Replace(`
+			Query:   fmt.Sprintf(`count by(name) ((time() - container_last_seen{%s}) > 60)`, CadvisorNameMatcher(containerName)),
+			NoAlert: true,
+			Panel:   monitoring.Panel().LegendFormat("{{name}}"),
+			Owner:   owner,
+			Interpretation: strings.Replace(`
+				This value is the number of times a container has not been seen for more than one minute. If you observe this
+				value change outside of those situations, it could indicate pods are beeing OOM killed or terminated for some other reasons.
+
 				- **Kubernetes:**
 					- Determine if the pod was OOM killed using 'kubectl describe pod {{CONTAINER_NAME}}' (look for 'OOMKilled: true') and, if so, consider increasing the memory limit in the relevant 'Deployment.yaml'.
 					- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'kubectl logs -p {{CONTAINER_NAME}}'.

--- a/monitoring/definitions/shared/shared.go
+++ b/monitoring/definitions/shared/shared.go
@@ -38,12 +38,18 @@ func (o Observable) Observable() monitoring.Observable { return monitoring.Obser
 // WithWarning overrides this Observable's warning-level alert with the given alert.
 func (o Observable) WithWarning(a *monitoring.ObservableAlertDefinition) Observable {
 	o.Warning = a
+	if a != nil {
+		o.NoAlert = false
+	}
 	return o
 }
 
 // WithCritical overrides this Observable's critical-level alert with the given alert.
 func (o Observable) WithCritical(a *monitoring.ObservableAlertDefinition) Observable {
 	o.Critical = a
+	if a != nil {
+		o.NoAlert = false
+	}
 	return o
 }
 

--- a/monitoring/definitions/symbols.go
+++ b/monitoring/definitions/symbols.go
@@ -48,7 +48,7 @@ func Symbols() *monitoring.Container {
 						shared.ContainerMemoryUsage("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 					{
-						shared.ContainerRestarts("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
+						shared.ContainerMissing("symbols", monitoring.ObservableOwnerCodeIntel).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/syntect_server.go
+++ b/monitoring/definitions/syntect_server.go
@@ -65,7 +65,7 @@ func SyntectServer() *monitoring.Container {
 						shared.ContainerMemoryUsage("syntect-server", monitoring.ObservableOwnerCloud).Observable(),
 					},
 					{
-						shared.ContainerRestarts("syntect-server", monitoring.ObservableOwnerCloud).Observable(),
+						shared.ContainerMissing("syntect-server", monitoring.ObservableOwnerCloud).Observable(),
 					},
 				},
 			},

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -1,8 +1,6 @@
 package definitions
 
 import (
-	"time"
-
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -39,14 +37,7 @@ func ZoektIndexServer() *monitoring.Container {
 						shared.ContainerMemoryUsage("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
 					},
 					{
-						// indexed-search does not have 0-downtime deploy, so deploys can
-						// cause extended container restarts. still seta warning alert for
-						// extended periods of container restarts, since this might still
-						// indicate a problem.
-						shared.ContainerMissing("zoekt-indexserver", monitoring.ObservableOwnerSearch).
-							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
-							WithCritical(nil).
-							Observable(),
+						shared.ContainerMissing("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
 						shared.ContainerIOUsage("zoekt-indexserver", monitoring.ObservableOwnerSearch).Observable(),
 					},
 				},

--- a/monitoring/definitions/zoekt_index_server.go
+++ b/monitoring/definitions/zoekt_index_server.go
@@ -43,7 +43,7 @@ func ZoektIndexServer() *monitoring.Container {
 						// cause extended container restarts. still seta warning alert for
 						// extended periods of container restarts, since this might still
 						// indicate a problem.
-						shared.ContainerRestarts("zoekt-indexserver", monitoring.ObservableOwnerSearch).
+						shared.ContainerMissing("zoekt-indexserver", monitoring.ObservableOwnerSearch).
 							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
 							WithCritical(nil).
 							Observable(),

--- a/monitoring/definitions/zoekt_web_server.go
+++ b/monitoring/definitions/zoekt_web_server.go
@@ -42,7 +42,7 @@ func ZoektWebServer() *monitoring.Container {
 						// cause extended container restarts. still seta warning alert for
 						// extended periods of container restarts, since this might still
 						// indicate a problem.
-						shared.ContainerRestarts("zoekt-webserver", monitoring.ObservableOwnerSearch).
+						shared.ContainerMissing("zoekt-webserver", monitoring.ObservableOwnerSearch).
 							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
 							WithCritical(nil).
 							Observable(),

--- a/monitoring/definitions/zoekt_web_server.go
+++ b/monitoring/definitions/zoekt_web_server.go
@@ -42,10 +42,7 @@ func ZoektWebServer() *monitoring.Container {
 						// cause extended container restarts. still seta warning alert for
 						// extended periods of container restarts, since this might still
 						// indicate a problem.
-						shared.ContainerMissing("zoekt-webserver", monitoring.ObservableOwnerSearch).
-							WithWarning(monitoring.Alert().Greater(1).For(10 * time.Minute)).
-							WithCritical(nil).
-							Observable(),
+						shared.ContainerMissing("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
 						shared.ContainerIOUsage("zoekt-webserver", monitoring.ObservableOwnerSearch).Observable(),
 					},
 				},

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -550,7 +550,7 @@ func (o Observable) validate() error {
 		if allAlertsEmpty && !o.NoAlert {
 			return fmt.Errorf("Warning or Critical must be set or explicitly disable alerts with NoAlert")
 		} else if !allAlertsEmpty && o.NoAlert {
-			return fmt.Errorf("No Warning or Critical alert is set, but NoAlert is also true")
+			return fmt.Errorf("An alert is set, but NoAlert is also true")
 		}
 		// PossibleSolutions if there are no alerts is redundant and likely an error
 		if o.PossibleSolutions != "" {


### PR DESCRIPTION
I tried to find alternatives, but I cant find any that fit both compose and Kubernetes. We might have to make do with some alerts only being available on advanced systems like Kubernetes, definitions for both, or a combination of those things.
Any alert that does not know about deployments and/or desired replica count was not accurate enough to avoid alerts during deployments. While the metric itself is accurate, a container has not reported for X amount of time, we cant identify if that is an OOM/panic or a container has been gracefully stopped for deployment as both cause the same effect.

cAdvisor also keeps container data for 5m after a container is removed, which is why we see the number increase for containers removed by a deployment up to almost `300`.

This also renames the metric/panel to Containers missing.