### PR TITLE
db: rename global variables

### DIFF
--- a/cmd/frontend/auth/user.go
+++ b/cmd/frontend/auth/user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -61,7 +62,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 			return actor.UID, false, false, "", nil
 		}
 
-		uid, lookupByExternalErr := db.ExternalAccounts.LookupUserAndSave(ctx, op.ExternalAccount, op.ExternalAccountData)
+		uid, lookupByExternalErr := db.GlobalExternalAccounts.LookupUserAndSave(ctx, op.ExternalAccount, op.ExternalAccountData)
 		if lookupByExternalErr == nil {
 			return uid, false, true, "", nil
 		}
@@ -70,7 +71,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 		}
 
 		if op.LookUpByUsername {
-			user, getByUsernameErr := db.Users.GetByUsername(ctx, op.UserProps.Username)
+			user, getByUsernameErr := db.GlobalUsers.GetByUsername(ctx, op.UserProps.Username)
 			if getByUsernameErr == nil {
 				return user.ID, false, false, "", nil
 			}
@@ -81,7 +82,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 				return 0, false, false, fmt.Sprintf("User account with username %q does not exist. Ask a site admin to create your account.", op.UserProps.Username), getByUsernameErr
 			}
 		} else if op.UserProps.EmailIsVerified {
-			user, getByVerifiedEmailErr := db.Users.GetByVerifiedEmail(ctx, op.UserProps.Email)
+			user, getByVerifiedEmailErr := db.GlobalUsers.GetByVerifiedEmail(ctx, op.UserProps.Email)
 			if getByVerifiedEmailErr == nil {
 				return user.ID, false, false, "", nil
 			}
@@ -97,7 +98,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 		}
 
 		// If CreateIfNotExist is true, create the new user, regardless of whether the email was verified or not.
-		userID, err := db.ExternalAccounts.CreateUserAndSave(ctx, op.UserProps, op.ExternalAccount, op.ExternalAccountData)
+		userID, err := db.GlobalExternalAccounts.CreateUserAndSave(ctx, op.UserProps, op.ExternalAccount, op.ExternalAccountData)
 		switch {
 		case db.IsUsernameExists(err):
 			return 0, false, false, fmt.Sprintf("Username %q already exists, but no verified email matched %q", op.UserProps.Username, op.UserProps.Email), err
@@ -107,7 +108,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 			return 0, false, false, "Unable to create a new user account due to a unexpected error. Ask a site admin for help.", err
 		}
 
-		if err = db.Authz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
+		if err = db.GlobalAuthz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
 			UserID: userID,
 			Perm:   authz.Read,
 			Type:   authz.PermRepos,
