### PR TITLE
dev/ci: do *not* run e2e sourcegraph/server tests with DEPLOY_TYPE=dev

### DIFF
--- a/dev/ci/e2e.sh
+++ b/dev/ci/e2e.sh
@@ -17,7 +17,7 @@ if curl --output /dev/null --silent --head --fail $URL; then
 fi
 
 echo "--- Running a daemonized $IMAGE as the test subject..."
-CONTAINER="$(docker container run -d -e DEPLOY_TYPE=dev "$IMAGE")"
+CONTAINER="$(docker container run -d "$IMAGE")"
 trap 'kill $(jobs -p -r)'" ; docker logs --timestamps $CONTAINER ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
 
 docker exec "$CONTAINER" apk add --no-cache socat


### PR DESCRIPTION
It appears that we introduced this in [this PR](https://github.com/sourcegraph/sourcegraph/pull/2975)
and, although there is no description, the intent was to prevent [this code from running](https://github.com/sourcegraph/sourcegraph/pull/2971/files#diff-8715b8ced982264b18aaeee9100672eec47a519289087c1d57c9c116b230836eR138).

However, it appears that code was never merged - at least blame says it has
not existed [since Sourcegraph became open source](https://github.com/sourcegraph/sourcegraph/blame/main/cmd/frontend/internal/auth/userpasswd/handlers.go#L188).

Also, the code is already protected by the user agent check - so I don't
think we need this.

**Most importantly:** having `DEPLOY_TYPE=dev` is *incredibly* bad because
it means we are not e2e testing the actual version of Sourcegraph we are
releasing! `conf.IsDeployTypeSingleDockerContainer()` will return *false*
when this is set, and various dev-only features will be turned on.

I only caught this because my PR to run some code in dev-only mode [failed](https://github.com/sourcegraph/sourcegraph/pull/17586).

Helps #17218

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
