### PR TITLE
Move onboarding tour logic to a hook

### DIFF
--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -270,7 +270,7 @@ export async function getCompletionItems(
                     suggestions: resolvedFilter.definition.suggestions.map(label => ({
                         label,
                         kind: Monaco.languages.CompletionItemKind.Text,
-                        insertText: label,
+                        insertText: label + ' ',
                         range: value ? toMonacoRange(value.range) : defaultRange,
                         command: COMPLETION_ITEM_SELECTED,
                     })),

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -149,7 +149,6 @@ describe('Search onboarding', () => {
             await driver.page.keyboard.type('test')
             await driver.page.waitForSelector('.test-tour-step-4')
             await driver.page.click('.test-search-button')
-            await driver.assertWindowLocation('/search?q=repo:sourcegraph+test&patternType=literal&onboardingTour=true')
             await driver.page.waitForSelector('.test-tour-step-5')
             await driver.page.click('.test-search-help-dropdown-button-icon')
         })

--- a/client/web/src/search/input/LazyMonacoQueryInput.test.tsx
+++ b/client/web/src/search/input/LazyMonacoQueryInput.test.tsx
@@ -29,7 +29,6 @@ describe('PlainQueryInput', () => {
                         versionContext={undefined}
                         globbing={false}
                         enableSmartQuery={false}
-                        showOnboardingTour={false}
                     />
                 )
                 .toJSON()
@@ -57,7 +56,6 @@ describe('PlainQueryInput', () => {
                         versionContext={undefined}
                         globbing={false}
                         enableSmartQuery={false}
-                        showOnboardingTour={false}
                     />
                 )
                 .toJSON()

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -1,18 +1,15 @@
 import * as H from 'history'
-import React, { useCallback, useMemo, useEffect } from 'react'
+import React, { useCallback } from 'react'
 import { ActivationProps } from '../../../../shared/src/components/activation/Activation'
 import { Form } from '../../../../branded/src/components/Form'
 import { submitSearch, QueryState } from '../helpers'
 import { SearchButton } from './SearchButton'
 import { PatternTypeProps, CaseSensitivityProps, CopyQueryButtonProps, OnboardingTourProps } from '..'
-import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { SettingsCascadeProps } from '../../../../shared/src/settings/settings'
 import { VersionContextProps } from '../../../../shared/src/search/util'
-import Shepherd from 'shepherd.js'
-import { defaultTourOptions, generateStepTooltip, HAS_CANCELLED_TOUR_KEY } from './SearchOnboardingTour'
-import { eventLogger } from '../../tracking/eventLogger'
-import { useLocalStorage } from '../../util/useLocalStorage'
+import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
+import { useSearchOnboardingTour } from './SearchOnboardingTour'
 
 interface Props
     extends ActivationProps,
@@ -31,7 +28,6 @@ interface Props
     enableSmartQuery: boolean
 }
 
-const HAS_COMPLETED_TOUR_KEY = 'has-completed-onboarding-tour'
 /**
  * The search item in the navbar
  */
@@ -43,81 +39,12 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
         },
         [props]
     )
