### PR TITLE
code insights: add dev option to disable code insights backend entirely

### DIFF
--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"os"
+	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/resolvers"
@@ -21,6 +23,11 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 	}
 	if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
 		// Code insights is not supported in single-container Docker demo deployments.
+		return nil
+	}
+	if v, _ := strconv.ParseBool(os.Getenv("DISABLE_CODE_INSIGHTS")); v {
+		// Dev option for disabling code insights. Helpful if e.g. you have issues running the
+		// codeinsights-db or don't want to spend resources on it.
 		return nil
 	}
 	timescale, err := initializeCodeInsightsDB()


### PR DESCRIPTION
It seems that for some reason our PostgresDSN code picks up `PGDATABASE`
when in reality it should only be picking up `CODEINSIGHTS_PGDATABASE` for Garo
as seen in [this Slack thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1611801989103400).

Probably the underlying pgx driver does this, and we just didn't notice it
with codeintel before because it uses the same DB whereas codeinsights does
not.

I will fix that, but this option immediately unblocks Garo and others who
might run into this - and it's a useful escape hatch anyway.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
