### PR TITLE
codeintel: Change rank behavior for uploads and indexes

### DIFF
--- a/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
+++ b/enterprise/cmd/executor-queue/internal/queues/codeintel/queue.go
@@ -47,7 +47,7 @@ func newWorkerStore(db dbutil.DB, observationContext *observation.Context) dbwor
 		ViewName:          "lsif_indexes_with_repository_name u",
 		ColumnExpressions: store.IndexColumnsWithNullRank,
 		Scan:              store.ScanFirstIndexRecord,
-		OrderByExpression: sqlf.Sprintf("u.queued_at"),
+		OrderByExpression: sqlf.Sprintf("u.queued_at, u.id"),
 		StalledMaxAge:     StalledJobMaximumAge,
 		MaxNumResets:      MaximumNumResets,
 	}

--- a/enterprise/internal/codeintel/stores/dbstore/worker.go
+++ b/enterprise/internal/codeintel/stores/dbstore/worker.go
@@ -27,7 +27,7 @@ var uploadWorkerStoreOptions = dbworkerstore.Options{
 	ViewName:          "lsif_uploads_with_repository_name u",
 	ColumnExpressions: uploadColumnsWithNullRank,
 	Scan:              scanFirstUploadRecord,
-	OrderByExpression: sqlf.Sprintf("uploaded_at"),
+	OrderByExpression: sqlf.Sprintf("u.uploaded_at, u.id"),
 	StalledMaxAge:     StalledUploadMaxAge,
 	MaxNumResets:      UploadMaxNumResets,
 }
@@ -53,7 +53,7 @@ var indexWorkerStoreOptions = dbworkerstore.Options{
 	ViewName:          "lsif_indexes_with_repository_name u",
 	ColumnExpressions: indexColumnsWithNullRank,
 	Scan:              scanFirstIndexRecord,
-	OrderByExpression: sqlf.Sprintf("queued_at"),
+	OrderByExpression: sqlf.Sprintf("u.queued_at, u.id"),
 	StalledMaxAge:     StalledIndexMaxAge,
 	MaxNumResets:      IndexMaxNumResets,
 }


### PR DESCRIPTION
We were previously using `RANK()` to find the relative ordering of the upload and index queues. We should instead use `ROW_NUMBER()` so that several index or upload records with the same insertion time don't occupy the same number.

Previously we would have something like (`#1`, `#1`, `#1`, `#4`, `#4`, `#6`, `#7`). Now we should have (`#1`, `#2`, `#3`, `#4`, `#5`, `#6`, `#7`).