### PR TITLE
Add "Handling errored changesets" how-to to documentation

### DIFF
--- a/doc/campaigns/how-tos/handling_errored_changesets.md
+++ b/doc/campaigns/how-tos/handling_errored_changesets.md
@@ -1,0 +1,57 @@
+# Handling errored changesets
+
+Publishing a changeset can result in an error for different reasons.
+
+Sometimes the problem can be fixed by automatically retrying to publish the changeset, but other errors require the user to re-apply the campaign spec to manually retry the publication.
+
+Errored changesets that are marked as **Retrying** are being automatically retried:
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/retrying_changeset.png" class="screenshot">
+
+Changesets that are marked as **Failed** require [manual re-applying of the campaign spec](#manual-retrying-by-re-applying-the-campaign-spec) to retry publishing:
+
+<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/failed_changeset.png" class="screenshot">
+
+## Types of errors
+
+Examples of errors that can be fixed by [automatically retrying](#automatic-retrying-of-errored-changesets):
+
+- Connecting to the code host failed
+- Code host responds with an error when trying to open a pull request
+- Internal network errors
+- ...
+
+Examples of errors that requires [manual retrying](#manual-retrying-by-re-applying-the-campaign-spec):
+
+- No [campaigns credentials](configuring_user_credentials.md) have been setup for the affected code host
+- The configured code host connection needs a different type of credentials (e.g. SSH keys, which are currently not supported)
+- A pull request for the specified branch already exists in another campaign
+- ...
+
+## Automatic retrying of errored changesets
+
+When Sourcegraph campaigns marks a changeset as **Retrying** it's automatically going to retry publishing it for up to 60 times.
+
+No user action is needed.
+
+## Manual retrying by re-applying the campaign spec
+
+Changesets that are marked as **Failed** won't be retried automatically. That's either because the number of automatic retries has been exhausted, or because retrying won't fix the error.
+
+In order to retry **Failed** (or even **Retrying**) changesets manually, you re-apply the campaign spec.
+
+**Option 1:** Preview and re-apply the campaign spec in the UI by running
+
+```bash
+src campaign preview -f YOUR_CAMPAIGN_SPEC.campaign.yaml
+```
+
+and clicking on the printed URL to apply the uploaded campaign spec.
+
+**Option 2:** Re-apply directly by running the following:
+
+```bash
+src campaign apply -f YOUR_CAMPAIGN_SPEC.campaign.yaml
+```
+
+See "[Creating a campaign](creating_a_campaign.md)" for more information on these commands.

--- a/doc/campaigns/how-tos/index.md
+++ b/doc/campaigns/how-tos/index.md
@@ -11,3 +11,4 @@ The following is a list of how-tos that show how to use [Sourcegraph campaigns](
 - [Site admin configuration for campaigns](site_admin_configuration.md)
 - [Configuring user credentials for campaigns](configuring_user_credentials.md)
 - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
+- [Handling errored changesets](handling_errored_changesets.md)

--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -87,6 +87,7 @@ Create a campaign by specifying a search query to get a list of repositories and
 - [Site admin configuration for campaigns](how-tos/site_admin_configuration.md)
 - [Configuring user credentials for campaigns](how-tos/configuring_user_credentials.md)
 - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
+- [Handling errored changesets](how-tos/handling_errored_changesets.md)
 
 ## Tutorials
 


### PR DESCRIPTION
This fixes #17359 by documenting the difference between "retrying" and "failed" changesets and how to automatically or manually retry publishing them.


Preview: [docs.sourcegraph.com/@doc-handling-errored-changesets/campaigns/how-tos/handling_errored_changesets](https://docs.sourcegraph.com/@doc-handling-errored-changesets/campaigns/how-tos/handling_errored_changesets)
