### PR TITLE
search: stream progress to webapp

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -287,7 +287,7 @@ func (r *RepositoryResolver) ToCommitSearchResult() (*CommitSearchResultResolver
 	return nil, false
 }
 
-func (r *RepositoryResolver) resultCount() int32 {
+func (r *RepositoryResolver) ResultCount() int32 {
 	return 1
 }
 

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -70,7 +70,7 @@ func (r *CommitSearchResultResolver) ToCommitSearchResult() (*CommitSearchResult
 	return r, true
 }
 
-func (r *CommitSearchResultResolver) resultCount() int32 {
+func (r *CommitSearchResultResolver) ResultCount() int32 {
 	return 1
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -144,7 +144,7 @@ func (sr *SearchResultsResolver) Results() []SearchResultResolver {
 func (sr *SearchResultsResolver) MatchCount() int32 {
 	var totalResults int32
 	for _, result := range sr.SearchResults {
-		totalResults += result.resultCount()
+		totalResults += result.ResultCount()
 	}
 	return totalResults
 }
@@ -298,7 +298,7 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 			if fm.InputRev != nil {
 				rev = *fm.InputRev
 			}
-			lines := fm.resultCount()
+			lines := fm.ResultCount()
 			addRepoFilter(fm.Repo, rev, lines)
 			addLangFilter(fm.path(), lines, fm.LimitHit())
 			addFileFilter(fm.path(), lines, fm.LimitHit())
@@ -2093,7 +2093,7 @@ type SearchResultResolver interface {
 	ToFileMatch() (*FileMatchResolver, bool)
 	ToCommitSearchResult() (*CommitSearchResultResolver, bool)
 
-	resultCount() int32
+	ResultCount() int32
 }
 
 // compareFileLengths sorts file paths such that they appear earlier if they

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -129,7 +129,7 @@ func (fm *FileMatchResolver) appendMatches(src *FileMatchResolver) {
 	fm.JLimitHit = fm.JLimitHit || src.JLimitHit
 }
 
-func (fm *FileMatchResolver) resultCount() int32 {
+func (fm *FileMatchResolver) ResultCount() int32 {
 	rc := len(fm.symbols) + fm.MatchCount
 	if rc > 0 {
 		return int32(rc)

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -1,0 +1,61 @@
+package search
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	sgapi "github.com/sourcegraph/sourcegraph/internal/api"
+	searchshared "github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming/api"
+)
+
+type progressAggregator struct {
+	Start      time.Time
+	MatchCount int
+	Stats      streaming.Stats
+}
+
+func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
+	// TODO implement Update such that we update api.ProgressStats to avoid
+	// re-reading the whole of stats.
+
+	p.Stats.Update(&event.Stats)
+
+	for _, result := range event.Results {
+		p.MatchCount += int(result.ResultCount())
+	}
+}
+
+func (p *progressAggregator) Build() api.Progress {
+	return api.BuildProgressEvent(api.ProgressStats{
+		MatchCount:          p.MatchCount,
+		ElapsedMilliseconds: int(time.Since(p.Start).Milliseconds()),
+		RepositoriesCount:   len(p.Stats.Repos),
+		ExcludedArchived:    p.Stats.ExcludedArchived,
+		ExcludedForks:       p.Stats.ExcludedForks,
+		Timedout:            getNames(p.Stats, searchshared.RepoStatusTimedout),
+		Missing:             getNames(p.Stats, searchshared.RepoStatusMissing),
+		Cloning:             getNames(p.Stats, searchshared.RepoStatusCloning),
+		LimitHit:            p.Stats.IsLimitHit,
+	})
+}
+
+type namerFunc string
+
+func (n namerFunc) Name() string {
+	return string(n)
+}
+
+func getNames(stats streaming.Stats, status searchshared.RepoStatus) []api.Namer {
+	var names []api.Namer
+	stats.Status.Filter(status, func(id sgapi.RepoID) {
+		if name, ok := stats.Repos[id]; ok {
+			names = append(names, namerFunc(name.Name))
+		} else {
+			names = append(names, namerFunc(fmt.Sprintf("UNKNOWN{ID=%d}", id)))
+		}
+	})
+	return names
+}


### PR DESCRIPTION
We add Stats aggregation to the top level streaming layer. This allows us to stream out progress updates as they happen.

This can be made way more efficient. There are also some changes that need to be made to the API/webapp. However, this is now functional and only affects people who enable streaming. So I would like to get this out so we can play with it in production.

Co-authored-by: @stefanhengl 