### PR TITLE
Add tools to redact secrets in ExternalService config blobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/ericchiang/k8s v1.2.0
 	github.com/fatih/astrewrite v0.0.0-20191207154002-9094e544fcef
 	github.com/fatih/color v1.9.0
+	github.com/fatih/structs v1.1.0
 	github.com/felixge/fgprof v0.9.1
 	github.com/felixge/httpsnoop v1.0.1
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,7 @@ github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/fgprof v0.9.1 h1:E6FUJ2Mlv043ipLOCFqo8+cHo9MhQ203E2cdEK/isEs=
 github.com/felixge/fgprof v0.9.1/go.mod h1:7/HK6JFtFaARhIljgP2IV8rJLIoHDoOYoUphsnGvqxE=

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -14,11 +14,9 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/fatih/structs"
 
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -26,47 +24,44 @@ const RedactedSecret = "REDACTED"
 
 // RedactExternalServiceConfig replaces any secret fields in the Config field with RedactedSecret, be sure to call
 // UnRedactExternalServiceConfig before writing back to the database, otherwise validation will throw errors.
-func RedactExternalServiceConfig(svc *ExternalService) error {
+func (e *ExternalService) RedactExternalServiceConfig() error {
 	var (
 		newCfg string
 		err    error
 	)
-	switch strings.ToUpper(svc.Kind) {
-	case extsvc.KindGitHub:
-		cfg := &schema.GitHubConnection{}
-		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token)
-	case extsvc.KindGitLab:
-		cfg := schema.GitLabConnection{}
-		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token)
-	case extsvc.KindBitbucketServer:
-		cfg := schema.BitbucketServerConnection{}
-		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token, &cfg.Password)
-	case extsvc.KindBitbucketCloud:
-		cfg := schema.BitbucketCloudConnection{}
-		newCfg, err = redactField(svc.Config, &cfg, &cfg.AppPassword)
-	case extsvc.KindAWSCodeCommit:
-		cfg := schema.AWSCodeCommitConnection{}
-		newCfg, err = redactField(svc.Config, &cfg, &cfg.SecretAccessKey)
-	case extsvc.KindPhabricator:
-		cfg := schema.PhabricatorConnection{}
-		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token)
-	case extsvc.KindPerforce:
-		cfg := schema.PerforceConnection{}
-		newCfg, err = redactField(svc.Config, &cfg, &cfg.P4Passwd)
-	case extsvc.KindGitolite:
+	cfg, err := e.Configuration()
+	if err != nil {
+		return err
+	}
+	switch cfg := cfg.(type) {
+	case *schema.GitHubConnection:
+		newCfg, err = redactField(e.Config, &cfg, &cfg.Token)
+	case *schema.GitLabConnection:
+		newCfg, err = redactField(e.Config, &cfg, &cfg.Token)
+	case *schema.BitbucketServerConnection:
+		newCfg, err = redactField(e.Config, &cfg, &cfg.Token, &cfg.Password)
+	case *schema.BitbucketCloudConnection:
+		newCfg, err = redactField(e.Config, &cfg, &cfg.AppPassword)
+	case *schema.AWSCodeCommitConnection:
+		newCfg, err = redactField(e.Config, &cfg, &cfg.SecretAccessKey)
+	case *schema.PhabricatorConnection:
+		newCfg, err = redactField(e.Config, &cfg, &cfg.Token)
+	case *schema.PerforceConnection:
+		newCfg, err = redactField(e.Config, &cfg, &cfg.P4Passwd)
+	case *schema.GitoliteConnection:
 		// no secret fields?
 		err = nil
-	case extsvc.KindOther:
+	case *schema.OtherExternalServiceConnection:
 		// no secret fields?
 		err = nil
 	default:
 		// return an error here, it's safer to fail than to incorrectly return unsafe data.
-		err = fmt.Errorf("RedactExternalServiceConfig: kind %q not implemented", svc.Kind)
+		err = fmt.Errorf("RedactExternalServiceConfig: kind %q not implemented", e.Kind)
 	}
 	if err != nil {
 		return err
 	}
