### PR TITLE
release: always set current version as min upgradeable version

### DIFF
--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -450,10 +450,8 @@ cc @${config.captainGitHubUsername}
                             `comby -in-place 'latestReleaseDockerServerImageBuild = newBuild(":[1]")' "latestReleaseDockerServerImageBuild = newBuild(\\"${release.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
                             `comby -in-place 'latestReleaseDockerComposeOrPureDocker = newBuild(":[1]")' "latestReleaseDockerComposeOrPureDocker = newBuild(\\"${release.version}\\")" cmd/frontend/internal/app/updatecheck/handler.go`,
 
-                            // Support previous release for now
-                            notPatchRelease
-                                ? `comby -in-place 'env["MINIMUM_UPGRADEABLE_VERSION"] = ":[1]"' 'env["MINIMUM_UPGRADEABLE_VERSION"] = "${previous.version}"' enterprise/dev/ci/ci/*.go`
-                                : 'echo "Skipping bumping of upgradable version for patch release"',
+                            // Support current release as the "previous release" going forward
+                            `comby -in-place 'env["MINIMUM_UPGRADEABLE_VERSION"] = ":[1]"' 'env["MINIMUM_UPGRADEABLE_VERSION"] = "${release.version}"' enterprise/dev/ci/ci/*.go`,
 
                             // Add a stub to add upgrade guide entries
                             notPatchRelease

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -267,7 +267,7 @@ func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	env["VAGRANT_SERVICE_ACCOUNT"] = "buildkite@sourcegraph-ci.iam.gserviceaccount.com"
 
 	// Test upgrades from mininum upgradeable Sourcegraph version - updated by release tool
-	env["MINIMUM_UPGRADEABLE_VERSION"] = "3.22.0"
+	env["MINIMUM_UPGRADEABLE_VERSION"] = "3.23.0"
 
 	env["DOCKER_CLUSTER_IMAGES_TXT"] = clusterDockerImages(images.SourcegraphDockerImages)
 


### PR DESCRIPTION
This change occurs as the release is being staged, so candidates should already be tested to upgrade from the previous version. Going forward, everything should be upgradeable from our _current_ version.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

Also double-checked that the comby command works at all:

![image](https://user-images.githubusercontent.com/23356519/105121892-20090b00-5b10-11eb-95a7-bd0ee7440f33.png)
