### PR TITLE
search: use SearchEvent instead of slices of results

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -301,7 +301,7 @@ func resultStream(stream SearchStream) (chan<- []SearchResultResolver, func(*str
 	}
 }
 
-// SetResultChannel will send all results down c.
+// SetStream will send all results down c.
 //
 // This is how our streaming and our batch interface co-exist. When this is
 // set, it exposes a way to stream out results as we collect them.
@@ -310,7 +310,7 @@ func resultStream(stream SearchStream) (chan<- []SearchResultResolver, func(*str
 // us to stream out things like dynamic filters or take into account
 // AND/OR. However, streaming is behind a feature flag for now, so this is to
 // make it visible in the browser.
-func (r *searchResolver) SetResultChannel(c SearchStream) {
+func (r *searchResolver) SetStream(c SearchStream) {
 	r.resultChannel = c
 }
 

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -552,6 +552,7 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 				}
 				// Only write if we have something to report back
 				if len(results) > 0 || status != 0 {
+					stats.Status = search.RepoStatusSingleton(repoRev.Repo.ID, status)
 					params.ResultChannel <- SearchEvent{
 						Results: commitSearchResultsToSearchResults(event.Results),
 						Stats:   stats,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1688,11 +1688,10 @@ func (a *aggregator) report(ctx context.Context, results []SearchResultResolver,
 		a.resultChannel <- SearchEvent{
 			Results: results,
 			Stats:   statsDeref(common),
+			Error:   err,
 		}
 	}
 
-	// TODO(keegan,stefan) we need to work out how to handle streamed stats vs
-	// collected stats once we want to stream progress.
 	a.collect(ctx, results, common, err)
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -868,13 +868,10 @@ func (r *searchResolver) evaluateAndStream(ctx context.Context, scopeParameters 
 	r2.resultChannel = sink
 
 	result, err := r2.evaluateAnd(ctx, scopeParameters, operands)
-	if err == nil && result.SearchResults != nil {
-		r.resultChannel <- SearchEvent{
-			Results: result.SearchResults,
-			Stats:   result.Stats,
-		}
-		// TODO(keegan,stefan) Stream error? Or does the return err below
-		// handle that?
+	r.resultChannel <- SearchEvent{
+		Results: result.SearchResults,
+		Stats:   result.Stats,
+		Error:   err,
 	}
 	return result, err
 }

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -171,20 +171,14 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		SearcherURLs: endpoint.Static("test"),
 	}
 
-	resultChannel := make(chan []SearchResultResolver)
+	resultChannel := make(chan SearchEvent)
 	var resultsFromChannel []*FileMatchResolver
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		var ok bool
-		var resultChunk []SearchResultResolver
-		for {
-			resultChunk, ok = <-resultChannel
-			if !ok {
-				break
-			}
-			for _, result := range resultChunk {
+		for event := range resultChannel {
+			for _, result := range event.Results {
 				fm, _ := result.ToFileMatch()
 				resultsFromChannel = append(resultsFromChannel, fm)
 			}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -84,10 +84,10 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	first := true
 
 	for {
-		var results []graphqlbackend.SearchResultResolver
+		var event graphqlbackend.SearchEvent
 		var ok bool
 		select {
-		case results, ok = <-resultsStream:
+		case event, ok = <-resultsStream:
 		case <-flushTicker.C:
 			ok = true
 			flushMatchesBuf()
@@ -97,7 +97,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 
-		for _, result := range results {
+		for _, result := range event.Results {
 			if fm, ok := result.ToFileMatch(); ok {
 				if syms := fm.Symbols(); len(syms) > 0 {
 					// Inlining to avoid exporting a bunch of stuff from
@@ -130,6 +130,8 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				flushMatchesBuf()
 			}
 		}
+
+		// TODO handle event.Stats
 
 		// Instantly send results if we have not sent any yet.
 		if first && len(matchesBuf) > 0 {
@@ -213,7 +215,7 @@ func toNamer(f func() []*graphqlbackend.RepositoryResolver) []api.Namer {
 
 type searchResolver interface {
 	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
-	SetResultChannel(c chan<- []graphqlbackend.SearchResultResolver)
+	SetResultChannel(c graphqlbackend.SearchStream)
 }
 
 func defaultNewSearchResolver(ctx context.Context, args *graphqlbackend.SearchArgs) (searchResolver, error) {
@@ -284,8 +286,8 @@ type finalResult struct {
 //
 //   - results is written to 0 or more times before closing.
 //   - final is written to once.
-func newResultsStream(ctx context.Context, search searchResolver) (results <-chan []graphqlbackend.SearchResultResolver, final <-chan finalResult) {
-	resultsC := make(chan []graphqlbackend.SearchResultResolver)
+func newResultsStream(ctx context.Context, search searchResolver) (results <-chan graphqlbackend.SearchEvent, final <-chan finalResult) {
+	resultsC := make(chan graphqlbackend.SearchEvent)
 	finalC := make(chan finalResult, 1)
 	go func() {
 		defer close(finalC)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -215,7 +215,7 @@ func toNamer(f func() []*graphqlbackend.RepositoryResolver) []api.Namer {
 
 type searchResolver interface {
 	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
-	SetResultChannel(c graphqlbackend.SearchStream)
+	SetStream(c graphqlbackend.SearchStream)
 }
 
 func defaultNewSearchResolver(ctx context.Context, args *graphqlbackend.SearchArgs) (searchResolver, error) {
@@ -293,7 +293,7 @@ func newResultsStream(ctx context.Context, search searchResolver) (results <-cha
 		defer close(finalC)
 		defer close(resultsC)
 
-		search.SetResultChannel(resultsC)
+		search.SetStream(resultsC)
 
 		r, err := search.Results(ctx)
 		finalC <- finalResult{resultsResolver: r, err: err}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -131,8 +131,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// TODO handle event.Stats
-
 		// Instantly send results if we have not sent any yet.
 		if first && len(matchesBuf) > 0 {
 			first = false

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -66,7 +66,7 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 		}, nil
 	}
 }
-func (h *mockSearchResolver) SetResultChannel(c graphqlbackend.SearchStream) {
+func (h *mockSearchResolver) SetStream(c graphqlbackend.SearchStream) {
 	h.c = c
 }
 

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -53,7 +53,7 @@ func TestDefaultNewSearchResolver(t *testing.T) {
 
 type mockSearchResolver struct {
 	done chan struct{}
-	c    chan<- []graphqlbackend.SearchResultResolver
+	c    graphqlbackend.SearchStream
 }
 
 func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.SearchResultsResolver, error) {
@@ -66,12 +66,12 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 		}, nil
 	}
 }
-func (h *mockSearchResolver) SetResultChannel(c chan<- []graphqlbackend.SearchResultResolver) {
+func (h *mockSearchResolver) SetResultChannel(c graphqlbackend.SearchStream) {
 	h.c = c
 }
 
 func (h *mockSearchResolver) Send(r []graphqlbackend.SearchResultResolver) {
-	h.c <- r
+	h.c <- graphqlbackend.SearchEvent{Results: r}
 }
 
 func (h *mockSearchResolver) Close() {


### PR DESCRIPTION
This updates all uses of our search stream channel to instead use a new
type SearchStream. This required updating both the text and commit
searches which support streaming. For text we adapt it to continue using
the old stream interface to update in a later commit. For commit we
directly use the new stream.

This commit is in preperation for streaming progress updates.