### PR TITLE
search: extract FileMatch from FileMatchResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -316,7 +316,7 @@ func repoOfResult(result SearchResultResolver) string {
 	case *RepositoryResolver:
 		return string(r.Name())
 	case *FileMatchResolver:
-		return r.Repo.Name()
+		return string(r.Repo.Name)
 	case *CommitSearchResultResolver:
 		// Pagination does not support commit searches at the
 		// moment. Ideally we want to return the repo associated

--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -52,7 +52,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		fmt.Fprintln(&b, "results:")
 		for i, result := range r.results {
 			fm, _ := result.ToFileMatch()
-			fmt.Fprintf(&b, "	[%d] %s %s\n", i, fm.Repo.innerRepo.Name, fm.JPath)
+			fmt.Fprintf(&b, "	[%d] %s %s\n", i, fm.Repo.Name, fm.JPath)
 		}
 		fmt.Fprintln(&b, "common.repos:")
 		var repos []string

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -182,7 +182,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 				return nil, err
 			}
 			for _, m := range matches {
-				matchingIDs[m.Repo.IDInt32()] = true
+				matchingIDs[m.Repo.ID] = true
 			}
 		}
 	} else {
@@ -210,7 +210,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 				return nil, err
 			}
 			for _, m := range matches {
-				matchingIDs[m.Repo.IDInt32()] = false
+				matchingIDs[m.Repo.ID] = false
 			}
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -38,17 +38,17 @@ func TestSearchRepositories(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
-				{
+				mkFileMatchResolver(FileMatch{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
-					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
-				},
+					Repo: &types.RepoName{ID: 123},
+				}),
 			}, &streaming.Stats{}, nil
 		case "bar/one":
 			return []*FileMatchResolver{
-				{
+				mkFileMatchResolver(FileMatch{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
-					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 789}},
-				},
+					Repo: &types.RepoName{ID: 789},
+				}),
 			}, &streaming.Stats{}, nil
 		case "foo/no-match":
 			return []*FileMatchResolver{}, &streaming.Stats{}, nil
@@ -136,10 +136,10 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
-				{
+				mkFileMatchResolver(FileMatch{
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
-					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
-				},
+					Repo: &types.RepoName{ID: 123},
+				}),
 			}, &streaming.Stats{}, nil
 		case "foo/no-match":
 			return []*FileMatchResolver{}, &streaming.Stats{}, nil
