### PR TITLE
Reintroduce active toggles for Code Monitors list view

### DIFF
--- a/client/branded/src/components/Toggle.tsx
+++ b/client/branded/src/components/Toggle.tsx
@@ -13,6 +13,8 @@ interface Props {
      */
     onToggle?: (value: boolean) => void
 
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
+
     /** The title attribute (tooltip). */
     title?: string
 
@@ -35,13 +37,17 @@ export const Toggle: React.FunctionComponent<Props> = ({
     value,
     tabIndex,
     onToggle,
+    onClick,
     dataTest,
     ariaLabel,
 }) => {
-    function onClick(event: React.MouseEvent<HTMLButtonElement>): void {
+    function onButtonClick(event: React.MouseEvent<HTMLButtonElement>): void {
         event.stopPropagation()
         if (!disabled && onToggle) {
             onToggle(!value)
+        }
+        if (!disabled && onClick) {
+            onClick(event)
         }
     }
 
@@ -52,7 +58,7 @@ export const Toggle: React.FunctionComponent<Props> = ({
             id={id}
             title={title}
             value={value ? 1 : 0}
-            onClick={onClick}
+            onClick={onButtonClick}
             tabIndex={tabIndex}
             disabled={disabled}
             role="switch"

--- a/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitorNode.test.tsx
@@ -1,6 +1,7 @@
 import { CodeMonitorNode } from './CodeMonitoringNode'
 import * as React from 'react'
 import * as H from 'history'
+import sinon from 'sinon'
 import { AuthenticatedUser } from '../../auth'
 import { mount } from 'enzyme'
 import { mockCodeMonitor } from './testing/util'
@@ -18,6 +19,7 @@ describe('CreateCodeMonitorPage', () => {
     test('Does not show "Send test email" option when showCodeMonitoringTestEmailButton is false', () => {
         const component = mount(
             <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
                 node={mockCodeMonitor.node}
                 authentictedUser={mockUser}
@@ -30,6 +32,7 @@ describe('CreateCodeMonitorPage', () => {
     test('Shows "Send test email" option to site admins on enabled code monitors', () => {
         const component = mount(
             <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
                 node={mockCodeMonitor.node}
                 authentictedUser={mockUser}
@@ -42,6 +45,7 @@ describe('CreateCodeMonitorPage', () => {
     test('Does not show "Send test email" option when code monitor is disabled', () => {
         const component = mount(
             <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
                 node={{ ...mockCodeMonitor.node, enabled: false }}
                 authentictedUser={mockUser}
@@ -54,6 +58,7 @@ describe('CreateCodeMonitorPage', () => {
     test('Does not show "Send test email" option to non-site admins', () => {
         const component = mount(
             <CodeMonitorNode
+                toggleCodeMonitorEnabled={sinon.spy()}
                 location={history.location}
                 node={mockCodeMonitor.node}
                 authentictedUser={{ ...mockUser, siteAdmin: false }}

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
@@ -3,6 +3,15 @@
     margin: -1px -1px calc(0.5rem - 1px) -1px;
     color: initial;
 
+    &__toggle-wrapper {
+        // stylelint-disable-next-line declaration-property-unit-whitelist
+        margin-top: 1px; // For visual alignment with the edit button
+    }
+
+    &__edit-button {
+        padding: 0;
+    }
+
     &:hover {
         text-decoration: initial;
         border: 2px solid #329af0;

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.test.tsx
@@ -59,4 +59,13 @@ describe('CodeMonitoringListPage', () => {
             mount(<CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(12)} />)
         ).toMatchSnapshot()
     })
+
+    test('Clicking enabled toggle calls toggleCodeMonitorEnabled', () => {
+        const component = mount(
+            <CodeMonitoringPage {...additionalProps} fetchUserCodeMonitors={generateMockFetchMonitors(1)} />
+        )
+        const toggle = component.find('.test-toggle-monitor-enabled')
+        toggle.simulate('click')
+        expect(additionalProps.toggleCodeMonitorEnabled.calledOnce)
+    })
 })

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -22,7 +22,7 @@ import { CodeMonitoringLogo } from './CodeMonitoringLogo'
 export interface CodeMonitoringPageProps
     extends BreadcrumbsProps,
         BreadcrumbSetters,
-        Pick<CodeMonitoringProps, 'fetchUserCodeMonitors'>,
+        Pick<CodeMonitoringProps, 'fetchUserCodeMonitors' | 'toggleCodeMonitorEnabled'>,
         SettingsCascadeProps<Settings> {
     authenticatedUser: AuthenticatedUser
     location: H.Location
@@ -32,7 +32,7 @@ export interface CodeMonitoringPageProps
 type CodeMonitorFilter = 'all' | 'user'
 
 export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps> = props => {
-    const { authenticatedUser, fetchUserCodeMonitors } = props
+    const { authenticatedUser, fetchUserCodeMonitors, toggleCodeMonitorEnabled } = props
 
     const queryConnection = useCallback(
         (args: Partial<ListUserCodeMonitorsVariables>) =>
@@ -255,6 +255,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                                                 props.settingsCascade.final?.experimentalFeatures
                                                     ?.showCodeMonitoringTestEmailButton) ||
                                             false,
+                                        toggleCodeMonitorEnabled,
                                     }}
                                     noun="code monitor"
                                     pluralNoun="code monitors"

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -194,6 +194,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                 },
                 "location": "[Location path=/code-monitoring]",
                 "showCodeMonitoringTestEmailButton": false,
+                "toggleCodeMonitorEnabled": [Function],
               }
             }
             noun="code monitor"
@@ -491,6 +492,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                     },
                     "location": "[Location path=/code-monitoring]",
                     "showCodeMonitoringTestEmailButton": false,
+                    "toggleCodeMonitorEnabled": [Function],
                   }
                 }
                 noun="code monitor"
@@ -540,6 +542,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -568,10 +571,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -620,6 +653,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -648,10 +682,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -700,6 +764,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -728,10 +793,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -780,6 +875,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -808,10 +904,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -860,6 +986,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -888,10 +1015,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -940,6 +1097,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -968,10 +1126,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -1020,6 +1208,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -1048,10 +1237,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -1100,6 +1319,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -1128,10 +1348,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -1180,6 +1430,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -1208,10 +1459,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -1260,6 +1541,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -1288,10 +1570,40 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -1517,6 +1829,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                 },
                 "location": "[Location path=/code-monitoring]",
                 "showCodeMonitoringTestEmailButton": false,
+                "toggleCodeMonitorEnabled": [Function],
               }
             }
             noun="code monitor"
@@ -1632,6 +1945,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                     },
                     "location": "[Location path=/code-monitoring]",
                     "showCodeMonitoringTestEmailButton": false,
+                    "toggleCodeMonitorEnabled": [Function],
                   }
                 }
                 noun="code monitor"
@@ -1681,6 +1995,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -1709,10 +2024,40 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -1761,6 +2106,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -1789,10 +2135,40 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -1841,6 +2217,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -1869,10 +2246,40 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -2098,6 +2505,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                 },
                 "location": "[Location path=/code-monitoring]",
                 "showCodeMonitoringTestEmailButton": false,
+                "toggleCodeMonitorEnabled": [Function],
               }
             }
             noun="code monitor"
@@ -2447,6 +2855,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                     },
                     "location": "[Location path=/code-monitoring]",
                     "showCodeMonitoringTestEmailButton": false,
+                    "toggleCodeMonitorEnabled": [Function],
                   }
                 }
                 noun="code monitor"
@@ -2496,6 +2905,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -2524,10 +2934,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -2576,6 +3016,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -2604,10 +3045,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -2656,6 +3127,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -2684,10 +3156,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -2736,6 +3238,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -2764,10 +3267,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -2816,6 +3349,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -2844,10 +3378,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -2896,6 +3460,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -2924,10 +3489,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -2976,6 +3571,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -3004,10 +3600,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -3056,6 +3682,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -3084,10 +3711,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -3136,6 +3793,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -3164,10 +3822,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -3216,6 +3904,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -3244,10 +3933,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -3296,6 +4015,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -3324,10 +4044,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit
@@ -3376,6 +4126,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                       }
                     }
                     showCodeMonitoringTestEmailButton={false}
+                    toggleCodeMonitorEnabled={[Function]}
                   >
                     <AnchorLink
                       className="code-monitoring-node card p-3"
@@ -3404,10 +4155,40 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                             </div>
                           </div>
                           <div
-                            className="d-flex flex-column"
+                            className="d-flex"
                           >
+                            <div
+                              className="code-monitoring-node__toggle-wrapper test-toggle-monitor-enabled"
+                            >
+                              <Toggle
+                                className="mr-3"
+                                disabled={false}
+                                onClick={[Function]}
+                                value={true}
+                              >
+                                <button
+                                  aria-checked={true}
+                                  className="toggle mr-3"
+                                  disabled={false}
+                                  onClick={[Function]}
+                                  role="switch"
+                                  type="button"
+                                  value={1}
+                                >
+                                  <span
+                                    className="toggle__bar toggle__bar--on"
+                                  />
+                                  <span
+                                    className="toggle__bar-shadow toggle__bar-shadow--on"
+                                  />
+                                  <span
+                                    className="toggle__knob toggle__knob--on"
+                                  />
+                                </button>
+                              </Toggle>
+                            </div>
                             <button
-                              className="btn btn-link"
+                              className="btn btn-link code-monitoring-node__edit-button"
                               type="button"
                             >
                               Edit


### PR DESCRIPTION
This PR adds back the toggles in code monitors list view after they were removed here: https://github.com/sourcegraph/sourcegraph/issues/17129