### PR TITLE
campaigns: fix horizontal alignment of states

### DIFF
--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -86,10 +86,20 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} className="mr-3" />}
                 {node.diffStat && <DiffStat {...node.diffStat} expandedCounts={true} separateLines={true} />}
             </div>
-            <span className={classNames('align-self-stretch d-none d-md-flex', node.checkState && 'p-2')}>
+            <span
+                className={classNames(
+                    'align-self-stretch d-none d-md-flex justify-content-center',
+                    node.checkState && 'p-2'
+                )}
+            >
                 {node.checkState && <ChangesetCheckStatusCell checkState={node.checkState} />}
             </span>
-            <span className={classNames('align-self-stretch d-none d-md-flex', node.reviewState && 'p-2')}>
+            <span
+                className={classNames(
+                    'align-self-stretch d-none d-md-flex justify-content-center',
+                    node.reviewState && 'p-2'
+                )}
+            >
                 {node.reviewState && <ChangesetReviewStatusCell reviewState={node.reviewState} />}
             </span>
             <div


### PR DESCRIPTION
I noticed this, somewhat embarrassingly, during a demo this morning. It's particularly noticeable when there are different states in the grid, since then they don't align with each other either.

Before and after:

![anim](https://user-images.githubusercontent.com/229984/105541480-ace8cb80-5cac-11eb-915a-45f12ec77163.gif)
