### PR TITLE
search: Fix segmentation fault from missing return

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -90,6 +90,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	resp, err := args.Zoekt.Client.Search(ctx, q, &searchOpts)
 	if err != nil {
 		c <- SearchEvent{Error: err}
+		return
 	}
 
 	mkStatusMap := func(mask search.RepoStatus) search.RepoStatusMap {


### PR DESCRIPTION
Adds a missing return that was causing a segfault down the line by accessing a `nil` response. 

Fixes #17626 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
