### PR TITLE
search: reenable repo has commit after intgration test

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -451,13 +451,11 @@ func TestSearch(t *testing.T) {
 				name:  "diff search, nonzero result",
 				query: `repo:^github\.com/sgtest/go-diff$ type:diff main count:1`,
 			},
-			// LG 2021-01-27 disabled failing test. The value of repohascommmitafter: should be set dynamically here,
-			// or this test will fail again in the future.
 			// Repohascommitafter
-			// {
-			// 	name:  `Repohascommitafter, nonzero result`,
-			// 	query: `repo:^github\.com/sgtest/go-diff$ repohascommitafter:"8 months ago" test patterntype:literal count:1`,
-			// },
+			{
+				name:  `Repohascommitafter, nonzero result`,
+				query: `repo:^github\.com/sgtest/go-diff$ repohascommitafter:"2019-01-01" test patterntype:literal count:1`,
+			},
 			// Regex text search
 			{
 				name:  `regex, unindexed, nonzero result`,


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/pull/17715#issue-562519207. We don't need to dynamically set this date, just a static date before a commit will do.

Will wait for `master-dry-run` build to be green.