### PR TITLE
Add commit changes column to campaigns preview UI

### DIFF
--- a/client/web/src/enterprise/campaigns/preview/list/GitBranchChangesetDescriptionInfo.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/GitBranchChangesetDescriptionInfo.tsx
@@ -49,9 +49,7 @@ export const GitBranchChangesetDescriptionInfo: React.FunctionComponent<Props> =
                                 </DeletedEntry>
                                 {previousCommit.body && (
                                     <DeletedEntry deleted={node.delta.commitMessageChanged}>
-                                        <p>
-                                            <pre className="text-wrap mb-0">{previousCommit.body}</pre>
-                                        </p>
+                                        <pre className="text-wrap">{previousCommit.body}</pre>
                                     </DeletedEntry>
                                 )}
                             </div>
@@ -70,11 +68,7 @@ export const GitBranchChangesetDescriptionInfo: React.FunctionComponent<Props> =
                 </div>
                 <div>
                     <h3>{commit.subject}</h3>
-                    {commit.body && (
-                        <p>
-                            <pre className="text-wrap mb-0">{commit.body}</pre>
-                        </p>
-                    )}
+                    {commit.body && <pre className="text-wrap">{commit.body}</pre>}
                 </div>
             </div>
         </>

--- a/client/web/src/enterprise/campaigns/preview/list/HiddenChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/HiddenChangesetApplyPreviewNode.tsx
@@ -49,6 +49,7 @@ export const HiddenChangesetApplyPreviewNode: React.FunctionComponent<HiddenChan
             </span>
         </div>
         <span />
+        <span />
     </>
 )
 

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewList.scss
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewList.scss
@@ -6,7 +6,7 @@
                 auto,
                 1fr
             )
-            [diffstat] min-content [end];
+            [commit_changes] min-content [diffstat] min-content [end];
         align-items: center;
     }
 }

--- a/client/web/src/enterprise/campaigns/preview/list/PreviewListHeader.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/PreviewListHeader.tsx
@@ -13,6 +13,7 @@ export const PreviewListHeader: React.FunctionComponent<PreviewListHeaderProps> 
         </h5>
         <h5 className="p-2 d-none d-sm-block text-uppercase text-nowrap">Actions</h5>
         <h5 className="p-2 d-none d-sm-block text-uppercase text-nowrap">Changeset information</h5>
-        <h5 className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">Changes</h5>
+        <h5 className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">Commit changes</h5>
+        <h5 className="p-2 d-none d-sm-block text-uppercase text-center text-nowrap">Change state</h5>
     </>
 )

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.scss
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.scss
@@ -35,6 +35,9 @@
             grid-column: 1 / -1;
         }
     }
+    &__commit-change-entry {
+        color: $gray-10;
+    }
 }
 
 .theme-dark {

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -497,6 +497,108 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
             },
         },
     },
