### PR TITLE
codeintel: Do not enable tracing for background tasks

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/updater.go
@@ -14,7 +14,6 @@ import (
 	basegitserver "github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 // Updater periodically re-calculates the commit and upload visibility graph for repositories
@@ -93,9 +92,6 @@ func (u *Updater) tryUpdate(ctx context.Context, repositoryID, dirtyToken int) (
 // the repository can be unmarked as long as the repository is not marked as dirty again before
 // the update completes.
 func (u *Updater) update(ctx context.Context, repositoryID, dirtyToken int) (err error) {
-	// Enable tracing on the context and trace the operation
-	ctx = ot.WithShouldTrace(ctx, true)
-
 	ctx, traceLog, endObservation := u.operations.commitUpdate.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 const MaxGitserverRequestsPerSecond = 20
@@ -115,9 +114,6 @@ func (u *IndexabilityUpdater) HandleError(err error) {
 }
 
 func (u *IndexabilityUpdater) queueRepository(ctx context.Context, repoUsageStatistics store.RepoUsageStatistics) (err error) {
-	// Enable tracing on the context and trace the operation
-	ctx = ot.WithShouldTrace(ctx, true)
-
 	ctx, traceLog, endObservation := u.operations.QueueRepository.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repoUsageStatistics.RepositoryID),

--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/inference"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 type IndexEnqueuer struct {
@@ -43,9 +42,6 @@ func (s *IndexEnqueuer) ForceQueueIndex(ctx context.Context, repositoryID int) e
 }
 
 func (s *IndexEnqueuer) queueIndex(ctx context.Context, repositoryID int, force bool) (err error) {
-	// Enable tracing on the context and trace the operation
-	ctx = ot.WithShouldTrace(ctx, true)
-
 	ctx, traceLog, endObservation := s.operations.QueueIndex.WithAndLogger(ctx, &err, observation.Args{
 		LogFields: []log.Field{
 			log.Int("repositoryID", repositoryID),

--- a/internal/workerutil/worker.go
+++ b/internal/workerutil/worker.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 // Worker is a generic consumer of records from the workerutil store.
@@ -189,9 +188,7 @@ func (w *Worker) dequeueAndHandle() (dequeued bool, err error) {
 // error only if there is an issue committing the transaction - no handler errors will bubble
 // up.
 func (w *Worker) handle(tx Store, record Record) (err error) {
-	// Enable tracing on the context and trace the remainder of the operation including the
-	// transaction commit call in the following deferred function.
-	ctx, endOperation := w.options.Metrics.operations.handle.With(ot.WithShouldTrace(w.ctx, true), &err, observation.Args{})
+	ctx, endOperation := w.options.Metrics.operations.handle.With(w.ctx, &err, observation.Args{})
 	defer endOperation(1, observation.Args{})
 
 	defer func() {


### PR DESCRIPTION
This was causing some logspam in dev (and production). We don't really need traces in the backend today (and if we do, we should make an easy way to get them).