### PR TITLE
Add tests for the changeset rewirer

### DIFF
--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -512,6 +512,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 			assertions := tc.wantChangeset
 			assertions.Repo = rs[0].ID
 			assertions.OwnedByCampaign = changesetOpts.OwnedByCampaign
+			assertions.AttachedTo = []int64{campaign.ID}
 			if changesetSpec != nil {
 				assertions.CurrentSpec = changesetSpec.ID
 			}

--- a/enterprise/internal/campaigns/reconciler/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler/reconciler_test.go
@@ -152,6 +152,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 			assertions := tc.wantChangeset
 			assertions.Repo = rs[0].ID
 			assertions.OwnedByCampaign = changesetOpts.OwnedByCampaign
+			assertions.AttachedTo = []int64{campaign.ID}
 			assertions.CurrentSpec = changesetSpec.ID
 			assertions.PreviousSpec = previousSpec.ID
 			ct.ReloadAndAssertChangeset(t, ctx, store, changeset, assertions)

--- a/enterprise/internal/campaigns/rewirer/rewirer.go
+++ b/enterprise/internal/campaigns/rewirer/rewirer.go
@@ -218,7 +218,7 @@ type ErrRepoNotSupported struct {
 
 func (e ErrRepoNotSupported) Error() string {
 	return fmt.Sprintf(
-		"External service type %s of repository %q is currently not supported for use with campaigns",
+		"Code host type %s of repository %q is currently not supported for use with campaigns",
 		e.ServiceType,
 		e.RepoName,
 	)

--- a/enterprise/internal/campaigns/rewirer/rewirer.go
+++ b/enterprise/internal/campaigns/rewirer/rewirer.go
@@ -1,7 +1,7 @@
 package rewirer
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
@@ -31,7 +31,7 @@ func (r *ChangesetRewirer) Rewire() (changesets []*campaigns.Changeset, err erro
 
 	for _, m := range r.mappings {
 		// If a Changeset that's currently attached to the campaign wasn't matched to a ChangesetSpec, it needs to be closed/detached.
-		if m.ChangesetSpecID == 0 {
+		if m.ChangesetSpec == nil {
 			changeset := m.Changeset
 
 			// If we don't have access to a repository, we don't detach nor close the changeset.
@@ -67,7 +67,7 @@ func (r *ChangesetRewirer) Rewire() (changesets []*campaigns.Changeset, err erro
 
 		var changeset *campaigns.Changeset
 
-		if m.ChangesetID != 0 {
+		if m.Changeset != nil {
 			changeset = m.Changeset
 			if spec.Spec.IsImportingExisting() {
 				r.attachTrackingChangeset(changeset)
@@ -114,7 +114,7 @@ func (r *ChangesetRewirer) updateChangesetToNewSpec(c *campaigns.Changeset, spec
 	c.CurrentSpecID = spec.ID
 
 	// Ensure that the changeset is attached to the campaign
-	c.Campaigns = append(c.Campaigns, campaigns.CampaignAssoc{CampaignID: r.campaignID})
+	attachToCampaign(c, r.campaignID)
 
 	// We need to enqueue it for the changeset reconciler, so the
 	// reconciler wakes up, compares old and new spec and, if
@@ -143,7 +143,7 @@ func (r *ChangesetRewirer) createTrackingChangeset(repo *types.Repo, externalID 
 func (r *ChangesetRewirer) attachTrackingChangeset(changeset *campaigns.Changeset) {
 	// We already have a changeset with the given repoID and
 	// externalID, so we can track it.
-	changeset.Campaigns = append(changeset.Campaigns, campaigns.CampaignAssoc{CampaignID: r.campaignID})
+	attachToCampaign(changeset, r.campaignID)
 
 	// If it's errored and not created by another campaign, we re-enqueue it.
 	if changeset.OwnedByCampaignID == 0 && (changeset.ReconcilerState == campaigns.ReconcilerStateErrored || changeset.ReconcilerState == campaigns.ReconcilerStateFailed) {
@@ -199,6 +199,33 @@ func (r *ChangesetRewirer) closeChangeset(changeset *campaigns.Changeset) {
 	}
 }
 
+func attachToCampaign(changeset *campaigns.Changeset, campaignID int64) {
+	for i := range changeset.Campaigns {
+		if changeset.Campaigns[i].CampaignID == campaignID {
+			changeset.Campaigns[i].Detach = false
+			return
+		}
+	}
+	changeset.Campaigns = append(changeset.Campaigns, campaigns.CampaignAssoc{CampaignID: campaignID})
+}
+
+// ErrRepoNotSupported is thrown by the rewirer when it encounters a mapping
+// targetting a repo on a code host that's not supported by campaigns.
+type ErrRepoNotSupported struct {
+	ServiceType string
+	RepoName    string
+}
+
+func (e ErrRepoNotSupported) Error() string {
+	return fmt.Sprintf(
+		"External service type %s of repository %q is currently not supported for use with campaigns",
+		e.ServiceType,
+		e.RepoName,
+	)
+}
+
+var _ error = ErrRepoNotSupported{}
+
 // checkRepoSupported checks whether the given repository is supported by campaigns
 // and if not it returns an error.
 func checkRepoSupported(repo *types.Repo) error {
@@ -206,9 +233,8 @@ func checkRepoSupported(repo *types.Repo) error {
 		return nil
 	}
 
-	return errors.Errorf(
-		"External service type %s of repository %q is currently not supported for use with campaigns",
-		repo.ExternalRepo.ServiceType,
-		repo.Name,
-	)
+	return &ErrRepoNotSupported{
+		ServiceType: repo.ExternalRepo.ServiceType,
+		RepoName:    string(repo.Name),
+	}
 }

--- a/enterprise/internal/campaigns/rewirer/rewirer_test.go
+++ b/enterprise/internal/campaigns/rewirer/rewirer_test.go
@@ -1,0 +1,381 @@
+package rewirer
+
+import (
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestRewirer_Rewire(t *testing.T) {
+	testCampaignID := int64(123)
+	testChangesetSpecID := int64(512)
+	testRepoID := api.RepoID(128)
+	testRepo := &types.Repo{
+		ID: testRepoID,
+		ExternalRepo: api.ExternalRepoSpec{
+			ServiceType: extsvc.TypeGitHub,
+		},
+	}
+	unsupportedTestRepoID := api.RepoID(256)
+	unsupportedTestRepo := &types.Repo{
+		ID: unsupportedTestRepoID,
+		ExternalRepo: api.ExternalRepoSpec{
+			ServiceType: extsvc.TypeBitbucketCloud,
+		},
+	}
+	testCases := []struct {
+		name           string
+		mappings       store.RewirerMappings
+		wantChangesets []ct.ChangesetAssertions
+		wantErr        error
+	}{
+		{
+			name:           "empty mappings",
+			mappings:       store.RewirerMappings{},
+			wantChangesets: []ct.ChangesetAssertions{},
+		},
+		// NO CHANGESET SPEC
+		{
+			name: "no spec matching existing imported changeset",
+			mappings: store.RewirerMappings{{
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:      testRepoID,
+					Campaigns: []campaigns.CampaignAssoc{{CampaignID: testCampaignID}},
+
+					// Imported changeset:
+					OwnedByCampaign: 0,
+					CurrentSpec:     0,
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{
+				// No match, should be re-enqueued and detached from the campaign.
+				assertResetQueued(ct.ChangesetAssertions{
+					Repo:       testRepoID,
+					DetachFrom: []int64{testCampaignID},
+				}),
+			},
+		},
+		{
+			name: "no spec matching existing unpublished branch changeset owned by this campaign",
+			mappings: store.RewirerMappings{{
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:      testRepoID,
+					Campaigns: []campaigns.CampaignAssoc{{CampaignID: testCampaignID}},
+
+					// Owned unpublished branch changeset:
+					PublicationState: campaigns.ChangesetPublicationStateUnpublished,
+					OwnedByCampaign:  testCampaignID,
+					CurrentSpec:      testChangesetSpecID,
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{
+				// No match, should be re-enqueued and detached from the campaign.
+				assertResetQueued(ct.ChangesetAssertions{
+					PublicationState: campaigns.ChangesetPublicationStateUnpublished,
+					OwnedByCampaign:  testCampaignID,
+					CurrentSpec:      testChangesetSpecID,
+					Repo:             testRepoID,
+					DetachFrom:       []int64{testCampaignID},
+				}),
+			},
+		},
+		{
+			name: "no spec matching existing published branch changeset owned by this campaign",
+			mappings: store.RewirerMappings{{
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:      testRepoID,
+					Campaigns: []campaigns.CampaignAssoc{{CampaignID: testCampaignID}},
+
+					// Owned, published branch changeset:
+					OwnedByCampaign:  testCampaignID,
+					CurrentSpec:      testChangesetSpecID,
+					PublicationState: campaigns.ChangesetPublicationStatePublished,
+					// Publication succeeded
+					ReconcilerState: campaigns.ReconcilerStateCompleted,
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{
+				// No match, should be re-enqueued and detached from the campaign.
+				assertResetQueued(ct.ChangesetAssertions{
+					PublicationState: campaigns.ChangesetPublicationStatePublished,
+					OwnedByCampaign:  testCampaignID,
+					CurrentSpec:      testChangesetSpecID,
+					// The changeset should be closed on the code host.
+					Closing:    true,
+					Repo:       testRepoID,
+					DetachFrom: []int64{testCampaignID},
+					// Current spec should have been made the previous spec.
+					PreviousSpec: testChangesetSpecID,
+				}),
+			},
+		},
+		{
+			name: "no spec matching existing changeset, no repo perms",
+			mappings: store.RewirerMappings{{
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:      0,
+					Campaigns: []campaigns.CampaignAssoc{{CampaignID: testCampaignID}},
+				}),
+				// No access to repo.
+				Repo: nil,
+			}},
+			// Nothing should be done.
+			wantChangesets: []ct.ChangesetAssertions{},
+		},
+		// END NO CHANGESET SPEC
+		// NO CHANGESET
+		{
+			name: "new importing spec",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					Repo: testRepoID,
+
+					// Importing spec
+					ExternalID: "123",
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{assertResetQueued(ct.ChangesetAssertions{
+				Repo:       testRepoID,
+				ExternalID: "123",
+				// Imported changesets always start as unpublished and will be set to published once the import succeeded.
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
+				AttachedTo:       []int64{testCampaignID},
+			})},
+		},
+		{
+			name: "new branch spec",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					ID:   testChangesetSpecID,
+					Repo: testRepoID,
+
+					// Branch spec
+					HeadRef: "refs/heads/test-branch",
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{assertResetQueued(ct.ChangesetAssertions{
+				Repo:             testRepoID,
+				PublicationState: campaigns.ChangesetPublicationStateUnpublished,
+				AttachedTo:       []int64{testCampaignID},
+				OwnedByCampaign:  testCampaignID,
+				CurrentSpec:      testChangesetSpecID,
+				// Diff stat is copied over from changeset spec
+				DiffStat: ct.TestChangsetSpecDiffStat,
+			})},
+		},
+		{
+			name: "unsupported repo",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					Repo:       unsupportedTestRepoID,
+					ExternalID: "123",
+				}),
+				RepoID: unsupportedTestRepoID,
+				Repo:   unsupportedTestRepo,
+			}},
+			wantErr: &ErrRepoNotSupported{
+				ServiceType: unsupportedTestRepo.ExternalRepo.ServiceType,
+				RepoName:    string(unsupportedTestRepo.Name),
+			},
+		},
+		{
+			name: "inaccessible repo",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					Repo:       testRepoID,
+					ExternalID: "123",
+				}),
+				RepoID: testRepoID,
+				Repo:   nil,
+			}},
+			wantErr: &database.RepoNotFoundErr{ID: testRepoID},
+		},
+		// END NO CHANGESET
+		// CHANGESET SPEC AND CHANGESET
+		{
+			name: "update importing spec: imported by other",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					Repo: testRepoID,
+
+					// Importing spec
+					ExternalID: "123",
+				}),
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:       testRepoID,
+					ExternalID: "123",
+					// Already attached to another campaign
+					Campaigns: []campaigns.CampaignAssoc{{CampaignID: testCampaignID + 1}},
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{
+				// Should not be reenqueued
+				{
+					Repo:       testRepoID,
+					ExternalID: "123",
+					// Now should be attached to both campaigns.
+					AttachedTo: []int64{testCampaignID + 1, testCampaignID},
+				},
+			},
+		},
+		{
+			name: "update importing spec: failed before",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					Repo: testRepoID,
+
+					// Importing spec
+					ExternalID: "123",
+				}),
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:       testRepoID,
+					ExternalID: "123",
+					// Already attached to another campaign
+					Campaigns:       []campaigns.CampaignAssoc{{CampaignID: testCampaignID + 1}},
+					ReconcilerState: campaigns.ReconcilerStateFailed,
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{assertResetQueued(ct.ChangesetAssertions{
+				Repo:       testRepoID,
+				ExternalID: "123",
+				// Now should be attached to both campaigns.
+				AttachedTo: []int64{testCampaignID + 1, testCampaignID},
+			})},
+		},
+		{
+			name: "update importing spec: created by other campaign",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					Repo: testRepoID,
+
+					// Importing spec
+					ExternalID: "123",
+				}),
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:       testRepoID,
+					ExternalID: "123",
+					// Already attached to another campaign
+					Campaigns: []campaigns.CampaignAssoc{{CampaignID: testCampaignID + 1}},
+					// Other campaign created this changeset.
+					OwnedByCampaign: testCampaignID + 1,
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{
+				// Changeset owned by another campaign should not be retried.
+				{
+					Repo:            testRepoID,
+					ExternalID:      "123",
+					OwnedByCampaign: testCampaignID + 1,
+					// Now should be attached to both campaigns.
+					AttachedTo: []int64{testCampaignID + 1, testCampaignID},
+				}},
+		},
+		{
+			name: "update branch spec",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					ID:   testChangesetSpecID + 1,
+					Repo: testRepoID,
+
+					// Branch spec
+					HeadRef: "refs/heads/test-branch",
+				}),
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:             testRepoID,
+					ExternalID:       "123",
+					CurrentSpec:      testChangesetSpecID,
+					Campaigns:        []campaigns.CampaignAssoc{{CampaignID: testCampaignID}},
+					OwnedByCampaign:  testCampaignID,
+					PublicationState: campaigns.ChangesetPublicationStatePublished,
+					ReconcilerState:  campaigns.ReconcilerStateCompleted,
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{assertResetQueued(ct.ChangesetAssertions{
+				Repo:             testRepoID,
+				ExternalID:       "123",
+				OwnedByCampaign:  testCampaignID,
+				AttachedTo:       []int64{testCampaignID},
+				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				CurrentSpec:      testChangesetSpecID + 1,
+				// The changeset was reconciled successfully before, so the previous spec should have been recorded.
+				PreviousSpec: testChangesetSpecID,
+			})},
+		},
+		{
+			name: "update branch spec - failed before",
+			mappings: store.RewirerMappings{{
+				ChangesetSpec: ct.BuildChangesetSpec(t, ct.TestSpecOpts{
+					ID:   testChangesetSpecID + 1,
+					Repo: testRepoID,
+
+					// Branch spec
+					HeadRef: "refs/heads/test-branch",
+				}),
+				Changeset: ct.BuildChangeset(ct.TestChangesetOpts{
+					Repo:             testRepoID,
+					ExternalID:       "123",
+					CurrentSpec:      testChangesetSpecID,
+					Campaigns:        []campaigns.CampaignAssoc{{CampaignID: testCampaignID}},
+					OwnedByCampaign:  testCampaignID,
+					PublicationState: campaigns.ChangesetPublicationStatePublished,
+					ReconcilerState:  campaigns.ReconcilerStateFailed,
+				}),
+				Repo: testRepo,
+			}},
+			wantChangesets: []ct.ChangesetAssertions{assertResetQueued(ct.ChangesetAssertions{
+				Repo:             testRepoID,
+				ExternalID:       "123",
+				OwnedByCampaign:  testCampaignID,
+				AttachedTo:       []int64{testCampaignID},
+				PublicationState: campaigns.ChangesetPublicationStatePublished,
+				CurrentSpec:      testChangesetSpecID + 1,
+				// The changeset was not reconciled successfully before, so the previous spec should have remained unset.
+				PreviousSpec: 0,
+			})},
+		},
+		// END CHANGESET SPEC AND CHANGESET
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := New(tc.mappings, testCampaignID)
+			changesets, err := r.Rewire()
+			if err != nil && tc.wantErr == nil {
+				t.Fatal(err)
+			}
+			if tc.wantErr != nil && err.Error() != tc.wantErr.Error() {
+				t.Fatalf("incorrect error returned. want=%+v have=%+v", tc.wantErr, err)
+			}
+			if have, want := len(changesets), len(tc.wantChangesets); have != want {
+				t.Fatalf("incorrect amount of changesets returned. want=%d have=%d", want, have)
+			}
+			for i, changeset := range changesets {
+				ct.AssertChangeset(t, changeset, tc.wantChangesets[i])
+			}
+		})
+	}
+}
+
+func assertResetQueued(a ct.ChangesetAssertions) ct.ChangesetAssertions {
+	a.ReconcilerState = campaigns.ReconcilerStateQueued
+	a.NumFailures = 0
+	a.NumResets = 0
+	a.FailureMessage = nil
+	a.SyncErrorMessage = nil
+	return a
+}

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -350,6 +350,7 @@ func TestService(t *testing.T) {
 			Repo:          rs[0].ID,
 			ExternalState: campaigns.ChangesetExternalStateOpen,
 			ExternalID:    "ext-id-5",
+			AttachedTo:    []int64{campaign.ID},
 
 			// The important fields:
 			ReconcilerState: campaigns.ReconcilerStateQueued,

--- a/enterprise/internal/campaigns/store/changesets_test.go
+++ b/enterprise/internal/campaigns/store/changesets_test.go
@@ -971,6 +971,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			ReconcilerState: campaigns.ReconcilerStateFailed,
 			OwnedByCampaign: campaignID,
 			FailureMessage:  &CanceledChangesetFailureMessage,
+			AttachedTo:      []int64{campaignID},
 		})
 
 		ct.ReloadAndAssertChangeset(t, ctx, s, c2, ct.ChangesetAssertions{
@@ -979,18 +980,21 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			OwnedByCampaign: campaignID,
 			FailureMessage:  &CanceledChangesetFailureMessage,
 			NumFailures:     1,
+			AttachedTo:      []int64{campaignID},
 		})
 
 		ct.ReloadAndAssertChangeset(t, ctx, s, c3, ct.ChangesetAssertions{
 			Repo:            repo.ID,
 			ReconcilerState: campaigns.ReconcilerStateCompleted,
 			OwnedByCampaign: campaignID,
+			AttachedTo:      []int64{campaignID},
 		})
 
 		ct.ReloadAndAssertChangeset(t, ctx, s, c4, ct.ChangesetAssertions{
 			Repo:             repo.ID,
 			ReconcilerState:  campaigns.ReconcilerStateQueued,
 			PublicationState: campaigns.ChangesetPublicationStateUnpublished,
+			AttachedTo:       []int64{campaignID},
 		})
 
 		ct.ReloadAndAssertChangeset(t, ctx, s, c5, ct.ChangesetAssertions{
@@ -998,6 +1002,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			ReconcilerState: campaigns.ReconcilerStateFailed,
 			FailureMessage:  &CanceledChangesetFailureMessage,
 			OwnedByCampaign: campaignID,
+			AttachedTo:      []int64{campaignID},
 		})
 	})
 
