### PR TITLE
search: extract SearchInputs

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -109,7 +109,7 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (_ SearchImplem
 	}
 
 	return &searchResolver{
-		SearchContext: &SearchContext{
+		SearchInputs: &SearchInputs{
 			Query:          queryInfo,
 			OriginalQuery:  args.Query,
 			VersionContext: args.VersionContext,
@@ -238,8 +238,8 @@ func getBoolPtr(b *bool, def bool) bool {
 	return *b
 }
 
-// SearchContext contains fields we set before kicking off search.
-type SearchContext struct {
+// SearchInputs contains fields we set before kicking off search.
+type SearchInputs struct {
 	Query          query.QueryInfo       // the query, either containing and/or expressions or otherwise ordinary
 	OriginalQuery  string                // the raw string of the original search query
 	Pagination     *searchPaginationInfo // pagination information, or nil if the request is not paginated.
@@ -250,7 +250,7 @@ type SearchContext struct {
 
 // searchResolver is a resolver for the GraphQL type `Search`
 type searchResolver struct {
-	*SearchContext
+	*SearchInputs
 	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating search subexpressions.
 
 	// resultChannel if non-nil will send all results we receive down it. See
@@ -329,8 +329,8 @@ func (r *searchResolver) SetStream(c SearchStream) {
 	r.resultChannel = c
 }
 
-func (r *searchResolver) Context() *SearchContext {
-	return r.SearchContext
+func (r *searchResolver) Inputs() *SearchInputs {
+	return r.SearchInputs
 }
 
 // rawQuery returns the original query string input.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -109,16 +109,18 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (_ SearchImplem
 	}
 
 	return &searchResolver{
-		query:          queryInfo,
-		originalQuery:  args.Query,
-		versionContext: args.VersionContext,
-		userSettings:   settings,
-		pagination:     pagination,
-		patternType:    searchType,
-		zoekt:          search.Indexed(),
-		searcherURLs:   search.SearcherURLs(),
-		reposMu:        &sync.Mutex{},
-		resolved:       &searchrepos.Resolved{},
+		SearchContext: &SearchContext{
+			Query:          queryInfo,
+			OriginalQuery:  args.Query,
+			VersionContext: args.VersionContext,
+			UserSettings:   settings,
+			Pagination:     pagination,
+			PatternType:    searchType,
+		},
+		zoekt:        search.Indexed(),
+		searcherURLs: search.SearcherURLs(),
+		reposMu:      &sync.Mutex{},
+		resolved:     &searchrepos.Resolved{},
 	}, nil
 }
 
@@ -236,14 +238,19 @@ func getBoolPtr(b *bool, def bool) bool {
 	return *b
 }
 
+// SearchContext contains fields we set before kicking off search.
+type SearchContext struct {
+	Query          query.QueryInfo       // the query, either containing and/or expressions or otherwise ordinary
+	OriginalQuery  string                // the raw string of the original search query
+	Pagination     *searchPaginationInfo // pagination information, or nil if the request is not paginated.
+	PatternType    query.SearchType
+	VersionContext *string
+	UserSettings   *schema.Settings
+}
+
 // searchResolver is a resolver for the GraphQL type `Search`
 type searchResolver struct {
-	query               query.QueryInfo       // the query, either containing and/or expressions or otherwise ordinary
-	originalQuery       string                // the raw string of the original search query
-	pagination          *searchPaginationInfo // pagination information, or nil if the request is not paginated.
-	patternType         query.SearchType
-	versionContext      *string
-	userSettings        *schema.Settings
+	*SearchContext
 	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating search subexpressions.
 
 	// resultChannel if non-nil will send all results we receive down it. See
@@ -322,14 +329,18 @@ func (r *searchResolver) SetStream(c SearchStream) {
 	r.resultChannel = c
 }
 
+func (r *searchResolver) Context() *SearchContext {
+	return r.SearchContext
+}
+
 // rawQuery returns the original query string input.
 func (r *searchResolver) rawQuery() string {
-	return r.originalQuery
+	return r.OriginalQuery
 }
 
 func (r *searchResolver) countIsSet() bool {
-	count, _ := r.query.StringValues(query.FieldCount)
-	max, _ := r.query.StringValues(query.FieldMax)
+	count, _ := r.Query.StringValues(query.FieldCount)
+	max, _ := r.Query.StringValues(query.FieldMax)
 	return len(count) > 0 || len(max) > 0
 }
 
@@ -337,20 +348,20 @@ const defaultMaxSearchResults = 30
 const maxSearchResultsPerPaginatedRequest = 5000
 
 func (r *searchResolver) maxResults() int32 {
-	if r.pagination != nil {
+	if r.Pagination != nil {
 		// Paginated search requests always consume an entire result set for a
 		// given repository, so we do not want any limit here. See
 		// search_pagination.go for details on why this is necessary .
 		return math.MaxInt32
 	}
-	count, _ := r.query.StringValues(query.FieldCount)
+	count, _ := r.Query.StringValues(query.FieldCount)
 	if len(count) > 0 {
 		n, _ := strconv.Atoi(count[0])
 		if n > 0 {
 			return int32(n)
 		}
 	}
-	max, _ := r.query.StringValues(query.FieldMax)
+	max, _ := r.Query.StringValues(query.FieldMax)
 	if len(max) > 0 {
 		n, _ := strconv.Atoi(max[0])
 		if n > 0 {
@@ -410,21 +421,21 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		}
 	}
 
-	repoFilters, minusRepoFilters := r.query.RegexpPatterns(query.FieldRepo)
+	repoFilters, minusRepoFilters := r.Query.RegexpPatterns(query.FieldRepo)
 	if effectiveRepoFieldValues != nil {
 		repoFilters = effectiveRepoFieldValues
 	}
-	repoGroupFilters, _ := r.query.StringValues(query.FieldRepoGroup)
+	repoGroupFilters, _ := r.Query.StringValues(query.FieldRepoGroup)
 
 	var settingForks, settingArchived bool
-	if v := r.userSettings.SearchIncludeForks; v != nil {
+	if v := r.UserSettings.SearchIncludeForks; v != nil {
 		settingForks = *v
 	}
-	if v := r.userSettings.SearchIncludeArchived; v != nil {
+	if v := r.UserSettings.SearchIncludeArchived; v != nil {
 		settingArchived = *v
 	}
 
-	forkStr, _ := r.query.StringValue(query.FieldFork)
+	forkStr, _ := r.Query.StringValue(query.FieldFork)
 	fork := searchrepos.ParseYesNoOnly(forkStr)
 	if fork == searchrepos.Invalid && !searchrepos.ExactlyOneRepo(repoFilters) && !settingForks {
 		// fork defaults to No unless either of:
@@ -433,7 +444,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		fork = searchrepos.No
 	}
 
-	archivedStr, _ := r.query.StringValue(query.FieldArchived)
+	archivedStr, _ := r.Query.StringValue(query.FieldArchived)
 	archived := searchrepos.ParseYesNoOnly(archivedStr)
 	if archived == searchrepos.Invalid && !searchrepos.ExactlyOneRepo(repoFilters) && !settingArchived {
 		// archived defaults to No unless either of:
@@ -442,14 +453,14 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		archived = searchrepos.No
 	}
 
-	visibilityStr, _ := r.query.StringValue(query.FieldVisibility)
+	visibilityStr, _ := r.Query.StringValue(query.FieldVisibility)
 	visibility := query.ParseVisibility(visibilityStr)
 
-	commitAfter, _ := r.query.StringValue(query.FieldRepoHasCommitAfter)
+	commitAfter, _ := r.Query.StringValue(query.FieldRepoHasCommitAfter)
 
 	var versionContextName string
-	if r.versionContext != nil {
-		versionContextName = *r.versionContext
+	if r.VersionContext != nil {
+		versionContextName = *r.VersionContext
 	}
 
 	tr.LazyPrintf("resolveRepositories - start")
@@ -458,7 +469,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		MinusRepoFilters:   minusRepoFilters,
 		RepoGroupFilters:   repoGroupFilters,
 		VersionContextName: versionContextName,
-		UserSettings:       r.userSettings,
+		UserSettings:       r.UserSettings,
 		OnlyForks:          fork == searchrepos.Only,
 		NoForks:            fork == searchrepos.No,
 		OnlyArchived:       archived == searchrepos.Only,
@@ -466,7 +477,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		OnlyPrivate:        visibility == query.Private,
 		OnlyPublic:         visibility == query.Public,
 		CommitAfter:        commitAfter,
-		Query:              r.query,
+		Query:              r.Query,
 	}
 	resolved, err := searchrepos.ResolveRepositories(ctx, options)
 	tr.LazyPrintf("resolveRepositories - done")
@@ -497,7 +508,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]*se
 	args := search.TextParameters{
 		PatternInfo:     p,
 		RepoPromise:     (&search.Promise{}).Resolve(resolved.RepoRevs),
-		Query:           r.query,
+		Query:           r.Query,
 		UseFullDeadline: r.searchTimeoutFieldSet(),
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -349,7 +349,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 				t.Fatal(err)
 			}
 			sr := searchResolver{
-				SearchContext: &SearchContext{
+				SearchInputs: &SearchInputs{
 					Query: q,
 					UserSettings: &schema.Settings{
 						SearchGlobbing: &test.globbing,

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -349,10 +349,11 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 				t.Fatal(err)
 			}
 			sr := searchResolver{
-				query: q,
-				userSettings: &schema.Settings{
-					SearchGlobbing: &test.globbing,
-				},
+				SearchContext: &SearchContext{
+					Query: q,
+					UserSettings: &schema.Settings{
+						SearchGlobbing: &test.globbing,
+					}},
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -91,28 +91,28 @@ func (r *SearchResultsResolver) PageInfo() *graphqlutil.PageInfo {
 //
 func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchResultsResolver, err error) {
 	start := time.Now()
-	if r.pagination == nil {
+	if r.Pagination == nil {
 		panic("never here: this method should never be called in this state")
 	}
 
 	tr, ctx := trace.New(ctx, "graphql.SearchResults.paginatedResults", r.rawQuery())
-	if r.pagination.cursor != nil {
+	if r.Pagination.cursor != nil {
 		tr.LogFields(
-			otlog.Int("Cursor.RepositoryOffset", int(r.pagination.cursor.RepositoryOffset)),
-			otlog.Int("Cursor.ResultOffset", int(r.pagination.cursor.ResultOffset)),
-			otlog.Bool("Cursor.Finished", r.pagination.cursor.Finished),
+			otlog.Int("Cursor.RepositoryOffset", int(r.Pagination.cursor.RepositoryOffset)),
+			otlog.Int("Cursor.ResultOffset", int(r.Pagination.cursor.ResultOffset)),
+			otlog.Bool("Cursor.Finished", r.Pagination.cursor.Finished),
 		)
 		log15.Info("paginated search continue request",
 			"query", fmt.Sprintf("%q", r.rawQuery()),
-			"RepositoryOffset", int(r.pagination.cursor.RepositoryOffset),
-			"ResultOffset", int(r.pagination.cursor.ResultOffset),
-			"Finished", r.pagination.cursor.Finished,
+			"RepositoryOffset", int(r.Pagination.cursor.RepositoryOffset),
+			"ResultOffset", int(r.Pagination.cursor.ResultOffset),
+			"Finished", r.Pagination.cursor.Finished,
 		)
 	} else {
 		tr.LogFields(otlog.String("Cursor", "nil"))
 		log15.Info("paginated search begin request", "query", fmt.Sprintf("%q", r.rawQuery()))
 	}
-	tr.LogFields(otlog.Int("Limit", int(r.pagination.limit)))
+	tr.LogFields(otlog.Int("Limit", int(r.Pagination.limit)))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -149,7 +149,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	args := search.TextParameters{
 		PatternInfo:     p,
 		RepoPromise:     (&search.Promise{}).Resolve(resolved.RepoRevs),
-		Query:           r.query,
+		Query:           r.Query,
 		UseFullDeadline: false,
 		Zoekt:           r.zoekt,
 		SearcherURLs:    r.searcherURLs,
@@ -177,7 +177,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	})
 
 	common := streaming.Stats{}
-	cursor, results, fileCommon, err := paginatedSearchFilesInRepos(ctx, &args, r.pagination)
+	cursor, results, fileCommon, err := paginatedSearchFilesInRepos(ctx, &args, r.Pagination)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	var alert *searchAlert
 
 	if len(resolved.MissingRepoRevs) > 0 {
-		alert = alertForMissingRepoRevs(r.patternType, resolved.MissingRepoRevs)
+		alert = alertForMissingRepoRevs(r.PatternType, resolved.MissingRepoRevs)
 	}
 
 	log15.Info("next cursor for paginated search request",

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -521,7 +521,7 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			sr := searchResolver{SearchContext: &SearchContext{Query: query}}
+			sr := searchResolver{SearchInputs: &SearchInputs{Query: query}}
 			p, err := sr.getPatternInfo(nil)
 			if err != nil {
 				t.Fatal(err)
@@ -830,7 +830,7 @@ func TestSearchResultsHydration(t *testing.T) {
 		t.Fatal(err)
 	}
 	resolver := &searchResolver{
-		SearchContext: &SearchContext{
+		SearchInputs: &SearchInputs{
 			Query:        q,
 			UserSettings: &schema.Settings{},
 		},
@@ -1063,7 +1063,7 @@ func TestGetExactFilePatterns(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			r := searchResolver{SearchContext: &SearchContext{Query: q, OriginalQuery: tt.in}}
+			r := searchResolver{SearchInputs: &SearchInputs{Query: q, OriginalQuery: tt.in}}
 			if got := r.getExactFilePatterns(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getExactFilePatterns() = %v, want %v", got, tt.want)
 			}
@@ -1264,10 +1264,10 @@ func TestEvaluateAnd(t *testing.T) {
 				t.Fatal(err)
 			}
 			resolver := &searchResolver{
-				SearchContext: &SearchContext{Query: q, UserSettings: &schema.Settings{}},
-				zoekt:         z,
-				reposMu:       &sync.Mutex{},
-				resolved:      &searchrepos.Resolved{},
+				SearchInputs: &SearchInputs{Query: q, UserSettings: &schema.Settings{}},
+				zoekt:        z,
+				reposMu:      &sync.Mutex{},
+				resolved:     &searchrepos.Resolved{},
 			}
 			results, err := resolver.Results(ctx)
 			if err != nil {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -521,7 +521,7 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			sr := searchResolver{query: query}
+			sr := searchResolver{SearchContext: &SearchContext{Query: query}}
 			p, err := sr.getPatternInfo(nil)
 			if err != nil {
 				t.Fatal(err)
@@ -829,7 +829,15 @@ func TestSearchResultsHydration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}, reposMu: &sync.Mutex{}, resolved: &searchrepos.Resolved{}}
+	resolver := &searchResolver{
+		SearchContext: &SearchContext{
+			Query:        q,
+			UserSettings: &schema.Settings{},
+		},
+		zoekt:    z,
+		reposMu:  &sync.Mutex{},
+		resolved: &searchrepos.Resolved{},
+	}
 	results, err := resolver.Results(ctx)
 	if err != nil {
 		t.Fatal("Results:", err)
@@ -1055,7 +1063,7 @@ func TestGetExactFilePatterns(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			r := searchResolver{query: q, originalQuery: tt.in}
+			r := searchResolver{SearchContext: &SearchContext{Query: q, OriginalQuery: tt.in}}
 			if got := r.getExactFilePatterns(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getExactFilePatterns() = %v, want %v", got, tt.want)
 			}
@@ -1255,7 +1263,12 @@ func TestEvaluateAnd(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			resolver := &searchResolver{query: q, zoekt: z, userSettings: &schema.Settings{}, reposMu: &sync.Mutex{}, resolved: &searchrepos.Resolved{}}
+			resolver := &searchResolver{
+				SearchContext: &SearchContext{Query: q, UserSettings: &schema.Settings{}},
+				zoekt:         z,
+				reposMu:       &sync.Mutex{},
+				resolved:      &searchrepos.Resolved{},
+			}
 			results, err := resolver.Results(ctx)
 			if err != nil {
 				t.Fatal("Results:", err)

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -92,7 +92,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	resolver := &searchResolver{
-		SearchContext: &SearchContext{
+		SearchInputs: &SearchInputs{
 			Query:        q,
 			PatternType:  query.SearchTypeStructural,
 			UserSettings: &schema.Settings{},

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -92,11 +92,13 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	resolver := &searchResolver{
-		query:        q,
-		patternType:  query.SearchTypeStructural,
+		SearchContext: &SearchContext{
+			Query:        q,
+			PatternType:  query.SearchTypeStructural,
+			UserSettings: &schema.Settings{},
+		},
 		zoekt:        z,
 		searcherURLs: endpoint.Static("test"),
-		userSettings: &schema.Settings{},
 		reposMu:      &sync.Mutex{},
 		resolved:     &repos.Resolved{},
 	}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -48,21 +48,21 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 	// If globbing is activated, convert regex patterns of repo, file, and repohasfile
 	// from "field:^foo$" to "field:^foo".
 	globbing := false
-	if getBoolPtr(r.userSettings.SearchGlobbing, false) {
+	if getBoolPtr(r.UserSettings.SearchGlobbing, false) {
 		globbing = true
 	}
-	if AndOrQuery, isAndOr := r.query.(*query.AndOrQuery); globbing && isAndOr {
+	if AndOrQuery, isAndOr := r.Query.(*query.AndOrQuery); globbing && isAndOr {
 		AndOrQuery.Query = query.FuzzifyRegexPatterns(AndOrQuery.Query)
 	}
 
 	args.applyDefaultsAndConstraints()
 
-	if len(r.query.ParseTree()) == 0 {
+	if len(r.Query.ParseTree()) == 0 {
 		return nil, nil
 	}
 
 	// Only suggest for type:file.
-	typeValues, _ := r.query.StringValues(query.FieldType)
+	typeValues, _ := r.Query.StringValues(query.FieldType)
 	for _, resultType := range typeValues {
 		if resultType != "file" {
 			return nil, nil
@@ -80,10 +80,10 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		// * If only repo fields (except 1 term in query), show repo suggestions.
 
 		var effectiveRepoFieldValues []string
-		if len(r.query.Values(query.FieldDefault)) == 1 && (len(r.query.Fields()) == 1 || (len(r.query.Fields()) == 2 && len(r.query.Values(query.FieldRepoGroup)) == 1)) {
-			effectiveRepoFieldValues = append(effectiveRepoFieldValues, r.query.Values(query.FieldDefault)[0].ToString())
-		} else if len(r.query.Values(query.FieldRepo)) > 0 && ((len(r.query.Values(query.FieldRepoGroup)) > 0 && len(r.query.Fields()) == 2) || (len(r.query.Values(query.FieldRepoGroup)) == 0 && len(r.query.Fields()) == 1)) {
-			effectiveRepoFieldValues, _ = r.query.RegexpPatterns(query.FieldRepo)
+		if len(r.Query.Values(query.FieldDefault)) == 1 && (len(r.Query.Fields()) == 1 || (len(r.Query.Fields()) == 2 && len(r.Query.Values(query.FieldRepoGroup)) == 1)) {
+			effectiveRepoFieldValues = append(effectiveRepoFieldValues, r.Query.Values(query.FieldDefault)[0].ToString())
+		} else if len(r.Query.Values(query.FieldRepo)) > 0 && ((len(r.Query.Values(query.FieldRepoGroup)) > 0 && len(r.Query.Fields()) == 2) || (len(r.Query.Values(query.FieldRepoGroup)) == 0 && len(r.Query.Fields()) == 1)) {
+			effectiveRepoFieldValues, _ = r.Query.RegexpPatterns(query.FieldRepo)
 		}
 
 		// If we have a query which is not valid, just ignore it since this is for a suggestion.
@@ -121,9 +121,9 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		// If only repos/repogroups and files are specified (and at most 1 term), then show file
 		// suggestions.  If the query has a single term, then consider it to be a `file:` filter (to
 		// make it easy to jump to files by just typing in their name, not `file:<their name>`).
-		hasOnlyEmptyRepoField := len(r.query.Values(query.FieldRepo)) > 0 && allEmptyStrings(r.query.RegexpPatterns(query.FieldRepo)) && len(r.query.Fields()) == 1
-		hasRepoOrFileFields := len(r.query.Values(query.FieldRepoGroup)) > 0 || len(r.query.Values(query.FieldRepo)) > 0 || len(r.query.Values(query.FieldFile)) > 0
-		if !hasOnlyEmptyRepoField && hasRepoOrFileFields && len(r.query.Values(query.FieldDefault)) <= 1 {
+		hasOnlyEmptyRepoField := len(r.Query.Values(query.FieldRepo)) > 0 && allEmptyStrings(r.Query.RegexpPatterns(query.FieldRepo)) && len(r.Query.Fields()) == 1
+		hasRepoOrFileFields := len(r.Query.Values(query.FieldRepoGroup)) > 0 || len(r.Query.Values(query.FieldRepo)) > 0 || len(r.Query.Values(query.FieldFile)) > 0
+		if !hasOnlyEmptyRepoField && hasRepoOrFileFields && len(r.Query.Values(query.FieldDefault)) <= 1 {
 			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 			defer cancel()
 			return r.suggestFilePaths(ctx, maxSearchSuggestions)
@@ -140,10 +140,10 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		// The "repo:" field must be specified for showing language suggestions.
 		// For performance reasons, only try to get languages of the first repository found
 		// within the scope of the "repo:" field value.
-		if len(r.query.Values(query.FieldRepo)) == 0 {
+		if len(r.Query.Values(query.FieldRepo)) == 0 {
 			return nil, nil
 		}
-		effectiveRepoFieldValues, _ := r.query.RegexpPatterns(query.FieldRepo)
+		effectiveRepoFieldValues, _ := r.Query.RegexpPatterns(query.FieldRepo)
 
 		validValues := effectiveRepoFieldValues[:0]
 		for _, v := range effectiveRepoFieldValues {
@@ -219,7 +219,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		fileMatches, _, err := searchSymbols(ctx, &search.TextParameters{
 			PatternInfo:  p,
 			RepoPromise:  (&search.Promise{}).Resolve(resolved.RepoRevs),
-			Query:        r.query,
+			Query:        r.Query,
 			Zoekt:        r.zoekt,
 			SearcherURLs: r.searcherURLs,
 		}, 7)
@@ -271,7 +271,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		// to avoid delaying repo and file suggestions for too long.
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
-		if len(r.query.Values(query.FieldDefault)) > 0 {
+		if len(r.Query.Values(query.FieldDefault)) > 0 {
 			results, err := r.doResults(ctx, "file") // only "file" result type
 			if err == context.DeadlineExceeded {
 				err = nil // don't log as error below

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -544,7 +544,7 @@ func TestVersionContext(t *testing.T) {
 			}
 
 			resolver := searchResolver{
-				SearchContext: &SearchContext{
+				SearchInputs: &SearchInputs{
 					Query:          qinfo,
 					VersionContext: &tc.versionContext,
 					UserSettings:   &schema.Settings{},

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -544,11 +544,13 @@ func TestVersionContext(t *testing.T) {
 			}
 
 			resolver := searchResolver{
-				query:          qinfo,
-				versionContext: &tc.versionContext,
-				userSettings:   &schema.Settings{},
-				reposMu:        &sync.Mutex{},
-				resolved:       &searchrepos.Resolved{},
+				SearchContext: &SearchContext{
+					Query:          qinfo,
+					VersionContext: &tc.versionContext,
+					UserSettings:   &schema.Settings{},
+				},
+				reposMu:  &sync.Mutex{},
+				resolved: &searchrepos.Resolved{},
 			}
 
 			database.Mocks.Repos.ListRepoNames = func(ctx context.Context, opts database.ReposListOptions) ([]*types.RepoName, error) {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -740,7 +740,7 @@ func BenchmarkSearchResults(b *testing.B) {
 			b.Fatal(err)
 		}
 		resolver := &searchResolver{
-			SearchContext: &SearchContext{
+			SearchInputs: &SearchInputs{
 				Query:        q,
 				UserSettings: &schema.Settings{},
 			},
@@ -818,7 +818,7 @@ func BenchmarkIntegrationSearchResults(b *testing.B) {
 			b.Fatal(err)
 		}
 		resolver := &searchResolver{
-			SearchContext: &SearchContext{
+			SearchInputs: &SearchInputs{
 				Query: q,
 			},
 			zoekt:    z,

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -740,11 +740,13 @@ func BenchmarkSearchResults(b *testing.B) {
 			b.Fatal(err)
 		}
 		resolver := &searchResolver{
-			query:        q,
-			zoekt:        z,
-			userSettings: &schema.Settings{},
-			reposMu:      &sync.Mutex{},
-			resolved:     &searchrepos.Resolved{},
+			SearchContext: &SearchContext{
+				Query:        q,
+				UserSettings: &schema.Settings{},
+			},
+			zoekt:    z,
+			reposMu:  &sync.Mutex{},
+			resolved: &searchrepos.Resolved{},
 		}
 		results, err := resolver.Results(ctx)
 		if err != nil {
@@ -815,7 +817,14 @@ func BenchmarkIntegrationSearchResults(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		resolver := &searchResolver{query: q, zoekt: z, reposMu: &sync.Mutex{}, resolved: &searchrepos.Resolved{}}
+		resolver := &searchResolver{
+			SearchContext: &SearchContext{
+				Query: q,
+			},
+			zoekt:    z,
+			reposMu:  &sync.Mutex{},
+			resolved: &searchrepos.Resolved{},
+		}
 		results, err := resolver.Results(ctx)
 		if err != nil {
 			b.Fatal("Results:", err)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -62,7 +62,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = eventWriter.Event("error", err.Error())
 		return
 	}
-
 	resultsStream, resultsStreamDone := newResultsStream(ctx, search)
 
 	progress := progressAggregator{
@@ -202,6 +201,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type searchResolver interface {
 	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
 	SetStream(c graphqlbackend.SearchStream)
+	Context() *graphqlbackend.SearchContext
 }
 
 func defaultNewSearchResolver(ctx context.Context, args *graphqlbackend.SearchArgs) (searchResolver, error) {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -201,7 +201,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type searchResolver interface {
 	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
 	SetStream(c graphqlbackend.SearchStream)
-	Context() *graphqlbackend.SearchContext
+	Inputs() *graphqlbackend.SearchInputs
 }
 
 func defaultNewSearchResolver(ctx context.Context, args *graphqlbackend.SearchArgs) (searchResolver, error) {

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -78,6 +78,6 @@ func (h *mockSearchResolver) Close() {
 	close(h.done)
 }
 
-func (h *mockSearchResolver) Context() *graphqlbackend.SearchContext {
-	return &graphqlbackend.SearchContext{}
+func (h *mockSearchResolver) Inputs() *graphqlbackend.SearchInputs {
+	return &graphqlbackend.SearchInputs{}
 }

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -77,3 +77,7 @@ func (h *mockSearchResolver) Send(r []graphqlbackend.SearchResultResolver) {
 func (h *mockSearchResolver) Close() {
 	close(h.done)
 }
+
+func (h *mockSearchResolver) Context() *graphqlbackend.SearchContext {
+	return &graphqlbackend.SearchContext{}
+}


### PR DESCRIPTION
This is a mechanical refactor that extracts read-only fields from
searchResolver and exports them. We also update the interface
`searchResolver` so that we can access the SearchContext from the
streaming consumer.

The purpose of this refactor is to make meta fields like `query` and
`patternType` accessible for alert creation in streaming.

The key change is in graphqlbackend/search.go type `searchResolver`.

The naming is obviously terrible, suggestions are welcome!



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
