### PR TITLE
Implement overhauled campaigns stats section

### DIFF
--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -51,6 +51,7 @@ const campaignDefaults: CampaignFields = {
         namespaceName: 'alice',
         url: '/users/alice',
     },
+    diffStat: { added: 1000, changed: 2000, deleted: 1000 },
     viewerCanAdminister: true,
     closedAt: null,
     description: '## What this campaign does\n\nTruly awesome things for example.',

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -66,6 +66,7 @@ const campaignDefaults: CampaignFields = {
         originalInput: 'name: awesome-campaign\ndescription: somestring',
         supersedingCampaignSpec: null,
     },
+    diffStat: { added: 1000, changed: 2000, deleted: 1000 },
 }
 
 const queryChangesets: typeof _queryChangesets = () =>

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -132,7 +132,12 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
                 total={campaign.changesetsStats.total}
                 className="mb-3"
             />
-            <CampaignStatsCard closedAt={campaign.closedAt} stats={campaign.changesetsStats} className="mb-3" />
+            <CampaignStatsCard
+                closedAt={campaign.closedAt}
+                stats={campaign.changesetsStats}
+                diff={campaign.diffStat}
+                className="mb-3"
+            />
             <Description history={history} description={campaign.description} />
             <CampaignTabs
                 campaign={campaign}

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
@@ -33,4 +33,8 @@
             padding-right: 0.5rem;
         }
     }
+    &__divider {
+        border: 1px solid var(--border-color);
+        height: 2rem;
+    }
 }

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.story.tsx
@@ -21,6 +21,7 @@ add('All states', () => (
                     total: 100,
                     unpublished: 55,
                 }}
+                diff={{ added: 1000, changed: 2000, deleted: 1000 }}
                 closedAt={null}
             />
         )}
@@ -40,6 +41,7 @@ add('Campaign closed', () => (
                     total: 100,
                     unpublished: 60,
                 }}
+                diff={{ added: 1000, changed: 2000, deleted: 1000 }}
                 closedAt={new Date().toISOString()}
             />
         )}
@@ -59,6 +61,7 @@ add('Campaign done', () => (
                     total: 100,
                     unpublished: 0,
                 }}
