### PR TITLE
detect REDACTED string when validating external service config

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
@@ -187,6 +188,13 @@ func (e *ExternalServiceStore) ValidateConfig(ctx context.Context, opt ValidateE
 	normalized, err = jsonc.Parse(opt.Config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to normalize JSON")
+	}
+
+	if bytes.Contains(normalized, []byte(types.RedactedSecret)) {
+		return nil, errors.Errorf(
+			"found unexpected Redacted string: %q, has ExternalService.UnredactConfig been called before attempting to write?",
+			types.RedactedSecret,
+		)
 	}
 
 	// For user-added external services, we need to prevent them from using disallowed fields.

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -237,6 +237,12 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			config:  `{"url": "https://github.com", "projectQuery": ["none"], "token": "` + types.RedactedSecret + `"}`,
 			wantErr: "found unexpected Redacted string: \"" + types.RedactedSecret + "\", has ExternalService.UnredactConfig been called before attempting to write?",
 		},
+		{
+			name:    "0 errors - potentially redacted string",
+			kind:    extsvc.KindGitHub,
+			config:  `{"url": "https://github.com", "repositoryQuery": ["github.com/srcgraph_redacted"], "token": "abc"}`,
+			wantErr: "<nil>",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -229,13 +229,13 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			name:    "1 errors - GitHub.com",
 			kind:    extsvc.KindGitHub,
 			config:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "` + types.RedactedSecret + `"}`,
-			wantErr: "found unexpected Redacted string: \"REDACTED\", has ExternalService.UnredactConfig been called before attempting to write?",
+			wantErr: "found unexpected Redacted string: \"" + types.RedactedSecret + "\", has ExternalService.UnredactConfig been called before attempting to write?",
 		},
 		{
 			name:    "1 errors - GitLab.com",
 			kind:    extsvc.KindGitLab,
 			config:  `{"url": "https://github.com", "projectQuery": ["none"], "token": "` + types.RedactedSecret + `"}`,
-			wantErr: "found unexpected Redacted string: \"REDACTED\", has ExternalService.UnredactConfig been called before attempting to write?",
+			wantErr: "found unexpected Redacted string: \"" + types.RedactedSecret + "\", has ExternalService.UnredactConfig been called before attempting to write?",
 		},
 	}
 	for _, test := range tests {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -225,6 +225,18 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			},
 			wantErr: `existing external service, "GITHUB 1", of same kind already added`,
 		},
+		{
+			name:    "1 errors - GitHub.com",
+			kind:    extsvc.KindGitHub,
+			config:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "` + types.RedactedSecret + `"}`,
+			wantErr: "found unexpected Redacted string: \"REDACTED\", has ExternalService.UnredactConfig been called before attempting to write?",
+		},
+		{
+			name:    "1 errors - GitLab.com",
+			kind:    extsvc.KindGitLab,
+			config:  `{"url": "https://github.com", "projectQuery": ["none"], "token": "` + types.RedactedSecret + `"}`,
+			wantErr: "found unexpected Redacted string: \"REDACTED\", has ExternalService.UnredactConfig been called before attempting to write?",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-const RedactedSecret = "REDACTED"
+const RedactedSecret = "SRCGRAPH_REDACTED"
 
 // RedactConfig replaces any secret fields in the Config field with RedactedSecret, be sure to call
 // UnRedactExternalServiceConfig before writing back to the database, otherwise validation will throw errors.

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -23,7 +23,7 @@ import (
 
 const RedactedSecret = "REDACTED"
 
-// RedactExternalServiceConfig replaces any secret fields in the Config field with RedactedSecret, be sure to call
+// RedactConfig replaces any secret fields in the Config field with RedactedSecret, be sure to call
 // UnRedactExternalServiceConfig before writing back to the database, otherwise validation will throw errors.
 func (e *ExternalService) RedactConfig() error {
 	var (
@@ -83,7 +83,7 @@ func redactField(buf string, v interface{}, fields ...*string) (string, error) {
 	return string(out), err
 }
 
-// UnredactExternalServiceConfig will replace redacted fields with their undredacted form from the 'old' ExternalService.
+// UnredactConfig will replace redacted fields with their undredacted form from the 'old' ExternalService.
 // You should call this when accepting updated config from a user that may have been
 // previously redacted, and pass in the unredacted form directly from the DB as the 'old' parameter
 func (e *ExternalService) UnredactConfig(old *ExternalService) error {


### PR DESCRIPTION
ref: #17261 

This PR adds a step to the ExternalService config validation function to detect any instances of the "REDACTED" string, this is important to make sure we don't accidentally write the obfuscated version of the config JSON to the database and lose the configured token.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
