### PR TITLE
notify Gonza on distribution issues

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -16,3 +16,4 @@ jobs:
                   team/search=@lguychard
                   team/code-intelligence=@macraig
                   team/code-insights=@joelkw @felixfbecker
+                  team/distribution=@pecigonzalo


### PR DESCRIPTION
Notifies @pecigonzalo for issues created for the distribution team. 

Related: https://github.com/sourcegraph/about/pull/2378