### PR TITLE
Delete saved searches when a user is hard deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Fixes an issue that prevented the hard deletion of a user if they had saved searches. [#181](https://github.com/sourcegraph/customer/issues/181)
 
 ### Removed
 

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -529,6 +529,9 @@ func (u *UserStore) HardDelete(ctx context.Context, id int32) (err error) {
 	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM settings WHERE user_id=%s", id)); err != nil {
 		return err
 	}
+	if err := tx.Exec(ctx, sqlf.Sprintf("DELETE FROM saved_searches WHERE user_id=%s", id)); err != nil {
+		return err
+	}
 
 	// Settings that were merely authored by this user should not be deleted. They may be global or
 	// org settings that apply to other users, too. There is currently no way to hard-delete

--- a/internal/db/users_test.go
+++ b/internal/db/users_test.go
@@ -565,6 +565,15 @@ func TestUsers_Delete(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			// Create a saved search owned by the user.
+			if _, err := SavedSearches.Create(ctx, &types.SavedSearch{
+				Description: "desc",
+				Query:       "foo",
+				UserID:      &user.ID,
+			}); err != nil {
+				t.Fatal(err)
+			}
+
 			if hard {
 				// Hard delete user.
 				if err := Users.HardDelete(ctx, user.ID); err != nil {


### PR DESCRIPTION
When a user that has saved searches gets hard deleted, it produces a key constraint violation.
This PR fixes this by deleting the saved searches prior to deleting the user.

Fixes https://github.com/sourcegraph/customer/issues/181