### PR TITLE
Implement faster resolver for global campaign diff stat

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -219,35 +219,11 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 }
 
 func (r *campaignResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffStat, error) {
-	changesetsConnection := &changesetsConnectionResolver{
-		store: r.store,
-		opts: store.ListChangesetsOpts{
-			CampaignID: r.Campaign.ID,
-		},
-		optsSafe: true,
-	}
-
-	changesets, err := changesetsConnection.Nodes(ctx)
+	diffStat, err := r.store.GetCampaignDiffStat(ctx, store.GetCampaignDiffStatOpts{CampaignID: r.Campaign.ID})
 	if err != nil {
 		return nil, err
 	}
-
-	totalStat := &graphqlbackend.DiffStat{}
-	for _, cs := range changesets {
-		// Not being able to convert is OK; it just means there's a hidden
-		// changeset that we can't use the stats from.
-		if external, ok := cs.ToExternalChangeset(); ok && external != nil {
-			stat, err := external.DiffStat(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if stat != nil {
-				totalStat.AddDiffStat(stat)
-			}
-		}
-	}
-
-	return totalStat, nil
+	return graphqlbackend.NewDiffStat(*diffStat), nil
 }
 
 func (r *campaignResolver) CurrentSpec(ctx context.Context) (graphqlbackend.CampaignSpecResolver, error) {

--- a/enterprise/internal/campaigns/store/campaigns.go
+++ b/enterprise/internal/campaigns/store/campaigns.go
@@ -2,9 +2,14 @@ package store
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
+	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
 	"github.com/sourcegraph/sourcegraph/internal/db/dbutil"
 )
 
@@ -267,6 +272,48 @@ func getCampaignQuery(opts *GetCampaignOpts) *sqlf.Query {
 		sqlf.Join(campaignColumns, ", "),
 		sqlf.Join(preds, "\n AND "),
 	)
+}
+
+type GetCampaignDiffStatOpts struct {
+	CampaignID int64
+}
+
+func (s *Store) GetCampaignDiffStat(ctx context.Context, opts GetCampaignDiffStatOpts) (*diff.Stat, error) {
+	authzConds, err := db.AuthzQueryConds(ctx, s.Handle().DB())
+	if err != nil {
+		return nil, errors.Wrap(err, "GetCampaignDiffStat generating authz query conds")
+	}
+	q := getCampaignDiffStatQuery(opts, authzConds)
+
+	var diffStat diff.Stat
+	err = s.query(ctx, q, func(sc scanner) error {
+		return sc.Scan(&diffStat.Added, &diffStat.Changed, &diffStat.Deleted)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &diffStat, nil
+}
+
+var getCampaignDiffStatQueryFmtstr = `
+-- source: enterprise/internal/campaigns/store.go:GetCampaignDiffStat
+SELECT
+	COALESCE(SUM(diff_stat_added), 0) AS added,
+	COALESCE(SUM(diff_stat_changed), 0) AS changed,
+	COALESCE(SUM(diff_stat_deleted), 0) AS deleted
+FROM
+	changesets
+INNER JOIN repo ON changesets.repo_id = repo.id
+WHERE
+	changesets.campaign_ids ? %s AND
+	repo.deleted_at IS NULL AND
+	-- authz conditions:
+	%s
+`
+
+func getCampaignDiffStatQuery(opts GetCampaignDiffStatOpts, authzConds *sqlf.Query) *sqlf.Query {
+	return sqlf.Sprintf(getCampaignDiffStatQueryFmtstr, strconv.Itoa(int(opts.CampaignID)), authzConds)
 }
 
 // ListCampaignsOpts captures the query options needed for

--- a/enterprise/internal/campaigns/store/campaigns_test.go
+++ b/enterprise/internal/campaigns/store/campaigns_test.go
@@ -9,8 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
 
+	"github.com/sourcegraph/go-diff/diff"
+
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/db"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
@@ -446,6 +451,64 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 				t.Fatalf("have err %v, want %v", have, want)
 			}
 		})
