### PR TITLE
search: remove tests that depend on legacy parser

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -46,7 +46,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	query, err := query.ParseAndCheck("p")
+	q, err := query.ParseLiteral("p")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	results, limitHit, timedOut, err := searchCommitsInRepo(ctx, search.CommitParameters{
 		RepoRevs:    repoRevs,
 		PatternInfo: &search.CommitPatternInfo{Pattern: "p", FileMatchLimit: int32(defaultMaxSearchResults)},
-		Query:       query,
+		Query:       q,
 		Diff:        true,
 	})
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -168,7 +168,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			// len(repos) could mean we miss some repos since there could be for example len(repos) file matches in
 			// the first repo and some more in other repos.
 			p := search.TextPatternInfo{IsRegExp: true, FileMatchLimit: math.MaxInt32, IncludePatterns: []string{pattern}, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
-			q, err := query.ParseAndCheck("file:" + pattern)
+			q, err := query.ParseLiteral("file:" + pattern)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -89,7 +89,7 @@ func TestSearchRepositories(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			q, err := query.ParseAndCheck(tc.q)
+			q, err := query.ParseLiteral(tc.q)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -70,7 +70,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 
 	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
-	q, err := query.ParseAndCheck("foo")
+	q, err := query.ParseLiteral("foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 
 	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
-	q, err := query.ParseAndCheck("foo")
+	q, err := query.ParseLiteral("foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 
 	zoekt := &searchbackend.Zoekt{Client: &searchbackend.FakeSearcher{}}
 
-	q, err := query.ParseAndCheck("foo")
+	q, err := query.ParseLiteral("foo")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -807,7 +807,7 @@ func BenchmarkIntegrationSearchResults(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		q, err := query.ParseAndCheck(`print index:only count:350`)
+		q, err := query.ParseLiteral(`print index:only count:350`)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1087,3 +1087,11 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 	}
 	return &AndOrQuery{Query: query}, nil
 }
+
+func ParseLiteral(in string) (QueryInfo, error) {
+	return ProcessAndOr(in, ParserOptions{SearchType: SearchTypeLiteral})
+}
+
+func ParseRegexp(in string) (QueryInfo, error) {
+	return ProcessAndOr(in, ParserOptions{SearchType: SearchTypeRegex})
+}


### PR DESCRIPTION
Towards removing `OrdinaryQuery` type and `query.ParseAndCheck` which are old parser code.

There are just a handful more test dependencies that need some more careful manual auditing.