### PR TITLE
dev: run codeinsights-db (TimescaleDB) as part of dev server

### DIFF
--- a/dev/Procfile
+++ b/dev/Procfile
@@ -14,6 +14,7 @@ zoekt-indexserver-0: ./dev/zoekt/wrapper indexserver 0
 zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1
 zoekt-webserver-0: ./dev/zoekt/wrapper webserver 0
 zoekt-webserver-1: ./dev/zoekt/wrapper webserver 1
+codeinsights-db: ./dev/codeinsights-db.sh
 keycloak: ./dev/auth-provider/keycloak.sh
 jaeger: ./dev/jaeger.sh
 docsite: ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080 || echo error starting docsite

--- a/dev/codeinsights-db.sh
+++ b/dev/codeinsights-db.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Description: Code Insights TimescaleDB.
+
+set -euf -o pipefail
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
+
+DISK="${HOME}/.sourcegraph-dev/data/codeinsights-db"
+if [ ! -e "${DISK}" ]; then
+  mkdir -p "${DISK}"
+fi
+
+IMAGE=sourcegraph/codeinsights-db:dev
+CONTAINER=codeinsights-db
+PORT=3370
+
+docker inspect $CONTAINER >/dev/null 2>&1 && docker rm -f $CONTAINER
+
+# Log file location: since we log outside of the Docker container, we should
+# log somewhere that's _not_ ~/.sourcegraph-dev/data/codeinsights-db, since that gets
+# volume mounted into the container and therefore has its own ownership
+# semantics.
+LOGS="${HOME}/.sourcegraph-dev/logs/codeinsights-db"
+mkdir -p "${LOGS}"
+
+# Now for the actual logging. TimescaleDB's output gets sent to stdout and stderr.
+# We want to capture that output, but because it's fairly noisy, don't want to
+# display it in the normal case.
+LOG_FILE="${LOGS}/codeinsights-db.log"
+
+# Quickly build image
+echo "codeinsights-db: building ${IMAGE}..."
+IMAGE=${IMAGE} CACHE=true ./docker-images/codeinsights-db/build.sh >"${LOG_FILE}" 2>&1 ||
+  (BUILD_EXIT_CODE=$? && echo "codeinsights-db build failed; dumping log:" && cat "${LOG_FILE}" && exit $BUILD_EXIT_CODE)
+
+function finish() {
+  EXIT_CODE=$?
+
+  # Exit code 2 indicates a normal Ctrl-C termination via goreman, so we'll
+  # only dump the log if it's not 0 _or_ 2.
+  if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 2 ]; then
+    echo "codeinsights-db exited with unexpected code ${EXIT_CODE}; dumping log:"
+    cat "${LOG_FILE}"
+  fi
+
+  # Ensure that we still return the same code so that goreman can do sensible
+  # things once this script exits.
+  return $EXIT_CODE
+}
+
+echo "codeinsights-db: serving on http://localhost:${PORT}"
+echo "codeinsights-db: note that logs are piped to ${LOG_FILE}"
+docker run --rm \
+  --name=${CONTAINER} \
+  --cpus=1 \
+  --memory=1g \
+  -e POSTGRES_PASSWORD=password \
+  -p 0.0.0.0:5435:5435 \
+  -v "${DISK}":/var/lib/postgresql/data \
+  ${IMAGE} >"${LOG_FILE}" 2>&1 || finish

--- a/enterprise/dev/Procfile
+++ b/enterprise/dev/Procfile
@@ -14,6 +14,7 @@ zoekt-indexserver-0: ./dev/zoekt/wrapper indexserver 0
 zoekt-indexserver-1: ./dev/zoekt/wrapper indexserver 1
 zoekt-webserver-0: ./dev/zoekt/wrapper webserver 0
 zoekt-webserver-1: ./dev/zoekt/wrapper webserver 1
+codeinsights-db: ./dev/codeinsights-db.sh
 keycloak: ./dev/auth-provider/keycloak.sh
 jaeger: ./dev/jaeger.sh
 docsite: ./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080 || echo error starting docsite


### PR DESCRIPTION
We plan to deploy TimescaleDB as a standalone container in our deployments
as the database backend for Code Insights, see: https://github.com/sourcegraph/sourcegraph/issues/17218

This runs the re-tagged `sourcegraph/codeinsights-db` TimescaleDB image
in our dev environments. This is different from how we run Postgres, where
we require devs to install and run it themselves. I think that running it
in Docker is nicer for most devs, and we can always add an option to disable
it later if anyone is interested in installing/running it on their machine
seperately.

Note that one cannot generally connect it to the same Postgres DB, because
TimescaleDB is often version-incompatible with the Postgres version we run
in dev environments (9.6 or latest 13, TimescaleDB only supports 11/12)

Part of #17226

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>