### PR TITLE
gitserver: abstract clone and fetch operations for different VCS

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -81,6 +82,18 @@ func main() {
 				return info.CloneURL, nil
 			}
 			return "", fmt.Errorf("no sources for %q", repo)
+		},
+		GetVCSSyncer: func(ctx context.Context, repo api.RepoName) (server.VCSSyncer, error) {
+			r, err := repoStore.GetByName(ctx, repo)
+			if err != nil {
+				return nil, errors.Wrap(err, "get repository")
+			}
+
+			switch r.ExternalRepo.ServiceType {
+			case extsvc.TypePerforce:
+				return &server.PerforceDepotSyncer{}, nil
+			}
+			return &server.GitRepoSyncer{}, nil
 		},
 	}
 	gitserver.RegisterMetrics()

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -247,6 +247,9 @@ func TestCleanupExpired(t *testing.T) {
 	s := &Server{
 		ReposDir:         root,
 		GetRemoteURLFunc: getRemoteURL,
+		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+			return &GitRepoSyncer{}, nil
+		},
 	}
 	s.Handler() // Handler as a side-effect sets up Server
 	s.cleanupRepos()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -127,7 +127,10 @@ type Server struct {
 	// GetRemoteURLFunc being nil.
 	GetRemoteURLFunc func(context.Context, api.RepoName) (string, error)
 
-	// TODO
+	// GetVCSSyncer is a function which returns the VCS syncer for a repository.
+	// This is used when cloning or fetching a repository. In production this will
+	// speak to the database to determine the code host type. In tests this is
+	// usually set to return a GitRepoSyncer.
 	GetVCSSyncer func(context.Context, api.RepoName) (VCSSyncer, error)
 
 	// skipCloneForTests is set by tests to avoid clones.

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -127,6 +127,9 @@ type Server struct {
 	// GetRemoteURLFunc being nil.
 	GetRemoteURLFunc func(context.Context, api.RepoName) (string, error)
 
+	// TODO
+	GetVCSSyncer func(context.Context, api.RepoName) (VCSSyncer, error)
+
 	// skipCloneForTests is set by tests to avoid clones.
 	skipCloneForTests bool
 
@@ -371,8 +374,14 @@ func (s *Server) handleIsRepoCloneable(w http.ResponseWriter, r *http.Request) {
 		remoteURL = "https://" + string(req.Repo) + ".git"
 	}
 
+	syncer, err := s.GetVCSSyncer(r.Context(), req.Repo)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	var resp protocol.IsRepoCloneableResponse
-	if err := s.isCloneable(r.Context(), remoteURL); err == nil {
+	if err := syncer.IsCloneable(r.Context(), remoteURL); err == nil {
 		resp = protocol.IsRepoCloneableResponse{Cloneable: true}
 	} else {
 		resp = protocol.IsRepoCloneableResponse{
@@ -768,7 +777,7 @@ type cloneOptions struct {
 	Overwrite bool
 }
 
-// cloneRepo issues a git clone command for the given repo. It is
+// cloneRepo performs a clone operation for the given repository. It is
 // non-blocking by default.
 func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOptions) (string, error) {
 	if strings.ToLower(string(repo)) == "github.com/sourcegraphtest/alwayscloningtest" {
@@ -781,6 +790,11 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 	// ensure we are not already cloning.
 	if progress, cloneInProgress := s.locker.Status(dir); cloneInProgress {
 		return progress, nil
+	}
+
+	syncer, err := s.GetVCSSyncer(ctx, repo)
+	if err != nil {
+		return "", errors.Wrap(err, "get VCS syncer")
 	}
 
 	url, err := s.getRemoteURL(ctx, repo)
@@ -800,7 +814,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 		return "", err // err will be a context error
 	}
 	defer cancel()
-	if err := s.isCloneable(ctx, url); err != nil {
+	if err := syncer.IsCloneable(ctx, url); err != nil {
 		return "", fmt.Errorf("error cloning repo: repo %s not cloneable: %s", repo, redactor.redact(err.Error()))
 	}
 
@@ -855,15 +869,11 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 		tmpPath = filepath.Join(tmpPath, ".git")
 		tmp := GitDir(tmpPath)
 
-		var cmd *exec.Cmd
-		if useRefspecOverrides() {
-			cmd, err = refspecOverridesCloneCmd(ctx, url, tmpPath)
-			if err != nil {
-				return err
-			}
-		} else {
-			cmd = exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", url, tmpPath)
+		cmd, err := syncer.CloneCommand(ctx, url, tmpPath)
+		if err != nil {
+			return errors.Wrap(err, "get clone command")
 		}
+
 		// see issue #7322: skip LFS content in repositories with Git LFS configured
 		cmd.Env = append(os.Environ(), "GIT_LFS_SKIP_SMUDGE=1")
 		log15.Info("cloning repo", "repo", repo, "tmp", tmpPath, "dst", dstPath)
@@ -1025,36 +1035,9 @@ func scanCRLF(data []byte, atEOF bool) (advance int, token []byte, err error) {
 	return 0, nil, nil
 }
 
-// testRepoExists is a test fixture that overrides the return value
-// for isCloneable when it is set.
-var testRepoExists func(ctx context.Context, url string) error
-
-// isCloneable checks to see if the Git remote URL is cloneable.
-func (s *Server) isCloneable(ctx context.Context, url string) error {
-	args := []string{"ls-remote", url, "HEAD"}
-	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(args))
-	defer cancel()
-
-	if strings.ToLower(string(protocol.NormalizeRepo(api.RepoName(url)))) == "github.com/sourcegraphtest/alwayscloningtest" {
-		return nil
-	}
-	if testRepoExists != nil {
-		return testRepoExists(ctx, url)
-	}
-
-	cmd := exec.CommandContext(ctx, "git", args...)
-	out, err := runWithRemoteOpts(ctx, cmd, nil)
-	if err != nil {
-		if ctxerr := ctx.Err(); ctxerr != nil {
-			err = ctxerr
-		}
-		if len(out) > 0 {
-			err = fmt.Errorf("%s (output follows)\n\n%s", err, out)
-		}
-		return err
-	}
-	return nil
-}
+// testGitRepoExists is a test fixture that overrides the return value for
+// GitRepoSyncer.IsCloneable when it is set.
+var testGitRepoExists func(ctx context.Context, url string) error
 
 var (
 	execRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -1354,28 +1337,16 @@ func (s *Server) doRepoUpdate2(repo api.RepoName) error {
 		return errors.Wrap(err, "failed to determine Git remote URL")
 	}
 
-	configRemoteOpts := true
-	var cmd *exec.Cmd
-	if customCmd := customFetchCmd(ctx, url); customCmd != nil {
-		cmd = customCmd
-		configRemoteOpts = false
-	} else if useRefspecOverrides() {
-		cmd = refspecOverridesFetchCmd(ctx, url)
-	} else {
-		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", url,
-			// Normal git refs
-			"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*",
-			// GitHub pull requests
-			"+refs/pull/*:refs/pull/*",
-			// GitLab merge requests
-			"+refs/merge-requests/*:refs/merge-requests/*",
-			// Bitbucket pull requests
-			"+refs/pull-requests/*:refs/pull-requests/*",
-			// Gerrit changesets
-			"+refs/changes/*:refs/changes/*",
-			// Possibly deprecated refs for sourcegraph zap experiment?
-			"+refs/sourcegraph/*:refs/sourcegraph/*")
+	syncer, err := s.GetVCSSyncer(ctx, repo)
+	if err != nil {
+		return errors.Wrap(err, "get VCS syncer")
 	}
+
+	cmd, configRemoteOpts, err := syncer.FetchCommand(ctx, url)
+	if err != nil {
+		return errors.Wrap(err, "get fetch command")
+	}
+
 	dir.Set(cmd)
 
 	// drop temporary pack files after a fetch. this function won't

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -115,14 +115,14 @@ func TestRequest(t *testing.T) {
 		return dir == s.dir("github.com/gorilla/mux") || dir == s.dir("my-mux")
 	}
 
-	testRepoExists = func(ctx context.Context, url string) error {
+	testGitRepoExists = func(ctx context.Context, url string) error {
 		if url == "https://github.com/nicksnyder/go-i18n.git" {
 			return nil
 		}
 		return errors.New("not cloneable")
 	}
 	defer func() {
-		testRepoExists = nil
+		testGitRepoExists = nil
 	}()
 
 	runCommandMock = func(ctx context.Context, cmd *exec.Cmd) (int, error) {

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -108,6 +108,9 @@ func TestRequest(t *testing.T) {
 		GetRemoteURLFunc: func(ctx context.Context, name api.RepoName) (string, error) {
 			return "https://" + string(name) + ".git", nil
 		},
+		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+			return &GitRepoSyncer{}, nil
+		},
 	}
 	h := s.Handler()
 
@@ -392,6 +395,9 @@ func TestCloneRepo(t *testing.T) {
 	s := &Server{
 		ReposDir:         reposDir,
 		GetRemoteURLFunc: staticGetRemoteURL(remote),
+		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+			return &GitRepoSyncer{}, nil
+		},
 		ctx:              context.Background(),
 		locker:           &RepositoryLocker{},
 		cloneLimiter:     mutablelimiter.New(1),
@@ -512,6 +518,9 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		server := &Server{
 			ReposDir:         reposDir,
 			GetRemoteURLFunc: staticGetRemoteURL(remote),
+			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+				return &GitRepoSyncer{}, nil
+			},
 			ctx:              ctx,
 			locker:           &RepositoryLocker{},
 			cloneLimiter:     mutablelimiter.New(1),
@@ -537,6 +546,9 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		server := &Server{
 			ReposDir:         reposDir,
 			GetRemoteURLFunc: staticGetRemoteURL(remote),
+			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+				return &GitRepoSyncer{}, nil
+			},
 			ctx:              ctx,
 			locker:           &RepositoryLocker{},
 			cloneLimiter:     mutablelimiter.New(1),
@@ -564,6 +576,9 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		s := &Server{
 			ReposDir:         reposDir,
 			GetRemoteURLFunc: staticGetRemoteURL(remote),
+			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+				return &GitRepoSyncer{}, nil
+			},
 			ctx:              ctx,
 			locker:           &RepositoryLocker{},
 			cloneLimiter:     mutablelimiter.New(1),
@@ -611,6 +626,9 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 		s := &Server{
 			ReposDir:         reposDir,
 			GetRemoteURLFunc: staticGetRemoteURL(remote),
+			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+				return &GitRepoSyncer{}, nil
+			},
 			ctx:              ctx,
 			locker:           &RepositoryLocker{},
 			cloneLimiter:     mutablelimiter.New(1),

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
@@ -89,17 +91,17 @@ func (s *GitRepoSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec
 // PerforceDepotSyncer is a syncer for Perforce depots.
 type PerforceDepotSyncer struct{}
 
-// TODO
+// TODO(jchen)
 func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error {
-	panic("implement me") // p4 ping
+	return errors.New("not yet implemented") // p4 ping
 }
 
-// TODO
+// TODO(jchen)
 func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error) {
-	panic("implement me") // git p4 clone
+	return nil, errors.New("not yet implemented") // git p4 clone
 }
 
-// TODO
+// TODO(jchen)
 func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
-	panic("implement me") // git p4 sync
+	return nil, false, errors.New("not yet implemented") // git p4 sync
 }

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
+)
+
+// TODO
+type VCSSyncer interface {
+	// IsCloneable checks to see if the VCS remote URL is cloneable.
+	IsCloneable(ctx context.Context, url string) error
+	// TODO
+	CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error)
+	// TODO
+	FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error)
+}
+
+// GitRepoSyncer is a syncer for Git repositories.
+type GitRepoSyncer struct{}
+
+// IsCloneable checks to see if the Git remote URL is cloneable.
+func (s *GitRepoSyncer) IsCloneable(ctx context.Context, url string) error {
+	args := []string{"ls-remote", url, "HEAD"}
+	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(args))
+	defer cancel()
+
+	if strings.ToLower(string(protocol.NormalizeRepo(api.RepoName(url)))) == "github.com/sourcegraphtest/alwayscloningtest" {
+		return nil
+	}
+	if testGitRepoExists != nil {
+		return testGitRepoExists(ctx, url)
+	}
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	out, err := runWithRemoteOpts(ctx, cmd, nil)
+	if err != nil {
+		if ctxerr := ctx.Err(); ctxerr != nil {
+			err = ctxerr
+		}
+		if len(out) > 0 {
+			err = fmt.Errorf("%s (output follows)\n\n%s", err, out)
+		}
+		return err
+	}
+	return nil
+}
+
+// TODO
+func (s *GitRepoSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error) {
+	if useRefspecOverrides() {
+		return refspecOverridesCloneCmd(ctx, url, tmpPath)
+	}
+	return exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", url, tmpPath), nil
+}
+
+// TODO
+func (s *GitRepoSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
+	configRemoteOpts = true
+	if customCmd := customFetchCmd(ctx, url); customCmd != nil {
+		cmd = customCmd
+		configRemoteOpts = false
+	} else if useRefspecOverrides() {
+		cmd = refspecOverridesFetchCmd(ctx, url)
+	} else {
+		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", url,
+			// Normal git refs
+			"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*",
+			// GitHub pull requests
+			"+refs/pull/*:refs/pull/*",
+			// GitLab merge requests
+			"+refs/merge-requests/*:refs/merge-requests/*",
+			// Bitbucket pull requests
+			"+refs/pull-requests/*:refs/pull-requests/*",
+			// Gerrit changesets
+			"+refs/changes/*:refs/changes/*",
+			// Possibly deprecated refs for sourcegraph zap experiment?
+			"+refs/sourcegraph/*:refs/sourcegraph/*")
+	}
+	return cmd, configRemoteOpts, nil
+}
+
+// PerforceDepotSyncer is a syncer for Perforce depots.
+type PerforceDepotSyncer struct{}
+
+// TODO
+func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error {
+	panic("implement me")
+}
+
+// TODO
+func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error) {
+	panic("implement me")
+}
+
+// TODO
+func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
+	panic("implement me")
+}

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -10,13 +10,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
 
-// TODO
+// VCSSyncer describes whether and how to sync content from a VCS remote to
+// local disk.
 type VCSSyncer interface {
-	// IsCloneable checks to see if the VCS remote URL is cloneable.
+	// IsCloneable checks to see if the VCS remote URL is cloneable. Any non-nil
+	// error indicates there is a problem.
 	IsCloneable(ctx context.Context, url string) error
-	// TODO
+	// CloneCommand returns the command to be executed for cloning from remote.
 	CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error)
-	// TODO
+	// FetchCommand returns the command to be executed for fetching updates from remote.
 	FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error)
 }
 
