### PR TITLE
Convert MonacoQueryInput to function component

### DIFF
--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -1,18 +1,17 @@
-import React from 'react'
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import * as H from 'history'
 import * as Monaco from 'monaco-editor'
-import { isEqual, isPlainObject } from 'lodash'
+import { isPlainObject } from 'lodash'
 import { MonacoEditor } from '../../components/MonacoEditor'
 import { QueryState } from '../helpers'
 import { getProviders } from '../../../../shared/src/search/query/providers'
-import { Subscription, Observable, Subject, Unsubscribable, ReplaySubject } from 'rxjs'
+import { Subscription, Observable, Unsubscribable, ReplaySubject } from 'rxjs'
 import { fetchSuggestions } from '../backend'
-import { map, distinctUntilChanged, filter, switchMap, withLatestFrom } from 'rxjs/operators'
 import { Omit } from 'utility-types'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { CaseSensitivityProps, PatternTypeProps, CopyQueryButtonProps } from '..'
 import { Toggles, TogglesProps } from './toggles/Toggles'
-import { hasProperty, isDefined } from '../../../../shared/src/util/types'
+import { hasProperty } from '../../../../shared/src/util/types'
 import { KeyboardShortcut } from '../../../../shared/src/keyboardShortcuts'
 import { KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR } from '../../keyboardShortcuts/keyboardShortcuts'
 import { observeResize } from '../../util/dom'
@@ -151,224 +150,87 @@ const hasCommandService = (editor: Monaco.editor.IStandaloneCodeEditor): editor 
  * This component should not be imported directly: use {@link LazyMonacoQueryInput} instead
  * to avoid bundling the Monaco editor on every page.
  */