-	svc.Config = newCfg
+	e.Config = newCfg
 	return nil
 }
 
@@ -87,57 +82,53 @@ func redactField(buf string, v interface{}, fields ...*string) (string, error) {
 	return string(out), err
 }
 
-// UnRedactExternalServiceConfig will replace redacted fields in the 'new' ExternalService with their undredacted form
-// from the 'old' ExternalService. You should call this when accepting updated config from a user that may have been
+// UnRedactExternalServiceConfig will replace redacted fields with their undredacted form from the 'old' ExternalService.
+// You should call this when accepting updated config from a user that may have been
 // previously redacted, and pass in the unredacted form directly from the DB as the 'old' parameter
-func UnRedactExternalServiceConfig(old, new *ExternalService) error {
-	if old.Kind != new.Kind {
+func (e *ExternalService) UnRedactExternalServiceConfig(old *ExternalService) error {
+	if old.Kind != e.Kind {
 		return fmt.Errorf(
-			"UnRedactExternalServiceConfig: unmatched external service kinds, old: %q, new: %q",
+			"UnRedactExternalServiceConfig: unmatched external service kinds, old: %q, e: %q",
 			old.Kind,
-			new.Kind,
+			e.Kind,
 		)
 	}
 	var (
 		unRedacted string
 		err        error
 	)
-	switch strings.ToUpper(new.Kind) {
-	case extsvc.KindGitHub:
-		cfg := schema.GitHubConnection{}
-		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
-	case extsvc.KindGitLab:
-		cfg := schema.GitLabConnection{}
-		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
-	case extsvc.KindBitbucketServer:
-		cfg := schema.BitbucketServerConnection{}
-		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token, &cfg.Password)
-	case extsvc.KindBitbucketCloud:
-		cfg := schema.BitbucketCloudConnection{}
-		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.AppPassword)
-	case extsvc.KindAWSCodeCommit:
-		cfg := schema.AWSCodeCommitConnection{}
-		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.SecretAccessKey)
-	case extsvc.KindPhabricator:
-		cfg := schema.PhabricatorConnection{}
-		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
-	case extsvc.KindPerforce:
-		cfg := schema.PerforceConnection{}
-		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.P4Passwd)
-	case extsvc.KindGitolite:
+	cfg, err := e.Configuration()
+	if err != nil {
+		return err
+	}
+	switch cfg := cfg.(type) {
+	case *schema.GitHubConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.Token)
+	case *schema.GitLabConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.Token)
+	case *schema.BitbucketServerConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.Token, &cfg.Password)
+	case *schema.BitbucketCloudConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.AppPassword)
+	case *schema.AWSCodeCommitConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.SecretAccessKey)
+	case *schema.PhabricatorConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.Token)
+	case *schema.PerforceConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.P4Passwd)
+	case *schema.GitoliteConnection:
 		// no secret fields?
 		err = nil
-	case extsvc.KindOther:
-		// no secret fields?
-		err = nil
+	case *schema.OtherExternalServiceConnection:
+		unRedacted, err = unRedactField(old.Config, e.Config, &cfg, &cfg.Url)
 	default:
 		// return an error here, it's safer to fail than to incorrectly return unsafe data.
-		err = fmt.Errorf("UnRedactExternalServiceConfig: kind %q not implemented", new.Kind)
+		err = fmt.Errorf("UnRedactExternalServiceConfig: kind %q not implemented", e.Kind)
 	}
 	if err != nil {
 		return err
 	}
