### PR TITLE
monitoring: explicitly point out team that owns alerts/panels

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -29,7 +29,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -55,7 +55,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -79,7 +79,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -103,7 +103,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -125,7 +125,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -148,7 +148,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -172,7 +172,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -196,7 +196,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -222,7 +222,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -248,7 +248,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -272,7 +272,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -296,7 +296,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -318,7 +318,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -341,7 +341,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -368,7 +368,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -395,7 +395,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -419,7 +419,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -443,7 +443,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -465,7 +465,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -488,7 +488,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -510,7 +510,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -532,7 +532,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -554,7 +554,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -576,7 +576,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -598,7 +598,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -620,7 +620,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -642,7 +642,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -664,7 +664,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -686,7 +686,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -708,7 +708,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -730,7 +730,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -752,7 +752,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -774,7 +774,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -796,7 +796,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -818,7 +818,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -840,7 +840,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -862,7 +862,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -884,7 +884,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -906,7 +906,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -928,7 +928,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -950,7 +950,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -972,7 +972,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -994,7 +994,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1016,7 +1016,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1038,7 +1038,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1060,7 +1060,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1082,7 +1082,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1105,7 +1105,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1128,7 +1128,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1151,7 +1151,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1173,7 +1173,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1195,7 +1195,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1218,7 +1218,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -1241,7 +1241,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -1265,7 +1265,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1289,7 +1289,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1313,7 +1313,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1337,7 +1337,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1361,7 +1361,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1385,7 +1385,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1399,7 +1399,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#frontend-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1408,7 +1407,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#frontend-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1430,7 +1431,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1452,7 +1453,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1477,7 +1478,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1495,7 +1496,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 - **Check if the problem may be an intermittent and temporary peak** using the "Container monitoring" section at the bottom of the Git Server dashboard.
 - **Single container deployments:** Consider upgrading to a [Docker Compose deployment](../install/docker-compose/migrate.md) which offers better scalability and resource isolation.
 - **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](../install/resource_estimator.md).
