### PR TITLE
repo-updater: Only exclude cloud_default external services from sync and index

### DIFF
--- a/internal/db/default_repos_test.go
+++ b/internal/db/default_repos_test.go
@@ -93,6 +93,11 @@ func TestListDefaultRepos(t *testing.T) {
 
 			-- insert one repo not referenced in the default repo table;
 			INSERT INTO repo(id, name) VALUES (12, 'github.com/foo/bar12');
+
+			-- insert a repo only references by a cloud_default external service
+			INSERT INTO repo(id, name) VALUES (13, 'github.com/foo/bar13');
+			INSERT INTO external_services(id, kind, display_name, config, cloud_default) VALUES (101, 'github', 'github', '{}', true);
+			INSERT INTO external_service_repos VALUES (101, 13, 'https://github.com/foo/bar13');
 		`)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/db/repos.go
+++ b/internal/db/repos.go
@@ -702,7 +702,7 @@ func (s *RepoStore) ListDefaultRepos(ctx context.Context, opts ListDefaultReposO
 	}
 
 	q := sqlf.Sprintf(`
--- source: internal/db/default_repos.go:defaultRepos.List
+-- source: internal/db/repos.go:RepoStore.ListDefaultRepos
 SELECT
     id,
     name
@@ -716,7 +716,7 @@ WHERE
             external_service_repos sr
             INNER JOIN external_services s ON s.id = sr.external_service_id
         WHERE
-			s.namespace_user_id IS NOT NULL
+			s.cloud_default = false
 			AND s.deleted_at IS NULL
 			AND r.id = sr.repo_id
             AND r.deleted_at IS NULL


### PR DESCRIPTION
On cloud we will now sync all external services in the background unless
they are flagged as cloud_default.

In practice this means that we won't sync our large GitHub and GitLab
public external services that own all of our "on demand sync" repos.
But, we will now start to sync all other external services whether they
are added by users or site admins.

Additionally, any repos synced by non cloud_default external services
will also be indexed.

After this change the following external services will begin to sync in the 
background and have their repos indexed:

Android, 1 repo: https://sourcegraph.com/site-admin/external-services/RXh0ZXJuYWxTZXJ2aWNlOjEx
OCF (Berkeley), 93 repos: https://sourcegraph.com/site-admin/external-services/RXh0ZXJuYWxTZXJ2aWNlOjM3
SrcHut, 2 repos: https://sourcegraph.com/site-admin/external-services/RXh0ZXJuYWxTZXJ2aWNlOjU=
Chromium, 1 repo: https://sourcegraph.com/site-admin/external-services/RXh0ZXJuYWxTZXJ2aWNlOjE2

Closes: https://github.com/sourcegraph/sourcegraph/issues/17472