### PR TITLE
search: add an explicit searchFilesInReposBatch function

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -177,7 +177,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			newArgs.RepoPromise = (&search.Promise{}).Resolve(repos)
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
-			matches, _, err := searchFilesInRepos(ctx, &newArgs, nil)
+			matches, _, err := searchFilesInReposBatch(ctx, &newArgs)
 			if err != nil {
 				return nil, err
 			}
@@ -205,7 +205,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 			newArgs.RepoPromise = rp
 			newArgs.Query = q
 			newArgs.UseFullDeadline = true
-			matches, _, err := searchFilesInRepos(ctx, &newArgs, nil)
+			matches, _, err := searchFilesInReposBatch(ctx, &newArgs)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
We want to make the normal interface for searchFilesInRepos to be
streaming. So it no longer makes sense to have return arguments. So we
introduce a batch interface which doesn't take a stream and does the
collection for us. I made the collection generic since I think we will
likely use this pattern more than once.

Additionally this makes our hacks for structural search clearer. I add
back the special logic around unsetting IsLimitHit.