### PR TITLE
repo-updater: Explicity disallow external services from syncing on Cloud

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -207,10 +207,10 @@ func Main(enterpriseInit EnterpriseInit) {
 	go watchSyncer(ctx, syncer, scheduler, gps)
 	go func() {
 		log.Fatal(syncer.Run(ctx, db, store, repos.SyncRunOptions{
-			EnqueueInterval:            repos.ConfRepoListUpdateInterval,
-			MinSyncInterval:            repos.ConfRepoListUpdateInterval,
-			IsCloud:                    envvar.SourcegraphDotComMode(),
-			ExcludedExternalServiceIDs: excludeFromSyncing,
+			EnqueueInterval:           repos.ConfRepoListUpdateInterval,
+			MinSyncInterval:           repos.ConfRepoListUpdateInterval,
+			IsCloud:                   envvar.SourcegraphDotComMode(),
+			ExcludeExternalServiceIDs: excludeFromSyncing,
 		}))
 	}()
 	server.Syncer = syncer

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -66,11 +66,11 @@ type Syncer struct {
 
 // SyncRunOptions contains options customizing sync Run behaviour.
 type SyncRunOptions struct {
-	EnqueueInterval            func() time.Duration // Defaults to 1 minute
-	IsCloud                    bool                 // Defaults to false
-	MinSyncInterval            func() time.Duration // Defaults to 1 minute
-	DequeueInterval            time.Duration        // Default to 10 seconds
-	ExcludedExternalServiceIDs []int64              // Opt out of background syncing for specific external services
+	EnqueueInterval           func() time.Duration // Defaults to 1 minute
+	IsCloud                   bool                 // Defaults to false
+	MinSyncInterval           func() time.Duration // Defaults to 1 minute
+	DequeueInterval           time.Duration        // Default to 10 seconds
+	ExcludeExternalServiceIDs []int64              // Opt out of background syncing for specific external services
 }
 
 // Run runs the Sync at the specified interval.
@@ -110,7 +110,7 @@ func (s *Syncer) Run(pctx context.Context, db *sql.DB, store *Store, opts SyncRu
 	for pctx.Err() == nil {
 		ctx, cancel := contextWithSignalCancel(pctx, s.enqueueSignal.Watch())
 
-		if err := store.EnqueueSyncJobs(ctx, opts.ExcludedExternalServiceIDs); err != nil && s.Logger != nil {
+		if err := store.EnqueueSyncJobs(ctx, opts.ExcludeExternalServiceIDs); err != nil && s.Logger != nil {
 			s.Logger.Error("Enqueuing sync jobs", "error", err)
 		}
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -1111,7 +1111,7 @@ func testSyncRun(db *sql.DB) func(t *testing.T, store *repos.Store) func(t *test
 
 			done := make(chan error)
 			go func() {
-				done <- syncer.Run(ctx, db, store, repos.RunOptions{
+				done <- syncer.Run(ctx, db, store, repos.SyncRunOptions{
 					EnqueueInterval: func() time.Duration { return time.Second },
 					IsCloud:         false,
 					MinSyncInterval: func() time.Duration { return 1 * time.Millisecond },
@@ -1252,7 +1252,7 @@ func testSyncer(db *sql.DB) func(t *testing.T, store *repos.Store) func(t *testi
 
 			done := make(chan error)
 			go func() {
-				done <- syncer.Run(ctx, db, store, repos.RunOptions{
+				done <- syncer.Run(ctx, db, store, repos.SyncRunOptions{
 					EnqueueInterval: func() time.Duration { return time.Second },
 					IsCloud:         false,
 					MinSyncInterval: func() time.Duration { return 1 * time.Minute },


### PR DESCRIPTION
Instead of ignoring all site level external services from syncing on
Cloud we instead limit it to only exclude our "global" external services
as these are the ones we expect to have very large numbers of repos.

Might fix: https://github.com/sourcegraph/sourcegraph/issues/17424