### PR TITLE
insights: add GraphQL backend scaffolding

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -20,6 +20,7 @@ type Services struct {
 	AuthzResolver             graphqlbackend.AuthzResolver
 	CampaignsResolver         graphqlbackend.CampaignsResolver
 	CodeIntelResolver         graphqlbackend.CodeIntelResolver
+	InsightsResolver          graphqlbackend.InsightsResolver
 	CodeMonitorsResolver      graphqlbackend.CodeMonitorsResolver
 	LicenseResolver           graphqlbackend.LicenseResolver
 }
@@ -43,6 +44,7 @@ func DefaultServices() Services {
 		NewExecutorProxyHandler:   func() http.Handler { return makeNotFoundHandler("executor proxy") },
 		AuthzResolver:             graphqlbackend.DefaultAuthzResolver,
 		CampaignsResolver:         graphqlbackend.DefaultCampaignsResolver,
+		InsightsResolver:          graphqlbackend.DefaultInsightsResolver,
 		CodeMonitorsResolver:      graphqlbackend.DefaultCodeMonitorsResolver,
 		LicenseResolver:           graphqlbackend.DefaultLicenseResolver,
 	}

--- a/cmd/frontend/graphqlbackend/CODENOTIFY
+++ b/cmd/frontend/graphqlbackend/CODENOTIFY
@@ -12,3 +12,7 @@ site_monitoring.go @bobheadxi
 # Campaigns
 campaigns.go @LawnGnome
 campaigns.go @eseliger
+
+# Insights
+insights.go @slimsag
+insights.go @felixfbecker

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -339,11 +339,12 @@ func prometheusGraphQLRequestName(requestName string) string {
 	return "other"
 }
 