@@ -125,7 +126,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 	if !userSaved {
 		// Update user in our DB if their profile info changed on the issuer. (Except username and
 		// email, which the user is somewhat likely to want to control separately on Sourcegraph.)
-		user, err := db.Users.GetByID(ctx, userID)
+		user, err := db.GlobalUsers.GetByID(ctx, userID)
 		if err != nil {
 			return 0, "Unexpected error getting the Sourcegraph user account. Ask a site admin for help.", err
 		}
@@ -137,7 +138,7 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 			userUpdate.AvatarURL = &op.UserProps.AvatarURL
 		}
 		if userUpdate != (db.UserUpdate{}) {
-			if err := db.Users.Update(ctx, user.ID, userUpdate); err != nil {
+			if err := db.GlobalUsers.Update(ctx, user.ID, userUpdate); err != nil {
 				return 0, "Unexpected error updating the Sourcegraph user account with new user profile information from the external account. Ask a site admin for help.", err
 			}
 		}
@@ -145,12 +146,12 @@ func GetAndSaveUser(ctx context.Context, op GetAndSaveUserOp) (userID int32, saf
 
 	// Create/update the external account and ensure it's associated with the user ID
 	if !extAcctSaved {
-		err := db.ExternalAccounts.AssociateUserAndSave(ctx, userID, op.ExternalAccount, op.ExternalAccountData)
+		err := db.GlobalExternalAccounts.AssociateUserAndSave(ctx, userID, op.ExternalAccount, op.ExternalAccountData)
 		if err != nil {
 			return 0, "Unexpected error associating the external account with your Sourcegraph user. The most likely cause for this problem is that another Sourcegraph user is already linked with this external account. A site admin or the other user can unlink the account to fix this problem.", err
 		}
 
-		if err = db.Authz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
+		if err = db.GlobalAuthz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
 			UserID: userID,
 			Perm:   authz.Read,
 			Type:   authz.PermRepos,

--- a/cmd/frontend/backend/configuration.go
+++ b/cmd/frontend/backend/configuration.go
@@ -17,7 +17,7 @@ type configuration struct{}
 // GetForSubject gets the latest settings for a single settings subject, without performing any
 // cascading (merging settings from multiple subjects).
 func (configuration) GetForSubject(ctx context.Context, subject api.SettingsSubject) (*schema.Settings, error) {
-	settings, err := db.Settings.GetLatest(ctx, subject)
+	settings, err := db.GlobalSettings.GetLatest(ctx, subject)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -35,7 +35,7 @@ func CheckOrgAccess(ctx context.Context, orgID int32) error {
 var ErrNotAnOrgMember = errors.New("current user is not an org member")
 
 func checkUserIsOrgMember(ctx context.Context, userID, orgID int32) error {
-	resp, err := db.OrgMembers.GetByOrgIDAndUserID(ctx, orgID, userID)
+	resp, err := db.GlobalOrgMembers.GetByOrgIDAndUserID(ctx, orgID, userID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return ErrNotAnOrgMember

--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -48,7 +48,7 @@ func (s *repos) Get(ctx context.Context, repo api.RepoID) (_ *types.Repo, err er
 	ctx, done := trace(ctx, "Repos", "Get", repo, &err)
 	defer done()
 
-	return db.Repos.Get(ctx, repo)
+	return db.GlobalRepos.Get(ctx, repo)
 }
 
 // GetByName retrieves the repository with the given name. On sourcegraph.com,
@@ -63,7 +63,7 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 	ctx, done := trace(ctx, "Repos", "GetByName", name, &err)
 	defer done()
 
-	switch repo, err := db.Repos.GetByName(ctx, name); {
+	switch repo, err := db.GlobalRepos.GetByName(ctx, name); {
 	case err == nil:
 		return repo, nil
 	case !errcode.IsNotFound(err):
@@ -73,7 +73,7 @@ func (s *repos) GetByName(ctx context.Context, name api.RepoName) (_ *types.Repo
 		if err := s.Add(ctx, name); err != nil {
 			return nil, err
 		}
-		return db.Repos.GetByName(ctx, name)
+		return db.GlobalRepos.GetByName(ctx, name)
 	case shouldRedirect(name):
 		return nil, ErrRepoSeeOther{RedirectURL: (&url.URL{
 			Scheme:   "https",
@@ -142,7 +142,7 @@ func (s *repos) List(ctx context.Context, opt db.ReposListOptions) (repos []*typ
 		done()
 	}()
 
-	return db.Repos.List(ctx, opt)
+	return db.GlobalRepos.List(ctx, opt)
 }
 
 // ListDefault calls db.DefaultRepos.List, with tracing.
@@ -155,7 +155,7 @@ func (s *repos) ListDefault(ctx context.Context) (repos []*types.RepoName, err e
 		}
 		done()
 	}()
-	return db.DefaultRepos.List(ctx)
+	return db.GlobalDefaultRepos.List(ctx)
 }
 
 func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api.CommitID, forceEnhancedLanguageDetection bool) (res *inventory.Inventory, err error) {

--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -36,7 +36,7 @@ func CheckUserIsSiteAdmin(ctx context.Context, userID int32) error {
 	if hasAuthzBypass(ctx) {
 		return nil
 	}
-	user, err := db.Users.GetByID(ctx, userID)
+	user, err := db.GlobalUsers.GetByID(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func CheckSiteAdminOrSameUser(ctx context.Context, subjectUserID int32) error {
 	if isSiteAdminErr == nil {
 		return nil
 	}
-	subjectUser, err := db.Users.GetByID(ctx, subjectUserID)
+	subjectUser, err := db.GlobalUsers.GetByID(ctx, subjectUserID)
 	if err != nil {
 		return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as an admin (%s)", isSiteAdminErr.Error())}
 	}
@@ -88,7 +88,7 @@ func CheckSiteAdminOrSameUser(ctx context.Context, subjectUserID int32) error {
 // CurrentUser gets the current authenticated user
 // It returns nil, nil if no user is found
 func CurrentUser(ctx context.Context) (*types.User, error) {
-	user, err := db.Users.GetByCurrentAuthUser(ctx)
+	user, err := db.GlobalUsers.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		if errcode.IsNotFound(err) || err == db.ErrNoCurrentUser {
 			return nil, nil

--- a/cmd/frontend/backend/users.go
+++ b/cmd/frontend/backend/users.go
@@ -19,7 +19,7 @@ func MakePasswordResetURL(ctx context.Context, userID int32) (*url.URL, error) {
 	if MockMakePasswordResetURL != nil {
 		return MockMakePasswordResetURL(ctx, userID)
 	}
-	resetCode, err := db.Users.RenewPasswordResetCode(ctx, userID)
+	resetCode, err := db.GlobalUsers.RenewPasswordResetCode(ctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/access_token.go
+++ b/cmd/frontend/graphqlbackend/access_token.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 )
@@ -27,7 +28,7 @@ func accessTokenByID(ctx context.Context, id graphql.ID) (*accessTokenResolver, 
 	if err != nil {
 		return nil, err
 	}
-	accessToken, err := db.AccessTokens.GetByID(ctx, accessTokenID)
+	accessToken, err := db.GlobalAccessTokens.GetByID(ctx, accessTokenID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/event_logs.go
+++ b/cmd/frontend/graphqlbackend/event_logs.go
@@ -28,7 +28,7 @@ type userEventLogsConnectionResolver struct {
 }
 
 func (r *userEventLogsConnectionResolver) Nodes(ctx context.Context) ([]*userEventLogResolver, error) {
-	events, err := db.EventLogs.ListAll(ctx, r.opt)
+	events, err := db.GlobalEventLogs.ListAll(ctx, r.opt)
 	if err != nil {
 		return nil, err
 	}
@@ -46,9 +46,9 @@ func (r *userEventLogsConnectionResolver) TotalCount(ctx context.Context) (int32
 	var err error
 
 	if r.opt.EventName != nil {
-		count, err = db.EventLogs.CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
+		count, err = db.GlobalEventLogs.CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
 	} else {
-		count, err = db.EventLogs.CountByUserID(ctx, r.opt.UserID)
+		count, err = db.GlobalEventLogs.CountByUserID(ctx, r.opt.UserID)
 	}
 
 	return int32(count), err
@@ -59,9 +59,9 @@ func (r *userEventLogsConnectionResolver) PageInfo(ctx context.Context) (*graphq
 	var err error
 
 	if r.opt.EventName != nil {
-		count, err = db.EventLogs.CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
+		count, err = db.GlobalEventLogs.CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
 	} else {
-		count, err = db.EventLogs.CountByUserID(ctx, r.opt.UserID)
+		count, err = db.GlobalEventLogs.CountByUserID(ctx, r.opt.UserID)
 	}
 
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -19,7 +20,7 @@ func externalAccountByID(ctx context.Context, id graphql.ID) (*externalAccountRe
 	if err != nil {
 		return nil, err
 	}
-	account, err := db.ExternalAccounts.Get(ctx, externalAccountID)
+	account, err := db.GlobalExternalAccounts.Get(ctx, externalAccountID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -81,7 +82,7 @@ func (r *externalAccountConnectionResolver) compute(ctx context.Context) ([]*ext
 			opt2.Limit++ // so we can detect if there is a next page
 		}
 
-		r.externalAccounts, r.err = db.ExternalAccounts.List(ctx, opt2)
+		r.externalAccounts, r.err = db.GlobalExternalAccounts.List(ctx, opt2)
 	})
 	return r.externalAccounts, r.err
 }
@@ -100,7 +101,7 @@ func (r *externalAccountConnectionResolver) Nodes(ctx context.Context) ([]*exter
 }
 
 func (r *externalAccountConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	count, err := db.ExternalAccounts.Count(ctx, r.opt)
+	count, err := db.GlobalExternalAccounts.Count(ctx, r.opt)
 	return int32(count), err
 }
 
@@ -119,7 +120,7 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 	if err != nil {
 		return nil, err
 	}
-	account, err := db.ExternalAccounts.Get(ctx, id)
+	account, err := db.GlobalExternalAccounts.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +130,7 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 		return nil, err
 	}
 
-	if err := db.ExternalAccounts.Delete(ctx, account.ID); err != nil {
+	if err := db.GlobalExternalAccounts.Delete(ctx, account.ID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -35,7 +35,7 @@ func externalServiceByID(ctx context.Context, gqlID graphql.ID) (*externalServic
 		return nil, err
 	}
 
-	es, err := db.ExternalServices.GetByID(ctx, id)
+	es, err := db.GlobalExternalServices.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (r *externalServiceResolver) Warning() *string {
 }
 
 func (r *externalServiceResolver) LastSyncError(ctx context.Context) (*string, error) {
-	latestError, err := db.ExternalServices.GetLastSyncError(ctx, r.externalService.ID)
+	latestError, err := db.GlobalExternalServices.GetLastSyncError(ctx, r.externalService.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (r *externalServiceResolver) LastSyncError(ctx context.Context) (*string, e
 }
 
 func (r *externalServiceResolver) RepoCount(ctx context.Context) (int32, error) {
-	return db.ExternalServices.RepoCount(ctx, r.externalService.ID)
+	return db.GlobalExternalServices.RepoCount(ctx, r.externalService.ID)
 }
 
 func (r *externalServiceResolver) LastSyncAt() DateTime {

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -82,7 +82,7 @@ func (r *schemaResolver) AddExternalService(ctx context.Context, args *addExtern
 		externalService.NamespaceUserID = namespaceUserID
 	}
 
-	if err := db.ExternalServices.Create(ctx, conf.Get, externalService); err != nil {
+	if err := db.GlobalExternalServices.Create(ctx, conf.Get, externalService); err != nil {
 		return nil, err
 	}
 
@@ -114,7 +114,7 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *updateEx
 		return nil, err
 	}
 
-	es, err := db.ExternalServices.GetByID(ctx, id)
+	es, err := db.GlobalExternalServices.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -138,12 +138,12 @@ func (*schemaResolver) UpdateExternalService(ctx context.Context, args *updateEx
 		DisplayName: args.Input.DisplayName,
 		Config:      args.Input.Config,
 	}
-	if err := db.ExternalServices.Update(ctx, ps, id, update); err != nil {
+	if err := db.GlobalExternalServices.Update(ctx, ps, id, update); err != nil {
 		return nil, err
 	}
 
 	// Fetch from database again to get all fields with updated values.
-	es, err = db.ExternalServices.GetByID(ctx, id)
+	es, err = db.GlobalExternalServices.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *deleteEx
 		return nil, err
 	}
 
-	es, err := db.ExternalServices.GetByID(ctx, id)
+	es, err := db.GlobalExternalServices.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (*schemaResolver) DeleteExternalService(ctx context.Context, args *deleteEx
 		}
 	}
 
-	if err := db.ExternalServices.Delete(ctx, id); err != nil {
+	if err := db.GlobalExternalServices.Delete(ctx, id); err != nil {
 		return nil, err
 	}
 	now := time.Now()
@@ -289,7 +289,7 @@ type externalServiceConnectionResolver struct {
 
 func (r *externalServiceConnectionResolver) compute(ctx context.Context) ([]*types.ExternalService, error) {
 	r.once.Do(func() {
-		r.externalServices, r.err = db.ExternalServices.List(ctx, r.opt)
+		r.externalServices, r.err = db.GlobalExternalServices.List(ctx, r.opt)
 	})
 	return r.externalServices, r.err
 }
@@ -310,7 +310,7 @@ func (r *externalServiceConnectionResolver) TotalCount(ctx context.Context) (int
 	// Reset pagination cursor to get correct total count
 	opt := r.opt
 	opt.AfterID = 0
-	count, err := db.ExternalServices.Count(ctx, opt)
+	count, err := db.GlobalExternalServices.Count(ctx, opt)
 	return int32(count), err
 }
 
@@ -333,7 +333,7 @@ func (r *externalServiceConnectionResolver) PageInfo(ctx context.Context) (*grap
 	// In case the number of results happens to be the same as the limit,
 	// we need another query to get accurate total count with same cursor
 	// to determine if there are more results than the limit we set.
-	count, err := db.ExternalServices.Count(ctx, r.opt)
+	count, err := db.GlobalExternalServices.Count(ctx, r.opt)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -107,7 +107,7 @@ func linksForRepository(ctx context.Context, repo *types.Repo) (phabRepo *types.
 	span.SetTag("ExternalRepo", repo.ExternalRepo)
 
 	var err error
-	phabRepo, err = db.Phabricator.GetByName(ctx, repo.Name)
+	phabRepo, err = db.GlobalPhabricator.GetByName(ctx, repo.Name)
 	if err != nil && !errcode.IsNotFound(err) {
 		ext.Error.Set(span, true)
 		span.SetTag("phabErr", err.Error())

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -747,7 +747,7 @@ func (r *schemaResolver) PhabricatorRepo(ctx context.Context, args *struct {
 		args.URI = args.Name
 	}
 
-	repo, err := db.Phabricator.GetByName(ctx, api.RepoName(*args.URI))
+	repo, err := db.GlobalPhabricator.GetByName(ctx, api.RepoName(*args.URI))
 	if err != nil {
 		return nil, err
 	}
@@ -808,13 +808,13 @@ func (r *codeHostRepositoryConnectionResolver) Nodes(ctx context.Context) ([]*co
 		)
 		// get all external services for user, or for the specified external service
 		if r.codeHost == 0 {
-			svcs, err = db.ExternalServices.List(ctx, db.ExternalServicesListOptions{NamespaceUserID: r.userID})
+			svcs, err = db.GlobalExternalServices.List(ctx, db.ExternalServicesListOptions{NamespaceUserID: r.userID})
 			if err != nil {
 				r.err = err
 				return
 			}
 		} else {
-			svc, err := db.ExternalServices.GetByID(ctx, r.codeHost)
+			svc, err := db.GlobalExternalServices.GetByID(ctx, r.codeHost)
 			if err != nil {
 				r.err = err
 				return
@@ -915,5 +915,5 @@ func allowPrivate(ctx context.Context, userID int32) (bool, error) {
 	if conf.ExternalServiceUserMode() == conf.ExternalServiceModeAll {
 		return true, nil
 	}
-	return db.Users.HasTag(ctx, userID, db.TagAllowUserExternalServicePrivate)
+	return db.GlobalUsers.HasTag(ctx, userID, db.TagAllowUserExternalServicePrivate)
 }

--- a/cmd/frontend/graphqlbackend/namespaces.go
+++ b/cmd/frontend/graphqlbackend/namespaces.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/db"
 )
 
@@ -57,7 +58,7 @@ func UnmarshalNamespaceID(id graphql.ID, userID *int32, orgID *int32) (err error
 }
 
 func (r *schemaResolver) NamespaceByName(ctx context.Context, args *struct{ Name string }) (*NamespaceResolver, error) {
-	namespace, err := db.Namespaces.GetByName(ctx, args.Name)
+	namespace, err := db.GlobalNamespaces.GetByName(ctx, args.Name)
 	if err == db.ErrNamespaceNotFound {
 		return nil, nil
 	}

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (r *schemaResolver) Organization(ctx context.Context, args struct{ Name string }) (*OrgResolver, error) {
-	org, err := db.Orgs.GetByName(ctx, args.Name)
+	org, err := db.GlobalOrgs.GetByName(ctx, args.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func OrgByID(ctx context.Context, id graphql.ID) (*OrgResolver, error) {
 }
 
 func OrgByIDInt32(ctx context.Context, orgID int32) (*OrgResolver, error) {
-	org, err := db.Orgs.GetByID(ctx, orgID)
+	org, err := db.GlobalOrgs.GetByID(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
@@ -91,13 +91,13 @@ func (o *OrgResolver) Members(ctx context.Context) (*staticUserConnectionResolve
 		return nil, err
 	}
 
-	memberships, err := db.OrgMembers.GetByOrgID(ctx, o.org.ID)
+	memberships, err := db.GlobalOrgMembers.GetByOrgID(ctx, o.org.ID)
 	if err != nil {
 		return nil, err
 	}
 	users := make([]*types.User, len(memberships))
 	for i, membership := range memberships {
-		user, err := db.Users.GetByID(ctx, membership.UserID)
+		user, err := db.GlobalUsers.GetByID(ctx, membership.UserID)
 		if err != nil {
 			return nil, err
 		}
@@ -117,7 +117,7 @@ func (o *OrgResolver) LatestSettings(ctx context.Context) (*settingsResolver, er
 		return nil, err
 	}
 
-	settings, err := db.Settings.GetLatest(ctx, o.settingsSubject())
+	settings, err := db.GlobalSettings.GetLatest(ctx, o.settingsSubject())
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (o *OrgResolver) ConfigurationCascade() *settingsCascade { return o.Setting
 
 func (o *OrgResolver) ViewerPendingInvitation(ctx context.Context) (*organizationInvitationResolver, error) {
 	if actor := actor.FromContext(ctx); actor.IsAuthenticated() {
-		orgInvitation, err := db.OrgInvitations.GetPending(ctx, o.org.ID, actor.UID)
+		orgInvitation, err := db.GlobalOrgInvitations.GetPending(ctx, o.org.ID, actor.UID)
 		if errcode.IsNotFound(err) {
 			return nil, nil
 		}
@@ -161,7 +161,7 @@ func (o *OrgResolver) ViewerIsMember(ctx context.Context) (bool, error) {
 	if !actor.IsAuthenticated() {
 		return false, nil
 	}
-	if _, err := db.OrgMembers.GetByOrgIDAndUserID(ctx, o.org.ID, actor.UID); err != nil {
+	if _, err := db.GlobalOrgMembers.GetByOrgIDAndUserID(ctx, o.org.ID, actor.UID); err != nil {
 		if errcode.IsNotFound(err) {
 			err = nil
 		}
@@ -193,13 +193,13 @@ func (*schemaResolver) CreateOrganization(ctx context.Context, args *struct {
 	if err := suspiciousnames.CheckNameAllowedForUserOrOrganization(args.Name); err != nil {
 		return nil, err
 	}
-	newOrg, err := db.Orgs.Create(ctx, args.Name, args.DisplayName)
+	newOrg, err := db.GlobalOrgs.Create(ctx, args.Name, args.DisplayName)
 	if err != nil {
 		return nil, err
 	}
 
 	// Add the current user as the first member of the new org.
-	_, err = db.OrgMembers.Create(ctx, newOrg.ID, currentUser.user.ID)
+	_, err = db.GlobalOrgMembers.Create(ctx, newOrg.ID, currentUser.user.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (*schemaResolver) UpdateOrganization(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	updatedOrg, err := db.Orgs.Update(ctx, orgID, args.DisplayName)
+	updatedOrg, err := db.GlobalOrgs.Update(ctx, orgID, args.DisplayName)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (*schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *str
 	}
 
 	log15.Info("removing user from org", "user", userID, "org", orgID)
-	return nil, db.OrgMembers.Remove(ctx, orgID, userID)
+	return nil, db.GlobalOrgMembers.Remove(ctx, orgID, userID)
 }
 
 func (*schemaResolver) AddUserToOrganization(ctx context.Context, args *struct {
@@ -272,7 +272,7 @@ func (*schemaResolver) AddUserToOrganization(ctx context.Context, args *struct {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := db.OrgMembers.Create(ctx, orgID, userToInvite.ID); err != nil {
+	if _, err := db.GlobalOrgMembers.Create(ctx, orgID, userToInvite.ID); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/db"
 )
 
@@ -22,7 +23,7 @@ func orgInvitationByID(ctx context.Context, id graphql.ID) (*organizationInvitat
 }
 
 func orgInvitationByIDInt64(ctx context.Context, id int64) (*organizationInvitationResolver, error) {
-	orgInvitation, err := db.OrgInvitations.GetByID(ctx, id)
+	orgInvitation, err := db.GlobalOrgInvitations.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +73,7 @@ func (r *organizationInvitationResolver) ResponseType() *string {
 
 func (r *organizationInvitationResolver) RespondURL(ctx context.Context) (*string, error) {
 	if r.v.Pending() {
-		org, err := db.Orgs.GetByID(ctx, r.v.OrgID)
+		org, err := db.GlobalOrgs.GetByID(ctx, r.v.OrgID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -21,14 +21,14 @@ import (
 )
 
 func getUserToInviteToOrganization(ctx context.Context, username string, orgID int32) (userToInvite *types.User, userEmailAddress string, err error) {
-	userToInvite, err = db.Users.GetByUsername(ctx, username)
+	userToInvite, err = db.GlobalUsers.GetByUsername(ctx, username)
 	if err != nil {
 		return nil, "", err
 	}
 
 	if conf.CanSendEmail() {
 		// Look up user's email address so we can send them an email (if needed).
-		email, verified, err := db.UserEmails.GetPrimaryEmail(ctx, userToInvite.ID)
+		email, verified, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, userToInvite.ID)
 		if err != nil && !errcode.IsNotFound(err) {
 			return nil, "", errors.WithMessage(err, "looking up invited user's primary email address")
 		}
@@ -38,7 +38,7 @@ func getUserToInviteToOrganization(ctx context.Context, username string, orgID i
 		}
 	}
 
-	if _, err := db.OrgMembers.GetByOrgIDAndUserID(ctx, orgID, userToInvite.ID); err == nil {
+	if _, err := db.GlobalOrgMembers.GetByOrgIDAndUserID(ctx, orgID, userToInvite.ID); err == nil {
 		return nil, "", errors.New("user is already a member of the organization")
 	} else if _, ok := err.(*db.ErrOrgMemberNotFound); !ok {
 		return nil, "", err
@@ -69,11 +69,11 @@ func (*schemaResolver) InviteUserToOrganization(ctx context.Context, args *struc
 	}
 
 	// Create the invitation.
-	org, err := db.Orgs.GetByID(ctx, orgID)
+	org, err := db.GlobalOrgs.GetByID(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
-	sender, err := db.Users.GetByCurrentAuthUser(ctx)
+	sender, err := db.GlobalUsers.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (*schemaResolver) InviteUserToOrganization(ctx context.Context, args *struc
 	if err != nil {
 		return nil, err
 	}
-	if _, err := db.OrgInvitations.Create(ctx, orgID, sender.ID, recipient.ID); err != nil {
+	if _, err := db.GlobalOrgInvitations.Create(ctx, orgID, sender.ID, recipient.ID); err != nil {
 		return nil, err
 	}
 	result := &inviteUserToOrganizationResult{
@@ -130,14 +130,14 @@ func (*schemaResolver) RespondToOrganizationInvitation(ctx context.Context, args
 
 	// 🚨 SECURITY: This fails if the org invitation's recipient is not the one given (or if the
 	// invitation is otherwise invalid), so we do not need to separately perform that check.
-	orgID, err := db.OrgInvitations.Respond(ctx, id, currentUser.user.ID, accept)
+	orgID, err := db.GlobalOrgInvitations.Respond(ctx, id, currentUser.user.ID, accept)
 	if err != nil {
 		return nil, err
 	}
 
 	if accept {
 		// The recipient accepted the invitation.
-		if _, err := db.OrgMembers.Create(ctx, orgID, currentUser.user.ID); err != nil {
+		if _, err := db.GlobalOrgMembers.Create(ctx, orgID, currentUser.user.ID); err != nil {
 			return nil, err
 		}
 	}
@@ -170,15 +170,15 @@ func (*schemaResolver) ResendOrganizationInvitationNotification(ctx context.Cont
 		return nil, errors.New("unable to send notification for invitation because sending emails is not enabled")
 	}
 
-	org, err := db.Orgs.GetByID(ctx, orgInvitation.v.OrgID)
+	org, err := db.GlobalOrgs.GetByID(ctx, orgInvitation.v.OrgID)
 	if err != nil {
 		return nil, err
 	}
-	sender, err := db.Users.GetByCurrentAuthUser(ctx)
+	sender, err := db.GlobalUsers.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	recipientEmail, recipientEmailVerified, err := db.UserEmails.GetPrimaryEmail(ctx, orgInvitation.v.RecipientUserID)
+	recipientEmail, recipientEmailVerified, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, orgInvitation.v.RecipientUserID)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (*schemaResolver) RevokeOrganizationInvitation(ctx context.Context, args *s
 		return nil, err
 	}
 
-	if err := db.OrgInvitations.Revoke(ctx, orgInvitation.v.ID); err != nil {
+	if err := db.GlobalOrgInvitations.Revoke(ctx, orgInvitation.v.ID); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil
@@ -222,7 +222,7 @@ func sendOrgInvitationNotification(ctx context.Context, org *types.Org, sender *
 		// Basic abuse prevention for Sourcegraph.com.
 
 		// Only allow email-verified users to send invites.
-		if _, senderEmailVerified, err := db.UserEmails.GetPrimaryEmail(ctx, sender.ID); err != nil {
+		if _, senderEmailVerified, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, sender.ID); err != nil {
 			return err
 		} else if !senderEmailVerified {
 			return errors.New("must verify your email address to invite a user to an organization")
@@ -232,7 +232,7 @@ func sendOrgInvitationNotification(ctx context.Context, org *types.Org, sender *
 		//
 		// There is no user invite quota for on-prem instances because we assume they can
 		// trust their users to not abuse invites.
-		if ok, err := db.Users.CheckAndDecrementInviteQuota(ctx, sender.ID); err != nil {
+		if ok, err := db.GlobalUsers.CheckAndDecrementInviteQuota(ctx, sender.ID); err != nil {
 			return err
 		} else if !ok {
 			return errors.New("invite quota exceeded (contact support to increase the quota)")

--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (r *UserResolver) OrganizationMemberships(ctx context.Context) (*organizationMembershipConnectionResolver, error) {
-	memberships, err := db.OrgMembers.GetByUserID(ctx, r.user.ID)
+	memberships, err := db.GlobalOrgMembers.GetByUserID(ctx, r.user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -30,7 +30,7 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 		return nil, err
 	}
 
-	orgs, err := db.Orgs.List(ctx, &r.opt)
+	orgs, err := db.GlobalOrgs.List(ctx, &r.opt)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (r *orgConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 		return 0, err
 	}
 
-	count, err := db.Orgs.Count(ctx, r.opt)
+	count, err := db.GlobalOrgs.Count(ctx, r.opt)
 	return int32(count), err
 }
 

--- a/cmd/frontend/graphqlbackend/person.go
+++ b/cmd/frontend/graphqlbackend/person.go
@@ -36,7 +36,7 @@ func NewPersonResolver(name, email string, includeUserInfo bool) *PersonResolver
 func (r *PersonResolver) resolveUser(ctx context.Context) (*types.User, error) {
 	r.once.Do(func() {
 		if r.includeUserInfo && r.email != "" {
-			r.user, r.err = db.Users.GetByVerifiedEmail(ctx, r.email)
+			r.user, r.err = db.GlobalUsers.GetByVerifiedEmail(ctx, r.email)
 			if errcode.IsNotFound(r.err) {
 				r.err = nil
 			}

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -241,7 +241,7 @@ func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *Tot
 		}()
 	}
 
-	count, err := db.Repos.Count(ctx, r.opt)
+	count, err := db.GlobalRepos.Count(ctx, r.opt)
 	return i32ptr(int32(count)), err
 }
 

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -33,7 +33,7 @@ func savedSearchByID(ctx context.Context, id graphql.ID) (*savedSearchResolver, 
 		return nil, err
 	}
 
-	ss, err := db.SavedSearches.GetByID(ctx, intID)
+	ss, err := db.GlobalSavedSearches.GetByID(ctx, intID)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func (r *schemaResolver) SavedSearches(ctx context.Context) ([]*savedSearchResol
 	if err != nil {
 		return nil, err
 	}
-	allSavedSearches, err := db.SavedSearches.ListSavedSearchesByUserID(ctx, currentUser.DatabaseID())
+	allSavedSearches, err := db.GlobalSavedSearches.ListSavedSearchesByUserID(ctx, currentUser.DatabaseID())
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +136,7 @@ func (r *schemaResolver) SendSavedSearchTestNotification(ctx context.Context, ar
 	if err != nil {
 		return nil, err
 	}
-	savedSearch, err := db.SavedSearches.GetByID(ctx, id)
+	savedSearch, err := db.GlobalSavedSearches.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 		return nil, errMissingPatternType
 	}
 
-	ss, err := db.SavedSearches.Create(ctx, &types.SavedSearch{
+	ss, err := db.GlobalSavedSearches.Create(ctx, &types.SavedSearch{
 		Description: args.Description,
 		Query:       args.Query,
 		Notify:      args.NotifyOwner,
@@ -238,7 +238,7 @@ func (r *schemaResolver) UpdateSavedSearch(ctx context.Context, args *struct {
 		return nil, errMissingPatternType
 	}
 
-	ss, err := db.SavedSearches.Update(ctx, &types.SavedSearch{
+	ss, err := db.GlobalSavedSearches.Update(ctx, &types.SavedSearch{
 		ID:          id,
 		Description: args.Description,
 		Query:       args.Query,
@@ -261,7 +261,7 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 	if err != nil {
 		return nil, err
 	}
-	ss, err := db.SavedSearches.GetByID(ctx, id)
+	ss, err := db.GlobalSavedSearches.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 	} else {
 		return nil, errors.New("failed to delete saved search: no Org ID or User ID associated with saved search")
 	}
-	err = db.SavedSearches.Delete(ctx, id)
+	err = db.GlobalSavedSearches.Delete(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -685,13 +685,13 @@ func expandUsernamesToEmails(ctx context.Context, values []string) (expandedValu
 			return nil, nil
 		}
 
-		user, err := db.Users.GetByUsername(ctx, strings.TrimPrefix(value, "@"))
+		user, err := db.GlobalUsers.GetByUsername(ctx, strings.TrimPrefix(value, "@"))
 		if errcode.IsNotFound(err) {
 			return nil, nil
 		} else if err != nil {
 			return nil, err
 		}
-		emails, err := db.UserEmails.ListByUser(ctx, db.UserEmailsListOptions{
+		emails, err := db.GlobalUserEmails.ListByUser(ctx, db.UserEmailsListOptions{
 			UserID: user.ID,
 		})
 		if err != nil {

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -610,7 +610,7 @@ func (n *numTotalReposCache) get(ctx context.Context) int {
 	n.RUnlock()
 
 	n.Lock()
-	newCount, err := db.Repos.Count(ctx, db.ReposListOptions{})
+	newCount, err := db.GlobalRepos.Count(ctx, db.ReposListOptions{})
 	if err != nil {
 		defer n.Unlock()
 		log15.Error("failed to determine numTotalRepos", "error", err)

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -22,7 +22,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 		return nil, err
 	}
 
-	es, err := db.ExternalServices.GetByID(ctx, id)
+	es, err := db.GlobalExternalServices.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 	// set to time.Zero to sync ASAP
 	es.NextSyncAt = time.Time{}
 
-	err = db.ExternalServices.Upsert(ctx, es)
+	err = db.GlobalExternalServices.Upsert(ctx, es)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/settings.go
+++ b/cmd/frontend/graphqlbackend/settings.go
@@ -45,7 +45,7 @@ func (o *settingsResolver) Author(ctx context.Context) (*UserResolver, error) {
 	}
 	if o.user == nil {
 		var err error
-		o.user, err = db.Users.GetByID(ctx, *o.settings.AuthorUserID)
+		o.user, err = db.GlobalUsers.GetByID(ctx, *o.settings.AuthorUserID)
 		if err != nil {
 			return nil, err
 		}
@@ -69,7 +69,7 @@ func settingsCreateIfUpToDate(ctx context.Context, subject *settingsSubject, las
 	}
 
 	// Update settings.
-	latestSettings, err := db.Settings.CreateIfUpToDate(ctx, subject.toSubject(), lastID, &authorUserID, contents)
+	latestSettings, err := db.GlobalSettings.CreateIfUpToDate(ctx, subject.toSubject(), lastID, &authorUserID, contents)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -47,7 +47,7 @@ func (r *settingsCascade) Subjects(ctx context.Context) ([]*settingsSubject, err
 		subjects = append(subjects, r.subject)
 
 	case r.subject.user != nil:
-		orgs, err := db.Orgs.GetByUserID(ctx, r.subject.user.user.ID)
+		orgs, err := db.GlobalOrgs.GetByUserID(ctx, r.subject.user.user.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/settings_mutation.go
+++ b/cmd/frontend/graphqlbackend/settings_mutation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/jsonx"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -194,7 +195,7 @@ func (r *settingsMutation) doUpdateSettings(ctx context.Context, computeEdits fu
 
 func (r *settingsMutation) getCurrentSettings(ctx context.Context) (string, error) {
 	// Get the settings file whose contents to mutate.
-	settings, err := db.Settings.GetLatest(ctx, r.subject.toSubject())
+	settings, err := db.GlobalSettings.GetLatest(ctx, r.subject.toSubject())
 	if err != nil {
 		return "", err
 	}

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -82,7 +83,7 @@ func (r *siteResolver) settingsSubject() api.SettingsSubject {
 }
 
 func (r *siteResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
-	settings, err := db.Settings.GetLatest(ctx, r.settingsSubject())
+	settings, err := db.GlobalSettings.GetLatest(ctx, r.settingsSubject())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -37,14 +38,14 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	// Collect username, verified email addresses, and external accounts to be used
 	// for revoking user permissions later, otherwise they will be removed from database
 	// if it's a hard delete.
-	user, err := db.Users.GetByID(ctx, userID)
+	user, err := db.GlobalUsers.GetByID(ctx, userID)
 	if err != nil {
 		return nil, errors.Wrap(err, "get user by ID")
 	}
 
 	var accounts []*extsvc.Accounts
 
-	extAccounts, err := db.ExternalAccounts.List(ctx, db.ExternalAccountsListOptions{UserID: userID})
+	extAccounts, err := db.GlobalExternalAccounts.List(ctx, db.ExternalAccountsListOptions{UserID: userID})
 	if err != nil {
 		return nil, errors.Wrap(err, "list external accounts")
 	}
@@ -56,7 +57,7 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 		})
 	}
 
-	verifiedEmails, err := db.UserEmails.ListByUser(ctx, db.UserEmailsListOptions{
+	verifiedEmails, err := db.GlobalUserEmails.ListByUser(ctx, db.UserEmailsListOptions{
 		UserID:       user.ID,
 		OnlyVerified: true,
 	})
@@ -74,11 +75,11 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	})
 
 	if args.Hard != nil && *args.Hard {
-		if err := db.Users.HardDelete(ctx, user.ID); err != nil {
+		if err := db.GlobalUsers.HardDelete(ctx, user.ID); err != nil {
 			return nil, err
 		}
 	} else {
-		if err := db.Users.Delete(ctx, user.ID); err != nil {
+		if err := db.GlobalUsers.Delete(ctx, user.ID); err != nil {
 			return nil, err
 		}
 	}
@@ -86,7 +87,7 @@ func (*schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	// NOTE: Practically, we don't reuse the ID for any new users, and the situation of left-over pending permissions
 	// is possible but highly unlikely. Therefore, there is no need to roll back user deletion even if this step failed.
 	// This call is purely for the purpose of cleanup.
-	if err := db.Authz.RevokeUserPermissions(ctx, &db.RevokeUserPermissionsArgs{
+	if err := db.GlobalAuthz.RevokeUserPermissions(ctx, &db.RevokeUserPermissionsArgs{
 		UserID:   user.ID,
 		Accounts: accounts,
 	}); err != nil {
@@ -109,7 +110,7 @@ func (*schemaResolver) DeleteOrganization(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err := db.Orgs.Delete(ctx, orgID); err != nil {
+	if err := db.GlobalOrgs.Delete(ctx, orgID); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil
@@ -138,7 +139,7 @@ func (*schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err := db.Users.SetIsSiteAdmin(ctx, userID, args.SiteAdmin); err != nil {
+	if err := db.GlobalUsers.SetIsSiteAdmin(ctx, userID, args.SiteAdmin); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -33,7 +33,7 @@ func needsRepositoryConfiguration(ctx context.Context) (bool, error) {
 		}
 	}
 
-	count, err := db.ExternalServices.Count(ctx, db.ExternalServicesListOptions{
+	count, err := db.GlobalExternalServices.Count(ctx, db.ExternalServicesListOptions{
 		Kinds: kinds,
 	})
 	if err != nil {
@@ -62,7 +62,7 @@ func (r *siteResolver) FreeUsersExceeded(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	userCount, err := db.Users.Count(ctx, nil)
+	userCount, err := db.GlobalUsers.Count(ctx, nil)
 	if err != nil {
 		return false, err
 	}

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -61,7 +61,7 @@ func (r *statusMessageResolver) Message() (string, error) {
 
 func (r *statusMessageResolver) ExternalService(ctx context.Context) (*externalServiceResolver, error) {
 	id := r.message.ExternalServiceSyncError.ExternalServiceId
-	externalService, err := db.ExternalServices.GetByID(ctx, id)
+	externalService, err := db.GlobalExternalServices.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -90,7 +90,7 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 	actor := actor.FromContext(ctx)
 	if actor.IsAuthenticated() {
 		uid = &actor.UID
-		e, _, err := db.UserEmails.GetPrimaryEmail(ctx, actor.UID)
+		e, _, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, actor.UID)
 		if err != nil && !errcode.IsNotFound(err) {
 			return nil, err
 		}
@@ -99,7 +99,7 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 		}
 	}
 
-	_, err := db.SurveyResponses.Create(ctx, uid, email, int(input.Score), input.Reason, input.Better)
+	_, err := db.GlobalSurveyResponses.Create(ctx, uid, email, int(input.Score), input.Reason, input.Better)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/survey_responses.go
+++ b/cmd/frontend/graphqlbackend/survey_responses.go
@@ -26,7 +26,7 @@ func (r *surveyResponseConnectionResolver) Nodes(ctx context.Context) ([]*survey
 		return nil, err
 	}
 
-	responses, err := db.SurveyResponses.GetAll(ctx)
+	responses, err := db.GlobalSurveyResponses.GetAll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (r *surveyResponseConnectionResolver) TotalCount(ctx context.Context) (int3
 		return 0, err
 	}
 
-	count, err := db.SurveyResponses.Count(ctx)
+	count, err := db.GlobalSurveyResponses.Count(ctx)
 	return int32(count), err
 }
 
@@ -54,7 +54,7 @@ func (r *surveyResponseConnectionResolver) AverageScore(ctx context.Context) (fl
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return 0, err
 	}
-	return db.SurveyResponses.Last30DaysAverageScore(ctx)
+	return db.GlobalSurveyResponses.Last30DaysAverageScore(ctx)
 }
 
 func (r *surveyResponseConnectionResolver) NetPromoterScore(ctx context.Context) (int32, error) {
@@ -62,7 +62,7 @@ func (r *surveyResponseConnectionResolver) NetPromoterScore(ctx context.Context)
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return 0, err
 	}
-	nps, err := db.SurveyResponses.Last30DaysNetPromoterScore(ctx)
+	nps, err := db.GlobalSurveyResponses.Last30DaysNetPromoterScore(ctx)
 	return int32(nps), err
 }
 
@@ -71,6 +71,6 @@ func (r *surveyResponseConnectionResolver) Last30DaysCount(ctx context.Context) 
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return 0, err
 	}
-	count, err := db.SurveyResponses.Last30DaysCount(ctx)
+	count, err := db.GlobalSurveyResponses.Last30DaysCount(ctx)
 	return int32(count), err
 }

--- a/cmd/frontend/graphqlbackend/tags.go
+++ b/cmd/frontend/graphqlbackend/tags.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 )
@@ -28,7 +29,7 @@ func (r *schemaResolver) SetTag(ctx context.Context, args *struct {
 		return nil, errors.New("setting tags is only supported for users")
 	}
 
-	if err := db.Users.SetTag(ctx, user.user.ID, args.Tag, args.Present); err != nil {
+	if err := db.GlobalUsers.SetTag(ctx, user.user.ID, args.Tag, args.Present); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/trial_request.go
+++ b/cmd/frontend/graphqlbackend/trial_request.go
@@ -23,7 +23,7 @@ func (r *schemaResolver) RequestTrial(ctx context.Context, args *struct {
 
 	// If user is authenticated, use their uid and overwrite the optional email field.
 	if actor := actor.FromContext(ctx); actor.IsAuthenticated() {
-		e, _, err := db.UserEmails.GetPrimaryEmail(ctx, actor.UID)
+		e, _, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, actor.UID)
 		if err != nil && !errcode.IsNotFound(err) {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -26,7 +26,7 @@ func (r *schemaResolver) User(ctx context.Context, args struct {
 }) (*UserResolver, error) {
 	switch {
 	case args.Username != nil:
-		user, err := db.Users.GetByUsername(ctx, *args.Username)
+		user, err := db.GlobalUsers.GetByUsername(ctx, *args.Username)
 		if err != nil {
 			return nil, err
 		}
@@ -40,7 +40,7 @@ func (r *schemaResolver) User(ctx context.Context, args struct {
 				return nil, err
 			}
 		}
-		user, err := db.Users.GetByVerifiedEmail(ctx, *args.Email)
+		user, err := db.GlobalUsers.GetByVerifiedEmail(ctx, *args.Email)
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +74,7 @@ func UserByID(ctx context.Context, id graphql.ID) (*UserResolver, error) {
 // UserByIDInt32 looks up and returns the user with the given database ID. If no such user exists,
 // it returns a non-nil error.
 func UserByIDInt32(ctx context.Context, id int32) (*UserResolver, error) {
-	user, err := db.Users.GetByID(ctx, id)
+	user, err := db.GlobalUsers.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (r *UserResolver) Email(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	email, _, err := db.UserEmails.GetPrimaryEmail(ctx, r.user.ID)
+	email, _, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, r.user.ID)
 	if err != nil && !errcode.IsNotFound(err) {
 		return "", err
 	}
@@ -154,7 +154,7 @@ func (r *UserResolver) LatestSettings(ctx context.Context) (*settingsResolver, e
 		return nil, err
 	}
 
-	settings, err := db.Settings.GetLatest(ctx, r.settingsSubject())
+	settings, err := db.GlobalSettings.GetLatest(ctx, r.settingsSubject())
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +213,7 @@ func (*schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (*U
 		}
 		update.Username = *args.Username
 	}
-	if err := db.Users.Update(ctx, userID, update); err != nil {
+	if err := db.GlobalUsers.Update(ctx, userID, update); err != nil {
 		return nil, err
 	}
 	return UserByIDInt32(ctx, userID)
@@ -222,7 +222,7 @@ func (*schemaResolver) UpdateUser(ctx context.Context, args *updateUserArgs) (*U
 // CurrentUser returns the authenticated user if any. If there is no authenticated user, it returns
 // (nil, nil). If some other error occurs, then the error is returned.
 func CurrentUser(ctx context.Context) (*UserResolver, error) {
-	user, err := db.Users.GetByCurrentAuthUser(ctx)
+	user, err := db.GlobalUsers.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		if errcode.IsNotFound(err) || err == db.ErrNoCurrentUser {
 			return nil, nil
@@ -233,7 +233,7 @@ func CurrentUser(ctx context.Context) (*UserResolver, error) {
 }
 
 func (r *UserResolver) Organizations(ctx context.Context) (*orgConnectionStaticResolver, error) {
-	orgs, err := db.Orgs.GetByUserID(ctx, r.user.ID)
+	orgs, err := db.GlobalOrgs.GetByUserID(ctx, r.user.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +258,7 @@ func (r *UserResolver) SurveyResponses(ctx context.Context) ([]*surveyResponseRe
 		return nil, err
 	}
 
-	responses, err := db.SurveyResponses.GetByUserID(ctx, r.user.ID)
+	responses, err := db.GlobalSurveyResponses.GetByUserID(ctx, r.user.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -300,7 +300,7 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 	NewPassword string
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: A user can only change their own password.
-	user, err := db.Users.GetByCurrentAuthUser(ctx)
+	user, err := db.GlobalUsers.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 		return nil, errors.New("no authenticated user")
 	}
 
-	if err := db.Users.UpdatePassword(ctx, user.ID, args.OldPassword, args.NewPassword); err != nil {
+	if err := db.GlobalUsers.UpdatePassword(ctx, user.ID, args.OldPassword, args.NewPassword); err != nil {
 		return nil, err
 	}
 
@@ -370,7 +370,7 @@ func (r *UserResolver) Repositories(ctx context.Context, args *ListUserRepositor
 			Descending: args.Descending,
 		}}
 	}
-	extSvcs, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{
+	extSvcs, err := db.GlobalExternalServices.List(ctx, db.ExternalServicesListOptions{
 		NamespaceUserID: r.user.ID,
 	})
 	if err != nil {
@@ -428,7 +428,7 @@ func viewerCanChangeUsername(ctx context.Context, userID int32) bool {
 // If that subject's username is different from the proposed one, then a
 // change is being attempted and may be rejected by viewerCanChangeUsername.
 func viewerIsChangingUsername(ctx context.Context, subjectUserID int32, proposedUsername string) bool {
-	subject, err := db.Users.GetByID(ctx, subjectUserID)
+	subject, err := db.GlobalUsers.GetByID(ctx, subjectUserID)
 	if err != nil {
 		log15.Warn("viewerIsChangingUsername", "error", err)
 		return true

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -21,7 +22,7 @@ func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error)
 		return nil, err
 	}
 
-	userEmails, err := db.UserEmails.ListByUser(ctx, db.UserEmailsListOptions{
+	userEmails, err := db.GlobalUserEmails.ListByUser(ctx, db.UserEmailsListOptions{
 		UserID: r.user.ID,
 	})
 	if err != nil {
@@ -46,7 +47,7 @@ type userEmailResolver struct {
 func (r *userEmailResolver) Email() string { return r.userEmail.Email }
 
 func (r *userEmailResolver) IsPrimary(ctx context.Context) (bool, error) {
-	email, _, err := db.UserEmails.GetPrimaryEmail(ctx, r.user.user.ID)
+	email, _, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, r.user.user.ID)
 	if err != nil {
 		return false, err
 	}
@@ -103,12 +104,12 @@ func (r *schemaResolver) RemoveUserEmail(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err := db.UserEmails.Remove(ctx, userID, args.Email); err != nil {
+	if err := db.GlobalUserEmails.Remove(ctx, userID, args.Email); err != nil {
 		return nil, err
 	}
 
 	// 🚨 SECURITY: If an email is removed, invalidate any existing password reset tokens that may have been sent to that email.
-	if err := db.Users.DeletePasswordResetCode(ctx, userID); err != nil {
+	if err := db.GlobalUsers.DeletePasswordResetCode(ctx, userID); err != nil {
 		return nil, err
 	}
 
@@ -135,7 +136,7 @@ func (r *schemaResolver) SetUserEmailPrimary(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err := db.UserEmails.SetPrimaryEmail(ctx, userID, args.Email); err != nil {
+	if err := db.GlobalUserEmails.SetPrimaryEmail(ctx, userID, args.Email); err != nil {
 		return nil, err
 	}
 
@@ -163,13 +164,13 @@ func (r *schemaResolver) SetUserEmailVerified(ctx context.Context, args *struct 
 	if err != nil {
 		return nil, err
 	}
-	if err := db.UserEmails.SetVerified(ctx, userID, args.Email, args.Verified); err != nil {
+	if err := db.GlobalUserEmails.SetVerified(ctx, userID, args.Email, args.Verified); err != nil {
 		return nil, err
 	}
 
 	// Avoid unnecessary calls if the email is set to unverified.
 	if args.Verified {
-		if err = db.Authz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
+		if err = db.GlobalAuthz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
 			UserID: userID,
 			Perm:   authz.Read,
 			Type:   authz.PermRepos,
@@ -194,12 +195,12 @@ func (r *schemaResolver) ResendVerificationEmail(ctx context.Context, args *stru
 		return nil, err
 	}
 
-	user, err := db.Users.GetByID(ctx, userID)
+	user, err := db.GlobalUsers.GetByID(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
 
-	lastSent, err := db.UserEmails.GetLatestVerificationSentEmail(ctx, args.Email)
+	lastSent, err := db.GlobalUserEmails.GetLatestVerificationSentEmail(ctx, args.Email)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +210,7 @@ func (r *schemaResolver) ResendVerificationEmail(ctx context.Context, args *stru
 		return nil, errors.New("Last verification email sent too recently")
 	}
 
-	email, verified, err := db.UserEmails.Get(ctx, userID, args.Email)
+	email, verified, err := db.GlobalUserEmails.Get(ctx, userID, args.Email)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +223,7 @@ func (r *schemaResolver) ResendVerificationEmail(ctx context.Context, args *stru
 		return nil, err
 	}
 
-	err = db.UserEmails.SetLastVerification(ctx, userID, email, code)
+	err = db.GlobalUserEmails.SetLastVerification(ctx, userID, email, code)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -74,12 +74,12 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, in
 			return
 		}
 
-		r.users, err = db.Users.List(ctx, &r.opt)
+		r.users, err = db.GlobalUsers.List(ctx, &r.opt)
 		if err != nil {
 			r.err = err
 			return
 		}
-		r.totalCount, r.err = db.Users.Count(ctx, &r.opt)
+		r.totalCount, r.err = db.GlobalUsers.Count(ctx, &r.opt)
 	})
 	return r.users, r.totalCount, r.err
 }
@@ -90,7 +90,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 	if r.useCache() {
 		users, _, err = r.compute(ctx)
 	} else {
-		users, err = db.Users.List(ctx, &r.opt)
+		users, err = db.GlobalUsers.List(ctx, &r.opt)
 	}
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) 
 	if r.useCache() {
 		_, count, err = r.compute(ctx)
 	} else {
-		count, err = db.Users.Count(ctx, &r.opt)
+		count, err = db.GlobalUsers.Count(ctx, &r.opt)
 	}
 	return int32(count), err
 }

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -29,7 +29,7 @@ func (*schemaResolver) CreateUser(ctx context.Context, args *struct {
 	}
 
 	// The new user will be created with a verified email address.
-	user, err := db.Users.Create(ctx, db.NewUser{
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{
 		Username:        args.Username,
 		Email:           email,
 		EmailIsVerified: true,
@@ -39,7 +39,7 @@ func (*schemaResolver) CreateUser(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err = db.Authz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
+	if err = db.GlobalAuthz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
 		UserID: user.ID,
 		Perm:   authz.Read,
 		Type:   authz.PermRepos,

--- a/cmd/frontend/graphqlbackend/users_randomize_password.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/auth/userpasswd"
@@ -43,7 +44,7 @@ func (*schemaResolver) RandomizeUserPassword(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	if err := db.Users.RandomizePasswordAndClearPasswordResetRateLimit(ctx, userID); err != nil {
+	if err := db.GlobalUsers.RandomizePasswordAndClearPasswordResetRateLimit(ctx, userID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/app/ping.go
+++ b/cmd/frontend/internal/app/ping.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/db"
 )
@@ -20,7 +21,7 @@ func latestPingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	ping, err := db.EventLogs.LatestPing(r.Context())
+	ping, err := db.GlobalEventLogs.LatestPing(r.Context())
 	switch err {
 	case sql.ErrNoRows:
 		_, _ = io.WriteString(w, "{}")

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -99,12 +99,12 @@ func hasFindRefsOccurred(ctx context.Context) (_ bool, err error) {
 
 func getTotalUsersCount(ctx context.Context) (_ int, err error) {
 	defer recordOperation("getTotalUsersCount")(&err)
-	return db.Users.Count(ctx, &db.UsersListOptions{})
+	return db.GlobalUsers.Count(ctx, &db.UsersListOptions{})
 }
 
 func getTotalReposCount(ctx context.Context) (_ int, err error) {
 	defer recordOperation("getTotalReposCount")(&err)
-	return db.Repos.Count(ctx, db.ReposListOptions{})
+	return db.GlobalRepos.Count(ctx, db.ReposListOptions{})
 }
 
 func getUsersActiveTodayCount(ctx context.Context) (_ int, err error) {
@@ -114,7 +114,7 @@ func getUsersActiveTodayCount(ctx context.Context) (_ int, err error) {
 
 func getInitialSiteAdminEmail(ctx context.Context) (_ string, err error) {
 	defer recordOperation("getInitialSiteAdminEmail")(&err)
-	return db.UserEmails.GetInitialSiteAdminEmail(ctx)
+	return db.GlobalUserEmails.GetInitialSiteAdminEmail(ctx)
 }
 
 func getAndMarshalCampaignsUsageJSON(ctx context.Context) (_ json.RawMessage, err error) {
@@ -428,7 +428,7 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 		return nil, err
 	}
 
-	err = db.EventLogs.Insert(ctx, &db.Event{
+	err = db.GlobalEventLogs.Insert(ctx, &db.Event{
 		UserID:          0,
 		Name:            "ping",
 		URL:             "",
@@ -452,7 +452,7 @@ func authProviderTypes() []string {
 
 func externalServiceKinds(ctx context.Context) (kinds []string, err error) {
 	defer recordOperation("externalServiceKinds")(&err)
-	kinds, err = db.ExternalServices.DistinctKinds(ctx)
+	kinds, err = db.GlobalExternalServices.DistinctKinds(ctx)
 	return kinds, err
 }
 

--- a/cmd/frontend/internal/app/verify_email.go
+++ b/cmd/frontend/internal/app/verify_email.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/db"
@@ -24,13 +25,13 @@ func serveVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// 🚨 SECURITY: require correct authed user to verify email
-	usr, err := db.Users.GetByCurrentAuthUser(ctx)
+	usr, err := db.GlobalUsers.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		httpLogAndError(w, "Could not get current user", http.StatusUnauthorized)
 		return
 	}
 
-	email, alreadyVerified, err := db.UserEmails.Get(ctx, usr.ID, email)
+	email, alreadyVerified, err := db.GlobalUserEmails.Get(ctx, usr.ID, email)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("No email %q found for user %d", email, usr.ID), http.StatusBadRequest)
 		return
@@ -39,7 +40,7 @@ func serveVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("User %d email %q is already verified", usr.ID, email), http.StatusBadRequest)
 		return
 	}
-	verified, err := db.UserEmails.Verify(ctx, usr.ID, email, verifyCode)
+	verified, err := db.GlobalUserEmails.Verify(ctx, usr.ID, email, verifyCode)
 	if err != nil {
 		httpLogAndError(w, "Could not verify user email", http.StatusInternalServerError, "userID", usr.ID, "email", email, "error", err)
 		return
@@ -49,7 +50,7 @@ func serveVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = db.Authz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
+	if err = db.GlobalAuthz.GrantPendingPermissions(ctx, &db.GrantPendingPermissionsArgs{
 		UserID: usr.ID,
 		Perm:   authz.Read,
 		Type:   authz.PermRepos,

--- a/cmd/frontend/internal/auth/override.go
+++ b/cmd/frontend/internal/auth/override.go
@@ -56,13 +56,13 @@ func OverrideAuthMiddleware(next http.Handler) http.Handler {
 
 			// Make the user a site admin because that is more useful for e2e tests and local dev
 			// scripting (which are the use cases of this override auth provider).
-			if err := db.Users.SetIsSiteAdmin(r.Context(), userID, true); err != nil {
+			if err := db.GlobalUsers.SetIsSiteAdmin(r.Context(), userID, true); err != nil {
 				log15.Error("Error setting auth-override user as site admin.", "error", err)
 				http.Error(w, "", http.StatusInternalServerError)
 				return
 			}
 
-			user, err := db.Users.GetByID(r.Context(), userID)
+			user, err := db.GlobalUsers.GetByID(r.Context(), userID)
 			if err != nil {
 				log15.Error("Error retrieving user from database.", "error", err)
 				http.Error(w, "", http.StatusInternalServerError)

--- a/cmd/frontend/internal/auth/userpasswd/reset_password.go
+++ b/cmd/frontend/internal/auth/userpasswd/reset_password.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -44,7 +45,7 @@ func HandleResetPasswordInit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	usr, err := db.Users.GetByVerifiedEmail(ctx, formData.Email)
+	usr, err := db.GlobalUsers.GetByVerifiedEmail(ctx, formData.Email)
 	if err != nil {
 		// 🚨 SECURITY: We don't show an error message when the user is not found
 		// as to not leak the existence of a given e-mail address in the database.
@@ -102,12 +103,12 @@ To reset the password for {{.Username}} on Sourcegraph, follow this link:
 
 // HandleSetPasswordEmail sends the password reset email directly to the user for users created by site admins.
 func HandleSetPasswordEmail(ctx context.Context, id int32) (string, error) {
-	e, _, err := db.UserEmails.GetPrimaryEmail(ctx, id)
+	e, _, err := db.GlobalUserEmails.GetPrimaryEmail(ctx, id)
 	if err != nil {
 		return "", errors.Wrap(err, "get user primary email")
 	}
 
-	usr, err := db.Users.GetByID(ctx, id)
+	usr, err := db.GlobalUsers.GetByID(ctx, id)
 	if err != nil {
 		return "", errors.Wrap(err, "get user by ID")
 	}
@@ -181,7 +182,7 @@ func HandleResetPasswordCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	success, err := db.Users.SetPassword(ctx, params.UserID, params.Code, params.Password)
+	success, err := db.GlobalUsers.SetPassword(ctx, params.UserID, params.Code, params.Password)
 	if err != nil {
 		httpLogAndError(w, "Unexpected error", http.StatusInternalServerError, "err", err)
 		return

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -99,7 +99,7 @@ func handleConfigOverrides() error {
 		if err != nil {
 			return errors.Wrap(err, "reading GLOBAL_SETTINGS_FILE")
 		}
-		currentSettings, err := db.Settings.GetLatest(ctx, api.SettingsSubject{Site: true})
+		currentSettings, err := db.GlobalSettings.GetLatest(ctx, api.SettingsSubject{Site: true})
 		if err != nil {
 			return errors.Wrap(err, "could not fetch current settings")
 		}
@@ -111,7 +111,7 @@ func handleConfigOverrides() error {
 			if currentSettings != nil {
 				lastID = &currentSettings.ID
 			}
-			_, err = db.Settings.CreateIfUpToDate(ctx, api.SettingsSubject{Site: true}, lastID, nil, globalSettings)
+			_, err = db.GlobalSettings.CreateIfUpToDate(ctx, api.SettingsSubject{Site: true}, lastID, nil, globalSettings)
 			if err != nil {
 				return errors.Wrap(err, "writing global setting override to database")
 			}
@@ -137,7 +137,7 @@ func handleConfigOverrides() error {
 			log.Warn("EXTSVC_CONFIG_FILE contains zero external service configurations")
 		}
 
-		existing, err := db.ExternalServices.List(ctx, db.ExternalServicesListOptions{
+		existing, err := db.GlobalExternalServices.List(ctx, db.ExternalServicesListOptions{
 			// NOTE: External services loaded from config file do not have namespace specified.
 			// Therefore, we only need to load those from database.
 			NoNamespace: true,
@@ -198,14 +198,14 @@ func handleConfigOverrides() error {
 		// Apply the delta update.
 		for extSvc := range toRemove {
 			log.Debug("Deleting external service", "id", extSvc.ID, "displayName", extSvc.DisplayName)
-			err := db.ExternalServices.Delete(ctx, extSvc.ID)
+			err := db.GlobalExternalServices.Delete(ctx, extSvc.ID)
 			if err != nil {
 				return errors.Wrap(err, "ExternalServices.Delete")
 			}
 		}
 		for extSvc := range toAdd {
 			log.Debug("Adding external service", "displayName", extSvc.DisplayName)
-			if err := db.ExternalServices.Create(ctx, confGet, extSvc); err != nil {
+			if err := db.GlobalExternalServices.Create(ctx, confGet, extSvc); err != nil {
 				return errors.Wrap(err, "ExternalServices.Create")
 			}
 		}
@@ -215,7 +215,7 @@ func handleConfigOverrides() error {
 			log.Debug("Updating external service", "id", id, "displayName", extSvc.DisplayName)
 
 			update := &db.ExternalServiceUpdate{DisplayName: &extSvc.DisplayName, Config: &extSvc.Config}
-			if err := db.ExternalServices.Update(ctx, ps, id, update); err != nil {
+			if err := db.GlobalExternalServices.Update(ctx, ps, id, update); err != nil {
 				return errors.Wrap(err, "ExternalServices.Update")
 			}
 		}

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
@@ -67,7 +68,7 @@ func AccessTokenAuthMiddleware(next http.Handler) http.Handler {
 			} else {
 				requiredScope = authz.ScopeSiteAdminSudo
 			}
-			subjectUserID, err := db.AccessTokens.Lookup(r.Context(), token, requiredScope)
+			subjectUserID, err := db.GlobalAccessTokens.Lookup(r.Context(), token, requiredScope)
 			if err != nil {
 				log15.Error("Invalid access token.", "token", token, "err", err)
 				http.Error(w, "Invalid access token.", http.StatusUnauthorized)
@@ -89,7 +90,7 @@ func AccessTokenAuthMiddleware(next http.Handler) http.Handler {
 
 				// Sudo to the other user if this is a sudo token. We already checked that the token has
 				// the necessary scope in the Lookup call above.
-				user, err := db.Users.GetByUsername(r.Context(), sudoUser)
+				user, err := db.GlobalUsers.GetByUsername(r.Context(), sudoUser)
 				if err != nil {
 					log15.Error("Invalid username used with sudo access token.", "sudoUser", sudoUser, "err", err)
 					var message string

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -50,7 +50,7 @@ func servePhabricatorRepoCreate(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	phabRepo, err := db.Phabricator.CreateOrUpdate(r.Context(), repo.Callsign, repo.RepoName, repo.URL)
+	phabRepo, err := db.GlobalPhabricator.CreateOrUpdate(r.Context(), repo.Callsign, repo.RepoName, repo.URL)
 	if err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func serveExternalServiceConfigs(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	services, err := db.ExternalServices.List(r.Context(), options)
+	services, err := db.GlobalExternalServices.List(r.Context(), options)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func serveExternalServicesList(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	services, err := db.ExternalServices.List(r.Context(), options)
+	services, err := db.GlobalExternalServices.List(r.Context(), options)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 	ctx := r.Context()
 	siteConfig := conf.Get().SiteConfiguration
 	getRepoIndexOptions := func(repoName string) (*searchbackend.RepoIndexOptions, error) {
-		repo, err := db.Repos.GetByName(ctx, api.RepoName(repoName))
+		repo, err := db.GlobalRepos.GetByName(ctx, api.RepoName(repoName))
 		if err != nil {
 			return nil, err
 		}
@@ -283,7 +283,7 @@ func (h *reposListServer) serveIndex(w http.ResponseWriter, r *http.Request) err
 }
 
 func serveReposListEnabled(w http.ResponseWriter, r *http.Request) error {
-	names, err := db.Repos.ListEnabledNames(r.Context())
+	names, err := db.GlobalRepos.ListEnabledNames(r.Context())
 	if err != nil {
 		return err
 	}
@@ -292,7 +292,7 @@ func serveReposListEnabled(w http.ResponseWriter, r *http.Request) error {
 
 func serveSavedQueriesListAll(w http.ResponseWriter, r *http.Request) error {
 	// List settings for all users, orgs, etc.
-	settings, err := db.SavedSearches.ListAll(r.Context())
+	settings, err := db.GlobalSavedSearches.ListAll(r.Context())
 	if err != nil {
 		return errors.Wrap(err, "db.SavedSearches.ListAll")
 	}
@@ -325,7 +325,7 @@ func serveSavedQueriesGetInfo(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	info, err := db.QueryRunnerState.Get(r.Context(), query)
+	info, err := db.GlobalQueryRunnerState.Get(r.Context(), query)
 	if err != nil {
 		return errors.Wrap(err, "SavedQueries.Get")
 	}
@@ -341,7 +341,7 @@ func serveSavedQueriesSetInfo(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	err = db.QueryRunnerState.Set(r.Context(), &db.SavedQueryInfo{
+	err = db.GlobalQueryRunnerState.Set(r.Context(), &db.SavedQueryInfo{
 		Query:        info.Query,
 		LastExecuted: info.LastExecuted,
 		LatestResult: info.LatestResult,
@@ -361,7 +361,7 @@ func serveSavedQueriesDeleteInfo(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	err = db.QueryRunnerState.Delete(r.Context(), query)
+	err = db.GlobalQueryRunnerState.Delete(r.Context(), query)
 	if err != nil {
 		return errors.Wrap(err, "SavedQueries.Delete")
 	}
@@ -375,7 +375,7 @@ func serveSettingsGetForSubject(w http.ResponseWriter, r *http.Request) error {
 	if err := json.NewDecoder(r.Body).Decode(&subject); err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	settings, err := db.Settings.GetLatest(r.Context(), subject)
+	settings, err := db.GlobalSettings.GetLatest(r.Context(), subject)
 	if err != nil {
 		return errors.Wrap(err, "Settings.GetLatest")
 	}
@@ -391,7 +391,7 @@ func serveOrgsListUsers(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	orgMembers, err := db.OrgMembers.GetByOrgID(r.Context(), orgID)
+	orgMembers, err := db.GlobalOrgMembers.GetByOrgID(r.Context(), orgID)
 	if err != nil {
 		return errors.Wrap(err, "OrgMembers.GetByOrgID")
 	}
@@ -411,7 +411,7 @@ func serveOrgsGetByName(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	org, err := db.Orgs.GetByName(r.Context(), orgName)
+	org, err := db.GlobalOrgs.GetByName(r.Context(), orgName)
 	if err != nil {
 		return errors.Wrap(err, "Orgs.GetByName")
 	}
@@ -427,7 +427,7 @@ func serveUsersGetByUsername(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	user, err := db.Users.GetByUsername(r.Context(), username)
+	user, err := db.GlobalUsers.GetByUsername(r.Context(), username)
 	if err != nil {
 		return errors.Wrap(err, "Users.GetByUsername")
 	}
@@ -443,7 +443,7 @@ func serveUserEmailsGetEmail(w http.ResponseWriter, r *http.Request) error {
 	if err != nil {
 		return errors.Wrap(err, "Decode")
 	}
-	email, _, err := db.UserEmails.GetPrimaryEmail(r.Context(), userID)
+	email, _, err := db.GlobalUserEmails.GetPrimaryEmail(r.Context(), userID)
 	if err != nil {
 		return errors.Wrap(err, "UserEmails.GetEmail")
 	}
@@ -533,7 +533,7 @@ func serveGitExec(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 
-	repo, err := db.Repos.Get(r.Context(), api.RepoID(repoID))
+	repo, err := db.GlobalRepos.Get(r.Context(), api.RepoID(repoID))
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_repo_authz_event.go
@@ -6,6 +6,7 @@ import (
 
 	gh "github.com/google/go-github/v28/github"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -49,7 +50,7 @@ func scheduleRepoUpdate(ctx context.Context, repo *gh.Repository) error {
 
 	// 🚨 SECURITY: we want to be able to find any private repo here, so set internal actor
 	ctx = actor.WithActor(ctx, &actor.Actor{Internal: true})
-	r, err := db.Repos.GetByName(ctx, api.RepoName("github.com/"+repo.GetFullName()))
+	r, err := db.GlobalRepos.GetByName(ctx, api.RepoName("github.com/"+repo.GetFullName()))
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
+++ b/cmd/frontend/internal/httpapi/webhookhandlers/handle_user_authz_event.go
@@ -57,7 +57,7 @@ func scheduleUserUpdate(ctx context.Context, extSvc *types.ExternalService, gith
 	if githubUser == nil {
 		return nil
 	}
-	accs, err := db.ExternalAccounts.List(ctx, db.ExternalAccountsListOptions{
+	accs, err := db.GlobalExternalAccounts.List(ctx, db.ExternalAccountsListOptions{
 		ServiceID:   fmt.Sprint(extSvc.ID),
 		ServiceType: "github",
 		AccountID:   githubUser.GetID(),

--- a/cmd/frontend/internal/search/repos/external_services.go
+++ b/cmd/frontend/internal/search/repos/external_services.go
@@ -20,12 +20,12 @@ func CurrentUserAllowedExternalServices(ctx context.Context) conf.ExternalServic
 	}
 
 	// The user may have a tag that opts them in
-	ok, _ := db.Users.HasTag(ctx, a.UID, db.TagAllowUserExternalServicePrivate)
+	ok, _ := db.GlobalUsers.HasTag(ctx, a.UID, db.TagAllowUserExternalServicePrivate)
 	if ok {
 		return conf.ExternalServiceModeAll
 	}
 
-	ok, _ = db.Users.HasTag(ctx, a.UID, db.TagAllowUserExternalServicePublic)
+	ok, _ = db.GlobalUsers.HasTag(ctx, a.UID, db.TagAllowUserExternalServicePublic)
 	if ok {
 		return conf.ExternalServiceModePublic
 	}

--- a/cmd/frontend/internal/search/repos/repo_groups.go
+++ b/cmd/frontend/internal/search/repos/repo_groups.go
@@ -66,7 +66,7 @@ func ResolveRepoGroups(ctx context.Context, settings *schema.Settings) (groups m
 	}
 
 	a := actor.FromContext(ctx)
-	names, err := db.Repos.GetUserAddedRepoNames(ctx, a.UID)
+	names, err := db.GlobalRepos.GetUserAddedRepoNames(ctx, a.UID)
 	if err != nil {
 		log15.Warn("getting user added repos", "err", err)
 		return groups, nil

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -103,7 +103,7 @@ func ResolveRepositories(ctx context.Context, op Options) (Resolved, error) {
 
 	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 && !hasTypeRepo(op.Query) {
 		start := time.Now()
-		defaultRepos, err = defaultRepositories(ctx, db.DefaultRepos.List, search.Indexed(), excludePatterns)
+		defaultRepos, err = defaultRepositories(ctx, db.GlobalDefaultRepos.List, search.Indexed(), excludePatterns)
 		if err != nil {
 			return Resolved{}, errors.Wrap(err, "getting list of default repos")
 		}
@@ -145,7 +145,7 @@ func ResolveRepositories(ctx context.Context, op Options) (Resolved, error) {
 			excludedC <- computeExcludedRepositories(ctx, op.Query, options)
 		}()
 
-		repos, err = db.Repos.ListRepoNames(ctx, options)
+		repos, err = db.GlobalRepos.ListRepoNames(ctx, options)
 		tr.LazyPrintf("Repos.List - done")
 
 		excluded = <-excludedC
@@ -433,7 +433,7 @@ func computeExcludedRepositories(ctx context.Context, q query.QueryInfo, op db.R
 			selectForks.OnlyForks = true
 			selectForks.NoForks = false
 			var err error
-			numExcludedForks, err = db.Repos.Count(ctx, selectForks)
+			numExcludedForks, err = db.GlobalRepos.Count(ctx, selectForks)
 			if err != nil {
 				log15.Warn("repo count for excluded fork", "err", err)
 			}
@@ -452,7 +452,7 @@ func computeExcludedRepositories(ctx context.Context, q query.QueryInfo, op db.R
 			selectArchived.OnlyArchived = true
 			selectArchived.NoArchived = false
 			var err error
-			numExcludedArchived, err = db.Repos.Count(ctx, selectArchived)
+			numExcludedArchived, err = db.GlobalRepos.Count(ctx, selectArchived)
 			if err != nil {
 				log15.Warn("repo count for excluded archive", "err", err)
 			}

--- a/cmd/frontend/internal/session/session.go
+++ b/cmd/frontend/internal/session/session.go
@@ -269,14 +269,14 @@ func deleteSession(w http.ResponseWriter, r *http.Request) error {
 // If an error occurs, return the error
 func InvalidateSessionCurrentUser(r *http.Request) error {
 	a := actor.FromContext(r.Context())
-	return db.Users.InvalidateSessionsByID(r.Context(), a.UID)
+	return db.GlobalUsers.InvalidateSessionsByID(r.Context(), a.UID)
 }
 
 // InvalidateSessionsByID invalidates all sessions for a user
 // If an error occurs, it returns the error
 func InvalidateSessionsByID(ctx context.Context, id int32) error {
 	// Get the user from the request context
-	return db.Users.InvalidateSessionsByID(ctx, id)
+	return db.GlobalUsers.InvalidateSessionsByID(ctx, id)
 }
 
 // CookieMiddleware is an http.Handler middleware that authenticates
@@ -360,7 +360,7 @@ func authenticateByCookie(r *http.Request, w http.ResponseWriter) context.Contex
 		}
 
 		// Check that user still exists.
-		usr, err := db.Users.GetByID(r.Context(), info.Actor.UID)
+		usr, err := db.GlobalUsers.GetByID(r.Context(), info.Actor.UID)
 		if err != nil {
 			if errcode.IsNotFound(err) {
 				_ = deleteSession(w, r) // clear the bad value

--- a/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/db"
 )
 
@@ -174,5 +175,5 @@ func LogEvent(ctx context.Context, name, url string, userID int32, userCookieID,
 		Source:          source,
 		Argument:        argument,
 	}
-	return db.EventLogs.Insert(ctx, info)
+	return db.GlobalEventLogs.Insert(ctx, info)
 }

--- a/enterprise/cmd/frontend/auth/oauth/session.go
+++ b/enterprise/cmd/frontend/auth/oauth/session.go
@@ -59,7 +59,7 @@ func SessionIssuer(s SessionIssuerHelper, sessionKey string) http.Handler {
 			return
 		}
 
-		user, err := db.Users.GetByID(r.Context(), actr.UID)
+		user, err := db.GlobalUsers.GetByID(r.Context(), actr.UID)
 		if err != nil {
 			log15.Error("OAuth failed: error retrieving user from database.", "error", err)
 			http.Error(w, "Authentication failed. Try signing in again (and clearing cookies for the current site). The error was: could not initiate session.", http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/auth/openidconnect/middleware.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/middleware.go
@@ -230,7 +230,7 @@ func authHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		user, err := db.Users.GetByID(r.Context(), actr.UID)
+		user, err := db.GlobalUsers.GetByID(r.Context(), actr.UID)
 		if err != nil {
 			log15.Error("OpenID Connect auth failed: error retrieving user from database.", "error", err)
 			http.Error(w, "Failed to retrieve user: "+err.Error(), http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/auth/saml/middleware.go
@@ -145,7 +145,7 @@ func samlSPHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		user, err := db.Users.GetByID(r.Context(), actor.UID)
+		user, err := db.GlobalUsers.GetByID(r.Context(), actor.UID)
 		if err != nil {
 			log15.Error("Error retrieving SAML-authenticated user from database.", "error", err)
 			http.Error(w, "Failed to retrieve user: "+err.Error(), http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/authz/authz.go
+++ b/enterprise/cmd/frontend/authz/authz.go
@@ -24,8 +24,8 @@ import (
 
 func Init(d dbutil.DB, clock func() time.Time) {
 	// TODO(efritz) - de-globalize assignments in this function
-	db.ExternalServices = edb.NewExternalServicesStore()
-	db.Authz = edb.NewAuthzStore(d, clock)
+	db.GlobalExternalServices = edb.NewExternalServicesStore()
+	db.GlobalAuthz = edb.NewAuthzStore(d, clock)
 
 	// Warn about usage of auth providers that are not enabled by the license.
 	graphqlbackend.AlertFuncs = append(graphqlbackend.AlertFuncs, func(args graphqlbackend.AlertFuncArgs) []*graphqlbackend.Alert {
@@ -39,7 +39,7 @@ func Init(d dbutil.DB, clock func() time.Time) {
 		}
 
 		// We can ignore problems returned here because they would have been surfaced in other places.
-		_, providers, _, _ := eauthz.ProvidersFromConfig(context.Background(), conf.Get(), db.ExternalServices)
+		_, providers, _, _ := eauthz.ProvidersFromConfig(context.Background(), conf.Get(), db.GlobalExternalServices)
 		if len(providers) == 0 {
 			return nil
 		}
@@ -131,7 +131,7 @@ func init() {
 	// Report any authz provider problems in external configs.
 	conf.ContributeWarning(func(cfg conf.Unified) (problems conf.Problems) {
 		_, _, seriousProblems, warnings :=
-			eauthz.ProvidersFromConfig(context.Background(), &cfg, db.ExternalServices)
+			eauthz.ProvidersFromConfig(context.Background(), &cfg, db.GlobalExternalServices)
 		problems = append(problems, conf.NewExternalServiceProblems(seriousProblems...)...)
 		problems = append(problems, conf.NewExternalServiceProblems(warnings...)...)
 		return problems

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -22,7 +22,7 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 		t := time.NewTicker(5 * time.Second)
 		for range t.C {
 			allowAccessByDefault, authzProviders, _, _ :=
-				eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices)
+				eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.GlobalExternalServices)
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -57,7 +57,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 
 		// TODO(asdine): GetByIDs now returns the complete repo information rather that only a subset.
 		// Ensure this doesn't have an impact on performance and switch to using ListRepoNames if needed.
-		r.repos, r.err = db.Repos.GetByIDs(ctx, repoIDs...)
+		r.repos, r.err = db.GlobalRepos.GetByIDs(ctx, repoIDs...)
 		if r.err != nil {
 			return
 		}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -75,7 +75,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		return nil, err
 	}
 	// Make sure the repo ID is valid.
-	if _, err = db.Repos.Get(ctx, repoID); err != nil {
+	if _, err = db.GlobalRepos.Get(ctx, repoID); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +102,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	cfg := globals.PermissionsUserMapping()
 	switch cfg.BindID {
 	case "email":
-		emails, err := db.UserEmails.GetVerifiedEmails(ctx, bindIDs...)
+		emails, err := db.GlobalUserEmails.GetVerifiedEmails(ctx, bindIDs...)
 		if err != nil {
 			return nil, err
 		}
@@ -113,7 +113,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 		}
 
 	case "username":
-		users, err := db.Users.GetByUsernames(ctx, bindIDs...)
+		users, err := db.GlobalUsers.GetByUsernames(ctx, bindIDs...)
 		if err != nil {
 			return nil, err
 		}
@@ -215,10 +215,10 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 	if args.Email != nil {
 		bindID = *args.Email
 		// 🚨 SECURITY: It is critical to ensure the email is verified.
-		user, err = db.Users.GetByVerifiedEmail(ctx, *args.Email)
+		user, err = db.GlobalUsers.GetByVerifiedEmail(ctx, *args.Email)
 	} else if args.Username != nil {
 		bindID = *args.Username
-		user, err = db.Users.GetByUsername(ctx, *args.Username)
+		user, err = db.GlobalUsers.GetByUsername(ctx, *args.Username)
 	} else {
 		return nil, errors.New("neither email nor username is given to identify a user")
 	}
@@ -281,7 +281,7 @@ func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.Rep
 		return nil, err
 	}
 	// Make sure the repo ID is valid.
-	if _, err = db.Repos.Get(ctx, repoID); err != nil {
+	if _, err = db.GlobalRepos.Get(ctx, repoID); err != nil {
 		return nil, err
 	}
 
@@ -337,7 +337,7 @@ func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID)
 		return nil, err
 	}
 	// Make sure the repo ID is valid and not soft-deleted.
-	if _, err = db.Repos.Get(ctx, repoID); err != nil {
+	if _, err = db.GlobalRepos.Get(ctx, repoID); err != nil {
 		return nil, err
 	}
 
@@ -372,7 +372,7 @@ func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (grap
 		return nil, err
 	}
 	// Make sure the user ID is valid and not soft-deleted.
-	if _, err = db.Users.GetByID(ctx, userID); err != nil {
+	if _, err = db.GlobalUsers.GetByID(ctx, userID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/users.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/users.go
@@ -55,7 +55,7 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, *g
 			}
 		}
 
-		r.users, r.err = db.Users.List(ctx, &db.UsersListOptions{
+		r.users, r.err = db.GlobalUsers.List(ctx, &db.UsersListOptions{
 			UserIDs: userIDs,
 		})
 		if r.err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/auth.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/auth.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
 func isSiteAdmin(ctx context.Context) bool {
-	user, err := db.Users.GetByCurrentAuthUser(ctx)
+	user, err := db.GlobalUsers.GetByCurrentAuthUser(ctx)
 	if err != nil {
 		if errcode.IsNotFound(err) || err == db.ErrNoCurrentUser {
 			return false

--- a/enterprise/cmd/frontend/internal/dotcom/billing/customers_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/customers_test.go
@@ -20,7 +20,7 @@ func TestGetOrAssignUserCustomerID(t *testing.T) {
 	}
 	defer func() { mockCreateCustomerID = nil }()
 
-	u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	u, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/billing/db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/db_test.go
@@ -18,7 +18,7 @@ func TestDBUsersBillingCustomerID(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("existing user", func(t *testing.T) {
-		u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+		u, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_expiration.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/license_expiration.go
@@ -100,7 +100,7 @@ func checkLastSubscriptionLicense(ctx context.Context, s *dbSubscription, clock 
 		return
 	}
 
-	user, err := db.Users.GetByID(ctx, s.UserID)
+	user, err := db.GlobalUsers.GetByID(ctx, s.UserID)
 	if err != nil {
 		log15.Error("startCheckForUpcomingLicenseExpirations: error looking up user", "error", err)
 		return

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_db_test.go
@@ -12,7 +12,7 @@ func TestProductLicenses_Create(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	u, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestProductLicenses_List(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	u1, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
+	u1, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u1"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_db_test.go
@@ -13,7 +13,7 @@ func TestProductSubscriptions_Create(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	u, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,11 +61,11 @@ func TestProductSubscriptions_List(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	u1, err := db.Users.Create(ctx, db.NewUser{Username: "u1"})
+	u1, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u1"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	u2, err := db.Users.Create(ctx, db.NewUser{Username: "u2"})
+	u2, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestProductSubscriptions_Update(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	u, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	u, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -25,15 +25,15 @@ import (
 func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
-	db.Users.BeforeCreateUser = enforcement.NewBeforeCreateUserHook(&usersStore{})
+	db.GlobalUsers.BeforeCreateUser = enforcement.NewBeforeCreateUserHook(&usersStore{})
 
 	// Enforce non-site admin roles in Free tier.
-	db.Users.AfterCreateUser = enforcement.NewAfterCreateUserHook()
-	db.Users.BeforeSetUserIsSiteAdmin = enforcement.NewBeforeSetUserIsSiteAdmin()
+	db.GlobalUsers.AfterCreateUser = enforcement.NewAfterCreateUserHook()
+	db.GlobalUsers.BeforeSetUserIsSiteAdmin = enforcement.NewBeforeSetUserIsSiteAdmin()
 
 	// Enforce the license's max external service count by preventing the creation of new external
 	// services when the max is reached.
-	db.ExternalServices.PreCreateExternalService = enforcement.NewPreCreateExternalServiceHook(&externalServicesStore{})
+	db.GlobalExternalServices.PreCreateExternalService = enforcement.NewPreCreateExternalServiceHook(&externalServicesStore{})
 
 	// Enforce the license's feature check for monitoring. If the license does not support the monitoring
 	// feature, then alternative debug handlers will be invoked.
@@ -114,11 +114,11 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 type usersStore struct{}
 
 func (usersStore) Count(ctx context.Context) (int, error) {
-	return db.Users.Count(ctx, nil)
+	return db.GlobalUsers.Count(ctx, nil)
 }
 
 type externalServicesStore struct{}
 
 func (externalServicesStore) Count(ctx context.Context, opts db.ExternalServicesListOptions) (int, error) {
-	return db.ExternalServices.Count(ctx, opts)
+	return db.GlobalExternalServices.Count(ctx, opts)
 }

--- a/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db_test.go
@@ -44,7 +44,7 @@ func TestRegistryExtensions_validNames(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,11 +117,11 @@ func TestRegistryExtensions(t *testing.T) {
 		}
 	}
 
-	user, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	org, err := db.Orgs.Create(ctx, "o", nil)
+	org, err := db.GlobalOrgs.Create(ctx, "o", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +359,7 @@ func TestRegistryExtensions_ListCount(t *testing.T) {
 		}
 	}
 
-	user, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -33,7 +33,7 @@ func extensionRegistryViewerPublishers(ctx context.Context) ([]graphqlbackend.Re
 	}
 	publishers = append(publishers, &registryPublisher{user: user})
 
-	orgs, err := db.Orgs.GetByUserID(ctx, user.DatabaseID())
+	orgs, err := db.GlobalOrgs.GetByUserID(ctx, user.DatabaseID())
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/registry/releases_db_test.go
+++ b/enterprise/cmd/frontend/internal/registry/releases_db_test.go
@@ -18,7 +18,7 @@ func TestRegistryExtensionReleases(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user, err := db.Users.Create(ctx, db.NewUser{Username: "u"})
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/precise-code-intel-worker/main.go
+++ b/enterprise/cmd/precise-code-intel-worker/main.go
@@ -125,7 +125,7 @@ func mustInitializeDB() *sql.DB {
 	ctx := context.Background()
 	go func() {
 		for range time.NewTicker(5 * time.Second).C {
-			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.ExternalServices)
+			allowAccessByDefault, authzProviders, _, _ := eiauthz.ProvidersFromConfig(ctx, conf.Get(), db.GlobalExternalServices)
 			authz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/cmd/repo-updater/authz/integration_test.go
+++ b/enterprise/cmd/repo-updater/authz/integration_test.go
@@ -118,7 +118,7 @@ func TestIntegration_GitHubPermissions(t *testing.T) {
 		ServiceID:   "https://github.com/",
 		AccountID:   "66464926",
 	}
-	userID, err := db.ExternalAccounts.CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
+	userID, err := db.GlobalExternalAccounts.CreateUserAndSave(ctx, newUser, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -182,7 +182,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 	ctx, save := s.observe(ctx, "PermsSyncer.syncUserPerms", "")
 	defer save(requestTypeUser, userID, &err)
 
-	user, err := db.Users.GetByID(ctx, userID)
+	user, err := db.GlobalUsers.GetByID(ctx, userID)
 	if err != nil {
 		return errors.Wrap(err, "get user")
 	}
@@ -222,7 +222,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			continue
 		}
 
-		err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID, acct.AccountSpec, acct.AccountData)
+		err = db.GlobalExternalAccounts.AssociateUserAndSave(ctx, user.ID, acct.AccountSpec, acct.AccountData)
 		if err != nil {
 			log15.Error("Could not associate external account to user",
 				"userID", user.ID,
@@ -255,7 +255,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			accountSuspended := errcode.IsAccountSuspended(errors.Cause(err))
 
 			if unauthorized || accountSuspended {
-				err = db.ExternalAccounts.TouchExpired(ctx, acct.ID)
+				err = db.GlobalExternalAccounts.TouchExpired(ctx, acct.ID)
 				if err != nil {
 					return errors.Wrapf(err, "set expired for external account %d", acct.ID)
 				}
@@ -273,7 +273,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			}
 			log15.Warn("PermsSyncer.syncUserPerms.proceedWithPartialResults", "userID", user.ID, "error", err)
 		} else {
-			err = db.ExternalAccounts.TouchLastValid(ctx, acct.ID)
+			err = db.GlobalExternalAccounts.TouchLastValid(ctx, acct.ID)
 			if err != nil {
 				return errors.Wrapf(err, "set last valid for external account %d", acct.ID)
 			}

--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -71,7 +71,7 @@ func startBackgroundPermsSync(ctx context.Context, syncer *authz.PermsSyncer, db
 		t := time.NewTicker(5 * time.Second)
 		for range t.C {
 			allowAccessByDefault, authzProviders, _, _ :=
-				frontendAuthz.ProvidersFromConfig(ctx, conf.Get(), ossDB.ExternalServices)
+				frontendAuthz.ProvidersFromConfig(ctx, conf.Get(), ossDB.GlobalExternalServices)
 			ossAuthz.SetProviders(allowAccessByDefault, authzProviders)
 		}
 	}()

--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -608,11 +608,11 @@ func loadCampaign(ctx context.Context, tx getCampaigner, id int64) (*campaigns.C
 }
 
 func loadUser(ctx context.Context, id int32) (*types.User, error) {
-	return db.Users.GetByID(ctx, id)
+	return db.GlobalUsers.GetByID(ctx, id)
 }
 
 func loadUserCredential(ctx context.Context, userID int32, repo *types.Repo) (*db.UserCredential, error) {
-	return db.UserCredentials.GetByScope(ctx, db.UserCredentialScope{
+	return db.GlobalUserCredentials.GetByScope(ctx, db.UserCredentialScope{
 		Domain:              db.UserCredentialDomainCampaigns,
 		UserID:              userID,
 		ExternalServiceType: repo.ExternalRepo.ServiceType,
@@ -628,7 +628,7 @@ func decorateChangesetBody(ctx context.Context, tx getCampaigner, cs *repos.Chan
 
 	// We need to get the namespace, since external campaign URLs are
 	// namespaced.
-	ns, err := db.Namespaces.GetByID(ctx, campaign.NamespaceOrgID, campaign.NamespaceUserID)
+	ns, err := db.GlobalNamespaces.GetByID(ctx, campaign.NamespaceOrgID, campaign.NamespaceUserID)
 	if err != nil {
 		return errors.Wrap(err, "retrieving namespace")
 	}

--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -658,7 +658,7 @@ func TestExecutor_LoadAuthenticator(t *testing.T) {
 
 	t.Run("owned by admin user with credential", func(t *testing.T) {
 		token := &auth.OAuthBearerToken{Token: "abcdef"}
-		if _, err := db.UserCredentials.Create(ctx, db.UserCredentialScope{
+		if _, err := db.GlobalUserCredentials.Create(ctx, db.UserCredentialScope{
 			Domain:              db.UserCredentialDomainCampaigns,
 			UserID:              admin.ID,
 			ExternalServiceType: repo.ExternalRepo.ServiceType,
@@ -684,7 +684,7 @@ func TestExecutor_LoadAuthenticator(t *testing.T) {
 
 	t.Run("owned by normal user with credential", func(t *testing.T) {
 		token := &auth.OAuthBearerToken{Token: "abcdef"}
-		if _, err := db.UserCredentials.Create(ctx, db.UserCredentialScope{
+		if _, err := db.GlobalUserCredentials.Create(ctx, db.UserCredentialScope{
 			Domain:              db.UserCredentialDomainCampaigns,
 			UserID:              user.ID,
 			ExternalServiceType: repo.ExternalRepo.ServiceType,
@@ -828,7 +828,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.credentials != nil {
-				cred, err := db.UserCredentials.Create(ctx, db.UserCredentialScope{
+				cred, err := db.GlobalUserCredentials.Create(ctx, db.UserCredentialScope{
 					Domain:              db.UserCredentialDomainCampaigns,
 					UserID:              tt.user.ID,
 					ExternalServiceType: tt.repo.ExternalRepo.ServiceType,
@@ -837,7 +837,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer func() { db.UserCredentials.Delete(ctx, cred.ID) }()
+				defer func() { db.GlobalUserCredentials.Delete(ctx, cred.ID) }()
 			}
 
 			campaignSpec := ct.CreateCampaignSpec(t, ctx, store, fmt.Sprintf("reconciler-credentials-%d", i), tt.user.ID)

--- a/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
@@ -183,7 +183,7 @@ func TestCampaignsListing(t *testing.T) {
 	userID := ct.CreateTestUser(t, true).ID
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
-	org, err := db.Orgs.Create(ctx, "org", nil)
+	org, err := db.GlobalOrgs.Create(ctx, "org", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -43,7 +43,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 	orgname := "test-org"
 	userID := ct.CreateTestUser(t, false).ID
 	adminID := ct.CreateTestUser(t, true).ID
-	org, err := db.Orgs.Create(ctx, orgname, nil)
+	org, err := db.GlobalOrgs.Create(ctx, orgname, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 	}
 
 	// Now soft-delete the creator and check that the campaign spec is still retrievable.
-	err = db.Users.Delete(ctx, userID)
+	err = db.GlobalUsers.Delete(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 	}
 
 	// Now hard-delete the creator and check that the campaign spec is still retrievable.
-	err = db.Users.HardDelete(ctx, userID)
+	err = db.GlobalUsers.HardDelete(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -29,7 +29,7 @@ func TestCampaignResolver(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 
 	userID := ct.CreateTestUser(t, true).ID
-	org, err := db.Orgs.Create(ctx, "test-campaign-resolver-org", nil)
+	org, err := db.GlobalOrgs.Create(ctx, "test-campaign-resolver-org", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestCampaignResolver(t *testing.T) {
 	}
 
 	// Now soft-delete the user and check we can still access the campaign in the org namespace.
-	err = db.Users.Delete(ctx, userID)
+	err = db.GlobalUsers.Delete(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestCampaignResolver(t *testing.T) {
 	}
 
 	// Now hard-delete the user and check we can still access the campaign in the org namespace.
-	err = db.Users.HardDelete(ctx, userID)
+	err = db.GlobalUsers.HardDelete(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -98,7 +98,7 @@ func (r *changesetsConnectionResolver) compute(ctx context.Context) (allChangese
 
 		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		r.reposByID, err = db.Repos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
+		r.reposByID, err = db.GlobalRepos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
 		if err != nil {
 			r.err = err
 			return

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -44,7 +44,7 @@ func NewChangesetSpecResolver(ctx context.Context, store *store.Store, changeset
 	// filters out repositories that the user doesn't have access to.
 	// In case we don't find a repository, it might be because it's deleted
 	// or because the user doesn't have access.
-	rs, err := db.Repos.GetByIDs(ctx, changesetSpec.RepoID)
+	rs, err := db.GlobalRepos.GetByIDs(ctx, changesetSpec.RepoID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -86,7 +86,7 @@ func (r *changesetSpecConnectionResolver) compute(ctx context.Context) (campaign
 
 		// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		r.reposByID, r.err = db.Repos.GetReposSetByIDs(ctx, r.changesetSpecs.RepoIDs()...)
+		r.reposByID, r.err = db.GlobalRepos.GetReposSetByIDs(ctx, r.changesetSpecs.RepoIDs()...)
 	})
 
 	return r.changesetSpecs, r.reposByID, r.next, r.err

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -34,7 +34,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 	esStore := db.NewExternalServicesStoreWith(cstore)
 
 	// Creating user with matching email to the changeset spec author.
-	user, err := db.Users.Create(ctx, db.NewUser{
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{
 		Username:        "mary",
 		Email:           ct.ChangesetSpecAuthorEmail,
 		EmailIsVerified: true,

--- a/enterprise/internal/campaigns/resolvers/code_host_connection.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection.go
@@ -79,7 +79,7 @@ func (c *campaignsCodeHostConnectionResolver) compute(ctx context.Context) (all,
 		}
 
 		// Fetch all user credentials to avoid N+1 per credential resolver.
-		creds, _, err := db.UserCredentials.List(ctx, db.UserCredentialsListOpts{Scope: db.UserCredentialScope{Domain: db.UserCredentialDomainCampaigns, UserID: c.userID}})
+		creds, _, err := db.GlobalUserCredentials.List(ctx, db.UserCredentialsListOpts{Scope: db.UserCredentialScope{Domain: db.UserCredentialDomainCampaigns, UserID: c.userID}})
 		if err != nil {
 			c.chsErr = err
 			return

--- a/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
@@ -42,7 +42,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 	bbsRepos, _ := ct.CreateBbsTestRepos(t, ctx, dbconn.Global, 1)
 	bbsRepo := bbsRepos[0]
 
-	cred, err := db.UserCredentials.Create(ctx, db.UserCredentialScope{
+	cred, err := db.GlobalUserCredentials.Create(ctx, db.UserCredentialScope{
 		Domain:              db.UserCredentialDomainCampaigns,
 		ExternalServiceID:   ghRepo.ExternalRepo.ServiceID,
 		ExternalServiceType: ghRepo.ExternalRepo.ServiceType,

--- a/enterprise/internal/campaigns/resolvers/main_test.go
+++ b/enterprise/internal/campaigns/resolvers/main_test.go
@@ -231,12 +231,12 @@ func addChangeset(t *testing.T, ctx context.Context, s *store.Store, c *campaign
 
 func pruneUserCredentials(t *testing.T) {
 	t.Helper()
-	creds, _, err := db.UserCredentials.List(context.Background(), db.UserCredentialsListOpts{})
+	creds, _, err := db.GlobalUserCredentials.List(context.Background(), db.UserCredentialsListOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, c := range creds {
-		if err := db.UserCredentials.Delete(context.Background(), c.ID); err != nil {
+		if err := db.GlobalUserCredentials.Delete(context.Background(), c.ID); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -340,7 +340,7 @@ func TestPermissionLevels(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					pruneUserCredentials(t)
 
-					cred, err := db.UserCredentials.Create(ctx, db.UserCredentialScope{
+					cred, err := db.GlobalUserCredentials.Create(ctx, db.UserCredentialScope{
 						Domain:              db.UserCredentialDomainCampaigns,
 						ExternalServiceID:   "https://github.com/",
 						ExternalServiceType: extsvc.TypeGitHub,
@@ -407,7 +407,7 @@ func TestPermissionLevels(t *testing.T) {
 				t.Run(tc.name, func(t *testing.T) {
 					pruneUserCredentials(t)
 
-					cred, err := db.UserCredentials.Create(ctx, db.UserCredentialScope{
+					cred, err := db.GlobalUserCredentials.Create(ctx, db.UserCredentialScope{
 						Domain:              db.UserCredentialDomainCampaigns,
 						ExternalServiceID:   "https://github.com/",
 						ExternalServiceType: extsvc.TypeGitHub,

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -110,7 +110,7 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 
 	// 🚨 SECURITY: db.Repos.Get uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
-	repo, err := db.Repos.Get(ctx, changeset.RepoID)
+	repo, err := db.GlobalRepos.Get(ctx, changeset.RepoID)
 	if err != nil && !errcode.IsNotFound(err) {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func (r *Resolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (
 		return nil, nil
 	}
 
-	cred, err := db.UserCredentials.GetByID(ctx, dbID)
+	cred, err := db.GlobalUserCredentials.GetByID(ctx, dbID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return nil, nil
@@ -818,7 +818,7 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 	}
 
 	// Throw error documented in schema.graphql.
-	existing, err := db.UserCredentials.GetByScope(ctx, scope)
+	existing, err := db.GlobalUserCredentials.GetByScope(ctx, scope)
 	if err != nil && !errcode.IsNotFound(err) {
 		return nil, err
 	}
@@ -838,7 +838,7 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 		a = &auth.OAuthBearerToken{Token: args.Credential}
 	}
 
-	cred, err := db.UserCredentials.Create(ctx, scope, a)
+	cred, err := db.GlobalUserCredentials.Create(ctx, scope, a)
 	if err != nil {
 		return nil, err
 	}
@@ -866,7 +866,7 @@ func (r *Resolver) DeleteCampaignsCredential(ctx context.Context, args *graphqlb
 	}
 
 	// Get existing credential.
-	cred, err := db.UserCredentials.GetByID(ctx, dbID)
+	cred, err := db.GlobalUserCredentials.GetByID(ctx, dbID)
 	if err != nil {
 		return nil, err
 	}
@@ -877,7 +877,7 @@ func (r *Resolver) DeleteCampaignsCredential(ctx context.Context, args *graphqlb
 	}
 
 	// This also fails if the credential was not found.
-	if err := db.UserCredentials.Delete(ctx, dbID); err != nil {
+	if err := db.GlobalUserCredentials.Delete(ctx, dbID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -854,7 +854,7 @@ func TestDeleteCampaignsCredential(t *testing.T) {
 
 	userID := ct.CreateTestUser(t, true).ID
 
-	cred, err := db.UserCredentials.Create(ctx, db.UserCredentialScope{
+	cred, err := db.GlobalUserCredentials.Create(ctx, db.UserCredentialScope{
 		Domain:              db.UserCredentialDomainCampaigns,
 		ExternalServiceType: extsvc.TypeGitHub,
 		ExternalServiceID:   "https://github.com/",

--- a/enterprise/internal/campaigns/service/service.go
+++ b/enterprise/internal/campaigns/service/service.go
@@ -92,7 +92,7 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 
 	// 🚨 SECURITY: db.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
-	accessibleReposByID, err := db.Repos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
+	accessibleReposByID, err := db.GlobalRepos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (s *Service) CreateChangesetSpec(ctx context.Context, rawSpec string, userI
 
 	// 🚨 SECURITY: We use db.Repos.Get to check whether the user has access to
 	// the repository or not.
-	if _, err = db.Repos.Get(ctx, spec.RepoID); err != nil {
+	if _, err = db.GlobalRepos.Get(ctx, spec.RepoID); err != nil {
 		return nil, err
 	}
 
@@ -381,7 +381,7 @@ func (s *Service) EnqueueChangesetSync(ctx context.Context, id int64) (err error
 
 	// 🚨 SECURITY: We use db.Repos.Get to check whether the user has access to
 	// the repository or not.
-	if _, err = db.Repos.Get(ctx, changeset.RepoID); err != nil {
+	if _, err = db.GlobalRepos.Get(ctx, changeset.RepoID); err != nil {
 		return err
 	}
 

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -452,7 +452,7 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("missing access to namespace org", func(t *testing.T) {
-			org, err := db.Orgs.Create(ctx, "test-org", nil)
+			org, err := db.GlobalOrgs.Create(ctx, "test-org", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -471,7 +471,7 @@ func TestService(t *testing.T) {
 			}
 
 			// Create org membership and try again
-			if _, err := db.OrgMembers.Create(ctx, org.ID, user.ID); err != nil {
+			if _, err := db.GlobalOrgMembers.Create(ctx, org.ID, user.ID); err != nil {
 				t.Fatal(err)
 			}
 
@@ -646,7 +646,7 @@ func TestService(t *testing.T) {
 		t.Run("new org namespace", func(t *testing.T) {
 			campaign := createCampaign(t, "old-name", admin.ID, admin.ID, 0)
 
-			org, err := db.Orgs.Create(ctx, "org", nil)
+			org, err := db.GlobalOrgs.Create(ctx, "org", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -669,7 +669,7 @@ func TestService(t *testing.T) {
 		t.Run("new org namespace but current user is missing access", func(t *testing.T) {
 			campaign := createCampaign(t, "old-name", user.ID, user.ID, 0)
 
-			org, err := db.Orgs.Create(ctx, "org-no-access", nil)
+			org, err := db.GlobalOrgs.Create(ctx, "org-no-access", nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/enterprise/internal/campaigns/state/state.go
+++ b/enterprise/internal/campaigns/state/state.go
@@ -612,7 +612,7 @@ func computeRev(ctx context.Context, repo api.RepoName, getOid, getRef func() (s
 // changesetRepoName looks up a api.RepoName based on the RepoID within a changeset.
 func changesetRepoName(ctx context.Context, c *campaigns.Changeset) (api.RepoName, error) {
 	// We need to use an internal actor here as the repo-updater otherwise has no access to the repo.
-	repo, err := db.Repos.Get(actor.WithActor(ctx, &actor.Actor{Internal: true}), c.RepoID)
+	repo, err := db.GlobalRepos.Get(actor.WithActor(ctx, &actor.Actor{Internal: true}), c.RepoID)
 	if err != nil {
 		return "", err
 	}

--- a/enterprise/internal/campaigns/store/changeset_specs.go
+++ b/enterprise/internal/campaigns/store/changeset_specs.go
@@ -424,7 +424,7 @@ func (rm RewirerMappings) Hydrate(ctx context.Context, store *Store) error {
 	if err != nil {
 		return err
 	}
-	accessibleReposByID, err := db.Repos.GetReposSetByIDs(ctx, rm.RepoIDs()...)
+	accessibleReposByID, err := db.GlobalRepos.GetReposSetByIDs(ctx, rm.RepoIDs()...)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/codemonitors/resolvers/resolvers_test.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers_test.go
@@ -188,7 +188,7 @@ func TestIsAllowedToEdit(t *testing.T) {
 	siteAdmin := insertTestUser(t, dbconn.Global, "cm-user3", true)
 
 	admContext := actor.WithActor(context.Background(), actor.FromUser(siteAdmin))
-	org, err := db.Orgs.Create(admContext, "cm-test-org", nil)
+	org, err := db.GlobalOrgs.Create(admContext, "cm-test-org", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestIsAllowedToCreate(t *testing.T) {
 	siteAdmin := insertTestUser(t, dbconn.Global, "cm-user3", true)
 
 	admContext := actor.WithActor(context.Background(), actor.FromUser(siteAdmin))
-	org, err := db.Orgs.Create(admContext, "cm-test-org", nil)
+	org, err := db.GlobalOrgs.Create(admContext, "cm-test-org", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/db/authz.go
+++ b/enterprise/internal/db/authz.go
@@ -61,7 +61,7 @@ func (s *authzStore) GrantPendingPermissions(ctx context.Context, args *db.Grant
 	switch cfg.BindID {
 	case "email":
 		// 🚨 SECURITY: It is critical to ensure only grant emails that are verified.
-		emails, err := db.UserEmails.ListByUser(ctx, db.UserEmailsListOptions{
+		emails, err := db.GlobalUserEmails.ListByUser(ctx, db.UserEmailsListOptions{
 			UserID:       args.UserID,
 			OnlyVerified: true,
 		})
@@ -79,7 +79,7 @@ func (s *authzStore) GrantPendingPermissions(ctx context.Context, args *db.Grant
 		}
 
 	case "username":
-		user, err := db.Users.GetByID(ctx, args.UserID)
+		user, err := db.GlobalUsers.GetByID(ctx, args.UserID)
 		if err != nil {
 			return errors.Wrap(err, "get user")
 		}

--- a/enterprise/internal/db/authz_test.go
+++ b/enterprise/internal/db/authz_test.go
@@ -22,7 +22,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user with initially verified email
-	user, err := db.Users.Create(ctx, db.NewUser{
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{
 		Email:           "alice@example.com",
 		Username:        "alice",
 		EmailIsVerified: true,
@@ -34,23 +34,23 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	code := "verify-code"
 
 	// Add and verify the second email
-	err = db.UserEmails.Add(ctx, user.ID, "alice2@example.com", &code)
+	err = db.GlobalUserEmails.Add(ctx, user.ID, "alice2@example.com", &code)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = db.UserEmails.SetVerified(ctx, user.ID, "alice2@example.com", true)
+	err = db.GlobalUserEmails.SetVerified(ctx, user.ID, "alice2@example.com", true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add third email and leave as unverified
-	err = db.UserEmails.Add(ctx, user.ID, "alice3@example.com", &code)
+	err = db.GlobalUserEmails.Add(ctx, user.ID, "alice3@example.com", &code)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Add two external accounts
-	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
+	err = db.GlobalExternalAccounts.AssociateUserAndSave(ctx, user.ID,
 		extsvc.AccountSpec{
 			ServiceType: "gitlab",
 			ServiceID:   "https://gitlab.com/",
@@ -61,7 +61,7 @@ func TestAuthzStore_GrantPendingPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = db.ExternalAccounts.AssociateUserAndSave(ctx, user.ID,
+	err = db.GlobalExternalAccounts.AssociateUserAndSave(ctx, user.ID,
 		extsvc.AccountSpec{
 			ServiceType: "github",
 			ServiceID:   "https://github.com/",

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -38,7 +38,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 		},
 	}
 	for {
-		svcs, err := db.ExternalServices.List(ctx, opt)
+		svcs, err := db.GlobalExternalServices.List(ctx, opt)
 		if err != nil {
 			return "", errors.Wrap(err, "list")
 		}

--- a/internal/db/access_tokens_test.go
+++ b/internal/db/access_tokens_test.go
@@ -14,7 +14,7 @@ func TestAccessTokens_Create(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	subject, err := Users.Create(ctx, NewUser{
+	subject, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@example.com",
 		Username:              "u1",
 		Password:              "p1",
@@ -24,7 +24,7 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	creator, err := Users.Create(ctx, NewUser{
+	creator, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a2@example.com",
 		Username:              "u2",
 		Password:              "p2",
@@ -34,12 +34,12 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tid0, tv0, err := AccessTokens.Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
+	tid0, tv0, err := GlobalAccessTokens.Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := AccessTokens.GetByID(ctx, tid0)
+	got, err := GlobalAccessTokens.GetByID(ctx, tid0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Errorf("got %q, want %q", got.Note, want)
 	}
 
-	gotSubjectUserID, err := AccessTokens.Lookup(ctx, tv0, "a")
+	gotSubjectUserID, err := GlobalAccessTokens.Lookup(ctx, tv0, "a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestAccessTokens_Create(t *testing.T) {
 		t.Errorf("got %v, want %v", gotSubjectUserID, want)
 	}
 
-	ts, err := AccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: subject.ID})
+	ts, err := GlobalAccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: subject.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestAccessTokens_Create(t *testing.T) {
 	}
 
 	// Accidentally passing the creator's UID in SubjectUserID should not return anything.
-	ts, err = AccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: creator.ID})
+	ts, err = GlobalAccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: creator.ID})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestAccessTokens_List(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	subject1, err := Users.Create(ctx, NewUser{
+	subject1, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@example.com",
 		Username:              "u1",
 		Password:              "p1",
@@ -98,7 +98,7 @@ func TestAccessTokens_List(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	subject2, err := Users.Create(ctx, NewUser{
+	subject2, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a2@example.com",
 		Username:              "u2",
 		Password:              "p2",
@@ -108,25 +108,25 @@ func TestAccessTokens_List(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = AccessTokens.Create(ctx, subject1.ID, []string{"a", "b"}, "n0", subject1.ID)
+	_, _, err = GlobalAccessTokens.Create(ctx, subject1.ID, []string{"a", "b"}, "n0", subject1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, _, err = AccessTokens.Create(ctx, subject1.ID, []string{"a", "b"}, "n1", subject1.ID)
+	_, _, err = GlobalAccessTokens.Create(ctx, subject1.ID, []string{"a", "b"}, "n1", subject1.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	{
 		// List all tokens.
-		ts, err := AccessTokens.List(ctx, AccessTokensListOptions{})
+		ts, err := GlobalAccessTokens.List(ctx, AccessTokensListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		if want := 2; len(ts) != want {
 			t.Errorf("got %d access tokens, want %d", len(ts), want)
 		}
-		count, err := AccessTokens.Count(ctx, AccessTokensListOptions{})
+		count, err := GlobalAccessTokens.Count(ctx, AccessTokensListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -137,7 +137,7 @@ func TestAccessTokens_List(t *testing.T) {
 
 	{
 		// List subject1's tokens.
-		ts, err := AccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: subject1.ID})
+		ts, err := GlobalAccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: subject1.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -148,7 +148,7 @@ func TestAccessTokens_List(t *testing.T) {
 
 	{
 		// List subject2's tokens.
-		ts, err := AccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: subject2.ID})
+		ts, err := GlobalAccessTokens.List(ctx, AccessTokensListOptions{SubjectUserID: subject2.ID})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,7 +167,7 @@ func TestAccessTokens_Lookup(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	subject, err := Users.Create(ctx, NewUser{
+	subject, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@example.com",
 		Username:              "u1",
 		Password:              "p1",
@@ -177,7 +177,7 @@ func TestAccessTokens_Lookup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	creator, err := Users.Create(ctx, NewUser{
+	creator, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "u2@example.com",
 		Username:              "u2",
 		Password:              "p2",
@@ -187,13 +187,13 @@ func TestAccessTokens_Lookup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tid0, tv0, err := AccessTokens.Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
+	tid0, tv0, err := GlobalAccessTokens.Create(ctx, subject.ID, []string{"a", "b"}, "n0", creator.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, scope := range []string{"a", "b"} {
-		gotSubjectUserID, err := AccessTokens.Lookup(ctx, tv0, scope)
+		gotSubjectUserID, err := GlobalAccessTokens.Lookup(ctx, tv0, scope)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -203,25 +203,25 @@ func TestAccessTokens_Lookup(t *testing.T) {
 	}
 
 	// Lookup with a nonexistent scope and ensure it fails.
-	if _, err := AccessTokens.Lookup(ctx, tv0, "x"); err == nil {
+	if _, err := GlobalAccessTokens.Lookup(ctx, tv0, "x"); err == nil {
 		t.Fatal(err)
 	}
 
 	// Lookup with an empty scope and ensure it fails.
-	if _, err := AccessTokens.Lookup(ctx, tv0, ""); err == nil {
+	if _, err := GlobalAccessTokens.Lookup(ctx, tv0, ""); err == nil {
 		t.Fatal(err)
 	}
 
 	// Delete a token and ensure Lookup fails on it.
-	if err := AccessTokens.DeleteByID(ctx, tid0, subject.ID); err != nil {
+	if err := GlobalAccessTokens.DeleteByID(ctx, tid0, subject.ID); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := AccessTokens.Lookup(ctx, tv0, "a"); err == nil {
+	if _, err := GlobalAccessTokens.Lookup(ctx, tv0, "a"); err == nil {
 		t.Fatal(err)
 	}
 
 	// Try to Lookup a token that was never created.
-	if _, err := AccessTokens.Lookup(ctx, "abcdefg" /* this token value was never created */, "a"); err == nil {
+	if _, err := GlobalAccessTokens.Lookup(ctx, "abcdefg" /* this token value was never created */, "a"); err == nil {
 		t.Fatal(err)
 	}
 }
@@ -236,7 +236,7 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("subject", func(t *testing.T) {
-		subject, err := Users.Create(ctx, NewUser{
+		subject, err := GlobalUsers.Create(ctx, NewUser{
 			Email:                 "u1@example.com",
 			Username:              "u1",
 			Password:              "p1",
@@ -245,7 +245,7 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		creator, err := Users.Create(ctx, NewUser{
+		creator, err := GlobalUsers.Create(ctx, NewUser{
 			Email:                 "u2@example.com",
 			Username:              "u2",
 			Password:              "p2",
@@ -255,24 +255,24 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, tv0, err := AccessTokens.Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
+		_, tv0, err := GlobalAccessTokens.Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := Users.Delete(ctx, subject.ID); err != nil {
+		if err := GlobalUsers.Delete(ctx, subject.ID); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := AccessTokens.Lookup(ctx, tv0, "a"); err == nil {
+		if _, err := GlobalAccessTokens.Lookup(ctx, tv0, "a"); err == nil {
 			t.Fatal("Lookup: want error looking up token for deleted subject user")
 		}
 
-		if _, _, err := AccessTokens.Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
+		if _, _, err := GlobalAccessTokens.Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
 			t.Fatal("Create: want error creating token for deleted subject user")
 		}
 	})
 
 	t.Run("creator", func(t *testing.T) {
-		subject, err := Users.Create(ctx, NewUser{
+		subject, err := GlobalUsers.Create(ctx, NewUser{
 			Email:                 "u3@example.com",
 			Username:              "u3",
 			Password:              "p3",
@@ -281,7 +281,7 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		creator, err := Users.Create(ctx, NewUser{
+		creator, err := GlobalUsers.Create(ctx, NewUser{
 			Email:                 "u4@example.com",
 			Username:              "u4",
 			Password:              "p4",
@@ -291,18 +291,18 @@ func TestAccessTokens_Lookup_deletedUser(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, tv0, err := AccessTokens.Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
+		_, tv0, err := GlobalAccessTokens.Create(ctx, subject.ID, []string{"a"}, "n0", creator.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := Users.Delete(ctx, creator.ID); err != nil {
+		if err := GlobalUsers.Delete(ctx, creator.ID); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := AccessTokens.Lookup(ctx, tv0, "a"); err == nil {
+		if _, err := GlobalAccessTokens.Lookup(ctx, tv0, "a"); err == nil {
 			t.Fatal("Lookup: want error looking up token for deleted creator user")
 		}
 
-		if _, _, err := AccessTokens.Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
+		if _, _, err := GlobalAccessTokens.Create(ctx, subject.ID, nil, "n0", creator.ID); err == nil {
 			t.Fatal("Create: want error creating token for deleted creator user")
 		}
 	})

--- a/internal/db/default_repos.go
+++ b/internal/db/default_repos.go
@@ -114,7 +114,7 @@ func (s *DefaultRepoStore) refreshCache(ctx context.Context) ([]*types.RepoName,
 		return repos, nil
 	}
 
-	repos, err := Repos.With(s).ListAllDefaultRepos(ctx)
+	repos, err := GlobalRepos.With(s).ListAllDefaultRepos(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "querying for default repos")
 	}

--- a/internal/db/default_repos_test.go
+++ b/internal/db/default_repos_test.go
@@ -62,9 +62,9 @@ func TestListDefaultRepos(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			DefaultRepos.resetCache()
+			GlobalDefaultRepos.resetCache()
 
-			repos, err := DefaultRepos.List(ctx)
+			repos, err := GlobalDefaultRepos.List(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -98,9 +98,9 @@ func TestListDefaultRepos(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		DefaultRepos.resetCache()
+		GlobalDefaultRepos.resetCache()
 
-		repos, err := DefaultRepos.List(ctx)
+		repos, err := GlobalDefaultRepos.List(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -153,7 +153,7 @@ func TestListDefaultReposInBatches(t *testing.T) {
 		}
 	}
 
-	repos, err := Repos.listAllDefaultRepos(ctx, 2)
+	repos, err := GlobalRepos.listAllDefaultRepos(ctx, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +197,7 @@ func TestListDefaultReposUncloned(t *testing.T) {
 		}
 	}
 
-	repos, err := Repos.ListDefaultRepos(ctx, ListDefaultReposOptions{
+	repos, err := GlobalRepos.ListDefaultRepos(ctx, ListDefaultReposOptions{
 		Limit:        3,
 		AfterID:      0,
 		OnlyUncloned: true,
@@ -223,7 +223,7 @@ func BenchmarkDefaultRepos_List_Empty(b *testing.B) {
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err := DefaultRepos.List(ctx)
+		_, err := GlobalDefaultRepos.List(ctx)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/db/event_logs_test.go
+++ b/internal/db/event_logs_test.go
@@ -53,7 +53,7 @@ func TestEventLogs_ValidInfo(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := EventLogs.Insert(ctx, tc.event)
+			err := GlobalEventLogs.Insert(ctx, tc.event)
 
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("have %+v, want %+v", have, want)
@@ -92,12 +92,12 @@ func TestEventLogs_CountUniqueUsersPerPeriod(t *testing.T) {
 	}
 
 	for _, e := range events {
-		if err := EventLogs.Insert(ctx, e); err != nil {
+		if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	values, err := EventLogs.CountUniqueUsersPerPeriod(ctx, Daily, now, 3, nil)
+	values, err := GlobalEventLogs.CountUniqueUsersPerPeriod(ctx, Daily, now, 3, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +136,7 @@ func TestEventLogs_UsersUsageCounts(t *testing.T) {
 						Timestamp: day.Add(time.Minute * time.Duration(rand.Intn(60*12))),
 					}
 
-					if err := EventLogs.Insert(ctx, e); err != nil {
+					if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -144,7 +144,7 @@ func TestEventLogs_UsersUsageCounts(t *testing.T) {
 		}
 	}
 
-	have, err := EventLogs.UsersUsageCounts(ctx)
+	have, err := GlobalEventLogs.UsersUsageCounts(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 							e.AnonymousUserID = "deadbeef"
 						}
 
-						if err := EventLogs.Insert(ctx, e); err != nil {
+						if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 							t.Fatal(err)
 						}
 					}
@@ -245,7 +245,7 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 		}
 	}
 
-	summary, err := EventLogs.siteUsage(ctx, now)
+	summary, err := GlobalEventLogs.siteUsage(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -303,7 +303,7 @@ func TestEventLogs_CodeIntelligenceCombinedWAU(t *testing.T) {
 				Timestamp: now.Add(-time.Hour * 24 * 3).Add(time.Minute * time.Duration(rand.Intn(60)-30)),
 			}
 
-			if err := EventLogs.Insert(ctx, e); err != nil {
+			if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -317,13 +317,13 @@ func TestEventLogs_CodeIntelligenceCombinedWAU(t *testing.T) {
 				Timestamp: now.Add(-time.Hour * 24 * 12).Add(time.Minute * time.Duration(rand.Intn(60)-30)),
 			}
 
-			if err := EventLogs.Insert(ctx, e); err != nil {
+			if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 				t.Fatal(err)
 			}
 		}
 	}
 
-	count, err := EventLogs.codeIntelligenceCombinedWAU(ctx, now)
+	count, err := GlobalEventLogs.codeIntelligenceCombinedWAU(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -371,7 +371,7 @@ func TestEventLogs_AggregatedCodeIntelEvents(t *testing.T) {
 						Timestamp: day.Add(time.Minute * time.Duration(rand.Intn(60)-30)),
 					}
 
-					if err := EventLogs.Insert(ctx, e); err != nil {
+					if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 						t.Fatal(err)
 					}
 				}
@@ -379,7 +379,7 @@ func TestEventLogs_AggregatedCodeIntelEvents(t *testing.T) {
 		}
 	}
 
-	events, err := EventLogs.aggregatedCodeIntelEvents(ctx, now)
+	events, err := GlobalEventLogs.aggregatedCodeIntelEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -426,12 +426,12 @@ func TestEventLogs_AggregatedSparseCodeIntelEvents(t *testing.T) {
 			Timestamp: now.Add(-time.Hour * 24 * 3), // This week
 		}
 
-		if err := EventLogs.Insert(ctx, e); err != nil {
+		if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	events, err := EventLogs.aggregatedCodeIntelEvents(ctx, now)
+	events, err := GlobalEventLogs.aggregatedCodeIntelEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -479,12 +479,12 @@ func TestEventLogs_AggregatedSparseSearchEvents(t *testing.T) {
 			Timestamp: now.Add(-time.Hour * 24 * 6), // This month
 		}
 
-		if err := EventLogs.Insert(ctx, e); err != nil {
+		if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	events, err := EventLogs.aggregatedSearchEvents(ctx, now)
+	events, err := GlobalEventLogs.aggregatedSearchEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -558,7 +558,7 @@ func TestEventLogs_AggregatedSearchEvents(t *testing.T) {
 							Timestamp: day.Add(time.Minute * time.Duration(rand.Intn(60)-30)),
 						}
 
-						if err := EventLogs.Insert(ctx, e); err != nil {
+						if err := GlobalEventLogs.Insert(ctx, e); err != nil {
 							t.Fatal(err)
 						}
 					}
@@ -567,7 +567,7 @@ func TestEventLogs_AggregatedSearchEvents(t *testing.T) {
 		}
 	}
 
-	events, err := EventLogs.aggregatedSearchEvents(ctx, now)
+	events, err := GlobalEventLogs.aggregatedSearchEvents(ctx, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -650,14 +650,14 @@ func TestEventLogs_ListAll(t *testing.T) {
 		}}
 
 	for _, event := range events {
-		if err := EventLogs.Insert(ctx, event); err != nil {
+		if err := GlobalEventLogs.Insert(ctx, event); err != nil {
 			t.Fatal(err)
 		}
 
 	}
 
 	searchResultQueriedEvent := "SearchResultsQueried"
-	have, err := EventLogs.ListAll(ctx, EventLogsListOptions{EventName: &searchResultQueriedEvent})
+	have, err := GlobalEventLogs.ListAll(ctx, EventLogsListOptions{EventName: &searchResultQueriedEvent})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -677,7 +677,7 @@ func TestEventLogs_LatestPing(t *testing.T) {
 
 	t.Run("with no pings in database", func(t *testing.T) {
 		ctx := context.Background()
-		ping, err := EventLogs.LatestPing(ctx)
+		ping, err := GlobalEventLogs.LatestPing(ctx)
 		if ping != nil {
 			t.Fatalf("have ping %+v, expected nil", ping)
 		}
@@ -711,12 +711,12 @@ func TestEventLogs_LatestPing(t *testing.T) {
 			},
 		}
 		for _, event := range events {
-			if err := EventLogs.Insert(ctx, event); err != nil {
+			if err := GlobalEventLogs.Insert(ctx, event); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		gotPing, err := EventLogs.LatestPing(ctx)
+		gotPing, err := GlobalEventLogs.LatestPing(ctx)
 		if err != nil || gotPing == nil {
 			t.Fatal(err)
 		}

--- a/internal/db/external_accounts.go
+++ b/internal/db/external_accounts.go
@@ -204,7 +204,7 @@ func (s *UserExternalAccountsStore) CreateUserAndSave(ctx context.Context, newUs
 		return Mocks.ExternalAccounts.CreateUserAndSave(newUser, spec, data)
 	}
 
-	usersTx, err := Users.Transact(ctx)
+	usersTx, err := GlobalUsers.Transact(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/external_accounts_test.go
+++ b/internal/db/external_accounts_test.go
@@ -26,12 +26,12 @@ func TestExternalAccounts_LookupUserAndSave(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+	userID, err := GlobalExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	lookedUpUserID, err := ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.AccountData{})
+	lookedUpUserID, err := GlobalExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user, err := Users.Create(ctx, NewUser{Username: "u"})
+	user, err := GlobalUsers.Create(ctx, NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,11 +65,11 @@ func TestExternalAccounts_AssociateUserAndSave(t *testing.T) {
 		AuthData: &authData,
 		Data:     &data,
 	}
-	if err := ExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, accountData); err != nil {
+	if err := GlobalExternalAccounts.AssociateUserAndSave(ctx, user.ID, spec, accountData); err != nil {
 		t.Fatal(err)
 	}
 
-	accounts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{})
+	accounts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,12 +110,12 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		AuthData: &authData,
 		Data:     &data,
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, accountData)
+	userID, err := GlobalExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, accountData)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	user, err := Users.GetByID(ctx, userID)
+	user, err := GlobalUsers.GetByID(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +123,7 @@ func TestExternalAccounts_CreateUserAndSave(t *testing.T) {
 		t.Errorf("got %q, want %q", user.Username, want)
 	}
 
-	accounts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{})
+	accounts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,12 +158,12 @@ func TestExternalAccounts_CreateUserAndSave_NilData(t *testing.T) {
 		AccountID:   "xd",
 	}
 
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+	userID, err := GlobalExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	user, err := Users.GetByID(ctx, userID)
+	user, err := GlobalUsers.GetByID(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestExternalAccounts_CreateUserAndSave_NilData(t *testing.T) {
 		t.Errorf("got %q, want %q", user.Username, want)
 	}
 
-	accounts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{})
+	accounts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,7 +221,7 @@ func TestExternalAccounts_List(t *testing.T) {
 	userIDs := make([]int32, 0, len(specs))
 
 	for i, spec := range specs {
-		id, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: fmt.Sprintf("u%d", i)}, spec, extsvc.AccountData{})
+		id, err := GlobalExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: fmt.Sprintf("u%d", i)}, spec, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -278,7 +278,7 @@ func TestExternalAccounts_List(t *testing.T) {
 
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
-			accounts, err := ExternalAccounts.List(ctx, c.args)
+			accounts, err := GlobalExternalAccounts.List(ctx, c.args)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -319,12 +319,12 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 		ClientID:    "xc",
 		AccountID:   "xd",
 	}
-	userID, err := ExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
+	userID, err := GlobalExternalAccounts.CreateUserAndSave(ctx, NewUser{Username: "u"}, spec, extsvc.AccountData{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{UserID: userID})
+	accts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{UserID: userID})
 	if err != nil {
 		t.Fatal(err)
 	} else if len(accts) != 1 {
@@ -333,12 +333,12 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	acct := accts[0]
 
 	t.Run("Exclude expired", func(t *testing.T) {
-		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
+		err := GlobalExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+		accts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
@@ -352,17 +352,17 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("LookupUserAndSave should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
+		err := GlobalExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		_, err = ExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.AccountData{})
+		_, err = GlobalExternalAccounts.LookupUserAndSave(ctx, spec, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+		accts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
@@ -376,17 +376,17 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("AssociateUserAndSave should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
+		err := GlobalExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ExternalAccounts.AssociateUserAndSave(ctx, userID, spec, extsvc.AccountData{})
+		err = GlobalExternalAccounts.AssociateUserAndSave(ctx, userID, spec, extsvc.AccountData{})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+		accts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})
@@ -400,17 +400,17 @@ func TestExternalAccounts_expiredAt(t *testing.T) {
 	})
 
 	t.Run("TouchLastValid should set expired_at to NULL", func(t *testing.T) {
-		err := ExternalAccounts.TouchExpired(ctx, acct.ID)
+		err := GlobalExternalAccounts.TouchExpired(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		err = ExternalAccounts.TouchLastValid(ctx, acct.ID)
+		err = GlobalExternalAccounts.TouchLastValid(ctx, acct.ID)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		accts, err := ExternalAccounts.List(ctx, ExternalAccountsListOptions{
+		accts, err := GlobalExternalAccounts.List(ctx, ExternalAccountsListOptions{
 			UserID:         userID,
 			ExcludeExpired: true,
 		})

--- a/internal/db/namespaces_test.go
+++ b/internal/db/namespaces_test.go
@@ -16,18 +16,18 @@ func TestNamespaces(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user and organization to test lookups.
-	user, err := Users.Create(ctx, NewUser{Username: "alice"})
+	user, err := GlobalUsers.Create(ctx, NewUser{Username: "alice"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	org, err := Orgs.Create(ctx, "Acme", nil)
+	org, err := GlobalOrgs.Create(ctx, "Acme", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Run("GetByID", func(t *testing.T) {
 		t.Run("no ID", func(t *testing.T) {
-			ns, err := Namespaces.GetByID(ctx, 0, 0)
+			ns, err := GlobalNamespaces.GetByID(ctx, 0, 0)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -37,7 +37,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("multiple IDs", func(t *testing.T) {
-			ns, err := Namespaces.GetByID(ctx, 123, 456)
+			ns, err := GlobalNamespaces.GetByID(ctx, 123, 456)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -47,7 +47,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("user not found", func(t *testing.T) {
-			ns, err := Namespaces.GetByID(ctx, user.ID+1, 0)
+			ns, err := GlobalNamespaces.GetByID(ctx, user.ID+1, 0)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -57,7 +57,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("organization not found", func(t *testing.T) {
-			ns, err := Namespaces.GetByID(ctx, 0, org.ID+1)
+			ns, err := GlobalNamespaces.GetByID(ctx, 0, org.ID+1)
 			if ns != nil {
 				t.Errorf("unexpected non-nil namespace: %v", ns)
 			}
@@ -67,7 +67,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("user", func(t *testing.T) {
-			ns, err := Namespaces.GetByID(ctx, 0, user.ID)
+			ns, err := GlobalNamespaces.GetByID(ctx, 0, user.ID)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			}
@@ -77,7 +77,7 @@ func TestNamespaces(t *testing.T) {
 		})
 
 		t.Run("organization", func(t *testing.T) {
-			ns, err := Namespaces.GetByID(ctx, org.ID, 0)
+			ns, err := GlobalNamespaces.GetByID(ctx, org.ID, 0)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			}
@@ -89,7 +89,7 @@ func TestNamespaces(t *testing.T) {
 
 	t.Run("GetByName", func(t *testing.T) {
 		t.Run("user", func(t *testing.T) {
-			ns, err := Namespaces.GetByName(ctx, "Alice")
+			ns, err := GlobalNamespaces.GetByName(ctx, "Alice")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -98,7 +98,7 @@ func TestNamespaces(t *testing.T) {
 			}
 		})
 		t.Run("organization", func(t *testing.T) {
-			ns, err := Namespaces.GetByName(ctx, "acme")
+			ns, err := GlobalNamespaces.GetByName(ctx, "acme")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -107,7 +107,7 @@ func TestNamespaces(t *testing.T) {
 			}
 		})
 		t.Run("not found", func(t *testing.T) {
-			if _, err := Namespaces.GetByName(ctx, "doesntexist"); err != ErrNamespaceNotFound {
+			if _, err := GlobalNamespaces.GetByName(ctx, "doesntexist"); err != ErrNamespaceNotFound {
 				t.Fatal(err)
 			}
 		})

--- a/internal/db/org_members.go
+++ b/internal/db/org_members.go
@@ -94,11 +94,11 @@ func (m *OrgMemberStore) Remove(ctx context.Context, orgID, userID int32) error 
 
 // GetByOrgID returns a list of all members of a given organization.
 func (m *OrgMemberStore) GetByOrgID(ctx context.Context, orgID int32) ([]*types.OrgMembership, error) {
-	org, err := Orgs.With(m).GetByID(ctx, orgID)
+	org, err := GlobalOrgs.With(m).GetByID(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
-	return OrgMembers.getBySQL(ctx, "INNER JOIN users ON org_members.user_id = users.id WHERE org_id=$1 AND users.deleted_at IS NULL ORDER BY upper(users.display_name), users.id", org.ID)
+	return GlobalOrgMembers.getBySQL(ctx, "INNER JOIN users ON org_members.user_id = users.id WHERE org_id=$1 AND users.deleted_at IS NULL ORDER BY upper(users.display_name), users.id", org.ID)
 }
 
 // ErrOrgMemberNotFound is the error that is returned when

--- a/internal/db/org_members_db_test.go
+++ b/internal/db/org_members_db_test.go
@@ -19,19 +19,19 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	ctx := context.Background()
 
 	// Create fixtures.
-	org1, err := Orgs.Create(ctx, "org1", nil)
+	org1, err := GlobalOrgs.Create(ctx, "org1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	org2, err := Orgs.Create(ctx, "org2", nil)
+	org2, err := GlobalOrgs.Create(ctx, "org2", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	org3, err := Orgs.Create(ctx, "org3", nil)
+	org3, err := GlobalOrgs.Create(ctx, "org3", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	user1, err := Users.Create(ctx, NewUser{
+	user1, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a1@example.com",
 		Username:              "u1",
 		Password:              "p",
@@ -40,7 +40,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = Users.Create(ctx, NewUser{
+	_, err = GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a2@example.com",
 		Username:              "u2",
 		Password:              "p",
@@ -49,7 +49,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := OrgMembers.Create(ctx, org1.ID, user1.ID); err != nil {
+	if _, err := GlobalOrgMembers.Create(ctx, org1.ID, user1.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,7 +61,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 		}
 		got := map[string][]int32{}
 		for _, org := range []*types.Org{org1, org2, org3} {
-			members, err := OrgMembers.GetByOrgID(ctx, org.ID)
+			members, err := GlobalOrgMembers.GetByOrgID(ctx, org.ID)
 			if err != nil {
 				return err
 			}
@@ -79,13 +79,13 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	}
 
 	// Try twice; it should be idempotent.
-	if err := OrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
+	if err := GlobalOrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {
 		t.Fatal(err)
 	}
-	if err := OrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
+	if err := GlobalOrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{"org1", "org3"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {
@@ -93,7 +93,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	}
 
 	// Passing an org that does not exist should not be an error.
-	if err := OrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{"doesntexist"}); err != nil {
+	if err := GlobalOrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{"doesntexist"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {
@@ -101,7 +101,7 @@ func TestOrgMembers_CreateMembershipInOrgsForAllUsers(t *testing.T) {
 	}
 
 	// An empty list shouldn't be an error.
-	if err := OrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{}); err != nil {
+	if err := GlobalOrgMembers.CreateMembershipInOrgsForAllUsers(ctx, []string{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := check(); err != nil {

--- a/internal/db/orgs_test.go
+++ b/internal/db/orgs_test.go
@@ -18,7 +18,7 @@ func TestOrgs_ValidNames(t *testing.T) {
 	for _, test := range usernamesForTests {
 		t.Run(test.name, func(t *testing.T) {
 			valid := true
-			if _, err := Orgs.Create(ctx, test.name, nil); err != nil {
+			if _, err := GlobalOrgs.Create(ctx, test.name, nil); err != nil {
 				if strings.Contains(err.Error(), "org name invalid") {
 					valid = false
 				} else {
@@ -39,22 +39,22 @@ func TestOrgs_Count(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	org, err := Orgs.Create(ctx, "a", nil)
+	org, err := GlobalOrgs.Create(ctx, "a", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Orgs.Count(ctx, OrgsListOptions{}); err != nil {
+	if count, err := GlobalOrgs.Count(ctx, OrgsListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
-	if err := Orgs.Delete(ctx, org.ID); err != nil {
+	if err := GlobalOrgs.Delete(ctx, org.ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Orgs.Count(ctx, OrgsListOptions{}); err != nil {
+	if count, err := GlobalOrgs.Count(ctx, OrgsListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -69,22 +69,22 @@ func TestOrgs_Delete(t *testing.T) {
 	ctx := context.Background()
 
 	displayName := "a"
-	org, err := Orgs.Create(ctx, "a", &displayName)
+	org, err := GlobalOrgs.Create(ctx, "a", &displayName)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Delete org.
-	if err := Orgs.Delete(ctx, org.ID); err != nil {
+	if err := GlobalOrgs.Delete(ctx, org.ID); err != nil {
 		t.Fatal(err)
 	}
 
 	// Org no longer exists.
-	_, err = Orgs.GetByID(ctx, org.ID)
+	_, err = GlobalOrgs.GetByID(ctx, org.ID)
 	if _, ok := err.(*OrgNotFoundError); !ok {
 		t.Errorf("got error %v, want *OrgNotFoundError", err)
 	}
-	orgs, err := Orgs.List(ctx, &OrgsListOptions{Query: "a"})
+	orgs, err := GlobalOrgs.List(ctx, &OrgsListOptions{Query: "a"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestOrgs_Delete(t *testing.T) {
 	}
 
 	// Can't delete already-deleted org.
-	err = Orgs.Delete(ctx, org.ID)
+	err = GlobalOrgs.Delete(ctx, org.ID)
 	if _, ok := err.(*OrgNotFoundError); !ok {
 		t.Errorf("got error %v, want *OrgNotFoundError", err)
 	}

--- a/internal/db/phabricator.go
+++ b/internal/db/phabricator.go
@@ -162,7 +162,7 @@ func (p *PhabricatorStore) GetByName(ctx context.Context, name api.RepoName) (*t
 		},
 	}
 	for {
-		svcs, err := ExternalServices.List(ctx, opt)
+		svcs, err := GlobalExternalServices.List(ctx, opt)
 		if err != nil {
 			return nil, errors.Wrap(err, "list")
 		}

--- a/internal/db/repos_db_test.go
+++ b/internal/db/repos_db_test.go
@@ -52,7 +52,7 @@ func createRepo(ctx context.Context, t *testing.T, repo *types.Repo) {
 		Archived:     repo.Archived,
 	}
 
-	if err := Repos.Upsert(ctx, op); err != nil {
+	if err := GlobalRepos.Upsert(ctx, op); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -63,7 +63,7 @@ func mustCreate(ctx context.Context, t *testing.T, repos ...*types.Repo) []*type
 	var createdRepos []*types.Repo
 	for _, repo := range repos {
 		createRepo(ctx, t, repo)
-		repo, err := Repos.GetByName(ctx, repo.Name)
+		repo, err := GlobalRepos.GetByName(ctx, repo.Name)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -225,7 +225,7 @@ func TestRepos_Get(t *testing.T) {
 		return &conf.Unified{}
 	}
 
-	err := ExternalServices.Create(ctx, confGet, &service)
+	err := GlobalExternalServices.Create(ctx, confGet, &service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +254,7 @@ func TestRepos_Get(t *testing.T) {
 		},
 	})
 
-	repo, err := Repos.Get(ctx, want[0].ID)
+	repo, err := GlobalRepos.Get(ctx, want[0].ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestRepos_GetByIDs(t *testing.T) {
 		},
 	})
 
-	repos, err := Repos.GetByIDs(ctx, want[0].ID, 404)
+	repos, err := GlobalRepos.GetByIDs(ctx, want[0].ID, 404)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ func TestRepos_List(t *testing.T) {
 		return &conf.Unified{}
 	}
 
-	err := ExternalServices.Create(ctx, confGet, &service)
+	err := GlobalExternalServices.Create(ctx, confGet, &service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -345,7 +345,7 @@ func TestRepos_List(t *testing.T) {
 		},
 	})
 
-	repos, err := Repos.List(ctx, ReposListOptions{})
+	repos, err := GlobalRepos.List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -363,7 +363,7 @@ func Test_GetUserAddedRepos(t *testing.T) {
 	ctx := actor.WithInternalActor(context.Background())
 
 	// Create a user
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a1@example.com",
 		Username:              "u1",
 		Password:              "p",
@@ -390,7 +390,7 @@ func Test_GetUserAddedRepos(t *testing.T) {
 	confGet := func() *conf.Unified {
 		return &conf.Unified{}
 	}
-	err = ExternalServices.Create(ctx, confGet, &service)
+	err = GlobalExternalServices.Create(ctx, confGet, &service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,7 +418,7 @@ func Test_GetUserAddedRepos(t *testing.T) {
 			},
 		},
 	}
-	err = Repos.Create(ctx, repo)
+	err = GlobalRepos.Create(ctx, repo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +427,7 @@ func Test_GetUserAddedRepos(t *testing.T) {
 		repo.Name,
 	}
 
-	have, err := Repos.GetUserAddedRepoNames(ctx, user.ID)
+	have, err := GlobalRepos.GetUserAddedRepoNames(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,28 +449,28 @@ func TestRepos_List_fork(t *testing.T) {
 	yours := mustCreate(ctx, t, &types.Repo{Name: "b/r", Fork: true})
 
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{OnlyForks: true})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, yours, repos)
 	}
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{NoForks: true})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{NoForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, mine, repos)
 	}
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{NoForks: true, OnlyForks: true})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{NoForks: true, OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, nil, repos)
 	}
 	{
-		repos, err := Repos.List(ctx, ReposListOptions{})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -502,7 +502,7 @@ func TestRepos_List_cloned(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.List(ctx, test.opt)
+			repos, err := GlobalRepos.List(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -535,7 +535,7 @@ func TestRepos_List_ids(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.List(ctx, test.opt)
+			repos, err := GlobalRepos.List(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -571,7 +571,7 @@ func TestRepos_List_serviceTypes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.List(ctx, test.opt)
+			repos, err := GlobalRepos.List(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -614,7 +614,7 @@ func TestRepos_List_pagination(t *testing.T) {
 		{limit: 4, offset: 4, exp: nil},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -654,7 +654,7 @@ func TestRepos_List_query1(t *testing.T) {
 		{"mno/p", []api.RepoName{"jkl/mno/pqr"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -695,7 +695,7 @@ func TestRepos_List_correct_ranking(t *testing.T) {
 		{"def/m", []api.RepoName{"def/mno"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -763,7 +763,7 @@ func TestRepos_List_sort(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy})
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -816,7 +816,7 @@ func TestRepos_List_patterns(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{
 			IncludePatterns: test.includePatterns,
 			ExcludePattern:  test.excludePattern,
 		})
@@ -936,7 +936,7 @@ func TestRepos_List_queryPattern(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos.List(ctx, ReposListOptions{
+		repos, err := GlobalRepos.List(ctx, ReposListOptions{
 			PatternQuery: test.q,
 		})
 		if err != nil {
@@ -963,14 +963,14 @@ func TestRepos_List_queryAndPatternsMutuallyExclusive(t *testing.T) {
 	wantErr := "Query and IncludePatterns/ExcludePattern options are mutually exclusive"
 
 	t.Run("Query and IncludePatterns", func(t *testing.T) {
-		_, err := Repos.List(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
+		_, err := GlobalRepos.List(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}
 	})
 
 	t.Run("Query and ExcludePattern", func(t *testing.T) {
-		_, err := Repos.List(ctx, ReposListOptions{Query: "x", ExcludePattern: "y"})
+		_, err := GlobalRepos.List(ctx, ReposListOptions{Query: "x", ExcludePattern: "y"})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}
@@ -990,7 +990,7 @@ func TestRepos_createRepo(t *testing.T) {
 		Name:        "a/b",
 		Description: "test"})
 
-	repo, err := Repos.GetByName(ctx, "a/b")
+	repo, err := GlobalRepos.GetByName(ctx, "a/b")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1034,7 +1034,7 @@ func TestRepos_List_useOr(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.List(ctx, test.opt)
+			repos, err := GlobalRepos.List(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1058,20 +1058,20 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 	services := types.MakeExternalServices()
 	service1 := services[0]
 	service2 := services[1]
-	if err := ExternalServices.Create(ctx, confGet, service1); err != nil {
+	if err := GlobalExternalServices.Create(ctx, confGet, service1); err != nil {
 		t.Fatal(err)
 	}
-	if err := ExternalServices.Create(ctx, confGet, service2); err != nil {
+	if err := GlobalExternalServices.Create(ctx, confGet, service2); err != nil {
 		t.Fatal(err)
 	}
 
 	mine := types.Repos{types.MakeGithubRepo(service1)}
-	if err := Repos.Create(ctx, mine...); err != nil {
+	if err := GlobalRepos.Create(ctx, mine...); err != nil {
 		t.Fatal(err)
 	}
 
 	yours := types.Repos{types.MakeGitlabRepo(service2)}
-	if err := Repos.Create(ctx, yours...); err != nil {
+	if err := GlobalRepos.Create(ctx, yours...); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1087,7 +1087,7 @@ func TestRepos_List_externalServiceID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.List(ctx, test.opt)
+			repos, err := GlobalRepos.List(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1119,7 +1119,7 @@ func TestRepos_ListRepoNames(t *testing.T) {
 		return &conf.Unified{}
 	}
 
-	err := ExternalServices.Create(ctx, confGet, &service)
+	err := GlobalExternalServices.Create(ctx, confGet, &service)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1129,7 +1129,7 @@ func TestRepos_ListRepoNames(t *testing.T) {
 	})
 	want := []*types.RepoName{{ID: repo[0].ID, Name: repo[0].Name}}
 
-	repos, err := Repos.ListRepoNames(ctx, ReposListOptions{})
+	repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1150,28 +1150,28 @@ func TestRepos_ListRepoNames_fork(t *testing.T) {
 	yours := repoNamesFromRepos(mustCreate(ctx, t, &types.Repo{Name: "b/r", Fork: true}))
 
 	{
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{OnlyForks: true})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, yours, repos)
 	}
 	{
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{NoForks: true})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{NoForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, mine, repos)
 	}
 	{
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{NoForks: true, OnlyForks: true})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{NoForks: true, OnlyForks: true})
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertJSONEqual(t, nil, repos)
 	}
 	{
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1203,7 +1203,7 @@ func TestRepos_ListRepoNames_cloned(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.ListRepoNames(ctx, test.opt)
+			repos, err := GlobalRepos.ListRepoNames(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1236,7 +1236,7 @@ func TestRepos_ListRepoNames_ids(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.ListRepoNames(ctx, test.opt)
+			repos, err := GlobalRepos.ListRepoNames(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1272,7 +1272,7 @@ func TestRepos_ListRepoNames_serviceTypes(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.ListRepoNames(ctx, test.opt)
+			repos, err := GlobalRepos.ListRepoNames(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1315,7 +1315,7 @@ func TestRepos_ListRepoNames_pagination(t *testing.T) {
 		{limit: 4, offset: 4, exp: nil},
 	}
 	for _, test := range tests {
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{LimitOffset: &LimitOffset{Limit: test.limit, Offset: test.offset}})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1355,7 +1355,7 @@ func TestRepos_ListRepoNames_correctFiltering(t *testing.T) {
 		{"mno/p", []api.RepoName{"jkl/mno/pqr"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{Query: test.query})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1396,7 +1396,7 @@ func TestRepos_ListRepoNames_query2(t *testing.T) {
 		{"def/m", []api.RepoName{"def/mno"}},
 	}
 	for _, test := range tests {
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{Query: test.query})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{Query: test.query})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1464,7 +1464,7 @@ func TestRepos_ListRepoNames_sort(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy})
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{Query: test.query, OrderBy: test.orderBy})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1517,7 +1517,7 @@ func TestRepos_ListRepoNames_patterns(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{
 			IncludePatterns: test.includePatterns,
 			ExcludePattern:  test.excludePattern,
 		})
@@ -1637,7 +1637,7 @@ func TestRepos_ListRepoNames_queryPattern(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		repos, err := Repos.ListRepoNames(ctx, ReposListOptions{
+		repos, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{
 			PatternQuery: test.q,
 		})
 		if err != nil {
@@ -1664,14 +1664,14 @@ func TestRepos_ListRepoNames_queryAndPatternsMutuallyExclusive(t *testing.T) {
 	wantErr := "Query and IncludePatterns/ExcludePattern options are mutually exclusive"
 
 	t.Run("Query and IncludePatterns", func(t *testing.T) {
-		_, err := Repos.ListRepoNames(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
+		_, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{Query: "x", IncludePatterns: []string{"y"}})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}
 	})
 
 	t.Run("Query and ExcludePattern", func(t *testing.T) {
-		_, err := Repos.ListRepoNames(ctx, ReposListOptions{Query: "x", ExcludePattern: "y"})
+		_, err := GlobalRepos.ListRepoNames(ctx, ReposListOptions{Query: "x", ExcludePattern: "y"})
 		if err == nil || !strings.Contains(err.Error(), wantErr) {
 			t.Fatalf("got error %v, want it to contain %q", err, wantErr)
 		}
@@ -1709,7 +1709,7 @@ func TestRepos_ListRepoNames_useOr(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.ListRepoNames(ctx, test.opt)
+			repos, err := GlobalRepos.ListRepoNames(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1733,20 +1733,20 @@ func TestRepos_ListRepoNames_externalServiceID(t *testing.T) {
 	services := types.MakeExternalServices()
 	service1 := services[0]
 	service2 := services[1]
-	if err := ExternalServices.Create(ctx, confGet, service1); err != nil {
+	if err := GlobalExternalServices.Create(ctx, confGet, service1); err != nil {
 		t.Fatal(err)
 	}
-	if err := ExternalServices.Create(ctx, confGet, service2); err != nil {
+	if err := GlobalExternalServices.Create(ctx, confGet, service2); err != nil {
 		t.Fatal(err)
 	}
 
 	mine := types.Repos{types.MakeGithubRepo(service1)}
-	if err := Repos.Create(ctx, mine...); err != nil {
+	if err := GlobalRepos.Create(ctx, mine...); err != nil {
 		t.Fatal(err)
 	}
 
 	yours := types.Repos{types.MakeGitlabRepo(service2)}
-	if err := Repos.Create(ctx, yours...); err != nil {
+	if err := GlobalRepos.Create(ctx, yours...); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1762,7 +1762,7 @@ func TestRepos_ListRepoNames_externalServiceID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			repos, err := Repos.ListRepoNames(ctx, test.opt)
+			repos, err := GlobalRepos.ListRepoNames(ctx, test.opt)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/db/repos_perm.go
+++ b/internal/db/repos_perm.go
@@ -64,7 +64,7 @@ func authzQueryConds(ctx context.Context) (*sqlf.Query, error) {
 	// there is no authz provider configured and access to all repositories are allowed by default.
 	bypassAuthz := isInternalActor(ctx) || (authzAllowByDefault && len(authzProviders) == 0)
 	if !bypassAuthz && actor.FromContext(ctx).IsAuthenticated() {
-		currentUser, err := Users.GetByCurrentAuthUser(ctx)
+		currentUser, err := GlobalUsers.GetByCurrentAuthUser(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/db/repos_perm_test.go
+++ b/internal/db/repos_perm_test.go
@@ -162,7 +162,7 @@ func TestRepos_getReposBySQL_checkPermissions(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up three users: alice, bob and admin
-	alice, err := Users.Create(ctx, NewUser{
+	alice, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "alice@example.com",
 		Username:              "alice",
 		Password:              "alice",
@@ -171,7 +171,7 @@ func TestRepos_getReposBySQL_checkPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bob, err := Users.Create(ctx, NewUser{
+	bob, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "bob@example.com",
 		Username:              "bob",
 		Password:              "bob",
@@ -180,7 +180,7 @@ func TestRepos_getReposBySQL_checkPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	admin, err := Users.Create(ctx, NewUser{
+	admin, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "admin@example.com",
 		Username:              "admin",
 		Password:              "admin",
@@ -192,11 +192,11 @@ func TestRepos_getReposBySQL_checkPermissions(t *testing.T) {
 
 	// Ensure only "admin" is the site admin, alice was prompted as site admin
 	// because it was the first user.
-	err = Users.SetIsSiteAdmin(ctx, admin.ID, true)
+	err = GlobalUsers.SetIsSiteAdmin(ctx, admin.ID, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = Users.SetIsSiteAdmin(ctx, alice.ID, false)
+	err = GlobalUsers.SetIsSiteAdmin(ctx, alice.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestRepos_getReposBySQL_checkPermissions(t *testing.T) {
 		Config:       `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
 		Unrestricted: true,
 	}
-	err = ExternalServices.Create(ctx, confGet, cindyExternalService)
+	err = GlobalExternalServices.Create(ctx, confGet, cindyExternalService)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,7 +305,7 @@ VALUES
 
 	// Alice should see "alice_public_repo", "alice_private_repo", "bob_public_repo", "cindy_private_repo"
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err := Repos.List(aliceCtx, ReposListOptions{})
+	repos, err := GlobalRepos.List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -316,7 +316,7 @@ VALUES
 
 	// Bob should see "alice_public_repo", "bob_private_repo", "bob_public_repo", "cindy_private_repo"
 	bobCtx := actor.WithActor(ctx, &actor.Actor{UID: bob.ID})
-	repos, err = Repos.List(bobCtx, ReposListOptions{})
+	repos, err = GlobalRepos.List(bobCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +327,7 @@ VALUES
 
 	// Admin should see all repositories
 	adminCtx := actor.WithActor(ctx, &actor.Actor{UID: admin.ID})
-	repos, err = Repos.List(adminCtx, ReposListOptions{})
+	repos, err = GlobalRepos.List(adminCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,7 +337,7 @@ VALUES
 	}
 
 	// A random user should only see "alice_public_repo", "bob_public_repo", "cindy_private_repo"
-	repos, err = Repos.List(ctx, ReposListOptions{})
+	repos, err = GlobalRepos.List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func TestRepos_getReposBySQL_permissionsUserMapping(t *testing.T) {
 	ctx := context.Background()
 
 	// Set up three users: alice, bob and admin
-	alice, err := Users.Create(ctx, NewUser{
+	alice, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "alice@example.com",
 		Username:              "alice",
 		Password:              "alice",
@@ -366,7 +366,7 @@ func TestRepos_getReposBySQL_permissionsUserMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	bob, err := Users.Create(ctx, NewUser{
+	bob, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "bob@example.com",
 		Username:              "bob",
 		Password:              "bob",
@@ -375,7 +375,7 @@ func TestRepos_getReposBySQL_permissionsUserMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	admin, err := Users.Create(ctx, NewUser{
+	admin, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "admin@example.com",
 		Username:              "admin",
 		Password:              "admin",
@@ -387,11 +387,11 @@ func TestRepos_getReposBySQL_permissionsUserMapping(t *testing.T) {
 
 	// Ensure only "admin" is the site admin, alice was prompted as site admin
 	// because it was the first user.
-	err = Users.SetIsSiteAdmin(ctx, admin.ID, true)
+	err = GlobalUsers.SetIsSiteAdmin(ctx, admin.ID, true)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = Users.SetIsSiteAdmin(ctx, alice.ID, false)
+	err = GlobalUsers.SetIsSiteAdmin(ctx, alice.ID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +462,7 @@ VALUES
 
 	// Alice should see "alice_private_repo" but not "alice_public_repo", "bob_public_repo", "bob_private_repo"
 	aliceCtx := actor.WithActor(ctx, &actor.Actor{UID: alice.ID})
-	repos, err := Repos.List(aliceCtx, ReposListOptions{})
+	repos, err := GlobalRepos.List(aliceCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,7 +473,7 @@ VALUES
 
 	// Bob should see "bob_private_repo" but not "alice_public_repo" or "bob_public_repo"
 	bobCtx := actor.WithActor(ctx, &actor.Actor{UID: bob.ID})
-	repos, err = Repos.List(bobCtx, ReposListOptions{})
+	repos, err = GlobalRepos.List(bobCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -484,7 +484,7 @@ VALUES
 
 	// Admin should see all repositories
 	adminCtx := actor.WithActor(ctx, &actor.Actor{UID: admin.ID})
-	repos, err = Repos.List(adminCtx, ReposListOptions{})
+	repos, err = GlobalRepos.List(adminCtx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,7 +494,7 @@ VALUES
 	}
 
 	// A random user sees nothing
-	repos, err = Repos.List(ctx, ReposListOptions{})
+	repos, err = GlobalRepos.List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/db/repos_test.go
+++ b/internal/db/repos_test.go
@@ -125,31 +125,31 @@ func TestRepos_Count(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := GlobalRepos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
-	if err := Repos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
+	if err := GlobalRepos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := GlobalRepos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
-	repos, err := Repos.List(ctx, ReposListOptions{})
+	repos, err := GlobalRepos.List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Repos.Delete(ctx, repos[0].ID); err != nil {
+	if err := GlobalRepos.Delete(ctx, repos[0].ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := GlobalRepos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -164,25 +164,25 @@ func TestRepos_Delete(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-	if err := Repos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
+	if err := GlobalRepos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := GlobalRepos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
-	repos, err := Repos.List(ctx, ReposListOptions{})
+	repos, err := GlobalRepos.List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Repos.Delete(ctx, repos[0].ID); err != nil {
+	if err := GlobalRepos.Delete(ctx, repos[0].ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Repos.Count(ctx, ReposListOptions{}); err != nil {
+	if count, err := GlobalRepos.Count(ctx, ReposListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -197,7 +197,7 @@ func TestRepos_Upsert(t *testing.T) {
 	ctx := context.Background()
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-	if _, err := Repos.GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
+	if _, err := GlobalRepos.GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
 		if err == nil {
 			t.Fatal("myrepo already present")
 		} else {
@@ -205,11 +205,11 @@ func TestRepos_Upsert(t *testing.T) {
 		}
 	}
 
-	if err := Repos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
+	if err := GlobalRepos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
 		t.Fatal(err)
 	}
 
-	rp, err := Repos.GetByName(ctx, "myrepo")
+	rp, err := GlobalRepos.GetByName(ctx, "myrepo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,11 +224,11 @@ func TestRepos_Upsert(t *testing.T) {
 		ServiceID:   "ext:test",
 	}
 
-	if err := Repos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "asdfasdf", Fork: false, ExternalRepo: ext}); err != nil {
+	if err := GlobalRepos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "asdfasdf", Fork: false, ExternalRepo: ext}); err != nil {
 		t.Fatal(err)
 	}
 
-	rp, err = Repos.GetByName(ctx, "myrepo")
+	rp, err = GlobalRepos.GetByName(ctx, "myrepo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,11 +244,11 @@ func TestRepos_Upsert(t *testing.T) {
 	}
 
 	// Rename. Detected by external repo
-	if err := Repos.Upsert(ctx, InsertRepoOp{Name: "myrepo/renamed", Description: "asdfasdf", Fork: false, ExternalRepo: ext}); err != nil {
+	if err := GlobalRepos.Upsert(ctx, InsertRepoOp{Name: "myrepo/renamed", Description: "asdfasdf", Fork: false, ExternalRepo: ext}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := Repos.GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
+	if _, err := GlobalRepos.GetByName(ctx, "myrepo"); !errcode.IsNotFound(err) {
 		if err == nil {
 			t.Fatal("myrepo should be renamed, but still present as myrepo")
 		} else {
@@ -256,7 +256,7 @@ func TestRepos_Upsert(t *testing.T) {
 		}
 	}
 
-	rp, err = Repos.GetByName(ctx, "myrepo/renamed")
+	rp, err = GlobalRepos.GetByName(ctx, "myrepo/renamed")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -285,11 +285,11 @@ func TestRepos_UpsertForkAndArchivedFields(t *testing.T) {
 			i++
 			name := api.RepoName(fmt.Sprintf("myrepo-%d", i))
 
-			if err := Repos.Upsert(ctx, InsertRepoOp{Name: name, Fork: fork, Archived: archived}); err != nil {
+			if err := GlobalRepos.Upsert(ctx, InsertRepoOp{Name: name, Fork: fork, Archived: archived}); err != nil {
 				t.Fatal(err)
 			}
 
-			rp, err := Repos.GetByName(ctx, name)
+			rp, err := GlobalRepos.GetByName(ctx, name)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -317,7 +317,7 @@ func TestRepos_Create(t *testing.T) {
 	ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
 	svcs := types.MakeExternalServices()
-	if err := ExternalServices.Upsert(ctx, svcs...); err != nil {
+	if err := GlobalExternalServices.Upsert(ctx, svcs...); err != nil {
 		t.Fatalf("Upsert error: %s", err)
 	}
 
@@ -327,7 +327,7 @@ func TestRepos_Create(t *testing.T) {
 	repo2 := types.MakeGitlabRepo(msvcs[extsvc.KindGitLab])
 
 	t.Run("no repos should not fail", func(t *testing.T) {
-		if err := Repos.Create(ctx); err != nil {
+		if err := GlobalRepos.Create(ctx); err != nil {
 			t.Fatalf("Create error: %s", err)
 		}
 	})
@@ -335,7 +335,7 @@ func TestRepos_Create(t *testing.T) {
 	t.Run("many repos", func(t *testing.T) {
 		want := types.GenerateRepos(7, repo1, repo2)
 
-		if err := Repos.Create(ctx, want...); err != nil {
+		if err := GlobalRepos.Create(ctx, want...); err != nil {
 			t.Fatalf("Create error: %s", err)
 		}
 
@@ -345,7 +345,7 @@ func TestRepos_Create(t *testing.T) {
 			t.Fatalf("Create didn't assign an ID to all repos: %v", noID.Names())
 		}
 
-		have, err := Repos.List(ctx, ReposListOptions{})
+		have, err := GlobalRepos.List(ctx, ReposListOptions{})
 		if err != nil {
 			t.Fatalf("List error: %s", err)
 		}

--- a/internal/db/saved_searches.go
+++ b/internal/db/saved_searches.go
@@ -184,7 +184,7 @@ func (s *SavedSearchStore) ListSavedSearchesByUserID(ctx context.Context, userID
 	s.ensureStore()
 
 	var savedSearches []*types.SavedSearch
-	orgs, err := Orgs.With(s).GetByUserID(ctx, userID)
+	orgs, err := GlobalOrgs.With(s).GetByUserID(ctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/saved_searches_test.go
+++ b/internal/db/saved_searches_test.go
@@ -19,7 +19,7 @@ func TestSavedSearchesIsEmpty(t *testing.T) {
 
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	isEmpty, err := SavedSearches.IsEmpty(ctx)
+	isEmpty, err := GlobalSavedSearches.IsEmpty(ctx)
 	if err != nil {
 		t.Fatal()
 	}
@@ -28,7 +28,7 @@ func TestSavedSearchesIsEmpty(t *testing.T) {
 		t.Errorf("want %v, got %v", want, isEmpty)
 	}
 
-	_, err = Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
+	_, err = GlobalUsers.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
 	}
@@ -41,12 +41,12 @@ func TestSavedSearchesIsEmpty(t *testing.T) {
 		UserID:      &userID,
 		OrgID:       nil,
 	}
-	_, err = SavedSearches.Create(ctx, fake)
+	_, err = GlobalSavedSearches.Create(ctx, fake)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	isEmpty, err = SavedSearches.IsEmpty(ctx)
+	isEmpty, err = GlobalSavedSearches.IsEmpty(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestSavedSearchesCreate(t *testing.T) {
 
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
+	_, err := GlobalUsers.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
 	}
@@ -76,7 +76,7 @@ func TestSavedSearchesCreate(t *testing.T) {
 		UserID:      &userID,
 		OrgID:       nil,
 	}
-	ss, err := SavedSearches.Create(ctx, fake)
+	ss, err := GlobalSavedSearches.Create(ctx, fake)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +105,7 @@ func TestSavedSearchesUpdate(t *testing.T) {
 
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
+	_, err := GlobalUsers.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
 	}
@@ -118,7 +118,7 @@ func TestSavedSearchesUpdate(t *testing.T) {
 		UserID:      &userID,
 		OrgID:       nil,
 	}
-	_, err = SavedSearches.Create(ctx, fake)
+	_, err = GlobalSavedSearches.Create(ctx, fake)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestSavedSearchesUpdate(t *testing.T) {
 		OrgID:       nil,
 	}
 
-	updatedSearch, err := SavedSearches.Update(ctx, updated)
+	updatedSearch, err := GlobalSavedSearches.Update(ctx, updated)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestSavedSearchesDelete(t *testing.T) {
 
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
+	_, err := GlobalUsers.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
 	}
@@ -163,17 +163,17 @@ func TestSavedSearchesDelete(t *testing.T) {
 		UserID:      &userID,
 		OrgID:       nil,
 	}
-	_, err = SavedSearches.Create(ctx, fake)
+	_, err = GlobalSavedSearches.Create(ctx, fake)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = SavedSearches.Delete(ctx, 1)
+	err = GlobalSavedSearches.Delete(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	allQueries, err := SavedSearches.ListAll(ctx)
+	allQueries, err := GlobalSavedSearches.ListAll(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,7 +190,7 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
+	_, err := GlobalUsers.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
 	}
@@ -203,7 +203,7 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 		UserID:      &userID,
 		OrgID:       nil,
 	}
-	ss, err := SavedSearches.Create(ctx, fake)
+	ss, err := GlobalSavedSearches.Create(ctx, fake)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestSavedSearchesGetByUserID(t *testing.T) {
 	if ss == nil {
 		t.Fatalf("no saved search returned, create failed")
 	}
-	savedSearch, err := SavedSearches.ListSavedSearchesByUserID(ctx, 1)
+	savedSearch, err := GlobalSavedSearches.ListSavedSearchesByUserID(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestSavedSearchesGetByID(t *testing.T) {
 
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
+	_, err := GlobalUsers.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
 	}
@@ -249,7 +249,7 @@ func TestSavedSearchesGetByID(t *testing.T) {
 		UserID:      &userID,
 		OrgID:       nil,
 	}
-	ss, err := SavedSearches.Create(ctx, fake)
+	ss, err := GlobalSavedSearches.Create(ctx, fake)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,7 +257,7 @@ func TestSavedSearchesGetByID(t *testing.T) {
 	if ss == nil {
 		t.Fatalf("no saved search returned, create failed")
 	}
-	savedSearch, err := SavedSearches.GetByID(ctx, ss.ID)
+	savedSearch, err := GlobalSavedSearches.GetByID(ctx, ss.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,7 +283,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	_, err := Users.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
+	_, err := GlobalUsers.Create(ctx, NewUser{DisplayName: "test", Email: "test@test.com", Username: "test", Password: "test", EmailVerificationCode: "c2"})
 	if err != nil {
 		t.Fatal("can't create user", err)
 	}
@@ -296,7 +296,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		UserID:      &userID,
 		OrgID:       nil,
 	}
-	ss, err := SavedSearches.Create(ctx, fake)
+	ss, err := GlobalSavedSearches.Create(ctx, fake)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -305,11 +305,11 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		t.Fatalf("no saved search returned, create failed")
 	}
 
-	org1, err := Orgs.Create(ctx, "org1", nil)
+	org1, err := GlobalOrgs.Create(ctx, "org1", nil)
 	if err != nil {
 		t.Fatal("can't create org1", err)
 	}
-	org2, err := Orgs.Create(ctx, "org2", nil)
+	org2, err := GlobalOrgs.Create(ctx, "org2", nil)
 	if err != nil {
 		t.Fatal("can't create org2", err)
 	}
@@ -322,7 +322,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		UserID:      nil,
 		OrgID:       &org1.ID,
 	}
-	orgSearch, err := SavedSearches.Create(ctx, orgFake)
+	orgSearch, err := GlobalSavedSearches.Create(ctx, orgFake)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,7 +338,7 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		UserID:      nil,
 		OrgID:       &org2.ID,
 	}
-	org2Search, err := SavedSearches.Create(ctx, org2Fake)
+	org2Search, err := GlobalSavedSearches.Create(ctx, org2Fake)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,16 +346,16 @@ func TestListSavedSearchesByUserID(t *testing.T) {
 		t.Fatalf("no saved search returned, org2 saved search create failed")
 	}
 
-	_, err = OrgMembers.Create(ctx, org1.ID, userID)
+	_, err = GlobalOrgMembers.Create(ctx, org1.ID, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = OrgMembers.Create(ctx, org2.ID, userID)
+	_, err = GlobalOrgMembers.Create(ctx, org2.ID, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	savedSearches, err := SavedSearches.ListSavedSearchesByUserID(ctx, userID)
+	savedSearches, err := GlobalSavedSearches.ListSavedSearchesByUserID(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/db/settings_test.go
+++ b/internal/db/settings_test.go
@@ -15,25 +15,25 @@ func TestSettings_ListAll(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user1, err := Users.Create(ctx, NewUser{Username: "u1"})
+	user1, err := GlobalUsers.Create(ctx, NewUser{Username: "u1"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	user2, err := Users.Create(ctx, NewUser{Username: "u2"})
+	user2, err := GlobalUsers.Create(ctx, NewUser{Username: "u2"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Try creating both with non-nil author and nil author.
-	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user1.ID}, nil, &user1.ID, `{"abc": 1}`); err != nil {
+	if _, err := GlobalSettings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user1.ID}, nil, &user1.ID, `{"abc": 1}`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user2.ID}, nil, nil, `{"xyz": 2}`); err != nil {
+	if _, err := GlobalSettings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user2.ID}, nil, nil, `{"xyz": 2}`); err != nil {
 		t.Fatal(err)
 	}
 
 	t.Run("all", func(t *testing.T) {
-		settings, err := Settings.ListAll(ctx, "")
+		settings, err := GlobalSettings.ListAll(ctx, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -43,7 +43,7 @@ func TestSettings_ListAll(t *testing.T) {
 	})
 
 	t.Run("impreciseSubstring", func(t *testing.T) {
-		settings, err := Settings.ListAll(ctx, "xyz")
+		settings, err := GlobalSettings.ListAll(ctx, "xyz")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -59,7 +59,7 @@ func TestSettings_ListAll(t *testing.T) {
 func TestCreateIfUpToDate(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
-	u, err := Users.Create(ctx, NewUser{Username: "test"})
+	u, err := GlobalUsers.Create(ctx, NewUser{Username: "test"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestCreateIfUpToDate(t *testing.T) {
 	t.Run("quicklink with safe link", func(t *testing.T) {
 		contents := "{\"quicklinks\": [{\"name\": \"malicious link test\",      \"url\": \"https://example.com\"}]}"
 
-		_, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
+		_, err := GlobalSettings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -78,7 +78,7 @@ func TestCreateIfUpToDate(t *testing.T) {
 
 		want := "invalid settings: quicklinks.0.url: Does not match pattern '^(https?://|/)'"
 
-		_, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
+		_, err := GlobalSettings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &u.ID}, nil, nil, contents)
 		if err == nil {
 			t.Log("Expected an error")
 			t.Fail()

--- a/internal/db/stores.go
+++ b/internal/db/stores.go
@@ -1,28 +1,26 @@
 package db
 
+// Global reference to database stores using the global dbconn.Global connection handle.
+// Deprecated: Use store constructors instead.
 var (
-	AccessTokens     = &AccessTokenStore{}
-	ExternalServices = &ExternalServiceStore{}
-	DefaultRepos     = &DefaultRepoStore{}
-	Repos            = &RepoStore{}
-	Phabricator      = &PhabricatorStore{}
-	QueryRunnerState = &QueryRunnerStateStore{}
-	Namespaces       = &NamespaceStore{}
-	Orgs             = &OrgStore{}
-	OrgMembers       = &OrgMemberStore{}
-	SavedSearches    = &SavedSearchStore{}
-	Settings         = &SettingStore{}
-	Users            = &UserStore{}
-	UserCredentials  = &UserCredentialsStore{}
-	UserEmails       = &UserEmailsStore{}
-	UserPublicRepos  = &UserPublicRepoStore{}
-	EventLogs        = &EventLogStore{}
-
-	SurveyResponses = &SurveyResponseStore{}
-
-	ExternalAccounts = &UserExternalAccountsStore{}
-
-	OrgInvitations = &OrgInvitationStore{}
-
-	Authz AuthzStore = &authzStore{}
+	GlobalAccessTokens                = &AccessTokenStore{}
+	GlobalExternalServices            = &ExternalServiceStore{}
+	GlobalDefaultRepos                = &DefaultRepoStore{}
+	GlobalRepos                       = &RepoStore{}
+	GlobalPhabricator                 = &PhabricatorStore{}
+	GlobalQueryRunnerState            = &QueryRunnerStateStore{}
+	GlobalNamespaces                  = &NamespaceStore{}
+	GlobalOrgs                        = &OrgStore{}
+	GlobalOrgMembers                  = &OrgMemberStore{}
+	GlobalSavedSearches               = &SavedSearchStore{}
+	GlobalSettings                    = &SettingStore{}
+	GlobalUsers                       = &UserStore{}
+	GlobalUserCredentials             = &UserCredentialsStore{}
+	GlobalUserEmails                  = &UserEmailsStore{}
+	GlobalUserPublicRepos             = &UserPublicRepoStore{}
+	GlobalEventLogs                   = &EventLogStore{}
+	GlobalSurveyResponses             = &SurveyResponseStore{}
+	GlobalExternalAccounts            = &UserExternalAccountsStore{}
+	GlobalOrgInvitations              = &OrgInvitationStore{}
+	GlobalAuthz            AuthzStore = &authzStore{}
 )

--- a/internal/db/survey_responses_test.go
+++ b/internal/db/survey_responses_test.go
@@ -15,7 +15,7 @@ func TestSurveyResponses_Create_Count(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	count, err := SurveyResponses.Count(ctx)
+	count, err := GlobalSurveyResponses.Count(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,12 +23,12 @@ func TestSurveyResponses_Create_Count(t *testing.T) {
 		t.Fatal("Expected Count to be 0.")
 	}
 
-	_, err = SurveyResponses.Create(ctx, nil, nil, 10, nil, nil)
+	_, err = GlobalSurveyResponses.Create(ctx, nil, nil, 10, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@a.com",
 		Username:              "u",
 		Password:              "p",
@@ -39,22 +39,22 @@ func TestSurveyResponses_Create_Count(t *testing.T) {
 	}
 
 	fakeResponse, fakeEmail := "lorem ipsum", "email@email.email"
-	_, err = SurveyResponses.Create(ctx, &user.ID, nil, 9, &fakeResponse, nil)
+	_, err = GlobalSurveyResponses.Create(ctx, &user.ID, nil, 9, &fakeResponse, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = SurveyResponses.Create(ctx, &user.ID, &fakeEmail, 8, nil, &fakeResponse)
+	_, err = GlobalSurveyResponses.Create(ctx, &user.ID, &fakeEmail, 8, nil, &fakeResponse)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = SurveyResponses.Create(ctx, nil, &fakeEmail, 8, nil, nil)
+	_, err = GlobalSurveyResponses.Create(ctx, nil, &fakeEmail, 8, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	count, err = SurveyResponses.Count(ctx)
+	count, err = GlobalSurveyResponses.Count(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/db/user_credentials_test.go
+++ b/internal/db/user_credentials_test.go
@@ -46,7 +46,7 @@ func TestUserCredentials_Create(t *testing.T) {
 				ExternalServiceID:   "https://github.com",
 			}
 
-			cred, err := UserCredentials.Create(ctx, scope, auth)
+			cred, err := GlobalUserCredentials.Create(ctx, scope, auth)
 			if err != nil {
 				t.Errorf("unexpected non-nil error: %v", err)
 			} else if cred == nil {
@@ -79,7 +79,7 @@ func TestUserCredentials_Create(t *testing.T) {
 			}
 
 			// Ensure that trying to insert again fails.
-			if cred, err := UserCredentials.Create(ctx, scope, auth); err == nil {
+			if cred, err := GlobalUserCredentials.Create(ctx, scope, auth); err == nil {
 				t.Error("unexpected nil error")
 			} else if cred != nil {
 				t.Errorf("unexpected non-nil credential: %v", cred)
@@ -92,7 +92,7 @@ func TestUserCredentials_Delete(t *testing.T) {
 	ctx, user := setUpUserCredentialTest(t)
 
 	t.Run("nonextant", func(t *testing.T) {
-		err := UserCredentials.Delete(ctx, 1)
+		err := GlobalUserCredentials.Delete(ctx, 1)
 		if err == nil {
 			t.Error("unexpected nil error")
 		}
@@ -115,16 +115,16 @@ func TestUserCredentials_Delete(t *testing.T) {
 		}
 		token := &auth.OAuthBearerToken{Token: "abcdef"}
 
-		cred, err := UserCredentials.Create(ctx, scope, token)
+		cred, err := GlobalUserCredentials.Create(ctx, scope, token)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if err := UserCredentials.Delete(ctx, cred.ID); err != nil {
+		if err := GlobalUserCredentials.Delete(ctx, cred.ID); err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
 
-		_, err = UserCredentials.GetByID(ctx, cred.ID)
+		_, err = GlobalUserCredentials.GetByID(ctx, cred.ID)
 		if _, ok := err.(UserCredentialNotFoundErr); !ok {
 			t.Errorf("unexpected error retrieving credential after deletion: %v", err)
 		}
@@ -135,7 +135,7 @@ func TestUserCredentials_GetByID(t *testing.T) {
 	ctx, user := setUpUserCredentialTest(t)
 
 	t.Run("nonextant", func(t *testing.T) {
-		cred, err := UserCredentials.GetByID(ctx, 1)
+		cred, err := GlobalUserCredentials.GetByID(ctx, 1)
 		if cred != nil {
 			t.Errorf("unexpected non-nil credential: %v", cred)
 		}
@@ -161,12 +161,12 @@ func TestUserCredentials_GetByID(t *testing.T) {
 		}
 		token := &auth.OAuthBearerToken{Token: "abcdef"}
 
-		want, err := UserCredentials.Create(ctx, scope, token)
+		want, err := GlobalUserCredentials.Create(ctx, scope, token)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		have, err := UserCredentials.GetByID(ctx, want.ID)
+		have, err := GlobalUserCredentials.GetByID(ctx, want.ID)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -188,7 +188,7 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 	token := &auth.OAuthBearerToken{Token: "abcdef"}
 
 	t.Run("nonextant", func(t *testing.T) {
-		cred, err := UserCredentials.GetByScope(ctx, scope)
+		cred, err := GlobalUserCredentials.GetByScope(ctx, scope)
 		if cred != nil {
 			t.Errorf("unexpected non-nil credential: %v", cred)
 		}
@@ -206,12 +206,12 @@ func TestUserCredentials_GetByScope(t *testing.T) {
 	})
 
 	t.Run("extant", func(t *testing.T) {
-		want, err := UserCredentials.Create(ctx, scope, token)
+		want, err := GlobalUserCredentials.Create(ctx, scope, token)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		have, err := UserCredentials.GetByScope(ctx, scope)
+		have, err := GlobalUserCredentials.GetByScope(ctx, scope)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -240,18 +240,18 @@ func TestUserCredentials_List(t *testing.T) {
 
 	// Unlike the other tests in this file, we'll set up a couple of credentials
 	// right now, and then list from there.
-	github, err := UserCredentials.Create(ctx, githubScope, token)
+	github, err := GlobalUserCredentials.Create(ctx, githubScope, token)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	gitlab, err := UserCredentials.Create(ctx, gitlabScope, token)
+	gitlab, err := GlobalUserCredentials.Create(ctx, gitlabScope, token)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	t.Run("not found", func(t *testing.T) {
-		creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+		creds, next, err := GlobalUserCredentials.List(ctx, UserCredentialsListOpts{
 			Scope: UserCredentialScope{
 				Domain: "this is not a valid domain",
 			},
@@ -289,7 +289,7 @@ func TestUserCredentials_List(t *testing.T) {
 		},
 	} {
 		t.Run("single match on "+name, func(t *testing.T) {
-			creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+			creds, next, err := GlobalUserCredentials.List(ctx, UserCredentialsListOpts{
 				Scope: tc.scope,
 			})
 			if err != nil {
@@ -314,7 +314,7 @@ func TestUserCredentials_List(t *testing.T) {
 		},
 	} {
 		t.Run("multiple matches on "+name, func(t *testing.T) {
-			creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+			creds, next, err := GlobalUserCredentials.List(ctx, UserCredentialsListOpts{
 				Scope: scope,
 			})
 			if err != nil {
@@ -329,7 +329,7 @@ func TestUserCredentials_List(t *testing.T) {
 		})
 
 		t.Run("pagination for "+name, func(t *testing.T) {
-			creds, next, err := UserCredentials.List(ctx, UserCredentialsListOpts{
+			creds, next, err := GlobalUserCredentials.List(ctx, UserCredentialsListOpts{
 				LimitOffset: &LimitOffset{Limit: 1},
 				Scope:       scope,
 			})
@@ -343,7 +343,7 @@ func TestUserCredentials_List(t *testing.T) {
 				t.Errorf("unexpected credentials:\n%s", diff)
 			}
 
-			creds, next, err = UserCredentials.List(ctx, UserCredentialsListOpts{
+			creds, next, err = GlobalUserCredentials.List(ctx, UserCredentialsListOpts{
 				LimitOffset: &LimitOffset{Limit: 1, Offset: next},
 				Scope:       scope,
 			})
@@ -364,7 +364,7 @@ func TestUserCredentials_Invalid(t *testing.T) {
 	ctx, user := setUpUserCredentialTest(t)
 
 	t.Run("marshal", func(t *testing.T) {
-		if _, err := UserCredentials.Create(ctx, UserCredentialScope{}, &invalidAuth{}); err == nil {
+		if _, err := GlobalUserCredentials.Create(ctx, UserCredentialScope{}, &invalidAuth{}); err == nil {
 			t.Error("unexpected nil error")
 		}
 	})
@@ -400,7 +400,7 @@ func TestUserCredentials_Invalid(t *testing.T) {
 			"malformed JSON":          insertRawCredential(t, "malformed", "this is not valid JSON"),
 		} {
 			t.Run(name, func(t *testing.T) {
-				if _, err := UserCredentials.GetByID(ctx, id); err == nil {
+				if _, err := GlobalUserCredentials.GetByID(ctx, id); err == nil {
 					t.Error("unexpected nil error")
 				} else if _, ok := err.(UserCredentialNotFoundErr); ok {
 					t.Error("unexpected not found error")
@@ -466,7 +466,7 @@ func setUpUserCredentialTest(t *testing.T) (context.Context, *types.User) {
 	ctx := context.Background()
 
 	// Create a user that allows us to link the credential somewhere.
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@example.com",
 		Username:              "u2",
 		Password:              "pw",

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -341,7 +341,7 @@ func (u *UserStore) create(ctx context.Context, info NewUser) (newUser *types.Us
 		for _, err := range errs {
 			log15.Warn(err.Error())
 		}
-		if err := OrgMembers.With(u).CreateMembershipInOrgsForAllUsers(ctx, orgs); err != nil {
+		if err := GlobalOrgMembers.With(u).CreateMembershipInOrgsForAllUsers(ctx, orgs); err != nil {
 			return nil, err
 		}
 

--- a/internal/db/users_test.go
+++ b/internal/db/users_test.go
@@ -78,7 +78,7 @@ func TestUsers_ValidUsernames(t *testing.T) {
 	for _, test := range usernamesForTests {
 		t.Run(test.name, func(t *testing.T) {
 			valid := true
-			if _, err := Users.Create(ctx, NewUser{Username: test.name}); err != nil {
+			if _, err := GlobalUsers.Create(ctx, NewUser{Username: test.name}); err != nil {
 				e, ok := err.(errCannotCreateUser)
 				if ok && (e.Code() == "users_username_max_length" || e.Code() == "users_username_valid_chars") {
 					valid = false
@@ -156,7 +156,7 @@ func TestUsers_Create_checkPasswordLength(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := Users.Create(ctx, NewUser{
+			_, err := GlobalUsers.Create(ctx, NewUser{
 				Username:              test.username,
 				Password:              test.password,
 				EnforcePasswordLength: test.enforce,
@@ -180,7 +180,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 	}
 
 	// Create site admin.
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@a.com",
 		Username:              "u",
 		Password:              "p",
@@ -194,7 +194,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 	}
 
 	// Creating a non-site-admin now that the site has already been initialized.
-	u2, err := Users.Create(ctx, NewUser{
+	u2, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a2@a2.com",
 		Username:              "u2",
 		Password:              "p2",
@@ -207,7 +207,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 		t.Fatal("want u2 not site admin because site is already initialized")
 	}
 	// Similar to the above, but expect an error because we pass FailIfNotInitialUser: true.
-	_, err = Users.Create(ctx, NewUser{
+	_, err = GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a3@a3.com",
 		Username:              "u3",
 		Password:              "p3",
@@ -219,7 +219,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 	}
 
 	// Delete the site admin.
-	if err := Users.Delete(ctx, user.ID); err != nil {
+	if err := GlobalUsers.Delete(ctx, user.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -227,7 +227,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 	if _, err := dbconn.Global.ExecContext(ctx, "UPDATE site_config SET initialized=false"); err != nil {
 		t.Fatal(err)
 	}
-	u4, err := Users.Create(ctx, NewUser{
+	u4, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a4@a4.com",
 		Username:              "u4",
 		Password:              "p4",
@@ -243,7 +243,7 @@ func TestUsers_Create_SiteAdmin(t *testing.T) {
 	if _, err := dbconn.Global.ExecContext(ctx, "UPDATE site_config SET initialized=false"); err != nil {
 		t.Fatal(err)
 	}
-	_, err = Users.Create(ctx, NewUser{
+	_, err = GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a5@a5.com",
 		Username:              "u5",
 		Password:              "p5",
@@ -262,7 +262,7 @@ func TestUsers_CheckAndDecrementInviteQuota(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@a.com",
 		Username:              "u",
 		Password:              "p",
@@ -287,19 +287,19 @@ func TestUsers_CheckAndDecrementInviteQuota(t *testing.T) {
 	// Decrementing should succeed while we have remaining quota. Keep going until we exhaust it.
 	// Since the quota is fairly low, this isn't too slow.
 	for inviteQuota > 0 {
-		if ok, err := Users.CheckAndDecrementInviteQuota(ctx, user.ID); !ok || err != nil {
+		if ok, err := GlobalUsers.CheckAndDecrementInviteQuota(ctx, user.ID); !ok || err != nil {
 			t.Fatal("initial CheckAndDecrementInviteQuota failed:", err)
 		}
 		inviteQuota--
 	}
 
 	// Now our quota is exhausted, and CheckAndDecrementInviteQuota should fail.
-	if ok, err := Users.CheckAndDecrementInviteQuota(ctx, user.ID); ok || err != nil {
+	if ok, err := GlobalUsers.CheckAndDecrementInviteQuota(ctx, user.ID); ok || err != nil {
 		t.Fatalf("over-limit CheckAndDecrementInviteQuota #1: got error %v", err)
 	}
 
 	// Check again that we're still over quota, just in case.
-	if ok, err := Users.CheckAndDecrementInviteQuota(ctx, user.ID); ok || err != nil {
+	if ok, err := GlobalUsers.CheckAndDecrementInviteQuota(ctx, user.ID); ok || err != nil {
 		t.Fatalf("over-limit CheckAndDecrementInviteQuota #2: got error %v", err)
 	}
 }
@@ -311,7 +311,7 @@ func TestUsers_ListCount(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@a.com",
 		Username:              "u",
 		Password:              "p",
@@ -322,39 +322,39 @@ func TestUsers_ListCount(t *testing.T) {
 	}
 	user.Tags = []string{}
 
-	if count, err := Users.Count(ctx, &UsersListOptions{}); err != nil {
+	if count, err := GlobalUsers.Count(ctx, &UsersListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 1; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
-	if users, err := Users.List(ctx, &UsersListOptions{}); err != nil {
+	if users, err := GlobalUsers.List(ctx, &UsersListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if users, want := normalizeUsers(users), normalizeUsers([]*types.User{user}); !reflect.DeepEqual(users, want) {
 		t.Errorf("got %+v, want %+v", users, want)
 	}
 
-	if count, err := Users.Count(ctx, &UsersListOptions{UserIDs: []int32{}}); err != nil {
+	if count, err := GlobalUsers.Count(ctx, &UsersListOptions{UserIDs: []int32{}}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
 	}
-	if users, err := Users.List(ctx, &UsersListOptions{UserIDs: []int32{}}); err != nil {
+	if users, err := GlobalUsers.List(ctx, &UsersListOptions{UserIDs: []int32{}}); err != nil {
 		t.Fatal(err)
 	} else if len(users) > 0 {
 		t.Errorf("got %d, want empty", len(users))
 	}
 
-	if users, err := Users.List(ctx, &UsersListOptions{}); err != nil {
+	if users, err := GlobalUsers.List(ctx, &UsersListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if users, want := normalizeUsers(users), normalizeUsers([]*types.User{user}); !reflect.DeepEqual(users, want) {
 		t.Errorf("got %+v, want %+v", users[0], user)
 	}
 
-	if err := Users.Delete(ctx, user.ID); err != nil {
+	if err := GlobalUsers.Delete(ctx, user.ID); err != nil {
 		t.Fatal(err)
 	}
 
-	if count, err := Users.Count(ctx, &UsersListOptions{}); err != nil {
+	if count, err := GlobalUsers.Count(ctx, &UsersListOptions{}); err != nil {
 		t.Fatal(err)
 	} else if want := 0; count != want {
 		t.Errorf("got %d, want %d", count, want)
@@ -368,7 +368,7 @@ func TestUsers_Update(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@a.com",
 		Username:              "u",
 		Password:              "p",
@@ -378,14 +378,14 @@ func TestUsers_Update(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := Users.Update(ctx, user.ID, UserUpdate{
+	if err := GlobalUsers.Update(ctx, user.ID, UserUpdate{
 		Username:    "u1",
 		DisplayName: strptr("d1"),
 		AvatarURL:   strptr("a1"),
 	}); err != nil {
 		t.Fatal(err)
 	}
-	user, err = Users.GetByID(ctx, user.ID)
+	user, err = GlobalUsers.GetByID(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,12 +399,12 @@ func TestUsers_Update(t *testing.T) {
 		t.Errorf("got avatar URL %q, want %q", user.AvatarURL, want)
 	}
 
-	if err := Users.Update(ctx, user.ID, UserUpdate{
+	if err := GlobalUsers.Update(ctx, user.ID, UserUpdate{
 		DisplayName: strptr(""),
 	}); err != nil {
 		t.Fatal(err)
 	}
-	user, err = Users.GetByID(ctx, user.ID)
+	user, err = GlobalUsers.GetByID(ctx, user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -419,7 +419,7 @@ func TestUsers_Update(t *testing.T) {
 	}
 
 	// Can't update to duplicate username.
-	user2, err := Users.Create(ctx, NewUser{
+	user2, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a2@a.com",
 		Username:              "u2",
 		Password:              "p2",
@@ -428,12 +428,12 @@ func TestUsers_Update(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := Users.Update(ctx, user2.ID, UserUpdate{Username: "u1"}); err == nil {
+	if err := GlobalUsers.Update(ctx, user2.ID, UserUpdate{Username: "u1"}); err == nil {
 		t.Fatal("want error when updating user to existing username")
 	}
 
 	// Can't update nonexistent user.
-	if err := Users.Update(ctx, 12345, UserUpdate{Username: "u12345"}); err == nil {
+	if err := GlobalUsers.Update(ctx, 12345, UserUpdate{Username: "u12345"}); err == nil {
 		t.Fatal("want error when updating nonexistent user")
 	}
 }
@@ -445,7 +445,7 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 	ctx := context.Background()
 
-	user, err := Users.Create(ctx, NewUser{
+	user, err := GlobalUsers.Create(ctx, NewUser{
 		Email:                 "a@a.com",
 		Username:              "u",
 		Password:              "p",
@@ -455,15 +455,15 @@ func TestUsers_GetByVerifiedEmail(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := Users.GetByVerifiedEmail(ctx, "a@a.com"); !errcode.IsNotFound(err) {
+	if _, err := GlobalUsers.GetByVerifiedEmail(ctx, "a@a.com"); !errcode.IsNotFound(err) {
 		t.Errorf("for unverified email, got error %v, want IsNotFound", err)
 	}
 
-	if err := UserEmails.SetVerified(ctx, user.ID, "a@a.com", true); err != nil {
+	if err := GlobalUserEmails.SetVerified(ctx, user.ID, "a@a.com", true); err != nil {
 		t.Fatal(err)
 	}
 
-	gotUser, err := Users.GetByVerifiedEmail(ctx, "a@a.com")
+	gotUser, err := GlobalUsers.GetByVerifiedEmail(ctx, "a@a.com")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -493,13 +493,13 @@ func TestUsers_GetByUsernames(t *testing.T) {
 	}
 
 	for _, newUser := range newUsers {
-		_, err := Users.Create(ctx, newUser)
+		_, err := GlobalUsers.Create(ctx, newUser)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	users, err := Users.GetByUsernames(ctx, "alice", "bob", "cindy")
+	users, err := GlobalUsers.GetByUsernames(ctx, "alice", "bob", "cindy")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -523,12 +523,12 @@ func TestUsers_Delete(t *testing.T) {
 			ctx := context.Background()
 			ctx = actor.WithActor(ctx, &actor.Actor{UID: 1, Internal: true})
 
-			otherUser, err := Users.Create(ctx, NewUser{Username: "other"})
+			otherUser, err := GlobalUsers.Create(ctx, NewUser{Username: "other"})
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			user, err := Users.Create(ctx, NewUser{
+			user, err := GlobalUsers.Create(ctx, NewUser{
 				Email:                 "a@a.com",
 				Username:              "u",
 				Password:              "p",
@@ -542,7 +542,7 @@ func TestUsers_Delete(t *testing.T) {
 			confGet := func() *conf.Unified {
 				return &conf.Unified{}
 			}
-			err = ExternalServices.Create(ctx, confGet, &types.ExternalService{
+			err = GlobalExternalServices.Create(ctx, confGet, &types.ExternalService{
 				Kind:            extsvc.KindGitHub,
 				DisplayName:     "GITHUB #1",
 				Config:          `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc", "authorization": {}}`,
@@ -553,20 +553,20 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// Create settings for the user, and for another user authored by this user.
-			if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user.ID}, nil, &user.ID, "{}"); err != nil {
+			if _, err := GlobalSettings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &user.ID}, nil, &user.ID, "{}"); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := Settings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &otherUser.ID}, nil, &user.ID, "{}"); err != nil {
+			if _, err := GlobalSettings.CreateIfUpToDate(ctx, api.SettingsSubject{User: &otherUser.ID}, nil, &user.ID, "{}"); err != nil {
 				t.Fatal(err)
 			}
 
 			// Create a repository to comply with the postgres repo constraint.
-			if err := Repos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
+			if err := GlobalRepos.Upsert(ctx, InsertRepoOp{Name: "myrepo", Description: "", Fork: false}); err != nil {
 				t.Fatal(err)
 			}
 
 			// Create a saved search owned by the user.
-			if _, err := SavedSearches.Create(ctx, &types.SavedSearch{
+			if _, err := GlobalSavedSearches.Create(ctx, &types.SavedSearch{
 				Description: "desc",
 				Query:       "foo",
 				UserID:      &user.ID,
@@ -576,22 +576,22 @@ func TestUsers_Delete(t *testing.T) {
 
 			if hard {
 				// Hard delete user.
-				if err := Users.HardDelete(ctx, user.ID); err != nil {
+				if err := GlobalUsers.HardDelete(ctx, user.ID); err != nil {
 					t.Fatal(err)
 				}
 			} else {
 				// Delete user.
-				if err := Users.Delete(ctx, user.ID); err != nil {
+				if err := GlobalUsers.Delete(ctx, user.ID); err != nil {
 					t.Fatal(err)
 				}
 			}
 
 			// User no longer exists.
-			_, err = Users.GetByID(ctx, user.ID)
+			_, err = GlobalUsers.GetByID(ctx, user.ID)
 			if !errcode.IsNotFound(err) {
 				t.Errorf("got error %v, want ErrUserNotFound", err)
 			}
-			users, err := Users.List(ctx, nil)
+			users, err := GlobalUsers.List(ctx, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -601,20 +601,20 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// User's settings no longer exist.
-			if settings, err := Settings.GetLatest(ctx, api.SettingsSubject{User: &user.ID}); err != nil {
+			if settings, err := GlobalSettings.GetLatest(ctx, api.SettingsSubject{User: &user.ID}); err != nil {
 				t.Error(err)
 			} else if settings != nil {
 				t.Errorf("got settings %+v, want nil", settings)
 			}
 			// Settings authored by user still exist but have nil author.
-			if settings, err := Settings.GetLatest(ctx, api.SettingsSubject{User: &otherUser.ID}); err != nil {
+			if settings, err := GlobalSettings.GetLatest(ctx, api.SettingsSubject{User: &otherUser.ID}); err != nil {
 				t.Fatal(err)
 			} else if settings.AuthorUserID != nil {
 				t.Errorf("got author %v, want nil", *settings.AuthorUserID)
 			}
 
 			// User's external services no longer exist
-			ess, err := ExternalServices.List(ctx, ExternalServicesListOptions{
+			ess, err := GlobalExternalServices.List(ctx, ExternalServicesListOptions{
 				NamespaceUserID: user.ID,
 			})
 			if err != nil {
@@ -625,7 +625,7 @@ func TestUsers_Delete(t *testing.T) {
 			}
 
 			// Can't delete already-deleted user.
-			err = Users.Delete(ctx, user.ID)
+			err = GlobalUsers.Delete(ctx, user.ID)
 			if !errcode.IsNotFound(err) {
 				t.Errorf("got error %v, want ErrUserNotFound", err)
 			}
@@ -646,7 +646,7 @@ func TestUsers_HasTag(t *testing.T) {
 	}
 
 	// lookup existing tag
-	ok, err := Users.HasTag(ctx, id, "foo")
+	ok, err := GlobalUsers.HasTag(ctx, id, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -655,7 +655,7 @@ func TestUsers_HasTag(t *testing.T) {
 	}
 
 	// lookup non-existing tag
-	ok, err = Users.HasTag(ctx, id, "baz")
+	ok, err = GlobalUsers.HasTag(ctx, id, "baz")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -664,7 +664,7 @@ func TestUsers_HasTag(t *testing.T) {
 	}
 
 	// lookup non-existing user
-	ok, err = Users.HasTag(ctx, id+1, "bar")
+	ok, err = GlobalUsers.HasTag(ctx, id+1, "bar")
 	if err == nil || ok {
 		t.Fatal("expected user to be not found")
 	}
@@ -691,13 +691,13 @@ func TestUsers_InvalidateSessions(t *testing.T) {
 	}
 
 	for _, newUser := range newUsers {
-		_, err := Users.Create(ctx, newUser)
+		_, err := GlobalUsers.Create(ctx, newUser)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	users, err := Users.GetByUsernames(ctx, "alice", "bob")
+	users, err := GlobalUsers.GetByUsernames(ctx, "alice", "bob")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -706,7 +706,7 @@ func TestUsers_InvalidateSessions(t *testing.T) {
 		t.Fatalf("got %d users, but want 2", len(users))
 	}
 	for i := range users {
-		if err := Users.InvalidateSessionsByID(ctx, users[i].ID); err != nil {
+		if err := GlobalUsers.InvalidateSessionsByID(ctx, users[i].ID); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -720,14 +720,14 @@ func TestUsers_SetTag(t *testing.T) {
 	ctx := context.Background()
 
 	// Create user.
-	u, err := Users.Create(ctx, NewUser{Username: "u"})
+	u, err := GlobalUsers.Create(ctx, NewUser{Username: "u"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	checkTags := func(t *testing.T, userID int32, wantTags []string) {
 		t.Helper()
-		u, err := Users.GetByID(ctx, userID)
+		u, err := GlobalUsers.GetByID(ctx, userID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -739,7 +739,7 @@ func TestUsers_SetTag(t *testing.T) {
 	}
 	checkUsersWithTag := func(t *testing.T, tag string, wantUsers []int32) {
 		t.Helper()
-		users, err := Users.List(ctx, &UsersListOptions{Tag: tag})
+		users, err := GlobalUsers.List(ctx, &UsersListOptions{Tag: tag})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -753,10 +753,10 @@ func TestUsers_SetTag(t *testing.T) {
 	}
 
 	t.Run("fails on nonexistent user", func(t *testing.T) {
-		if err := Users.SetTag(ctx, 1234 /* doesn't exist */, "t", true); !errcode.IsNotFound(err) {
+		if err := GlobalUsers.SetTag(ctx, 1234 /* doesn't exist */, "t", true); !errcode.IsNotFound(err) {
 			t.Errorf("got err %v, want errcode.IsNotFound", err)
 		}
-		if err := Users.SetTag(ctx, 1234 /* doesn't exist */, "t", false); !errcode.IsNotFound(err) {
+		if err := GlobalUsers.SetTag(ctx, 1234 /* doesn't exist */, "t", false); !errcode.IsNotFound(err) {
 			t.Errorf("got err %v, want errcode.IsNotFound", err)
 		}
 	})
@@ -767,27 +767,27 @@ func TestUsers_SetTag(t *testing.T) {
 	})
 
 	t.Run("adds and removes tag", func(t *testing.T) {
-		if err := Users.SetTag(ctx, u.ID, "t1", true); err != nil {
+		if err := GlobalUsers.SetTag(ctx, u.ID, "t1", true); err != nil {
 			t.Fatal(err)
 		}
 		checkTags(t, u.ID, []string{"t1"})
 		checkUsersWithTag(t, "t1", []int32{u.ID})
 
 		t.Run("deduplicates", func(t *testing.T) {
-			if err := Users.SetTag(ctx, u.ID, "t1", true); err != nil {
+			if err := GlobalUsers.SetTag(ctx, u.ID, "t1", true); err != nil {
 				t.Fatal(err)
 			}
 			checkTags(t, u.ID, []string{"t1"})
 		})
 
-		if err := Users.SetTag(ctx, u.ID, "t2", true); err != nil {
+		if err := GlobalUsers.SetTag(ctx, u.ID, "t2", true); err != nil {
 			t.Fatal(err)
 		}
 		checkTags(t, u.ID, []string{"t1", "t2"})
 		checkUsersWithTag(t, "t1", []int32{u.ID})
 		checkUsersWithTag(t, "t2", []int32{u.ID})
 
-		if err := Users.SetTag(ctx, u.ID, "t1", false); err != nil {
+		if err := GlobalUsers.SetTag(ctx, u.ID, "t1", false); err != nil {
 			t.Fatal(err)
 		}
 		checkTags(t, u.ID, []string{"t2"})
@@ -795,13 +795,13 @@ func TestUsers_SetTag(t *testing.T) {
 		checkUsersWithTag(t, "t2", []int32{u.ID})
 
 		t.Run("removing nonexistent tag is noop", func(t *testing.T) {
-			if err := Users.SetTag(ctx, u.ID, "t1", false); err != nil {
+			if err := GlobalUsers.SetTag(ctx, u.ID, "t1", false); err != nil {
 				t.Fatal(err)
 			}
 			checkTags(t, u.ID, []string{"t2"})
 		})
 
-		if err := Users.SetTag(ctx, u.ID, "t2", false); err != nil {
+		if err := GlobalUsers.SetTag(ctx, u.ID, "t2", false); err != nil {
 			t.Fatal(err)
 		}
 		checkTags(t, u.ID, []string{})

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -256,7 +256,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 	// Unless explicitly specified with the "all" setting or the owner of the service has the "AllowUserExternalServicePrivate" tag,
 	// user added external services should only sync public code.
 	if isUserOwned && conf.ExternalServiceUserMode() != conf.ExternalServiceModeAll {
-		ok, err := db.Users.HasTag(ctx, svc.NamespaceUserID, db.TagAllowUserExternalServicePrivate)
+		ok, err := db.GlobalUsers.HasTag(ctx, svc.NamespaceUserID, db.TagAllowUserExternalServicePrivate)
 		if err != nil {
 			return errors.Wrap(err, "checking user tag")
 		}

--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -9,7 +9,7 @@ import (
 )
 
 func GetSiteUsageStats(ctx context.Context, monthsOnly bool) (*types.SiteUsageStatistics, error) {
-	summary, err := db.EventLogs.SiteUsage(ctx)
+	summary, err := db.GlobalEventLogs.SiteUsage(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func groupSiteUsageStats(summary types.SiteUsageSummary, monthsOnly bool) *types
 
 // GetAggregatedCodeIntelStats returns aggregated statistics for code intelligence usage.
 func GetAggregatedCodeIntelStats(ctx context.Context) (*types.NewCodeIntelUsageStatistics, error) {
-	codeIntelEvents, err := db.EventLogs.AggregatedCodeIntelEvents(ctx)
+	codeIntelEvents, err := db.GlobalEventLogs.AggregatedCodeIntelEvents(ctx)
 	if err != nil {
 		return nil, err
 	} else if len(codeIntelEvents) == 0 {
@@ -67,7 +67,7 @@ func GetAggregatedCodeIntelStats(ctx context.Context) (*types.NewCodeIntelUsageS
 	}
 	stats := groupAggregatedCodeIntelStats(codeIntelEvents)
 
-	usersCount, err := db.EventLogs.CodeIntelligenceCombinedWAU(ctx)
+	usersCount, err := db.GlobalEventLogs.CodeIntelligenceCombinedWAU(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func groupAggregatedCodeIntelStats(rawEvents []types.CodeIntelAggregatedEvent) *
 
 // GetAggregatedSearchStats returns aggregates statistics for search usage.
 func GetAggregatedSearchStats(ctx context.Context) (*types.SearchUsageStatistics, error) {
-	events, err := db.EventLogs.AggregatedSearchEvents(ctx)
+	events, err := db.GlobalEventLogs.AggregatedSearchEvents(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/campaigns_test.go
+++ b/internal/usagestats/campaigns_test.go
@@ -54,7 +54,7 @@ func TestCampaignsUsageStatistics(t *testing.T) {
 	}
 
 	// Create a user.
-	user, err := db.Users.Create(ctx, db.NewUser{Username: "test"})
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{Username: "test"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/usagestats/event_handlers.go
+++ b/internal/usagestats/event_handlers.go
@@ -111,5 +111,5 @@ func logLocalEvent(ctx context.Context, name, url string, userID int32, userCook
 		Argument:        argument,
 		Timestamp:       timeNow().UTC(),
 	}
-	return db.EventLogs.Insert(ctx, info)
+	return db.GlobalEventLogs.Insert(ctx, info)
 }

--- a/internal/usagestats/retention_test.go
+++ b/internal/usagestats/retention_test.go
@@ -41,7 +41,7 @@ func TestRetentionUsageStatistics(t *testing.T) {
 	}}
 
 	for _, event := range events {
-		err := db.EventLogs.Insert(ctx, &event)
+		err := db.GlobalEventLogs.Insert(ctx, &event)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/usagestats/usage_stats.go
+++ b/internal/usagestats/usage_stats.go
@@ -22,12 +22,12 @@ var (
 // GetArchive generates and returns a usage statistics ZIP archive containing the CSV
 // files defined in RFC 145, or an error in case of failure.
 func GetArchive(ctx context.Context) ([]byte, error) {
-	counts, err := db.EventLogs.UsersUsageCounts(ctx)
+	counts, err := db.GlobalEventLogs.UsersUsageCounts(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	dates, err := db.Users.ListDates(ctx)
+	dates, err := db.GlobalUsers.ListDates(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -113,27 +113,27 @@ func GetByUserID(ctx context.Context, userID int32) (*types.UserUsageStatistics,
 		return MockGetByUserID(userID)
 	}
 
-	pageViews, err := db.EventLogs.CountByUserIDAndEventNamePrefix(ctx, userID, "View")
+	pageViews, err := db.GlobalEventLogs.CountByUserIDAndEventNamePrefix(ctx, userID, "View")
 	if err != nil {
 		return nil, err
 	}
-	searchQueries, err := db.EventLogs.CountByUserIDAndEventName(ctx, userID, "SearchResultsQueried")
+	searchQueries, err := db.GlobalEventLogs.CountByUserIDAndEventName(ctx, userID, "SearchResultsQueried")
 	if err != nil {
 		return nil, err
 	}
-	codeIntelligenceActions, err := db.EventLogs.CountByUserIDAndEventNames(ctx, userID, []string{"hover", "findReferences", "goToDefinition.preloaded", "goToDefinition"})
+	codeIntelligenceActions, err := db.GlobalEventLogs.CountByUserIDAndEventNames(ctx, userID, []string{"hover", "findReferences", "goToDefinition.preloaded", "goToDefinition"})
 	if err != nil {
 		return nil, err
 	}
-	findReferencesActions, err := db.EventLogs.CountByUserIDAndEventName(ctx, userID, "findReferences")
+	findReferencesActions, err := db.GlobalEventLogs.CountByUserIDAndEventName(ctx, userID, "findReferences")
 	if err != nil {
 		return nil, err
 	}
-	lastActiveTime, err := db.EventLogs.MaxTimestampByUserID(ctx, userID)
+	lastActiveTime, err := db.GlobalEventLogs.MaxTimestampByUserID(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
-	lastCodeHostIntegrationTime, err := db.EventLogs.MaxTimestampByUserIDAndSource(ctx, userID, "CODEHOSTINTEGRATION")
+	lastCodeHostIntegrationTime, err := db.GlobalEventLogs.MaxTimestampByUserIDAndSource(ctx, userID, "CODEHOSTINTEGRATION")
 	if err != nil {
 		return nil, err
 	}
@@ -152,27 +152,27 @@ func GetByUserID(ctx context.Context, userID int32) (*types.UserUsageStatistics,
 func GetUsersActiveTodayCount(ctx context.Context) (int, error) {
 	now := timeNow().UTC()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs.CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1))
+	return db.GlobalEventLogs.CountUniqueUsersAll(ctx, today, today.AddDate(0, 0, 1))
 }
 
 // ListRegisteredUsersToday returns a list of the registered users that were active today.
 func ListRegisteredUsersToday(ctx context.Context) ([]int32, error) {
 	now := timeNow().UTC()
 	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	return db.EventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 1))
+	return db.GlobalEventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 1))
 }
 
 // ListRegisteredUsersThisWeek returns a list of the registered users that were active this week.
 func ListRegisteredUsersThisWeek(ctx context.Context) ([]int32, error) {
 	start := timeutil.StartOfWeek(timeNow().UTC(), 0)
-	return db.EventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 7))
+	return db.GlobalEventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 0, 7))
 }
 
 // ListRegisteredUsersThisMonth returns a list of the registered users that were active this month.
 func ListRegisteredUsersThisMonth(ctx context.Context) ([]int32, error) {
 	now := timeNow().UTC()
 	start := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-	return db.EventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 1, 0))
+	return db.GlobalEventLogs.ListUniqueUsersAll(ctx, start, start.AddDate(0, 1, 0))
 }
 
 // SiteUsageStatisticsOptions contains options for the number of daily, weekly, and monthly periods in
@@ -229,17 +229,17 @@ func activeUsers(ctx context.Context, periodType db.PeriodType, periods int) ([]
 		return []*types.SiteActivityPeriod{}, nil
 	}
 
-	uniqueUsers, err := db.EventLogs.CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, nil)
+	uniqueUsers, err := db.GlobalEventLogs.CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, nil)
 	if err != nil {
 		return nil, err
 	}
-	registeredUniqueUsers, err := db.EventLogs.CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &db.CountUniqueUsersOptions{
+	registeredUniqueUsers, err := db.GlobalEventLogs.CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &db.CountUniqueUsersOptions{
 		RegisteredOnly: true,
 	})
 	if err != nil {
 		return nil, err
 	}
-	integrationUniqueUsers, err := db.EventLogs.CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &db.CountUniqueUsersOptions{
+	integrationUniqueUsers, err := db.GlobalEventLogs.CountUniqueUsersPerPeriod(ctx, periodType, timeNow().UTC(), periods, &db.CountUniqueUsersOptions{
 		IntegrationOnly: true,
 	})
 	if err != nil {

--- a/internal/usagestats/usage_stats_test.go
+++ b/internal/usagestats/usage_stats_test.go
@@ -22,7 +22,7 @@ func TestGetArchive(t *testing.T) {
 	now := time.Now().UTC()
 	ctx := context.Background()
 
-	user, err := db.Users.Create(ctx, db.NewUser{
+	user, err := db.GlobalUsers.Create(ctx, db.NewUser{
 		Email:           "foo@bar.com",
 		Username:        "admin",
 		EmailIsVerified: true,
@@ -39,12 +39,12 @@ func TestGetArchive(t *testing.T) {
 		Timestamp: now,
 	}
 
-	err = db.EventLogs.Insert(ctx, event)
+	err = db.GlobalEventLogs.Insert(ctx, event)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	dates, err := db.Users.ListDates(ctx)
+	dates, err := db.GlobalUsers.ListDates(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR renames global store variables to something more embarassing and adds a depreciation comment to notify everyone that we are moving away from using dbconn.Global.
