### PR TITLE
search: respect passed in context for Promise.Get

### DIFF
--- a/internal/search/promise.go
+++ b/internal/search/promise.go
@@ -6,9 +6,6 @@ import (
 )
 
 type Promise struct {
-	getOnce sync.Once
-	err     error
-
 	initOnce sync.Once
 	done     chan struct{}
 
@@ -31,18 +28,18 @@ func (p *Promise) Resolve(v interface{}) *Promise {
 }
 
 // Get returns the value. It blocks until the promise resolves or the context is
-// canceled. Further calls to Get will always return the original results, IE err
-// will stay nil even if the context expired between the first and the second
-// call. Vice versa, if ctx finishes while resolving, then we will always return
-// ctx.Err()
+// canceled.
 func (p *Promise) Get(ctx context.Context) (interface{}, error) {
-	p.getOnce.Do(func() {
-		p.init()
-		select {
-		case <-ctx.Done():
-			p.err = ctx.Err()
-		case <-p.done:
-		}
-	})
-	return p.value, p.err
+	p.init()
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-p.done:
+	}
+	return p.value, nil
 }

--- a/internal/search/types_test.go
+++ b/internal/search/types_test.go
@@ -46,10 +46,10 @@ func TestPromiseGetConcurrent(t *testing.T) {
 	cancel()
 
 	out, err = p.Get(ctx)
-	if err != nil {
-		t.Fatal("error should have been nil, because we canceled the context after the first call to get")
+	if err != context.Canceled {
+		t.Fatalf("got %s, but error should have been \"context canceled\"", err)
 	}
-	if ok := reflect.DeepEqual(in, out); !ok {
-		t.Fatalf("got %+v, expected %+v", out, in)
+	if out != nil {
+		t.Fatalf("got %+v, expected nil", out)
 	}
 }


### PR DESCRIPTION
This reverts commit 7711864 and fixes a bug we introduced. By design,
select statements choose a case at random if more than one case is
ready. Hence the behavior of Get was nondeterministic if the context was
canceled before calling Get. This fix does not completely remove
randomness but it is good enough for all practical purposes. Randomness
was almost certainly the reason why CI checks were all green but tests failed
during the build.

Co-authored-by: Keegan Carruthers-Smith <keegan.csmith@gmail.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
