### PR TITLE
search: enable symbol search by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - New site config option `"log": { "sentry": { "backendDSN": "<REDACTED>" } }` to use a separate Sentry project for backend errors. [#17363](https://github.com/sourcegraph/sourcegraph/pull/17363)
+- Symbol results are now part of the default search types. [#17425](https://github.com/sourcegraph/sourcegraph/pull/17425)
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1573,7 +1573,7 @@ func (r *searchResolver) determineResultTypes(args search.TextParameters, forceO
 	} else {
 		resultTypes, _ = r.query.StringValues(query.FieldType)
 		if len(resultTypes) == 0 {
-			resultTypes = []string{"file", "path", "repo"}
+			resultTypes = []string{"file", "path", "repo", "symbol"}
 		}
 	}
 	for _, resultType := range resultTypes {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -167,8 +167,8 @@ func TestSearchResults(t *testing.T) {
 		if !calledSearchFilesInRepos.Load() {
 			t.Error("!calledSearchFilesInRepos")
 		}
-		if calledSearchSymbols {
-			t.Error("calledSearchSymbols")
+		if !calledSearchSymbols {
+			t.Error("!calledSearchSymbols")
 		}
 	})
 
@@ -202,8 +202,8 @@ func TestSearchResults(t *testing.T) {
 		calledSearchSymbols := false
 		mockSearchSymbols = func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, common *streaming.Stats, err error) {
 			calledSearchSymbols = true
-			if want := `"foo\\d \"bar*\""`; args.PatternInfo.Pattern != want {
-				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
+			if d := cmp.Diff(`foo\\d "bar\*"`, args.PatternInfo.Pattern); d != "" {
+				t.Errorf("(-want, +got):\n%s", d)
 			}
 			// TODO return mock results here and assert that they are output as results
 			return nil, nil, nil
@@ -213,8 +213,8 @@ func TestSearchResults(t *testing.T) {
 		calledSearchFilesInRepos := atomic.NewBool(false)
 		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
 			calledSearchFilesInRepos.Store(true)
-			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {
-				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
+			if d := cmp.Diff(`foo\\d "bar\*"`, args.PatternInfo.Pattern); d != "" {
+				t.Errorf("(-want, +got):\n%s", d)
 			}
 			repo := &types.RepoName{ID: 1, Name: "repo"}
 			fm := mkFileMatch(repo, "dir/file", 123)
@@ -232,7 +232,7 @@ func TestSearchResults(t *testing.T) {
 		if !calledSearchFilesInRepos.Load() {
 			t.Error("!calledSearchFilesInRepos")
 		}
-		if calledSearchSymbols {
+		if !calledSearchSymbols {
 			t.Error("calledSearchSymbols")
 		}
 	})


### PR DESCRIPTION
If you don't specify a type we now include symbol results by
default. This was a feature we removed a while ago due to performance
problems. However, symbols have been indexed for many months so this
feature should be safe to enable again.

This has a low chance of causing production issues, so not hiding behind
a feature flag. Will monitor the performance impact in production and
revert if there are surprises.