### PR TITLE
user-public-store: Remove dependency to global dbconn

### DIFF
--- a/internal/db/user_public_repos.go
+++ b/internal/db/user_public_repos.go
@@ -3,48 +3,43 @@ package db
 import (
 	"context"
 	"database/sql"
-	"sync"
 
 	"github.com/keegancsmith/sqlf"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/db/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
 type UserPublicRepoStore struct {
-	store *basestore.Store
-
-	once sync.Once
+	*basestore.Store
 }
 
 // NewUserPublicRepoStoreWithDB instantiates and returns a new RepoStore with prepared statements.
 func NewUserPublicRepoStoreWithDB(db dbutil.DB) *UserPublicRepoStore {
-	return &UserPublicRepoStore{store: basestore.NewWithDB(db, sql.TxOptions{})}
+	return &UserPublicRepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
-// ensureStore instantiates a basestore.Store if necessary, using the dbconn.Global handle.
-// This function ensures access to dbconn happens after the rest of the code or tests have
-// initialized it.
-func (s *UserPublicRepoStore) ensureStore() {
-	s.once.Do(func() {
-		if s.store == nil {
-			s.store = basestore.NewWithDB(dbconn.Global, sql.TxOptions{})
-		}
-	})
+// NewUserPublicRepoStoreWithDB instantiates and returns a new UserPublicRepoStore using the other store handle.
+func NewUserPublicRepoStoreWith(other basestore.ShareableStore) *UserPublicRepoStore {
+	return &UserPublicRepoStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
+func (s *UserPublicRepoStore) With(other basestore.ShareableStore) *UserPublicRepoStore {
+	return &UserPublicRepoStore{Store: s.Store.With(other)}
+}
+
+func (s *UserPublicRepoStore) Transact(ctx context.Context) (*UserPublicRepoStore, error) {
+	txBase, err := s.Store.Transact(ctx)
+	return &UserPublicRepoStore{Store: txBase}, err
 }
 
 func (s *UserPublicRepoStore) SetUserRepo(ctx context.Context, userID int32, repoID api.RepoID) error {
-	s.ensureStore()
-
-	return s.store.Exec(ctx, sqlf.Sprintf("INSERT INTO user_public_repos(user_id, repo_id) VALUES (%v, %v)", userID, repoID))
+	return s.Store.Exec(ctx, sqlf.Sprintf("INSERT INTO user_public_repos(user_id, repo_id) VALUES (%v, %v)", userID, repoID))
 }
 
 func (s *UserPublicRepoStore) ListByUser(ctx context.Context, userID int32) ([]int32, error) {
-	s.ensureStore()
-
-	rows, err := basestore.ScanInt32s(s.store.Query(ctx, sqlf.Sprintf("SELECT repo_id FROM user_public_repos WHERE user_id = %v", userID)))
+	rows, err := basestore.ScanInt32s(s.Store.Query(ctx, sqlf.Sprintf("SELECT repo_id FROM user_public_repos WHERE user_id = %v", userID)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/user_public_repos_test.go
+++ b/internal/db/user_public_repos_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/db/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/db/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -12,10 +12,10 @@ func TestUserPublicRepos_Set(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 
-	user, err := Users.Create(ctx, NewUser{
+	user, err := NewUserStoreWithDB(db).Create(ctx, NewUser{
 		Username: "u",
 		Password: "p",
 	})
@@ -23,24 +23,27 @@ func TestUserPublicRepos_Set(t *testing.T) {
 		t.Errorf("Expected no error, got %s ", err)
 	}
 
-	err = Repos.Create(ctx, &types.Repo{
+	repoStore := NewRepoStoreWithDB(db)
+
+	err = repoStore.Create(ctx, &types.Repo{
 		Name: "test",
 	})
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 
-	repo, err := Repos.GetByName(ctx, "test")
+	repo, err := repoStore.GetByName(ctx, "test")
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 
-	err = UserPublicRepos.SetUserRepo(ctx, user.ID, repo.ID)
+	upStore := NewUserPublicRepoStoreWithDB(db)
+	err = upStore.SetUserRepo(ctx, user.ID, repo.ID)
 	if err != nil {
 		t.Errorf("Expected no error, got %s", err)
 	}
 
-	repoIDs, err := UserPublicRepos.ListByUser(ctx, user.ID)
+	repoIDs, err := upStore.ListByUser(ctx, user.ID)
 	if err != nil {
 		t.Fatalf("Expected no error, got %s", err)
 	}


### PR DESCRIPTION
This is the first concrete step towards getting rid of `dbconn.Global`. New stores must no longer use `ensureStore` and must be created and passed around by services needing them.