-- **Refer to the [dashboards reference](./dashboards.md#gitserver-running-git-commands)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1505,7 +1505,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#gitserver-running-git-commands).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1529,7 +1531,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1554,7 +1556,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1583,7 +1585,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1607,7 +1609,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1631,7 +1633,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1655,7 +1657,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1679,7 +1681,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1693,7 +1695,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#gitserver-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1702,7 +1703,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#gitserver-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1724,7 +1727,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1746,7 +1749,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1770,7 +1773,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1794,7 +1797,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1818,7 +1821,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1842,7 +1845,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1866,7 +1869,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1890,7 +1893,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1914,7 +1917,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1928,7 +1931,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#github-proxy-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1937,7 +1939,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#github-proxy-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1959,7 +1963,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1981,7 +1985,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2003,7 +2007,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2027,7 +2031,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2041,7 +2045,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#postgres-postgres-up)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2050,7 +2053,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-postgres-up).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2065,7 +2070,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Possible solutions**
 
 - Ensure the Postgres exporter can access the Postgres database. Also, check the Postgres exporter logs for errors.
-- **Refer to the [dashboards reference](./dashboards.md#postgres-pg-exporter-err)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2074,7 +2078,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-pg-exporter-err).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2089,7 +2095,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 **Possible solutions**
 
 - The database migration has been in progress for 5 or more minutes - please contact Sourcegraph if this persists.
-- **Refer to the [dashboards reference](./dashboards.md#postgres-migration-in-progress)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2098,7 +2103,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-migration-in-progress).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2122,7 +2129,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2146,7 +2153,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2170,7 +2177,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2194,7 +2201,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2216,7 +2223,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2238,7 +2245,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2260,7 +2267,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2282,7 +2289,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2304,7 +2311,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2326,7 +2333,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2348,7 +2355,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2370,7 +2377,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2392,7 +2399,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2414,7 +2421,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2436,7 +2443,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2458,7 +2465,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2480,7 +2487,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2502,7 +2509,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2531,7 +2538,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2555,7 +2562,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2579,7 +2586,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2603,7 +2610,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2627,7 +2634,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2651,7 +2658,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2675,7 +2682,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2689,7 +2696,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#precise-code-intel-worker-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2698,7 +2704,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#precise-code-intel-worker-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2720,7 +2728,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2742,7 +2750,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2771,7 +2779,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2795,7 +2803,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2819,7 +2827,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2843,7 +2851,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2867,7 +2875,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2891,7 +2899,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2915,7 +2923,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2929,7 +2937,6 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#query-runner-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -2938,7 +2945,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#query-runner-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2960,7 +2969,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2982,7 +2991,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -3011,7 +3020,7 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3040,7 +3049,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3069,7 +3078,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3092,7 +3101,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3115,7 +3124,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3138,7 +3147,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3161,7 +3170,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3184,7 +3193,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3207,7 +3216,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3230,7 +3239,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3253,7 +3262,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3276,7 +3285,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3299,7 +3308,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3322,7 +3331,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3345,7 +3354,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3368,7 +3377,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3391,7 +3400,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3415,7 +3424,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3438,7 +3447,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3462,7 +3471,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3486,7 +3495,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3509,7 +3518,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3532,7 +3541,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3556,7 +3565,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3579,7 +3588,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3602,7 +3611,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3625,7 +3634,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3648,7 +3657,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3671,7 +3680,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3694,7 +3703,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3718,7 +3727,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3742,7 +3751,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3766,7 +3775,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3790,7 +3799,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3814,7 +3823,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3838,7 +3847,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3852,7 +3861,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#repo-updater-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -3861,7 +3869,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#repo-updater-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3883,7 +3893,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3905,7 +3915,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -3927,7 +3937,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -3949,7 +3959,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -3978,7 +3988,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4002,7 +4012,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4026,7 +4036,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4050,7 +4060,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4074,7 +4084,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4098,7 +4108,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4122,7 +4132,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4136,7 +4146,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#searcher-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -4145,7 +4154,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#searcher-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4167,7 +4178,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4189,7 +4200,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4211,7 +4222,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4233,7 +4244,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4262,7 +4273,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4286,7 +4297,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4310,7 +4321,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4334,7 +4345,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4358,7 +4369,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4382,7 +4393,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4406,7 +4417,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4420,7 +4431,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#symbols-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -4429,7 +4439,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#symbols-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4451,7 +4463,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4473,7 +4485,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -4497,7 +4509,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -4521,7 +4533,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -4545,7 +4557,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -4569,7 +4581,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -4593,7 +4605,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -4617,7 +4629,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -4639,7 +4651,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -4663,7 +4675,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4687,7 +4699,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4711,7 +4723,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4735,7 +4747,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4759,7 +4771,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4783,7 +4795,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4807,7 +4819,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4829,7 +4841,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4851,7 +4863,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4875,7 +4887,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4899,7 +4911,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4923,7 +4935,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4947,7 +4959,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4971,7 +4983,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -4995,7 +5007,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -5010,7 +5022,6 @@ with your code hosts connections or networking issues affecting communication wi
 **Possible solutions**
 
 - Try increasing resources for Prometheus.
-- **Refer to the [dashboards reference](./dashboards.md#prometheus-prometheus-rule-group-evaluation)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -5019,7 +5030,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#prometheus-prometheus-rule-group-evaluation).
+
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5042,7 +5055,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5057,7 +5070,6 @@ with your code hosts connections or networking issues affecting communication wi
 **Possible solutions**
 
 - Ensure that your [`observability.alerts` configuration](https://docs.sourcegraph.com/admin/observability/alerting#setting-up-alerting) (in site configuration) is valid.
-- **Refer to the [dashboards reference](./dashboards.md#prometheus-alertmanager-config-status)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -5066,7 +5078,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#prometheus-alertmanager-config-status).
+
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5089,7 +5103,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5105,7 +5119,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 - Check Prometheus logs for messages related to configuration loading.
 - Ensure any custom configuration you have provided Prometheus is valid.
-- **Refer to the [dashboards reference](./dashboards.md#prometheus-prometheus-config-status)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -5114,7 +5127,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#prometheus-prometheus-config-status).
+
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5137,7 +5152,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5160,7 +5175,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5184,7 +5199,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5208,7 +5223,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5232,7 +5247,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5256,7 +5271,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5280,7 +5295,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5304,7 +5319,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5326,7 +5341,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -5348,7 +5363,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5370,7 +5385,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5392,7 +5407,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5414,7 +5429,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5436,7 +5451,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5465,7 +5480,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5489,7 +5504,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5513,7 +5528,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5537,7 +5552,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5561,7 +5576,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5585,7 +5600,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5609,7 +5624,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5623,7 +5638,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#executor-queue-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -5632,7 +5646,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#executor-queue-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5654,7 +5670,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5676,7 +5692,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5698,7 +5714,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5720,7 +5736,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5742,7 +5758,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5764,7 +5780,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5786,7 +5802,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5808,7 +5824,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5832,7 +5848,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5856,7 +5872,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5880,7 +5896,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5904,7 +5920,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5928,7 +5944,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5952,7 +5968,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5966,7 +5982,6 @@ with your code hosts connections or networking issues affecting communication wi
 
 **Possible solutions**
 
-- **Refer to the [dashboards reference](./dashboards.md#precise-code-intel-indexer-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -5975,7 +5990,9 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#precise-code-intel-indexer-go-goroutines).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -5997,7 +6014,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -6019,7 +6036,7 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -9,13 +9,13 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 ## frontend: 99th_percentile_search_request_duration
 
-<p class="subtitle">99th percentile successful search request duration over 5m (search)</p>
+<p class="subtitle">99th percentile successful search request duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful search request duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Get details on the exact queries that are slow** by configuring `"observability.logSlowSearches": 20,` in the site configuration and looking for `frontend` warning logs prefixed with `slow search request` for additional details.
 - **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -29,17 +29,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: 90th_percentile_search_request_duration
 
-<p class="subtitle">90th percentile successful search request duration over 5m (search)</p>
+<p class="subtitle">90th percentile successful search request duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 15s+ 90th percentile successful search request duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Get details on the exact queries that are slow** by configuring `"observability.logSlowSearches": 15,` in the site configuration and looking for `frontend` warning logs prefixed with `slow search request` for additional details.
 - **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -53,18 +55,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: hard_timeout_search_responses
 
-<p class="subtitle">hard timeout search responses every 5m (search)</p>
+<p class="subtitle">hard timeout search responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard timeout search responses every 5m for 15m0s
 - <span class="badge badge-critical">critical</span> frontend: 5%+ hard timeout search responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -75,18 +79,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: hard_error_search_responses
 
-<p class="subtitle">hard error search responses every 5m (search)</p>
+<p class="subtitle">hard error search responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard error search responses every 5m for 15m0s
 - <span class="badge badge-critical">critical</span> frontend: 5%+ hard error search responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -97,17 +103,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: partial_timeout_search_responses
 
-<p class="subtitle">partial timeout search responses every 5m (search)</p>
+<p class="subtitle">partial timeout search responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ partial timeout search responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -117,17 +125,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: search_alert_user_suggestions
 
-<p class="subtitle">search alert user suggestions shown every 5m (search)</p>
+<p class="subtitle">search alert user suggestions shown every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ search alert user suggestions shown every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - This indicates your user`s are making syntax errors or similar user errors.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -138,17 +148,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: page_load_latency
 
-<p class="subtitle">90th percentile page load latency over all routes over 10m (cloud)</p>
+<p class="subtitle">90th percentile page load latency over all routes over 10m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> frontend: 2s+ 90th percentile page load latency over all routes over 10m
 
-**Possible solutions:**
+**Possible solutions**
 
 - Confirm that the Sourcegraph frontend has enough CPU/memory using the provisioning panels.
 - Trace a request to see what the slowest part is: https://docs.sourcegraph.com/admin/observability/tracing
@@ -160,17 +172,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: blob_load_latency
 
-<p class="subtitle">90th percentile blob load latency over 10m (cloud)</p>
+<p class="subtitle">90th percentile blob load latency over 10m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> frontend: 5s+ 90th percentile blob load latency over 10m
 
-**Possible solutions:**
+**Possible solutions**
 
 - Confirm that the Sourcegraph frontend has enough CPU/memory using the provisioning panels.
 - Trace a request to see what the slowest part is: https://docs.sourcegraph.com/admin/observability/tracing
@@ -182,17 +196,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: 99th_percentile_search_codeintel_request_duration
 
-<p class="subtitle">99th percentile code-intel successful search request duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile code-intel successful search request duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile code-intel successful search request duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Get details on the exact queries that are slow** by configuring `"observability.logSlowSearches": 20,` in the site configuration and looking for `frontend` warning logs prefixed with `slow search request` for additional details.
 - **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -206,17 +222,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: 90th_percentile_search_codeintel_request_duration
 
-<p class="subtitle">90th percentile code-intel successful search request duration over 5m (code-intel)</p>
+<p class="subtitle">90th percentile code-intel successful search request duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 15s+ 90th percentile code-intel successful search request duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Get details on the exact queries that are slow** by configuring `"observability.logSlowSearches": 15,` in the site configuration and looking for `frontend` warning logs prefixed with `slow search request` for additional details.
 - **Check that most repositories are indexed** by visiting https://sourcegraph.example.com/site-admin/repositories?filter=needs-index (it should show few or no results.)
@@ -230,18 +248,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: hard_timeout_search_codeintel_responses
 
-<p class="subtitle">hard timeout search code-intel responses every 5m (code-intel)</p>
+<p class="subtitle">hard timeout search code-intel responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard timeout search code-intel responses every 5m for 15m0s
 - <span class="badge badge-critical">critical</span> frontend: 5%+ hard timeout search code-intel responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -252,18 +272,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: hard_error_search_codeintel_responses
 
-<p class="subtitle">hard error search code-intel responses every 5m (code-intel)</p>
+<p class="subtitle">hard error search code-intel responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard error search code-intel responses every 5m for 15m0s
 - <span class="badge badge-critical">critical</span> frontend: 5%+ hard error search code-intel responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -274,17 +296,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: partial_timeout_search_codeintel_responses
 
-<p class="subtitle">partial timeout search code-intel responses every 5m (code-intel)</p>
+<p class="subtitle">partial timeout search code-intel responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ partial timeout search code-intel responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -294,17 +318,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: search_codeintel_alert_user_suggestions
 
-<p class="subtitle">search code-intel alert user suggestions shown every 5m (code-intel)</p>
+<p class="subtitle">search code-intel alert user suggestions shown every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ search code-intel alert user suggestions shown every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - This indicates a bug in Sourcegraph, please [open an issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -315,17 +341,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: 99th_percentile_search_api_request_duration
 
-<p class="subtitle">99th percentile successful search API request duration over 5m (search)</p>
+<p class="subtitle">99th percentile successful search API request duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 50s+ 99th percentile successful search API request duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Get details on the exact queries that are slow** by configuring `"observability.logSlowSearches": 20,` in the site configuration and looking for `frontend` warning logs prefixed with `slow search request` for additional details.
 - **If your users are requesting many results** with a large `count:` parameter, consider using our [search pagination API](../../api/graphql/search.md).
@@ -340,17 +368,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: 90th_percentile_search_api_request_duration
 
-<p class="subtitle">90th percentile successful search API request duration over 5m (search)</p>
+<p class="subtitle">90th percentile successful search API request duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 40s+ 90th percentile successful search API request duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Get details on the exact queries that are slow** by configuring `"observability.logSlowSearches": 15,` in the site configuration and looking for `frontend` warning logs prefixed with `slow search request` for additional details.
 - **If your users are requesting many results** with a large `count:` parameter, consider using our [search pagination API](../../api/graphql/search.md).
@@ -365,18 +395,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: hard_timeout_search_api_responses
 
-<p class="subtitle">hard timeout search API responses every 5m (search)</p>
+<p class="subtitle">hard timeout search API responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard timeout search API responses every 5m for 15m0s
 - <span class="badge badge-critical">critical</span> frontend: 5%+ hard timeout search API responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -387,18 +419,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: hard_error_search_api_responses
 
-<p class="subtitle">hard error search API responses every 5m (search)</p>
+<p class="subtitle">hard error search API responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2%+ hard error search API responses every 5m for 15m0s
 - <span class="badge badge-critical">critical</span> frontend: 5%+ hard error search API responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -409,17 +443,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: partial_timeout_search_api_responses
 
-<p class="subtitle">partial timeout search API responses every 5m (search)</p>
+<p class="subtitle">partial timeout search API responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ partial timeout search API responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -429,17 +465,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: search_api_alert_user_suggestions
 
-<p class="subtitle">search API alert user suggestions shown every 5m (search)</p>
+<p class="subtitle">search API alert user suggestions shown every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ search API alert user suggestions shown every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - This indicates your user`s search API requests have syntax errors or a similar user error. Check the responses the API sends back for an explanation.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -450,17 +488,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: codeintel_resolvers_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful resolver duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful resolver duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful resolver duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -470,17 +510,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_resolvers_errors
 
-<p class="subtitle">resolver errors every 5m (code-intel)</p>
+<p class="subtitle">resolver errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ resolver errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -490,17 +532,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_api_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful codeintel API operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful codeintel API operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful codeintel API operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -510,17 +554,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_api_errors
 
-<p class="subtitle">code intel API errors every 5m (code-intel)</p>
+<p class="subtitle">code intel API errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ code intel API errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -530,17 +576,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful database store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful database store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful database store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -550,17 +598,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_dbstore_errors
 
-<p class="subtitle">database store errors every 5m (code-intel)</p>
+<p class="subtitle">database store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ database store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -570,17 +620,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_upload_workerstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful upload worker store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful upload worker store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful upload worker store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -590,17 +642,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_upload_workerstore_errors
 
-<p class="subtitle">upload worker store errors every 5m (code-intel)</p>
+<p class="subtitle">upload worker store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ upload worker store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -610,17 +664,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_index_workerstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful index worker store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful index worker store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful index worker store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -630,17 +686,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_index_workerstore_errors
 
-<p class="subtitle">index worker store errors every 5m (code-intel)</p>
+<p class="subtitle">index worker store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ index worker store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -650,17 +708,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful LSIF store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful LSIF store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful LSIF store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -670,17 +730,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_lsifstore_errors
 
-<p class="subtitle">lSIF store errors every 5m (code-intel)</p>
+<p class="subtitle">lSIF store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ lSIF store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -690,17 +752,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_uploadstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful upload store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful upload store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful upload store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -710,17 +774,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_uploadstore_errors
 
-<p class="subtitle">upload store errors every 5m (code-intel)</p>
+<p class="subtitle">upload store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ upload store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -730,17 +796,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_gitserverclient_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful gitserver client operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful gitserver client operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful gitserver client operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -750,17 +818,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_gitserverclient_errors
 
-<p class="subtitle">gitserver client errors every 5m (code-intel)</p>
+<p class="subtitle">gitserver client errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ gitserver client errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -770,17 +840,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_commit_graph_queue_size
 
-<p class="subtitle">commit graph queue size (code-intel)</p>
+<p class="subtitle">commit graph queue size</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 100+ commit graph queue size
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -790,17 +862,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_commit_graph_queue_growth_rate
 
-<p class="subtitle">commit graph queue growth rate over 30m (code-intel)</p>
+<p class="subtitle">commit graph queue growth rate over 30m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5+ commit graph queue growth rate over 30m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -810,17 +884,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_commit_graph_updater_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful commit graph updater operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful commit graph updater operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful commit graph updater operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -830,17 +906,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_commit_graph_updater_errors
 
-<p class="subtitle">commit graph updater errors every 5m (code-intel)</p>
+<p class="subtitle">commit graph updater errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ commit graph updater errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -850,17 +928,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_janitor_errors
 
-<p class="subtitle">janitor errors every 5m (code-intel)</p>
+<p class="subtitle">janitor errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ janitor errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -870,17 +950,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_background_upload_resets
 
-<p class="subtitle">upload records re-queued (due to unresponsive worker) every 5m (code-intel)</p>
+<p class="subtitle">upload records re-queued (due to unresponsive worker) every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ upload records re-queued (due to unresponsive worker) every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -890,17 +972,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_background_upload_reset_failures
 
-<p class="subtitle">upload records errored due to repeated reset every 5m (code-intel)</p>
+<p class="subtitle">upload records errored due to repeated reset every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ upload records errored due to repeated reset every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -910,17 +994,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_background_index_resets
 
-<p class="subtitle">index records re-queued (due to unresponsive indexer) every 5m (code-intel)</p>
+<p class="subtitle">index records re-queued (due to unresponsive indexer) every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ index records re-queued (due to unresponsive indexer) every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -930,17 +1016,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_background_index_reset_failures
 
-<p class="subtitle">index records errored due to repeated reset every 5m (code-intel)</p>
+<p class="subtitle">index records errored due to repeated reset every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ index records errored due to repeated reset every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -950,17 +1038,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_indexing_errors
 
-<p class="subtitle">indexing errors every 5m (code-intel)</p>
+<p class="subtitle">indexing errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ indexing errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -970,17 +1060,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: codeintel_autoindex_enqueuer_errors
 
-<p class="subtitle">index enqueuer errors every 5m (code-intel)</p>
+<p class="subtitle">index enqueuer errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20+ index enqueuer errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -990,17 +1082,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## frontend: internal_indexed_search_error_responses
 
-<p class="subtitle">internal indexed search error responses every 5m (search)</p>
+<p class="subtitle">internal indexed search error responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ internal indexed search error responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check the Zoekt Web Server dashboard for indications it might be unhealthy.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1011,17 +1105,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: internal_unindexed_search_error_responses
 
-<p class="subtitle">internal unindexed search error responses every 5m (search)</p>
+<p class="subtitle">internal unindexed search error responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ internal unindexed search error responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check the Searcher dashboard for indications it might be unhealthy.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1032,17 +1128,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## frontend: internal_api_error_responses
 
-<p class="subtitle">internal API error responses every 5m by route (cloud)</p>
+<p class="subtitle">internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ internal API error responses every 5m by route for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - May not be a substantial issue, check the `frontend` logs for potential causes.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1053,17 +1151,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: 99th_percentile_gitserver_duration
 
-<p class="subtitle">99th percentile successful gitserver query duration over 5m (cloud)</p>
+<p class="subtitle">99th percentile successful gitserver query duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 20s+ 99th percentile successful gitserver query duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1073,17 +1173,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: gitserver_error_responses
 
-<p class="subtitle">gitserver error responses every 5m (cloud)</p>
+<p class="subtitle">gitserver error responses every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 5%+ gitserver error responses every 5m for 15m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1093,17 +1195,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: observability_test_alert_warning
 
-<p class="subtitle">warning test alert metric (distribution)</p>
+<p class="subtitle">warning test alert metric</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 1+ warning test alert metric
 
-**Possible solutions:**
+**Possible solutions**
 
 - This alert is triggered via the `triggerObservabilityTestAlert` GraphQL endpoint, and will automatically resolve itself.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1114,17 +1218,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## frontend: observability_test_alert_critical
 
-<p class="subtitle">critical test alert metric (distribution)</p>
+<p class="subtitle">critical test alert metric</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> frontend: 1+ critical test alert metric
 
-**Possible solutions:**
+**Possible solutions**
 
 - This alert is triggered via the `triggerObservabilityTestAlert` GraphQL endpoint, and will automatically resolve itself.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1135,17 +1241,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## frontend: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
@@ -1157,17 +1265,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (cloud)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
@@ -1179,17 +1289,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the (frontend|sourcegraph-frontend) service.
 - **Docker Compose:** Consider increasing `cpus:` of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
@@ -1201,17 +1313,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the (frontend|sourcegraph-frontend) service.
 - **Docker Compose:** Consider increasing `memory:` of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
@@ -1223,17 +1337,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
@@ -1245,17 +1361,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
@@ -1267,17 +1385,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: go_goroutines
 
-<p class="subtitle">maximum active goroutines (cloud)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#frontend-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1288,17 +1408,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (cloud)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> frontend: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1308,17 +1430,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## frontend: pods_available_percentage
 
-<p class="subtitle">percentage pods available (cloud)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> frontend: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1328,18 +1452,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: disk_space_remaining
 
-<p class="subtitle">disk space remaining by instance (cloud)</p>
+<p class="subtitle">disk space remaining by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: less than 25% disk space remaining by instance
 - <span class="badge badge-critical">critical</span> gitserver: less than 15% disk space remaining by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Provision more disk space:** Sourcegraph will begin deleting least-used repository clones at 10% disk space remaining which may result in decreased performance, users having to wait for repositories to clone, etc.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1351,18 +1477,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: running_git_commands
 
-<p class="subtitle">running git commands (cloud)</p>
+<p class="subtitle">running git commands</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 50+ running git commands for 2m0s
 - <span class="badge badge-critical">critical</span> gitserver: 100+ running git commands for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Check if the problem may be an intermittent and temporary peak** using the "Container monitoring" section at the bottom of the Git Server dashboard.
 - **Single container deployments:** Consider upgrading to a [Docker Compose deployment](../install/docker-compose/migrate.md) which offers better scalability and resource isolation.
@@ -1377,17 +1505,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: repository_clone_queue_size
 
-<p class="subtitle">repository clone queue size (cloud)</p>
+<p class="subtitle">repository clone queue size</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 25+ repository clone queue size
 
-**Possible solutions:**
+**Possible solutions**
 
 - **If you just added several repositories**, the warning may be expected.
 - **Check which repositories need cloning**, by visiting e.g. https://sourcegraph.example.com/site-admin/repositories?filter=not-cloned
@@ -1399,17 +1529,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: repository_existence_check_queue_size
 
-<p class="subtitle">repository existence check queue size (cloud)</p>
+<p class="subtitle">repository existence check queue size</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 25+ repository existence check queue size
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Check the code host status indicator for errors:** on the Sourcegraph app homepage, when signed in as an admin click the cloud icon in the top right corner of the page.
 - **Check if the issue continues to happen after 30 minutes**, it may be temporary.
@@ -1422,17 +1554,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: frontend_internal_api_error_responses
 
-<p class="subtitle">frontend-internal API error responses every 5m by route (cloud)</p>
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 2%+ frontend-internal API error responses every 5m by route for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
 - **Kubernetes:**
@@ -1449,17 +1583,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the gitserver container in `docker-compose.yml`.
@@ -1471,17 +1607,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (cloud)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of gitserver container in `docker-compose.yml`.
@@ -1493,17 +1631,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the gitserver service.
 - **Docker Compose:** Consider increasing `cpus:` of the gitserver container in `docker-compose.yml`.
@@ -1515,17 +1655,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the gitserver container in `docker-compose.yml`.
@@ -1537,17 +1679,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: go_goroutines
 
-<p class="subtitle">maximum active goroutines (cloud)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#gitserver-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1558,17 +1702,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (cloud)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> gitserver: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1578,17 +1724,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## gitserver: pods_available_percentage
 
-<p class="subtitle">percentage pods available (cloud)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> gitserver: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1598,17 +1746,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: github_proxy_waiting_requests
 
-<p class="subtitle">number of requests waiting on the global mutex (cloud)</p>
+<p class="subtitle">number of requests waiting on the global mutex</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 100+ number of requests waiting on the global mutex for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - 								- **Check github-proxy logs for network connection issues.
 								- **Check github status.
@@ -1620,17 +1770,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the github-proxy container in `docker-compose.yml`.
@@ -1642,17 +1794,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (cloud)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of github-proxy container in `docker-compose.yml`.
@@ -1664,17 +1818,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the github-proxy service.
 - **Docker Compose:** Consider increasing `cpus:` of the github-proxy container in `docker-compose.yml`.
@@ -1686,17 +1842,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the github-proxy service.
 - **Docker Compose:** Consider increasing `memory:` of the github-proxy container in `docker-compose.yml`.
@@ -1708,17 +1866,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the github-proxy container in `docker-compose.yml`.
@@ -1730,17 +1890,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of github-proxy container in `docker-compose.yml`.
@@ -1752,17 +1914,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: go_goroutines
 
-<p class="subtitle">maximum active goroutines (cloud)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#github-proxy-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1773,17 +1937,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (cloud)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> github-proxy: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1793,17 +1959,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## github-proxy: pods_available_percentage
 
-<p class="subtitle">percentage pods available (cloud)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> github-proxy: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1813,17 +1981,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: connections
 
-<p class="subtitle">active connections (cloud)</p>
+<p class="subtitle">active connections</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: less than 5 active connections for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1833,18 +2003,20 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: transaction_durations
 
-<p class="subtitle">maximum transaction durations (cloud)</p>
+<p class="subtitle">maximum transaction durations</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: 300ms+ maximum transaction durations for 5m0s
 - <span class="badge badge-critical">critical</span> postgres: 500ms+ maximum transaction durations for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -1855,17 +2027,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: postgres_up
 
-<p class="subtitle">database availability (cloud)</p>
+<p class="subtitle">database availability</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> postgres: less than 0 database availability for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#postgres-postgres-up)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -1876,17 +2050,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: pg_exporter_err
 
-<p class="subtitle">errors scraping postgres exporter (cloud)</p>
+<p class="subtitle">errors scraping postgres exporter</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: 1+ errors scraping postgres exporter for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Ensure the Postgres exporter can access the Postgres database. Also, check the Postgres exporter logs for errors.
 - **Refer to the [dashboards reference](./dashboards.md#postgres-pg-exporter-err)** for more help interpreting this alert and metric.
@@ -1898,17 +2074,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: migration_in_progress
 
-<p class="subtitle">active schema migration (cloud)</p>
+<p class="subtitle">active schema migration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> postgres: 1+ active schema migration for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - The database migration has been in progress for 5 or more minutes - please contact Sourcegraph if this persists.
 - **Refer to the [dashboards reference](./dashboards.md#postgres-migration-in-progress)** for more help interpreting this alert and metric.
@@ -1920,17 +2098,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the (pgsql|codeintel-db) service.
 - **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
@@ -1942,17 +2122,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the (pgsql|codeintel-db) service.
 - **Docker Compose:** Consider increasing `memory:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
@@ -1964,17 +2146,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the (pgsql|codeintel-db) container in `docker-compose.yml`.
@@ -1986,17 +2170,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> postgres: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of (pgsql|codeintel-db) container in `docker-compose.yml`.
@@ -2008,17 +2194,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## postgres: pods_available_percentage
 
-<p class="subtitle">percentage pods available (cloud)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> postgres: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2028,17 +2216,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## precise-code-intel-worker: upload_queue_size
 
-<p class="subtitle">queue size (code-intel)</p>
+<p class="subtitle">queue size</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 100+ queue size
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2048,17 +2238,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: upload_queue_growth_rate
 
-<p class="subtitle">queue growth rate over 30m (code-intel)</p>
+<p class="subtitle">queue growth rate over 30m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 5+ queue growth rate over 30m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2068,17 +2260,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: job_errors
 
-<p class="subtitle">job errors errors every 5m (code-intel)</p>
+<p class="subtitle">job errors errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20+ job errors errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2088,17 +2282,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_dbstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful database store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful database store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20s+ 99th percentile successful database store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2108,17 +2304,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_dbstore_errors
 
-<p class="subtitle">database store errors every 5m (code-intel)</p>
+<p class="subtitle">database store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20+ database store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2128,17 +2326,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_workerstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful worker store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful worker store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20s+ 99th percentile successful worker store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2148,17 +2348,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_workerstore_errors
 
-<p class="subtitle">worker store errors every 5m (code-intel)</p>
+<p class="subtitle">worker store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20+ worker store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2168,17 +2370,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_lsifstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful LSIF store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful LSIF store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20s+ 99th percentile successful LSIF store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2188,17 +2392,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_lsifstore_errors
 
-<p class="subtitle">lSIF store errors every 5m (code-intel)</p>
+<p class="subtitle">lSIF store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20+ lSIF store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2208,17 +2414,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_uploadstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful upload store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful upload store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20s+ 99th percentile successful upload store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2228,17 +2436,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_uploadstore_errors
 
-<p class="subtitle">upload store errors every 5m (code-intel)</p>
+<p class="subtitle">upload store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20+ upload store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2248,17 +2458,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_gitserverclient_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful gitserver client operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful gitserver client operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20s+ 99th percentile successful gitserver client operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2268,17 +2480,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: codeintel_gitserverclient_errors
 
-<p class="subtitle">gitserver client errors every 5m (code-intel)</p>
+<p class="subtitle">gitserver client errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 20+ gitserver client errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2288,17 +2502,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: frontend_internal_api_error_responses
 
-<p class="subtitle">frontend-internal API error responses every 5m by route (code-intel)</p>
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 2%+ frontend-internal API error responses every 5m by route for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
 - **Kubernetes:**
@@ -2315,17 +2531,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -2337,17 +2555,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (code-intel)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
@@ -2359,17 +2579,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the precise-code-intel-worker service.
 - **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -2381,17 +2603,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the precise-code-intel-worker service.
 - **Docker Compose:** Consider increasing `memory:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -2403,17 +2627,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -2425,17 +2651,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
@@ -2447,17 +2675,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: go_goroutines
 
-<p class="subtitle">maximum active goroutines (code-intel)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#precise-code-intel-worker-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2468,17 +2698,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (code-intel)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-worker: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2488,17 +2720,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-worker: pods_available_percentage
 
-<p class="subtitle">percentage pods available (code-intel)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> precise-code-intel-worker: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2508,17 +2742,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## query-runner: frontend_internal_api_error_responses
 
-<p class="subtitle">frontend-internal API error responses every 5m by route (search)</p>
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 2%+ frontend-internal API error responses every 5m by route for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
 - **Kubernetes:**
@@ -2535,17 +2771,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (search)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of query-runner container in `docker-compose.yml`.
@@ -2557,17 +2795,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the query-runner container in `docker-compose.yml`.
@@ -2579,17 +2819,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the query-runner service.
 - **Docker Compose:** Consider increasing `cpus:` of the query-runner container in `docker-compose.yml`.
@@ -2601,17 +2843,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the query-runner service.
 - **Docker Compose:** Consider increasing `memory:` of the query-runner container in `docker-compose.yml`.
@@ -2623,17 +2867,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the query-runner container in `docker-compose.yml`.
@@ -2645,17 +2891,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of query-runner container in `docker-compose.yml`.
@@ -2667,17 +2915,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: go_goroutines
 
-<p class="subtitle">maximum active goroutines (search)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#query-runner-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2688,17 +2938,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (search)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> query-runner: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2708,17 +2960,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## query-runner: pods_available_percentage
 
-<p class="subtitle">percentage pods available (search)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> query-runner: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -2728,17 +2982,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## repo-updater: frontend_internal_api_error_responses
 
-<p class="subtitle">frontend-internal API error responses every 5m by route (cloud)</p>
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 2%+ frontend-internal API error responses every 5m by route for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
 - **Kubernetes:**
@@ -2755,17 +3011,19 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: src_repoupdater_max_sync_backoff
 
-<p class="subtitle">time since oldest sync (cloud)</p>
+<p class="subtitle">time since oldest sync</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 32400s+ time since oldest sync for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - An alert here indicates that no code host connections have synced in at least 9h0m0s. This indicates that there could be a configuration issue
 with your code hosts connections or networking issues affecting communication with your code hosts.
@@ -2782,17 +3040,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: src_repoupdater_syncer_sync_errors_total
 
-<p class="subtitle">sync error rate (cloud)</p>
+<p class="subtitle">sync error rate</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 0+ sync error rate for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - An alert here indicates errors syncing repo metadata with code hosts. This indicates that there could be a configuration issue
 with your code hosts connections or networking issues affecting communication with your code hosts.
@@ -2809,17 +3069,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: syncer_sync_start
 
-<p class="subtitle">sync was started (cloud)</p>
+<p class="subtitle">sync was started</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 0 sync was started for 9h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs for errors.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2830,17 +3092,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: syncer_sync_duration
 
-<p class="subtitle">95th repositories sync duration (cloud)</p>
+<p class="subtitle">95th repositories sync duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 30s+ 95th repositories sync duration for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check the network latency is reasonable (<50ms) between the Sourcegraph and the code host
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2851,17 +3115,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: source_duration
 
-<p class="subtitle">95th repositories source duration (cloud)</p>
+<p class="subtitle">95th repositories source duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 30s+ 95th repositories source duration for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check the network latency is reasonable (<50ms) between the Sourcegraph and the code host
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2872,17 +3138,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: syncer_synced_repos
 
-<p class="subtitle">repositories synced (cloud)</p>
+<p class="subtitle">repositories synced</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 0 repositories synced for 9h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check network connectivity to code hosts
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2893,17 +3161,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: sourced_repos
 
-<p class="subtitle">repositories sourced (cloud)</p>
+<p class="subtitle">repositories sourced</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 0 repositories sourced for 9h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check network connectivity to code hosts
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2914,17 +3184,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: user_added_repos
 
-<p class="subtitle">total number of user added repos (cloud)</p>
+<p class="subtitle">total number of user added repos</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 180000+ total number of user added repos for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check for unusual spikes in user added repos. Each user is only allowed to add 2000
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2935,17 +3207,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: purge_failed
 
-<p class="subtitle">repositories purge failed (cloud)</p>
+<p class="subtitle">repositories purge failed</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 0+ repositories purge failed for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater`s connectivity with gitserver and gitserver logs
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2956,17 +3230,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: sched_auto_fetch
 
-<p class="subtitle">repositories scheduled due to hitting a deadline (cloud)</p>
+<p class="subtitle">repositories scheduled due to hitting a deadline</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 0 repositories scheduled due to hitting a deadline for 9h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs. This is expected to fire if there are no user added code hosts
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2977,17 +3253,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: sched_known_repos
 
-<p class="subtitle">repositories managed by the scheduler (cloud)</p>
+<p class="subtitle">repositories managed by the scheduler</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 0 repositories managed by the scheduler for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs. This is expected to fire if there are no user added code hosts
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -2998,17 +3276,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: sched_update_queue_length
 
-<p class="subtitle">rate of growth of update queue length over 5 minutes (cloud)</p>
+<p class="subtitle">rate of growth of update queue length over 5 minutes</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 0+ rate of growth of update queue length over 5 minutes for 2h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs for indications that the queue is not being processed. The queue length should trend downwards over time as items are sent to GitServer
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3019,17 +3299,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: sched_loops
 
-<p class="subtitle">scheduler loops (cloud)</p>
+<p class="subtitle">scheduler loops</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: less than 0 scheduler loops for 9h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs for errors. This is expected to fire if there are no user added code hosts
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3040,17 +3322,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: sched_error
 
-<p class="subtitle">repositories schedule error rate (cloud)</p>
+<p class="subtitle">repositories schedule error rate</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 1+ repositories schedule error rate for 1m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs for errors
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3061,17 +3345,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: perms_syncer_perms
 
-<p class="subtitle">time gap between least and most up to date permissions (cloud)</p>
+<p class="subtitle">time gap between least and most up to date permissions</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 259200s+ time gap between least and most up to date permissions for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3082,17 +3368,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: perms_syncer_stale_perms
 
-<p class="subtitle">number of entities with stale permissions (cloud)</p>
+<p class="subtitle">number of entities with stale permissions</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 100+ number of entities with stale permissions for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3103,17 +3391,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: perms_syncer_no_perms
 
-<p class="subtitle">number of entities with no permissions (cloud)</p>
+<p class="subtitle">number of entities with no permissions</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 100+ number of entities with no permissions for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Enabled permissions for the first time:** Wait for few minutes and see if the number goes down.
 - **Otherwise:** Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
@@ -3125,17 +3415,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: perms_syncer_sync_duration
 
-<p class="subtitle">95th permissions sync duration (cloud)</p>
+<p class="subtitle">95th permissions sync duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 30s+ 95th permissions sync duration for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check the network latency is reasonable (<50ms) between the Sourcegraph and the code host.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3146,17 +3438,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: perms_syncer_queue_size
 
-<p class="subtitle">permissions sync queued items (cloud)</p>
+<p class="subtitle">permissions sync queued items</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 100+ permissions sync queued items for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Enabled permissions for the first time:** Wait for few minutes and see if the number goes down.
 - **Otherwise:** Increase the API rate limit to [GitHub](https://docs.sourcegraph.com/admin/external_service/github#github-com-rate-limits), [GitLab](https://docs.sourcegraph.com/admin/external_service/gitlab#internal-rate-limits) or [Bitbucket Server](https://docs.sourcegraph.com/admin/external_service/bitbucket_server#internal-rate-limits).
@@ -3168,17 +3462,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: perms_syncer_sync_errors
 
-<p class="subtitle">permissions sync error rate (cloud)</p>
+<p class="subtitle">permissions sync error rate</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 1+ permissions sync error rate for 1m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check the network connectivity the Sourcegraph and the code host.
 - Check if API rate limit quota is exhausted on the code host.
@@ -3190,17 +3486,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: src_repoupdater_external_services_total
 
-<p class="subtitle">the total number of external services (cloud)</p>
+<p class="subtitle">the total number of external services</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 20000+ the total number of external services for 1h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check for spikes in external services, could be abuse
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3211,17 +3509,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: src_repoupdater_user_external_services_total
 
-<p class="subtitle">the total number of user added external services (cloud)</p>
+<p class="subtitle">the total number of user added external services</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 20000+ the total number of user added external services for 1h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check for spikes in external services, could be abuse
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3232,17 +3532,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: repoupdater_queued_sync_jobs_total
 
-<p class="subtitle">the total number of queued sync jobs (cloud)</p>
+<p class="subtitle">the total number of queued sync jobs</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 100+ the total number of queued sync jobs for 1h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Check if jobs are failing to sync:** "SELECT * FROM external_service_sync_jobs WHERE state = `errored`";
 - **Increase the number of workers** using the `repoConcurrentExternalServiceSyncers` site config.
@@ -3254,17 +3556,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: repoupdater_completed_sync_jobs_total
 
-<p class="subtitle">the total number of completed sync jobs (cloud)</p>
+<p class="subtitle">the total number of completed sync jobs</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 100000+ the total number of completed sync jobs for 1h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs. Jobs older than 1 day should have been removed.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3275,17 +3579,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: repoupdater_errored_sync_jobs_total
 
-<p class="subtitle">the total number of errored sync jobs (cloud)</p>
+<p class="subtitle">the total number of errored sync jobs</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 100+ the total number of errored sync jobs for 1h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check repo-updater logs. Check code host connectivity
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3296,17 +3602,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: github_graphql_rate_limit_remaining
 
-<p class="subtitle">remaining calls to GitHub graphql API before hitting the rate limit (cloud)</p>
+<p class="subtitle">remaining calls to GitHub graphql API before hitting the rate limit</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: less than 250 remaining calls to GitHub graphql API before hitting the rate limit
 
-**Possible solutions:**
+**Possible solutions**
 
 - Try restarting the pod to get a different public IP.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3317,17 +3625,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: github_rest_rate_limit_remaining
 
-<p class="subtitle">remaining calls to GitHub rest API before hitting the rate limit (cloud)</p>
+<p class="subtitle">remaining calls to GitHub rest API before hitting the rate limit</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: less than 250 remaining calls to GitHub rest API before hitting the rate limit
 
-**Possible solutions:**
+**Possible solutions**
 
 - Try restarting the pod to get a different public IP.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3338,17 +3648,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: github_search_rate_limit_remaining
 
-<p class="subtitle">remaining calls to GitHub search API before hitting the rate limit (cloud)</p>
+<p class="subtitle">remaining calls to GitHub search API before hitting the rate limit</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: less than 5 remaining calls to GitHub search API before hitting the rate limit
 
-**Possible solutions:**
+**Possible solutions**
 
 - Try restarting the pod to get a different public IP.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3359,17 +3671,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: gitlab_rest_rate_limit_remaining
 
-<p class="subtitle">remaining calls to GitLab rest API before hitting the rate limit (cloud)</p>
+<p class="subtitle">remaining calls to GitLab rest API before hitting the rate limit</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: less than 30 remaining calls to GitLab rest API before hitting the rate limit
 
-**Possible solutions:**
+**Possible solutions**
 
 - Try restarting the pod to get a different public IP.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3380,17 +3694,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the repo-updater container in `docker-compose.yml`.
@@ -3402,17 +3718,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (cloud)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: 90%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of repo-updater container in `docker-compose.yml`.
@@ -3424,17 +3742,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the repo-updater service.
 - **Docker Compose:** Consider increasing `cpus:` of the repo-updater container in `docker-compose.yml`.
@@ -3446,17 +3766,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the repo-updater service.
 - **Docker Compose:** Consider increasing `memory:` of the repo-updater container in `docker-compose.yml`.
@@ -3468,17 +3790,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the repo-updater container in `docker-compose.yml`.
@@ -3490,17 +3814,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of repo-updater container in `docker-compose.yml`.
@@ -3512,17 +3838,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: go_goroutines
 
-<p class="subtitle">maximum active goroutines (cloud)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#repo-updater-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3533,17 +3861,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (cloud)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> repo-updater: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3553,17 +3883,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## repo-updater: pods_available_percentage
 
-<p class="subtitle">percentage pods available (cloud)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> repo-updater: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3573,17 +3905,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## searcher: unindexed_search_request_errors
 
-<p class="subtitle">unindexed search request errors every 5m by code (search)</p>
+<p class="subtitle">unindexed search request errors every 5m by code</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 5%+ unindexed search request errors every 5m by code for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3593,17 +3927,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: replica_traffic
 
-<p class="subtitle">requests per second over 10m (search)</p>
+<p class="subtitle">requests per second over 10m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 5+ requests per second over 10m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3613,17 +3949,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: frontend_internal_api_error_responses
 
-<p class="subtitle">frontend-internal API error responses every 5m by route (search)</p>
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 2%+ frontend-internal API error responses every 5m by route for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
 - **Kubernetes:**
@@ -3640,17 +3978,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the searcher container in `docker-compose.yml`.
@@ -3662,17 +4002,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (search)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of searcher container in `docker-compose.yml`.
@@ -3684,17 +4026,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the searcher service.
 - **Docker Compose:** Consider increasing `cpus:` of the searcher container in `docker-compose.yml`.
@@ -3706,17 +4050,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the searcher service.
 - **Docker Compose:** Consider increasing `memory:` of the searcher container in `docker-compose.yml`.
@@ -3728,17 +4074,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the searcher container in `docker-compose.yml`.
@@ -3750,17 +4098,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of searcher container in `docker-compose.yml`.
@@ -3772,17 +4122,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: go_goroutines
 
-<p class="subtitle">maximum active goroutines (search)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#searcher-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -3793,17 +4145,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (search)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> searcher: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3813,17 +4167,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## searcher: pods_available_percentage
 
-<p class="subtitle">percentage pods available (search)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> searcher: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3833,17 +4189,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## symbols: store_fetch_failures
 
-<p class="subtitle">store fetch failures every 5m (code-intel)</p>
+<p class="subtitle">store fetch failures every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 5+ store fetch failures every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3853,17 +4211,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: current_fetch_queue_size
 
-<p class="subtitle">current fetch queue size (code-intel)</p>
+<p class="subtitle">current fetch queue size</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 25+ current fetch queue size
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -3873,17 +4233,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: frontend_internal_api_error_responses
 
-<p class="subtitle">frontend-internal API error responses every 5m by route (code-intel)</p>
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 2%+ frontend-internal API error responses every 5m by route for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
 - **Kubernetes:**
@@ -3900,17 +4262,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the symbols container in `docker-compose.yml`.
@@ -3922,17 +4286,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (code-intel)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of symbols container in `docker-compose.yml`.
@@ -3944,17 +4310,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the symbols service.
 - **Docker Compose:** Consider increasing `cpus:` of the symbols container in `docker-compose.yml`.
@@ -3966,17 +4334,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the symbols service.
 - **Docker Compose:** Consider increasing `memory:` of the symbols container in `docker-compose.yml`.
@@ -3988,17 +4358,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the symbols container in `docker-compose.yml`.
@@ -4010,17 +4382,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of symbols container in `docker-compose.yml`.
@@ -4032,17 +4406,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: go_goroutines
 
-<p class="subtitle">maximum active goroutines (code-intel)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#symbols-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -4053,17 +4429,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (code-intel)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> symbols: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4073,17 +4451,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## symbols: pods_available_percentage
 
-<p class="subtitle">percentage pods available (code-intel)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> symbols: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4093,17 +4473,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## syntect-server: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> syntect-server: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the syntect-server container in `docker-compose.yml`.
@@ -4115,17 +4497,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## syntect-server: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (cloud)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> syntect-server: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of syntect-server container in `docker-compose.yml`.
@@ -4137,17 +4521,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## syntect-server: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> syntect-server: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the syntect-server service.
 - **Docker Compose:** Consider increasing `cpus:` of the syntect-server container in `docker-compose.yml`.
@@ -4159,17 +4545,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## syntect-server: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> syntect-server: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the syntect-server service.
 - **Docker Compose:** Consider increasing `memory:` of the syntect-server container in `docker-compose.yml`.
@@ -4181,17 +4569,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## syntect-server: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (cloud)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> syntect-server: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the syntect-server container in `docker-compose.yml`.
@@ -4203,17 +4593,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## syntect-server: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (cloud)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> syntect-server: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of syntect-server container in `docker-compose.yml`.
@@ -4225,17 +4617,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## syntect-server: pods_available_percentage
 
-<p class="subtitle">percentage pods available (cloud)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> syntect-server: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4245,18 +4639,20 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+
 <br />
 
 ## zoekt-indexserver: average_resolve_revision_duration
 
-<p class="subtitle">average resolve revision duration over 5m (search)</p>
+<p class="subtitle">average resolve revision duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 15s+ average resolve revision duration over 5m
 - <span class="badge badge-critical">critical</span> zoekt-indexserver: 30s+ average resolve revision duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4267,17 +4663,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-indexserver: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the zoekt-indexserver container in `docker-compose.yml`.
@@ -4289,17 +4687,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-indexserver: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (search)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of zoekt-indexserver container in `docker-compose.yml`.
@@ -4311,17 +4711,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-indexserver: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the zoekt-indexserver service.
 - **Docker Compose:** Consider increasing `cpus:` of the zoekt-indexserver container in `docker-compose.yml`.
@@ -4333,17 +4735,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-indexserver: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the zoekt-indexserver service.
 - **Docker Compose:** Consider increasing `memory:` of the zoekt-indexserver container in `docker-compose.yml`.
@@ -4355,17 +4759,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-indexserver: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the zoekt-indexserver container in `docker-compose.yml`.
@@ -4377,17 +4783,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-indexserver: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-indexserver: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of zoekt-indexserver container in `docker-compose.yml`.
@@ -4399,17 +4807,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-indexserver: pods_available_percentage
 
-<p class="subtitle">percentage pods available (search)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> zoekt-indexserver: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4419,17 +4829,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-webserver: indexed_search_request_errors
 
-<p class="subtitle">indexed search request errors every 5m by code (search)</p>
+<p class="subtitle">indexed search request errors every 5m by code</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-webserver: 5%+ indexed search request errors every 5m by code for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4439,17 +4851,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-webserver: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-webserver: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml`.
@@ -4461,17 +4875,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-webserver: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (search)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-webserver: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of zoekt-webserver container in `docker-compose.yml`.
@@ -4483,17 +4899,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-webserver: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-webserver: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the zoekt-webserver service.
 - **Docker Compose:** Consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml`.
@@ -4505,17 +4923,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-webserver: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-webserver: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the zoekt-webserver service.
 - **Docker Compose:** Consider increasing `memory:` of the zoekt-webserver container in `docker-compose.yml`.
@@ -4527,17 +4947,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-webserver: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (search)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-webserver: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the zoekt-webserver container in `docker-compose.yml`.
@@ -4549,17 +4971,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## zoekt-webserver: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (search)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> zoekt-webserver: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of zoekt-webserver container in `docker-compose.yml`.
@@ -4571,17 +4995,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+
 <br />
 
 ## prometheus: prometheus_rule_group_evaluation
 
-<p class="subtitle">average prometheus rule group evaluation duration over 10m (distribution)</p>
+<p class="subtitle">average prometheus rule group evaluation duration over 10m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 30s+ average prometheus rule group evaluation duration over 10m
 
-**Possible solutions:**
+**Possible solutions**
 
 - Try increasing resources for Prometheus.
 - **Refer to the [dashboards reference](./dashboards.md#prometheus-prometheus-rule-group-evaluation)** for more help interpreting this alert and metric.
@@ -4593,17 +5019,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: alertmanager_notifications_failed_total
 
-<p class="subtitle">failed alertmanager notifications over 1m (distribution)</p>
+<p class="subtitle">failed alertmanager notifications over 1m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 0+ failed alertmanager notifications over 1m
 
-**Possible solutions:**
+**Possible solutions**
 
 - Ensure that your [`observability.alerts` configuration](https://docs.sourcegraph.com/admin/observability/alerting#setting-up-alerting) (in site configuration) is valid.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -4614,17 +5042,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: alertmanager_config_status
 
-<p class="subtitle">alertmanager configuration reload status (distribution)</p>
+<p class="subtitle">alertmanager configuration reload status</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: less than 1 alertmanager configuration reload status
 
-**Possible solutions:**
+**Possible solutions**
 
 - Ensure that your [`observability.alerts` configuration](https://docs.sourcegraph.com/admin/observability/alerting#setting-up-alerting) (in site configuration) is valid.
 - **Refer to the [dashboards reference](./dashboards.md#prometheus-alertmanager-config-status)** for more help interpreting this alert and metric.
@@ -4636,17 +5066,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: prometheus_tsdb_op_failure
 
-<p class="subtitle">prometheus tsdb failures by operation over 1m (distribution)</p>
+<p class="subtitle">prometheus tsdb failures by operation over 1m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 0+ prometheus tsdb failures by operation over 1m
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check Prometheus logs for messages related to the failing operation.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -4657,17 +5089,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: prometheus_config_status
 
-<p class="subtitle">prometheus configuration reload status (distribution)</p>
+<p class="subtitle">prometheus configuration reload status</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: less than 1 prometheus configuration reload status
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check Prometheus logs for messages related to configuration loading.
 - Ensure any custom configuration you have provided Prometheus is valid.
@@ -4680,17 +5114,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: prometheus_target_sample_exceeded
 
-<p class="subtitle">prometheus scrapes that exceed the sample limit over 10m (distribution)</p>
+<p class="subtitle">prometheus scrapes that exceed the sample limit over 10m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 0+ prometheus scrapes that exceed the sample limit over 10m
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check Prometheus logs for messages related to target scrape failures.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -4701,17 +5137,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: prometheus_target_sample_duplicate
 
-<p class="subtitle">prometheus scrapes rejected due to duplicate timestamps over 10m (distribution)</p>
+<p class="subtitle">prometheus scrapes rejected due to duplicate timestamps over 10m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 0+ prometheus scrapes rejected due to duplicate timestamps over 10m
 
-**Possible solutions:**
+**Possible solutions**
 
 - Check Prometheus logs for messages related to target scrape failures.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -4722,17 +5160,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (distribution)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the prometheus container in `docker-compose.yml`.
@@ -4744,17 +5184,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (distribution)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of prometheus container in `docker-compose.yml`.
@@ -4766,17 +5208,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (distribution)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the prometheus service.
 - **Docker Compose:** Consider increasing `cpus:` of the prometheus container in `docker-compose.yml`.
@@ -4788,17 +5232,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (distribution)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the prometheus service.
 - **Docker Compose:** Consider increasing `memory:` of the prometheus container in `docker-compose.yml`.
@@ -4810,17 +5256,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (distribution)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the prometheus container in `docker-compose.yml`.
@@ -4832,17 +5280,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (distribution)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> prometheus: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of prometheus container in `docker-compose.yml`.
@@ -4854,17 +5304,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## prometheus: pods_available_percentage
 
-<p class="subtitle">percentage pods available (distribution)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> prometheus: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4874,17 +5326,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+
 <br />
 
 ## executor-queue: codeintel_queue_size
 
-<p class="subtitle">queue size (code-intel)</p>
+<p class="subtitle">queue size</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 100+ queue size
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4894,17 +5348,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: codeintel_queue_growth_rate
 
-<p class="subtitle">queue growth rate over 30m (code-intel)</p>
+<p class="subtitle">queue growth rate over 30m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 5+ queue growth rate over 30m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4914,17 +5370,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: codeintel_job_errors
 
-<p class="subtitle">job errors every 5m (code-intel)</p>
+<p class="subtitle">job errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 20+ job errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4934,17 +5392,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: codeintel_workerstore_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful worker store operation duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful worker store operation duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 20s+ 99th percentile successful worker store operation duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4954,17 +5414,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: codeintel_workerstore_errors
 
-<p class="subtitle">worker store errors every 5m (code-intel)</p>
+<p class="subtitle">worker store errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 20+ worker store errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -4974,17 +5436,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: frontend_internal_api_error_responses
 
-<p class="subtitle">frontend-internal API error responses every 5m by route (code-intel)</p>
+<p class="subtitle">frontend-internal API error responses every 5m by route</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 2%+ frontend-internal API error responses every 5m by route for 5m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Single-container deployments:** Check `docker logs $CONTAINER_ID` for logs starting with `repo-updater` that indicate requests to the frontend service are failing.
 - **Kubernetes:**
@@ -5001,17 +5465,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the executor-queue container in `docker-compose.yml`.
@@ -5023,17 +5489,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (code-intel)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of executor-queue container in `docker-compose.yml`.
@@ -5045,17 +5513,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the executor-queue service.
 - **Docker Compose:** Consider increasing `cpus:` of the executor-queue container in `docker-compose.yml`.
@@ -5067,17 +5537,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the executor-queue service.
 - **Docker Compose:** Consider increasing `memory:` of the executor-queue container in `docker-compose.yml`.
@@ -5089,17 +5561,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the executor-queue container in `docker-compose.yml`.
@@ -5111,17 +5585,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of executor-queue container in `docker-compose.yml`.
@@ -5133,17 +5609,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: go_goroutines
 
-<p class="subtitle">maximum active goroutines (code-intel)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#executor-queue-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -5154,17 +5632,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (code-intel)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> executor-queue: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5174,17 +5654,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## executor-queue: pods_available_percentage
 
-<p class="subtitle">percentage pods available (code-intel)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> executor-queue: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5194,17 +5676,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: codeintel_job_errors
 
-<p class="subtitle">job errors every 5m (code-intel)</p>
+<p class="subtitle">job errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 20+ job errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5214,17 +5698,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: executor_apiclient_99th_percentile_duration
 
-<p class="subtitle">99th percentile successful API request duration over 5m (code-intel)</p>
+<p class="subtitle">99th percentile successful API request duration over 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 20s+ 99th percentile successful API request duration over 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5234,17 +5720,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: executor_apiclient_errors
 
-<p class="subtitle">aPI errors every 5m (code-intel)</p>
+<p class="subtitle">aPI errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 20+ aPI errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5254,17 +5742,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: executor_setup_command_errors
 
-<p class="subtitle">setup command errors every 5m (code-intel)</p>
+<p class="subtitle">setup command errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 20+ setup command errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5274,17 +5764,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: executor_exec_command_errors
 
-<p class="subtitle">exec command errors every 5m (code-intel)</p>
+<p class="subtitle">exec command errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 20+ exec command errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5294,17 +5786,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: executor_teardown_command_errors
 
-<p class="subtitle">teardown command errors every 5m (code-intel)</p>
+<p class="subtitle">teardown command errors every 5m</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 20+ teardown command errors every 5m
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5314,17 +5808,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: container_cpu_usage
 
-<p class="subtitle">container cpu usage total (1m average) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (1m average) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 99%+ container cpu usage total (1m average) across all cores by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -5336,17 +5832,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: container_memory_usage
 
-<p class="subtitle">container memory usage by instance (code-intel)</p>
+<p class="subtitle">container memory usage by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 99%+ container memory usage by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
@@ -5358,17 +5856,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: provisioning_container_cpu_usage_long_term
 
-<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 80%+ container cpu usage total (90th percentile over 1d) across all cores by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the `Deployment.yaml` for the precise-code-intel-worker service.
 - **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -5380,17 +5880,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: provisioning_container_memory_usage_long_term
 
-<p class="subtitle">container memory usage (1d maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (1d maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 80%+ container memory usage (1d maximum) by instance for 336h0m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limits in the `Deployment.yaml` for the precise-code-intel-worker service.
 - **Docker Compose:** Consider increasing `memory:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -5402,17 +5904,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: provisioning_container_cpu_usage_short_term
 
-<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance (code-intel)</p>
+<p class="subtitle">container cpu usage total (5m maximum) across all cores by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 90%+ container cpu usage total (5m maximum) across all cores by instance for 30m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing CPU limits in the the relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `cpus:` of the precise-code-intel-worker container in `docker-compose.yml`.
@@ -5424,17 +5928,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: provisioning_container_memory_usage_short_term
 
-<p class="subtitle">container memory usage (5m maximum) by instance (code-intel)</p>
+<p class="subtitle">container memory usage (5m maximum) by instance</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 90%+ container memory usage (5m maximum) by instance
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Kubernetes:** Consider increasing memory limit in relevant `Deployment.yaml`.
 - **Docker Compose:** Consider increasing `memory:` of precise-code-intel-worker container in `docker-compose.yml`.
@@ -5446,17 +5952,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: go_goroutines
 
-<p class="subtitle">maximum active goroutines (code-intel)</p>
+<p class="subtitle">maximum active goroutines</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 10000+ maximum active goroutines for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Refer to the [dashboards reference](./dashboards.md#precise-code-intel-indexer-go-goroutines)** for more help interpreting this alert and metric.
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
@@ -5467,17 +5975,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: go_gc_duration_seconds
 
-<p class="subtitle">maximum go garbage collection duration (code-intel)</p>
+<p class="subtitle">maximum go garbage collection duration</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-warning">warning</span> precise-code-intel-indexer: 2s+ maximum go garbage collection duration
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5487,17 +5997,19 @@ with your code hosts connections or networking issues affecting communication wi
 ]
 ```
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+
 <br />
 
 ## precise-code-intel-indexer: pods_available_percentage
 
-<p class="subtitle">percentage pods available (code-intel)</p>
+<p class="subtitle">percentage pods available</p>
 
-**Descriptions:**
+**Descriptions**
 
 - <span class="badge badge-critical">critical</span> precise-code-intel-indexer: less than 90% percentage pods available for 10m0s
 
-**Possible solutions:**
+**Possible solutions**
 
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
@@ -5506,6 +6018,8 @@ with your code hosts connections or networking issues affecting communication wi
   "critical_precise-code-intel-indexer_pods_available_percentage"
 ]
 ```
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16,9 +16,9 @@ To learn more about Sourcegraph's metrics and how to view these dashboards, see 
 
 This panel indicates 99th percentile successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-request-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-request-duration).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -26,9 +26,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-perc
 
 This panel indicates 90th percentile successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-request-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-request-duration).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -36,9 +36,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-perc
 
 This panel indicates hard timeout search responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -46,9 +46,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-time
 
 This panel indicates hard error search responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -56,9 +56,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-erro
 
 This panel indicates partial timeout search responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -66,9 +66,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-t
 
 This panel indicates search alert user suggestions shown every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-alert-user-suggestions) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-search-alert-user-suggestions).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -76,9 +76,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-al
 
 This panel indicates 90th percentile page load latency over all routes over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-page-load-latency) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-page-load-latency).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -86,9 +86,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-page-load
 
 This panel indicates 90th percentile blob load latency over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-blob-load-latency) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-blob-load-latency).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -98,9 +98,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-blob-load
 
 This panel indicates 99th percentile code-intel successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-codeintel-request-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-codeintel-request-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -108,9 +108,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-perc
 
 This panel indicates 90th percentile code-intel successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-codeintel-request-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-codeintel-request-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -118,9 +118,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-perc
 
 This panel indicates hard timeout search code-intel responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -128,9 +128,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-time
 
 This panel indicates hard error search code-intel responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -138,9 +138,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-erro
 
 This panel indicates partial timeout search code-intel responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-codeintel-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-codeintel-responses).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -148,9 +148,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-t
 
 This panel indicates search code-intel alert user suggestions shown every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-codeintel-alert-user-suggestions) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-search-codeintel-alert-user-suggestions).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -160,9 +160,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-co
 
 This panel indicates 99th percentile successful search API request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-api-request-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-api-request-duration).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -170,9 +170,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-perc
 
 This panel indicates 90th percentile successful search API request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-api-request-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-api-request-duration).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -180,9 +180,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-perc
 
 This panel indicates hard timeout search API responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-api-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-api-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -190,9 +190,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-time
 
 This panel indicates hard error search API responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -200,9 +200,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-erro
 
 This panel indicates partial timeout search API responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-api-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-api-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -210,9 +210,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-t
 
 This panel indicates search API alert user suggestions shown every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-api-alert-user-suggestions) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-search-api-alert-user-suggestions).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -222,9 +222,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-ap
 
 This panel indicates 99th percentile successful resolver duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -232,9 +232,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates resolver errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -242,9 +242,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful codeintel API operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -252,9 +252,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates code intel API errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -264,9 +264,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful database store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -274,9 +274,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates database store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -284,9 +284,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful upload worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -294,9 +294,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates upload worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -304,9 +304,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful index worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -314,9 +314,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates index worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -324,9 +324,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful LSIF store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -334,9 +334,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates lSIF store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -344,9 +344,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful upload store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -354,9 +354,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates upload store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -364,9 +364,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful gitserver client operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -374,9 +374,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates gitserver client errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -386,9 +386,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates commit graph queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-size) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-size).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -396,9 +396,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates commit graph queue growth rate over 30m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-growth-rate) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-growth-rate).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -406,9 +406,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful commit graph updater operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -416,9 +416,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates commit graph updater errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -428,9 +428,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates janitor errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-janitor-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-janitor-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -438,7 +438,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates upload records expired or deleted every 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -446,7 +446,7 @@ This panel indicates upload records expired or deleted every 5m.
 
 This panel indicates index records expired or deleted every 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -454,7 +454,7 @@ This panel indicates index records expired or deleted every 5m.
 
 This panel indicates data for unreferenced upload records removed every 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -462,9 +462,9 @@ This panel indicates data for unreferenced upload records removed every 5m.
 
 This panel indicates upload records re-queued (due to unresponsive worker) every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-resets) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-resets).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -472,9 +472,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates upload records errored due to repeated reset every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-reset-failures) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-reset-failures).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -482,9 +482,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates index records re-queued (due to unresponsive indexer) every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-resets) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-resets).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -492,9 +492,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates index records errored due to repeated reset every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-reset-failures) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-reset-failures).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -504,7 +504,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful indexing operation duration over 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -512,9 +512,9 @@ This panel indicates 99th percentile successful indexing operation duration over
 
 This panel indicates indexing errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-indexing-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-indexing-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -522,7 +522,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates 99th percentile successful index enqueuer operation duration over 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -530,9 +530,9 @@ This panel indicates 99th percentile successful index enqueuer operation duratio
 
 This panel indicates index enqueuer errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-autoindex-enqueuer-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-autoindex-enqueuer-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -542,9 +542,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 This panel indicates internal indexed search error responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-indexed-search-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-internal-indexed-search-error-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -552,9 +552,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-
 
 This panel indicates internal unindexed search error responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-unindexed-search-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-internal-unindexed-search-error-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -562,9 +562,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-
 
 This panel indicates internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -572,9 +572,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-
 
 This panel indicates 99th percentile successful gitserver query duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-gitserver-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-gitserver-duration).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -582,9 +582,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-perc
 
 This panel indicates gitserver error responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-gitserver-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-gitserver-error-responses).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -592,9 +592,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-gitserver
 
 This panel indicates warning test alert metric.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-warning) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-warning).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -602,9 +602,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-observabi
 
 This panel indicates critical test alert metric.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -614,9 +614,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-observabi
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -624,9 +624,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-container
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -644,7 +644,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' (frontend|sourcegraph-frontend)` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs (frontend|sourcegraph-frontend)` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -654,9 +654,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -664,9 +664,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-provision
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -674,9 +674,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-provision
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -684,9 +684,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-provision
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -698,9 +698,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -708,9 +708,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-gorout
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -720,9 +720,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-gc-dur
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -734,9 +734,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-pods-avai
 
 This panel indicates disk space remaining by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-disk-space-remaining) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-disk-space-remaining).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -746,9 +746,9 @@ This panel indicates running git commands.
 
 A high value signals load.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-running-git-commands) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-running-git-commands).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -756,9 +756,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-running-
 
 This panel indicates repository clone queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-clone-queue-size) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-repository-clone-queue-size).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -766,9 +766,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-reposito
 
 This panel indicates repository existence check queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-existence-check-queue-size) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-repository-existence-check-queue-size).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -784,7 +784,7 @@ If this value is consistently high, consider the following:
 - **Single container deployments:** Upgrade to a [Docker Compose deployment](../install/docker-compose/migrate.md) which offers better scalability and resource isolation.
 - **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](../install/resource_estimator.md).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -792,9 +792,9 @@ If this value is consistently high, consider the following:
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -804,9 +804,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-frontend
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -814,9 +814,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-containe
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -834,7 +834,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' gitserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the gitserver container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs gitserver` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -845,7 +845,7 @@ This panel indicates filesystem reads and writes rate by instance over 1h.
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -855,9 +855,9 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -867,7 +867,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 Git Server is expected to use up all the memory it is provided.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -875,9 +875,9 @@ Git Server is expected to use up all the memory it is provided.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -887,7 +887,7 @@ This panel indicates container memory usage (5m maximum) by instance.
 
 Git Server is expected to use up all the memory it is provided.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -899,9 +899,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -909,9 +909,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-gorou
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -921,9 +921,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-du
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -937,9 +937,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-pods-ava
 
 This panel indicates number of requests waiting on the global mutex.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-github-proxy-waiting-requests) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-github-proxy-waiting-requests).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -949,9 +949,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-githu
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -959,9 +959,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-conta
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -979,7 +979,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' github-proxy` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the github-proxy container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs github-proxy` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -989,9 +989,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -999,9 +999,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provi
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1009,9 +1009,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provi
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1019,9 +1019,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provi
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1033,9 +1033,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1043,9 +1043,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-go
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1055,9 +1055,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1069,9 +1069,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-pods-
 
 This panel indicates active connections.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-connections) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-connections).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1079,9 +1079,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-connectio
 
 This panel indicates maximum transaction durations.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1093,9 +1093,9 @@ This panel indicates database availability.
 
 A non-zero value indicates the database is online.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-postgres-up) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-postgres-up).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1105,9 +1105,9 @@ This panel indicates errors scraping postgres exporter.
 
 This value indicates issues retrieving metrics from postgres_exporter.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-pg-exporter-err) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-pg-exporter-err).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1117,9 +1117,9 @@ This panel indicates active schema migration.
 
 A 0 value indicates that no migration is in progress.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1129,9 +1129,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-migration
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1139,9 +1139,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-provision
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1149,9 +1149,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-provision
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1159,9 +1159,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-provision
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1171,9 +1171,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-provision
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1187,9 +1187,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-pods-avai
 
 This panel indicates queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-size) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-size).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1197,9 +1197,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates queue growth rate over 30m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-growth-rate) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-growth-rate).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1207,9 +1207,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates job errors errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-job-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-job-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1217,7 +1217,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates active workers processing uploads.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1225,7 +1225,7 @@ This panel indicates active workers processing uploads.
 
 This panel indicates active jobs.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1235,7 +1235,7 @@ This panel indicates active jobs.
 
 This panel indicates 99th percentile successful job duration over 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1245,9 +1245,9 @@ This panel indicates 99th percentile successful job duration over 5m.
 
 This panel indicates 99th percentile successful database store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1255,9 +1255,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates database store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1265,9 +1265,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1275,9 +1275,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1285,9 +1285,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful LSIF store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1295,9 +1295,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates lSIF store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1305,9 +1305,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful upload store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1315,9 +1315,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates upload store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1325,9 +1325,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful gitserver client operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1335,9 +1335,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates gitserver client errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1347,9 +1347,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1359,9 +1359,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1369,9 +1369,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1389,7 +1389,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1399,9 +1399,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1409,9 +1409,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1419,9 +1419,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1429,9 +1429,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1443,9 +1443,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1453,9 +1453,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1465,9 +1465,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -1479,9 +1479,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1491,9 +1491,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-front
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1501,9 +1501,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-conta
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1521,7 +1521,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' query-runner` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the query-runner container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs query-runner` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1531,9 +1531,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1541,9 +1541,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provi
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1551,9 +1551,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provi
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1561,9 +1561,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provi
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1575,9 +1575,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1585,9 +1585,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-go
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1597,9 +1597,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-gc
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -1611,9 +1611,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-pods-
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1626,7 +1626,7 @@ This panel indicates time since last sync.
 A high value here indicates issues synchronizing repository permissions.
 If the value is persistently high, make sure all external services have valid tokens.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1634,9 +1634,9 @@ If the value is persistently high, make sure all external services have valid to
 
 This panel indicates time since oldest sync.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-max-sync-backoff) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-max-sync-backoff).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1644,9 +1644,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-r
 
 This panel indicates sync error rate.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1654,9 +1654,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-r
 
 This panel indicates sync was started.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1664,9 +1664,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-synce
 
 This panel indicates 95th repositories sync duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-duration).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1674,9 +1674,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-synce
 
 This panel indicates 95th repositories source duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-source-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-source-duration).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1684,9 +1684,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sourc
 
 This panel indicates repositories synced.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1694,9 +1694,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-synce
 
 This panel indicates repositories sourced.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1704,9 +1704,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sourc
 
 This panel indicates total number of user added repos.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1714,9 +1714,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-user-
 
 This panel indicates repositories purge failed.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-purge-failed) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-purge-failed).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1724,9 +1724,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-purge
 
 This panel indicates repositories scheduled due to hitting a deadline.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-auto-fetch) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-auto-fetch).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1737,7 +1737,7 @@ This panel indicates repositories scheduled due to user traffic.
 Check repo-updater logs if this value is persistently high.
 This does not indicate anything if there are no user added code hosts.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1745,9 +1745,9 @@ This does not indicate anything if there are no user added code hosts.
 
 This panel indicates repositories managed by the scheduler.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-known-repos) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-known-repos).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1755,9 +1755,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched
 
 This panel indicates rate of growth of update queue length over 5 minutes.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-update-queue-length) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-update-queue-length).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1765,9 +1765,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched
 
 This panel indicates scheduler loops.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-loops) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-loops).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1775,9 +1775,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched
 
 This panel indicates repositories schedule error rate.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-error) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-error).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1787,9 +1787,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched
 
 This panel indicates time gap between least and most up to date permissions.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-perms) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-perms).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1797,9 +1797,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms
 
 This panel indicates number of entities with stale permissions.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-stale-perms) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-stale-perms).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1807,9 +1807,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms
 
 This panel indicates number of entities with no permissions.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-no-perms) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-no-perms).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1817,9 +1817,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms
 
 This panel indicates 95th permissions sync duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-duration).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1827,9 +1827,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms
 
 This panel indicates permissions sync queued items.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-queue-size) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-queue-size).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1837,9 +1837,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms
 
 This panel indicates permissions sync error rate.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-errors).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1849,9 +1849,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms
 
 This panel indicates the total number of external services.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-external-services-total) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-external-services-total).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1859,9 +1859,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-r
 
 This panel indicates the total number of user added external services.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-user-external-services-total) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-user-external-services-total).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1869,9 +1869,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-r
 
 This panel indicates the total number of queued sync jobs.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-queued-sync-jobs-total) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-queued-sync-jobs-total).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1879,9 +1879,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repou
 
 This panel indicates the total number of completed sync jobs.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-completed-sync-jobs-total) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-completed-sync-jobs-total).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1889,9 +1889,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repou
 
 This panel indicates the total number of errored sync jobs.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-errored-sync-jobs-total) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-errored-sync-jobs-total).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1899,9 +1899,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repou
 
 This panel indicates remaining calls to GitHub graphql API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-graphql-rate-limit-remaining) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-github-graphql-rate-limit-remaining).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1909,9 +1909,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-githu
 
 This panel indicates remaining calls to GitHub rest API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-rest-rate-limit-remaining) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-github-rest-rate-limit-remaining).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1919,9 +1919,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-githu
 
 This panel indicates remaining calls to GitHub search API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-search-rate-limit-remaining) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-github-search-rate-limit-remaining).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1929,9 +1929,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-githu
 
 This panel indicates remaining calls to GitLab rest API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-gitlab-rest-rate-limit-remaining) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-gitlab-rest-rate-limit-remaining).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1941,9 +1941,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-gitla
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1951,9 +1951,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-conta
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1971,7 +1971,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' repo-updater` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the repo-updater container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs repo-updater` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1981,9 +1981,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -1991,9 +1991,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provi
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2001,9 +2001,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provi
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2011,9 +2011,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provi
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2025,9 +2025,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2035,9 +2035,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-go
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2047,9 +2047,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2061,9 +2061,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-pods-
 
 This panel indicates unindexed search request errors every 5m by code.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-unindexed-search-request-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-unindexed-search-request-errors).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2071,9 +2071,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-unindexed
 
 This panel indicates requests per second over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-replica-traffic) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-replica-traffic).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2081,9 +2081,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-replica-t
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2093,9 +2093,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-frontend-
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2103,9 +2103,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-container
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2123,7 +2123,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' searcher` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the searcher container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs searcher` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2133,9 +2133,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2143,9 +2143,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-provision
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2153,9 +2153,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-provision
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2163,9 +2163,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-provision
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2177,9 +2177,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2187,9 +2187,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gorout
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2199,9 +2199,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gc-dur
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2213,9 +2213,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-pods-avai
 
 This panel indicates store fetch failures every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-store-fetch-failures) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-store-fetch-failures).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2223,9 +2223,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-store-fetc
 
 This panel indicates current fetch queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-current-fetch-queue-size) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-current-fetch-queue-size).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2233,9 +2233,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-current-fe
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2245,9 +2245,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-frontend-i
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2255,9 +2255,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2275,7 +2275,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' symbols` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the symbols container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs symbols` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2285,9 +2285,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2295,9 +2295,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioni
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2305,9 +2305,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioni
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2315,9 +2315,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioni
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2329,9 +2329,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2339,9 +2339,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-gorouti
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2351,9 +2351,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-gc-dura
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2365,7 +2365,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-pods-avail
 
 This panel indicates syntax highlighting errors every 5m.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2373,7 +2373,7 @@ This panel indicates syntax highlighting errors every 5m.
 
 This panel indicates syntax highlighting timeouts every 5m.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2381,7 +2381,7 @@ This panel indicates syntax highlighting timeouts every 5m.
 
 This panel indicates syntax highlighting panics every 5m.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2389,7 +2389,7 @@ This panel indicates syntax highlighting panics every 5m.
 
 This panel indicates syntax highlighter worker deaths every 5m.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2399,9 +2399,9 @@ This panel indicates syntax highlighter worker deaths every 5m.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2409,9 +2409,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-con
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2429,7 +2429,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' syntect-server` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the syntect-server container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs syntect-server` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2439,9 +2439,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2449,9 +2449,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pro
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2459,9 +2459,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pro
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2469,9 +2469,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pro
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2481,9 +2481,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pro
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2495,9 +2495,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pod
 
 This panel indicates average resolve revision duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-average-resolve-revision-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-average-resolve-revision-duration).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2507,9 +2507,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2517,9 +2517,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2537,7 +2537,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-indexserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-indexserver container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-indexserver` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2548,7 +2548,7 @@ This panel indicates filesystem reads and writes rate by instance over 1h.
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2558,9 +2558,9 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2568,9 +2568,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2578,9 +2578,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2588,9 +2588,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2600,9 +2600,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2614,9 +2614,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 This panel indicates indexed search request errors every 5m by code.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-indexed-search-request-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-indexed-search-request-errors).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2626,9 +2626,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-in
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2636,9 +2636,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-co
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2656,7 +2656,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-webserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-webserver container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-webserver` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2667,7 +2667,7 @@ This panel indicates filesystem reads and writes rate by instance over 1h.
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
-<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
+<sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
 <br />
 
