### PR TITLE
docker-images: tag TimescaleDB as sourcegraph/codeinsights-db

### DIFF
--- a/docker-images/codeinsights-db/build.sh
+++ b/docker-images/codeinsights-db/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -ex
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# This merely re-tags the image to match our official Sourcegraph versioning andimage naming scheme.
+docker pull timescale/timescaledb:2.0.0-pg12-oss@sha256:08ea7cda3b6891c1815af449493c322969d8d9cf283a7af501ce22c6672b51a1
+docker tag timescale/timescaledb:2.0.0-pg12-oss@sha256:08ea7cda3b6891c1815af449493c322969d8d9cf283a7af501ce22c6672b51a1 "$IMAGE"


### PR DESCRIPTION
We plan to deploy TimescaleDB as a standalone container in our deployments
as the database backend for Code Insights, see: https://github.com/sourcegraph/sourcegraph/issues/17218

TimescaleDB is effectively just a Postgres extension, but we will use
their official Docker image as they lag behind on the supported Postgres
versions a bit (12 vs. 13 currently) and we want isolation.

This PR merely tags the image according to our regular Docker image naming
scheme.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>