### PR TITLE
streaming search: fixing minor bugs related to progress count

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -335,10 +335,6 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                         </h3>
                     </div>
                 )}
-
-                {results?.state === 'complete' && results?.results.length > 0 && (
-                    <small className="d-block my-4 text-center">Showing {results?.results.length} results</small>
-                )}
             </div>
         </div>
     )

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
@@ -60,6 +60,28 @@ add('1 result from 1 repository, in progress', () => {
     )
 })
 
+add('big numbers, done', () => {
+    const progress: Progress = {
+        durationMs: 52500,
+        matchCount: 1234567,
+        repositoriesCount: 8901,
+        skipped: [],
+    }
+
+    return (
+        <WebStory>
+            {() => (
+                <StreamingProgress
+                    progress={progress}
+                    state="complete"
+                    onSearchAgain={onSearchAgain}
+                    history={history}
+                />
+            )}
+        </WebStory>
+    )
+})
+
 add('2 results from 2 repositories, complete, skipped with info', () => {
     const progress: Progress = {
         durationMs: 1500,

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -35,4 +35,15 @@ describe('StreamingProgressCount', () => {
 
         expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()
     })
+
+    it('should render correctly for big numbers complete', () => {
+        const progress: Progress = {
+            durationMs: 52500,
+            matchCount: 1234567,
+            repositoriesCount: 8901,
+            skipped: [],
+        }
+
+        expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()
+    })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -4,6 +4,19 @@ import * as React from 'react'
 import { pluralize } from '../../../../../../shared/src/util/strings'
 import { StreamingProgressProps } from './StreamingProgress'
 
+const abbreviateNumber = (number: number): string => {
+    if (number < 1e3) {
+        return number.toString()
+    }
+    if (number >= 1e3 && number < 1e6) {
+        return (number / 1e3).toFixed(1) + 'k+'
+    }
+    if (number >= 1e6 && number < 1e9) {
+        return (number / 1e6).toFixed(1) + 'm+'
+    }
+    return (number / 1e9).toFixed(1) + 'b+'
+}
+
 export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgressProps, 'progress' | 'state'>> = ({
     progress,
     state,
@@ -14,11 +27,13 @@ export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgr
         })}
     >
         <CalculatorIcon className="mr-2 icon-inline" />
-        {progress.matchCount} {pluralize('result', progress.matchCount)} in {(progress.durationMs / 1000).toFixed(2)}s
+        {abbreviateNumber(progress.matchCount)} {pluralize('result', progress.matchCount)} in{' '}
+        {(progress.durationMs / 1000).toFixed(2)}s
         {progress.repositoriesCount && (
             <>
                 {' '}
-                from {progress.repositoriesCount} {pluralize('repository', progress.repositoriesCount, 'repositories')}
+                from {abbreviateNumber(progress.repositoriesCount)}{' '}
+                {pluralize('repository', progress.repositoriesCount, 'repositories')}
             </>
         )}
     </div>

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -20,7 +20,8 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
     0
      
     results
-     in 
+     in
+     
     0.00
     s
   </div>
@@ -48,7 +49,8 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
     1
      
     result
-     in 
+     in
+     
     1.25
     s
      
@@ -81,12 +83,47 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
     123
      
     results
-     in 
+     in
+     
     1.25
     s
      
     from 
     500
+     
+    repositories
+  </div>
+</StreamingProgressCount>
+`;
+
+exports[`StreamingProgressCount should render correctly for big numbers complete 1`] = `
+<StreamingProgressCount
+  progress={
+    Object {
+      "durationMs": 52500,
+      "matchCount": 1234567,
+      "repositoriesCount": 8901,
+      "skipped": Array [],
+    }
+  }
+  state="complete"
+>
+  <div
+    className="streaming-progress__count d-flex align-items-center"
+  >
+    <Memo(CalculatorIcon)
+      className="mr-2 icon-inline"
+    />
+    1.2m+
+     
+    results
+     in
+     
+    52.50
+    s
+     
+    from 
+    8.9k+
      
     repositories
   </div>

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -439,11 +439,7 @@ const messageHandlers: {
                 // The EventSource API can return a DOM event that is not an Error object
                 // (e.g. doesn't have the message property), so we need to construct our own here.
                 // See https://developer.mozilla.org/en-US/docs/Web/API/EventSource/error_event
-                observer.error(
-                    new Error(
-                        'There was a network error retrieving search results. Check your Internet connection and try again.'
-                    )
-                )
+                observer.error(new Error('The connection was closed before the search was completed.'))
             }
             eventSource.close()
         }),

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -439,7 +439,11 @@ const messageHandlers: {
                 // The EventSource API can return a DOM event that is not an Error object
                 // (e.g. doesn't have the message property), so we need to construct our own here.
                 // See https://developer.mozilla.org/en-US/docs/Web/API/EventSource/error_event
-                observer.error(new Error('The connection was closed before your search was completed. This may be due to a problem with a firewall, VPN or proxy, or a failure with the Sourcegraph server.'))
+                observer.error(
+                    new Error(
+                        'The connection was closed before your search was completed. This may be due to a problem with a firewall, VPN or proxy, or a failure with the Sourcegraph server.'
+                    )
+                )
             }
             eventSource.close()
         }),

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -439,7 +439,7 @@ const messageHandlers: {
                 // The EventSource API can return a DOM event that is not an Error object
                 // (e.g. doesn't have the message property), so we need to construct our own here.
                 // See https://developer.mozilla.org/en-US/docs/Web/API/EventSource/error_event
-                observer.error(new Error('The connection was closed before the search was completed.'))
+                observer.error(new Error('The connection was closed before your search was completed. This may be due to a problem with a firewall, VPN or proxy, or a failure with the Sourcegraph server.'))
             }
             eventSource.close()
         }),


### PR DESCRIPTION
- Remove count from bottom of search results (fixes #17562)
- Update closed connection error message (fixes #17561)
- Abbreviates result counts in the progress indicator (eg. `1234` becomes `1.2k+`; related to #17560)

![image](https://user-images.githubusercontent.com/206864/105532016-0f3acf80-5c9f-11eb-88fb-87d80b96570c.png)