+                diff={{ added: 1000, changed: 2000, deleted: 1000 }}
                 closedAt={null}
             />
         )}

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ProgressCheckIcon from 'mdi-react/ProgressCheckIcon'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import classNames from 'classnames'
-import { CampaignFields, ChangesetsStatsFields } from '../../../graphql-operations'
+import { CampaignFields, ChangesetsStatsFields, DiffStatFields } from '../../../graphql-operations'
 import { CampaignStateBadge } from './CampaignStateBadge'
 import {
     ChangesetStatusUnpublished,
@@ -12,14 +12,21 @@ import {
     ChangesetStatusDraft,
 } from './changesets/ChangesetStatusCell'
 import { pluralize } from '../../../../../shared/src/util/strings'
+import { DiffStat } from '../../../components/diff/DiffStat'
 
 interface CampaignStatsCardProps {
     stats: ChangesetsStatsFields
+    diff: DiffStatFields
     closedAt: CampaignFields['closedAt']
     className?: string
 }
 
-export const CampaignStatsCard: React.FunctionComponent<CampaignStatsCardProps> = ({ stats, closedAt, className }) => {
+export const CampaignStatsCard: React.FunctionComponent<CampaignStatsCardProps> = ({
+    stats,
+    diff,
+    closedAt,
+    className,
+}) => {
     const percentComplete =
         stats.total === 0 ? 0 : (((stats.closed + stats.merged + stats.deleted) / stats.total) * 100).toFixed(0)
     const isCompleted = stats.closed + stats.merged + stats.deleted === stats.total
@@ -28,49 +35,50 @@ export const CampaignStatsCard: React.FunctionComponent<CampaignStatsCardProps> 
         CampaignStatusIcon = CheckCircleOutlineIcon
     }
     return (
-        <div className={classNames('card', className)}>
-            <div className="card-body p-3">
-                <div className="d-flex flex-wrap justify-content-between align-items-center">
-                    <div className="d-flex flex-wrap align-items-center flex-grow-1">
-                        <h2 className="m-0 mr-3">
-                            <CampaignStateBadge isClosed={!!closedAt} className="campaign-stats-card__state-badge" />
-                        </h2>
-                        <h1 className="d-inline mb-0">
-                            <CampaignStatusIcon
-                                className={classNames(
-                                    'icon-inline mr-2',
-                                    isCompleted && 'text-success',
-                                    !isCompleted && 'text-muted'
-                                )}
-                            />
-                        </h1>{' '}
-                        <span className="lead text-nowrap campaign-stats-card__completeness">
-                            {percentComplete}% complete
-                        </span>
-                        <div className="d-flex flex-wrap justify-content-end flex-grow-1">
-                            <CampaignStatsTotalAction count={stats.total} />
-                            <ChangesetStatusUnpublished
-                                label={<span className="text-muted">{stats.unpublished} unpublished</span>}
-                                className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
-                            />
-                            <ChangesetStatusDraft
-                                label={<span className="text-muted">{stats.draft} draft</span>}
-                                className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
-                            />
-                            <ChangesetStatusOpen
-                                label={<span className="text-muted">{stats.open} open</span>}
-                                className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
-                            />
-                            <ChangesetStatusClosed
-                                label={<span className="text-muted">{stats.closed} closed</span>}
-                                className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
-                            />
-                            <ChangesetStatusMerged
-                                label={<span className="text-muted">{stats.merged} merged</span>}
-                                className="d-flex flex-grow-0 pl-2 text-truncate campaign-stats-card__stat"
-                            />
-                        </div>
-                    </div>
+        <div className={classNames(className)}>
+            <div className="d-flex flex-wrap align-items-center flex-grow-1">
+                <h2 className="m-0">
+                    <CampaignStateBadge isClosed={!!closedAt} className="campaign-stats-card__state-badge" />
+                </h2>
+                <div className="campaign-stats-card__divider mx-4" />
+                <div className="d-flex align-items-center">
+                    <h1 className="d-inline mb-0">
+                        <CampaignStatusIcon
+                            className={classNames(
+                                'icon-inline mr-2',
+                                isCompleted && 'text-success',
+                                !isCompleted && 'text-muted'
+                            )}
+                        />
+                    </h1>{' '}
+                    <span className="lead text-nowrap campaign-stats-card__completeness">
+                        {percentComplete}% complete
+                    </span>
+                </div>
+                <div className="campaign-stats-card__divider mx-4" />
+                <DiffStat {...diff} expandedCounts={true} separateLines={true} />
+                <div className="d-flex flex-wrap justify-content-end flex-grow-1">
+                    <CampaignStatsTotalAction count={stats.total} />
+                    <ChangesetStatusUnpublished
+                        label={<span className="text-muted">{stats.unpublished} unpublished</span>}
+                        className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
+                    />
+                    <ChangesetStatusDraft
+                        label={<span className="text-muted">{stats.draft} draft</span>}
+                        className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
+                    />
+                    <ChangesetStatusOpen
+                        label={<span className="text-muted">{stats.open} open</span>}
+                        className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
+                    />
+                    <ChangesetStatusClosed
+                        label={<span className="text-muted">{stats.closed} closed</span>}
+                        className="d-flex flex-grow-0 px-2 text-truncate campaign-stats-card__stat"
+                    />
+                    <ChangesetStatusMerged
+                        label={<span className="text-muted">{stats.merged} merged</span>}
+                        className="d-flex flex-grow-0 pl-2 text-truncate campaign-stats-card__stat"
+                    />
                 </div>
             </div>
         </div>

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -60,6 +60,10 @@ const campaignFragment = gql`
             url
         }
 
+        diffStat {
+            ...DiffStatFields
+        }
+
         updatedAt
         closedAt
         viewerCanAdminister
@@ -78,6 +82,8 @@ const campaignFragment = gql`
     }
 
     ${changesetsStatsFragment}
+
+    ${diffStatFields}
 `
 
 const changesetLabelFragment = gql`

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -271,6 +271,7 @@ function mockCommonGraphQLResponses(
                     namespaceName: entityType === 'user' ? 'alice' : 'test-org',
                     url: namespaceURL,
                 },
+                diffStat: { added: 1000, changed: 2000, deleted: 1000 },
                 url: `${namespaceURL}/campaigns/test-campaign`,
                 viewerCanAdminister: true,
                 lastAppliedAt: subDays(new Date(), 5).toISOString(),


### PR DESCRIPTION
For the update UI, we introduced a stats bar to the preview page. This aligns the designs of the two and also finally has a place for the combined diff stat again.

![image](https://user-images.githubusercontent.com/19534377/105508565-cb5ebf00-5ccc-11eb-99f8-f0c7035c25fd.png)
