### PR TITLE
gitserver: able to clone and fetch Perforce depots

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -58,7 +58,7 @@ func (r *repositoryMirrorInfoResolver) repoUpdateSchedulerInfo(ctx context.Conte
 
 // TODO(flying-robot): this regex and the majority of the removeUserInfo function can
 // be extracted to a common location in a subsequent change.
-var nonSCPURLRegex = lazyregexp.New(`^(git\+)?(https?|ssh|rsync|file|git)://`)
+var nonSCPURLRegex = lazyregexp.New(`^(git\+)?(https?|ssh|rsync|file|git|perforce)://`)
 
 func (r *repositoryMirrorInfoResolver) RemoteURL(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: The remote URL might contain secret credentials in the URL userinfo, so

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -117,25 +119,18 @@ func decomposePerforceCloneURL(cloneURL string) (username, password, host, depot
 	return url.User.Username(), password, url.Host, url.Path, nil
 }
 
-// IsCloneable checks to see if the Perforce remote URL is cloneable.
-func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error {
-	username, password, host, _, err := decomposePerforceCloneURL(url)
-	if err != nil {
-		return errors.Wrap(err, "decompose")
-	}
-	_ = password // TODO
-
+// ping sends one message to the Perforce Server to check connectivity.
+func (s *PerforceDepotSyncer) ping(ctx context.Context, host, username string) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	// FIXME: Need to find a way to determine if depot exists instead of a general ping to the Perforce server.
 	cmd := exec.CommandContext(ctx, "p4", "ping", "-c", "1")
 	cmd.Env = append(os.Environ(),
 		"P4PORT="+host,
 		"P4USER="+username,
 	)
+
 	out, err := runWith(ctx, cmd, false, nil)
-	fmt.Println("out:", string(out)) // TODO: Delete me
 	if err != nil {
 		if ctxerr := ctx.Err(); ctxerr != nil {
 			err = ctxerr
@@ -148,13 +143,91 @@ func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error
 	return nil
 }
 
+// login performs a "p4 login" operation against the Perforce Server to obtain a session.
+func (s *PerforceDepotSyncer) login(ctx context.Context, host, username, password string) error {
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "p4", "login", "-a")
+	cmd.Env = append(os.Environ(),
+		"P4PORT="+host,
+		"P4USER="+username,
+	)
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return errors.Wrap(err, "get stdin pipe")
+	}
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			if strings.Contains(stdout.String(), "Enter password: ") {
+				_, err = stdin.Write([]byte(password + "\n"))
+				if err != nil {
+					log15.Error("Failed to enter p4 login password", "error", err)
+					return
+				}
+
+				log15.Debug("PerforceDepotSyncer.login.passwordEntered", "host", host, "username", username)
+				return
+			}
+		}
+	}()
+
+	_, err = runCommand(ctx, cmd)
+	return err
+}
+
+// pingWithLogin attempts to ping the Perforce Server and performs a login operation when needed.
+func (s *PerforceDepotSyncer) pingWithLogin(ctx context.Context, host, username, password string) error {
+	// Attempt to check connectivity, may be prompted to login (again)
+	err := s.ping(ctx, host, username)
+	if err == nil {
+		return nil // The ping worked, session still validate for the user
+	} else if !strings.Contains(err.Error(), "Your session has expired, please login again.") &&
+		!strings.Contains(err.Error(), "Perforce password (P4PASSWD) invalid or unset.") {
+		return errors.Wrap(err, "ping")
+	}
+
+	err = s.login(ctx, host, username, password)
+	if err != nil {
+		return errors.Wrap(err, "login")
+	}
+	return nil
+}
+
+// IsCloneable checks to see if the Perforce remote URL is cloneable.
+func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error {
+	username, password, host, _, err := decomposePerforceCloneURL(url)
+	if err != nil {
+		return errors.Wrap(err, "decompose")
+	}
+
+	// FIXME: Need to find a way to determine if depot exists instead of a general ping to the Perforce server.
+	return s.pingWithLogin(ctx, host, username, password)
+}
+
 // CloneCommand returns the command to be executed for cloning a Perforce depot as a Git repository.
 func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (*exec.Cmd, error) {
 	username, password, host, depot, err := decomposePerforceCloneURL(url)
 	if err != nil {
 		return nil, errors.Wrap(err, "decompose")
 	}
-	_ = password // TODO
+
+	err = s.pingWithLogin(ctx, host, username, password)
+	if err != nil {
+		return nil, errors.Wrap(err, "ping with login")
+	}
 
 	cmd := exec.CommandContext(ctx, "git", "p4", "clone", "--bare", depot+"@all", tmpPath)
 	cmd.Env = append(os.Environ(),
@@ -171,7 +244,11 @@ func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, url string) (cmd
 	if err != nil {
 		return nil, false, errors.Wrap(err, "decompose")
 	}
-	_ = password // TODO
+
+	err = s.pingWithLogin(ctx, host, username, password)
+	if err != nil {
+		return nil, false, errors.Wrap(err, "ping with login")
+	}
 
 	cmd = exec.CommandContext(ctx, "git", "p4", "sync")
 	cmd.Env = append(os.Environ(),

--- a/cmd/gitserver/server/vcs_syncer_test.go
+++ b/cmd/gitserver/server/vcs_syncer_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestDecomposePerforceCloneURL(t *testing.T) {
+	t.Run("not a perforce scheme", func(t *testing.T) {
+		_, _, _, _, err := decomposePerforceCloneURL("https://www.google.com")
+		if err == nil {
+			t.Fatal("Want non-nil error but got nil")
+		}
+	})
+
+	// Tests are driven from "Examples" from the page:
+	// https://www.perforce.com/manuals/cmdref/Content/CmdRef/P4PORT.html
+	tests := []struct {
+		cloneURL     string
+		wantHost     string
+		wantUsername string
+		wantPassword string
+		wantDepot    string
+	}{
+		{
+			cloneURL:     "perforce://admin:password@ssl:111.222.333.444:1666//Sourcegraph/",
+			wantHost:     "ssl:111.222.333.444:1666",
+			wantUsername: "admin",
+			wantPassword: "password",
+			wantDepot:    "//Sourcegraph/",
+		},
+		{
+			cloneURL:     "perforce://admin@ssl:111.222.333.444:1666//Sourcegraph/",
+			wantHost:     "ssl:111.222.333.444:1666",
+			wantUsername: "admin",
+			wantDepot:    "//Sourcegraph/",
+		},
+		{
+			cloneURL:  "perforce://ssl:111.222.333.444:1666//Sourcegraph/",
+			wantHost:  "ssl:111.222.333.444:1666",
+			wantDepot: "//Sourcegraph/",
+		},
+		{
+			cloneURL: "perforce://ssl:111.222.333.444:1666",
+			wantHost: "ssl:111.222.333.444:1666",
+		},
+
+		{
+			cloneURL:     "perforce://admin:password@ssl6:[::]:1818ssl64:[::]:1818//Sourcegraph/",
+			wantHost:     "ssl6:[::]:1818ssl64:[::]:1818",
+			wantUsername: "admin",
+			wantPassword: "password",
+			wantDepot:    "//Sourcegraph/",
+		},
+		{
+			cloneURL:     "perforce://admin:password@tcp6:[2001:db8::123]:1818//Sourcegraph/Cloud/",
+			wantHost:     "tcp6:[2001:db8::123]:1818",
+			wantUsername: "admin",
+			wantPassword: "password",
+			wantDepot:    "//Sourcegraph/Cloud/",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.cloneURL, func(t *testing.T) {
+			username, password, host, depot, err := decomposePerforceCloneURL(test.cloneURL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if host != test.wantHost {
+				t.Fatalf("Host: want %q but got %q", test.wantHost, host)
+			}
+			if username != test.wantUsername {
+				t.Fatalf("Username: want %q but got %q", test.wantUsername, username)
+			}
+			if password != test.wantPassword {
+				t.Fatalf("Password: want %q but got %q", test.wantPassword, password)
+			}
+			if depot != test.wantDepot {
+				t.Fatalf("Depot: want %q but got %q", test.wantDepot, depot)
+			}
+		})
+	}
+}

--- a/enterprise/internal/db/external_services_test.go
+++ b/enterprise/internal/db/external_services_test.go
@@ -1164,8 +1164,8 @@ func TestExternalServices_ValidateConfig(t *testing.T) {
 			}
 `,
 			assert: includes(
-				`depots.0: Does not match pattern '^\/[\/\w]+/$'`,
-				`depots.1: Does not match pattern '^\/[\/\w]+/$'`,
+				`depots.0: Does not match pattern '^\/[\/\S]+\/$'`,
+				`depots.1: Does not match pattern '^\/[\/\S]+\/$'`,
 			),
 		},
 		{

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -6,8 +6,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -58,22 +56,6 @@ func composePerforceCloneURL(username, password, host, depot string) string {
 		Path:   depot,
 	}
 	return cloneURL.String()
-}
-
-// DecomposePerforceCloneURL decomposes information back from a clone URL for a
-// Perforce depot.
-func DecomposePerforceCloneURL(cloneURL string) (username, password, host, depot string, err error) {
-	url, err := url.Parse(cloneURL)
-	if err != nil {
-		return "", "", "", "", err
-	}
-
-	if url.Scheme != "perforce" {
-		return "", "", "", "", errors.New(`scheme is not "perforce"`)
-	}
-
-	password, _ = url.User.Password()
-	return url.User.Username(), password, url.Host, url.Path, nil
 }
 
 func (s PerforceSource) makeRepo(depot string) *types.Repo {

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -25,7 +25,7 @@
     "depots": {
       "description": "Depots can have arbitrary paths, e.g. a path to depot root or a subdirectory.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^\\/[\\/\\w]+/$" },
+      "items": { "type": "string", "pattern": "^\\/[\\/\\S]+\\/$" },
       "examples": [["//Sourcegraph/", "//Engineering/Cloud/"]]
     },
     "maxChanges": {

--- a/schema/perforce_stringdata.go
+++ b/schema/perforce_stringdata.go
@@ -30,7 +30,7 @@ const PerforceSchemaJSON = `{
     "depots": {
       "description": "Depots can have arbitrary paths, e.g. a path to depot root or a subdirectory.",
       "type": "array",
-      "items": { "type": "string", "pattern": "^\\/[\\/\\w]+/$" },
+      "items": { "type": "string", "pattern": "^\\/[\\/\\S]+\\/$" },
       "examples": [["//Sourcegraph/", "//Engineering/Cloud/"]]
     },
     "maxChanges": {


### PR DESCRIPTION
This PR adds the ability to actually clone and fetch Perforce Depots as Git repositories, include handling of its session-based authentication.

Part of #16703

### TODO

- [x] Redact username and password from repository "Settings > Remote repository URL"
- [x] Handle interactive password input: https://stackoverflow.com/questions/44471749/golang-enter-ssh-sudo-password-on-prompt-or-exit
- [x] Tests