-	new.Config = unRedacted
+	e.Config = unRedacted
 	return nil
 }
 

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -85,7 +85,7 @@ func redactField(buf string, v interface{}, fields ...*string) (string, error) {
 // UnRedactExternalServiceConfig will replace redacted fields with their undredacted form from the 'old' ExternalService.
 // You should call this when accepting updated config from a user that may have been
 // previously redacted, and pass in the unredacted form directly from the DB as the 'old' parameter
-func (e *ExternalService) UnRedactExternalServiceConfig(old *ExternalService) error {
+func (e *ExternalService) UnredactConfig(old *ExternalService) error {
 	if old.Kind != e.Kind {
 		return fmt.Errorf(
 			"UnRedactExternalServiceConfig: unmatched external service kinds, old: %q, e: %q",

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -24,7 +24,7 @@ const RedactedSecret = "REDACTED"
 
 // RedactExternalServiceConfig replaces any secret fields in the Config field with RedactedSecret, be sure to call
 // UnRedactExternalServiceConfig before writing back to the database, otherwise validation will throw errors.
-func (e *ExternalService) RedactExternalServiceConfig() error {
+func (e *ExternalService) RedactConfig() error {
 	var (
 		newCfg string
 		err    error

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -133,7 +133,13 @@ func (e *ExternalService) UnredactConfig(old *ExternalService) error {
 }
 
 func unRedactField(old, new string, cfg interface{}, fields ...*string) (string, error) {
-	err := json.Unmarshal([]byte(old), cfg)
+	// first we zero the fields on cfg, as they will contain data we don't need from the e.Configuration() call
+	// we just want an empty struct of the correct type for marshaling into
+	err := zeroFields(cfg)
+	if err != nil {
+		return "", err
+	}
+	err = json.Unmarshal([]byte(old), cfg)
 	if err != nil {
 		return "", err
 	}

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -1,0 +1,206 @@
+/*
+	The functions in this file are used to redact secrets from ExternalServices in transit, eg when written back and
+	forth between the client and API, as we don't want to leak an access token once it's been configured. Any config
+	written back from the client with a redacted token should then be updated with the real token from the database,
+	the validation in the ExternalService DB methods will check for this field and throw an error if it's not been
+	replaced, to prevent us accidentally blanking tokens in the DB.
+	This is risky, hacky, and ugly, and we fully intend to replace it ASAP, once our Vault tooling is ready we will
+	migrate external services into their own tables for each kind, and encrypt secrets using Vault's KMS.
+	if you wanna speak to someone about this talk to @arussellsaw or the Cloud team.
+*/
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/structs"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+const RedactedSecret = "REDACTED"
+
+// RedactExternalServiceConfig replaces any secret fields in the Config field with RedactedSecret, be sure to call
+// UnRedactExternalServiceConfig before writing back to the database, otherwise validation will throw errors.
+func RedactExternalServiceConfig(svc *ExternalService) error {
+	var (
+		newCfg string
+		err    error
+	)
+	switch strings.ToUpper(svc.Kind) {
+	case extsvc.KindGitHub:
+		cfg := &schema.GitHubConnection{}
+		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token)
+	case extsvc.KindGitLab:
+		cfg := schema.GitLabConnection{}
+		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token)
+	case extsvc.KindBitbucketServer:
+		cfg := schema.BitbucketServerConnection{}
+		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token, &cfg.Password)
+	case extsvc.KindBitbucketCloud:
+		cfg := schema.BitbucketCloudConnection{}
+		newCfg, err = redactField(svc.Config, &cfg, &cfg.AppPassword)
+	case extsvc.KindAWSCodeCommit:
+		cfg := schema.AWSCodeCommitConnection{}
+		newCfg, err = redactField(svc.Config, &cfg, &cfg.SecretAccessKey)
+	case extsvc.KindPhabricator:
+		cfg := schema.PhabricatorConnection{}
+		newCfg, err = redactField(svc.Config, &cfg, &cfg.Token)
+	case extsvc.KindPerforce:
+		cfg := schema.PerforceConnection{}
+		newCfg, err = redactField(svc.Config, &cfg, &cfg.P4Passwd)
+	case extsvc.KindGitolite:
+		// no secret fields?
+		err = nil
+	case extsvc.KindOther:
+		// no secret fields?
+		err = nil
+	default:
+		// return an error here, it's safer to fail than to incorrectly return unsafe data.
+		err = fmt.Errorf("RedactExternalServiceConfig: kind %q not implemented", svc.Kind)
+	}
+	if err != nil {
+		return err
+	}
+	svc.Config = newCfg
+	return nil
+}
+
+// redactField will unmarshal the passed JSON string into the passed value, and then replace the pointer fields you pass
+// with RedactedSecret, see RedactExternalServiceConfig for usage examples.
+// who needs generics anyway?
+func redactField(buf string, v interface{}, fields ...*string) (string, error) {
+	err := json.Unmarshal([]byte(buf), v)
+	if err != nil {
+		return "", err
+	}
+	for _, field := range fields {
+		if *field != "" {
+			*field = RedactedSecret
+		}
+	}
+	out, err := json.Marshal(v)
+	return string(out), err
+}
+
+// UnRedactExternalServiceConfig will replace redacted fields in the 'new' ExternalService with their undredacted form
+// from the 'old' ExternalService. You should call this when accepting updated config from a user that may have been
+// previously redacted, and pass in the unredacted form directly from the DB as the 'old' parameter
+func UnRedactExternalServiceConfig(old, new *ExternalService) error {
+	if old.Kind != new.Kind {
+		return fmt.Errorf(
+			"UnRedactExternalServiceConfig: unmatched external service kinds, old: %q, new: %q",
+			old.Kind,
+			new.Kind,
+		)
+	}
+	switch strings.ToUpper(new.Kind) {
+	case extsvc.KindGitHub:
+		cfg := schema.GitHubConnection{}
+		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
+		if err != nil {
+			return err
+		}
+		new.Config = unRedacted
+	case extsvc.KindGitLab:
+		cfg := schema.GitLabConnection{}
+		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
+		if err != nil {
+			return err
+		}
+		new.Config = unRedacted
+	case extsvc.KindBitbucketServer:
+		cfg := schema.BitbucketServerConnection{}
+		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token, &cfg.Password)
+		if err != nil {
+			return err
+		}
+		new.Config = unRedacted
+	case extsvc.KindBitbucketCloud:
+		cfg := schema.BitbucketCloudConnection{}
+		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.AppPassword)
+		if err != nil {
+			return err
+		}
+		new.Config = unRedacted
+	case extsvc.KindAWSCodeCommit:
+		cfg := schema.AWSCodeCommitConnection{}
+		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.SecretAccessKey)
+		if err != nil {
+			return err
+		}
+		new.Config = unRedacted
+	case extsvc.KindPhabricator:
+		cfg := schema.PhabricatorConnection{}
+		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
+		if err != nil {
+			return err
+		}
+		new.Config = unRedacted
+	case extsvc.KindPerforce:
+		cfg := schema.PerforceConnection{}
+		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.P4Passwd)
+		if err != nil {
+			return err
+		}
+		new.Config = unRedacted
+	case extsvc.KindGitolite:
+		// no secret fields?
+		return nil
+	case extsvc.KindOther:
+		// no secret fields?
+		return nil
+	default:
+		// return an error here, it's safer to fail than to incorrectly return unsafe data.
+		return fmt.Errorf("UnRedactExternalServiceConfig: kind %q not implemented", new.Kind)
+	}
+	return nil
+}
+
+func unRedactField(old, new string, cfg interface{}, fields ...*string) (string, error) {
+	err := json.Unmarshal([]byte(old), cfg)
+	if err != nil {
+		return "", err
+	}
+	// first take copies of the unredacted fields from the old JSON
+	oldSecrets := []string{}
+	for _, field := range fields {
+		oldSecrets = append(oldSecrets, *field)
+	}
+	// zero the fields of our config in case we are deleting any fields, the unmarshaler might preserve
+	// fields from the old JSON otherwise.
+	err = zeroFields(cfg)
+	if err != nil {
+		return "", err
+	}
+	// now we unmarshal the new JSON that contains redacted fields
+	err = json.Unmarshal([]byte(new), cfg)
+	for i, field := range fields {
+		// only replace fields that are RedactedSecret, so the user can still update their config
+		if *field == RedactedSecret {
+			*field = oldSecrets[i]
+		}
+	}
+
+	// marshal the output, now containing the new json with redacted fields replaced with fields from the old JSON
+	out, err := json.Marshal(cfg)
+	return string(out), err
+}
+
+// zeroFields zeroes the fields of a struct
+func zeroFields(s interface{}) error {
+	for _, f := range structs.Fields(s) {
+		if f.IsZero() {
+			continue
+		}
+		err := f.Zero()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -98,66 +98,46 @@ func UnRedactExternalServiceConfig(old, new *ExternalService) error {
 			new.Kind,
 		)
 	}
+	var (
+		unRedacted string
+		err        error
+	)
 	switch strings.ToUpper(new.Kind) {
 	case extsvc.KindGitHub:
 		cfg := schema.GitHubConnection{}
-		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
-		if err != nil {
-			return err
-		}
-		new.Config = unRedacted
+		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
 	case extsvc.KindGitLab:
 		cfg := schema.GitLabConnection{}
-		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
-		if err != nil {
-			return err
-		}
-		new.Config = unRedacted
+		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
 	case extsvc.KindBitbucketServer:
 		cfg := schema.BitbucketServerConnection{}
-		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token, &cfg.Password)
-		if err != nil {
-			return err
-		}
-		new.Config = unRedacted
+		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token, &cfg.Password)
 	case extsvc.KindBitbucketCloud:
 		cfg := schema.BitbucketCloudConnection{}
-		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.AppPassword)
-		if err != nil {
-			return err
-		}
-		new.Config = unRedacted
+		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.AppPassword)
 	case extsvc.KindAWSCodeCommit:
 		cfg := schema.AWSCodeCommitConnection{}
