### PR TITLE
web: log GoToCodeHostClicked again

### DIFF
--- a/client/web/src/repo/actions/GoToCodeHostAction.tsx
+++ b/client/web/src/repo/actions/GoToCodeHostAction.tsx
@@ -116,6 +116,8 @@ export const GoToCodeHostAction: React.FunctionComponent<Props> = props => {
 
     const onClick = useCallback(
         (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+            eventLogger.log('GoToCodeHostClicked')
+
             if (showPopover) {
                 event.preventDefault()
                 setShowPopover(false)


### PR DESCRIPTION
Forgot to log this event when refactoring last year