### PR TITLE
adds support for node version inference and changing via n

### DIFF
--- a/enterprise/internal/codeintel/autoindex/inference/typescript.go
+++ b/enterprise/internal/codeintel/autoindex/inference/typescript.go
@@ -95,23 +95,12 @@ func (r lsifTscJobRecognizer) InferIndexJobs(paths []string, gitserver Gitserver
 }
 
 func checkCanDeriveNodeVersion(path string, paths []string, gitserver GitserverClientWrapper) bool {
-	hasEnginesField := func(packageJSONPath string) (hasField bool) {
-		packageJSON := &packageJSONEngine{}
-		if b, err := gitserver.RawContents(context.TODO(), packageJSONPath); err == nil {
-			if err := json.Unmarshal(b, packageJSON); err == nil {
-				if packageJSON.Engines != nil && packageJSON.Engines.Node != nil {
-					return true
-				}
-			}
-		}
-		return
-	}
 	for _, dir := range ancestorDirs(path) {
 		packageJSONPath := filepath.Join(dir, "package.json")
 		nvmrcPath := filepath.Join(dir, ".nvmrc")
 		nodeVersionPath := filepath.Join(dir, ".node-version")
 		nnodeVersionPath := filepath.Join(dir, ".n-node-version")
-		if (contains(paths, packageJSONPath) && hasEnginesField(packageJSONPath)) ||
+		if (contains(paths, packageJSONPath) && hasEnginesField(packageJSONPath, gitserver)) ||
 			contains(paths, nvmrcPath) ||
 			contains(paths, nodeVersionPath) ||
 			contains(paths, nnodeVersionPath) {
@@ -119,6 +108,18 @@ func checkCanDeriveNodeVersion(path string, paths []string, gitserver GitserverC
 		}
 	}
 	return false
+}
+
+func hasEnginesField(packageJSONPath string, gitserver GitserverClientWrapper) (hasField bool) {
+	packageJSON := &packageJSONEngine{}
+	if b, err := gitserver.RawContents(context.TODO(), packageJSONPath); err == nil {
+		if err := json.Unmarshal(b, packageJSON); err == nil {
+			if packageJSON.Engines != nil && packageJSON.Engines.Node != nil {
+				return true
+			}
+		}
+	}
+	return
 }
 
 func checkLernaFile(path string, paths []string, gitserver GitserverClientWrapper) (isYarn bool) {


### PR DESCRIPTION
Currently using an image with src-cli in it for the individual steps. Do we want this? I dont see why not, given the final stage could (ab)use src-cli with local-steps anyways @efritz 