### PR TITLE
search: Fix issue with type:commit where message and pattern return different results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Fixes an issue that prevented the hard deletion of a user if they had saved searches. [#181](https://github.com/sourcegraph/customer/issues/181)
+- Fixes an issue that caused some missing results for `type:commit` when a pattern was used instead of the `message` field. [#17490](https://github.com/sourcegraph/sourcegraph/pull/17490#issuecomment-764004758)
 
 ### Removed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -440,11 +440,11 @@ func TestSearch(t *testing.T) {
 			},
 			{
 				name:  "commit search, non-zero result message",
-				query: `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard message:highlight after:'december 1 2020' before:'december 8 2020'`,
+				query: `repo:^ghe\.sgdev\.org/sourcegraph/gorilla-mux$ type:commit author:kushmansingh@icloud.com before:"december 10 2016" message:option`,
 			},
 			{
 				name:  "commit search, non-zero result pattern",
-				query: `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard highlight after:'december 1 2020' before:'december 8 2020'`,
+				query: `repo:^ghe\.sgdev\.org/sourcegraph/gorilla-mux$ type:commit author:kushmansingh@icloud.com before:"december 10 2016" option`,
 			},
 			// Diff search
 			{

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -440,11 +440,11 @@ func TestSearch(t *testing.T) {
 			},
 			{
 				name:  "commit search, non-zero result message",
-				query: `repo:^ghe\.sgdev\.org/sourcegraph/gorilla-mux$ type:commit author:kushmansingh@icloud.com before:"december 10 2016" message:option`,
+				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ type:commit message:test`,
 			},
 			{
 				name:  "commit search, non-zero result pattern",
-				query: `repo:^ghe\.sgdev\.org/sourcegraph/gorilla-mux$ type:commit author:kushmansingh@icloud.com before:"december 10 2016" option`,
+        query: `repo:^github\.com/sgtest/sourcegraph-typescript$ type:commit test`,
 			},
 			// Diff search
 			{

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -439,12 +439,12 @@ func TestSearch(t *testing.T) {
 				},
 			},
 			{
-				name:       "commit search, non-zero result message",
-        query:      `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard message:highlight after:'december 1 2020' before:'december 8 2020'`,
+				name:  "commit search, non-zero result message",
+				query: `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard message:highlight after:'december 1 2020' before:'december 8 2020'`,
 			},
 			{
-				name:       "commit search, non-zero result pattern",
-				query:      `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard highlight after:'december 1 2020' before:'december 8 2020'`,
+				name:  "commit search, non-zero result pattern",
+				query: `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard highlight after:'december 1 2020' before:'december 8 2020'`,
 			},
 			// Diff search
 			{

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -438,6 +438,14 @@ func TestSearch(t *testing.T) {
 					ProposedQueries: nil,
 				},
 			},
+			{
+				name:       "commit search, non-zero result message",
+        query:      `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard message:highlight after:'december 1 2020' before:'december 8 2020'`,
+			},
+			{
+				name:       "commit search, non-zero result pattern",
+				query:      `repo:^github\.com/sourcegraph/sourcegraph$ type:commit author:rijnard highlight after:'december 1 2020' before:'december 8 2020'`,
+			},
 			// Diff search
 			{
 				name:  "diff search, nonzero result",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -444,7 +444,7 @@ func TestSearch(t *testing.T) {
 			},
 			{
 				name:  "commit search, non-zero result pattern",
-        query: `repo:^github\.com/sgtest/sourcegraph-typescript$ type:commit test`,
+				query: `repo:^github\.com/sgtest/sourcegraph-typescript$ type:commit test`,
 			},
 			// Diff search
 			{

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -468,7 +468,7 @@ func rawShowSearch(ctx context.Context, repo api.RepoName, opt RawLogDiffSearchO
 
 func logDiffCommonArgs(opt RawLogDiffSearchOptions) []string {
 	var args []string
-	if opt.Query.Pattern != "" {
+	if opt.Query.Pattern != "" && opt.Diff {
 		var queryArg string
 		if opt.MatchChangedOccurrenceCount {
 			queryArg = "-S"


### PR DESCRIPTION
The `git log` command was being built with the `-G` flag when a pattern was used for search, which restricts matches to diffs only. This was leading to incorrect results, and different results between `type:commit query` and `type:commit message:query`. 

This skips adding the `-G` flag when `type:commit`. 

Fixes #13313

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
