### PR TITLE
campaigns: Cleanup some little things

### DIFF
--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -65,7 +65,7 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 
 	reposStore := db.ReposWith(e.tx)
 
-	e.repo, err = loadRepo(ctx, reposStore, e.ch.RepoID)
+	e.repo, err = reposStore.Get(ctx, e.ch.RepoID)
 	if err != nil {
 		return errors.Wrap(err, "failed to load repository")
 	}

--- a/enterprise/internal/campaigns/reconciler/util.go
+++ b/enterprise/internal/campaigns/reconciler/util.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -20,19 +19,6 @@ type RepoStore interface {
 // TODO: copy-pasted
 type ExternalServiceStore interface {
 	List(context.Context, db.ExternalServicesListOptions) ([]*types.ExternalService, error)
-}
-
-// TODO: copy-pasted
-func loadRepo(ctx context.Context, tx RepoStore, id api.RepoID) (*types.Repo, error) {
-	r, err := tx.Get(ctx, id)
-	if err != nil {
-		if errcode.IsNotFound(err) {
-			return nil, errors.Errorf("repo not found: %d", id)
-		}
-		return nil, err
-	}
-
-	return r, nil
 }
 
 // TODO: copy-pasted

--- a/enterprise/internal/campaigns/syncer/util.go
+++ b/enterprise/internal/campaigns/syncer/util.go
@@ -5,24 +5,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/db"
-	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
-
-func loadRepo(ctx context.Context, tx RepoStore, id api.RepoID) (*types.Repo, error) {
-	r, err := tx.Get(ctx, id)
-	if err != nil {
-		if errcode.IsNotFound(err) {
-			return nil, errors.Errorf("repo not found: %d", id)
-		}
-		return nil, err
-	}
-
-	return r, nil
-}
 
 func loadExternalService(ctx context.Context, esStore ExternalServiceStore, repo *types.Repo) (*types.ExternalService, error) {
 	var externalService *types.ExternalService


### PR DESCRIPTION
I found these while browsing the code, trying to understand the selection of auth tokens for the syncer.

- The repoStore.Get method already returns an error with that error message, so no need to wrap it another time. Saves us a copy-pasted helper
- Handle potential nil index access in buildChangesetSource
- Correctly store error in syncChangeset so transactions are correctly rolled back