### PR TITLE
codeinsights: do not run on server & fix CI failure

### DIFF
--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -17,7 +17,7 @@ if curl --output /dev/null --silent --head --fail $URL; then
 fi
 
 echo "--- Running a daemonized $IMAGE as the test subject..."
-CONTAINER="$(docker container run -d -e DEPLOY_TYPE=dev -e GOTRACEBACK=all "$IMAGE")"
+CONTAINER="$(docker container run -d -e GOTRACEBACK=all "$IMAGE")"
 trap 'kill $(jobs -p -r)'" ; docker logs --timestamps $CONTAINER ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
 
 docker exec "$CONTAINER" apk add --no-cache socat

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -19,6 +19,10 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 		// TimescaleDB in those deployments. https://github.com/sourcegraph/sourcegraph/issues/17218
 		return nil
 	}
+	if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
+		// Code insights is not supported in single-container Docker demo deployments.
+		return nil
+	}
 	timescale, err := initializeCodeInsightsDB()
 	if err != nil {
 		return err


### PR DESCRIPTION
 dev/ci: do not set DEPLOY_TYPE=dev for backend integration tests

These are effectively end-to-end tests, so setting this is very bad
for the same reason described in #17731

Should also fix the current CI failure on `main`.

Helps #17218

---

code insights: do not run on sourcegraph/server

Code Insights will not, at least initially, be supported on demo sourcegraph/server
deployments. This codifies that.

See #17222
