### PR TITLE
Fix configuration of multi-branch indexing in docs

### DIFF
--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -112,7 +112,7 @@ Your site admin can configure indexed branches in site configuration under the `
 "experimentalFeatures": {
   "search.index.branches": {
    "github.com/sourcegraph/sourcegraph": ["3.15", "develop"],
-   "github.com/sourcegraph/src-cli": "next"
+   "github.com/sourcegraph/src-cli": ["next"]
   }
 }
 ```


### PR DESCRIPTION
The docs showed a configuration where the branches to be indexed is a
string, but validation fails if it's not configured as an array.

<img width="981" alt="image" src="https://user-images.githubusercontent.com/12631702/105754181-fd5b6580-5f06-11eb-98d5-3950be4a2503.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
