### PR TITLE
search: only return limit results from each zoekt

### DIFF
--- a/internal/search/zoekt/zoekt.go
+++ b/internal/search/zoekt/zoekt.go
@@ -81,17 +81,9 @@ func SearchOpts(ctx context.Context, k int, query *search.TextPatternInfo) zoekt
 		TotalMaxMatchCount:     100 * k,
 		ShardMaxImportantMatch: 15 * k,
 		TotalMaxImportantMatch: 25 * k,
-		MaxDocDisplayCount:     2 * defaultMaxSearchResults,
-	}
-
-	// We want zoekt to return more than FileMatchLimit results since we use
-	// the extra results to populate reposLimitHit. Additionally the defaults
-	// are very low, so we always want to return at least 2000.
-	if query.FileMatchLimit > defaultMaxSearchResults {
-		searchOpts.MaxDocDisplayCount = 2 * int(query.FileMatchLimit)
-	}
-	if searchOpts.MaxDocDisplayCount < 2000 {
-		searchOpts.MaxDocDisplayCount = 2000
+		// Ask for 2000 more results so we have results to populate
+		// RepoStatusLimitHit.
+		MaxDocDisplayCount: int(query.FileMatchLimit) + 2000,
 	}
 
 	if userProbablyWantsToWaitLonger := query.FileMatchLimit > defaultMaxSearchResults; userProbablyWantsToWaitLonger {


### PR DESCRIPTION
Previously we would ask for 2 * limit results from Zoekt. However, we
would just throw away every result over limit. The documented reason for
asking for more was for more accurate limit hit per repo statistics. To
avoid asking for a lot more in the case of a large limit, we instead
always ask for 2000 more than the limit.