### PR TITLE
campaigns: Extend campaign spec schema with `workspaces`

### DIFF
--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -56,6 +56,28 @@
         ]
       }
     },
+    "workspaces": {
+      "type": "array",
+      "description": "Different workspace configurations",
+      "items": {
+        "title": "WorkspaceConfiguration",
+        "type": "object",
+        "description": "Configuration for how to setup workspaces in repositories",
+        "additionalProperties": false,
+        "required": ["rootAtLocationOf"],
+        "properties": {
+          "rootAtLocationOf": {
+            "type": "string",
+            "description": "The name of the file that sits at the root of the desired workspace"
+          },
+          "in": {
+            "type": "string",
+            "description": "The repositories in which to apply the workspace configuration",
+            "examples": ["github.com/sourcegraph/*"]
+          }
+        }
+      }
+    },
     "steps": {
       "type": "array",
       "description": "The sequence of commands to run (for each repository branch matched in the `on` property) to produce the campaign's changes.",
@@ -85,7 +107,7 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}" ]
                 },
                 "format": {
                   "type": "string",
@@ -128,7 +150,7 @@
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": { "type": "string" }
+            "additionalProperties": {"type": "string"}
           }
         }
       }
@@ -243,9 +265,7 @@
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": {
-                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
-                },
+                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -58,7 +58,7 @@
     },
     "workspaces": {
       "type": "array",
-      "description": "Different workspace configurations",
+      "description": "Individual workspace configurations for one or more repositories that define which workspaces to use for the execution of steps in the repositories.",
       "items": {
         "title": "WorkspaceConfiguration",
         "type": "object",
@@ -68,12 +68,13 @@
         "properties": {
           "rootAtLocationOf": {
             "type": "string",
-            "description": "The name of the file that sits at the root of the desired workspace"
+            "description": "The name of the file that sits at the root of the desired workspace.",
+            "examples": ["package.json", "go.mod", "Gemfile", "Cargo.toml", "README.md"]
           },
           "in": {
             "type": "string",
-            "description": "The repositories in which to apply the workspace configuration",
-            "examples": ["github.com/sourcegraph/*"]
+            "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
+            "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
           }
         }
       }

--- a/schema/campaign_spec.schema.json
+++ b/schema/campaign_spec.schema.json
@@ -107,7 +107,7 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}" ]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",
@@ -150,7 +150,7 @@
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": {"type": "string"}
+            "additionalProperties": { "type": "string" }
           }
         }
       }
@@ -265,7 +265,9 @@
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
+                "additionalProperties": {
+                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
+                },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -61,6 +61,28 @@ const CampaignSpecSchemaJSON = `{
         ]
       }
     },
+    "workspaces": {
+      "type": "array",
+      "description": "Different workspace configurations",
+      "items": {
+        "title": "WorkspaceConfiguration",
+        "type": "object",
+        "description": "Configuration for how to setup workspaces in repositories",
+        "additionalProperties": false,
+        "required": ["rootAtLocationOf"],
+        "properties": {
+          "rootAtLocationOf": {
+            "type": "string",
+            "description": "The name of the file that sits at the root of the desired workspace"
+          },
+          "in": {
+            "type": "string",
+            "description": "The repositories in which to apply the workspace configuration",
+            "examples": ["github.com/sourcegraph/*"]
+          }
+        }
+      }
+    },
     "steps": {
       "type": "array",
       "description": "The sequence of commands to run (for each repository branch matched in the ` + "`" + `on` + "`" + ` property) to produce the campaign's changes.",
@@ -90,7 +112,7 @@ const CampaignSpecSchemaJSON = `{
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}" ]
                 },
                 "format": {
                   "type": "string",
@@ -133,7 +155,7 @@ const CampaignSpecSchemaJSON = `{
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": { "type": "string" }
+            "additionalProperties": {"type": "string"}
           }
         }
       }
@@ -248,9 +270,7 @@ const CampaignSpecSchemaJSON = `{
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": {
-                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
-                },
+                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -112,7 +112,7 @@ const CampaignSpecSchemaJSON = `{
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}" ]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",
@@ -155,7 +155,7 @@ const CampaignSpecSchemaJSON = `{
           "files": {
             "type": "object",
             "description": "Files that should be mounted into or be created inside the Docker container.",
-            "additionalProperties": {"type": "string"}
+            "additionalProperties": { "type": "string" }
           }
         }
       }
