### PR TITLE
cli: bump minimum version

### DIFF
--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.24.1"
+const MinimumVersion = "3.24.3"


### PR DESCRIPTION
Technically, we haven't released 3.24.3 yet because we hit a GitHub rate limit on the releaser job, but I promise not to enable automerge on this until that release is complete.