@@ -25,16 +27,16 @@ type GitRepoSyncer struct{}
 
 // IsCloneable checks to see if the Git remote URL is cloneable.
 func (s *GitRepoSyncer) IsCloneable(ctx context.Context, url string) error {
-	args := []string{"ls-remote", url, "HEAD"}
-	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(args))
-	defer cancel()
-
 	if strings.ToLower(string(protocol.NormalizeRepo(api.RepoName(url)))) == "github.com/sourcegraphtest/alwayscloningtest" {
 		return nil
 	}
 	if testGitRepoExists != nil {
 		return testGitRepoExists(ctx, url)
 	}
+
+	args := []string{"ls-remote", url, "HEAD"}
+	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(args))
+	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", args...)
 	out, err := runWithRemoteOpts(ctx, cmd, nil)
@@ -50,7 +52,7 @@ func (s *GitRepoSyncer) IsCloneable(ctx context.Context, url string) error {
 	return nil
 }
 
-// TODO
+// CloneCommand returns the command to be executed for cloning a Git repository.
 func (s *GitRepoSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error) {
 	if useRefspecOverrides() {
 		return refspecOverridesCloneCmd(ctx, url, tmpPath)
@@ -58,7 +60,7 @@ func (s *GitRepoSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (
 	return exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", url, tmpPath), nil
 }
 
-// TODO
+// FetchCommand returns the command to be executed for fetching updates of a Git repository.
 func (s *GitRepoSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
 	configRemoteOpts = true
 	if customCmd := customFetchCmd(ctx, url); customCmd != nil {
@@ -89,15 +91,15 @@ type PerforceDepotSyncer struct{}
 
 // TODO
 func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error {
-	panic("implement me")
+	panic("implement me") // p4 ping
 }
 
 // TODO
 func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error) {
-	panic("implement me")
+	panic("implement me") // git p4 clone
 }
 
 // TODO
 func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
-	panic("implement me")
+	panic("implement me") // git p4 sync
 }

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -95,6 +95,9 @@ func TestClient_Archive(t *testing.T) {
 			}
 			return "", fmt.Errorf("no remote for %s", name)
 		},
+		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
+			return &server.GitRepoSyncer{}, nil
+		},
 	}).Handler())
 	defer srv.Close()
 

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -50,6 +50,10 @@ func (s PerforceSource) makeRepo(depot string) *types.Repo {
 	}
 	name := strings.Trim(depot, "/")
 	urn := s.svc.URN()
