### PR TITLE
search: Fix matcher not set for comby

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -597,7 +597,24 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}()
 	}
 
-	if isStructuralSearch {
+	if isStructuralSearch && args.PatternInfo.CombyRule == `where "zoekt" == "zoekt"` {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
+			for _, repo := range indexed.Repos() {
+				repos = append(repos, repo)
+			}
+
+			err := callSearcherOverRepos(repos, nil)
+			if err != nil {
+				mu.Lock()
+				searchErr = err
+				mu.Unlock()
+			}
+		}()
+	} else if isStructuralSearch {
 		wg.Add(1)
 		go func() {
 			// TODO limitHit, handleRepoSearchResult

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -266,7 +266,12 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 		return nil, false, false, err
 	}
 
-	matches, limitHit, err = structuralSearch(ctx, zipFile.Name(), p.Pattern, p.CombyRule, p.Languages, nil, p.Repo)
+	includePatterns := make([]string, len(zoektMatches))
+	for i, match := range zoektMatches {
+		includePatterns[i] = match.FileName
+	}
+
+	matches, limitHit, err = structuralSearch(ctx, zipFile.Name(), p.Pattern, p.CombyRule, p.Languages, includePatterns, p.Repo)
 	return matches, limitHit, false, err
 }
 

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -248,7 +248,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			Languages:                    p.Languages,
 		}
 
-	repoBranches := map[string][]string{string(p.Repo): {"HEAD"}}
+	repoBranches := map[string][]string{string(p.Repo): {string(p.Commit)}}
 	useFullDeadline := false
 	zoektMatches, limitHit, _, err := zoektSearch(ctx, patternInfo, repoBranches, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -248,7 +248,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			Languages:                    p.Languages,
 		}
 
-	repoBranches := map[string][]string{string(p.Repo): {string(p.Commit)}}
+	repoBranches := map[string][]string{string(p.Repo): {"HEAD"}}
 	useFullDeadline := false
 	zoektMatches, limitHit, _, err := zoektSearch(ctx, patternInfo, repoBranches, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes an issue where the new code path for structural search wasn't populating the `Matcher` arg for comby, so some structural search results weren't being returned. 

Depends on #17539 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