-func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz AuthzResolver, codeMonitors CodeMonitorsResolver, license LicenseResolver) (*graphql.Schema, error) {
+func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, insights InsightsResolver, authz AuthzResolver, codeMonitors CodeMonitorsResolver, license LicenseResolver) (*graphql.Schema, error) {
 	resolver := &schemaResolver{
 		CampaignsResolver: defaultCampaignsResolver{},
 		AuthzResolver:     defaultAuthzResolver{},
 		CodeIntelResolver: defaultCodeIntelResolver{},
+		InsightsResolver:  defaultInsightsResolver{},
 		LicenseResolver:   defaultLicenseResolver{},
 	}
 	if campaigns != nil {
@@ -353,6 +354,10 @@ func NewSchema(campaigns CampaignsResolver, codeIntel CodeIntelResolver, authz A
 	if codeIntel != nil {
 		EnterpriseResolvers.codeIntelResolver = codeIntel
 		resolver.CodeIntelResolver = codeIntel
+	}
+	if insights != nil {
+		EnterpriseResolvers.insightsResolver = insights
+		resolver.InsightsResolver = insights
 	}
 	if authz != nil {
 		EnterpriseResolvers.authzResolver = authz
@@ -558,6 +563,7 @@ type schemaResolver struct {
 	CampaignsResolver
 	AuthzResolver
 	CodeIntelResolver
+	InsightsResolver
 	CodeMonitorsResolver
 	LicenseResolver
 }
@@ -566,6 +572,7 @@ type schemaResolver struct {
 // in enterprise mode. These resolver instances are nil when running as OSS.
 var EnterpriseResolvers = struct {
 	codeIntelResolver    CodeIntelResolver
+	insightsResolver     InsightsResolver
 	authzResolver        AuthzResolver
 	campaignsResolver    CampaignsResolver
 	codeMonitorsResolver CodeMonitorsResolver

--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -1,0 +1,42 @@
+package graphqlbackend
+
+import (
+	"context"
+	"errors"
+)
+
+// This file just contains stub GraphQL resolvers and data types for Code Insights which merely
+// return an error if not running in enterprise mode. The actual resolvers can be found in
+// enterprise/internal/insights/resolvers
+
+type InsightsDataPointResolver interface {
+	DateTime() DateTime
+	Value() float64
+}
+
+type InsightsPointsArgs struct {
+	From *DateTime
+	To   *DateTime
+}
+
+type InsightsResolver interface {
+	// Root resolver
+	Insights(ctx context.Context) (InsightsResolver, error)
+
+	// Insights type resolvers.
+	Points(ctx context.Context, args *InsightsPointsArgs) ([]InsightsDataPointResolver, error)
+}
+
+var insightsOnlyInEnterprise = errors.New("insights are only available in enterprise")
+
+type defaultInsightsResolver struct{}
+
+func (defaultInsightsResolver) Insights(ctx context.Context) (InsightsResolver, error) {
+	return nil, insightsOnlyInEnterprise
+}
+
+func (defaultInsightsResolver) Points(ctx context.Context, args *InsightsPointsArgs) ([]InsightsDataPointResolver, error) {
+	return nil, insightsOnlyInEnterprise
+}
+
+var DefaultInsightsResolver InsightsResolver = defaultInsightsResolver{}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2398,6 +2398,31 @@ type ChangesetEventConnection {
 }
 
 """
+Insights about code.
+"""
+type Insights {
+    """
+    Data points over a time range (inclusive)
+    """
+    points(from: DateTime, to: DateTime): [InsightDataPoint!]!
+}
+
+"""
+A code insight data point.
+"""
+type InsightDataPoint {
+    """
+    The time of this data point.
+    """
+    dateTime: DateTime!
+
+    """
+    The value of the insight at this point in time.
+    """
+    value: Float!
+}
+
+"""
 A new external service.
 """
 input AddExternalServiceInput {
@@ -2710,6 +2735,11 @@ type Query {
         """
         name: String!
     ): Campaign
+
+    """
+    EXPERIMENTAL: Queries code insights
+    """
+    insights: Insights
 
     """
     Looks up a repository by either name or cloneURL.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2391,6 +2391,31 @@ type ChangesetEventConnection {
 }
 
 """
+Insights about code.
+"""
+type Insights {
+    """
+    Data points over a time range (inclusive)
+    """
+    points(from: DateTime, to: DateTime): [InsightDataPoint!]!
+}
+
+"""
+A code insight data point.
+"""
+type InsightDataPoint {
+    """
+    The time of this data point.
+    """
+    dateTime: DateTime!
+
+    """
+    The value of the insight at this point in time.
+    """
+    value: Float!
+}
+
+"""
 A new external service.
 """
 input AddExternalServiceInput {
@@ -2703,6 +2728,11 @@ type Query {
         """
         name: String!
     ): Campaign
+
+    """
+    EXPERIMENTAL: Queries code insights
+    """
+    insights: Insights
 
     """
     Looks up a repository by either name or cloneURL.

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -17,7 +17,7 @@ func mustParseGraphQLSchema(t *testing.T) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {
-		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil, nil, nil)
+		parsedSchema, parseSchemaErr = NewSchema(nil, nil, nil, nil, nil, nil)
 	})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -209,7 +209,7 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 		return errors.New("dbconn.Global is nil when trying to parse GraphQL schema")
 	}
 
-	schema, err := graphqlbackend.NewSchema(enterprise.CampaignsResolver, enterprise.CodeIntelResolver, enterprise.AuthzResolver, enterprise.CodeMonitorsResolver, enterprise.LicenseResolver)
+	schema, err := graphqlbackend.NewSchema(enterprise.CampaignsResolver, enterprise.CodeIntelResolver, enterprise.InsightsResolver, enterprise.AuthzResolver, enterprise.CodeMonitorsResolver, enterprise.LicenseResolver)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -45,7 +45,7 @@ func mustParseGraphQLSchema(t *testing.T, db *sql.DB) *graphql.Schema {
 	t.Helper()
 
 	parseSchemaOnce.Do(func() {
-		parsedSchema, parseSchemaErr = graphqlbackend.NewSchema(nil, nil, NewResolver(db, clock), nil, nil)
+		parsedSchema, parseSchemaErr = graphqlbackend.NewSchema(nil, nil, nil, NewResolver(db, clock), nil, nil)
 	})
 	if parseSchemaErr != nil {
 		t.Fatal(parseSchemaErr)

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/executor"
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
 
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/graphqlbackend"
@@ -35,6 +36,7 @@ var initFunctions = map[string]func(ctx context.Context, enterpriseServices *ent
 	"licensing":    licensing.Init,
 	"executor":     executor.Init,
 	"codeintel":    codeintel.Init,
+	"insights":     insights.Init,
 	"campaigns":    campaigns.InitFrontend,
 	"codemonitors": codemonitors.Init,
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
@@ -77,7 +77,7 @@ func TestCampaignConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -191,7 +191,7 @@ func TestCampaignsListing(t *testing.T) {
 	store := store.New(dbconn.Global)
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -83,7 +83,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -60,7 +60,7 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
@@ -70,7 +70,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
@@ -98,7 +98,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 		OwnedByCampaign:  campaign.ID,
 	})
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -110,7 +110,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	addChangeset(t, ctx, cstore, changeset3, campaign.ID)
 	addChangeset(t, ctx, cstore, changeset4, campaign.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -170,7 +170,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 		}
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
@@ -96,7 +96,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	addChangeset(t, ctx, cstore, changeset, campaign.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -70,7 +70,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -63,7 +63,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_test.go
@@ -176,7 +176,7 @@ func TestChangesetResolver(t *testing.T) {
 	// Associate the changeset with a campaign, so it's considered in syncer logic.
 	addChangeset(t, ctx, cstore, syncedGitHubChangeset, campaign.ID)
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
@@ -52,7 +52,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(&Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -38,7 +38,7 @@ func TestPermissionLevels(t *testing.T) {
 
 	cstore := store.New(dbconn.Global)
 	sr := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -758,7 +758,7 @@ func TestRepositoryPermissions(t *testing.T) {
 
 	cstore := store.New(dbconn.Global)
 	sr := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -34,7 +34,7 @@ import (
 func TestNullIDResilience(t *testing.T) {
 	sr := &Resolver{store: store.New(dbconn.Global)}
 
-	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(sr, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -276,7 +276,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestApplyCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -512,7 +512,7 @@ func TestCreateCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -586,7 +586,7 @@ func TestMoveCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -803,7 +803,7 @@ func TestCreateCampaignsCredential(t *testing.T) {
 	cstore := store.New(dbconn.Global)
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -867,7 +867,7 @@ func TestDeleteCampaignsCredential(t *testing.T) {
 	cstore := store.New(dbconn.Global)
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -387,7 +387,7 @@ func TestQueryMonitor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	schema, err := graphqlbackend.NewSchema(nil, nil, nil, r, nil)
+	schema, err := graphqlbackend.NewSchema(nil, nil, nil, nil, r, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -623,7 +623,7 @@ func TestEditCodeMonitor(t *testing.T) {
 
 	// Update the code monitor.
 	// We update all fields, delete one action, and add a new action.
-	schema, err := graphqlbackend.NewSchema(nil, nil, nil, r, nil)
+	schema, err := graphqlbackend.NewSchema(nil, nil, nil, nil, r, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/insights/CODENOTIFY
+++ b/enterprise/internal/insights/CODENOTIFY
@@ -1,0 +1,2 @@
+**/* @slimsag
+**/* @felixfbecker

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -1,0 +1,14 @@
+package insights
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/resolvers"
+)
+
+// Init initializes the given enterpriseServices to include the required resolvers for insights.
+func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
+	enterpriseServices.InsightsResolver = resolvers.New()
+	return nil
+}

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -1,0 +1,24 @@
+package resolvers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+// Resolver is the GraphQL resolver of all things related to Insights.
+type Resolver struct{}
+
+// New returns a new Resolver whose store uses the given db
+func New() graphqlbackend.InsightsResolver {
+	return &Resolver{}
+}
+
+func (r *Resolver) Insights(ctx context.Context) (graphqlbackend.InsightsResolver, error) {
+	return r, nil
+}
+
+func (r *Resolver) Points(ctx context.Context, args *graphqlbackend.InsightsPointsArgs) ([]graphqlbackend.InsightsDataPointResolver, error) {
+	return nil, errors.New("not yet implemented")
+}

--- a/enterprise/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/internal/licensing/resolvers/resolvers_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEnterpriseLicenseHasFeature(t *testing.T) {
 	r := &LicenseResolver{}
-	schema, err := graphqlbackend.NewSchema(nil, nil, nil, nil, r)
+	schema, err := graphqlbackend.NewSchema(nil, nil, nil, nil, nil, r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/db/dbconn/migration.go
+++ b/internal/db/dbconn/migration.go
@@ -12,6 +12,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
+	codeinsightsMigrations "github.com/sourcegraph/sourcegraph/migrations/codeinsights"
 	codeintelMigrations "github.com/sourcegraph/sourcegraph/migrations/codeintel"
 	frontendMigrations "github.com/sourcegraph/sourcegraph/migrations/frontend"
 )
@@ -30,6 +31,10 @@ var databases = map[string]struct {
 	"codeintel": {
 		MigrationsTable: "codeintel_schema_migrations",
 		Resource:        bindata.Resource(codeintelMigrations.AssetNames(), codeintelMigrations.Asset),
+	},
+	"codeinsights": {
+		MigrationsTable: "codeinsights_schema_migrations",
+		Resource:        bindata.Resource(codeinsightsMigrations.AssetNames(), codeinsightsMigrations.Asset),
 	},
 }
 


### PR DESCRIPTION
This adds the needed GraphQL backend scaffolding for code insights (#17218). The actual
schema here is not important and will definitely change.

I've based this on what we do for Code Intel, Campaigns, and Code Monitoring.
It seemed a large enough change (without actually implementing any GraphQL APIs)
to warrant sending separately. This way, PRs that implement actual APIs for
Code Insights can be reviewed on solely that, rather than all the scaffolding that
is required.

What this PR does:

* Registers stub GraphQL resolvers for non-enterprise Sourcegraph versions.
* Injects GraphQL resolvers for enterprise Sourcegraph versions.
* Prepares to (but does not yet) run database migrations for code insights.

Helps #17221

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