@@ -2677,9 +2677,9 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2687,9 +2687,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-pr
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2697,9 +2697,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-pr
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2707,9 +2707,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-pr
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
 <br />
 
@@ -2726,9 +2726,9 @@ This panel indicates average prometheus rule group evaluation duration over 10m.
 A high value here indicates Prometheus rule evaluation is taking longer than expected.
 It might indicate that certain rule groups are taking too long to evaluate, or Prometheus is underprovisioned.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-rule-group-evaluation) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-rule-group-evaluation).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2738,9 +2738,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometh
 
 This panel indicates failed alertmanager notifications over 1m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notifications-failed-total) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notifications-failed-total).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2750,9 +2750,9 @@ This panel indicates alertmanager configuration reload status.
 
 A `1` indicates Alertmanager reloaded its configuration successfully.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-config-status) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-config-status).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2762,9 +2762,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertma
 
 This panel indicates prometheus tsdb failures by operation over 1m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-tsdb-op-failure) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-tsdb-op-failure).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2774,9 +2774,9 @@ This panel indicates prometheus configuration reload status.
 
 A `1` indicates Prometheus reloaded its configuration successfully.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-config-status) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-config-status).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2784,9 +2784,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometh
 
 This panel indicates prometheus scrapes that exceed the sample limit over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-exceeded) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-exceeded).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2794,9 +2794,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometh
 
 This panel indicates prometheus scrapes rejected due to duplicate timestamps over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-duplicate) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-duplicate).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2806,9 +2806,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometh
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2816,9 +2816,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-contain
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2836,7 +2836,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' prometheus` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the prometheus container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs prometheus` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2846,9 +2846,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2856,9 +2856,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisi
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2866,9 +2866,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisi
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2876,9 +2876,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisi
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2888,9 +2888,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisi
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
+<sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
 <br />
 
