### PR TITLE
search: stream commit results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -551,7 +551,7 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 					status = status & search.RepoStatusTimedout
 				}
 				// Only write if we have something to report back
-				if len(results) > 0 || status != 0 {
+				if len(event.Results) > 0 || status != 0 {
 					stats.Status = search.RepoStatusSingleton(repoRev.Repo.ID, status)
 					params.ResultChannel <- SearchEvent{
 						Results: commitSearchResultsToSearchResults(event.Results),


### PR DESCRIPTION
This was a regression where we would stop streaming down commit
results. We checked the wrong results field.