### PR TITLE
Make changesetStats use the same logic as changeset.state

### DIFF
--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -377,6 +377,9 @@ type CampaignsConnectionResolver interface {
 }
 
 type ChangesetsStatsResolver interface {
+	Retrying() int32
+	Failed() int32
+	Processing() int32
 	Unpublished() int32
 	Draft() int32
 	Open() int32

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2332,6 +2332,18 @@ type ChangesetsStats {
     """
     deleted: Int!
     """
+    The count of changesets in retrying state.
+    """
+    retrying: Int!
+    """
+    The count of changesets in failed state.
+    """
+    failed: Int!
+    """
+    The count of changesets that are currently processing or enqueued to be.
+    """
+    processing: Int!
+    """
     The count of all changesets.
     """
     total: Int!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2325,6 +2325,18 @@ type ChangesetsStats {
     """
     deleted: Int!
     """
+    The count of changesets in retrying state.
+    """
+    retrying: Int!
+    """
+    The count of changesets in failed state.
+    """
+    failed: Int!
+    """
+    The count of changesets that are currently processing or enqueued to be.
+    """
+    processing: Int!
+    """
     The count of all changesets.
     """
     total: Int!

--- a/enterprise/internal/campaigns/resolvers/changesets_stats.go
+++ b/enterprise/internal/campaigns/resolvers/changesets_stats.go
@@ -11,6 +11,15 @@ type changesetsStatsResolver struct {
 
 var _ graphqlbackend.ChangesetsStatsResolver = &changesetsStatsResolver{}
 
+func (r *changesetsStatsResolver) Retrying() int32 {
+	return r.stats.Retrying
+}
+func (r *changesetsStatsResolver) Failed() int32 {
+	return r.stats.Failed
+}
+func (r *changesetsStatsResolver) Processing() int32 {
+	return r.stats.Processing
+}
 func (r *changesetsStatsResolver) Unpublished() int32 {
 	return r.stats.Unpublished
 }

--- a/enterprise/internal/campaigns/store/changesets_test.go
+++ b/enterprise/internal/campaigns/store/changesets_test.go
@@ -1113,37 +1113,46 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 
 		baseOpts := ct.TestChangesetOpts{Repo: repo.ID}
 
+		// Closed changeset
 		opts1 := baseOpts
 		opts1.Campaign = campaignID
 		opts1.ExternalState = campaigns.ChangesetExternalStateClosed
+		opts1.ReconcilerState = campaigns.ReconcilerStateCompleted
 		opts1.PublicationState = campaigns.ChangesetPublicationStatePublished
 		ct.CreateChangeset(t, ctx, s, opts1)
 
+		// Deleted changeset
 		opts2 := baseOpts
 		opts2.Campaign = campaignID
 		opts2.ExternalState = campaigns.ChangesetExternalStateDeleted
+		opts2.ReconcilerState = campaigns.ReconcilerStateCompleted
 		opts2.PublicationState = campaigns.ChangesetPublicationStatePublished
 		ct.CreateChangeset(t, ctx, s, opts2)
 
+		// Open changeset
 		opts3 := baseOpts
 		opts3.Campaign = campaignID
 		opts3.OwnedByCampaign = campaignID
 		opts3.ExternalState = campaigns.ChangesetExternalStateOpen
+		opts3.ReconcilerState = campaigns.ReconcilerStateCompleted
 		opts3.PublicationState = campaigns.ChangesetPublicationStatePublished
 		ct.CreateChangeset(t, ctx, s, opts3)
 
+		// Open changeset in a deleted repository
 		opts4 := baseOpts
 		// In a deleted repository.
 		opts4.Repo = deletedRepo.ID
 		opts4.Campaign = campaignID
 		opts4.ExternalState = campaigns.ChangesetExternalStateOpen
+		opts4.ReconcilerState = campaigns.ReconcilerStateCompleted
 		opts4.PublicationState = campaigns.ChangesetPublicationStatePublished
 		ct.CreateChangeset(t, ctx, s, opts4)
 
+		// Open changeset in a different campaign
 		opts5 := baseOpts
-		// In a different campaign.
 		opts5.Campaign = campaignID + 999
 		opts5.ExternalState = campaigns.ChangesetExternalStateOpen
+		opts5.ReconcilerState = campaigns.ReconcilerStateCompleted
 		opts5.PublicationState = campaigns.ChangesetPublicationStatePublished
 		ct.CreateChangeset(t, ctx, s, opts5)
 

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -705,7 +705,7 @@ func WithExternalID(id string) func(*Changeset) bool {
 
 // ChangesetsStats holds stats information on a list of changesets.
 type ChangesetsStats struct {
-	Unpublished, Draft, Open, Merged, Closed, Deleted, Total int32
+	Retrying, Failed, Processing, Unpublished, Draft, Open, Merged, Closed, Deleted, Total int32
 }
 
 // ChangesetEventKindFor returns the ChangesetEventKind for the given


### PR DESCRIPTION
This was actually way easier than I expected it to be. 
Before, the logic was a little different so in the stats bar you would see 10 failed, but when filtering by state failed, you might get 0 results, which gives the impression some results might be hidden from you. This fixes it by using the same conditions for the different statuses. Also, I've extended the type by the missing states, just so the SQL query is complete and easier to compare. I don't use it _yet_.

Closes https://github.com/sourcegraph/sourcegraph/issues/16781