@@ -270,7 +270,9 @@ const CampaignSpecSchemaJSON = `{
               "items": {
                 "type": "object",
                 "description": "An object with one field: the key is the glob pattern to match against repository names; the value will be used as the published flag for matching repositories.",
-                "additionalProperties": { "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }] },
+                "additionalProperties": {
+                  "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }]
+                },
                 "minProperties": 1,
                 "maxProperties": 1
               }

--- a/schema/campaign_spec_stringdata.go
+++ b/schema/campaign_spec_stringdata.go
@@ -63,7 +63,7 @@ const CampaignSpecSchemaJSON = `{
     },
     "workspaces": {
       "type": "array",
-      "description": "Different workspace configurations",
+      "description": "Individual workspace configurations for one or more repositories that define which workspaces to use for the execution of steps in the repositories.",
       "items": {
         "title": "WorkspaceConfiguration",
         "type": "object",
@@ -73,12 +73,13 @@ const CampaignSpecSchemaJSON = `{
         "properties": {
           "rootAtLocationOf": {
             "type": "string",
-            "description": "The name of the file that sits at the root of the desired workspace"
+            "description": "The name of the file that sits at the root of the desired workspace.",
+            "examples": ["package.json", "go.mod", "Gemfile", "Cargo.toml", "README.md"]
           },
           "in": {
             "type": "string",
-            "description": "The repositories in which to apply the workspace configuration",
-            "examples": ["github.com/sourcegraph/*"]
+            "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
+            "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
           }
         }
       }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -325,6 +325,8 @@ type CampaignSpec struct {
 	Steps []*Step `json:"steps,omitempty"`
 	// TransformChanges description: Optional transformations to apply to the changes produced in each repository.
 	TransformChanges *TransformChanges `json:"transformChanges,omitempty"`
+	// Workspaces description: Different workspace configurations
+	Workspaces []*WorkspaceConfiguration `json:"workspaces,omitempty"`
 }
 
 // ChangesetTemplate description: A template describing how to create (and update) changesets with the file changes produced by the command steps.
@@ -1357,4 +1359,12 @@ type VersionContextRevision struct {
 type Webhooks struct {
 	// Secret description: Secret for authenticating incoming webhook payloads
 	Secret string `json:"secret,omitempty"`
+}
+
+// WorkspaceConfiguration description: Configuration for how to setup workspaces in repositories
+type WorkspaceConfiguration struct {
+	// In description: The repositories in which to apply the workspace configuration
+	In string `json:"in,omitempty"`
+	// RootAtLocationOf description: The name of the file that sits at the root of the desired workspace
+	RootAtLocationOf string `json:"rootAtLocationOf"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -325,7 +325,7 @@ type CampaignSpec struct {
 	Steps []*Step `json:"steps,omitempty"`
 	// TransformChanges description: Optional transformations to apply to the changes produced in each repository.
 	TransformChanges *TransformChanges `json:"transformChanges,omitempty"`
-	// Workspaces description: Different workspace configurations
+	// Workspaces description: Individual workspace configurations for one or more repositories that define which workspaces to use for the execution of steps in the repositories.
 	Workspaces []*WorkspaceConfiguration `json:"workspaces,omitempty"`
 }
 
@@ -1363,8 +1363,8 @@ type Webhooks struct {
 
 // WorkspaceConfiguration description: Configuration for how to setup workspaces in repositories
 type WorkspaceConfiguration struct {
-	// In description: The repositories in which to apply the workspace configuration
+	// In description: The repositories in which to apply the workspace configuration. Supports globbing.
 	In string `json:"in,omitempty"`
-	// RootAtLocationOf description: The name of the file that sits at the root of the desired workspace
+	// RootAtLocationOf description: The name of the file that sits at the root of the desired workspace.
 	RootAtLocationOf string `json:"rootAtLocationOf"`
 }


### PR DESCRIPTION
This PR contains the schema changes necessary for the automatic workspace discovery implemented in https://github.com/sourcegraph/src-cli/pull/442.