@@ -2904,9 +2904,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-pods-av
 
 This panel indicates queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-size) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-size).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2914,9 +2914,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-cod
 
 This panel indicates queue growth rate over 30m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-growth-rate) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-growth-rate).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2924,9 +2924,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-cod
 
 This panel indicates job errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-job-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-job-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2934,7 +2934,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-cod
 
 This panel indicates active executors processing codeintel jobs.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2942,7 +2942,7 @@ This panel indicates active executors processing codeintel jobs.
 
 This panel indicates active jobs.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2952,9 +2952,9 @@ This panel indicates active jobs.
 
 This panel indicates 99th percentile successful worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2962,9 +2962,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-cod
 
 This panel indicates worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2974,9 +2974,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-cod
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2986,9 +2986,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-fro
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -2996,9 +2996,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-con
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3016,7 +3016,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' executor-queue` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the executor-queue container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs executor-queue` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3026,9 +3026,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3036,9 +3036,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pro
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3046,9 +3046,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pro
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3056,9 +3056,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pro
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3070,9 +3070,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3080,9 +3080,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3092,9 +3092,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3108,7 +3108,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pod
 
 This panel indicates 99th percentile successful job duration over 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3116,7 +3116,7 @@ This panel indicates 99th percentile successful job duration over 5m.
 
 This panel indicates active handlers processing jobs.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3124,9 +3124,9 @@ This panel indicates active handlers processing jobs.
 
 This panel indicates job errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-codeintel-job-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-codeintel-job-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3136,9 +3136,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful API request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-99th-percentile-duration) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-99th-percentile-duration).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3146,9 +3146,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates aPI errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3158,7 +3158,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful setup command duration over 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3166,9 +3166,9 @@ This panel indicates 99th percentile successful setup command duration over 5m.
 
 This panel indicates setup command errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-setup-command-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-setup-command-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3176,7 +3176,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful exec command duration over 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3184,9 +3184,9 @@ This panel indicates 99th percentile successful exec command duration over 5m.
 
 This panel indicates exec command errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-exec-command-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-exec-command-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3194,7 +3194,7 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates 99th percentile successful teardown command duration over 5m.
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3202,9 +3202,9 @@ This panel indicates 99th percentile successful teardown command duration over 5
 
 This panel indicates teardown command errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-teardown-command-errors) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-teardown-command-errors).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3214,9 +3214,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-cpu-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-cpu-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3224,9 +3224,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-memory-usage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-memory-usage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3244,7 +3244,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3254,9 +3254,9 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3264,9 +3264,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-long-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3274,9 +3274,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3284,9 +3284,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-short-term).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3298,9 +3298,9 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-goroutines) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-goroutines).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3308,9 +3308,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-gc-duration-seconds) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-gc-duration-seconds).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 
