### PR TITLE
code monitoring: fix node color in dark mode

### DIFF
--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
@@ -1,10 +1,10 @@
 .code-monitoring-node {
     // stylelint-disable-next-line declaration-property-unit-whitelist
     margin: -1px -1px calc(0.5rem - 1px) -1px;
-    color: initial;
+    color: var(--link-hover-color);
 
     &:hover {
-        text-decoration: initial;
+        text-decoration: none;
         border: 2px solid #329af0;
         // stylelint-disable-next-line declaration-property-unit-whitelist
         margin: -2px -2px calc(0.5rem - 2px) -2px;


### PR DESCRIPTION
Looks like `color: initial;` is not reliable depending on browser. I could repro this bug on Safari but not Chrome. Best to set a fixed color instead of relying on the browser's default.

Fixes #17408