### PR TITLE
search: Fix structural search not respecting file filters

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -241,6 +241,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			IsWordMatch:                  p.IsWordMatch,
 			IsCaseSensitive:              p.IsCaseSensitive,
 			FileMatchLimit:               int32(fileMatchLimit),
+			IncludePatterns:              p.IncludePatterns,
 			ExcludePattern:               p.ExcludePattern,
 			PathPatternsAreCaseSensitive: p.PathPatternsAreCaseSensitive,
 			PatternMatchesContent:        p.PatternMatchesContent,


### PR DESCRIPTION
This fixes an issue where the new structural search code path wouldn't
respect file filters added to the query.

Fixes #17568 
Depends on #17539 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
