### PR TITLE
docker-images: update zoekt build scripts for new go.mod

### DIFF
--- a/docker-images/indexed-searcher/build.sh
+++ b/docker-images/indexed-searcher/build.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
-version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($5, 2)}')
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
 
 docker pull index.docker.io/sourcegraph/zoekt-webserver:"$version"
 docker tag index.docker.io/sourcegraph/zoekt-webserver:"$version" "$IMAGE"

--- a/docker-images/search-indexer/build.sh
+++ b/docker-images/search-indexer/build.sh
@@ -10,7 +10,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # The images are tagged using the same pseudo-versions as go mod, so we
 # extract the version from our go.mod
 
-version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($5, 2)}')
+version=$(go mod edit -print | awk '/sourcegraph\/zoekt/ {print substr($4, 2)}')
 
 docker pull index.docker.io/sourcegraph/zoekt-indexserver:"$version"
 docker tag index.docker.io/sourcegraph/zoekt-indexserver:"$version" "$IMAGE"


### PR DESCRIPTION
We now have the zoekt images specified as part of a block of replace
directives. So the part with the version is now the fourth field instead
of fifth. (ie the word replace is gone).

Fixes a regression introduced in #17601