### PR TITLE
search: rename 'Code Monitoring' nav item to 'Monitoring'

### DIFF
--- a/client/web/src/enterprise/campaigns/icons.tsx
+++ b/client/web/src/enterprise/campaigns/icons.tsx
@@ -21,7 +21,11 @@ type Icon = React.FunctionComponent<{
  * The base campaign icon, which may have its class and viewBox overridden by
  * the exported components.
  */
-const BaseCampaignsIcon: BaseIcon = React.memo(function BaseCampaignsIcon({ className = '', viewBox = '0 0 20 20' }) {
+const BaseCampaignsIcon: BaseIcon = React.memo(function BaseCampaignsIcon({
+    className = '',
+    viewBox = '0 0 20 20',
+    ...props
+}) {
     return (
         <svg
             width="20"
@@ -29,6 +33,7 @@ const BaseCampaignsIcon: BaseIcon = React.memo(function BaseCampaignsIcon({ clas
             fill="currentColor"
             className={className}
             viewBox={viewBox}
+            {...props}
             xmlns="http://www.w3.org/2000/svg"
         >
             <path
@@ -56,7 +61,7 @@ const BaseCampaignsIcon: BaseIcon = React.memo(function BaseCampaignsIcon({ clas
  * 20x20. If the icon's left side needs to be flush with the left edge, use
  * {@link CampaignsIconFlushLeft} instead.
  */
-export const CampaignsIcon: Icon = ({ className }) => <BaseCampaignsIcon className={className} />
+export const CampaignsIcon: Icon = props => <BaseCampaignsIcon {...props} />
 
 /**
  * The same icon as {@link CampaignsIcon}, except the icon has no internal
@@ -64,23 +69,14 @@ export const CampaignsIcon: Icon = ({ className }) => <BaseCampaignsIcon classNa
  * should be flush with the left edges of other content displayed above and/or
  * below it.
  */
-export const CampaignsIconFlushLeft: Icon = ({ className }) => (
-    <BaseCampaignsIcon className={className} viewBox="2 0 20 20" />
-)
+export const CampaignsIconFlushLeft: Icon = props => <BaseCampaignsIcon {...props} viewBox="2 0 20 20" />
 
 /**
  * The base component for the navbar version of the campaigns icon, with
  * different proportions and bounding box.
  */
-const BaseCampaignsIconNav: BaseIcon = ({ className = '', viewBox }) => (
-    <svg
-        width="20"
-        height="20"
-        className={className}
-        viewBox={viewBox}
-        fill="currentColor"
-        xmlns="http://www.w3.org/2000/svg"
-    >
+const BaseCampaignsIconNav: BaseIcon = props => (
+    <svg width="20" height="20" {...props} fill="currentColor" xmlns="http://www.w3.org/2000/svg">
         <path
             fillRule="evenodd"
             clipRule="evenodd"
@@ -104,14 +100,10 @@ const BaseCampaignsIconNav: BaseIcon = ({ className = '', viewBox }) => (
  * The nav icon with a viewbox set up to align the icon with the other icons on
  * the global navbar.
  */
-export const CampaignsIconNav: Icon = ({ className }) => (
-    <BaseCampaignsIconNav className={className} viewBox="0 -3 38 38" />
-)
+export const CampaignsIconNav: Icon = props => <BaseCampaignsIconNav {...props} viewBox="0 -3 38 38" />
 
 /**
  * The nav icon with a viewbox set up to align the icon with the other icons on
  * the namespace navbar.
  */
-export const CampaignsIconNamespaceNav: Icon = ({ className }) => (
-    <BaseCampaignsIconNav className={className} viewBox="0 0 36 36" />
-)
+export const CampaignsIconNamespaceNav: Icon = props => <BaseCampaignsIconNav {...props} viewBox="0 0 36 36" />

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringLogo.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringLogo.tsx
@@ -1,14 +1,9 @@
-import React from 'react'
+import React, { SVGProps } from 'react'
 
-export const CodeMonitoringLogo: React.FunctionComponent<{ className?: string }> = (props: { className?: string }) => (
-    <svg
-        width="20"
-        height="20"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        xmlns="http://www.w3.org/2000/svg"
-        className={props.className}
-    >
+export const CodeMonitoringLogo: React.FunctionComponent<SVGProps<SVGSVGElement>> = (
+    props: SVGProps<SVGSVGElement>
+) => (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" {...props}>
         <path
             fillRule="evenodd"
             clipRule="evenodd"

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNavItem.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNavItem.tsx
@@ -5,9 +5,8 @@ import { CodeMonitoringLogo } from './CodeMonitoringLogo'
 export const CodeMonitoringNavItem: React.FunctionComponent = () => (
     <LinkWithIconOnlyTooltip
         to="/code-monitoring"
-        text="Code Monitoring"
+        text="Monitoring"
         icon={CodeMonitoringLogo}
-        tooltip="Code monitoring"
         className="nav-link btn btn-link px-1 text-decoration-none"
         activeClassName="active"
     />

--- a/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"
@@ -411,6 +412,7 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"
@@ -808,6 +810,7 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"
@@ -1176,6 +1179,7 @@ exports[`NavLinks authed self-hosted /search 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"
@@ -1554,6 +1558,7 @@ exports[`NavLinks unauthed Sourcegraph.com /foo 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"
@@ -1696,6 +1701,7 @@ exports[`NavLinks unauthed Sourcegraph.com /search 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"
@@ -1848,6 +1854,7 @@ exports[`NavLinks unauthed self-hosted /foo 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"
@@ -1978,6 +1985,7 @@ exports[`NavLinks unauthed self-hosted /search 1`] = `
     >
       <svg
         class="icon-inline d-lg-none"
+        data-tooltip="Campaigns"
         fill="currentColor"
         height="20"
         viewBox="0 -3 38 38"

--- a/client/web/src/site-admin/SiteAdminSidebar.tsx
+++ b/client/web/src/site-admin/SiteAdminSidebar.tsx
@@ -51,7 +51,7 @@ export const SiteAdminSidebar: React.FunctionComponent<SiteAdminSidebarProps> = 
             Instrumentation
         </a>
         <a href="/-/debug/grafana" className={SIDEBAR_BUTTON_CLASS}>
-            Monitoring
+            Site Monitoring
         </a>
         <a href="/-/debug/jaeger" className={SIDEBAR_BUTTON_CLASS}>
             Tracing


### PR DESCRIPTION
- Rename 'Code Monitoring' nav item to 'Monitoring' (only the nav item, it's still called 'Code Monitoring' elsewhere, including the Code Monitoring page itself and the URL)
- Rename the Graphana link in the Site Admin page from 'Monitoring' to 'Site Monitoring' to avoid confusion
- Fixed a bug where certain nav items did not have tooltips because the tooltip prop wasn't being forwarded to the actual DOM element. This affected both Code Monitoring and Campaigns nav items.

![image](https://user-images.githubusercontent.com/206864/105103973-4bcfb680-5a66-11eb-9826-d68df70d04c2.png)

![image](https://user-images.githubusercontent.com/206864/105103987-51c59780-5a66-11eb-9134-3d68d226f32e.png)


Fixes #17423