-
-    const tour = useMemo(() => new Shepherd.Tour(defaultTourOptions), [])
-    const [hasCancelledTour, setHasCancelledTour] = useLocalStorage(HAS_CANCELLED_TOUR_KEY, false)
-    const [hasCompletedTour, setHasCompletedTour] = useLocalStorage(HAS_COMPLETED_TOUR_KEY, false)
-
-    useEffect(() => {
-        tour.addSteps([
-            {
-                id: 'view-search-reference',
-                text: generateStepTooltip({
-                    tour,
-                    dangerousTitleHtml: 'Review the search reference',
-                    stepNumber: 5,
-                    totalStepCount: 5,
-                }),
-                attachTo: {
-                    element: '.search-help-dropdown-button',
-                    on: 'bottom',
-                },
-                when: {
-                    show() {
-                        eventLogger.log('ViewedOnboardingTourSearchReferenceStep')
-                    },
-                },
-                advanceOn: { selector: '.search-help-dropdown-button', event: 'click' },
-            },
-        ])
-    }, [tour])
-
-    useEffect(() => {
-        const url = new URLSearchParams(props.location.search)
-        if (
-            url.has('onboardingTour') &&
-            props.showOnboardingTour &&
-            hasCancelledTour !== true &&
-            hasCompletedTour !== true
-        ) {
-            tour.show('view-search-reference')
-        }
-    }, [tour, props.showOnboardingTour, props.location.search, hasCancelledTour, hasCompletedTour])
-
-    useEffect(() => {
-        const onCancelled = (): void => setHasCancelledTour(true)
-        const onCompleted = (): void => setHasCompletedTour(true)
-        tour.on('cancel', onCancelled)
-        tour.on('complete', onCompleted)
-        return () => {
-            tour.off('cancel', onCancelled)
-            tour.off('complete', onCompleted)
-        }
-    }, [tour, props.location, props.history, setHasCompletedTour, setHasCancelledTour])
-
-    useEffect(() => {
-        if (hasCancelledTour || hasCompletedTour) {
-            const queryParameters = new URLSearchParams(props.location.search)
-            if (queryParameters.has('onboardingTour')) {
-                queryParameters.delete('onboardingTour')
-                props.history.replace({
-                    search: queryParameters.toString(),
-                    hash: props.history.location.hash,
-                })
-            }
-        }
-    }, [hasCancelledTour, hasCompletedTour, props.history, props.location.search])
-
-    useEffect(
-        () => () => {
-            // End tour on unmount.
-            if (tour.isActive()) {
-                tour.complete()
-            }
-        },
-        [tour]
-    )
-
+    const onboardingTourQueryInputProps = useSearchOnboardingTour({
+        ...props,
+        inputLocation: 'global-navbar',
+        queryState: props.navbarSearchState,
+        setQueryState: props.onChange,
+    })
     return (
         <Form
             className="search--navbar-item d-flex align-items-flex-start flex-grow-1 flex-shrink-past-contents"
@@ -125,6 +52,7 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
         >
             <LazyMonacoQueryInput
                 {...props}
+                {...onboardingTourQueryInputProps}
                 hasGlobalQueryBehavior={true}
                 queryState={props.navbarSearchState}
                 onSubmit={onSubmit}

--- a/client/web/src/search/input/SearchOnboardingTour.ts
+++ b/client/web/src/search/input/SearchOnboardingTour.ts
@@ -1,15 +1,25 @@
 /**
  * This file contains utility functions for the search onboarding tour.
  */
+import * as H from 'history'
+import { useCallback, useEffect, useState, useMemo } from 'react'
 import Shepherd from 'shepherd.js'
 import { eventLogger } from '../../tracking/eventLogger'
 import { isEqual } from 'lodash'
 import { LANGUAGES } from '../../../../shared/src/search/query/filters'
+import { MonacoQueryInputProps } from './MonacoQueryInput'
+import { scanSearchQuery } from '../../../../shared/src/search/query/scanner'
+import { Token } from '../../../../shared/src/search/query/token'
+import Tour from 'shepherd.js/src/types/tour'
+import { useLocalStorage } from '../../util/useLocalStorage'
+import { QueryState } from '../helpers'
+import { daysActiveCount } from '../../marketing/util'
 
 export const HAS_CANCELLED_TOUR_KEY = 'has-cancelled-onboarding-tour'
+export const HAS_COMPLETED_TOUR_KEY = 'has-completed-onboarding-tour'
 export const HAS_SEEN_TOUR_KEY = 'has-seen-onboarding-tour'
 
-export const defaultTourOptions: Shepherd.Tour.TourOptions = {
+const defaultTourOptions: Shepherd.Tour.TourOptions = {
     useModalOverlay: false,
     defaultStepOptions: {
         arrow: true,
@@ -32,7 +42,7 @@ export const defaultTourOptions: Shepherd.Tour.TourOptions = {
  * generateStep creates the content for tooltips for the search tour. All steps that just contain
  * simple text should use this function to populate the step's `text` field.
  */
-export function generateStepTooltip(options: {
+function generateStepTooltip(options: {
     tour: Shepherd.Tour
     dangerousTitleHtml: string
     stepNumber: number
@@ -68,7 +78,7 @@ export function generateStepTooltip(options: {
  * @param tour the tour instance.
  * @param stepNumber the step number.
  */
-export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number, totalStepCount: number): HTMLElement {
+function generateBottomRow(tour: Shepherd.Tour, stepNumber: number, totalStepCount: number): HTMLElement {
     const closeTourButton = document.createElement('button')
     closeTourButton.className = 'btn btn-link p-0 test-tour-close-button'
     closeTourButton.textContent = 'Close tour'
@@ -95,7 +105,7 @@ export function generateBottomRow(tour: Shepherd.Tour, stepNumber: number, total
  * @param languageButtonHandler the handler for the "search a language" button.
  * @param repositoryButtonHandler the handler for the "search a repository" button.
  */
-export function createStep1Tooltip(
+function createStep1Tooltip(
     tour: Shepherd.Tour,
     languageButtonHandler: () => void,
     repositoryButtonHandler: () => void
@@ -135,67 +145,402 @@ export function createStep1Tooltip(
     })
 }
 
-/**
- * Generates the tooltip content for the "add code" step in the repository path, which asks users to input their own terms into the query.
- *
- * @param tour the tour instance
- */
-export function createAddCodeStepTooltip(tour: Shepherd.Tour): HTMLElement {
-    return generateStepTooltip({
-        tour,
-        dangerousTitleHtml: 'Add code to your search',
-        stepNumber: 3,
-        totalStepCount: 5,
-        description: 'Type the name of a function, variable or other code.',
-    })
-}
+type TourStepID = 'filter-repository' | 'filter-lang' | 'add-query-term'
+
+const TOUR_STEPS = ['filter-repository', 'filter-lang', 'add-query-term'] as TourStepID[]
 
 /**
- * Generates the tooltip content for the "add code" step in the language path, which asks users to input their own terms into the query.
- * It provides an example based on the language they selected in the previous step.
- *
- * @param tour the tour instance.
- * @param languageQuery the current query including a `lang:` filter. Used for language queries so we know what examples to suggest.
- * @param exampleCallback the callback to be run when clicking the example query.
+ * Returns `true` if, while on the filter-(repository|lang) step,
+ * the search query is a (repo|lang) filter with no value.
  */
-export function createAddCodeStepWithLanguageExampleTooltip(tour: Shepherd.Tour): HTMLElement {
-    return generateStepTooltip({
-        tour,
-        dangerousTitleHtml: 'Add code to your search',
-        stepNumber: 3,
-        totalStepCount: 5,
-        description: 'Type the name of a function, variable or other code.',
-    })
-}
-
-/**
- * Determines whether a query contains a valid `lang:$LANGUAGE` query. There is an edge case where this will return true for
- * language names that are subsets of other languages (e.g. java is a subset of javascript). The caller should ensure there is
- * enough debouncing time for this edge case to be mitigated.
- */
-export const isValidLangQuery = (query: string): boolean => LANGUAGES.map(lang => `lang:${lang}`).includes(query)
-
-export const isCurrentTourStep = (step: string, tour?: Shepherd.Tour): boolean | undefined =>
-    tour && isEqual(tour.getCurrentStep(), tour.getById(step))
-
-export const advanceLangStep = (query: string, tour: Shepherd.Tour | undefined): void => {
-    if (query !== 'lang:' && isValidLangQuery(query.trim()) && tour?.getById('filter-lang').isOpen()) {
-        tour?.show('add-query-term')
+const shouldTriggerSuggestions = (currentTourStep: TourStepID | undefined, queryTokens: Token[]): boolean => {
+    if (queryTokens.length !== 1) {
+        return false
     }
-}
-
-export const advanceRepoStep = (query: string, tour: Shepherd.Tour | undefined): void => {
-    if (tour?.getById('filter-repository').isOpen() && query !== 'repo:') {
-        tour?.show('add-query-term')
+    const filterToken = queryTokens[0]
+    if (filterToken.type !== 'filter' || filterToken.value !== undefined) {
+        return false
     }
+    return currentTourStep === 'filter-repository'
+        ? filterToken.field.value === 'repo'
+        : currentTourStep === 'filter-lang'
+        ? filterToken.field.value === 'lang'
+        : false
 }
 
-export const runAdvanceLangOrRepoStep = (query: string, tour: Shepherd.Tour | undefined): void => {
-    if (tour) {
-        if (query !== 'lang:' && isValidLangQuery(query.trim()) && tour.getById('filter-lang').isOpen()) {
-            advanceLangStep(query, tour)
-        } else if (tour.getById('filter-repository').isOpen() && query !== 'repo:') {
-            advanceRepoStep(query, tour)
+/**
+ * Returns `true` if, while on the filter-(repository|lang) step,
+ * the search query is a valid (repo|lang) filter followed by whitespace.
+ * -
+ */
+const shouldAdvanceLangOrRepoStep = (currentTourStep: TourStepID | undefined, queryTokens: Token[]): boolean => {
+    if (queryTokens.length !== 2) {
+        return false
+    }
+    const [filterToken, whitespaceToken] = queryTokens
+    if (filterToken.type !== 'filter' || whitespaceToken.type !== 'whitespace') {
+        return false
+    }
+    if (currentTourStep === 'filter-repository') {
+        return filterToken.field.value === 'repo' && filterToken.value !== undefined
+    }
+    if (currentTourStep === 'filter-lang') {
+        return (
+            filterToken.field.value === 'lang' &&
+            filterToken.value?.type === 'literal' &&
+            LANGUAGES.includes(filterToken.value?.value)
+        )
+    }
+    return false
+}
+
+/**
+ * Returns true if, while on the add-query-term step, the search query
+ * contains a search pattern.
+ */
+const shouldShowSubmitSearch = (currentTourStep: TourStepID | undefined, queryTokens: Token[]): boolean =>
+    currentTourStep === 'add-query-term' && queryTokens.some(({ type }) => type === 'pattern')
+
+/**
+ * A hook returning the current step ID of the Shepherd Tour.
+ */
+const useCurrentStep = (tour: Tour): TourStepID | undefined => {
+    const [currentStep, setCurrentStep] = useState<TourStepID | undefined>()
+    useEffect(() => {
+        setCurrentStep(TOUR_STEPS.find(stepID => isEqual(tour.getCurrentStep(), tour.getById(stepID))))
+        const listener = ({ step }: { step: Shepherd.Step }): void => {
+            setCurrentStep(TOUR_STEPS.find(stepID => isEqual(step, tour.getById(stepID))))
         }
+        tour.on('show', listener)
+        return () => {
+            tour.off('show', listener)
+        }
+    }, [tour, setCurrentStep])
+    return currentStep
+}
+
+const useTourWithSteps = ({
+    inputLocation,
+    setQueryState,
+}: Pick<UseSearchOnboardingTourOptions, 'inputLocation' | 'setQueryState'>): Tour => {
+    const tour = useMemo(() => new Shepherd.Tour(defaultTourOptions), [])
+    useEffect(() => {
+        if (inputLocation === 'search-homepage') {
+            tour.addSteps([
+                {
+                    id: 'start-tour',
+                    text: createStep1Tooltip(
+                        tour,
+                        () => {
+                            setQueryState({ query: 'lang:' })
+                            tour.show('filter-lang')
+                        },
+                        () => {
+                            setQueryState({ query: 'repo:' })
+                            tour.show('filter-repository')
+                        }
+                    ),
+                    attachTo: {
+                        element: '.search-page__input-container',
+                        on: 'bottom',
+                    },
+                },
+                {
+                    id: 'filter-lang',
+                    text: generateStepTooltip({
+                        tour,
+                        dangerousTitleHtml: 'Type to filter the language autocomplete',
+                        stepNumber: 2,
+                        totalStepCount: 5,
+                    }),
+                    when: {
+                        show() {
+                            eventLogger.log('ViewedOnboardingTourFilterLangStep')
+                        },
+                    },
+                    attachTo: {
+                        element: '.search-page__input-container',
+                        on: 'top',
+                    },
+                },
+                {
+                    id: 'filter-repository',
+                    text: generateStepTooltip({
+                        tour,
+                        dangerousTitleHtml:
+                            "Type the name of a repository you've used recently to filter the autocomplete list",
+                        stepNumber: 2,
+                        totalStepCount: 5,
+                    }),
+                    when: {
+                        show() {
+                            eventLogger.log('ViewedOnboardingTourFilterRepoStep')
+                        },
+                    },
+                    attachTo: {
+                        element: '.search-page__input-container',
+                        on: 'top',
+                    },
+                },
+                {
+                    id: 'add-query-term',
+                    text: generateStepTooltip({
+                        tour,
+                        dangerousTitleHtml: 'Add code to your search',
+                        stepNumber: 3,
+                        totalStepCount: 5,
+                        description: 'Type the name of a function, variable or other code.',
+                    }),
+                    when: {
+                        show() {
+                            eventLogger.log('ViewedOnboardingTourAddQueryTermStep')
+                        },
+                    },
+                    attachTo: {
+                        element: '.search-page__input-container',
+                        on: 'bottom',
+                    },
+                },
+                {
+                    id: 'submit-search',
+                    text: generateStepTooltip({
+                        tour,
+                        dangerousTitleHtml: 'Use <kbd>return</kbd> or the search button to run your search',
+                        stepNumber: 4,
+                        totalStepCount: 5,
+                    }),
+                    when: {
+                        show() {
+                            eventLogger.log('ViewedOnboardingTourSubmitSearchStep')
+                        },
+                    },
+                    attachTo: {
+                        element: '.search-button',
+                        on: 'top',
+                    },
+                    advanceOn: { selector: '.search-button__btn', event: 'click' },
+                },
+            ])
+        } else {
+            tour.addSteps([
+                {
+                    id: 'view-search-reference',
+                    text: generateStepTooltip({
+                        tour,
+                        dangerousTitleHtml: 'Review the search reference',
+                        stepNumber: 5,
+                        totalStepCount: 5,
+                    }),
+                    attachTo: {
+                        element: '.search-help-dropdown-button',
+                        on: 'bottom',
+                    },
+                    when: {
+                        show() {
+                            eventLogger.log('ViewedOnboardingTourSearchReferenceStep')
+                        },
+                    },
+                    advanceOn: { selector: '.search-help-dropdown-button', event: 'click' },
+                },
+            ])
+        }
+    }, [tour, inputLocation, setQueryState])
+    return tour
+}
+
+type OnboardingTourQueryParameters = [{ key: 'onboardingTour'; value: 'true' }]
+
+interface UseSearchOnboardingTourOptions {
+    /**
+     * Whether the onboarding tour feature flag is enabled.
+     */
+    showOnboardingTour: boolean
+    /**
+     * Where the onboarding tour is being displayed.
+     */
+    inputLocation: 'search-homepage' | 'global-navbar'
+
+    /**
+     * A callback allowing the onboarding tour to trigger
+     * updates to the search query.
+     */
+    setQueryState: (queryState: QueryState) => void
+
+    /**
+     * The query currently displayed in the query input.
+     */
+    queryState: QueryState
+    history: H.History
+    location: H.Location
+}
+
+/**
+ * Represents the object returned by `useSearchOnboardingTour`.
+ *
+ * The subset of MonacoQueryInput props should be passed down to the input component.
+ */
+interface UseSearchOnboardingTourReturnValue
+    extends Pick<MonacoQueryInputProps, 'onCompletionItemSelected' | 'onSuggestionsInitialized' | 'onFocus'> {
+    /**
+     * Query parameters that should be added when submitting a search,
+     * which will trigger the display of further onboarding tour steps on the search result page.
+     */
+    additionalQueryParameters: OnboardingTourQueryParameters | undefined
+    /**
+     * Whether the query input should be focused by default
+     * (`false` on the search homepage when the tour is active).
+     */
+    shouldFocusQueryInput: boolean
+}
+
+/**
+ * A hook that handles displaying and running the search onboarding tour,
+ * to be used in conjunction with the MonacoQueryInput.
+ *
+ * See {@link UseSearchOnboardingTourOptions} and {@link UseSearchOnboardingTourReturnValue}
+ */
+export const useSearchOnboardingTour = ({
+    showOnboardingTour,
+    inputLocation,
+    queryState,
+    setQueryState,
+    history,
+    location,
+}: UseSearchOnboardingTourOptions): UseSearchOnboardingTourReturnValue => {
+    const tour = useTourWithSteps({ inputLocation, setQueryState })
+    // True when the user has seen the tour on the search homepage
+    const [hasSeenTour, setHasSeenTour] = useLocalStorage(HAS_SEEN_TOUR_KEY, false)
+    // True when the user has manually cancelled the tour
+    const [hasCancelledTour, setHasCancelledTour] = useLocalStorage(HAS_CANCELLED_TOUR_KEY, false)
+    // True when the user has completed the tour on the search results page
+    const [hasCompletedTour, setHasCompletedTour] = useLocalStorage(HAS_COMPLETED_TOUR_KEY, false)
+    const shouldShowTour = useMemo(
+        () =>
+            showOnboardingTour &&
+            daysActiveCount === 1 &&
+            !hasCancelledTour &&
+            !hasCompletedTour &&
+            (inputLocation === 'global-navbar' || !hasSeenTour),
+        [hasCancelledTour, hasCompletedTour, hasSeenTour, showOnboardingTour, inputLocation]
+    )
+
+    // Start the tour on the 'view-search-reference' step if the onboardingTour
+    // query parameter is present in the URL. Clean the parameter from the URL.
+    useEffect(() => {
+        const queryParameters = new URLSearchParams(location.search)
+        if (queryParameters.has('onboardingTour')) {
+            if (shouldShowTour) {
+                tour.start()
+                tour.show('view-search-reference')
+            }
+            queryParameters.delete('onboardingTour')
+            history.replace({
+                search: queryParameters.toString(),
+                hash: history.location.hash,
+            })
+        }
+    }, [tour, shouldShowTour, location.search, history])
+
+    // Start the Tour when the query input is focused on the search homepage.
+    const onFocus = useCallback(() => {
+        if (shouldShowTour && !tour.isActive() && inputLocation === 'search-homepage') {
+            tour.start()
+        }
+    }, [shouldShowTour, tour, inputLocation])
+    const shouldFocusQueryInput = useMemo(() => shouldShowTour && inputLocation !== 'search-homepage', [
+        shouldShowTour,
+        inputLocation,
+    ])
+
+    // Hook into Tour cancellation and completion events.
+    useEffect(() => {
+        const onCancelled = (): void => {
+            setHasCancelledTour(true)
+            // If the user closed the tour, we don't want to show
+            // any further popups, so set this to false.
+            setAdditionalQueryParameters(undefined)
+        }
+        const onCompleted = (): void => {
+            if (inputLocation === 'search-homepage') {
+                // When the tour is 'completed' on the search homepage,
+                // set HAS_SEEN to true, but not HAS_COMPLETED,
+                // as we'll still want the user to see the last step on the
+                // search results page.
+                setHasSeenTour(true)
+            } else {
+                // On other pages, set the tour to completed.
+                setHasCompletedTour(true)
+            }
+        }
+        tour.on('cancel', onCancelled)
+        tour.on('complete', onCompleted)
+        return () => {
+            tour.off('cancel', onCancelled)
+            tour.off('complete', onCompleted)
+        }
+    }, [tour, setHasCompletedTour, setHasCancelledTour, setHasSeenTour, inputLocation])
+
+    // 'Complete' tour on unmount.
+    // This will not necessarily result in HAS_COMPLETED_CODE_MONITOR
+    // being set to true (see completion event handler).
+    useEffect(
+        () => () => {
+            if (tour.isActive()) {
+                tour.complete()
+            }
+        },
+        [tour]
+    )
+    // Upon mounting, set whether we should add the onboardingTour query parameter upon submitting searches
+    // (used to display further steps of the tour on the search results page),
+    // and log the ViewOnboardingTour event if the tour is being seen on the search homepage.
+    const [additionalQueryParameters, setAdditionalQueryParameters] = useState<
+        OnboardingTourQueryParameters | undefined
+    >()
+    useEffect(() => {
+        if (shouldShowTour) {
+            setAdditionalQueryParameters([{ key: 'onboardingTour', value: 'true' }])
+            if (inputLocation === 'search-homepage') {
+                eventLogger.log('ViewOnboardingTour')
+            }
+        }
+    }, [tour, shouldShowTour, setAdditionalQueryParameters, inputLocation])
+
+    // A handle allowing to trigger display of the MonacoQueryInput suggestions widget.
+    const [suggestions, onSuggestionsInitialized] = useState<{ trigger: () => void }>()
+
+    // On query or step changes, advance the Tour if appropriate.
+    const currentStep = useCurrentStep(tour)
+    const queryTokens = useMemo((): Token[] => {
+        const scannedQuery = scanSearchQuery(queryState.query)
+        return scannedQuery.type === 'success' ? scannedQuery.term : []
+    }, [queryState.query])
+    useEffect(() => {
+        if (!tour.isActive()) {
+            return
+        }
+        if (shouldTriggerSuggestions(currentStep, queryTokens)) {
+            suggestions?.trigger()
+        } else if (shouldAdvanceLangOrRepoStep(currentStep, queryTokens)) {
+            tour.show('add-query-term')
+        } else if (shouldShowSubmitSearch(currentStep, queryTokens)) {
+            tour.show('submit-search')
+        }
+    }, [suggestions, queryTokens, tour, currentStep])
+
+    // When a completion item is selected,
+    // advance the repo or lang step if appropriate.
+    const onCompletionItemSelected = useCallback(() => {
+        if (shouldAdvanceLangOrRepoStep(currentStep, queryTokens)) {
+            tour.show('add-query-term')
+        }
+    }, [queryTokens, tour, currentStep])
+
+    return {
+        onCompletionItemSelected,
+        onFocus,
+        onSuggestionsInitialized,
+        additionalQueryParameters,
+        shouldFocusQueryInput,
     }
 }

--- a/client/web/src/search/input/SearchPageInput.tsx
+++ b/client/web/src/search/input/SearchPageInput.tsx
@@ -2,7 +2,7 @@ import * as H from 'history'
 import React, { useState, useCallback, useEffect, useMemo } from 'react'
 import { Form } from 'reactstrap'
 import { VersionContextDropdown } from '../../nav/VersionContextDropdown'
-import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
+import { useSearchOnboardingTour } from './SearchOnboardingTour'
 import { KeyboardShortcutsProps } from '../../keyboardShortcuts/keyboardShortcuts'
 import { SearchButton } from './SearchButton'
 import { Link } from '../../../../shared/src/components/Link'
@@ -20,24 +20,15 @@ import {
     OnboardingTourProps,
     parseSearchURLQuery,
 } from '..'
-import { eventLogger } from '../../tracking/eventLogger'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { VersionContextProps } from '../../../../shared/src/search/util'
 import { VersionContext } from '../../schema/site.schema'
 import { submitSearch, SubmitSearchParameters } from '../helpers'
-import {
-    generateStepTooltip,
-    createStep1Tooltip,
-    HAS_SEEN_TOUR_KEY,
-    HAS_CANCELLED_TOUR_KEY,
-    defaultTourOptions,
-} from './SearchOnboardingTour'
-import { useLocalStorage } from '../../util/useLocalStorage'
-import Shepherd from 'shepherd.js'
+
 import { AuthenticatedUser } from '../../auth'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
-import { daysActiveCount } from '../../marketing/util'
+import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
 
 interface Props
     extends SettingsCascadeProps<Settings>,
@@ -88,153 +79,25 @@ export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) =>
     const quickLinks =
         (isSettingsValid<Settings>(props.settingsCascade) && props.settingsCascade.final.quicklinks) || []
 
-    const [hasSeenTour, setHasSeenTour] = useLocalStorage(HAS_SEEN_TOUR_KEY, false)
-    const [hasCancelledTour, setHasCancelledTour] = useLocalStorage(HAS_CANCELLED_TOUR_KEY, false)
-
-    // tourWasActive denotes whether the tour was ever active while this component was rendered, in order
-    // for us to know whether to show the structural search informational step on the results page.
-    const [tourWasActive, setTourWasActive] = useState(false)
-
+    // This component is also used on the RepogroupPage.
+    // The search onboarding tour should only be shown on the homepage.
     const isHomepage = useMemo(
         () => props.location.pathname === '/search' && !parseSearchURLQuery(props.location.search),
         [props.location.pathname, props.location.search]
     )
+    const showOnboardingTour = props.showOnboardingTour && isHomepage
 
-    const showOnboardingTour =
-        props.showOnboardingTour && isHomepage && daysActiveCount === 1 && !hasSeenTour && !hasCancelledTour
-
-    const tour = useMemo(() => new Shepherd.Tour(defaultTourOptions), [])
-
-    useEffect(() => {
-        if (showOnboardingTour) {
-            tour.addSteps([
-                {
-                    id: 'start-tour',
-                    text: createStep1Tooltip(
-                        tour,
-                        () => {
-                            setUserQueryState({ query: 'lang:' })
-                            tour.show('filter-lang')
-                        },
-                        () => {
-                            setUserQueryState({ query: 'repo:' })
-                            tour.show('filter-repository')
-                        }
-                    ),
-                    attachTo: {
-                        element: '.search-page__input-container',
-                        on: 'bottom',
-                    },
-                },
-                {
-                    id: 'filter-lang',
-                    text: generateStepTooltip({
-                        tour,
-                        dangerousTitleHtml: 'Type to filter the language autocomplete',
-                        stepNumber: 2,
-                        totalStepCount: 5,
-                    }),
-                    when: {
-                        show() {
-                            eventLogger.log('ViewedOnboardingTourFilterLangStep')
-                        },
-                    },
-                    attachTo: {
-                        element: '.search-page__input-container',
-                        on: 'top',
-                    },
-                },
-                {
-                    id: 'filter-repository',
-                    text: generateStepTooltip({
-                        tour,
-                        dangerousTitleHtml:
-                            "Type the name of a repository you've used recently to filter the autocomplete list",
-                        stepNumber: 2,
-                        totalStepCount: 5,
-                    }),
-                    when: {
-                        show() {
-                            eventLogger.log('ViewedOnboardingTourFilterRepoStep')
-                        },
-                    },
-                    attachTo: {
-                        element: '.search-page__input-container',
-                        on: 'top',
-                    },
-                },
-                {
-                    id: 'add-query-term',
-                    text: generateStepTooltip({
-                        tour,
-                        dangerousTitleHtml: 'Add code to your search',
-                        stepNumber: 3,
-                        totalStepCount: 5,
-                        description: 'Type the name of a function, variable or other code.',
-                    }),
-                    when: {
-                        show() {
-                            eventLogger.log('ViewedOnboardingTourAddQueryTermStep')
-                        },
-                    },
-                    attachTo: {
-                        element: '.search-page__input-container',
-                        on: 'bottom',
-                    },
-                },
-                {
-                    id: 'submit-search',
-                    text: generateStepTooltip({
-                        tour,
-                        dangerousTitleHtml: 'Use <kbd>return</kbd> or the search button to run your search',
-                        stepNumber: 4,
-                        totalStepCount: 5,
-                    }),
-                    when: {
-                        show() {
-                            eventLogger.log('ViewedOnboardingTourSubmitSearchStep')
-                        },
-                    },
-                    attachTo: {
-                        element: '.search-button',
-                        on: 'top',
-                    },
-                    advanceOn: { selector: '.search-button__btn', event: 'click' },
-                },
-            ])
-        }
-    }, [tour, showOnboardingTour])
-
-    useEffect(() => {
-        if (showOnboardingTour) {
-            setTourWasActive(true)
-            eventLogger.log('ViewOnboardingTour')
-        }
-        return
-    }, [tour, showOnboardingTour, hasCancelledTour])
-
-    useEffect(
-        () => () => {
-            // End tour on unmount.
-            if (tour.isActive()) {
-                tour.complete()
-            }
-        },
-        [tour]
-    )
-
-    useMemo(() => {
-        tour.on('complete', () => {
-            setHasSeenTour(true)
-        })
-        tour.on('cancel', () => {
-            setHasCancelledTour(true)
-            // If the user closed the tour, we don't want to show
-            // any further popups, so set this to false.
-            setTourWasActive(false)
-        })
-    }, [tour, setHasSeenTour, setHasCancelledTour])
-
+    const {
+        additionalQueryParameters,
+        shouldFocusQueryInput,
+        ...onboardingTourQueryInputProps
+    } = useSearchOnboardingTour({
+        ...props,
+        showOnboardingTour,
+        inputLocation: 'search-homepage',
+        queryState: userQueryState,
+        setQueryState: setUserQueryState,
+    })
     const onSubmit = useCallback(
         (event?: React.FormEvent<HTMLFormElement>): void => {
             event?.preventDefault()
@@ -244,10 +107,10 @@ export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) =>
                     ? `${props.hiddenQueryPrefix} ${userQueryState.query}`
                     : userQueryState.query,
                 source: 'home',
-                searchParameters: tourWasActive ? [{ key: 'onboardingTour', value: 'true' }] : undefined,
+                searchParameters: additionalQueryParameters,
             })
         },
-        [props, userQueryState.query, tourWasActive]
+        [props, userQueryState.query, additionalQueryParameters]
     )
 
     return (
@@ -267,12 +130,12 @@ export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) =>
                     )}
                     <LazyMonacoQueryInput
                         {...props}
+                        {...onboardingTourQueryInputProps}
                         hasGlobalQueryBehavior={true}
                         queryState={userQueryState}
                         onChange={setUserQueryState}
                         onSubmit={onSubmit}
-                        autoFocus={showOnboardingTour ? tour.isActive() : props.autoFocus !== false}
-                        tour={showOnboardingTour ? tour : undefined}
+                        autoFocus={showOnboardingTour ? shouldFocusQueryInput : props.autoFocus !== false}
                     />
                     <SearchButton />
                 </div>

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -17,7 +17,11 @@ import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
 import { eventLogger } from '../../tracking/eventLogger'
 import { NavItemDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
-import { HAS_SEEN_TOUR_KEY, HAS_CANCELLED_TOUR_KEY } from '../../search/input/SearchOnboardingTour'
+import {
+    HAS_SEEN_TOUR_KEY,
+    HAS_CANCELLED_TOUR_KEY,
+    HAS_COMPLETED_TOUR_KEY,
+} from '../../search/input/SearchOnboardingTour'
 import { OnboardingTourProps } from '../../search'
 import { AuthenticatedUser } from '../../auth'
 import { UserAreaUserFields } from '../../graphql-operations'
@@ -42,6 +46,7 @@ export interface UserSettingsSidebarProps extends UserAreaRouteContext, Onboardi
 function reEnableSearchTour(): void {
     localStorage.setItem(HAS_SEEN_TOUR_KEY, 'false')
     localStorage.setItem(HAS_CANCELLED_TOUR_KEY, 'false')
+    localStorage.setItem(HAS_COMPLETED_TOUR_KEY, 'false')
 }
 
 /** Sidebar for user account pages. */


### PR DESCRIPTION
Fixes #17321

Moves all code specific to the search onboarding tour out of `MonacoQueryInput.tsx`, and into a `useSearchOnboardingTour` hook.

This is a stepping stone towards enabling us to reuse the `MonacoQueryInput` elsewhere in the application (eg. #17320).

Also moves partly duplicated logic from `SearchPageInput` and `NavbarSearchItem` into the same hook.

Onboarding tour functionality remains the same, but the logic looks different due to using hooks only, as well as using the frontend query scanner for validation logic instead of checks on query strings. Sorry for the large diff! I added plenty of comments, both in the code and in the PR, to help understand what's going on.

The onboarding tour is extensively tested through search integration tests.

