### PR TITLE
Don't load all sync states when page slice is empty

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
@@ -60,13 +60,16 @@ func (r *changesetApplyPreviewConnectionResolver) Nodes(ctx context.Context) ([]
 		return nil, err
 	}
 
-	syncData, err := r.store.ListChangesetSyncData(ctx, store.ListChangesetSyncDataOpts{ChangesetIDs: mappings.ChangesetIDs()})
-	if err != nil {
-		return nil, err
-	}
 	scheduledSyncs := make(map[int64]time.Time)
-	for _, d := range syncData {
-		scheduledSyncs[d.ChangesetID] = syncer.NextSync(time.Now, d)
+	changesetIDs := mappings.ChangesetIDs()
+	if len(changesetIDs) > 0 {
+		syncData, err := r.store.ListChangesetSyncData(ctx, store.ListChangesetSyncDataOpts{ChangesetIDs: changesetIDs})
+		if err != nil {
+			return nil, err
+		}
+		for _, d := range syncData {
+			scheduledSyncs[d.ChangesetID] = syncer.NextSync(time.Now, d)
+		}
 	}
 
 	resolvers := make([]graphqlbackend.ChangesetApplyPreviewResolver, 0, len(mappings))

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -43,13 +43,16 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 		return nil, err
 	}
 
-	syncData, err := r.store.ListChangesetSyncData(ctx, store.ListChangesetSyncDataOpts{ChangesetIDs: changesetsPage.IDs()})
-	if err != nil {
-		return nil, err
-	}
 	scheduledSyncs := make(map[int64]time.Time)
-	for _, d := range syncData {
-		scheduledSyncs[d.ChangesetID] = syncer.NextSync(time.Now, d)
+	changesetIDs := changesetsPage.IDs()
+	if len(changesetIDs) > 0 {
+		syncData, err := r.store.ListChangesetSyncData(ctx, store.ListChangesetSyncDataOpts{ChangesetIDs: changesetIDs})
+		if err != nil {
+			return nil, err
+		}
+		for _, d := range syncData {
+			scheduledSyncs[d.ChangesetID] = syncer.NextSync(time.Now, d)
+		}
 	}
 
 	resolvers := make([]graphqlbackend.ChangesetResolver, 0, len(changesetsPage))


### PR DESCRIPTION
When the list of IDs is empty, the store will just attempt to load all changeset sync states, which takes some time, depending on the count of changesets. This made queries for empty page slices be way slower than for non-empty ones.