-export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps> {
-    private componentUpdates = new ReplaySubject<MonacoQueryInputProps>(1)
-    private searchQueries = this.componentUpdates.pipe(
-        map(({ queryState }) => queryState.query),
-        distinctUntilChanged()
-    )
-    private containerRefs = new Subject<HTMLElement | null>()
-    private editorRefs = new Subject<Monaco.editor.IStandaloneCodeEditor | null>()
-    private subscriptions = new Subscription()
+export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = ({
+    queryState,
+    onFocus,
+    onChange,
+    onSubmit,
+    onSuggestionsInitialized,
+    onCompletionItemSelected,
+    autoFocus,
+    ...props
+}) => {
+    const [editor, setEditor] = useState<Monaco.editor.IStandaloneCodeEditor>()
 
-    constructor(props: MonacoQueryInputProps) {
-        super(props)
-        // Trigger a layout of the Monaco editor when its container gets resized.
-        // The Monaco editor doesn't auto-resize with its container:
-        // https://github.com/microsoft/monaco-editor/issues/28
-        this.subscriptions.add(
-            this.containerRefs
-                .pipe(
-                    switchMap(container => (container ? observeResize(container) : [])),
-                    withLatestFrom(this.editorRefs),
-                    map(([, editor]) => editor),
-                    filter(isDefined)
-                )
-                .subscribe(editor => {
-                    editor.layout()
-                })
-        )
-    }
-
-    public componentDidMount(): void {
-        this.componentUpdates.next(this.props)
-    }
-
-    public componentDidUpdate(): void {
-        this.componentUpdates.next(this.props)
-    }
-
-    public componentWillUnmount(): void {
-        this.subscriptions.unsubscribe()
-    }
-
-    public render(): JSX.Element {
-        const options: Monaco.editor.IEditorOptions = {
-            readOnly: false,
-            lineNumbers: 'off',
-            lineHeight: 16,
-            // Match the query input's height for suggestion items line height.
-            suggestLineHeight: 34,
-            minimap: {
-                enabled: false,
-            },
-            scrollbar: {
-                vertical: 'hidden',
-                horizontal: 'hidden',
-            },
-            glyphMargin: false,
-            lineDecorationsWidth: 0,
-            lineNumbersMinChars: 0,
-            overviewRulerBorder: false,
-            folding: false,
-            rulers: [],
-            overviewRulerLanes: 0,
-            wordBasedSuggestions: false,
-            quickSuggestions: false,
-            fixedOverflowWidgets: true,
-            contextmenu: false,
-            links: false,
-            // Display the cursor as a 1px line.
-            cursorStyle: 'line',
-            cursorWidth: 1,
+    // Trigger a layout of the Monaco editor when its container gets resized.
+    // The Monaco editor doesn't auto-resize with its container:
+    // https://github.com/microsoft/monaco-editor/issues/28
+    const [container, setContainer] = useState<HTMLElement | null>()
+    useLayoutEffect(() => {
+        if (!editor || !container) {
+            return
         }
-        return (
-            <>
-                <div ref={this.containerRefs.next.bind(this.containerRefs)} className="monaco-query-input-container">
-                    <div className="flex-grow-1 flex-shrink-past-contents" onFocus={this.props.onFocus}>
-                        <MonacoEditor
-                            id="monaco-query-input"
-                            language={SOURCEGRAPH_SEARCH}
-                            value={this.props.queryState.query}
-                            height={17}
-                            isLightTheme={this.props.isLightTheme}
-                            editorWillMount={this.editorWillMount}
-                            onEditorCreated={this.onEditorCreated}
-                            options={options}
-                            border={false}
-                            keyboardShortcutForFocus={KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR}
-                            className="test-query-input"
-                        />
-                    </div>
-                    <Toggles
-                        {...this.props}
-                        navbarSearchQuery={this.props.queryState.query}
-                        className="monaco-query-input-container__toggle-container"
-                    />
-                </div>
-            </>
-        )
-    }
-
-    private onChange = (query: string): void => {
-        this.props.onChange({ query, fromUserInput: true })
-    }
-
-    private onSubmit = (): void => {
-        this.props.onSubmit()
-    }
-
-    private editorWillMount = (monaco: typeof Monaco): void => {
-        // Register themes and code intelligence providers.
-        this.subscriptions.add(
-            this.componentUpdates
-                .pipe(
-                    map(({ patternType, globbing, enableSmartQuery, interpretComments }) => ({
-                        patternType,
-                        globbing,
-                        enableSmartQuery,
-                        interpretComments,
-                    })),
-                    distinctUntilChanged((a, b) => isEqual(a, b)),
-                    switchMap(
-                        options =>
-                            new Observable(() =>
-                                addSourcegraphSearchCodeIntelligence(monaco, this.searchQueries, options)
-                            )
-                    )
-                )
-                .subscribe()
-        )
-    }
-
-    private onEditorCreated = (editor: Monaco.editor.IStandaloneCodeEditor): void => {
-        this.props.onSuggestionsInitialized?.({
-            trigger: () => editor.trigger('triggerSuggestions', 'editor.action.triggerSuggest', {}),
+        const subscription = observeResize(container).subscribe(() => {
+            editor.layout()
         })
+        return () => subscription.unsubscribe()
+    }, [editor, container])
 
-        if (this.props.onCompletionItemSelected) {
-            if (!hasCommandService(editor)) {
-                throw new Error('Could not call onCompletionItemSelected: editor has no commandService')
-            }
-            this.subscriptions.add(
-                editor._commandService.addCommand({
-                    id: 'completionItemSelected',
-                    handler: this.props.onCompletionItemSelected,
-                })
-            )
+    // Register themes and code intelligence providers. The providers are passed
+    // a ReplaySubject of search queries to avoid registering new providers on
+    // every query change. The ReplaySubject is updated with useLayoutEffect
+    // so that the update is synchronous, otherwise providers run off
+    // an outdated query.
+    //
+    // TODO: use a ref instead and get rid of RxJS usage here altogether?
+    const [monacoInstance, setMonacoInstance] = useState<typeof Monaco>()
+    const searchQueries = useMemo(() => new ReplaySubject<string>(1), [])
+    useLayoutEffect(() => {
+        searchQueries.next(queryState.query)
+    }, [queryState.query, searchQueries])
+    const { patternType, globbing, enableSmartQuery, interpretComments } = props
+    useEffect(() => {
+        if (!monacoInstance) {
+            return
+        }
+        const subscription = addSourcegraphSearchCodeIntelligence(monacoInstance, searchQueries, {
+            patternType,
+            globbing,
+            enableSmartQuery,
+            interpretComments,
+        })
+        return () => subscription.unsubscribe()
+    }, [monacoInstance, searchQueries, patternType, globbing, enableSmartQuery, interpretComments])
+
+    // Register suggestions handle
+    useEffect(() => {
+        if (editor) {
+            onSuggestionsInitialized?.({
+                trigger: () => editor.trigger('triggerSuggestions', 'editor.action.triggerSuggest', {}),
+            })
+        }
+    }, [editor, onSuggestionsInitialized])
+
+    // Register onCompletionSelected handler
+    useEffect(() => {
+        if (!editor || !onCompletionItemSelected) {
+            return
+        }
+        if (!hasCommandService(editor)) {
+            throw new Error('Could not call onCompletionItemSelected: editor has no commandService')
         }
 
-        this.editorRefs.next(editor)
-        // Accessibility: allow tab usage to move focus to
-        // next previous focusable element (and not to insert the tab character).
-        // - Cannot be set through IEditorOptions
-        // - Cannot be called synchronously (otherwise risks being overridden by Monaco defaults)
-        this.subscriptions.add(
-            toUnsubscribable(
-                editor.onDidFocusEditorText(() => {
-                    editor.createContextKey('editorTabMovesFocus', true)
-                })
-            )
-        )
+        editor._commandService.addCommand({
+            id: 'completionItemSelected',
+            handler: onCompletionItemSelected,
+        })
+    }, [editor, onCompletionItemSelected])
 
-        // Focus the editor if the autoFocus prop is truthy
-        this.subscriptions.add(
-            this.componentUpdates
-                .pipe(
-                    map(({ autoFocus }) => autoFocus),
-                    filter(autoFocus => !!autoFocus),
-                    distinctUntilChanged()
-                )
-                .subscribe(() => {
-                    editor.focus()
-                })
-        )
-
-        // If an edit wasn't triggered by the user,
-        // place the cursor at the end of the query.
-        this.subscriptions.add(
-            this.componentUpdates
-                .pipe(
-                    map(({ queryState }) => queryState),
-                    filter(({ fromUserInput }) => !fromUserInput),
-                    distinctUntilChanged((a, b) => a.query === b.query)
-                )
-                .subscribe(() => {
-                    const position = {
-                        // +2 as Monaco is 1-indexed.
-                        column: editor.getValue().length + 2,
-                        lineNumber: 1,
-                    }
-                    editor.setPosition(position)
-                    editor.revealPosition(position)
-                })
-        )
-
-        // Prevent newline insertion in model, and surface query changes with stripped newlines.
-        this.subscriptions.add(
-            toUnsubscribable(
-                editor.onDidChangeModelContent(() => {
-                    this.onChange(editor.getValue().replace(/[\n\r↵]/g, ''))
-                })
-            )
-        )
-
-        // Submit on enter, hiding the suggestions widget if it's visible.
-        this.subscriptions.add(
-            toUnsubscribable(
-                editor.addAction({
-                    id: 'submitOnEnter',
-                    label: 'submitOnEnter',
-                    keybindings: [Monaco.KeyCode.Enter],
-                    run: () => {
-                        this.onSubmit()
-                        editor.trigger('submitOnEnter', 'hideSuggestWidget', [])
-                    },
-                })
-            )
-        )
-
-        // Disable default Monaco keybindings
+    // Disable default Monaco keybindings
+    useEffect(() => {
+        if (!editor) {
+            return
+        }
         if (!hasKeybindingService(editor)) {
             // Throw an error if hasKeybindingService() returns false,
             // to surface issues with this workaround when upgrading Monaco.
@@ -385,5 +247,126 @@ export class MonacoQueryInput extends React.PureComponent<MonacoQueryInputProps>
         // Free CMD+L keybinding, which is part of Monaco's CoreNavigationCommands, and
         // not exposed on editor._actions.
         editor._standaloneKeybindingService.addDynamicKeybinding('-expandLineSelection')
+    }, [editor])
+
+    // Accessibility: allow tab usage to move focus to
+    // next previous focusable element (and not to insert the tab character).
+    // - Cannot be set through IEditorOptions
+    // - Cannot be called synchronously (otherwise risks being overridden by Monaco defaults)
+    useEffect(() => {
+        if (!editor) {
+            return
+        }
+        const disposable = editor.onDidFocusEditorText(() => {
+            editor.createContextKey('editorTabMovesFocus', true)
+        })
+        return () => disposable.dispose()
+    }, [editor])
+
+    // Focus the editor if the autoFocus prop is truthy
+    useEffect(() => {
+        if (!editor || !autoFocus) {
+            return
+        }
+        editor.focus()
+    }, [editor, autoFocus])
+
+    // If an edit wasn't triggered by the user,
+    // place the cursor at the end of the query.
+    useEffect(() => {
+        if (!editor || queryState.fromUserInput) {
+            return
+        }
+        const position = {
+            // +2 as Monaco is 1-indexed.
+            column: editor.getValue().length + 2,
+            lineNumber: 1,
+        }
+        editor.setPosition(position)
+        editor.revealPosition(position)
+    }, [editor, queryState])
+
+    // Prevent newline insertion in model, and surface query changes with stripped newlines.
+    useEffect(() => {
+        if (!editor) {
+            return
+        }
+        const disposable = editor.onDidChangeModelContent(() => {
+            onChange({ query: editor.getValue().replace(/[\n\r↵]/g, ''), fromUserInput: true })
+        })
+        return () => disposable.dispose()
+    }, [editor, onChange])
+
+    // Submit on enter, hiding the suggestions widget if it's visible.
+    useEffect(() => {
+        if (!editor) {
+            return
+        }
+        const disposable = editor.addAction({
+            id: 'submitOnEnter',
+            label: 'submitOnEnter',
+            keybindings: [Monaco.KeyCode.Enter],
+            run: () => {
+                onSubmit()
+                editor.trigger('submitOnEnter', 'hideSuggestWidget', [])
+            },
+        })
+        return () => disposable.dispose()
+    }, [editor, onSubmit])
+
+    const options: Monaco.editor.IEditorOptions = {
+        readOnly: false,
+        lineNumbers: 'off',
+        lineHeight: 16,
+        // Match the query input's height for suggestion items line height.
+        suggestLineHeight: 34,
+        minimap: {
+            enabled: false,
+        },
+        scrollbar: {
+            vertical: 'hidden',
+            horizontal: 'hidden',
+        },
+        glyphMargin: false,
+        lineDecorationsWidth: 0,
+        lineNumbersMinChars: 0,
+        overviewRulerBorder: false,
+        folding: false,
+        rulers: [],
+        overviewRulerLanes: 0,
+        wordBasedSuggestions: false,
+        quickSuggestions: false,
+        fixedOverflowWidgets: true,
+        contextmenu: false,
+        links: false,
+        // Display the cursor as a 1px line.
+        cursorStyle: 'line',
+        cursorWidth: 1,
     }
+    return (
+        <>
+            <div ref={setContainer} className="monaco-query-input-container">
+                <div className="flex-grow-1 flex-shrink-past-contents" onFocus={onFocus}>
+                    <MonacoEditor
+                        id="monaco-query-input"
+                        language={SOURCEGRAPH_SEARCH}
+                        value={queryState.query}
+                        height={17}
+                        isLightTheme={props.isLightTheme}
+                        editorWillMount={setMonacoInstance}
+                        onEditorCreated={setEditor}
+                        options={options}
+                        border={false}
+                        keyboardShortcutForFocus={KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR}
+                        className="test-query-input"
+                    />
+                </div>
+                <Toggles
+                    {...props}
+                    navbarSearchQuery={queryState.query}
+                    className="monaco-query-input-container__toggle-container"
+                />
+            </div>
+        </>
+    )
 }


### PR DESCRIPTION
Fixes #17322 

Stacked on #17450

Converts the MonacoQueryInput to a function component. This allows us to get rid of the nasty `this.componentUpdates` / `this.subscriptions` pattern, and will make the component much nicer to work with for any future edits. The query input is extensively tested with integration tests.
