### PR TITLE
dev: give codeinsights-db more time to start

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -13,6 +13,7 @@ echo "--- comby install"
 # For code insights test
 ./dev/codeinsights-db.sh &
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
+export DB_STARTUP_TIMEOUT=30s # codeinsights-db needs more time to start in some instances.
 
 # Separate out time for go mod from go test
 echo "--- go mod download"

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -64,6 +64,7 @@ export CODEINTEL_PG_ALLOW_SINGLE_DB=true
 # Code Insights uses a separate database, because it's easier to run TimescaleDB in
 # Docker than install as a Postgres extension in dev environments.
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
+export DB_STARTUP_TIMEOUT=30s # codeinsights-db needs more time to start in some instances.
 
 # Default to "info" level debugging, and "condensed" log format (nice for human readers)
 export SRC_LOG_LEVEL=${SRC_LOG_LEVEL:-info}


### PR DESCRIPTION
The 10s timeout is pretty aggressive when a bunch of services are starting
and leads to codeinsights-db not having enough time to start before the
frontend gives up, so raise it to 30s in dev environments only.

If we had a better way to describe service dependencies with goreman,
we could avoid this - but this seems harmless.

Related to [this Slack thread](https://sourcegraph.slack.com/archives/C07KZF47K/p1611801989103400)

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
