### PR TITLE
executor: Ping the frontend before starting up

### DIFF
--- a/docker-images/codeinsights-db/build.sh
+++ b/docker-images/codeinsights-db/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -ex
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# This merely re-tags the image to match our official Sourcegraph versioning andimage naming scheme.
+docker pull timescale/timescaledb:2.0.0-pg12-oss@sha256:08ea7cda3b6891c1815af449493c322969d8d9cf283a7af501ce22c6672b51a1
+docker tag timescale/timescaledb:2.0.0-pg12-oss@sha256:08ea7cda3b6891c1815af449493c322969d8d9cf283a7af501ce22c6672b51a1 "$IMAGE"

--- a/enterprise/cmd/executor/internal/apiclient/client.go
+++ b/enterprise/cmd/executor/internal/apiclient/client.go
@@ -147,6 +147,17 @@ func (c *Client) MarkFailed(ctx context.Context, queueName string, jobID int, er
 	return c.client.DoAndDrop(ctx, req)
 }
 
+func (c *Client) Ping(ctx context.Context, jobIDs []int) (err error) {
+	req, err := c.makeRequest("POST", "heartbeat", executor.HeartbeatRequest{
+		ExecutorName: c.options.ExecutorName,
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.client.DoAndDrop(ctx, req)
+}
+
 func (c *Client) Heartbeat(ctx context.Context, jobIDs []int) (err error) {
 	strJobIDs := make([]string, len(jobIDs))
 	for _, jobID := range jobIDs {

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -60,7 +60,7 @@ func NewWorker(options Options, observationContext *observation.Context) gorouti
 	queueStore := apiclient.New(options.ClientOptions, observationContext)
 	store := &storeShim{queueName: options.QueueName, queueStore: queueStore}
 
-	if !connectToFrontend(queueStore) {
+	if !connectToFrontend(queueStore, options) {
 		os.Exit(1)
 	}
 
@@ -82,7 +82,14 @@ func NewWorker(options Options, observationContext *observation.Context) gorouti
 	}
 }
 
-func connectToFrontend(queueStore *apiclient.Client) bool {
+// connectToFrontend will ping the configured Sourcegraph instance until it receives a 200 response.
+// For the first minute, "connection refused" errors will not be emitted. This is to stop log spam
+// in dev environments where the executor may start up before the frontend. This method returns true
+// after a ping is successful and returns false if a user signal is received.
+func connectToFrontend(queueStore *apiclient.Client, options Options) bool {
+	start := time.Now()
+	log15.Info("Connecting to Sourcegraph instance", "url", options.ClientOptions.EndpointOptions.URL)
+
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
@@ -90,31 +97,30 @@ func connectToFrontend(queueStore *apiclient.Client) bool {
 	signal.Notify(signals, syscall.SIGHUP, syscall.SIGINT)
 	defer signal.Stop(signals)
 
-	log15.Info("Connecting to Sourcegraph instance")
-
-outerLoop:
 	for {
-		select {
-		case <-ticker.C:
-		case <-signals:
-			log15.Error("Signal received while connecting to Sourcegraph")
-			return false
-		}
-
 		err := queueStore.Ping(context.Background(), nil)
 		if err == nil {
 			log15.Info("Connected to Sourcegraph instance")
 			return true
 		}
 
+		quiet := false
 		for ex := err; ex != nil; ex = errors.Unwrap(ex) {
-			if e, ok := ex.(*os.SyscallError); ok {
-				if e.Syscall == "connect" {
-					continue outerLoop
-				}
+			var e *os.SyscallError
+			if errors.As(ex, &e) && e.Syscall == "connect" && time.Since(start) < time.Minute {
+				quiet = true
 			}
 		}
 
-		log15.Error("Failed to connect to Sourcegraph instance", "error", err)
+		if !quiet {
+			log15.Error("Failed to connect to Sourcegraph instance", "error", err)
+		}
+
+		select {
+		case <-ticker.C:
+		case <-signals:
+			log15.Error("Signal received while connecting to Sourcegraph")
+			return false
+		}
 	}
 }


### PR DESCRIPTION
This should help reduce the dev log spam that occurs while the frontend is starting up and the executor is FRANTICALLY trying to get it to delegate it some work.

Sorry my services have such a good work ethic.