+	})
+
+	t.Run("GetCampaignDiffStat", func(t *testing.T) {
+		userID := ct.CreateTestUser(t, false).ID
+		userCtx := actor.WithActor(ctx, actor.FromUser(userID))
+		repoStore := db.ReposWith(s)
+		esStore := db.ExternalServicesWith(s)
+		repo := ct.TestRepo(t, esStore, extsvc.KindGitHub)
+		repo.Private = true
+		if err := repoStore.Create(ctx, repo); err != nil {
+			t.Fatal(err)
+		}
+
+		campaignID := cs[0].ID
+		var testDiffStatCount int32 = 10
+		ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{
+			Repo:            repo.ID,
+			Campaigns:       []campaigns.CampaignAssoc{{CampaignID: campaignID}},
+			DiffStatAdded:   testDiffStatCount,
+			DiffStatChanged: testDiffStatCount,
+			DiffStatDeleted: testDiffStatCount,
+		})
+
+		{
+			want := &diff.Stat{
+				Added:   testDiffStatCount,
+				Changed: testDiffStatCount,
+				Deleted: testDiffStatCount,
+			}
+			opts := GetCampaignDiffStatOpts{CampaignID: campaignID}
+			have, err := s.GetCampaignDiffStat(userCtx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+		}
+
+		// Now revoke repo access, and check that we don't see it in the diff stat anymore.
+		ct.MockRepoPermissions(t, 0, repo.ID)
+		{
+			want := &diff.Stat{
+				Added:   0,
+				Changed: 0,
+				Deleted: 0,
+			}
+			opts := GetCampaignDiffStatOpts{CampaignID: campaignID}
+			have, err := s.GetCampaignDiffStat(userCtx, opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Fatal(diff)
+			}
+		}
 	})
 
 	t.Run("Delete", func(t *testing.T) {

--- a/enterprise/internal/campaigns/testing/changeset.go
+++ b/enterprise/internal/campaigns/testing/changeset.go
@@ -27,6 +27,10 @@ type TestChangesetOpts struct {
 	ExternalReviewState campaigns.ChangesetReviewState
 	ExternalCheckState  campaigns.ChangesetCheckState
 
+	DiffStatAdded   int32
+	DiffStatChanged int32
+	DiffStatDeleted int32
+
 	PublicationState campaigns.ChangesetPublicationState
 
 	ReconcilerState campaigns.ReconcilerState
@@ -100,6 +104,12 @@ func BuildChangeset(opts TestChangesetOpts) *campaigns.Changeset {
 
 	if opts.Campaign != 0 {
 		changeset.Campaigns = []campaigns.CampaignAssoc{{CampaignID: opts.Campaign}}
+	}
+
+	if opts.DiffStatAdded > 0 || opts.DiffStatChanged > 0 || opts.DiffStatDeleted > 0 {
+		changeset.DiffStatAdded = &opts.DiffStatAdded
+		changeset.DiffStatChanged = &opts.DiffStatChanged
+		changeset.DiffStatDeleted = &opts.DiffStatDeleted
 	}
 
 	return changeset

--- a/enterprise/internal/campaigns/testing/repos.go
+++ b/enterprise/internal/campaigns/testing/repos.go
@@ -26,7 +26,7 @@ func TestRepo(t *testing.T, store *idb.ExternalServiceStore, serviceKind string)
 	svc := types.ExternalService{
 		Kind:        serviceKind,
 		DisplayName: serviceKind + " - Test",
-		Config:      `{"url": "https://github.com"}`,
+		Config:      `{"url": "https://github.com", "authorization": {}}`,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -320,7 +320,7 @@ func (s *RepoStore) getReposBySQL(ctx context.Context, minimal bool, fromClause,
 		querySuffix = sqlf.Sprintf("")
 	}
 
-	authzConds, err := authzQueryConds(ctx, s.Handle().DB())
+	authzConds, err := AuthzQueryConds(ctx, s.Handle().DB())
 	if err != nil {
 		return err
 	}
@@ -1207,7 +1207,7 @@ func (*RepoStore) listSQL(opt ReposListOptions) (conds []*sqlf.Query, err error)
 func (s *RepoStore) GetUserAddedRepoNames(ctx context.Context, userID int32) ([]api.RepoName, error) {
 	s.ensureStore()
 
-	authzConds, err := authzQueryConds(ctx, s.Handle().DB())
+	authzConds, err := AuthzQueryConds(ctx, s.Handle().DB())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/repos_perm.go
+++ b/internal/db/repos_perm.go
@@ -43,10 +43,10 @@ OR  (
 
 var errPermissionsUserMappingConflict = errors.New("The permissions user mapping (site configuration `permissions.userMapping`) cannot be enabled when other authorization providers are in use, please contact site admin to resolve it.")
 
-// authzQueryConds returns a query clause for enforcing repository permissions.
+// AuthzQueryConds returns a query clause for enforcing repository permissions.
 // It uses `repo` as the table name to filter out repository IDs and should be
 // used as an AND condition in a complete SQL query.
-func authzQueryConds(ctx context.Context, db dbutil.DB) (*sqlf.Query, error) {
+func AuthzQueryConds(ctx context.Context, db dbutil.DB) (*sqlf.Query, error) {
 	authzAllowByDefault, authzProviders := authz.GetProviders()
 	usePermissionsUserMapping := globals.PermissionsUserMapping().Enabled
 

--- a/internal/db/repos_perm_test.go
+++ b/internal/db/repos_perm_test.go
@@ -59,7 +59,7 @@ func TestAuthzQueryConds(t *testing.T) {
 		authz.SetProviders(false, []authz.Provider{&fakeProvider{}})
 		defer authz.SetProviders(true, nil)
 
-		_, err := authzQueryConds(context.Background(), db)
+		_, err := AuthzQueryConds(context.Background(), db)
 		gotErr := fmt.Sprintf("%v", err)
 		if diff := cmp.Diff(errPermissionsUserMappingConflict.Error(), gotErr); diff != "" {
 			t.Fatalf("Mismatch (-want +got):\n%s", diff)
@@ -71,7 +71,7 @@ func TestAuthzQueryConds(t *testing.T) {
 		globals.SetPermissionsUserMapping(&schema.PermissionsUserMapping{Enabled: true})
 		defer globals.SetPermissionsUserMapping(before)
 
-		got, err := authzQueryConds(context.Background(), db)
+		got, err := AuthzQueryConds(context.Background(), db)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,7 +136,7 @@ func TestAuthzQueryConds(t *testing.T) {
 			authz.SetProviders(test.authzAllowByDefault, nil)
 			defer authz.SetProviders(true, nil)
 
-			q, err := authzQueryConds(test.setup(), db)
+			q, err := AuthzQueryConds(test.setup(), db)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Before we had to load all the changesets, which including metadata can take quite a while for larger campaigns (quite some data to be sent). This approach asks the DB directly, while respecting repo permissions, and is close to instant, removing the need to lazy-load the diff stat on the campaigns page.

TODO: I can't figure out why the test fails, if you have an idea, please comment :) Otherwise I'll debug that next. Opening up for review anyways, since I assume the test fix won't change much.