### PR TITLE
Fix validation messages of code monitor query

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -52,6 +52,9 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                             filter.value &&
                                             isDiffOrCommit(filter.value.quotedValue)))
                             )
+                            if (!hasTypeDiffOrCommitFilter) {
+                                return 'Code monitors require queries to specify either `type:commit` or `type:diff`.'
+                            }
                             const hasPattern = tokens.term.some(term => term.type === 'pattern')
                             const hasPatternTypeFilter = filters.some(
                                 filter =>
@@ -60,15 +63,10 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                     filter.value &&
                                     validateFilter(filter.field.value, filter.value)
                             )
-                            if (hasTypeDiffOrCommitFilter && hasPatternTypeFilter) {
-                                return undefined
-                            }
-                            if (!hasTypeDiffOrCommitFilter) {
-                                return 'Code monitors require queries to specify either `type:commit` or `type:diff`.'
-                            }
                             if (!hasPatternTypeFilter && hasPattern) {
                                 return 'Code monitors require queries to specify a `patternType:` of literal or regexp.'
                             }
+                            return undefined
                         }
                         return 'Failed to parse query'
                     },


### PR DESCRIPTION
Currently, the message for missing patternType is never shown, so I had to look in the code to figure out how it's supposed to work, because the error message was just generic a 'Failed to parse query'. This fixes it by reordering the conditions.
One open question: For queries that have no pattern specified, it always returns failed to parse query currently. Is that desired? It seems not and I removed that check for now.