-		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.SecretAccessKey)
-		if err != nil {
-			return err
-		}
-		new.Config = unRedacted
+		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.SecretAccessKey)
 	case extsvc.KindPhabricator:
 		cfg := schema.PhabricatorConnection{}
-		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
-		if err != nil {
-			return err
-		}
-		new.Config = unRedacted
+		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.Token)
 	case extsvc.KindPerforce:
 		cfg := schema.PerforceConnection{}
-		unRedacted, err := unRedactField(old.Config, new.Config, &cfg, &cfg.P4Passwd)
-		if err != nil {
-			return err
-		}
-		new.Config = unRedacted
+		unRedacted, err = unRedactField(old.Config, new.Config, &cfg, &cfg.P4Passwd)
 	case extsvc.KindGitolite:
 		// no secret fields?
-		return nil
+		err = nil
 	case extsvc.KindOther:
 		// no secret fields?
-		return nil
+		err = nil
 	default:
 		// return an error here, it's safer to fail than to incorrectly return unsafe data.
-		return fmt.Errorf("UnRedactExternalServiceConfig: kind %q not implemented", new.Kind)
+		err = fmt.Errorf("UnRedactExternalServiceConfig: kind %q not implemented", new.Kind)
 	}
+	if err != nil {
+		return err
+	}
+	new.Config = unRedacted
 	return nil
 }
 

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 
@@ -73,8 +74,8 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 	}
 
 	// our updated fields are still here
