### PR TITLE
search: aggregator is stream based

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1745,15 +1745,13 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 	if args.PatternInfo.IsStructuralPat && args.PatternInfo.FileMatchLimit == defaultMaxSearchResults && len(fileResults) == 0 && err == nil {
 		// No results for structural search? Automatically search again and force Zoekt
 		// to resolve more potential file matches by setting a higher FileMatchLimit.
-		args.PatternInfo.FileMatchLimit = 1000
-		fileResults, stats, err = searchFilesInRepos(ctx, args, a.stream)
-		if len(fileResults) == 0 {
-			// Still no results? Give up.
-			log15.Warn("Structural search gives up after more exhaustive attempt. Results may have been missed.")
-			if stats != nil {
-				stats.IsLimitHit = false // Ensure we don't display "Show more".
-			}
-		}
+		patternCopy := *(args.PatternInfo)
+		patternCopy.FileMatchLimit = 1000
+		argsCopy := *args
+		argsCopy.PatternInfo = &patternCopy
+		args = &argsCopy
+
+		_, _, _ = searchFilesInRepos(ctx, args, a.stream)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1656,16 +1656,6 @@ func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameter
 }
 
 func newAggregator(ctx context.Context, stream SearchStream) *aggregator {
-	if stream == nil {
-		sink := make(chan SearchEvent)
-		stream = sink
-		// TODO when do we close sink?
-		go func() {
-			for range sink {
-			}
-		}()
-	}
-
 	childStream := make(chan SearchEvent, cap(stream))
 	agg := &aggregator{
 		stream: childStream,
@@ -1684,7 +1674,9 @@ func newAggregator(ctx context.Context, stream SearchStream) *aggregator {
 			}
 			agg.results = append(agg.results, event.Results...)
 			agg.common.Update(&event.Stats)
-			stream <- event
+			if stream != nil {
+				stream <- event
+			}
 		}
 	}()
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1705,6 +1705,9 @@ type aggregator struct {
 	multiErr *multierror.Error
 }
 
+// get finalises aggregation over the stream and returns the aggregated
+// result. It should only be called once each do* function is finished
+// running.
 func (a *aggregator) get() ([]SearchResultResolver, streaming.Stats, *multierror.Error) {
 	close(a.stream)
 	<-a.done
@@ -2031,6 +2034,8 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 
 	timer.Stop()
 
+	// We have to call get once all waitgroups are done since it relies on
+	// collecting from the streams.
 	results, common, multiErr := agg.get()
 
 	tr.LazyPrintf("results=%d %s", len(results), &common)

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -21,7 +21,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 		return nil, err
 	}
 
-	langs, err := searchResultsStatsLanguages(ctx, srr.Results())
+	langs, err := searchResultsStatsLanguages(ctx, srr.SearchResults)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -308,7 +308,15 @@ func fileMatchResultsToSearchResults(results []*FileMatchResolver) []SearchResul
 // For c != nil searchFilesInRepos will send results down c.
 func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream SearchStream) (res []*FileMatchResolver, common *streaming.Stats, finalErr error) {
 	if mockSearchFilesInRepos != nil {
-		return mockSearchFilesInRepos(args)
+		results, stats, err := mockSearchFilesInRepos(args)
+		if stream != nil {
+			stream <- SearchEvent{
+				Results: fileMatchResultsToSearchResults(results),
+				Stats:   statsDeref(stats),
+				Error:   err,
+			}
+		}
+		return results, stats, err
 	}
 
 	c, cleanup := resultStream(stream)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -313,7 +313,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 	c, cleanup := resultStream(stream)
 	defer func() {
-		cleanup(common)
+		cleanup(common, finalErr)
 	}()
 
 	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %s", args.PatternInfo.Pattern))


### PR DESCRIPTION
We update the aggregator to be stream based. This is mostly a design change, but functionally we now ensure that every error and stats is reported on the stream. This will allow us to accurately report progress from the HTTP layer down the the client. Additionally, we are now much closer to making the graphqlbackend for search purely stream based.

Co-authored-by: @stefanhengl 