### PR TITLE
Support revision (version/tag) for Godoc handler for Sourcegraph redirection link

### DIFF
--- a/cmd/frontend/internal/app/gddo.go
+++ b/cmd/frontend/internal/app/gddo.go
@@ -65,6 +65,10 @@ func serveGDDORefs(w http.ResponseWriter, r *http.Request) error {
 		return &errcode.HTTPErr{Status: http.StatusBadRequest, Err: errors.New("repo, pkg, and def must be specified in query string")}
 	}
 
+	if idx := strings.Index(repo, "@"); idx >= 0 {
+		pkg += repo[idx:]
+	}
+
 	http.Redirect(w, r, fmt.Sprintf("/go/%s/-/%s", pkg, def), http.StatusMovedPermanently)
 	return nil
 }


### PR DESCRIPTION
Fixes: #15557

**What and why**
This PR will support adding revision (version/tag) for the incoming request handler from Godoc's golang package, which will be used to  further add the Sourcegraph link redirection to the new Golang package documentation site pkg.go.dev replacing .org. I think this will be beneficial since all of the requests to the Godoc will all be redirected to pkg.go.dev in the near future ([announcement](https://blog.golang.org/godoc.org-redirect)).
The [issue](https://github.com/golang/go/issues/39703), [PR](https://github.com/golang/pkgsite/pull/9), and [short demo](https://youtu.be/OathLmQVM5g) for the Sourcegraph redirection on pkg.go.dev can be found on the respective link. 

**How**
This will enable adding the revision (version/tag) for the URL constructed on the pkg.go.dev site compared to the one constructed at godoc.org. The expected one will works like this, starting at the godoc handler:
https://sourcegraph.com/-/godoc/refs?def=SyslogHook%2FFire&pkg=github.com%2Fsirupsen%2Flogrus%2Fhooks%2Fsyslog&repo=github.com%2Fsirupsen%2Flogrus@v0.7.0&source=pkgsite
redirected to Go's package handler
https://sourcegraph.com/go/github.com/sirupsen/logrus@v0.7.0/hooks/syslog/-/SyslogHook/Fire
and the finally redirected to the respective file content at 
http://sourcegraph.com/github.com/sirupsen/logrus@v0.7.0/-/blob/hooks/syslog/syslog.go#L25:25&tab=references

Short demo can be seen below. We can see that:
1. It also supports method and submodule of the particular package.
2. Method SyslogHook's Fire is at [line 25](https://github.com/sirupsen/logrus/blob/v0.7.0/hooks/syslog/syslog.go#L25) at the version v0.7.0 while it's located at [line 28](https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go#L28) at the latest/default version (v1.3.0) of the logrus package.

https://user-images.githubusercontent.com/7043511/105463273-600fef80-5cc2-11eb-8ab1-43412f430020.mp4

**Alternatives**
I am using the `path/to/repo@v1.2.3` style to append the version to the particular repo since this is how I found the Sourcegraph(sourcegraph.com/**github.com/sirupsen/logrus@v0.7.0**/-/blob/hooks/syslog/syslog.go#L25:25&tab=references) and pkg.go.dev(pkg.go.dev/**github.com/sirupsen/logrus@v1.3.0**) implement it. 
I am open to input whether it's better to just use another query param for the link (become 
sourcegraph.com/-/godoc/refs?def=DEF&pkg=PKG&repo=REPO&ver=1.3.0&source=pkgsite 
instead of 
sourcegraph.com/-/godoc/refs?def=DEF&pkg=PKG&repo=REPO@v1.3.0&source=pkgsite)

**Additional context**
I don't add much since almost all of mechanics are already handled by the current codebase and also @sqs gave me really helpful pointers on the changes that needs to be done. Thank you so much 🙂 