@@ -3320,9 +3320,9 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-pods-available-percentage) for alerts related to this panel.
+> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-pods-available-percentage).
 
-<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -16,7 +16,7 @@ To learn more about Sourcegraph's metrics and how to view these dashboards, see 
 
 This panel indicates 99th percentile successful search request duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-request-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-request-duration).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -26,7 +26,7 @@ This panel indicates 99th percentile successful search request duration over 5m.
 
 This panel indicates 90th percentile successful search request duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-request-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-request-duration).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -36,7 +36,7 @@ This panel indicates 90th percentile successful search request duration over 5m.
 
 This panel indicates hard timeout search responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -46,7 +46,7 @@ This panel indicates hard timeout search responses every 5m.
 
 This panel indicates hard error search responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -56,7 +56,7 @@ This panel indicates hard error search responses every 5m.
 
 This panel indicates partial timeout search responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -66,7 +66,7 @@ This panel indicates partial timeout search responses every 5m.
 
 This panel indicates search alert user suggestions shown every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-search-alert-user-suggestions).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-search-alert-user-suggestions).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -76,7 +76,7 @@ This panel indicates search alert user suggestions shown every 5m.
 
 This panel indicates 90th percentile page load latency over all routes over 10m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-page-load-latency).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-page-load-latency).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -86,7 +86,7 @@ This panel indicates 90th percentile page load latency over all routes over 10m.
 
 This panel indicates 90th percentile blob load latency over 10m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-blob-load-latency).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-blob-load-latency).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -98,7 +98,7 @@ This panel indicates 90th percentile blob load latency over 10m.
 
 This panel indicates 99th percentile code-intel successful search request duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-codeintel-request-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-codeintel-request-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -108,7 +108,7 @@ This panel indicates 99th percentile code-intel successful search request durati
 
 This panel indicates 90th percentile code-intel successful search request duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-codeintel-request-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-codeintel-request-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -118,7 +118,7 @@ This panel indicates 90th percentile code-intel successful search request durati
 
 This panel indicates hard timeout search code-intel responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -128,7 +128,7 @@ This panel indicates hard timeout search code-intel responses every 5m.
 
 This panel indicates hard error search code-intel responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -138,7 +138,7 @@ This panel indicates hard error search code-intel responses every 5m.
 
 This panel indicates partial timeout search code-intel responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-codeintel-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-codeintel-responses).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -148,7 +148,7 @@ This panel indicates partial timeout search code-intel responses every 5m.
 
 This panel indicates search code-intel alert user suggestions shown every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-search-codeintel-alert-user-suggestions).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-search-codeintel-alert-user-suggestions).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -160,7 +160,7 @@ This panel indicates search code-intel alert user suggestions shown every 5m.
 
 This panel indicates 99th percentile successful search API request duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-api-request-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-api-request-duration).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -170,7 +170,7 @@ This panel indicates 99th percentile successful search API request duration over
 
 This panel indicates 90th percentile successful search API request duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-api-request-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-api-request-duration).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -180,7 +180,7 @@ This panel indicates 90th percentile successful search API request duration over
 
 This panel indicates hard timeout search API responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-api-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-api-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -190,7 +190,7 @@ This panel indicates hard timeout search API responses every 5m.
 
 This panel indicates hard error search API responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -200,7 +200,7 @@ This panel indicates hard error search API responses every 5m.
 
 This panel indicates partial timeout search API responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-api-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-api-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -210,7 +210,7 @@ This panel indicates partial timeout search API responses every 5m.
 
 This panel indicates search API alert user suggestions shown every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-search-api-alert-user-suggestions).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-search-api-alert-user-suggestions).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -222,7 +222,7 @@ This panel indicates search API alert user suggestions shown every 5m.
 
 This panel indicates 99th percentile successful resolver duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -232,7 +232,7 @@ This panel indicates 99th percentile successful resolver duration over 5m.
 
 This panel indicates resolver errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -242,7 +242,7 @@ This panel indicates resolver errors every 5m.
 
 This panel indicates 99th percentile successful codeintel API operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -252,7 +252,7 @@ This panel indicates 99th percentile successful codeintel API operation duration
 
 This panel indicates code intel API errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -264,7 +264,7 @@ This panel indicates code intel API errors every 5m.
 
 This panel indicates 99th percentile successful database store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -274,7 +274,7 @@ This panel indicates 99th percentile successful database store operation duratio
 
 This panel indicates database store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -284,7 +284,7 @@ This panel indicates database store errors every 5m.
 
 This panel indicates 99th percentile successful upload worker store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -294,7 +294,7 @@ This panel indicates 99th percentile successful upload worker store operation du
 
 This panel indicates upload worker store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -304,7 +304,7 @@ This panel indicates upload worker store errors every 5m.
 
 This panel indicates 99th percentile successful index worker store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -314,7 +314,7 @@ This panel indicates 99th percentile successful index worker store operation dur
 
 This panel indicates index worker store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -324,7 +324,7 @@ This panel indicates index worker store errors every 5m.
 
 This panel indicates 99th percentile successful LSIF store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -334,7 +334,7 @@ This panel indicates 99th percentile successful LSIF store operation duration ov
 
 This panel indicates lSIF store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -344,7 +344,7 @@ This panel indicates lSIF store errors every 5m.
 
 This panel indicates 99th percentile successful upload store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -354,7 +354,7 @@ This panel indicates 99th percentile successful upload store operation duration 
 
 This panel indicates upload store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -364,7 +364,7 @@ This panel indicates upload store errors every 5m.
 
 This panel indicates 99th percentile successful gitserver client operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -374,7 +374,7 @@ This panel indicates 99th percentile successful gitserver client operation durat
 
 This panel indicates gitserver client errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -386,7 +386,7 @@ This panel indicates gitserver client errors every 5m.
 
 This panel indicates commit graph queue size.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-size).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-size).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -396,7 +396,7 @@ This panel indicates commit graph queue size.
 
 This panel indicates commit graph queue growth rate over 30m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-growth-rate).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-growth-rate).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -406,7 +406,7 @@ This panel indicates commit graph queue growth rate over 30m.
 
 This panel indicates 99th percentile successful commit graph updater operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -416,7 +416,7 @@ This panel indicates 99th percentile successful commit graph updater operation d
 
 This panel indicates commit graph updater errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -428,7 +428,7 @@ This panel indicates commit graph updater errors every 5m.
 
 This panel indicates janitor errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-janitor-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-janitor-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -462,7 +462,7 @@ This panel indicates data for unreferenced upload records removed every 5m.
 
 This panel indicates upload records re-queued (due to unresponsive worker) every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-resets).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-resets).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -472,7 +472,7 @@ This panel indicates upload records re-queued (due to unresponsive worker) every
 
 This panel indicates upload records errored due to repeated reset every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-reset-failures).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-reset-failures).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -482,7 +482,7 @@ This panel indicates upload records errored due to repeated reset every 5m.
 
 This panel indicates index records re-queued (due to unresponsive indexer) every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-resets).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-resets).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -492,7 +492,7 @@ This panel indicates index records re-queued (due to unresponsive indexer) every
 
 This panel indicates index records errored due to repeated reset every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-reset-failures).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-reset-failures).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -512,7 +512,7 @@ This panel indicates 99th percentile successful indexing operation duration over
 
 This panel indicates indexing errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-indexing-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-indexing-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -530,7 +530,7 @@ This panel indicates 99th percentile successful index enqueuer operation duratio
 
 This panel indicates index enqueuer errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-autoindex-enqueuer-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-codeintel-autoindex-enqueuer-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -542,7 +542,7 @@ This panel indicates index enqueuer errors every 5m.
 
 This panel indicates internal indexed search error responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-internal-indexed-search-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-internal-indexed-search-error-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -552,7 +552,7 @@ This panel indicates internal indexed search error responses every 5m.
 
 This panel indicates internal unindexed search error responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-internal-unindexed-search-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-internal-unindexed-search-error-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -562,7 +562,7 @@ This panel indicates internal unindexed search error responses every 5m.
 
 This panel indicates internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -572,7 +572,7 @@ This panel indicates internal API error responses every 5m by route.
 
 This panel indicates 99th percentile successful gitserver query duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-gitserver-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-gitserver-duration).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -582,7 +582,7 @@ This panel indicates 99th percentile successful gitserver query duration over 5m
 
 This panel indicates gitserver error responses every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-gitserver-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-gitserver-error-responses).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -592,7 +592,7 @@ This panel indicates gitserver error responses every 5m.
 
 This panel indicates warning test alert metric.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-warning).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-warning).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -602,7 +602,7 @@ This panel indicates warning test alert metric.
 
 This panel indicates critical test alert metric.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -614,7 +614,7 @@ This panel indicates critical test alert metric.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -624,7 +624,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -654,7 +654,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -664,7 +664,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -674,7 +674,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -684,7 +684,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -698,7 +698,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -708,7 +708,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -720,7 +720,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#frontend-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -734,7 +734,7 @@ This panel indicates percentage pods available.
 
 This panel indicates disk space remaining by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-disk-space-remaining).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-disk-space-remaining).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -746,7 +746,7 @@ This panel indicates running git commands.
 
 A high value signals load.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-running-git-commands).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-running-git-commands).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -756,7 +756,7 @@ A high value signals load.
 
 This panel indicates repository clone queue size.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-repository-clone-queue-size).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-repository-clone-queue-size).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -766,7 +766,7 @@ This panel indicates repository clone queue size.
 
 This panel indicates repository existence check queue size.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-repository-existence-check-queue-size).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-repository-existence-check-queue-size).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -792,7 +792,7 @@ If this value is consistently high, consider the following:
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -804,7 +804,7 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -814,7 +814,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -855,7 +855,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -875,7 +875,7 @@ Git Server is expected to use up all the memory it is provided.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -899,7 +899,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -909,7 +909,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -921,7 +921,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#gitserver-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#gitserver-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -937,7 +937,7 @@ This panel indicates percentage pods available.
 
 This panel indicates number of requests waiting on the global mutex.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-github-proxy-waiting-requests).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-github-proxy-waiting-requests).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -949,7 +949,7 @@ This panel indicates number of requests waiting on the global mutex.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -959,7 +959,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -989,7 +989,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -999,7 +999,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1009,7 +1009,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1019,7 +1019,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1033,7 +1033,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1043,7 +1043,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1055,7 +1055,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#github-proxy-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#github-proxy-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1069,7 +1069,7 @@ This panel indicates percentage pods available.
 
 This panel indicates active connections.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-connections).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-connections).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1079,7 +1079,7 @@ This panel indicates active connections.
 
 This panel indicates maximum transaction durations.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1093,7 +1093,7 @@ This panel indicates database availability.
 
 A non-zero value indicates the database is online.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-postgres-up).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-postgres-up).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1105,7 +1105,7 @@ This panel indicates errors scraping postgres exporter.
 
 This value indicates issues retrieving metrics from postgres_exporter.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-pg-exporter-err).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-pg-exporter-err).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1117,7 +1117,7 @@ This panel indicates active schema migration.
 
 A 0 value indicates that no migration is in progress.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1129,7 +1129,7 @@ A 0 value indicates that no migration is in progress.
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1139,7 +1139,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1149,7 +1149,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1159,7 +1159,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1171,7 +1171,7 @@ This panel indicates container memory usage (5m maximum) by instance.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1187,7 +1187,7 @@ This panel indicates percentage pods available.
 
 This panel indicates queue size.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-size).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-size).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1197,7 +1197,7 @@ This panel indicates queue size.
 
 This panel indicates queue growth rate over 30m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-growth-rate).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-growth-rate).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1207,7 +1207,7 @@ This panel indicates queue growth rate over 30m.
 
 This panel indicates job errors errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-job-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-job-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1245,7 +1245,7 @@ This panel indicates 99th percentile successful job duration over 5m.
 
 This panel indicates 99th percentile successful database store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1255,7 +1255,7 @@ This panel indicates 99th percentile successful database store operation duratio
 
 This panel indicates database store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1265,7 +1265,7 @@ This panel indicates database store errors every 5m.
 
 This panel indicates 99th percentile successful worker store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1275,7 +1275,7 @@ This panel indicates 99th percentile successful worker store operation duration 
 
 This panel indicates worker store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1285,7 +1285,7 @@ This panel indicates worker store errors every 5m.
 
 This panel indicates 99th percentile successful LSIF store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1295,7 +1295,7 @@ This panel indicates 99th percentile successful LSIF store operation duration ov
 
 This panel indicates lSIF store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1305,7 +1305,7 @@ This panel indicates lSIF store errors every 5m.
 
 This panel indicates 99th percentile successful upload store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1315,7 +1315,7 @@ This panel indicates 99th percentile successful upload store operation duration 
 
 This panel indicates upload store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1325,7 +1325,7 @@ This panel indicates upload store errors every 5m.
 
 This panel indicates 99th percentile successful gitserver client operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1335,7 +1335,7 @@ This panel indicates 99th percentile successful gitserver client operation durat
 
 This panel indicates gitserver client errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1347,7 +1347,7 @@ This panel indicates gitserver client errors every 5m.
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1359,7 +1359,7 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1369,7 +1369,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1399,7 +1399,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1409,7 +1409,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1419,7 +1419,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1429,7 +1429,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1443,7 +1443,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1453,7 +1453,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1465,7 +1465,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -1479,7 +1479,7 @@ This panel indicates percentage pods available.
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1491,7 +1491,7 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1501,7 +1501,7 @@ This panel indicates container memory usage by instance.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1531,7 +1531,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1541,7 +1541,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1551,7 +1551,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1561,7 +1561,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1575,7 +1575,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1585,7 +1585,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1597,7 +1597,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#query-runner-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#query-runner-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -1611,7 +1611,7 @@ This panel indicates percentage pods available.
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1634,7 +1634,7 @@ If the value is persistently high, make sure all external services have valid to
 
 This panel indicates time since oldest sync.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-max-sync-backoff).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-max-sync-backoff).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1644,7 +1644,7 @@ This panel indicates time since oldest sync.
 
 This panel indicates sync error rate.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1654,7 +1654,7 @@ This panel indicates sync error rate.
 
 This panel indicates sync was started.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1664,7 +1664,7 @@ This panel indicates sync was started.
 
 This panel indicates 95th repositories sync duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-duration).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1674,7 +1674,7 @@ This panel indicates 95th repositories sync duration.
 
 This panel indicates 95th repositories source duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-source-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-source-duration).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1684,7 +1684,7 @@ This panel indicates 95th repositories source duration.
 
 This panel indicates repositories synced.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1694,7 +1694,7 @@ This panel indicates repositories synced.
 
 This panel indicates repositories sourced.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1704,7 +1704,7 @@ This panel indicates repositories sourced.
 
 This panel indicates total number of user added repos.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1714,7 +1714,7 @@ This panel indicates total number of user added repos.
 
 This panel indicates repositories purge failed.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-purge-failed).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-purge-failed).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1724,7 +1724,7 @@ This panel indicates repositories purge failed.
 
 This panel indicates repositories scheduled due to hitting a deadline.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-auto-fetch).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-auto-fetch).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1745,7 +1745,7 @@ This does not indicate anything if there are no user added code hosts.
 
 This panel indicates repositories managed by the scheduler.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-known-repos).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-known-repos).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1755,7 +1755,7 @@ This panel indicates repositories managed by the scheduler.
 
 This panel indicates rate of growth of update queue length over 5 minutes.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-update-queue-length).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-update-queue-length).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1765,7 +1765,7 @@ This panel indicates rate of growth of update queue length over 5 minutes.
 
 This panel indicates scheduler loops.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-loops).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-loops).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1775,7 +1775,7 @@ This panel indicates scheduler loops.
 
 This panel indicates repositories schedule error rate.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-error).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-sched-error).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1787,7 +1787,7 @@ This panel indicates repositories schedule error rate.
 
 This panel indicates time gap between least and most up to date permissions.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-perms).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-perms).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1797,7 +1797,7 @@ This panel indicates time gap between least and most up to date permissions.
 
 This panel indicates number of entities with stale permissions.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-stale-perms).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-stale-perms).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1807,7 +1807,7 @@ This panel indicates number of entities with stale permissions.
 
 This panel indicates number of entities with no permissions.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-no-perms).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-no-perms).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1817,7 +1817,7 @@ This panel indicates number of entities with no permissions.
 
 This panel indicates 95th permissions sync duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-duration).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1827,7 +1827,7 @@ This panel indicates 95th permissions sync duration.
 
 This panel indicates permissions sync queued items.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-queue-size).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-queue-size).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1837,7 +1837,7 @@ This panel indicates permissions sync queued items.
 
 This panel indicates permissions sync error rate.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-errors).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1849,7 +1849,7 @@ This panel indicates permissions sync error rate.
 
 This panel indicates the total number of external services.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-external-services-total).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-external-services-total).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1859,7 +1859,7 @@ This panel indicates the total number of external services.
 
 This panel indicates the total number of user added external services.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-user-external-services-total).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-user-external-services-total).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1869,7 +1869,7 @@ This panel indicates the total number of user added external services.
 
 This panel indicates the total number of queued sync jobs.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-queued-sync-jobs-total).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-queued-sync-jobs-total).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1879,7 +1879,7 @@ This panel indicates the total number of queued sync jobs.
 
 This panel indicates the total number of completed sync jobs.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-completed-sync-jobs-total).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-completed-sync-jobs-total).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1889,7 +1889,7 @@ This panel indicates the total number of completed sync jobs.
 
 This panel indicates the total number of errored sync jobs.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-errored-sync-jobs-total).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-errored-sync-jobs-total).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1899,7 +1899,7 @@ This panel indicates the total number of errored sync jobs.
 
 This panel indicates remaining calls to GitHub graphql API before hitting the rate limit.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-github-graphql-rate-limit-remaining).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-github-graphql-rate-limit-remaining).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1909,7 +1909,7 @@ This panel indicates remaining calls to GitHub graphql API before hitting the ra
 
 This panel indicates remaining calls to GitHub rest API before hitting the rate limit.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-github-rest-rate-limit-remaining).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-github-rest-rate-limit-remaining).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1919,7 +1919,7 @@ This panel indicates remaining calls to GitHub rest API before hitting the rate 
 
 This panel indicates remaining calls to GitHub search API before hitting the rate limit.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-github-search-rate-limit-remaining).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-github-search-rate-limit-remaining).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1929,7 +1929,7 @@ This panel indicates remaining calls to GitHub search API before hitting the rat
 
 This panel indicates remaining calls to GitLab rest API before hitting the rate limit.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-gitlab-rest-rate-limit-remaining).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-gitlab-rest-rate-limit-remaining).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1941,7 +1941,7 @@ This panel indicates remaining calls to GitLab rest API before hitting the rate 
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1951,7 +1951,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1981,7 +1981,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -1991,7 +1991,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2001,7 +2001,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2011,7 +2011,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2025,7 +2025,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2035,7 +2035,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2047,7 +2047,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#repo-updater-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#repo-updater-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2061,7 +2061,7 @@ This panel indicates percentage pods available.
 
 This panel indicates unindexed search request errors every 5m by code.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-unindexed-search-request-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-unindexed-search-request-errors).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2071,7 +2071,7 @@ This panel indicates unindexed search request errors every 5m by code.
 
 This panel indicates requests per second over 10m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-replica-traffic).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-replica-traffic).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2081,7 +2081,7 @@ This panel indicates requests per second over 10m.
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2093,7 +2093,7 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2103,7 +2103,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2133,7 +2133,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2143,7 +2143,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2153,7 +2153,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2163,7 +2163,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2177,7 +2177,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2187,7 +2187,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2199,7 +2199,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2213,7 +2213,7 @@ This panel indicates percentage pods available.
 
 This panel indicates store fetch failures every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-store-fetch-failures).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-store-fetch-failures).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2223,7 +2223,7 @@ This panel indicates store fetch failures every 5m.
 
 This panel indicates current fetch queue size.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-current-fetch-queue-size).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-current-fetch-queue-size).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2233,7 +2233,7 @@ This panel indicates current fetch queue size.
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2245,7 +2245,7 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2255,7 +2255,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2285,7 +2285,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2295,7 +2295,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2305,7 +2305,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2315,7 +2315,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2329,7 +2329,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2339,7 +2339,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2351,7 +2351,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#symbols-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#symbols-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2399,7 +2399,7 @@ This panel indicates syntax highlighter worker deaths every 5m.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#syntect-server-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2409,7 +2409,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#syntect-server-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2439,7 +2439,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2449,7 +2449,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2459,7 +2459,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2469,7 +2469,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2481,7 +2481,7 @@ This panel indicates container memory usage (5m maximum) by instance.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#syntect-server-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#syntect-server-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).*</sub>
 