+    'Update commit message': {
+        __typename: 'VisibleChangesetApplyPreview',
+        operations: [ChangesetSpecOperation.PUSH],
+        delta: {
+            titleChanged: false,
+            baseRefChanged: false,
+            diffChanged: false,
+            bodyChanged: false,
+            authorEmailChanged: false,
+            authorNameChanged: false,
+            commitMessageChanged: true,
+        },
+        targets: {
+            __typename: 'VisibleApplyPreviewTargetsUpdate',
+            changesetSpec: baseChangesetSpec(true),
+            changeset: {
+                id: '123123',
+                title: 'the old title',
+                state: ChangesetState.OPEN,
+                currentSpec: {
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        baseRef: 'main',
+                        body: 'body',
+                        commits: [
+                            {
+                                subject: 'Abc',
+                                body: 'Current commit message',
+                                author: {
+                                    avatarURL: null,
+                                    displayName: 'alice',
+                                    email: 'alice@sourcegraph.test',
+                                    user: null,
+                                },
+                            },
+                        ],
+                        title: 'Title',
+                    },
+                },
+                author: {
+                    displayName: 'Alice',
+                    email: 'alice@email.test',
+                    user: {
+                        displayName: 'Alice',
+                        url: '/users/alice',
+                        username: 'alice',
+                    },
+                },
+            },
+        },
+    },
+    'Update commit author': {
+        __typename: 'VisibleChangesetApplyPreview',
+        operations: [ChangesetSpecOperation.PUSH],
+        delta: {
+            titleChanged: false,
+            baseRefChanged: false,
+            diffChanged: false,
+            bodyChanged: false,
+            authorEmailChanged: true,
+            authorNameChanged: true,
+            commitMessageChanged: false,
+        },
+        targets: {
+            __typename: 'VisibleApplyPreviewTargetsUpdate',
+            changesetSpec: baseChangesetSpec(true),
+            changeset: {
+                id: '123123',
+                title: 'the old title',
+                state: ChangesetState.OPEN,
+                currentSpec: {
+                    description: {
+                        __typename: 'GitBranchChangesetDescription',
+                        baseRef: 'main',
+                        body: 'body',
+                        commits: [
+                            {
+                                subject: 'Abc',
+                                body: 'Current commit message',
+                                author: {
+                                    avatarURL: null,
+                                    displayName: 'alice',
+                                    email: 'alice@sourcegraph.test',
+                                    user: null,
+                                },
+                            },
+                        ],
+                        title: 'Title',
+                    },
+                },
+                author: {
+                    displayName: 'Bob',
+                    email: 'bob@email.test',
+                    user: {
+                        displayName: 'Bob',
+                        url: '/users/bob',
+                        username: 'bob',
+                    },
+                },
+            },
+        },
+    },
 }
 
 const queryEmptyFileDiffs = () => of({ totalCount: 0, pageInfo: { endCursor: null, hasNextPage: false }, nodes: [] })

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -12,6 +12,9 @@ import { DiffStat } from '../../../../components/diff/DiffStat'
 import { PreviewActions } from './PreviewActions'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import CardTextOutlineIcon from 'mdi-react/CardTextOutlineIcon'
+import FileDocumentEditOutlineIcon from 'mdi-react/FileDocumentEditOutlineIcon'
+import AccountEditIcon from 'mdi-react/AccountEditIcon'
 import { FileDiffConnection } from '../../../../components/diff/FileDiffConnection'
 import { FileDiffNode } from '../../../../components/diff/FileDiffNode'
 import { FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
@@ -85,7 +88,27 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<VisibleCh
                     </div>
                 </div>
             </div>
-            <div className="visible-changeset-apply-preview-node__list-cell d-flex justify-content-center align-content-center align-self-stretch">
+            <div className="d-flex justify-content-center align-content-center align-self-stretch">
+                {node.delta.commitMessageChanged && (
+                    <div className="d-flex justify-content-center align-items-center flex-column mx-1 visible-changeset-apply-preview-node__commit-change-entry">
+                        <CardTextOutlineIcon data-tooltip="The commit message changed" className="icon-inline" />
+                        <span className="text-nowrap">Commit msg</span>
+                    </div>
+                )}
+                {node.delta.diffChanged && (
+                    <div className="d-flex justify-content-center align-items-center flex-column mx-1 visible-changeset-apply-preview-node__commit-change-entry">
+                        <FileDocumentEditOutlineIcon data-tooltip="The diff changed" className="icon-inline" />
+                        <span className="text-nowrap">Diff</span>
+                    </div>
+                )}
+                {(node.delta.authorNameChanged || node.delta.authorEmailChanged) && (
+                    <div className="d-flex justify-content-center align-items-center flex-column mx-1 visible-changeset-apply-preview-node__commit-change-entry">
+                        <AccountEditIcon data-tooltip="The commit author details changed" className="icon-inline" />
+                        <span className="text-nowrap">Author</span>
+                    </div>
+                )}
+            </div>
+            <div className="visible-changeset-apply-preview-node__list-cell d-flex justify-content-center align-items-center align-self-stretch">
                 <ApplyDiffStat spec={node} />
             </div>
             {/* The button for expanding the information used on xs devices. */}

--- a/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/campaigns/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -92,7 +92,7 @@ export const VisibleChangesetApplyPreviewNode: React.FunctionComponent<VisibleCh
                 {node.delta.commitMessageChanged && (
                     <div className="d-flex justify-content-center align-items-center flex-column mx-1 visible-changeset-apply-preview-node__commit-change-entry">
                         <CardTextOutlineIcon data-tooltip="The commit message changed" className="icon-inline" />
-                        <span className="text-nowrap">Commit msg</span>
+                        <span className="text-nowrap">Message</span>
                     </div>
                 )}
                 {node.delta.diffChanged && (


### PR DESCRIPTION
As per the design, this adds the column to indicate what changes cause a push to the list view.