+
+	// e.g. perforce://admin:password@ssl:111.222.333.444:1666//Sourcegraph/
+	cloneURL := fmt.Sprintf("perforce://%s:%s@%s%s", s.config.P4User, s.config.P4Passwd, s.config.P4Port, depot)
+
 	return &types.Repo{
 		Name: api.RepoName(name),
 		URI:  name,
@@ -62,7 +66,7 @@ func (s PerforceSource) makeRepo(depot string) *types.Repo {
 		Sources: map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,
-				CloneURL: "perforce:" + depot, // e.g. perforce://Sourcegraph/
+				CloneURL: cloneURL,
 			},
 		},
 		Metadata: map[string]interface{}{

--- a/internal/repos/testdata/golden/PerforceSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/PerforceSource_makeRepo_simple
@@ -19,7 +19,7 @@
    "Sources": {
     "extsvc:perforce:1": {
      "ID": "extsvc:perforce:1",
-     "CloneURL": "perforce://Sourcegraph/"
+     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Sourcegraph/"
     }
    },
    "Metadata": {
@@ -46,7 +46,7 @@
    "Sources": {
     "extsvc:perforce:1": {
      "ID": "extsvc:perforce:1",
-     "CloneURL": "perforce://Engineering/Cloud/"
+     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Engineering/Cloud/"
     }
    },
    "Metadata": {

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -63,7 +63,7 @@ func init() {
 			GetRemoteURLFunc: func(ctx context.Context, name api.RepoName) (string, error) {
 				return filepath.Join(root, "remotes", string(name)), nil
 			},
-			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSCommander, error) {
+			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSSyncer, error) {
 				return &server.GitRepoSyncer{}, nil
 			},
 		}).Handler(),

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -57,12 +57,17 @@ func init() {
 		log.Fatal(err)
 	}
 
-	srv := &http.Server{Handler: (&server.Server{
-		ReposDir: filepath.Join(root, "repos"),
-		GetRemoteURLFunc: func(ctx context.Context, name api.RepoName) (string, error) {
-			return filepath.Join(root, "remotes", string(name)), nil
-		},
-	}).Handler()}
+	srv := &http.Server{
+		Handler: (&server.Server{
+			ReposDir: filepath.Join(root, "repos"),
+			GetRemoteURLFunc: func(ctx context.Context, name api.RepoName) (string, error) {
+				return filepath.Join(root, "remotes", string(name)), nil
+			},
+			GetVCSSyncer: func(ctx context.Context, name api.RepoName) (server.VCSCommander, error) {
+				return &server.GitRepoSyncer{}, nil
+			},
+		}).Handler(),
+	}
 	go func() {
 		if err := srv.Serve(l); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This is the first (refactoring) step towards syncing depots from a Perforce Server. We need to abstract the syncer definition because clone and fetch requires different sets of commands to be executed for a Git and Perforce remote.

This PR does not add support for syncing Perforce depots yet but to put up for review to get people's eyes on whether the approach I'm taking makes sense.

Part of #16703