@@ -2495,7 +2495,7 @@ This panel indicates percentage pods available.
 
 This panel indicates average resolve revision duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-average-resolve-revision-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-average-resolve-revision-duration).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2507,7 +2507,7 @@ This panel indicates average resolve revision duration over 5m.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2517,7 +2517,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2558,7 +2558,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2568,7 +2568,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2578,7 +2578,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2588,7 +2588,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2600,7 +2600,7 @@ This panel indicates container memory usage (5m maximum) by instance.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2614,7 +2614,7 @@ This panel indicates percentage pods available.
 
 This panel indicates indexed search request errors every 5m by code.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-indexed-search-request-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-indexed-search-request-errors).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2626,7 +2626,7 @@ This panel indicates indexed search request errors every 5m by code.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2636,7 +2636,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2677,7 +2677,7 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2687,7 +2687,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2697,7 +2697,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2707,7 +2707,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -2726,7 +2726,7 @@ This panel indicates average prometheus rule group evaluation duration over 10m.
 A high value here indicates Prometheus rule evaluation is taking longer than expected.
 It might indicate that certain rule groups are taking too long to evaluate, or Prometheus is underprovisioned.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-rule-group-evaluation).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-rule-group-evaluation).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2738,7 +2738,7 @@ It might indicate that certain rule groups are taking too long to evaluate, or P
 
 This panel indicates failed alertmanager notifications over 1m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notifications-failed-total).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notifications-failed-total).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2750,7 +2750,7 @@ This panel indicates alertmanager configuration reload status.
 
 A `1` indicates Alertmanager reloaded its configuration successfully.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-config-status).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-config-status).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2762,7 +2762,7 @@ A `1` indicates Alertmanager reloaded its configuration successfully.
 
 This panel indicates prometheus tsdb failures by operation over 1m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-tsdb-op-failure).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-tsdb-op-failure).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2774,7 +2774,7 @@ This panel indicates prometheus configuration reload status.
 
 A `1` indicates Prometheus reloaded its configuration successfully.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-config-status).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-config-status).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2784,7 +2784,7 @@ A `1` indicates Prometheus reloaded its configuration successfully.
 
 This panel indicates prometheus scrapes that exceed the sample limit over 10m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-exceeded).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-exceeded).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2794,7 +2794,7 @@ This panel indicates prometheus scrapes that exceed the sample limit over 10m.
 
 This panel indicates prometheus scrapes rejected due to duplicate timestamps over 10m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-duplicate).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-duplicate).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2806,7 +2806,7 @@ This panel indicates prometheus scrapes rejected due to duplicate timestamps ove
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2816,7 +2816,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2846,7 +2846,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2856,7 +2856,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2866,7 +2866,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2876,7 +2876,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2888,7 +2888,7 @@ This panel indicates container memory usage (5m maximum) by instance.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#prometheus-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#prometheus-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).*</sub>
 
@@ -2904,7 +2904,7 @@ This panel indicates percentage pods available.
 
 This panel indicates queue size.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-size).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-size).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2914,7 +2914,7 @@ This panel indicates queue size.
 
 This panel indicates queue growth rate over 30m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-growth-rate).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-growth-rate).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2924,7 +2924,7 @@ This panel indicates queue growth rate over 30m.
 
 This panel indicates job errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-job-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-job-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2952,7 +2952,7 @@ This panel indicates active jobs.
 
 This panel indicates 99th percentile successful worker store operation duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2962,7 +2962,7 @@ This panel indicates 99th percentile successful worker store operation duration 
 
 This panel indicates worker store errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2974,7 +2974,7 @@ This panel indicates worker store errors every 5m.
 
 This panel indicates frontend-internal API error responses every 5m by route.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2986,7 +2986,7 @@ This panel indicates frontend-internal API error responses every 5m by route.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -2996,7 +2996,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3026,7 +3026,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3036,7 +3036,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3046,7 +3046,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3056,7 +3056,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3070,7 +3070,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3080,7 +3080,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3092,7 +3092,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#executor-queue-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#executor-queue-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3124,7 +3124,7 @@ This panel indicates active handlers processing jobs.
 
 This panel indicates job errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-codeintel-job-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-codeintel-job-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3136,7 +3136,7 @@ This panel indicates job errors every 5m.
 
 This panel indicates 99th percentile successful API request duration over 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-99th-percentile-duration).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-99th-percentile-duration).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3146,7 +3146,7 @@ This panel indicates 99th percentile successful API request duration over 5m.
 
 This panel indicates aPI errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3166,7 +3166,7 @@ This panel indicates 99th percentile successful setup command duration over 5m.
 
 This panel indicates setup command errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-setup-command-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-setup-command-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3184,7 +3184,7 @@ This panel indicates 99th percentile successful exec command duration over 5m.
 
 This panel indicates exec command errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-exec-command-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-exec-command-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3202,7 +3202,7 @@ This panel indicates 99th percentile successful teardown command duration over 5
 
 This panel indicates teardown command errors every 5m.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-teardown-command-errors).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-teardown-command-errors).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3214,7 +3214,7 @@ This panel indicates teardown command errors every 5m.
 
 This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-cpu-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-cpu-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3224,7 +3224,7 @@ This panel indicates container cpu usage total (1m average) across all cores by 
 
 This panel indicates container memory usage by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-memory-usage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-memory-usage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3254,7 +3254,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3264,7 +3264,7 @@ This panel indicates container cpu usage total (90th percentile over 1d) across 
 
 This panel indicates container memory usage (1d maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-long-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-long-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3274,7 +3274,7 @@ This panel indicates container memory usage (1d maximum) by instance.
 
 This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3284,7 +3284,7 @@ This panel indicates container cpu usage total (5m maximum) across all cores by 
 
 This panel indicates container memory usage (5m maximum) by instance.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-short-term).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-short-term).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3298,7 +3298,7 @@ This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-goroutines).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-goroutines).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3308,7 +3308,7 @@ A high value here indicates a possible goroutine leak.
 
 This panel indicates maximum go garbage collection duration.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-gc-duration-seconds).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-gc-duration-seconds).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
@@ -3320,7 +3320,7 @@ This panel indicates maximum go garbage collection duration.
 
 This panel indicates percentage pods available.
 
-> NOTE: Alerts related to this panel are available in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-pods-available-percentage).
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-pods-available-percentage).
 
 <sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -14,65 +14,81 @@ To learn more about Sourcegraph's metrics and how to view these dashboards, see 
 
 #### frontend: 99th_percentile_search_request_duration
 
-This search panel indicates 99th percentile successful search request duration over 5m.
+This panel indicates 99th percentile successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-request-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-request-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: 90th_percentile_search_request_duration
 
-This search panel indicates 90th percentile successful search request duration over 5m.
+This panel indicates 90th percentile successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-request-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-request-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: hard_timeout_search_responses
 
-This search panel indicates hard timeout search responses every 5m.
+This panel indicates hard timeout search responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: hard_error_search_responses
 
-This search panel indicates hard error search responses every 5m.
+This panel indicates hard error search responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: partial_timeout_search_responses
 
-This search panel indicates partial timeout search responses every 5m.
+This panel indicates partial timeout search responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: search_alert_user_suggestions
 
-This search panel indicates search alert user suggestions shown every 5m.
+This panel indicates search alert user suggestions shown every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-alert-user-suggestions) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-alert-user-suggestions) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: page_load_latency
 
-This cloud panel indicates 90th percentile page load latency over all routes over 10m.
+This panel indicates 90th percentile page load latency over all routes over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-page-load-latency) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-page-load-latency) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: blob_load_latency
 
-This cloud panel indicates 90th percentile blob load latency over 10m.
+This panel indicates 90th percentile blob load latency over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-blob-load-latency) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-blob-load-latency) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -80,49 +96,61 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-blob-load
 
 #### frontend: 99th_percentile_search_codeintel_request_duration
 
-This code-intel panel indicates 99th percentile code-intel successful search request duration over 5m.
+This panel indicates 99th percentile code-intel successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-codeintel-request-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-codeintel-request-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: 90th_percentile_search_codeintel_request_duration
 
-This code-intel panel indicates 90th percentile code-intel successful search request duration over 5m.
+This panel indicates 90th percentile code-intel successful search request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-codeintel-request-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-codeintel-request-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: hard_timeout_search_codeintel_responses
 
-This code-intel panel indicates hard timeout search code-intel responses every 5m.
+This panel indicates hard timeout search code-intel responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-codeintel-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: hard_error_search_codeintel_responses
 
-This code-intel panel indicates hard error search code-intel responses every 5m.
+This panel indicates hard error search code-intel responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-codeintel-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: partial_timeout_search_codeintel_responses
 
-This code-intel panel indicates partial timeout search code-intel responses every 5m.
+This panel indicates partial timeout search code-intel responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-codeintel-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-codeintel-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: search_codeintel_alert_user_suggestions
 
-This code-intel panel indicates search code-intel alert user suggestions shown every 5m.
+This panel indicates search code-intel alert user suggestions shown every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-codeintel-alert-user-suggestions) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-codeintel-alert-user-suggestions) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -130,49 +158,61 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-co
 
 #### frontend: 99th_percentile_search_api_request_duration
 
-This search panel indicates 99th percentile successful search API request duration over 5m.
+This panel indicates 99th percentile successful search API request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-api-request-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-search-api-request-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: 90th_percentile_search_api_request_duration
 
-This search panel indicates 90th percentile successful search API request duration over 5m.
+This panel indicates 90th percentile successful search API request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-api-request-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-search-api-request-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: hard_timeout_search_api_responses
 
-This search panel indicates hard timeout search API responses every 5m.
+This panel indicates hard timeout search API responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-api-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-timeout-search-api-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: hard_error_search_api_responses
 
-This search panel indicates hard error search API responses every 5m.
+This panel indicates hard error search API responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-hard-error-search-api-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: partial_timeout_search_api_responses
 
-This search panel indicates partial timeout search API responses every 5m.
+This panel indicates partial timeout search API responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-api-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-partial-timeout-search-api-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: search_api_alert_user_suggestions
 
-This search panel indicates search API alert user suggestions shown every 5m.
+This panel indicates search API alert user suggestions shown every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-api-alert-user-suggestions) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-api-alert-user-suggestions) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -180,33 +220,41 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-search-ap
 
 #### frontend: codeintel_resolvers_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful resolver duration over 5m.
+This panel indicates 99th percentile successful resolver duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_resolvers_errors
 
-This code-intel panel indicates resolver errors every 5m.
+This panel indicates resolver errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-resolvers-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_api_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful codeintel API operation duration over 5m.
+This panel indicates 99th percentile successful codeintel API operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_api_errors
 
-This code-intel panel indicates code intel API errors every 5m.
+This panel indicates code intel API errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-api-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -214,97 +262,121 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 #### frontend: codeintel_dbstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful database store operation duration over 5m.
+This panel indicates 99th percentile successful database store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_dbstore_errors
 
-This code-intel panel indicates database store errors every 5m.
+This panel indicates database store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-dbstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_upload_workerstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful upload worker store operation duration over 5m.
+This panel indicates 99th percentile successful upload worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_upload_workerstore_errors
 
-This code-intel panel indicates upload worker store errors every 5m.
+This panel indicates upload worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-upload-workerstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_index_workerstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful index worker store operation duration over 5m.
+This panel indicates 99th percentile successful index worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_index_workerstore_errors
 
-This code-intel panel indicates index worker store errors every 5m.
+This panel indicates index worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-index-workerstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_lsifstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful LSIF store operation duration over 5m.
+This panel indicates 99th percentile successful LSIF store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_lsifstore_errors
 
-This code-intel panel indicates lSIF store errors every 5m.
+This panel indicates lSIF store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-lsifstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_uploadstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful upload store operation duration over 5m.
+This panel indicates 99th percentile successful upload store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_uploadstore_errors
 
-This code-intel panel indicates upload store errors every 5m.
+This panel indicates upload store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-uploadstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_gitserverclient_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful gitserver client operation duration over 5m.
+This panel indicates 99th percentile successful gitserver client operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_gitserverclient_errors
 
-This code-intel panel indicates gitserver client errors every 5m.
+This panel indicates gitserver client errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-gitserverclient-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -312,33 +384,41 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 #### frontend: codeintel_commit_graph_queue_size
 
-This code-intel panel indicates commit graph queue size.
+This panel indicates commit graph queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-size) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-size) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_commit_graph_queue_growth_rate
 
-This code-intel panel indicates commit graph queue growth rate over 30m.
+This panel indicates commit graph queue growth rate over 30m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-growth-rate) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-queue-growth-rate) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_commit_graph_updater_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful commit graph updater operation duration over 5m.
+This panel indicates 99th percentile successful commit graph updater operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_commit_graph_updater_errors
 
-This code-intel panel indicates commit graph updater errors every 5m.
+This panel indicates commit graph updater errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-commit-graph-updater-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -346,62 +426,75 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 #### frontend: codeintel_janitor_errors
 
-This code-intel panel indicates janitor errors every 5m.
+This panel indicates janitor errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-janitor-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-janitor-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_upload_records_removed
 
-This code-intel panel indicates upload records expired or deleted every 5m.
+This panel indicates upload records expired or deleted every 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_index_records_removed
 
-This code-intel panel indicates index records expired or deleted every 5m.
+This panel indicates index records expired or deleted every 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_lsif_data_removed
 
-This code-intel panel indicates data for unreferenced upload records removed every 5m.
+This panel indicates data for unreferenced upload records removed every 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_background_upload_resets
 
-This code-intel panel indicates upload records re-queued (due to unresponsive worker) every 5m.
+This panel indicates upload records re-queued (due to unresponsive worker) every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-resets) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-resets) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_background_upload_reset_failures
 
-This code-intel panel indicates upload records errored due to repeated reset every 5m.
+This panel indicates upload records errored due to repeated reset every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-reset-failures) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-upload-reset-failures) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_background_index_resets
 
-This code-intel panel indicates index records re-queued (due to unresponsive indexer) every 5m.
+This panel indicates index records re-queued (due to unresponsive indexer) every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-resets) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-resets) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_background_index_reset_failures
 
-This code-intel panel indicates index records errored due to repeated reset every 5m.
+This panel indicates index records errored due to repeated reset every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-reset-failures) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-background-index-reset-failures) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -409,31 +502,37 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 #### frontend: codeintel_indexing_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful indexing operation duration over 5m.
+This panel indicates 99th percentile successful indexing operation duration over 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_indexing_errors
 
-This code-intel panel indicates indexing errors every 5m.
+This panel indicates indexing errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-indexing-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-indexing-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_autoindex_enqueuer_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful index enqueuer operation duration over 5m.
+This panel indicates 99th percentile successful index enqueuer operation duration over 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### frontend: codeintel_autoindex_enqueuer_errors
 
-This code-intel panel indicates index enqueuer errors every 5m.
+This panel indicates index enqueuer errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-autoindex-enqueuer-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel-autoindex-enqueuer-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -441,57 +540,71 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-codeintel
 
 #### frontend: internal_indexed_search_error_responses
 
-This search panel indicates internal indexed search error responses every 5m.
+This panel indicates internal indexed search error responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-indexed-search-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-indexed-search-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: internal_unindexed_search_error_responses
 
-This search panel indicates internal unindexed search error responses every 5m.
+This panel indicates internal unindexed search error responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-unindexed-search-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-unindexed-search-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### frontend: internal_api_error_responses
 
-This cloud panel indicates internal API error responses every 5m by route.
+This panel indicates internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: 99th_percentile_gitserver_duration
 
-This cloud panel indicates 99th percentile successful gitserver query duration over 5m.
+This panel indicates 99th percentile successful gitserver query duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-gitserver-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-99th-percentile-gitserver-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: gitserver_error_responses
 
-This cloud panel indicates gitserver error responses every 5m.
+This panel indicates gitserver error responses every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-gitserver-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-gitserver-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: observability_test_alert_warning
 
-This distribution panel indicates warning test alert metric.
+This panel indicates warning test alert metric.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-warning) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-warning) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### frontend: observability_test_alert_critical
 
-This distribution panel indicates critical test alert metric.
+This panel indicates critical test alert metric.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-observability-test-alert-critical) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
@@ -499,23 +612,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-observabi
 
 #### frontend: container_cpu_usage
 
-This cloud panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: container_memory_usage
 
-This cloud panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: container_missing
 
-This cloud panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -527,6 +644,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' (frontend|sourcegraph-frontend)` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the (frontend|sourcegraph-frontend) container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs (frontend|sourcegraph-frontend)` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -534,33 +652,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### frontend: provisioning_container_cpu_usage_long_term
 
-This cloud panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: provisioning_container_memory_usage_long_term
 
-This cloud panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: provisioning_container_cpu_usage_short_term
 
-This cloud panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: provisioning_container_memory_usage_short_term
 
-This cloud panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -568,19 +694,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-provision
 
 #### frontend: go_goroutines
 
-This cloud panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### frontend: go_gc_duration_seconds
 
-This cloud panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -588,9 +718,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-go-gc-dur
 
 #### frontend: pods_available_percentage
 
-This cloud panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#frontend-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#frontend-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -600,41 +732,49 @@ Refer to the [alert solutions reference](./alert_solutions.md#frontend-pods-avai
 
 #### gitserver: disk_space_remaining
 
-This cloud panel indicates disk space remaining by instance.
+This panel indicates disk space remaining by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-disk-space-remaining) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-disk-space-remaining) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: running_git_commands
 
-This cloud panel indicates running git commands.
+This panel indicates running git commands.
 
 A high value signals load.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-running-git-commands) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-running-git-commands) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: repository_clone_queue_size
 
-This cloud panel indicates repository clone queue size.
+This panel indicates repository clone queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-clone-queue-size) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-clone-queue-size) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: repository_existence_check_queue_size
 
-This cloud panel indicates repository existence check queue size.
+This panel indicates repository existence check queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-existence-check-queue-size) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-repository-existence-check-queue-size) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: echo_command_duration_test
 
-This cloud panel indicates echo test command duration.
+This panel indicates echo test command duration.
 
 A high value here likely indicates a problem, especially if consistently high.
 You can query for individual commands using `sum by (cmd)(src_gitserver_exec_running)` in Grafana (`/-/debug/grafana`) to see if a specific Git Server command might be spiking in frequency.
@@ -644,14 +784,17 @@ If this value is consistently high, consider the following:
 - **Single container deployments:** Upgrade to a [Docker Compose deployment](../install/docker-compose/migrate.md) which offers better scalability and resource isolation.
 - **Kubernetes and Docker Compose:** Check that you are running a similar number of git server replicas and that their CPU/memory limits are allocated according to what is shown in the [Sourcegraph resource estimator](../install/resource_estimator.md).
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: frontend_internal_api_error_responses
 
-This cloud panel indicates frontend-internal API error responses every 5m by route.
+This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -659,23 +802,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-frontend
 
 #### gitserver: container_cpu_usage
 
-This cloud panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: container_memory_usage
 
-This cloud panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: container_missing
 
-This cloud panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -687,16 +834,18 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' gitserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the gitserver container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs gitserver` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: fs_io_operations
 
-This cloud panel indicates filesystem reads and writes rate by instance over 1h.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -704,35 +853,41 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 #### gitserver: provisioning_container_cpu_usage_long_term
 
-This cloud panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: provisioning_container_memory_usage_long_term
 
-This cloud panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
 Git Server is expected to use up all the memory it is provided.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: provisioning_container_cpu_usage_short_term
 
-This cloud panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: provisioning_container_memory_usage_short_term
 
-This cloud panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
 Git Server is expected to use up all the memory it is provided.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -740,19 +895,23 @@ Git Server is expected to use up all the memory it is provided.
 
 #### gitserver: go_goroutines
 
-This cloud panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### gitserver: go_gc_duration_seconds
 
-This cloud panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -760,9 +919,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-go-gc-du
 
 #### gitserver: pods_available_percentage
 
-This cloud panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#gitserver-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#gitserver-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -774,9 +935,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#gitserver-pods-ava
 
 #### github-proxy: github_proxy_waiting_requests
 
-This cloud panel indicates number of requests waiting on the global mutex.
+This panel indicates number of requests waiting on the global mutex.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-github-proxy-waiting-requests) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-github-proxy-waiting-requests) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -784,23 +947,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-githu
 
 #### github-proxy: container_cpu_usage
 
-This cloud panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### github-proxy: container_memory_usage
 
-This cloud panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### github-proxy: container_missing
 
