### PR TITLE
Express search code intelligence as hook

### DIFF
--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -30,7 +30,7 @@ const latin1Alpha = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜ�
  * hovers, completions and diagnostics for the Sourcegraph search syntax.
  */
 export function getProviders(
-    queryRef: {
+    queryReference: {
         current:
             | undefined
             | {
@@ -67,22 +67,22 @@ export function getProviders(
         },
         hover: {
             provideHover: (textModel, position, token) => {
-                if (!queryRef.current || queryRef.current.scanned.type === 'error') {
+                if (!queryReference.current || queryReference.current.scanned.type === 'error') {
                     return null
                 }
-                return getHoverResult(queryRef.current.scanned.term, position, options.enableSmartQuery)
+                return getHoverResult(queryReference.current.scanned.term, position, options.enableSmartQuery)
             },
         },
         completion: {
             // An explicit list of trigger characters is needed for the Monaco editor to show completions.
             triggerCharacters: [...printable, ...latin1Alpha],
             provideCompletionItems: (textModel, position) => {
-                if (!queryRef.current || queryRef.current.scanned.type === 'error') {
+                if (!queryReference.current || queryReference.current.scanned.type === 'error') {
                     return null
                 }
-                fetchSuggestionsRequests.next(queryRef.current.rawQuery)
+                fetchSuggestionsRequests.next(queryReference.current.rawQuery)
                 return getCompletionItems(
-                    queryRef.current.scanned.term,
+                    queryReference.current.scanned.term,
                     position,
                     debouncedDynamicSuggestions,
                     options.globbing

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -1,19 +1,17 @@
 import * as Monaco from 'monaco-editor'
-import { Observable, fromEventPattern, of } from 'rxjs'
+import { Observable, ReplaySubject } from 'rxjs'
 import { scanSearchQuery } from './scanner'
-import { map, first, takeUntil, publishReplay, refCount, switchMap, debounceTime, share } from 'rxjs/operators'
 import { getMonacoTokens } from './decoratedToken'
-import { getDiagnostics } from './diagnostics'
 import { getCompletionItems } from './completion'
 import { getHoverResult } from './hover'
 import { SearchSuggestion } from '../suggestions'
 import { SearchPatternType } from '../../graphql-operations'
+import { debounceTime, share, switchMap } from 'rxjs/operators'
 
 interface SearchFieldProviders {
     tokens: Monaco.languages.TokensProvider
     hover: Monaco.languages.HoverProvider
     completion: Monaco.languages.CompletionItemProvider
-    diagnostics: Observable<Monaco.editor.IMarkerData[]>
 }
 
 /**
@@ -32,7 +30,14 @@ const latin1Alpha = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜ�
  * hovers, completions and diagnostics for the Sourcegraph search syntax.
  */
 export function getProviders(
-    searchQueries: Observable<string>,
+    queryRef: {
+        current:
+            | undefined
+            | {
+                  rawQuery: string
+                  scanned: ReturnType<typeof scanSearchQuery>
+              }
+    },
     fetchSuggestions: (input: string) => Observable<SearchSuggestion[]>,
     options: {
         patternType: SearchPatternType
@@ -41,68 +46,48 @@ export function getProviders(
         interpretComments?: boolean
     }
 ): SearchFieldProviders {
-    const scannedQueries = searchQueries.pipe(
-        map(rawQuery => {
-            const scanned = scanSearchQuery(rawQuery, options.interpretComments ?? false, options.patternType)
-            return { rawQuery, scanned }
-        }),
-        publishReplay(1),
-        refCount()
+    const fetchSuggestionsRequests = new ReplaySubject<string>(1)
+    const debouncedDynamicSuggestions = fetchSuggestionsRequests.pipe(
+        debounceTime(300),
+        switchMap(fetchSuggestions),
+        share()
     )
-
-    const debouncedDynamicSuggestions = searchQueries.pipe(debounceTime(300), switchMap(fetchSuggestions), share())
-
     return {
         tokens: {
             getInitialState: () => SCANNER_STATE,
             tokenize: line => {
                 const result = scanSearchQuery(line, options.interpretComments ?? false, options.patternType)
-                if (result.type === 'success') {
-                    return {
-                        tokens: getMonacoTokens(result.term, options.enableSmartQuery),
-                        endState: SCANNER_STATE,
-                    }
-                }
-                return { endState: SCANNER_STATE, tokens: [] }
+                return result.type === 'success'
+                    ? {
+                          tokens: getMonacoTokens(result.term, options.enableSmartQuery),
+                          endState: SCANNER_STATE,
+                      }
+                    : { endState: SCANNER_STATE, tokens: [] }
             },
         },
         hover: {
-            provideHover: (textModel, position, token) =>
-                scannedQueries
-                    .pipe(
-                        first(),
-                        map(({ scanned }) =>
-                            scanned.type === 'error'
-                                ? null
-                                : getHoverResult(scanned.term, position, options.enableSmartQuery)
-                        ),
-                        takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
-                    )
-                    .toPromise(),
+            provideHover: (textModel, position, token) => {
+                if (!queryRef.current || queryRef.current.scanned.type === 'error') {
+                    return null
+                }
+                return getHoverResult(queryRef.current.scanned.term, position, options.enableSmartQuery)
+            },
         },
         completion: {
             // An explicit list of trigger characters is needed for the Monaco editor to show completions.
             triggerCharacters: [...printable, ...latin1Alpha],
-            provideCompletionItems: (textModel, position, context, token) =>
-                scannedQueries
-                    .pipe(
-                        first(),
-                        switchMap(scannedQuery =>
-                            scannedQuery.scanned.type === 'error'
-                                ? of(null)
-                                : getCompletionItems(
-                                      scannedQuery.scanned.term,
-                                      position,
-                                      debouncedDynamicSuggestions,
-                                      options.globbing
-                                  )
-                        ),
-                        takeUntil(fromEventPattern(handler => token.onCancellationRequested(handler)))
-                    )
-                    .toPromise(),
+            provideCompletionItems: (textModel, position) => {
+                if (!queryRef.current || queryRef.current.scanned.type === 'error') {
+                    return null
+                }
+                fetchSuggestionsRequests.next(queryRef.current.rawQuery)
+                return getCompletionItems(
+                    queryRef.current.scanned.term,
+                    position,
+                    debouncedDynamicSuggestions,
+                    options.globbing
+                )
+            },
         },
-        diagnostics: scannedQueries.pipe(
-            map(({ scanned }) => (scanned.type === 'success' ? getDiagnostics(scanned.term, options.patternType) : []))
-        ),
     }
 }

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -1,6 +1,6 @@
 import * as Monaco from 'monaco-editor'
 import { Observable, ReplaySubject } from 'rxjs'
-import { ScanResult } from './scanner'
+import { ScanResult, scanSearchQuery } from './scanner'
 import { getMonacoTokens } from './decoratedToken'
 import { getCompletionItems } from './completion'
 import { getHoverResult } from './hover'

--- a/client/shared/src/search/query/providers.ts
+++ b/client/shared/src/search/query/providers.ts
@@ -1,12 +1,13 @@
 import * as Monaco from 'monaco-editor'
 import { Observable, ReplaySubject } from 'rxjs'
-import { scanSearchQuery } from './scanner'
+import { ScanResult } from './scanner'
 import { getMonacoTokens } from './decoratedToken'
 import { getCompletionItems } from './completion'
 import { getHoverResult } from './hover'
 import { SearchSuggestion } from '../suggestions'
 import { SearchPatternType } from '../../graphql-operations'
 import { debounceTime, share, switchMap } from 'rxjs/operators'
+import { Token } from './token'
 
 interface SearchFieldProviders {
     tokens: Monaco.languages.TokensProvider
@@ -35,7 +36,7 @@ export function getProviders(
             | undefined
             | {
                   rawQuery: string
-                  scanned: ReturnType<typeof scanSearchQuery>
+                  scanned: ScanResult<Token[]>
               }
     },
     fetchSuggestions: (input: string) => Observable<SearchSuggestion[]>,


### PR DESCRIPTION
Stacked on #17513

As I was working on #17513 I realised we could greatly simplify how we hook up our search language code intelligence to the Monaco query input by using a ref for the search query, instead of an rxjs subject.

With this change, code intelligence logic for the monaco editor is now encapsulated in a `useSourcegraphSearchCodeIntelligence` hook. Almost all RxJS usage has been removed.

And now I'll stop with my tech debt refactors, promise :)
