### PR TITLE
search: fix segfault

### DIFF
--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -59,7 +59,7 @@ func (s *HorizontalSearcher) doStreamSearch(ctx context.Context, q query.Q, opts
 
 		// Stop stream if we encounter an error.
 		if r.Error != nil {
-			results <- StreamSearchEvent{Error: err}
+			results <- r
 			return
 		}
 

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -114,7 +114,7 @@ func TestHorizontalSearcher(t *testing.T) {
 	searcher.Close()
 }
 
-func TestHorizontalSearcherError(t *testing.T) {
+func TestDoStreamSearch(t *testing.T) {
 	var endpoints atomicMap
 	endpoints.Store(prefixMap{"1"})
 

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -114,6 +114,31 @@ func TestHorizontalSearcher(t *testing.T) {
 	searcher.Close()
 }
 
+func TestHorizontalSearcherError(t *testing.T) {
+	var endpoints atomicMap
+	endpoints.Store(prefixMap{"1"})
+
+	searcher := &HorizontalSearcher{
+		Map: &endpoints,
+		Dial: func(endpoint string) StreamSearcher {
+			client := &mockSearcher{
+				searchResult: nil,
+				searchError:  fmt.Errorf("test error"),
+			}
+			// Return metered searcher to test that codepath
+			return NewMeteredSearcher(endpoint, &StreamSearchAdapter{client})
+		},
+	}
+	defer searcher.Close()
+
+	c := searcher.StreamSearch(context.Background(), nil, nil)
+	for event := range c {
+		if event.Error == nil {
+			t.Fatalf("received non-nil error, but expected an error")
+		}
+	}
+}
+
 func TestSyncSearchers(t *testing.T) {
 	// This test exists to ensure we test the slow path for
 	// HorizontalSearcher.searchers. The slow-path is


### PR DESCRIPTION
The error streamed back was pointing to a nil error rather than the
error encountered, so we'd get an event with both a nil error and a nil
result.

For context, this was causing a segmentation fault further up the chain when we were trying to access the fields of `StreamSearchEvent.SearchResult`: https://sourcegraph.slack.com/archives/CMBA8F926/p1611088281013800

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