-This cloud panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -812,6 +979,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' github-proxy` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the github-proxy container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs github-proxy` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -819,33 +987,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### github-proxy: provisioning_container_cpu_usage_long_term
 
-This cloud panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### github-proxy: provisioning_container_memory_usage_long_term
 
-This cloud panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### github-proxy: provisioning_container_cpu_usage_short_term
 
-This cloud panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### github-proxy: provisioning_container_memory_usage_short_term
 
-This cloud panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -853,19 +1029,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-provi
 
 #### github-proxy: go_goroutines
 
-This cloud panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### github-proxy: go_gc_duration_seconds
 
-This cloud panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -873,9 +1053,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-go-gc
 
 #### github-proxy: pods_available_percentage
 
-This cloud panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -885,17 +1067,21 @@ Refer to the [alert solutions reference](./alert_solutions.md#github-proxy-pods-
 
 #### postgres: connections
 
-This cloud panel indicates active connections.
+This panel indicates active connections.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-connections) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-connections) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### postgres: transaction_durations
 
-This cloud panel indicates maximum transaction durations.
+This panel indicates maximum transaction durations.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-transaction-durations) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -903,31 +1089,37 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-transacti
 
 #### postgres: postgres_up
 
-This cloud panel indicates database availability.
+This panel indicates database availability.
 
 A non-zero value indicates the database is online.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-postgres-up) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-postgres-up) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### postgres: pg_exporter_err
 
-This cloud panel indicates errors scraping postgres exporter.
+This panel indicates errors scraping postgres exporter.
 
 This value indicates issues retrieving metrics from postgres_exporter.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-pg-exporter-err) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-pg-exporter-err) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### postgres: migration_in_progress
 
-This cloud panel indicates active schema migration.
+This panel indicates active schema migration.
 
 A 0 value indicates that no migration is in progress.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -935,33 +1127,41 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-migration
 
 #### postgres: provisioning_container_cpu_usage_long_term
 
-This cloud panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### postgres: provisioning_container_memory_usage_long_term
 
-This cloud panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### postgres: provisioning_container_cpu_usage_short_term
 
-This cloud panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### postgres: provisioning_container_memory_usage_short_term
 
-This cloud panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -969,9 +1169,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-provision
 
 #### postgres: pods_available_percentage
 
-This cloud panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#postgres-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -983,39 +1185,47 @@ Refer to the [alert solutions reference](./alert_solutions.md#postgres-pods-avai
 
 #### precise-code-intel-worker: upload_queue_size
 
-This code-intel panel indicates queue size.
+This panel indicates queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-size) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-size) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: upload_queue_growth_rate
 
-This code-intel panel indicates queue growth rate over 30m.
+This panel indicates queue growth rate over 30m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-growth-rate) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-upload-queue-growth-rate) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: job_errors
 
-This code-intel panel indicates job errors errors every 5m.
+This panel indicates job errors errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-job-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-job-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: active_workers
 
-This code-intel panel indicates active workers processing uploads.
+This panel indicates active workers processing uploads.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: active_jobs
 
-This code-intel panel indicates active jobs.
+This panel indicates active jobs.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1023,8 +1233,9 @@ This code-intel panel indicates active jobs.
 
 #### precise-code-intel-worker: job_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful job duration over 5m.
+This panel indicates 99th percentile successful job duration over 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1032,81 +1243,101 @@ This code-intel panel indicates 99th percentile successful job duration over 5m.
 
 #### precise-code-intel-worker: codeintel_dbstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful database store operation duration over 5m.
+This panel indicates 99th percentile successful database store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_dbstore_errors
 
-This code-intel panel indicates database store errors every 5m.
+This panel indicates database store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-dbstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_workerstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful worker store operation duration over 5m.
+This panel indicates 99th percentile successful worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_workerstore_errors
 
-This code-intel panel indicates worker store errors every 5m.
+This panel indicates worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-workerstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_lsifstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful LSIF store operation duration over 5m.
+This panel indicates 99th percentile successful LSIF store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_lsifstore_errors
 
-This code-intel panel indicates lSIF store errors every 5m.
+This panel indicates lSIF store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-lsifstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_uploadstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful upload store operation duration over 5m.
+This panel indicates 99th percentile successful upload store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_uploadstore_errors
 
-This code-intel panel indicates upload store errors every 5m.
+This panel indicates upload store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-uploadstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_gitserverclient_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful gitserver client operation duration over 5m.
+This panel indicates 99th percentile successful gitserver client operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: codeintel_gitserverclient_errors
 
-This code-intel panel indicates gitserver client errors every 5m.
+This panel indicates gitserver client errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-codeintel-gitserverclient-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1114,9 +1345,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-worker: frontend_internal_api_error_responses
 
-This code-intel panel indicates frontend-internal API error responses every 5m by route.
+This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1124,23 +1357,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-worker: container_cpu_usage
 
-This code-intel panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: container_memory_usage
 
-This code-intel panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: container_missing
 
-This code-intel panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -1152,6 +1389,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1159,33 +1397,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### precise-code-intel-worker: provisioning_container_cpu_usage_long_term
 
-This code-intel panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: provisioning_container_memory_usage_long_term
 
-This code-intel panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: provisioning_container_cpu_usage_short_term
 
-This code-intel panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: provisioning_container_memory_usage_short_term
 
-This code-intel panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1193,19 +1439,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-worker: go_goroutines
 
-This code-intel panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-worker: go_gc_duration_seconds
 
-This code-intel panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1213,9 +1463,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-worker: pods_available_percentage
 
-This code-intel panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-worker-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1225,9 +1477,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### query-runner: frontend_internal_api_error_responses
 
-This search panel indicates frontend-internal API error responses every 5m by route.
+This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1235,23 +1489,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-front
 
 #### query-runner: container_memory_usage
 
-This search panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### query-runner: container_cpu_usage
 
-This search panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### query-runner: container_missing
 
-This search panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -1263,6 +1521,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' query-runner` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the query-runner container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs query-runner` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1270,33 +1529,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### query-runner: provisioning_container_cpu_usage_long_term
 
-This search panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### query-runner: provisioning_container_memory_usage_long_term
 
-This search panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### query-runner: provisioning_container_cpu_usage_short_term
 
-This search panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### query-runner: provisioning_container_memory_usage_short_term
 
-This search panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1304,19 +1571,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-provi
 
 #### query-runner: go_goroutines
 
-This search panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### query-runner: go_gc_duration_seconds
 
-This search panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1324,9 +1595,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-go-gc
 
 #### query-runner: pods_available_percentage
 
-This search panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#query-runner-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#query-runner-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1336,9 +1609,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#query-runner-pods-
 
 #### repo-updater: frontend_internal_api_error_responses
 
-This cloud panel indicates frontend-internal API error responses every 5m by route.
+This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1346,133 +1621,163 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-front
 
 #### repo-updater: syncer_sync_last_time
 
-This cloud panel indicates time since last sync.
+This panel indicates time since last sync.
 
 A high value here indicates issues synchronizing repository permissions.
 If the value is persistently high, make sure all external services have valid tokens.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: src_repoupdater_max_sync_backoff
 
-This cloud panel indicates time since oldest sync.
+This panel indicates time since oldest sync.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-max-sync-backoff) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-max-sync-backoff) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: src_repoupdater_syncer_sync_errors_total
 
-This cloud panel indicates sync error rate.
+This panel indicates sync error rate.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-syncer-sync-errors-total) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: syncer_sync_start
 
-This cloud panel indicates sync was started.
+This panel indicates sync was started.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-start) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: syncer_sync_duration
 
-This cloud panel indicates 95th repositories sync duration.
+This panel indicates 95th repositories sync duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-sync-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: source_duration
 
-This cloud panel indicates 95th repositories source duration.
+This panel indicates 95th repositories source duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-source-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-source-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: syncer_synced_repos
 
-This cloud panel indicates repositories synced.
+This panel indicates repositories synced.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-syncer-synced-repos) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: sourced_repos
 
-This cloud panel indicates repositories sourced.
+This panel indicates repositories sourced.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sourced-repos) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: user_added_repos
 
-This cloud panel indicates total number of user added repos.
+This panel indicates total number of user added repos.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-user-added-repos) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: purge_failed
 
-This cloud panel indicates repositories purge failed.
+This panel indicates repositories purge failed.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-purge-failed) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-purge-failed) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: sched_auto_fetch
 
-This cloud panel indicates repositories scheduled due to hitting a deadline.
+This panel indicates repositories scheduled due to hitting a deadline.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-auto-fetch) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-auto-fetch) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: sched_manual_fetch
 
-This cloud panel indicates repositories scheduled due to user traffic.
+This panel indicates repositories scheduled due to user traffic.
 
 Check repo-updater logs if this value is persistently high.
 This does not indicate anything if there are no user added code hosts.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: sched_known_repos
 
-This cloud panel indicates repositories managed by the scheduler.
+This panel indicates repositories managed by the scheduler.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-known-repos) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-known-repos) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: sched_update_queue_length
 
-This cloud panel indicates rate of growth of update queue length over 5 minutes.
+This panel indicates rate of growth of update queue length over 5 minutes.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-update-queue-length) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-update-queue-length) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: sched_loops
 
-This cloud panel indicates scheduler loops.
+This panel indicates scheduler loops.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-loops) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-loops) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: sched_error
 
-This cloud panel indicates repositories schedule error rate.
+This panel indicates repositories schedule error rate.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-error) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched-error) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1480,49 +1785,61 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-sched
 
 #### repo-updater: perms_syncer_perms
 
-This cloud panel indicates time gap between least and most up to date permissions.
+This panel indicates time gap between least and most up to date permissions.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-perms) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-perms) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: perms_syncer_stale_perms
 
-This cloud panel indicates number of entities with stale permissions.
+This panel indicates number of entities with stale permissions.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-stale-perms) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-stale-perms) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: perms_syncer_no_perms
 
-This cloud panel indicates number of entities with no permissions.
+This panel indicates number of entities with no permissions.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-no-perms) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-no-perms) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: perms_syncer_sync_duration
 
-This cloud panel indicates 95th permissions sync duration.
+This panel indicates 95th permissions sync duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: perms_syncer_queue_size
 
-This cloud panel indicates permissions sync queued items.
+This panel indicates permissions sync queued items.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-queue-size) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-queue-size) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: perms_syncer_sync_errors
 
-This cloud panel indicates permissions sync error rate.
+This panel indicates permissions sync error rate.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms-syncer-sync-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1530,73 +1847,91 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-perms
 
 #### repo-updater: src_repoupdater_external_services_total
 
-This cloud panel indicates the total number of external services.
+This panel indicates the total number of external services.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-external-services-total) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-external-services-total) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: src_repoupdater_user_external_services_total
 
-This cloud panel indicates the total number of user added external services.
+This panel indicates the total number of user added external services.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-user-external-services-total) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-src-repoupdater-user-external-services-total) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: repoupdater_queued_sync_jobs_total
 
-This cloud panel indicates the total number of queued sync jobs.
+This panel indicates the total number of queued sync jobs.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-queued-sync-jobs-total) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-queued-sync-jobs-total) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: repoupdater_completed_sync_jobs_total
 
-This cloud panel indicates the total number of completed sync jobs.
+This panel indicates the total number of completed sync jobs.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-completed-sync-jobs-total) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-completed-sync-jobs-total) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: repoupdater_errored_sync_jobs_total
 
-This cloud panel indicates the total number of errored sync jobs.
+This panel indicates the total number of errored sync jobs.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-errored-sync-jobs-total) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-repoupdater-errored-sync-jobs-total) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: github_graphql_rate_limit_remaining
 
-This cloud panel indicates remaining calls to GitHub graphql API before hitting the rate limit.
+This panel indicates remaining calls to GitHub graphql API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-graphql-rate-limit-remaining) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-graphql-rate-limit-remaining) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: github_rest_rate_limit_remaining
 
-This cloud panel indicates remaining calls to GitHub rest API before hitting the rate limit.
+This panel indicates remaining calls to GitHub rest API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-rest-rate-limit-remaining) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-rest-rate-limit-remaining) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: github_search_rate_limit_remaining
 
-This cloud panel indicates remaining calls to GitHub search API before hitting the rate limit.
+This panel indicates remaining calls to GitHub search API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-search-rate-limit-remaining) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-github-search-rate-limit-remaining) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: gitlab_rest_rate_limit_remaining
 
-This cloud panel indicates remaining calls to GitLab rest API before hitting the rate limit.
+This panel indicates remaining calls to GitLab rest API before hitting the rate limit.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-gitlab-rest-rate-limit-remaining) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-gitlab-rest-rate-limit-remaining) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1604,23 +1939,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-gitla
 
 #### repo-updater: container_cpu_usage
 
-This cloud panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: container_memory_usage
 
-This cloud panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: container_missing
 
-This cloud panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -1632,6 +1971,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' repo-updater` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the repo-updater container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs repo-updater` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1639,33 +1979,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### repo-updater: provisioning_container_cpu_usage_long_term
 
-This cloud panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: provisioning_container_memory_usage_long_term
 
-This cloud panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: provisioning_container_cpu_usage_short_term
 
-This cloud panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: provisioning_container_memory_usage_short_term
 
-This cloud panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1673,19 +2021,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-provi
 
 #### repo-updater: go_goroutines
 
-This cloud panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### repo-updater: go_gc_duration_seconds
 
-This cloud panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1693,9 +2045,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-go-gc
 
 #### repo-updater: pods_available_percentage
 
-This cloud panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1705,25 +2059,31 @@ Refer to the [alert solutions reference](./alert_solutions.md#repo-updater-pods-
 
 #### searcher: unindexed_search_request_errors
 
-This search panel indicates unindexed search request errors every 5m by code.
+This panel indicates unindexed search request errors every 5m by code.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-unindexed-search-request-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-unindexed-search-request-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: replica_traffic
 
-This search panel indicates requests per second over 10m.
+This panel indicates requests per second over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-replica-traffic) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-replica-traffic) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: frontend_internal_api_error_responses
 
-This search panel indicates frontend-internal API error responses every 5m by route.
+This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1731,23 +2091,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-frontend-
 
 #### searcher: container_cpu_usage
 
-This search panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: container_memory_usage
 
-This search panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: container_missing
 
-This search panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -1759,6 +2123,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' searcher` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the searcher container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs searcher` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1766,33 +2131,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### searcher: provisioning_container_cpu_usage_long_term
 
-This search panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: provisioning_container_memory_usage_long_term
 
-This search panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: provisioning_container_cpu_usage_short_term
 
-This search panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: provisioning_container_memory_usage_short_term
 
-This search panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1800,19 +2173,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-provision
 
 #### searcher: go_goroutines
 
-This search panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### searcher: go_gc_duration_seconds
 
-This search panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1820,9 +2197,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-go-gc-dur
 
 #### searcher: pods_available_percentage
 
-This search panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#searcher-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -1832,25 +2211,31 @@ Refer to the [alert solutions reference](./alert_solutions.md#searcher-pods-avai
 
 #### symbols: store_fetch_failures
 
-This code-intel panel indicates store fetch failures every 5m.
+This panel indicates store fetch failures every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-store-fetch-failures) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-store-fetch-failures) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: current_fetch_queue_size
 
-This code-intel panel indicates current fetch queue size.
+This panel indicates current fetch queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-current-fetch-queue-size) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-current-fetch-queue-size) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: frontend_internal_api_error_responses
 
-This code-intel panel indicates frontend-internal API error responses every 5m by route.
+This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1858,23 +2243,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-frontend-i
 
 #### symbols: container_cpu_usage
 
-This code-intel panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: container_memory_usage
 
-This code-intel panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: container_missing
 
-This code-intel panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -1886,6 +2275,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' symbols` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the symbols container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs symbols` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1893,33 +2283,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### symbols: provisioning_container_cpu_usage_long_term
 
-This code-intel panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: provisioning_container_memory_usage_long_term
 
-This code-intel panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: provisioning_container_cpu_usage_short_term
 
-This code-intel panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: provisioning_container_memory_usage_short_term
 
-This code-intel panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1927,19 +2325,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-provisioni
 
 #### symbols: go_goroutines
 
-This code-intel panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### symbols: go_gc_duration_seconds
 
-This code-intel panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1947,9 +2349,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-go-gc-dura
 
 #### symbols: pods_available_percentage
 
-This code-intel panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#symbols-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#symbols-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -1959,29 +2363,33 @@ Refer to the [alert solutions reference](./alert_solutions.md#symbols-pods-avail
 
 #### syntect-server: syntax_highlighting_errors
 
-This cloud panel indicates syntax highlighting errors every 5m.
+This panel indicates syntax highlighting errors every 5m.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: syntax_highlighting_timeouts
 
-This cloud panel indicates syntax highlighting timeouts every 5m.
+This panel indicates syntax highlighting timeouts every 5m.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: syntax_highlighting_panics
 
-This cloud panel indicates syntax highlighting panics every 5m.
+This panel indicates syntax highlighting panics every 5m.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: syntax_highlighting_worker_deaths
 
-This cloud panel indicates syntax highlighter worker deaths every 5m.
+This panel indicates syntax highlighter worker deaths every 5m.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -1989,23 +2397,27 @@ This cloud panel indicates syntax highlighter worker deaths every 5m.
 
 #### syntect-server: container_cpu_usage
 
-This cloud panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: container_memory_usage
 
-This cloud panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: container_missing
 
-This cloud panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -2017,6 +2429,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' syntect-server` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the syntect-server container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs syntect-server` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -2024,33 +2437,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### syntect-server: provisioning_container_cpu_usage_long_term
 
-This cloud panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: provisioning_container_memory_usage_long_term
 
-This cloud panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: provisioning_container_cpu_usage_short_term
 
-This cloud panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
 #### syntect-server: provisioning_container_memory_usage_short_term
 
-This cloud panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -2058,9 +2479,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pro
 
 #### syntect-server: pods_available_percentage
 
-This cloud panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -2070,9 +2493,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#syntect-server-pod
 
 #### zoekt-indexserver: average_resolve_revision_duration
 
-This search panel indicates average resolve revision duration over 5m.
+This panel indicates average resolve revision duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-average-resolve-revision-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-average-resolve-revision-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -2080,23 +2505,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 #### zoekt-indexserver: container_cpu_usage
 
-This search panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-indexserver: container_memory_usage
 
-This search panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-indexserver: container_missing
 
