### PR TITLE
Fix loading all changeset events into memory when campaign is empty

### DIFF
--- a/enterprise/internal/campaigns/resolvers/campaign.go
+++ b/enterprise/internal/campaigns/resolvers/campaign.go
@@ -200,10 +200,14 @@ func (r *campaignResolver) ChangesetCountsOverTime(
 		end = args.To.Time.UTC()
 	}
 
-	eventsOpts := store.ListChangesetEventsOpts{ChangesetIDs: cs.IDs(), Kinds: state.RequiredEventTypesForHistory}
-	es, _, err := r.store.ListChangesetEvents(ctx, eventsOpts)
-	if err != nil {
-		return resolvers, err
+	var es []*campaigns.ChangesetEvent
+	changesetIDs := cs.IDs()
+	if len(changesetIDs) > 0 {
+		eventsOpts := store.ListChangesetEventsOpts{ChangesetIDs: changesetIDs, Kinds: state.RequiredEventTypesForHistory}
+		es, _, err = r.store.ListChangesetEvents(ctx, eventsOpts)
+		if err != nil {
+			return resolvers, err
+		}
 	}
 
 	counts, err := state.CalcCounts(start, end, cs, es...)


### PR DESCRIPTION
This took 1.5s for an empty campaign against my local DB. Now it takes 24ms. This would become even bigger of a problem once users have more events in their databases.
