### PR TITLE
Update services definition for debug proxy

### DIFF
--- a/dev/src-prof-services.json
+++ b/dev/src-prof-services.json
@@ -8,6 +8,8 @@
   { "Name": "precise-code-intel-worker", "Host": "127.0.0.1:6088" },
   { "Name": "executor-queue", "Host": "127.0.0.1:6091" },
   { "Name": "executor", "Host": "127.0.0.1:6092" },
-  { "Name": "zoekt-indexserver", "Host": "127.0.0.1:6072" },
-  { "Name": "zoekt-webserver", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" }
+  { "Name": "zoekt-indexserver-0", "Host": "127.0.0.1:6072" },
+  { "Name": "zoekt-indexserver-1", "Host": "127.0.0.1:6073" },
+  { "Name": "zoekt-webserver-0", "Host": "127.0.0.1:3070", "DefaultPath": "/debug/requests/" },
+  { "Name": "zoekt-webserver-1", "Host": "127.0.0.1:3071", "DefaultPath": "/debug/requests/" }
 ]


### PR DESCRIPTION
By default, when starting sourcegraph in dev mode, two instances of
`zoekt-indexserver` and `zoekt-webserver` are started, but the debug
proxy definition only included one of each.

Fixes #17622 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
