### PR TITLE
Remove unneeded call to ensureStore

### DIFF
--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -186,7 +186,6 @@ func (s *RepoStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (ma
 	if err != nil {
 		return nil, err
 	}
-	s.ensureStore()
 
 	repoMap := make(map[api.RepoID]*types.Repo, len(repos))
 	for _, r := range repos {


### PR DESCRIPTION
This call is not needed, as there is no usage of the store afterwards. 