### PR TITLE
search: Send structural search request directly to searcher

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -597,7 +597,24 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}()
 	}
 
-	if isStructuralSearch {
+	if isStructuralSearch && args.PatternInfo.CombyRule == `where "zoekt" == "zoekt"` {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
+			for _, repo := range indexed.Repos() {
+				repos = append(repos, repo)
+			}
+
+			err := callSearcherOverRepos(repos, nil)
+			if err != nil {
+				mu.Lock()
+				searchErr = err
+				mu.Unlock()
+			}
+		}()
+	} else if isStructuralSearch {
 		wg.Add(1)
 		go func() {
 			// TODO limitHit, handleRepoSearchResult

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -248,7 +248,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			Languages:                    p.Languages,
 		}
 
-	repoBranches := map[string][]string{string(p.Repo): {"HEAD"}}
+	repoBranches := map[string][]string{string(p.Repo): {string(p.Commit)}}
 	useFullDeadline := false
 	zoektMatches, limitHit, _, err := zoektSearch(ctx, patternInfo, repoBranches, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -248,7 +248,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			Languages:                    p.Languages,
 		}
 
-	repoBranches := map[string][]string{string(p.Repo): {string(p.Commit)}}
+	repoBranches := map[string][]string{string(p.Repo): {"HEAD"}}
 	useFullDeadline := false
 	zoektMatches, limitHit, _, err := zoektSearch(ctx, patternInfo, repoBranches, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {


### PR DESCRIPTION
This PR activates the new structural search code path starting from the frontend given a special comby rule. Now, instead of querying Zoekt for the list of files to send to searcher to search, a structural search query is forwarded directly to searcher, which will handle querying Zoekt directly.

This code path is only activated if `rule:'where "zoekt" == "zoekt"` is set. For example, `repo:^github\.com/kubernetes/kubernetes$ Eventf(cj, :[1]) rule:'where "zoekt" == "zoekt"'`.

For the above query, on my dev environment, this change reduced query time from 1.7s cold / 0.4s warm to 0.1s using the new path. Note that, for very broad queries like `fmt.Errorf(:[1])`, performance is much worse against the warm case since the file contents need to be transferred every time. 

Unresolved issues that will be fixed in followup PRs:
- File filtering does not work with the new code path (#17568)
- Some queries give a different number of results under the new code path. This appears to be because the `Matcher` arg is not set (#17569)
- Support searching indexed branches other than HEAD (#17493)
- UseFullDeadline is not respected (#17492)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
