### PR TITLE
deps: document alertmanager fork, reorganize module replaces

### DIFF
--- a/doc/dev/background-information/observability/prometheus.md
+++ b/doc/dev/background-information/observability/prometheus.md
@@ -4,7 +4,7 @@
 > See the [metrics and dashboards documentation](../../../admin/observability/metrics.md#prometheus).
 
 We ship a custom Prometheus image as part of a standard Sourcegraph distribution.
-It currently bundles Alertmanager as well as integrations to the Sourcegraph web application.
+It currently [bundles Alertmanager](#alertmanager) as well as [integrations to the Sourcegraph web application](#prom-wrapper).
 Learn more about it in our [monitoring architecture](https://about.sourcegraph.com/handbook/engineering/observability/monitoring_architecture#sourcegraph-prometheus).
 
 Adding recording rules, alerts, etc. to this image is handled by the [monitoring generator](./monitoring-generator.md).
@@ -20,11 +20,19 @@ To learn more about developing metrics, see the [observability developer guides]
 ## Prom-wrapper
 
 The entrypoint of the image is a sidecar program called the prom-wrapper.
+It manages Prometheus and Alertmanager, and provides integration with the Sourcgraph frontend.
 Learn more about it [here](https://about.sourcegraph.com/handbook/engineering/observability/monitoring_architecture#prom-wrapper).
 
 The source code for this program is currently kept in [`docker-images/prometheus/cmd/prom-wrapper`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/prometheus/cmd/prom-wrapper).
 
 To learn more about developing our observability stack, see the [local Sourcegraph monitoring development guide](../../how-to/monitoring_local_dev.md).
+
+## Alertmanager
+
+The [Sourcegraph Prometheus image ships with Alertmanager](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Edocker-images/prometheus/Dockerfile+FROM+prom/alertmanager&patternType=literal), which provides our [alerting capabilities](../../../admin/observability/alerting.md).
+
+Note that [prom-wrapper](#prom-wrapper) uses a [fork of Alertmanager](https://github.com/sourcegraph/alertmanager) to better manipulate Alertmanager configuration - prom-wrapper needs to be able to write alertmanager configuration with secrets, etc, which the Alertmanager project is currently not planning on accepting changes for ([alertmanager#2316](https://github.com/prometheus/alertmanager/pull/2316)).
+This *does not* affect the version of Alertmanager that we ship with, the fork exists purely for use as a library.
 
 ## Upgrading Prometheus or Alertmanager
 

--- a/docker-images/prometheus/cmd/prom-wrapper/main.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/main.go
@@ -1,5 +1,7 @@
-// Command grafana-wrapper provides a wrapper command for Grafana that
-// also handles Sourcegraph configuration changes and making changes to Grafana.
+// Command prom-wrapper provides a wrapper command for Prometheus that
+// also handles Sourcegraph configuration changes and making changes to Prometheus.
+//
+// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/gorilla/sessions v1.2.1
 	github.com/gosimple/slug v1.9.0 // indirect
 	github.com/goware/urlx v0.3.1
-	github.com/grafana-tools/sdk v0.0.0-20200908142517-0a69ce5bbb82
+	github.com/grafana-tools/sdk v0.0.0-20210121201358-e16eca879125
 	github.com/graph-gophers/graphql-go v0.0.0-20200819123640-3b5ddcd884ae
 	github.com/graphql-go/graphql v0.7.9
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
@@ -219,25 +219,25 @@ replace (
 // These entries indicate temporary replace directives due to a pending pull request upstream
 // or issues with specific versions.
 replace (
+	// Pending: https://github.com/gchaincl/sqlhooks/pull/33
+	github.com/gchaincl/sqlhooks => github.com/asdine/sqlhooks v1.3.1-0.20210120094401-480358310a5b
+	// Pending: https://github.com/ghodss/yaml/pull/65
+	github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
 	// protobuf v1.3.5+ causes issues - https://github.com/sourcegraph/sourcegraph/issues/11804
 	github.com/golang/protobuf => github.com/golang/protobuf v1.3.5
 	// We need our fork until https://github.com/graph-gophers/graphql-go/pull/400 is merged upstream
 	// Our change limits the number of goroutines spawned by resolvers which was causing memory spikes on our frontend
 	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20201007040903-ec61a5417d66
-	// Pending: https://github.com/gchaincl/sqlhooks/pull/33
-	github.com/gchaincl/sqlhooks => github.com/asdine/sqlhooks v1.3.1-0.20210120094401-480358310a5b
-	// Pending: https://github.com/ghodss/yaml/pull/65
-	github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
 )
 
 // Status unclear replace directives
 // =================================
 // These entries indicate replace directives that are defined for unknown reasons.
 replace (
+	github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8
+	github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
 	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
 	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.6.1-0.20201216035416-70944041979a
 	github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
-	github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8
 	golang.org/x/oauth2 => github.com/sourcegraph/oauth2 v0.0.0-20201011192344-605770292164
-	github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
 )

--- a/go.mod
+++ b/go.mod
@@ -199,40 +199,47 @@ require (
 	honnef.co/go/tools v0.0.1-2020.1.5 // indirect
 )
 
+// Permanent replace directives
+// ============================
+// These entries indicate permanent replace directives due to significant changes from upstream
+// or intentional forks.
+replace (
+	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201124084228-b6ed3e04a806
+	// prom-wrapper needs to be able to write alertmanager configuration with secrets, etc, which
+	// the Alertmanager project is currently not planning on accepting changes for (https://github.com/prometheus/alertmanager/pull/2316)
+	//
+	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
+	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534
+	// We publish 'enterprise/dev/ci/images' as a package for import in other tooling.
+	// When developing Sourcegraph itself, this replace uses the local package instead of a pushed version.
+	github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images => ./enterprise/dev/ci/images
+)
+
+// Temporary replace directives
+// ============================
+// These entries indicate temporary replace directives due to a pending pull request upstream
+// or issues with specific versions.
 replace (
 	// protobuf v1.3.5+ causes issues - https://github.com/sourcegraph/sourcegraph/issues/11804
 	github.com/golang/protobuf => github.com/golang/protobuf v1.3.5
-
 	// We need our fork until https://github.com/graph-gophers/graphql-go/pull/400 is merged upstream
 	// Our change limits the number of goroutines spawned by resolvers which was causing memory spikes on our frontend
 	github.com/graph-gophers/graphql-go => github.com/sourcegraph/graphql-go v0.0.0-20201007040903-ec61a5417d66
-	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
-
-	// prom-wrapper needs to be able to write alertmanager configuration with secrets, etc, which
-	// the alertmanager project is currently not planning on accepting changes for.
-	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534
-
-	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.6.1-0.20201216035416-70944041979a
+	// Pending: https://github.com/gchaincl/sqlhooks/pull/33
+	github.com/gchaincl/sqlhooks => github.com/asdine/sqlhooks v1.3.1-0.20210120094401-480358310a5b
+	// Pending: https://github.com/ghodss/yaml/pull/65
+	github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
 )
 
-// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-replace github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201124084228-b6ed3e04a806
-
-replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
-
-replace github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8
-
-replace golang.org/x/oauth2 => github.com/sourcegraph/oauth2 v0.0.0-20201011192344-605770292164
-
-replace github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
-
-// See: https://github.com/ghodss/yaml/pull/65
-replace github.com/ghodss/yaml => github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152
-
-replace github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images => ./enterprise/dev/ci/images
-
-// Pending: https://github.com/grafana-tools/sdk/pull/121
-replace github.com/grafana-tools/sdk => github.com/sourcegraph/grafana-sdk v0.0.0-20210112115824-13757501ee8a
-
-// Pending: https://github.com/gchaincl/sqlhooks/pull/33
-replace github.com/gchaincl/sqlhooks => github.com/asdine/sqlhooks v1.3.1-0.20210120094401-480358310a5b
+// Status unclear replace directives
+// =================================
+// These entries indicate replace directives that are defined for unknown reasons.
+replace (
+	github.com/mattn/goreman => github.com/sourcegraph/goreman v0.1.2-0.20180928223752-6e9a2beb830d
+	github.com/russellhaering/gosaml2 => github.com/sourcegraph/gosaml2 v0.6.1-0.20201216035416-70944041979a
+	github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
+	github.com/dghubble/gologin => github.com/sourcegraph/gologin v1.0.2-0.20181110030308-c6f1b62954d8
+	golang.org/x/oauth2 => github.com/sourcegraph/oauth2 v0.0.0-20201011192344-605770292164
+	github.com/golang/lint => golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f
+)

--- a/go.mod
+++ b/go.mod
@@ -206,9 +206,7 @@ require (
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
 	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20201124084228-b6ed3e04a806
-	// prom-wrapper needs to be able to write alertmanager configuration with secrets, etc, which
-	// the Alertmanager project is currently not planning on accepting changes for (https://github.com/prometheus/alertmanager/pull/2316)
-	//
+	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534
 	// We publish 'enterprise/dev/ci/images' as a package for import in other tooling.

--- a/go.sum
+++ b/go.sum
@@ -719,6 +719,7 @@ github.com/gostaticanalysis/analysisutil v0.0.3 h1:iwp+5/UAyzQSFgQ4uR2sni99sJ8Eo
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/goware/urlx v0.3.1 h1:BbvKl8oiXtJAzOzMqAQ0GfIhf96fKeNEZfm9ocNSUBI=
 github.com/goware/urlx v0.3.1/go.mod h1:h8uwbJy68o+tQXCGZNa9D73WN8n0r9OBae5bUnLcgjw=
+github.com/grafana-tools/sdk v0.0.0-20200908142517-0a69ce5bbb82/go.mod h1:aqBqJVTJmj0MTX9cP8wuReJPte6HyttMDzSS2u8nJwo=
 github.com/graphql-go/graphql v0.7.9 h1:5Va/Rt4l5g3YjwDnid3vFfn43faaQBq7rMcIZ0VnV34=
 github.com/graphql-go/graphql v0.7.9/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
 github.com/gregjones/httpcache v0.0.0-20170920190843-316c5e0ff04e/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,6 @@ github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/garyburd/redigo v1.1.1-0.20170914051019-70e1b1943d4f/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
-github.com/gchaincl/sqlhooks v1.3.0 h1:yKPXxW9a5CjXaVf2HkQn6wn7TZARvbAOAelr3H8vK2Y=
-github.com/gchaincl/sqlhooks v1.3.0/go.mod h1:9BypXnereMT0+Ys8WGWHqzgkkOfHIhyeUCqXC24ra34=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20200312180434-e5170e3280fb h1:7a6ctCrx5JrYRFTLMFKx48cNztTAkvReSn08g8LSaTg=
@@ -719,7 +717,8 @@ github.com/gostaticanalysis/analysisutil v0.0.3 h1:iwp+5/UAyzQSFgQ4uR2sni99sJ8Eo
 github.com/gostaticanalysis/analysisutil v0.0.3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
 github.com/goware/urlx v0.3.1 h1:BbvKl8oiXtJAzOzMqAQ0GfIhf96fKeNEZfm9ocNSUBI=
 github.com/goware/urlx v0.3.1/go.mod h1:h8uwbJy68o+tQXCGZNa9D73WN8n0r9OBae5bUnLcgjw=
-github.com/grafana-tools/sdk v0.0.0-20200908142517-0a69ce5bbb82/go.mod h1:aqBqJVTJmj0MTX9cP8wuReJPte6HyttMDzSS2u8nJwo=
+github.com/grafana-tools/sdk v0.0.0-20210121201358-e16eca879125 h1:Z9GKXtHIPff/dbXUeueg5tMiuYy1G+pUrNzLjfP4dMc=
+github.com/grafana-tools/sdk v0.0.0-20210121201358-e16eca879125/go.mod h1:aqBqJVTJmj0MTX9cP8wuReJPte6HyttMDzSS2u8nJwo=
 github.com/graphql-go/graphql v0.7.9 h1:5Va/Rt4l5g3YjwDnid3vFfn43faaQBq7rMcIZ0VnV34=
 github.com/graphql-go/graphql v0.7.9/go.mod h1:k6yrAYQaSP59DC5UVxbgxESlmVyojThKdORUqGDGmrI=
 github.com/gregjones/httpcache v0.0.0-20170920190843-316c5e0ff04e/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -1382,8 +1381,6 @@ github.com/sourcegraph/gosaml2 v0.6.1-0.20201216035416-70944041979a h1:O2mWuMjZ1
 github.com/sourcegraph/gosaml2 v0.6.1-0.20201216035416-70944041979a/go.mod h1:CtzxpPr4+bevsATaqR0rw3aqrNlX274b+3C6vFTLCk8=
 github.com/sourcegraph/gosyntect v0.0.0-20200429204402-842ed26129d0 h1:AEImdu3+4bPQegJFuRHwDQq+F6qTgnF+m2ksHA8y/W8=
 github.com/sourcegraph/gosyntect v0.0.0-20200429204402-842ed26129d0/go.mod h1:WiNJKgKTnR3psOIGzVZQjLqZjJZuoL3F8tCh25Uk8dU=
-github.com/sourcegraph/grafana-sdk v0.0.0-20210112115824-13757501ee8a h1:Wy8RU8C2H0OmsfAv6oidY5zpE26mKjGG+ypqVnR76vE=
-github.com/sourcegraph/grafana-sdk v0.0.0-20210112115824-13757501ee8a/go.mod h1:aqBqJVTJmj0MTX9cP8wuReJPte6HyttMDzSS2u8nJwo=
 github.com/sourcegraph/graphql-go v0.0.0-20201007040903-ec61a5417d66 h1:BJFJIKMLgYynYNHS1ufZ/JhMAIK2j5Elbk2rNbSRfm4=
 github.com/sourcegraph/graphql-go v0.0.0-20201007040903-ec61a5417d66/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf h1:oAdWFqhStsWiiMP/vkkHiMXqFXzl1XfUNOdxKJbd6bI=


### PR DESCRIPTION
Documenting our Alertmanager fork, and did a best-effort cleanup of our `replace` directives as well into 3 categories:

- Permanent replace directives
- Temporary replace directives
- Status unclear replace directives

Closes https://github.com/sourcegraph/sourcegraph/issues/17498

Once this merges I'll ask in `#dev-chat` to see if anyone with context can help us clean up the "status unclear" replace directives

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