-	if !reflect.DeepEqual(finalCfg.Repos, newCfg.Repos) {
-		t.Errorf("expected %s, got %s", newCfg.Repos, finalCfg.Repos)
+	if diff := cmp.Diff(finalCfg.Repos, newCfg.Repos); diff != "" {
+		t.Errorf("unexpected diff: %s", diff)
 	}
 	// and the secret is no longer redacted
 	if want, got := someSecret, finalCfg.Token; want != got {

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -1,0 +1,83 @@
+package types
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
+	// this test simulates the round trip of a user editing external service config via our APIs
+	someSecret := "this is a secret, i hope no one steals it"
+	cfg := schema.GitHubConnection{
+		Token: someSecret,
+		Repos: []string{
+			"foo",
+			"bar",
+		},
+	}
+	buf, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	old := string(buf)
+	// first we redact the config as it was received from the DB, then write the redacted form to the user
+	svc := ExternalService{
+		Kind:   extsvc.KindGitHub,
+		Config: old,
+	}
+	if err := RedactExternalServiceConfig(&svc); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// now we have the redacted form, we check that the relevant fields are correctly redacted
+	newCfg := schema.GitHubConnection{}
+	if err := json.Unmarshal([]byte(svc.Config), &newCfg); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if want, got := RedactedSecret, newCfg.Token; want != got {
+		t.Errorf("want: %q, got: %q", want, got)
+	}
+
+	// now we simulate a user updating their config, and writing it back to the API containing redacted secrets
+	oldSvc := ExternalService{
+		Kind:   extsvc.KindGitHub,
+		Config: old,
+	}
+	// the user added a new repo
+	newCfg.Repos = append(newCfg.Repos, "baz")
+	buf, err = json.Marshal(newCfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// this config now contains a redacted token
+	newSvc := ExternalService{
+		Kind:   extsvc.KindGitHub,
+		Config: string(buf),
+	}
+	// unredact fields in newSvc config
+	if err := UnRedactExternalServiceConfig(&oldSvc, &newSvc); err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// the config is now safe to write to the DB, let's unmarshal it again to make sure that no fields are redacted
+	// still, and that our updated fields are there
+	finalCfg := schema.GitHubConnection{}
+	if err := json.Unmarshal([]byte(newSvc.Config), &finalCfg); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// our updated fields are still here
+	if !reflect.DeepEqual(finalCfg.Repos, newCfg.Repos) {
+		t.Errorf("expected %s, got %s", newCfg.Repos, finalCfg.Repos)
+	}
+	// and the secret is no longer redacted
+	if want, got := someSecret, finalCfg.Token; want != got {
+		t.Errorf("want: %q, got %q", want, got)
+	}
+}

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -30,7 +30,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 		Kind:   extsvc.KindGitHub,
 		Config: old,
 	}
-	if err := RedactExternalServiceConfig(&svc); err != nil {
+	if err := svc.RedactExternalServiceConfig(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -61,7 +61,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 		Config: string(buf),
 	}
 	// unredact fields in newSvc config
-	if err := UnRedactExternalServiceConfig(&oldSvc, &newSvc); err != nil {
+	if err := newSvc.UnRedactExternalServiceConfig(&oldSvc); err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
 

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -30,7 +30,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 		Kind:   extsvc.KindGitHub,
 		Config: old,
 	}
-	if err := svc.RedactExternalServiceConfig(); err != nil {
+	if err := svc.RedactConfig(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
@@ -61,7 +61,7 @@ func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
 		Config: string(buf),
 	}
 	// unredact fields in newSvc config
-	if err := newSvc.UnRedactExternalServiceConfig(&oldSvc); err != nil {
+	if err := newSvc.UnredactConfig(&oldSvc); err != nil {
 		t.Errorf("unexpected error: %s", err)
 	}
 


### PR DESCRIPTION
This PR only adds the utility functions for redacting, there will be two further PRs, one for updating the DB validation to detect redacted fields and throw an error if we try to write one, and another to actually use these utilities. i wanted to break this into multiple PRs because this code incurs a decent bit of risk, and want as detailed a review on this as possible.

some context pulled straight from a comment in secret.go:

>  The functions in this file are used to redact secrets from ExternalServices in transit, eg when written back and
  forth between the client and API, as we don't want to leak an access token once it's been configured. Any config
  written back from the client with a redacted token should then be updated with the real token from the database,
  the validation in the ExternalService DB methods will check for this field and throw an error if it's not been
  replaced, to prevent us accidentally blanking tokens in the DB.
  This is risky, hacky, and ugly, and we fully intend to replace it ASAP, once our Vault tooling is ready we will
  migrate external services into their own tables for each kind, and encrypt secrets using Vault's KMS.
  if you wanna speak to someone about this talk to @arussellsaw or the Cloud team.

ref: https://github.com/sourcegraph/sourcegraph/issues/17261

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