@@ -154,10 +154,10 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *streaming.Stats, err error) {
 			return []*FileMatchResolver{
-				{
+				mkFileMatchResolver(FileMatch{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
-					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
-				},
+					Repo: &types.RepoName{ID: 123},
+				}),
 			}, &streaming.Stats{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustInclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
@@ -189,10 +189,10 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *streaming.Stats, err error) {
 			return []*FileMatchResolver{
-				{
+				mkFileMatchResolver(FileMatch{
 					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
-					Repo: &RepositoryResolver{innerRepo: &types.Repo{ID: 123}},
-				},
+					Repo: &types.RepoName{ID: 123},
+				}),
 			}, &streaming.Stats{}, nil
 		}
 		pat := &search.TextPatternInfo{Pattern: "", FilePatternsReposMustExclude: []string{"foo"}, IsRegExp: true, FileMatchLimit: 1, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
@@ -284,5 +284,16 @@ func BenchmarkSearchRepositories(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func mkFileMatchResolver(fm FileMatch) *FileMatchResolver {
+	var repo *RepositoryResolver
+	if fm.Repo != nil {
+		repo = &RepositoryResolver{innerRepo: fm.Repo.ToRepo()}
+	}
+	return &FileMatchResolver{
+		FileMatch:    fm,
+		RepoResolver: repo,
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -302,7 +302,7 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 				rev = *fm.InputRev
 			}
 			lines := fm.ResultCount()
-			addRepoFilter(fm.Repo, rev, lines)
+			addRepoFilter(fm.RepoResolver, rev, lines)
 			addLangFilter(fm.path(), lines, fm.LimitHit())
 			addFileFilter(fm.path(), lines, fm.LimitHit())
 
@@ -398,7 +398,7 @@ func (sr *SearchResultsResolver) blameFileMatch(ctx context.Context, fm *FileMat
 		return time.Time{}, nil
 	}
 	lm := fm.LineMatches()[0]
-	hunks, err := git.BlameFile(ctx, fm.Repo.innerRepo.Name, fm.path(), &git.BlameOptions{
+	hunks, err := git.BlameFile(ctx, fm.Repo.Name, fm.path(), &git.BlameOptions{
 		NewestCommit: fm.CommitID,
 		StartLine:    int(lm.LineNumber()),
 		EndLine:      int(lm.LineNumber()),
@@ -2132,7 +2132,7 @@ func compareSearchResults(left, right SearchResultResolver, exactFilePatterns ma
 		case *RepositoryResolver:
 			return string(r.Name()), "", nil
 		case *FileMatchResolver:
-			return r.Repo.Name(), r.JPath, nil
+			return string(r.Repo.Name), r.JPath, nil
 		case *CommitSearchResultResolver:
 			// Commits are relatively sorted by date, and after repo
 			// or path names. We use ~ as the key for repo and

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -60,12 +60,12 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 		for _, n := range lineNumbers {
 			lines = append(lines, &lineMatch{JLineNumber: n})
 		}
-		return &FileMatchResolver{
+		return mkFileMatchResolver(FileMatch{
 			JPath:        path,
 			JLineMatches: lines,
-			Repo:         &RepositoryResolver{innerRepo: &types.Repo{Name: "r"}},
+			Repo:         &types.RepoName{Name: "r"},
 			CommitID:     wantCommitID,
-		}
+		})
 	}
 
 	tests := map[string]struct {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -962,11 +962,13 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 			fields: fields{
 				results: []SearchResultResolver{
 					&FileMatchResolver{
-						symbols: []*searchSymbolResult{
-							// 1
-							{},
-							// 2
-							{},
+						FileMatch: FileMatch{
+							symbols: []*searchSymbolResult{
+								// 1
+								{},
+								// 2
+								{},
+							},
 						},
 					},
 				},
@@ -979,11 +981,13 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 			fields: fields{
 				results: []SearchResultResolver{
 					&FileMatchResolver{
-						symbols: []*searchSymbolResult{
-							// 1
-							{},
-							// 2
-							{},
+						FileMatch: FileMatch{
+							symbols: []*searchSymbolResult{
+								// 1
+								{},
+								// 2
+								{},
+							},
 						},
 					},
 				},
@@ -1065,10 +1069,10 @@ func TestGetExactFilePatterns(t *testing.T) {
 
 func TestCompareSearchResults(t *testing.T) {
 	makeResult := func(repo, file string) *FileMatchResolver {
-		return &FileMatchResolver{
-			Repo:  &RepositoryResolver{innerRepo: &types.Repo{Name: api.RepoName(repo)}},
+		return mkFileMatchResolver(FileMatch{
+			Repo:  &types.RepoName{Name: api.RepoName(repo)},
 			JPath: file,
-		}
+		})
 	}
 
 	tests := []struct {

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -162,11 +162,14 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 			repoResolvers[repoRev.Repo.Name] = &RepositoryResolver{innerRepo: repoRev.Repo.ToRepo()}
 		}
 		matches[i] = &FileMatchResolver{
-			JPath:     file.FileName,
-			JLimitHit: fileLimitHit,
-			uri:       fileMatchURI(repoRev.Repo.Name, "", file.FileName),
-			Repo:      repoResolvers[repoRev.Repo.Name],
-			CommitID:  api.CommitID(file.Version),
+			FileMatch: FileMatch{
+				JPath:     file.FileName,
+				JLimitHit: fileLimitHit,
+				uri:       fileMatchURI(repoRev.Repo.Name, "", file.FileName),
+				Repo:      repoRev.Repo,
+				CommitID:  api.CommitID(file.Version),
+			},
+			RepoResolver: repoResolvers[repoRev.Repo.Name],
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -279,13 +279,16 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 			fileMatch.symbols = append(fileMatch.symbols, symbolRes)
 		} else {
 			fileMatch := &FileMatchResolver{
-				JPath:   symbolRes.symbol.Path,
-				symbols: []*searchSymbolResult{symbolRes},
-				uri:     uri,
-				Repo:    repoResolver,
-				// Don't get commit from GitCommitResolver.OID() because we don't want to
-				// slow search results down when they are coming from zoekt.
-				CommitID: api.CommitID(symbolRes.commit.oid),
+				FileMatch: FileMatch{
+					JPath:   symbolRes.symbol.Path,
+					symbols: []*searchSymbolResult{symbolRes},
+					uri:     uri,
+					Repo:    repoRevs.Repo,
+					// Don't get commit from GitCommitResolver.OID() because we don't want to
+					// slow search results down when they are coming from zoekt.
+					CommitID: api.CommitID(symbolRes.commit.oid),
+				},
+				RepoResolver: repoResolver,
 			}
 			fileMatchesByURI[uri] = fileMatch
 			fileMatches = append(fileMatches, fileMatch)

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -66,17 +66,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("one file match, one symbol", func(t *testing.T) {
-		res := []*FileMatchResolver{
-			{
-				symbols: []*searchSymbolResult{
-					{
-						symbol: protocol.Symbol{
-							Name: "symbol-name-1",
-						},
-					},
-				},
+		res := mkSymbolFileMatchResolvers([]*searchSymbolResult{{
+			symbol: protocol.Symbol{
+				Name: "symbol-name-1",
 			},
-		}
+		}})
 
 		t.Run("symbol count is 1", func(t *testing.T) {
 			nsym := symbolCount(res)
@@ -101,26 +95,15 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, one symbol per file", func(t *testing.T) {
-		res := []*FileMatchResolver{
-			{
-				symbols: []*searchSymbolResult{
-					{
-						symbol: protocol.Symbol{
-							Name: "symbol-name-1",
-						},
-					},
-				},
+		res := mkSymbolFileMatchResolvers([]*searchSymbolResult{{
+			symbol: protocol.Symbol{
+				Name: "symbol-name-1",
 			},
-			{
-				symbols: []*searchSymbolResult{
-					{
-						symbol: protocol.Symbol{
-							Name: "symbol-name-2",
-						},
-					},
-				},
+		}}, []*searchSymbolResult{{
+			symbol: protocol.Symbol{
+				Name: "symbol-name-2",
 			},
-		}
+		}})
 
 		t.Run("symbol count is 2", func(t *testing.T) {
 			nsym := symbolCount(res)
@@ -153,20 +136,13 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, multiple symbols per file", func(t *testing.T) {
-		res := []*FileMatchResolver{
-			{
-				symbols: []*searchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
-				},
-			},
-			{
-				symbols: []*searchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
-					{symbol: protocol.Symbol{Name: "symbol-name-4"}},
-				},
-			},
-		}
+		res := mkSymbolFileMatchResolvers([]*searchSymbolResult{
+			{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+			{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+		}, []*searchSymbolResult{
+			{symbol: protocol.Symbol{Name: "symbol-name-3"}},
+			{symbol: protocol.Symbol{Name: "symbol-name-4"}},
+		})
 
 		t.Run("symbol count is 4", func(t *testing.T) {
 			nsym := symbolCount(res)
@@ -187,60 +163,38 @@ func TestLimitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 1 => one file match with one symbol",
 				limit: 1,
-				want: []*FileMatchResolver{
-					{
-						symbols: []*searchSymbolResult{
-							{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-						},
-					},
-				},
+				want: mkSymbolFileMatchResolvers([]*searchSymbolResult{
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+				}),
 			},
 			{
 				name:  "limit 2 => one file match with all symbols",
 				limit: 2,
-				want: []*FileMatchResolver{
-					{
-						symbols: []*searchSymbolResult{
-							{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-							{symbol: protocol.Symbol{Name: "symbol-name-2"}},
-						},
-					},
-				},
+				want: mkSymbolFileMatchResolvers([]*searchSymbolResult{
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+				}),
 			},
 			{
 				name:  "limit 3 => two file matches with three symbols",
 				limit: 3,
-				want: []*FileMatchResolver{
-					{
-						symbols: []*searchSymbolResult{
-							{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-							{symbol: protocol.Symbol{Name: "symbol-name-2"}},
-						},
-					},
-					{
-						symbols: []*searchSymbolResult{
-							{symbol: protocol.Symbol{Name: "symbol-name-3"}},
-						},
-					},
-				},
+				want: mkSymbolFileMatchResolvers([]*searchSymbolResult{
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+				}, []*searchSymbolResult{
+					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
+				}),
 			},
 			{
 				name:  "limit 4 => two file matches with all symbols",
 				limit: 4,
-				want: []*FileMatchResolver{
-					{
-						symbols: []*searchSymbolResult{
-							{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-							{symbol: protocol.Symbol{Name: "symbol-name-2"}},
-						},
-					},
-					{
-						symbols: []*searchSymbolResult{
-							{symbol: protocol.Symbol{Name: "symbol-name-3"}},
-							{symbol: protocol.Symbol{Name: "symbol-name-4"}},
-						},
-					},
-				},
+				want: mkSymbolFileMatchResolvers([]*searchSymbolResult{
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+				}, []*searchSymbolResult{
+					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-4"}},
+				}),
 			},
 		}
 
@@ -270,4 +224,14 @@ func TestSymbolRange(t *testing.T) {
 			t.Fatal(diff)
 		}
 	})
+}
+
+func mkSymbolFileMatchResolvers(symbols ...[]*searchSymbolResult) []*FileMatchResolver {
+	var resolvers []*FileMatchResolver
+	for _, s := range symbols {
+		resolvers = append(resolvers, mkFileMatchResolver(FileMatch{
+			symbols: s,
+		}))
+	}
+	return resolvers
 }

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -589,12 +589,12 @@ func mkFileMatch(repo *types.RepoName, path string, lineNumbers ...int32) *FileM
 	for _, n := range lineNumbers {
 		lines = append(lines, &lineMatch{JLineNumber: n})
 	}
-	return &FileMatchResolver{
+	return mkFileMatchResolver(FileMatch{
 		uri:          fileMatchURI(repo.Name, "", path),
 		JPath:        path,
 		JLineMatches: lines,
-		Repo:         &RepositoryResolver{innerRepo: repo.ToRepo()},
-	}
+		Repo:         repo,
+	})
 }
 
 func repoRev(revSpec string) *search.RepositoryRevisions {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -37,20 +37,26 @@ var textSearchLimiter = mutablelimiter.New(32)
 // A light wrapper around the search service. We implement the service here so
 // that we can unmarshal the result directly into graphql resolvers.
 
-// FileMatchResolver is a resolver for the GraphQL type `FileMatch`
-type FileMatchResolver struct {
+type FileMatch struct {
 	JPath        string       `json:"Path"`
 	JLineMatches []*lineMatch `json:"LineMatches"`
 	JLimitHit    bool         `json:"LimitHit"`
 	MatchCount   int          // Number of matches. Different from len(JLineMatches), as multiple lines may correspond to one logical match.
 	symbols      []*searchSymbolResult
 	uri          string
-	Repo         *RepositoryResolver
+	Repo         *types.RepoName
 	CommitID     api.CommitID
 	// InputRev is the Git revspec that the user originally requested to search. It is used to
 	// preserve the original revision specifier from the user instead of navigating them to the
 	// absolute commit ID when they select a result.
 	InputRev *string
+}
+
+// FileMatchResolver is a resolver for the GraphQL type `FileMatch`
+type FileMatchResolver struct {
+	FileMatch
+
+	RepoResolver *RepositoryResolver
 }
 
 func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
@@ -67,7 +73,7 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 	// values for all other fields.
 	return &GitTreeEntryResolver{
 		commit: &GitCommitResolver{
-			repoResolver: fm.Repo,
+			repoResolver: fm.RepoResolver,
 			oid:          GitObjectID(fm.CommitID),
 			inputRev:     fm.InputRev,
 		},
@@ -76,7 +82,7 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 }
 
 func (fm *FileMatchResolver) Repository() *RepositoryResolver {
-	return fm.Repo
+	return fm.RepoResolver
 }
 
 func (fm *FileMatchResolver) RevSpec() *gitRevSpec {
@@ -223,15 +229,17 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 		}
 
 		resolvers = append(resolvers, &FileMatchResolver{
-			JPath:        fm.Path,
-			JLineMatches: lineMatches,
-			JLimitHit:    fm.LimitHit,
-			MatchCount:   fm.MatchCount,
-
-			uri:      workspace + fm.Path,
-			Repo:     repoResolver,
-			CommitID: commit,
-			InputRev: &rev,
+			FileMatch: FileMatch{
+				JPath:        fm.Path,
+				JLineMatches: lineMatches,
+				JLimitHit:    fm.LimitHit,
+				MatchCount:   fm.MatchCount,
+				Repo:         repo,
+				uri:          workspace + fm.Path,
+				CommitID:     commit,
+				InputRev:     &rev,
+			},
+			RepoResolver: repoResolver,
 		})
 	}
 
@@ -641,7 +649,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 						mu.Unlock()
 						return
 					}
-					name := string(fm.Repo.Name())
+					name := string(fm.Repo.Name)
 					partition[name] = append(partition[name], fm.JPath)
 				}
 

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -35,17 +35,13 @@ func TestSearchFilesInRepos(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{
-				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
-				},
-			}, false, nil
+			return []*FileMatchResolver{mkFileMatchResolver(FileMatch{
+				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			})}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{
-				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
-				},
-			}, false, nil
+			return []*FileMatchResolver{mkFileMatchResolver(FileMatch{
+				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			})}, false, nil
 		case "foo/empty":
 			return nil, false, nil
 		case "foo/cloning":
@@ -130,23 +126,17 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{
-				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
-				},
-			}, false, nil
+			return []*FileMatchResolver{mkFileMatchResolver(FileMatch{
+				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			})}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{
-				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
-				},
-			}, false, nil
+			return []*FileMatchResolver{mkFileMatchResolver(FileMatch{
+				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			})}, false, nil
 		case "foo/three":
-			return []*FileMatchResolver{
-				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
-				},
-			}, false, nil
+			return []*FileMatchResolver{mkFileMatchResolver(FileMatch{
+				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			})}, false, nil
 		default:
 			return nil, false, errors.New("Unexpected repo")
 		}
@@ -208,11 +198,9 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
-			return []*FileMatchResolver{
-				{
-					uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
-				},
-			}, false, nil
+			return []*FileMatchResolver{mkFileMatchResolver(FileMatch{
+				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			})}, false, nil
 		default:
 			panic("unexpected repo")
 		}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -414,18 +414,21 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 					symbols = zoektFileMatchToSymbolResults(repoResolver, inputRev, &file)
 				}
 				fm := &FileMatchResolver{
-					JPath:        file.FileName,
-					JLineMatches: lines,
-					JLimitHit:    fileLimitHit,
-					MatchCount:   matchCount, // We do not use resp.MatchCount because it counts the number of lines matched, not the number of fragments.
-					uri:          fileMatchURI(repo.Name, inputRev, file.FileName),
-					symbols:      symbols,
-					Repo:         repoResolver,
-					CommitID:     api.CommitID(file.Version),
-					InputRev:     &inputRev,
+					FileMatch: FileMatch{
+						JPath:        file.FileName,
+						JLineMatches: lines,
+						JLimitHit:    fileLimitHit,
+						MatchCount:   matchCount, // We do not use resp.MatchCount because it counts the number of lines matched, not the number of fragments.
+						uri:          fileMatchURI(repo.Name, inputRev, file.FileName),
+						symbols:      symbols,
+						Repo:         repo,
+						CommitID:     api.CommitID(file.Version),
+						InputRev:     &inputRev,
+					},
+					RepoResolver: repoResolver,
 				}
 				matches = append(matches, fm)
-				if id := fm.Repo.innerRepo.ID; lastID != id {
+				if id := repo.ID; lastID != id {
 					statusMap.Update(id, search.RepoStatusSearched|search.RepoStatusIndexed)
 					lastID = id
 				}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -305,7 +305,7 @@ func fromFileMatch(fm *graphqlbackend.FileMatchResolver) eventFileMatch {
 	return eventFileMatch{
 		Type:        fileMatch,
 		Path:        fm.JPath,
-		Repository:  fm.Repo.Name(),
+		Repository:  string(fm.Repo.Name),
 		Branches:    branches,
 		Version:     string(fm.CommitID),
 		LineMatches: lineMatches,
@@ -321,7 +321,7 @@ func fromSymbolMatch(fm *graphqlbackend.FileMatchResolver, symbols []symbol) eve
 	return eventSymbolMatch{
 		Type:       symbolMatch,
 		Path:       fm.JPath,
-		Repository: fm.Repo.Name(),
+		Repository: string(fm.Repo.Name),
 		Branches:   branches,
 		Version:    string(fm.CommitID),
 		Symbols:    symbols,


### PR DESCRIPTION
This is a first step towards a FileMatch type which doesn't depend on
GraphQL resolvers. It still depends on GitCommitResolver via the symbol
results. However, this commit detaches the dependency on
RepositoryResolver.

Our goal is to extract core search logic out of the graphqlbackend. Our
next commit will replace uses of FileMatchResolver with FileMatch. These
will only be converted into FileMatchResolvers in the
SearchResultsResolver.

Co-authored-by: Stefan Hengl <stefan@sourcegraph.com>