### PR TITLE
db: Use cloud_default column

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -142,9 +142,11 @@ func Main(enterpriseInit EnterpriseInit) {
 		server.SourcegraphDotComMode = true
 
 		es, err := store.ExternalServiceStore.List(ctx, idb.ExternalServicesListOptions{
-			// On Cloud we want to fetch only site level external services here
-			NamespaceUserID: -1,
-			Kinds:           []string{extsvc.KindGitHub, extsvc.KindGitLab},
+			// On Cloud we only want to fetch site level external services here where the
+			// cloud_default flag has been set.
+			NamespaceUserID:  -1,
+			OnlyCloudDefault: true,
+			Kinds:            []string{extsvc.KindGitHub, extsvc.KindGitLab},
 		})
 
 		if err != nil {
@@ -160,11 +162,11 @@ func Main(enterpriseInit EnterpriseInit) {
 			// We only allow one external service per kind to be flagged as CloudGlobal, so pick those.
 			switch c := cfg.(type) {
 			case *schema.GitHubConnection:
-				if strings.HasPrefix(c.Url, "https://github.com") && c.Token != "" && c.CloudGlobal {
+				if strings.HasPrefix(c.Url, "https://github.com") && c.Token != "" {
 					server.GithubDotComSource, err = repos.NewGithubSource(e, cf)
 				}
 			case *schema.GitLabConnection:
-				if strings.HasPrefix(c.Url, "https://gitlab.com") && c.Token != "" && c.CloudGlobal {
+				if strings.HasPrefix(c.Url, "https://gitlab.com") && c.Token != "" {
 					server.GitLabDotComSource, err = repos.NewGitLabSource(e, cf)
 				}
 			}

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -159,7 +159,6 @@ func Main(enterpriseInit EnterpriseInit) {
 				log.Fatalf("bad external service config: %v", err)
 			}
 
-			// We only allow one external service per kind to be flagged as CloudGlobal, so pick those.
 			switch c := cfg.(type) {
 			case *schema.GitHubConnection:
 				if strings.HasPrefix(c.Url, "https://github.com") && c.Token != "" {

--- a/internal/db/external_services.go
+++ b/internal/db/external_services.go
@@ -103,8 +103,8 @@ type ExternalServiceKind struct {
 type ExternalServicesListOptions struct {
 	// When specified, only include external services with the given IDs.
 	IDs []int64
-	// When true, only include external services not under any namespace (i.e. owned by all site admins),
-	// and value of NamespaceUserID is ignored.
+	// When true, only include external services not under any namespace (i.e. owned
+	// by all site admins), and value of NamespaceUserID is ignored.
 	NoNamespace bool
 	// When specified, only include external services under given user namespace.
 	NamespaceUserID int32
@@ -115,6 +115,10 @@ type ExternalServicesListOptions struct {
 	AfterID int64
 	// Possible values are ASC or DESC. Defaults to DESC.
 	OrderByDirection string
+	// When true, will only return services that have the cloud_default flag set to
+	// true.
+	OnlyCloudDefault bool
+
 	*LimitOffset
 }
 
@@ -141,6 +145,9 @@ func (o ExternalServicesListOptions) sqlConditions() []*sqlf.Query {
 	}
 	if o.AfterID > 0 {
 		conds = append(conds, sqlf.Sprintf(`id < %d`, o.AfterID))
+	}
+	if o.OnlyCloudDefault {
+		conds = append(conds, sqlf.Sprintf("cloud_default = true"))
 	}
 	return conds
 }
@@ -308,11 +315,6 @@ func (e *ExternalServiceStore) validateGitHubConnection(ctx context.Context, id 
 
 	err = multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, extsvc.KindGitHub, c))
 
-	if envvar.SourcegraphDotComMode() && c.CloudGlobal {
-		// We're setting this one to global, make sure it's the only one
-		err = multierror.Append(err, e.validateSingleGlobalConnection(ctx, id, extsvc.KindGitHub))
-	}
-
 	return err.ErrorOrNil()
 }
 
@@ -323,11 +325,6 @@ func (e *ExternalServiceStore) validateGitLabConnection(ctx context.Context, id 
 	}
 
 	err = multierror.Append(err, e.validateDuplicateRateLimits(ctx, id, extsvc.KindGitLab, c))
-
-	if envvar.SourcegraphDotComMode() && c.CloudGlobal {
-		// We're setting this one to global, make sure it's the only one
-		err = multierror.Append(err, e.validateSingleGlobalConnection(ctx, id, extsvc.KindGitLab))
-	}
 
 	return err.ErrorOrNil()
 }
@@ -349,52 +346,6 @@ func (e *ExternalServiceStore) validateBitbucketServerConnection(ctx context.Con
 
 func (e *ExternalServiceStore) validateBitbucketCloudConnection(ctx context.Context, id int64, c *schema.BitbucketCloudConnection) error {
 	return e.validateDuplicateRateLimits(ctx, id, extsvc.KindBitbucketCloud, c)
-}
-
-// validateSingleGlobalConnection returns an error if more than one external service for the given kind has its
-// CloudGlobal flag set.
-func (e *ExternalServiceStore) validateSingleGlobalConnection(ctx context.Context, id int64, kind string) error {
-	opt := ExternalServicesListOptions{
-		Kinds: []string{kind},
-		// We only care about site admin external services
-		NoNamespace: true,
-		LimitOffset: &LimitOffset{
-			Limit: 500, // The number is randomly chosen
-		},
-	}
-	for {
-		svcs, err := e.List(ctx, opt)
-		if err != nil {
-			return errors.Wrap(err, "list")
-		}
-		if len(svcs) == 0 {
-			// No more results, exiting
-			return nil
-		}
-		opt.AfterID = svcs[len(svcs)-1].ID // Advance the cursor
-
-		for _, svc := range svcs {
-			c, err := extsvc.ParseConfig(svc.Kind, svc.Config)
-			if err != nil {
-				return errors.Wrap(err, "parsing config")
-			}
-			var storedIsGlobal bool
-			switch x := c.(type) {
-			case *schema.GitHubConnection:
-				storedIsGlobal = x.CloudGlobal
-			case *schema.GitLabConnection:
-				storedIsGlobal = x.CloudGlobal
-			}
-			if svc.ID != id && storedIsGlobal {
-				return fmt.Errorf("existing external service, %q, already set as global", svc.DisplayName)
-			}
-		}
-
-		if len(svcs) < opt.Limit {
-			break // Less results than limit means we've reached end
-		}
-	}
-	return nil
 }
 
 // validateDuplicateRateLimits returns an error if given config has duplicated non-default rate limit

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -133,7 +133,7 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 		searchClient = github.NewV3SearchClient(apiURL, token, cli)
 	)
 
-	if !envvar.SourcegraphDotComMode() || c.CloudGlobal {
+	if !envvar.SourcegraphDotComMode() || svc.CloudDefault {
 		for resource, monitor := range map[string]*ratelimit.Monitor{
 			"rest":    v3Client.RateLimitMonitor(),
 			"graphql": v4Client.RateLimitMonitor(),

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -100,7 +100,7 @@ func newGitLabSource(svc *types.ExternalService, c *schema.GitLabConnection, cf 
 
 	client := provider.GetPATClient(c.Token, "")
 
-	if !envvar.SourcegraphDotComMode() || c.CloudGlobal {
+	if !envvar.SourcegraphDotComMode() || svc.CloudDefault {
 		client.RateLimitMonitor().SetCollector(func(remaining float64) {
 			gitlabRemainingGauge.WithLabelValues("rest", svc.DisplayName).Set(remaining)
 		})

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -169,7 +169,8 @@
       "title": "CloudGlobal",
       "description": "When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "deprecationMessage": "DEPRECATED: The cloud_default flag should be set in the database instead"
     }
   }
 }

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -174,7 +174,8 @@ const GitHubSchemaJSON = `{
       "title": "CloudGlobal",
       "description": "When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "deprecationMessage": "The cloud_default flag should be set in the database instead"
     }
   }
 }

--- a/schema/github_stringdata.go
+++ b/schema/github_stringdata.go
@@ -175,7 +175,7 @@ const GitHubSchemaJSON = `{
       "description": "When set to true, this external service will be chosen as our 'Global' GitHub service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
       "type": "boolean",
       "default": false,
-      "deprecationMessage": "The cloud_default flag should be set in the database instead"
+      "deprecationMessage": "DEPRECATED: The cloud_default flag should be set in the database instead"
     }
   }
 }

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -199,7 +199,7 @@
       "description": "When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
       "type": "boolean",
       "default": false,
-      "deprecationMessage": "DEPRECATED: The cloud_default flag should be set in the database instead",
+      "deprecationMessage": "DEPRECATED: The cloud_default flag should be set in the database instead"
     }
   },
   "definitions": {

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -198,7 +198,8 @@
       "title": "CloudGlobal",
       "description": "When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "deprecationMessage": "DEPRECATED: The cloud_default flag should be set in the database instead",
     }
   },
   "definitions": {

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -203,7 +203,8 @@ const GitLabSchemaJSON = `{
       "title": "CloudGlobal",
       "description": "When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "deprecationMessage": "The cloud_default flag should be set in the database instead"
     }
   },
   "definitions": {

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -204,7 +204,7 @@ const GitLabSchemaJSON = `{
       "description": "When set to true, this external service will be chosen as our 'Global' GitLab service. Only valid on Sourcegraph.com. Only one service can have this flag set.",
       "type": "boolean",
       "default": false,
-      "deprecationMessage": "The cloud_default flag should be set in the database instead"
+      "deprecationMessage": "DEPRECATED: The cloud_default flag should be set in the database instead"
     }
   },
   "definitions": {


### PR DESCRIPTION
This change just switched to using the new `cloud_default` column on the `external_services` table instead of external service config to choose our "default" sources on cloud.

This does not yet change syncing behaviour which will be done in a followup PR.

Part of: https://github.com/sourcegraph/sourcegraph/issues/17472