### PR TITLE
Prefill the code intel index configuration field with the inferred configuration

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_configuration.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_configuration.go
@@ -2,19 +2,18 @@ package graphql
 
 import (
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
 type IndexConfigurationResolver struct {
-	configuration store.IndexConfiguration
+	configuration []byte
 }
 
-func NewIndexConfigurationResolver(configuration store.IndexConfiguration) gql.IndexConfigurationResolver {
+func NewIndexConfigurationResolver(configuration []byte) gql.IndexConfigurationResolver {
 	return &IndexConfigurationResolver{
 		configuration: configuration,
 	}
 }
 
 func (r *IndexConfigurationResolver) Configuration() *string {
-	return strPtr(string(r.configuration.Data))
+	return strPtr(string(r.configuration))
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/api"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
@@ -71,4 +72,5 @@ type LSIFStore interface {
 
 type IndexEnqueuer interface {
 	ForceQueueIndex(ctx context.Context, repositoryID int) error
+	InferIndexConfiguration(ctx context.Context, repositoryID int) (*config.IndexConfiguration, error)
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -81,8 +81,8 @@ func NewMockResolver() *MockResolver {
 			},
 		},
 		IndexConfigurationFunc: &ResolverIndexConfigurationFunc{
-			defaultHook: func(context.Context, int) (dbstore.IndexConfiguration, error) {
-				return dbstore.IndexConfiguration{}, nil
+			defaultHook: func(context.Context, int) ([]byte, error) {
+				return nil, nil
 			},
 		},
 		IndexConnectionResolverFunc: &ResolverIndexConnectionResolverFunc{
@@ -701,15 +701,15 @@ func (c ResolverGetUploadByIDFuncCall) Results() []interface{} {
 // ResolverIndexConfigurationFunc describes the behavior when the
 // IndexConfiguration method of the parent MockResolver instance is invoked.
 type ResolverIndexConfigurationFunc struct {
-	defaultHook func(context.Context, int) (dbstore.IndexConfiguration, error)
-	hooks       []func(context.Context, int) (dbstore.IndexConfiguration, error)
+	defaultHook func(context.Context, int) ([]byte, error)
+	hooks       []func(context.Context, int) ([]byte, error)
 	history     []ResolverIndexConfigurationFuncCall
 	mutex       sync.Mutex
 }
 
 // IndexConfiguration delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockResolver) IndexConfiguration(v0 context.Context, v1 int) (dbstore.IndexConfiguration, error) {
+func (m *MockResolver) IndexConfiguration(v0 context.Context, v1 int) ([]byte, error) {
 	r0, r1 := m.IndexConfigurationFunc.nextHook()(v0, v1)
 	m.IndexConfigurationFunc.appendCall(ResolverIndexConfigurationFuncCall{v0, v1, r0, r1})
 	return r0, r1
@@ -718,7 +718,7 @@ func (m *MockResolver) IndexConfiguration(v0 context.Context, v1 int) (dbstore.I
 // SetDefaultHook sets function that is called when the IndexConfiguration
 // method of the parent MockResolver instance is invoked and the hook queue
 // is empty.
-func (f *ResolverIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int) (dbstore.IndexConfiguration, error)) {
+func (f *ResolverIndexConfigurationFunc) SetDefaultHook(hook func(context.Context, int) ([]byte, error)) {
 	f.defaultHook = hook
 }
 
@@ -726,7 +726,7 @@ func (f *ResolverIndexConfigurationFunc) SetDefaultHook(hook func(context.Contex
 // IndexConfiguration method of the parent MockResolver instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *ResolverIndexConfigurationFunc) PushHook(hook func(context.Context, int) (dbstore.IndexConfiguration, error)) {
+func (f *ResolverIndexConfigurationFunc) PushHook(hook func(context.Context, int) ([]byte, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -734,21 +734,21 @@ func (f *ResolverIndexConfigurationFunc) PushHook(hook func(context.Context, int
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *ResolverIndexConfigurationFunc) SetDefaultReturn(r0 dbstore.IndexConfiguration, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (dbstore.IndexConfiguration, error) {
+func (f *ResolverIndexConfigurationFunc) SetDefaultReturn(r0 []byte, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) ([]byte, error) {
 		return r0, r1
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *ResolverIndexConfigurationFunc) PushReturn(r0 dbstore.IndexConfiguration, r1 error) {
-	f.PushHook(func(context.Context, int) (dbstore.IndexConfiguration, error) {
+func (f *ResolverIndexConfigurationFunc) PushReturn(r0 []byte, r1 error) {
+	f.PushHook(func(context.Context, int) ([]byte, error) {
 		return r0, r1
 	})
 }
 
-func (f *ResolverIndexConfigurationFunc) nextHook() func(context.Context, int) (dbstore.IndexConfiguration, error) {
+func (f *ResolverIndexConfigurationFunc) nextHook() func(context.Context, int) ([]byte, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -789,7 +789,7 @@ type ResolverIndexConfigurationFuncCall struct {
 	Arg1 int
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
-	Result0 dbstore.IndexConfiguration
+	Result0 []byte
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
 	Result1 error

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/enqueuer"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -29,5 +32,55 @@ func TestQueryResolver(t *testing.T) {
 
 	if queryResolver != nil {
 		t.Errorf("expected nil-valued resolver")
+	}
+}
+
+func TestFallbackIndexConfiguration(t *testing.T) {
+	mockDBStore := NewMockDBStore()
+	mockEnqueuerDBStore := enqueuer.NewMockDBStore()
+	mockLSIFStore := NewMockLSIFStore()
+	mockCodeIntelAPI := NewMockCodeIntelAPI() // returns no dumps
+	gitServerClient := enqueuer.NewMockGitserverClient()
+	indexEnqueuer := enqueuer.NewIndexEnqueuer(mockEnqueuerDBStore, gitServerClient, &observation.TestContext)
+
+	resolver := NewResolver(mockDBStore, mockLSIFStore, mockCodeIntelAPI, indexEnqueuer, nil, &observation.TestContext)
+
+	mockDBStore.GetIndexConfigurationByRepositoryIDFunc.SetDefaultReturn(dbstore.IndexConfiguration{}, false, nil)
+	gitServerClient.HeadFunc.SetDefaultReturn("deadbeef", nil)
+	gitServerClient.ListFilesFunc.SetDefaultReturn([]string{"go.mod"}, nil)
+
+	json, err := resolver.IndexConfiguration(context.Background(), 0)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	diff := cmp.Diff(string(json), `{
+	"shared_steps": [],
+	"index_jobs": [
+		{
+			"steps": [
+				{
+					"root": "",
+					"image": "sourcegraph/lsif-go:latest",
+					"commands": [
+						"go mod download"
+					]
+				}
+			],
+			"local_steps": [],
+			"root": "",
+			"indexer": "sourcegraph/lsif-go:latest",
+			"indexer_args": [
+				"lsif-go",
+				"--no-animation"
+			],
+			"outfile": ""
+		}
+	]
+}`)
+
+	if diff != "" {
+		t.Fatalf("Unexpected fallback index configuration:\n%s\n", diff)
 	}
 }

--- a/enterprise/internal/codeintel/autoindex/config/json.go
+++ b/enterprise/internal/codeintel/autoindex/config/json.go
@@ -1,70 +1,15 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 )
 
-type jsonIndexConfiguration struct {
-	SharedSteps []jsonDockerStep `json:"shared_steps"`
-	IndexJobs   []jsonIndexJob   `json:"index_jobs"`
-}
-
-type jsonIndexJob struct {
-	Steps       []jsonDockerStep `json:"steps"`
-	LocalSteps  []string         `json:"local_steps"`
-	Root        string           `json:"root"`
-	Indexer     string           `json:"indexer"`
-	IndexerArgs []string         `json:"indexer_args"`
-	Outfile     string           `json:"outfile"`
-}
-
-type jsonDockerStep struct {
-	Root     string   `json:"root"`
-	Image    string   `json:"image"`
-	Commands []string `json:"commands"`
-}
-
 func UnmarshalJSON(data []byte) (IndexConfiguration, error) {
-	jsonData, err := jsonc.Parse(string(data))
-	if err != nil {
+	configuration := IndexConfiguration{}
+	if err := jsonc.Unmarshal(string(data), &configuration); err != nil {
 		return IndexConfiguration{}, fmt.Errorf("invalid JSON: %v", err)
 	}
-
-	configuration := jsonIndexConfiguration{}
-	if err := json.Unmarshal(jsonData, &configuration); err != nil {
-		return IndexConfiguration{}, fmt.Errorf("invalid JSON: %v", err)
-	}
-
-	var indexJobs []IndexJob
-	for _, value := range configuration.IndexJobs {
-		indexJobs = append(indexJobs, IndexJob{
-			Steps:       convertJSONDockerSteps(value.Steps),
-			LocalSteps:  value.LocalSteps,
-			Root:        value.Root,
-			Indexer:     value.Indexer,
-			IndexerArgs: value.IndexerArgs,
-			Outfile:     value.Outfile,
-		})
-	}
-
-	return IndexConfiguration{
-		SharedSteps: convertJSONDockerSteps(configuration.SharedSteps),
-		IndexJobs:   indexJobs,
-	}, nil
-}
-
-func convertJSONDockerSteps(raw []jsonDockerStep) []DockerStep {
-	steps := []DockerStep{}
-	for _, val := range raw {
-		steps = append(steps, DockerStep{
-			Root:     val.Root,
-			Image:    val.Image,
-			Commands: val.Commands,
-		})
-	}
-
-	return steps
+	return configuration, nil
 }

--- a/enterprise/internal/codeintel/autoindex/config/json.go
+++ b/enterprise/internal/codeintel/autoindex/config/json.go
@@ -1,10 +1,46 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 )
+
+// default json behaviour is to render nil slices as "null", so we manually
+// set all nil slices in the struct to empty slice
+func MarshalJSON(config IndexConfiguration) ([]byte, error) {
+	nonNil := config
+	if nonNil.IndexJobs == nil {
+		nonNil.IndexJobs = []IndexJob{}
+	}
+	if nonNil.SharedSteps == nil {
+		nonNil.SharedSteps = []DockerStep{}
+	}
+	for idx := range nonNil.SharedSteps {
+		if nonNil.SharedSteps[idx].Commands == nil {
+			nonNil.SharedSteps[idx].Commands = []string{}
+		}
+	}
+	for idx := range nonNil.IndexJobs {
+		if nonNil.IndexJobs[idx].IndexerArgs == nil {
+			nonNil.IndexJobs[idx].IndexerArgs = []string{}
+		}
+		if nonNil.IndexJobs[idx].LocalSteps == nil {
+			nonNil.IndexJobs[idx].LocalSteps = []string{}
+		}
+		if nonNil.IndexJobs[idx].Steps == nil {
+			nonNil.IndexJobs[idx].Steps = []DockerStep{}
+		}
+		for stepIdx := range nonNil.IndexJobs[idx].Steps {
+			if nonNil.IndexJobs[idx].Steps[stepIdx].Commands == nil {
+				nonNil.IndexJobs[idx].Steps[stepIdx].Commands = []string{}
+			}
+		}
+	}
+
+	return json.MarshalIndent(nonNil, "", "    ")
+}
 
 func UnmarshalJSON(data []byte) (IndexConfiguration, error) {
 	configuration := IndexConfiguration{}

--- a/enterprise/internal/codeintel/autoindex/config/json_test.go
+++ b/enterprise/internal/codeintel/autoindex/config/json_test.go
@@ -66,7 +66,7 @@ func TestUnmarshalJSON(t *testing.T) {
 				IndexerArgs: []string{"--no-animation"},
 			},
 			{
-				Steps:       []DockerStep{},
+				Steps:       nil,
 				Root:        "web/",
 				Indexer:     "lsif-tsc",
 				IndexerArgs: []string{"-p", "."},

--- a/enterprise/internal/codeintel/autoindex/config/types.go
+++ b/enterprise/internal/codeintel/autoindex/config/types.go
@@ -1,21 +1,21 @@
 package config
 
 type IndexConfiguration struct {
-	SharedSteps []DockerStep
-	IndexJobs   []IndexJob
+	SharedSteps []DockerStep `json:"shared_steps" yaml:"shared_steps"`
+	IndexJobs   []IndexJob   `json:"index_jobs" yaml:"index_jobs"`
 }
 
 type IndexJob struct {
-	Steps       []DockerStep
-	LocalSteps  []string
-	Root        string
-	Indexer     string
-	IndexerArgs []string
-	Outfile     string
+	Steps       []DockerStep `json:"steps" yaml:"steps"`
+	LocalSteps  []string     `json:"local_steps" yaml:"local_steps"`
+	Root        string       `json:"root" yaml:"root"`
+	Indexer     string       `json:"indexer" yaml:"indexer"`
+	IndexerArgs []string     `json:"indexer_args" yaml:"indexer_args"`
+	Outfile     string       `json:"outfile" yaml:"outfile"`
 }
 
 type DockerStep struct {
-	Root     string
-	Image    string
-	Commands []string
+	Root     string   `json:"root" yaml:"root"`
+	Image    string   `json:"image" yaml:"image"`
+	Commands []string `json:"commands" yaml:"commands"`
 }

--- a/enterprise/internal/codeintel/autoindex/config/yaml.go
+++ b/enterprise/internal/codeintel/autoindex/config/yaml.go
@@ -6,66 +6,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type yamlIndexConfiguration struct {
-	SharedSteps []yamlDockerStep `yaml:"shared_steps"`
-	IndexJobs   []yamlIndexJob   `yaml:"index_jobs"`
-}
-
-type yamlIndexJob struct {
-	Steps       []yamlDockerStep `yaml:"steps"`
-	LocalSteps  []string         `yaml:"local_steps"`
-	Root        string           `yaml:"root"`
-	Indexer     string           `yaml:"indexer"`
-	IndexerArgs []string         `yaml:"indexer_args"`
-	Outfile     string           `yaml:"outfile"`
-}
-
-type yamlDockerStep struct {
-	Root     string   `yaml:"root"`
-	Image    string   `yaml:"image"`
-	Commands []string `yaml:"commands"`
-}
-
 func UnmarshalYAML(data []byte) (IndexConfiguration, error) {
-	configuration := yamlIndexConfiguration{}
+	configuration := IndexConfiguration{}
 	if err := yaml.Unmarshal(data, &configuration); err != nil {
 		return IndexConfiguration{}, fmt.Errorf("invalid YAML: %v", err)
 	}
-
-	var indexJobs []IndexJob
-	for _, value := range configuration.IndexJobs {
-		indexJobs = append(indexJobs, IndexJob{
-			Steps:       convertYAMLDockerSteps(value.Steps),
-			LocalSteps:  value.LocalSteps,
-			Root:        value.Root,
-			Indexer:     value.Indexer,
-			IndexerArgs: sliceize(value.IndexerArgs),
-			Outfile:     value.Outfile,
-		})
-	}
-
-	return IndexConfiguration{
-		SharedSteps: convertYAMLDockerSteps(configuration.SharedSteps),
-		IndexJobs:   indexJobs,
-	}, nil
-}
-
-func convertYAMLDockerSteps(raw []yamlDockerStep) []DockerStep {
-	steps := []DockerStep{}
-	for _, val := range raw {
-		steps = append(steps, DockerStep{
-			Root:     val.Root,
-			Image:    val.Image,
-			Commands: sliceize(val.Commands),
-		})
-	}
-
-	return steps
-}
-
-func sliceize(v []string) []string {
-	if v == nil {
-		return []string{}
-	}
-	return v
+	return configuration, nil
 }

--- a/enterprise/internal/codeintel/autoindex/config/yaml_test.go
+++ b/enterprise/internal/codeintel/autoindex/config/yaml_test.go
@@ -56,7 +56,7 @@ func TestUnmarshalYAML(t *testing.T) {
 				IndexerArgs: []string{"--no-animation"},
 			},
 			{
-				Steps:       []DockerStep{},
+				Steps:       nil,
 				Root:        "web/",
 				Indexer:     "lsif-tsc",
 				IndexerArgs: []string{"-p", "."},

--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -69,7 +69,7 @@ func (s *IndexEnqueuer) InferIndexConfiguration(ctx context.Context, repositoryI
 
 	return &config.IndexConfiguration{
 		SharedSteps: nil,
-		IndexJobs: indexJobs,
+		IndexJobs:   indexJobs,
 	}, nil
 }
 

--- a/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -68,8 +68,7 @@ func (s *IndexEnqueuer) InferIndexConfiguration(ctx context.Context, repositoryI
 	}
 
 	return &config.IndexConfiguration{
-		SharedSteps: nil,
-		IndexJobs:   indexJobs,
+		IndexJobs: indexJobs,
 	}, nil
 }
 

--- a/enterprise/internal/codeintel/autoindex/enqueuer/observability.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/observability.go
@@ -8,7 +8,8 @@ import (
 )
 
 type operations struct {
-	QueueIndex *observation.Operation
+	QueueIndex              *observation.Operation
+	InferIndexConfiguration *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -28,6 +29,7 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
-		QueueIndex: op("QueueIndex"),
+		QueueIndex:              op("QueueIndex"),
+		InferIndexConfiguration: op("InferIndexConfiguration"),
 	}
 }

--- a/enterprise/internal/codeintel/autoindex/inference/go.go
+++ b/enterprise/internal/codeintel/autoindex/inference/go.go
@@ -3,6 +3,8 @@ package inference
 import (
 	"path/filepath"
 	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 )
 
 const lsifGoImage = "sourcegraph/lsif-go:latest"
@@ -21,7 +23,7 @@ func (r lsifGoJobRecognizer) CanIndex(paths []string, gitserver GitserverClientW
 	return false
 }
 
-func (r lsifGoJobRecognizer) InferIndexJobs(paths []string, gitserver GitserverClientWrapper) (indexes []IndexJob) {
+func (r lsifGoJobRecognizer) InferIndexJobs(paths []string, gitserver GitserverClientWrapper) (indexes []config.IndexJob) {
 	for _, path := range paths {
 		if !r.canIndexPath(path) {
 			continue
@@ -29,7 +31,7 @@ func (r lsifGoJobRecognizer) InferIndexJobs(paths []string, gitserver GitserverC
 
 		root := dirWithoutDot(path)
 
-		dockerSteps := []DockerStep{
+		dockerSteps := []config.DockerStep{
 			{
 				Root:     root,
 				Image:    lsifGoImage,
@@ -37,8 +39,8 @@ func (r lsifGoJobRecognizer) InferIndexJobs(paths []string, gitserver GitserverC
 			},
 		}
 
-		indexes = append(indexes, IndexJob{
-			DockerSteps: dockerSteps,
+		indexes = append(indexes, config.IndexJob{
+			Steps:       dockerSteps,
 			Root:        root,
 			Indexer:     lsifGoImage,
 			IndexerArgs: []string{"lsif-go", "--no-animation"},

--- a/enterprise/internal/codeintel/autoindex/inference/go_test.go
+++ b/enterprise/internal/codeintel/autoindex/inference/go_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 )
 
 func TestLSIFGoJobRecognizerCanIndex(t *testing.T) {
@@ -38,9 +39,9 @@ func TestLsifGoJobRecognizerInferIndexJobsGoModRoot(t *testing.T) {
 		"go.mod",
 	}
 
-	expectedIndexJobs := []IndexJob{
+	expectedIndexJobs := []config.IndexJob{
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "",
 					Image:    lsifGoImage,
@@ -66,9 +67,9 @@ func TestLsifGoJobRecognizerInferIndexJobsGoModSubdirs(t *testing.T) {
 		"c/go.mod",
 	}
 
-	expectedIndexJobs := []IndexJob{
+	expectedIndexJobs := []config.IndexJob{
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "a",
 					Image:    lsifGoImage,
@@ -81,7 +82,7 @@ func TestLsifGoJobRecognizerInferIndexJobsGoModSubdirs(t *testing.T) {
 			Outfile:     "",
 		},
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "b",
 					Image:    lsifGoImage,
@@ -94,7 +95,7 @@ func TestLsifGoJobRecognizerInferIndexJobsGoModSubdirs(t *testing.T) {
 			Outfile:     "",
 		},
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "c",
 					Image:    lsifGoImage,

--- a/enterprise/internal/codeintel/autoindex/inference/recognizers.go
+++ b/enterprise/internal/codeintel/autoindex/inference/recognizers.go
@@ -2,6 +2,8 @@ package inference
 
 import (
 	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 )
 
 // IndexJobRecognizer infers index jobs from repository structure.
@@ -14,26 +16,11 @@ type IndexJobRecognizer interface {
 	// correct given the list of file paths that describe a repository.
 	// The given file paths should be all of the file path matches in the
 	// repository that matches any pattern returned from Patterns.
-	InferIndexJobs(paths []string, gitserver GitserverClientWrapper) []IndexJob
+	InferIndexJobs(paths []string, gitserver GitserverClientWrapper) []config.IndexJob
 
 	// Patterns returns a set of regular expressions that match file paths
 	// which are of interest to InferIndexJobs.
 	Patterns() []*regexp.Regexp
-}
-
-type IndexJob struct {
-	DockerSteps []DockerStep
-	LocalSteps  []string
-	Root        string
-	Indexer     string
-	IndexerArgs []string
-	Outfile     string
-}
-
-type DockerStep struct {
-	Root     string
-	Image    string
-	Commands []string
 }
 
 // Recognizers is a list of registered index job recognizers.

--- a/enterprise/internal/codeintel/autoindex/inference/typescript.go
+++ b/enterprise/internal/codeintel/autoindex/inference/typescript.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"path/filepath"
 	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 )
 
 const (
@@ -36,7 +38,7 @@ func (r lsifTscJobRecognizer) CanIndex(paths []string, gitserver GitserverClient
 	return false
 }
 
-func (r lsifTscJobRecognizer) InferIndexJobs(paths []string, gitserver GitserverClientWrapper) (indexes []IndexJob) {
+func (r lsifTscJobRecognizer) InferIndexJobs(paths []string, gitserver GitserverClientWrapper) (indexes []config.IndexJob) {
 	for _, path := range paths {
 		if !r.canIndexPath(path) {
 			continue
@@ -45,7 +47,7 @@ func (r lsifTscJobRecognizer) InferIndexJobs(paths []string, gitserver Gitserver
 		// check first if anywhere along the ancestor path there is a lerna.json
 		isYarn := checkLernaFile(path, paths, gitserver)
 
-		var dockerSteps []DockerStep
+		var dockerSteps []config.DockerStep
 
 		for _, dir := range ancestorDirs(path) {
 			if !contains(paths, filepath.Join(dir, "package.json")) {
@@ -59,7 +61,7 @@ func (r lsifTscJobRecognizer) InferIndexJobs(paths []string, gitserver Gitserver
 				commands = append(commands, "npm install")
 			}
 
-			dockerSteps = append(dockerSteps, DockerStep{
+			dockerSteps = append(dockerSteps, config.DockerStep{
 				Root:     dir,
 				Image:    lsifTscImage,
 				Commands: commands,
@@ -81,7 +83,7 @@ func (r lsifTscJobRecognizer) InferIndexJobs(paths []string, gitserver Gitserver
 			dockerSteps[i], dockerSteps[n-i-1] = dockerSteps[n-i-1], dockerSteps[i]
 		}
 
-		indexes = append(indexes, IndexJob{
+		indexes = append(indexes, config.IndexJob{
 			DockerSteps: dockerSteps,
 			LocalSteps:  localSteps,
 			Root:        dirWithoutDot(path),

--- a/enterprise/internal/codeintel/autoindex/inference/typescript.go
+++ b/enterprise/internal/codeintel/autoindex/inference/typescript.go
@@ -84,7 +84,7 @@ func (r lsifTscJobRecognizer) InferIndexJobs(paths []string, gitserver Gitserver
 		}
 
 		indexes = append(indexes, config.IndexJob{
-			DockerSteps: dockerSteps,
+			Steps:       dockerSteps,
 			LocalSteps:  localSteps,
 			Root:        dirWithoutDot(path),
 			Indexer:     lsifTscImage,

--- a/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
+++ b/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
@@ -342,10 +342,10 @@ func TestLSIFTscNodeVersionInferrence(t *testing.T) {
 		},
 	}
 
-	expectedJobs := [][]IndexJob{
+	expectedJobs := [][]config.IndexJob{
 		{
 			{
-				DockerSteps: []DockerStep{
+				Steps: []config.DockerStep{
 					{
 						Root:     "",
 						Image:    lsifTscImage,
@@ -363,7 +363,7 @@ func TestLSIFTscNodeVersionInferrence(t *testing.T) {
 		},
 		{
 			{
-				DockerSteps: []DockerStep{
+				Steps: []config.DockerStep{
 					{
 						Root:     "",
 						Image:    lsifTscImage,

--- a/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
+++ b/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 )
 
 func TestLSIFTscJobRecognizerCanIndex(t *testing.T) {
@@ -39,9 +40,9 @@ func TestLsifTscJobRecognizerInferIndexJobsTsConfigRoot(t *testing.T) {
 		"tsconfig.json",
 	}
 
-	expectedIndexJobs := []IndexJob{
+	expectedIndexJobs := []config.IndexJob{
 		{
-			DockerSteps: nil,
+			Steps: nil,
 			Root:        "",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},
@@ -61,23 +62,23 @@ func TestLsifTscJobRecognizerInferIndexJobsTsConfigSubdirs(t *testing.T) {
 		"c/tsconfig.json",
 	}
 
-	expectedIndexJobs := []IndexJob{
+	expectedIndexJobs := []config.IndexJob{
 		{
-			DockerSteps: nil,
+			Steps: nil,
 			Root:        "a",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},
 			Outfile:     "",
 		},
 		{
-			DockerSteps: nil,
+			Steps: nil,
 			Root:        "b",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},
 			Outfile:     "",
 		},
 		{
-			DockerSteps: nil,
+			Steps: nil,
 			Root:        "c",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},
@@ -102,9 +103,9 @@ func TestLsifTscJobRecognizerInferIndexJobsInstallSteps(t *testing.T) {
 		"foo/bar/yarn.lock",
 	}
 
-	expectedIndexJobs := []IndexJob{
+	expectedIndexJobs := []config.IndexJob{
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "",
 					Image:    lsifTscImage,
@@ -117,7 +118,7 @@ func TestLsifTscJobRecognizerInferIndexJobsInstallSteps(t *testing.T) {
 			Outfile:     "",
 		},
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "",
 					Image:    lsifTscImage,
@@ -130,7 +131,7 @@ func TestLsifTscJobRecognizerInferIndexJobsInstallSteps(t *testing.T) {
 			Outfile:     "",
 		},
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "",
 					Image:    lsifTscImage,
@@ -148,7 +149,7 @@ func TestLsifTscJobRecognizerInferIndexJobsInstallSteps(t *testing.T) {
 			Outfile:     "",
 		},
 		{
-			DockerSteps: []DockerStep{
+			Steps: []config.DockerStep{
 				{
 					Root:     "",
 					Image:    lsifTscImage,
@@ -241,10 +242,10 @@ func TestLSIFTscLernaConfig(t *testing.T) {
 		},
 	}
 
-	expectedJobs := [][]IndexJob{
+	expectedJobs := [][]config.IndexJob{
 		{
 			{
-				DockerSteps: []DockerStep{
+				Steps: []config.DockerStep{
 					{
 						Root:     "",
 						Image:    lsifTscImage,
@@ -260,7 +261,7 @@ func TestLSIFTscLernaConfig(t *testing.T) {
 		},
 		{
 			{
-				DockerSteps: []DockerStep{
+				Steps: []config.DockerStep{
 					{
 						Root:     "",
 						Image:    lsifTscImage,
@@ -276,7 +277,7 @@ func TestLSIFTscLernaConfig(t *testing.T) {
 		},
 		{
 			{
-				DockerSteps: []DockerStep{
+				Steps: []config.DockerStep{
 					{
 						Root:     "",
 						Image:    lsifTscImage,
@@ -292,7 +293,7 @@ func TestLSIFTscLernaConfig(t *testing.T) {
 		},
 		{
 			{
-				DockerSteps: []DockerStep{
+				Steps: []config.DockerStep{
 					{
 						Root:     "",
 						Image:    lsifTscImage,

--- a/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
+++ b/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
@@ -42,7 +42,7 @@ func TestLsifTscJobRecognizerInferIndexJobsTsConfigRoot(t *testing.T) {
 
 	expectedIndexJobs := []config.IndexJob{
 		{
-			Steps: nil,
+			Steps:       nil,
 			Root:        "",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},
@@ -64,21 +64,21 @@ func TestLsifTscJobRecognizerInferIndexJobsTsConfigSubdirs(t *testing.T) {
 
 	expectedIndexJobs := []config.IndexJob{
 		{
-			Steps: nil,
+			Steps:       nil,
 			Root:        "a",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},
 			Outfile:     "",
 		},
 		{
-			Steps: nil,
+			Steps:       nil,
 			Root:        "b",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},
 			Outfile:     "",
 		},
 		{
-			Steps: nil,
+			Steps:       nil,
 			Root:        "c",
 			Indexer:     lsifTscImage,
 			IndexerArgs: []string{"lsif-tsc", "-p", "."},


### PR DESCRIPTION
closes #17489 

works by: when the frontend requests the index config for a repo, if there's a DB miss then we run the inference engine and render the results as JSON