-This search panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -2108,16 +2537,18 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-indexserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-indexserver container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-indexserver` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-indexserver: fs_io_operations
 
-This cloud panel indicates filesystem reads and writes rate by instance over 1h.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -2125,33 +2556,41 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 #### zoekt-indexserver: provisioning_container_cpu_usage_long_term
 
-This search panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-indexserver: provisioning_container_memory_usage_long_term
 
-This search panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-indexserver: provisioning_container_cpu_usage_short_term
 
-This search panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-indexserver: provisioning_container_memory_usage_short_term
 
-This search panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -2159,9 +2598,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 #### zoekt-indexserver: pods_available_percentage
 
-This search panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -2171,9 +2612,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-indexserver-
 
 #### zoekt-webserver: indexed_search_request_errors
 
-This search panel indicates indexed search request errors every 5m by code.
+This panel indicates indexed search request errors every 5m by code.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-indexed-search-request-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-indexed-search-request-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -2181,23 +2624,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-in
 
 #### zoekt-webserver: container_cpu_usage
 
-This search panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-webserver: container_memory_usage
 
-This search panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-webserver: container_missing
 
-This search panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -2209,16 +2656,18 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' zoekt-webserver` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the zoekt-webserver container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs zoekt-webserver` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-webserver: fs_io_operations
 
-This cloud panel indicates filesystem reads and writes rate by instance over 1h.
+This panel indicates filesystem reads and writes rate by instance over 1h.
 
 This value indicates the number of filesystem read and write operations by containers of this service.
 When extremely high, this can indicate a resource usage problem, or can cause problems with the service itself, especially if high values or spikes correlate with {{CONTAINER_NAME}} issues.
 
+<sub>Managed by the [Sourcegraph Cloud team](https://about.sourcegraph.com/handbook/engineering/cloud).</sub>
 
 <br />
 
@@ -2226,33 +2675,41 @@ When extremely high, this can indicate a resource usage problem, or can cause pr
 
 #### zoekt-webserver: provisioning_container_cpu_usage_long_term
 
-This search panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-webserver: provisioning_container_memory_usage_long_term
 
-This search panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-webserver: provisioning_container_cpu_usage_short_term
 
-This search panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
 #### zoekt-webserver: provisioning_container_memory_usage_short_term
 
-This search panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).</sub>
 
 <br />
 
@@ -2264,12 +2721,14 @@ Refer to the [alert solutions reference](./alert_solutions.md#zoekt-webserver-pr
 
 #### prometheus: prometheus_rule_group_evaluation
 
-This distribution panel indicates average prometheus rule group evaluation duration over 10m.
+This panel indicates average prometheus rule group evaluation duration over 10m.
 
 A high value here indicates Prometheus rule evaluation is taking longer than expected.
 It might indicate that certain rule groups are taking too long to evaluate, or Prometheus is underprovisioned.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-rule-group-evaluation) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-rule-group-evaluation) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
@@ -2277,19 +2736,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometh
 
 #### prometheus: alertmanager_notifications_failed_total
 
-This distribution panel indicates failed alertmanager notifications over 1m.
+This panel indicates failed alertmanager notifications over 1m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notifications-failed-total) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-notifications-failed-total) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: alertmanager_config_status
 
-This distribution panel indicates alertmanager configuration reload status.
+This panel indicates alertmanager configuration reload status.
 
 A `1` indicates Alertmanager reloaded its configuration successfully.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-config-status) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertmanager-config-status) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
@@ -2297,35 +2760,43 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-alertma
 
 #### prometheus: prometheus_tsdb_op_failure
 
-This distribution panel indicates prometheus tsdb failures by operation over 1m.
+This panel indicates prometheus tsdb failures by operation over 1m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-tsdb-op-failure) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-tsdb-op-failure) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: prometheus_config_status
 
-This distribution panel indicates prometheus configuration reload status.
+This panel indicates prometheus configuration reload status.
 
 A `1` indicates Prometheus reloaded its configuration successfully.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-config-status) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-config-status) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: prometheus_target_sample_exceeded
 
-This distribution panel indicates prometheus scrapes that exceed the sample limit over 10m.
+This panel indicates prometheus scrapes that exceed the sample limit over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-exceeded) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-exceeded) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: prometheus_target_sample_duplicate
 
-This distribution panel indicates prometheus scrapes rejected due to duplicate timestamps over 10m.
+This panel indicates prometheus scrapes rejected due to duplicate timestamps over 10m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-duplicate) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometheus-target-sample-duplicate) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
@@ -2333,23 +2804,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-prometh
 
 #### prometheus: container_cpu_usage
 
-This distribution panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: container_memory_usage
 
-This distribution panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: container_missing
 
-This distribution panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -2361,6 +2836,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' prometheus` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the prometheus container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs prometheus` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
@@ -2368,33 +2844,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### prometheus: provisioning_container_cpu_usage_long_term
 
-This distribution panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: provisioning_container_memory_usage_long_term
 
-This distribution panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: provisioning_container_cpu_usage_short_term
 
-This distribution panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
 #### prometheus: provisioning_container_memory_usage_short_term
 
-This distribution panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
@@ -2402,9 +2886,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-provisi
 
 #### prometheus: pods_available_percentage
 
-This distribution panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#prometheus-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#prometheus-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution).</sub>
 
 <br />
 
@@ -2416,39 +2902,47 @@ Refer to the [alert solutions reference](./alert_solutions.md#prometheus-pods-av
 
 #### executor-queue: codeintel_queue_size
 
-This code-intel panel indicates queue size.
+This panel indicates queue size.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-size) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-size) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: codeintel_queue_growth_rate
 
-This code-intel panel indicates queue growth rate over 30m.
+This panel indicates queue growth rate over 30m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-growth-rate) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-queue-growth-rate) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: codeintel_job_errors
 
-This code-intel panel indicates job errors every 5m.
+This panel indicates job errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-job-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-job-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: codeintel_active_executors
 
-This code-intel panel indicates active executors processing codeintel jobs.
+This panel indicates active executors processing codeintel jobs.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: codeintel_active_jobs
 
-This code-intel panel indicates active jobs.
+This panel indicates active jobs.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2456,17 +2950,21 @@ This code-intel panel indicates active jobs.
 
 #### executor-queue: codeintel_workerstore_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful worker store operation duration over 5m.
+This panel indicates 99th percentile successful worker store operation duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: codeintel_workerstore_errors
 
-This code-intel panel indicates worker store errors every 5m.
+This panel indicates worker store errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-codeintel-workerstore-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2474,9 +2972,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-cod
 
 #### executor-queue: frontend_internal_api_error_responses
 
-This code-intel panel indicates frontend-internal API error responses every 5m by route.
+This panel indicates frontend-internal API error responses every 5m by route.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-frontend-internal-api-error-responses) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2484,23 +2984,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-fro
 
 #### executor-queue: container_cpu_usage
 
-This code-intel panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: container_memory_usage
 
-This code-intel panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: container_missing
 
-This code-intel panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -2512,6 +3016,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' executor-queue` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the executor-queue container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs executor-queue` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2519,33 +3024,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### executor-queue: provisioning_container_cpu_usage_long_term
 
-This code-intel panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: provisioning_container_memory_usage_long_term
 
-This code-intel panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: provisioning_container_cpu_usage_short_term
 
-This code-intel panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: provisioning_container_memory_usage_short_term
 
-This code-intel panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2553,19 +3066,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pro
 
 #### executor-queue: go_goroutines
 
-This code-intel panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### executor-queue: go_gc_duration_seconds
 
-This code-intel panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2573,9 +3090,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-go-
 
 #### executor-queue: pods_available_percentage
 
-This code-intel panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2587,23 +3106,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#executor-queue-pod
 
 #### precise-code-intel-indexer: codeintel_job_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful job duration over 5m.
+This panel indicates 99th percentile successful job duration over 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: codeintel_active_handlers
 
-This code-intel panel indicates active handlers processing jobs.
+This panel indicates active handlers processing jobs.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: codeintel_job_errors
 
-This code-intel panel indicates job errors every 5m.
+This panel indicates job errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-codeintel-job-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-codeintel-job-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2611,17 +3134,21 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-indexer: executor_apiclient_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful API request duration over 5m.
+This panel indicates 99th percentile successful API request duration over 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-99th-percentile-duration) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-99th-percentile-duration) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: executor_apiclient_errors
 
-This code-intel panel indicates aPI errors every 5m.
+This panel indicates aPI errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-apiclient-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2629,46 +3156,55 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-indexer: executor_setup_command_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful setup command duration over 5m.
+This panel indicates 99th percentile successful setup command duration over 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: executor_setup_command_errors
 
-This code-intel panel indicates setup command errors every 5m.
+This panel indicates setup command errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-setup-command-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-setup-command-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: executor_exec_command_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful exec command duration over 5m.
+This panel indicates 99th percentile successful exec command duration over 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: executor_exec_command_errors
 
-This code-intel panel indicates exec command errors every 5m.
+This panel indicates exec command errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-exec-command-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-exec-command-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: executor_teardown_command_99th_percentile_duration
 
-This code-intel panel indicates 99th percentile successful teardown command duration over 5m.
+This panel indicates 99th percentile successful teardown command duration over 5m.
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: executor_teardown_command_errors
 
-This code-intel panel indicates teardown command errors every 5m.
+This panel indicates teardown command errors every 5m.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-teardown-command-errors) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-executor-teardown-command-errors) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2676,23 +3212,27 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-indexer: container_cpu_usage
 
-This code-intel panel indicates container cpu usage total (1m average) across all cores by instance.
+This panel indicates container cpu usage total (1m average) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-cpu-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-cpu-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: container_memory_usage
 
-This code-intel panel indicates container memory usage by instance.
+This panel indicates container memory usage by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-memory-usage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-container-memory-usage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: container_missing
 
-This code-intel panel indicates container missing.
+This panel indicates container missing.
 
 This value is the number of times a container has not been seen for more than one minute. If you observe this
 value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
@@ -2704,6 +3244,7 @@ value change independent of deployment events (such as an upgrade), it could ind
 	- Determine if the pod was OOM killed using `docker inspect -f '{{json .State}}' precise-code-intel-worker` (look for `"OOMKilled":true`) and, if so, consider increasing the memory limit of the precise-code-intel-worker container in `docker-compose.yml`.
 	- Check the logs before the container restarted to see if there are `panic:` messages or similar using `docker logs precise-code-intel-worker` (note this will include logs from the previous and currently running container).
 
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2711,33 +3252,41 @@ value change independent of deployment events (such as an upgrade), it could ind
 
 #### precise-code-intel-indexer: provisioning_container_cpu_usage_long_term
 
-This code-intel panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
+This panel indicates container cpu usage total (90th percentile over 1d) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: provisioning_container_memory_usage_long_term
 
-This code-intel panel indicates container memory usage (1d maximum) by instance.
+This panel indicates container memory usage (1d maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-long-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-long-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: provisioning_container_cpu_usage_short_term
 
-This code-intel panel indicates container cpu usage total (5m maximum) across all cores by instance.
+This panel indicates container cpu usage total (5m maximum) across all cores by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-cpu-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: provisioning_container_memory_usage_short_term
 
-This code-intel panel indicates container memory usage (5m maximum) by instance.
+This panel indicates container memory usage (5m maximum) by instance.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-short-term) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-provisioning-container-memory-usage-short-term) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2745,19 +3294,23 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-indexer: go_goroutines
 
-This code-intel panel indicates maximum active goroutines.
+This panel indicates maximum active goroutines.
 
 A high value here indicates a possible goroutine leak.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-goroutines) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-goroutines) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
 #### precise-code-intel-indexer: go_gc_duration_seconds
 
-This code-intel panel indicates maximum go garbage collection duration.
+This panel indicates maximum go garbage collection duration.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-gc-duration-seconds) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-go-gc-duration-seconds) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 
@@ -2765,9 +3318,11 @@ Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel
 
 #### precise-code-intel-indexer: pods_available_percentage
 
-This code-intel panel indicates percentage pods available.
+This panel indicates percentage pods available.
 
-Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-pods-available-percentage) for relevant alerts.
+Refer to the [alert solutions reference](./alert_solutions.md#precise-code-intel-indexer-pods-available-percentage) for alerts related to this panel.
+
+<sub>Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).</sub>
 
 <br />
 

--- a/monitoring/monitoring/README.md
+++ b/monitoring/monitoring/README.md
@@ -125,7 +125,7 @@ type Group struct {
 }
 ```
 
-## type [Observable](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L422-L534>)
+## type [Observable](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L437-L549>)
 
 Observable describes a metric about a container that can be observed\. For example\, memory usage\.
 
@@ -247,7 +247,7 @@ type Observable struct {
 }
 ```
 
-## type [ObservableAlertDefinition](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L598-L604>)
+## type [ObservableAlertDefinition](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L613-L619>)
 
 ObservableAlertDefinition defines when an alert would be considered firing\.
 
@@ -257,7 +257,7 @@ type ObservableAlertDefinition struct {
 }
 ```
 
-### func [Alert](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L593>)
+### func [Alert](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L608>)
 
 ```go
 func Alert() *ObservableAlertDefinition
@@ -265,7 +265,7 @@ func Alert() *ObservableAlertDefinition
 
 Alert provides a builder for defining alerting on an Observable\.
 
-### func \(\*ObservableAlertDefinition\) [For](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L636>)
+### func \(\*ObservableAlertDefinition\) [For](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L651>)
 
 ```go
 func (a *ObservableAlertDefinition) For(d time.Duration) *ObservableAlertDefinition
@@ -273,7 +273,7 @@ func (a *ObservableAlertDefinition) For(d time.Duration) *ObservableAlertDefinit
 
 For indicates how long the given thresholds must be exceeded for this alert to be considered firing\. Defaults to 0s \(immediately alerts when threshold is exceeded\)\.
 
-### func \(\*ObservableAlertDefinition\) [Greater](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L621>)
+### func \(\*ObservableAlertDefinition\) [Greater](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L636>)
 
 ```go
 func (a *ObservableAlertDefinition) Greater(f float64) *ObservableAlertDefinition
@@ -281,7 +281,7 @@ func (a *ObservableAlertDefinition) Greater(f float64) *ObservableAlertDefinitio
 
 Greater indicates the alert should fire when strictly greater to this value\.
 
-### func \(\*ObservableAlertDefinition\) [GreaterOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L607>)
+### func \(\*ObservableAlertDefinition\) [GreaterOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L622>)
 
 ```go
 func (a *ObservableAlertDefinition) GreaterOrEqual(f float64) *ObservableAlertDefinition
@@ -289,7 +289,7 @@ func (a *ObservableAlertDefinition) GreaterOrEqual(f float64) *ObservableAlertDe
 
 GreaterOrEqual indicates the alert should fire when greater or equal the given value\.
 
-### func \(\*ObservableAlertDefinition\) [Less](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L628>)
+### func \(\*ObservableAlertDefinition\) [Less](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L643>)
 
 ```go
 func (a *ObservableAlertDefinition) Less(f float64) *ObservableAlertDefinition
@@ -297,7 +297,7 @@ func (a *ObservableAlertDefinition) Less(f float64) *ObservableAlertDefinition
 
 Less indicates the alert should fire when strictly less than this value\.
 
-### func \(\*ObservableAlertDefinition\) [LessOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L614>)
+### func \(\*ObservableAlertDefinition\) [LessOrEqual](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/monitoring.go#L629>)
 
 ```go
 func (a *ObservableAlertDefinition) LessOrEqual(f float64) *ObservableAlertDefinition

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -138,16 +138,16 @@ func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) err
 		possibleSolutions, _ := toMarkdown(o.PossibleSolutions, true)
 		fmt.Fprintf(&d.alertSolutions, "%s\n", possibleSolutions)
 	}
-	// add link to panel information IF there are additional details available
-	if o.Interpretation != "" && o.Interpretation != "none" {
-		fmt.Fprintf(&d.alertSolutions, "- **Refer to the [dashboards reference](./%s#%s)** for more help interpreting this alert and metric.\n",
-			dashboardsDocsFile, observableDocAnchor(c, o))
-	}
 	// add silencing configuration as another solution
 	fmt.Fprintf(&d.alertSolutions, "- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:\n\n")
 	fmt.Fprintf(&d.alertSolutions, "```json\n%s\n```\n\n", fmt.Sprintf(`"observability.silenceAlerts": [
 %s
 ]`, strings.Join(prometheusAlertNames, ",\n")))
+	// add link to panel information IF there are additional details available
+	if o.Interpretation != "" && o.Interpretation != "none" {
+		fmt.Fprintf(&d.alertSolutions, "> NOTE: More help interpreting this metric is available in the [dashboards reference](./%s#%s).\n\n",
+			dashboardsDocsFile, observableDocAnchor(c, o))
+	}
 	// add owner
 	fprintOwnedBy(&d.alertSolutions, o.Owner)
 	// render break for readability
@@ -165,7 +165,7 @@ func (d *documentation) renderDashboardPanelEntry(c *Container, o Observable) er
 	}
 	// add link to alert solutions IF there is an alert attached
 	if !o.NoAlert {
-		fmt.Fprintf(&d.dashboards, "Refer to the [alert solutions reference](./%s#%s) for alerts related to this panel.\n\n",
+		fmt.Fprintf(&d.dashboards, "> NOTE: Alerts related to this panel are available in the [alert solutions reference](./%s#%s).\n\n",
 			alertSolutionsFile, observableDocAnchor(c, o))
 	}
 	// add owner

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -165,7 +165,7 @@ func (d *documentation) renderDashboardPanelEntry(c *Container, o Observable) er
 	}
 	// add link to alert solutions IF there is an alert attached
 	if !o.NoAlert {
-		fmt.Fprintf(&d.dashboards, "> NOTE: Alerts related to this panel are available in the [alert solutions reference](./%s#%s).\n\n",
+		fmt.Fprintf(&d.dashboards, "> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./%s#%s).\n\n",
 			alertSolutionsFile, observableDocAnchor(c, o))
 	}
 	// add owner

--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -36,6 +36,7 @@ To learn more about Sourcegraph's metrics and how to view these dashboards, see 
 
 `
 
+// fprintSubtitle prints subtitle-class text
 func fprintSubtitle(w io.Writer, text string) {
 	fmt.Fprintf(w, "<p class=\"subtitle\">%s</p>\n\n", text)
 }
@@ -46,6 +47,11 @@ func fprintSubtitle(w io.Writer, text string) {
 func fprintObservableHeader(w io.Writer, c *Container, o *Observable, headerLevel int) {
 	fmt.Fprint(w, strings.Repeat("#", headerLevel))
 	fmt.Fprintf(w, " %s: %s\n\n", c.Name, o.Name)
+}
+
+// fprintOwnedBy prints information about who owns a particular monitoring definition.
+func fprintOwnedBy(w io.Writer, owner ObservableOwner) {
+	fmt.Fprintf(w, "<sub>*Managed by the %s.*</sub>\n", owner.toMarkdown())
 }
 
 // Create an anchor link that matches `fprintObservableHeader`
@@ -101,11 +107,11 @@ func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) err
 	}
 
 	fprintObservableHeader(&d.alertSolutions, c, &o, 2)
-	fprintSubtitle(&d.alertSolutions, fmt.Sprintf(`%s (%s)`, o.Description, o.Owner))
+	fprintSubtitle(&d.alertSolutions, o.Description)
 
 	var prometheusAlertNames []string // collect names for silencing configuration
 	// Render descriptions of various levels of this alert
-	fmt.Fprintf(&d.alertSolutions, "**Descriptions:**\n\n")
+	fmt.Fprintf(&d.alertSolutions, "**Descriptions**\n\n")
 	for _, alert := range []struct {
 		level     string
 		threshold *ObservableAlertDefinition
@@ -127,7 +133,7 @@ func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) err
 	fmt.Fprint(&d.alertSolutions, "\n")
 
 	// Render solutions for dealing with this alert
-	fmt.Fprintf(&d.alertSolutions, "**Possible solutions:**\n\n")
+	fmt.Fprintf(&d.alertSolutions, "**Possible solutions**\n\n")
 	if o.PossibleSolutions != "none" {
 		possibleSolutions, _ := toMarkdown(o.PossibleSolutions, true)
 		fmt.Fprintf(&d.alertSolutions, "%s\n", possibleSolutions)
@@ -142,14 +148,16 @@ func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) err
 	fmt.Fprintf(&d.alertSolutions, "```json\n%s\n```\n\n", fmt.Sprintf(`"observability.silenceAlerts": [
 %s
 ]`, strings.Join(prometheusAlertNames, ",\n")))
+	// add owner
+	fprintOwnedBy(&d.alertSolutions, o.Owner)
 	// render break for readability
-	fmt.Fprint(&d.alertSolutions, "<br />\n\n")
+	fmt.Fprint(&d.alertSolutions, "\n<br />\n\n")
 	return nil
 }
 
 func (d *documentation) renderDashboardPanelEntry(c *Container, o Observable) error {
 	fprintObservableHeader(&d.dashboards, c, &o, 4)
-	fmt.Fprintf(&d.dashboards, "This %s panel indicates %s.\n\n", o.Owner, o.Description)
+	fmt.Fprintf(&d.dashboards, "This panel indicates %s.\n\n", o.Description)
 	// render interpretation reference if available
 	if o.Interpretation != "" && o.Interpretation != "none" {
 		interpretation, _ := toMarkdown(o.Interpretation, false)
@@ -157,9 +165,11 @@ func (d *documentation) renderDashboardPanelEntry(c *Container, o Observable) er
 	}
 	// add link to alert solutions IF there is an alert attached
 	if !o.NoAlert {
-		fmt.Fprintf(&d.dashboards, "Refer to the [alert solutions reference](./%s#%s) for relevant alerts.\n",
+		fmt.Fprintf(&d.dashboards, "Refer to the [alert solutions reference](./%s#%s) for alerts related to this panel.\n\n",
 			alertSolutionsFile, observableDocAnchor(c, o))
 	}
+	// add owner
+	fprintOwnedBy(&d.dashboards, o.Owner)
 	// render break for readability
 	fmt.Fprint(&d.dashboards, "\n<br />\n\n")
 	return nil

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -416,6 +416,21 @@ const (
 	ObservableOwnerCloud        ObservableOwner = "cloud"
 )
 
+// toMarkdown returns a Markdown string that also links to the owner's team page
+func (o ObservableOwner) toMarkdown() string {
+	var teamName string
+	// special cases for differences in how a team is named in ObservableOwner and how
+	// they are named in the handbook.
+	// see https://about.sourcegraph.com/company/team/org_chart#engineering
+	switch o {
+	case ObservableOwnerCodeIntel:
+		teamName = "code-intelligence"
+	default:
+		teamName = string(o)
+	}
+	return fmt.Sprintf("[Sourcegraph %s team](https://about.sourcegraph.com/handbook/engineering/%s)", upperFirst(teamName), teamName)
+}
+
 // Observable describes a metric about a container that can be observed. For example, memory usage.
 //
 // These correspond to Grafana graphs.


### PR DESCRIPTION
Generated dashboard and alerts docs now more explicitly point out the team that owns it. Also links back to the handbook.

Also moves reference links to `> NOTE:` blocks after feedback from @pecigonzalo about the readability of the dashboard docs, I think this is nicer on the eye? (more colour is nice maybe?)

![image](https://user-images.githubusercontent.com/23356519/105188295-b53aec80-5b6e-11eb-8e5c-9aac6a578cdf.png)

![image](https://user-images.githubusercontent.com/23356519/105188479-ea473f00-5b6e-11eb-8079-455e60588a28.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
