### PR TITLE
chore: Reduce logspam from nginx

### DIFF
--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -20,7 +20,7 @@ http {
 
     access_log off;
     upstream backend {
-        server localhost:3082 max_fails=0;
+        server 127.0.0.1:3082 max_fails=0;
     }
 
     client_body_temp_path dev/nginx/body;


### PR DESCRIPTION
I have no clue why, but when we make this change we no longer get long streams of Connection refused errors while the executor is running.