### PR TITLE
frontend: manually initialize the router

### DIFF
--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router"
 	uirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui/router"
 	"github.com/sourcegraph/sourcegraph/internal/actor"

--- a/cmd/frontend/auth/non_public_test.go
+++ b/cmd/frontend/auth/non_public_test.go
@@ -8,15 +8,14 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
-	// Import for side effects so that the UI router gets created and is accessible in the
-	// ../app/ui/router package's Router var.
-	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func TestAllowAnonymousRequest(t *testing.T) {
+	ui.InitRouter()
 	// Ensure auth.public is false (be robust against some other tests having side effects that
 	// change it, or changed defaults).
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthPublic: false, AuthProviders: []schema.AuthProviders{{Builtin: &schema.BuiltinAuthProvider{}}}}})
@@ -54,6 +53,7 @@ func TestAllowAnonymousRequest(t *testing.T) {
 }
 
 func TestNewUserRequiredAuthzMiddleware(t *testing.T) {
+	ui.InitRouter()
 	// Ensure auth.public is false (be robust against some other tests having side effects that
 	// change it, or changed defaults).
 	conf.Mock(&conf.Unified{SiteConfiguration: schema.SiteConfiguration{AuthPublic: false, AuthProviders: []schema.AuthProviders{{Builtin: &schema.BuiltinAuthProvider{}}}}})

--- a/cmd/frontend/internal/app/ui/handlers_test.go
+++ b/cmd/frontend/internal/app/ui/handlers_test.go
@@ -30,6 +30,7 @@ func TestRedirects(t *testing.T) {
 	check := func(t *testing.T, path string, wantStatusCode int, wantRedirectLocation string, userAgent string) {
 		t.Helper()
 
+		InitRouter()
 		rw := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", path, nil)
 		req.Header.Set("User-Agent", userAgent)

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -102,6 +102,14 @@ func Router() *mux.Router {
 	return uirouter.Router
 }
 
+// InitRouter create the router that serves pages for our web app
+// and assigns it to uirouter.Router.
+// The router can be accessed by calling Router().
+func InitRouter() {
+	router := newRouter()
+	initRouter(router)
+}
+
 var mockServeRepo func(w http.ResponseWriter, r *http.Request)
 
 func newRouter() *mux.Router {
@@ -183,10 +191,6 @@ func newRouter() *mux.Router {
 	return r
 }
 
-func init() {
-	initRouter()
-}
-
 // brandNameSubtitle returns a string with the specified title sequence and the brand name as the
 // last title component. This function indirectly calls conf.Get(), so should not be invoked from
 // any function that is invoked by an init function.
@@ -194,10 +198,10 @@ func brandNameSubtitle(titles ...string) string {
 	return strings.Join(append(titles, globals.Branding().BrandName), " - ")
 }
 
-func initRouter() {
-	// basic pages with static titles
-	router := newRouter()
+func initRouter(router *mux.Router) {
 	uirouter.Router = router // make accessible to other packages
+
+	// basic pages with static titles
 	router.Get(routeHome).Handler(handler(serveHome))
 	router.Get(routeThreads).Handler(handler(serveBrandedPageString("Threads", nil)))
 	router.Get(routeInsights).Handler(handler(serveBrandedPageString("Insights", nil)))

--- a/cmd/frontend/internal/app/ui/router_test.go
+++ b/cmd/frontend/internal/app/ui/router_test.go
@@ -22,12 +22,10 @@ import (
 func init() {
 	// Enable SourcegraphDotComMode for all tests in this package.
 	envvar.MockSourcegraphDotComMode(true)
-
-	// Reinit router
-	initRouter()
 }
 
 func TestRouter(t *testing.T) {
+	router := Router()
 	tests := []struct {
 		path      string
 		wantRoute string
@@ -196,7 +194,7 @@ func TestRouter(t *testing.T) {
 				routeMatch mux.RouteMatch
 				routeName  string
 			)
-			match := Router().Match(&http.Request{Method: "GET", URL: &url.URL{Path: tst.path}}, &routeMatch)
+			match := router.Match(&http.Request{Method: "GET", URL: &url.URL{Path: tst.path}}, &routeMatch)
 			if match {
 				routeName = routeMatch.Route.GetName()
 			}
@@ -211,6 +209,8 @@ func TestRouter(t *testing.T) {
 }
 
 func TestRouter_RootPath(t *testing.T) {
+	router := Router()
+
 	tests := []struct {
 		repo   api.RepoName
 		exists bool
@@ -247,7 +247,7 @@ func TestRouter_RootPath(t *testing.T) {
 			// Perform a request that we expect to redirect to the about subdomain.
 			rec := httptest.NewRecorder()
 			req := &http.Request{Method: "GET", URL: &url.URL{Path: "/" + string(tst.repo)}}
-			Router().ServeHTTP(rec, req)
+			router.ServeHTTP(rec, req)
 			if !tst.exists {
 				// expecting redirect
 				if rec.Code != http.StatusTemporaryRedirect {

--- a/cmd/frontend/internal/app/ui/router_test.go
+++ b/cmd/frontend/internal/app/ui/router_test.go
@@ -25,6 +25,7 @@ func init() {
 }
 
 func TestRouter(t *testing.T) {
+	InitRouter()
 	router := Router()
 	tests := []struct {
 		path      string
@@ -209,6 +210,7 @@ func TestRouter(t *testing.T) {
 }
 
 func TestRouter_RootPath(t *testing.T) {
+	InitRouter()
 	router := Router()
 
 	tests := []struct {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/updatecheck"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/bg"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli/loghandlers"
@@ -129,6 +130,8 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 	if err != nil {
 		log.Fatalf("ERROR: %v", err)
 	}
+
+	ui.InitRouter()
 
 	if err := handleConfigOverrides(); err != nil {
 		log.Fatal("applying config overrides:", err)


### PR DESCRIPTION
The frontend router is now initialized manually in the main function, making it easier to inject dependencies to the handlers.