@@ -1096,6 +1101,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		for changeset, want := range changesets {
 			want.Repo = repo.ID
 			want.OwnedByCampaign = campaignID
+			want.AttachedTo = []int64{campaignID}
 			ct.ReloadAndAssertChangeset(t, ctx, s, changeset, want)
 		}
 	})

--- a/enterprise/internal/campaigns/testing/changeset_spec.go
+++ b/enterprise/internal/campaigns/testing/changeset_spec.go
@@ -12,6 +12,7 @@ import (
 )
 
 type TestSpecOpts struct {
+	ID           int64
 	User         int32
 	Repo         api.RepoID
 	CampaignSpec int64
@@ -54,6 +55,7 @@ func BuildChangesetSpec(t *testing.T, opts TestSpecOpts) *campaigns.ChangesetSpe
 	}
 
 	spec := &campaigns.ChangesetSpec{
+		ID:             opts.ID,
 		UserID:         opts.User,
 		RepoID:         opts.Repo,
 		CampaignSpecID: opts.CampaignSpec,

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -631,6 +631,33 @@ func (c *Changeset) AttachedTo(campaignID int64) bool {
 	return false
 }
 
+// Attach attaches the campaign with the given ID to the changeset.
+// If the campaign is already attached, this is a noop.
+// If the campaign is still attached but is marked as to be detached,
+// the detach flag is removed.
+func (c *Changeset) Attach(campaignID int64) {
+	for i := range c.Campaigns {
+		if c.Campaigns[i].CampaignID == campaignID {
+			c.Campaigns[i].Detach = false
+			return
+		}
+	}
+	c.Campaigns = append(c.Campaigns, CampaignAssoc{CampaignID: campaignID})
+}
+
+// Detach marks the given campaign as to-be-detached. Returns true, if the
+// campaign currently is attached to the campaign. This function is a noop,
+// if the given campaign was not attached to the changeset.
+func (c *Changeset) Detach(campaignID int64) bool {
+	for i := range c.Campaigns {
+		if c.Campaigns[i].CampaignID == campaignID {
+			c.Campaigns[i].Detach = true
+			return true
+		}
+	}
+	return false
+}
+
 // SupportsLabels returns whether the code host on which the changeset is
 // hosted supports labels and whether it's safe to call the
 // (*Changeset).Labels() method.


### PR DESCRIPTION
Since we split up packages, there's no reported coverage on this piece of code anymore, and that was actually on purpose, to force me to do this at some point.
This introduces DB state independent tests for the rewirer, so they are easy to write and maintain.
Ultimately the goal should become to reduce the tests for service.ApplyCampaign to a bare minimum, and have each component tested individually.
