### PR TITLE
ci: verbose panic logging in integration tests

### DIFF
--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -17,7 +17,7 @@ if curl --output /dev/null --silent --head --fail $URL; then
 fi
 
 echo "--- Running a daemonized $IMAGE as the test subject..."
-CONTAINER="$(docker container run -d -e DEPLOY_TYPE=dev "$IMAGE")"
+CONTAINER="$(docker container run -d -e DEPLOY_TYPE=dev -e GOTRACEBACK=all "$IMAGE")"
 trap 'kill $(jobs -p -r)'" ; docker logs --timestamps $CONTAINER ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
 
 docker exec "$CONTAINER" apk add --no-cache socat


### PR DESCRIPTION
This is to help correlate a panic in a goroutine with everything else
that is going on. Quoting the go documentation:

  GOTRACEBACK=all adds stack traces for all user-created goroutines.

Related to https://github.com/sourcegraph/sourcegraph/issues/17542