### PR TITLE
search: streaming's searchResolver is a subset of SearchImplementer

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -49,6 +49,9 @@ type SearchImplementer interface {
 	Suggestions(context.Context, *searchSuggestionsArgs) ([]*searchSuggestionResolver, error)
 	//lint:ignore U1000 is used by graphql via reflection
 	Stats(context.Context) (*searchResultsStats, error)
+
+	SetStream(c SearchStream)
+	Inputs() *SearchInputs
 }
 
 // NewSearchImplementer returns a SearchImplementer that provides search results and suggestions.

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -671,3 +671,8 @@ func (searchAlert) Suggestions(context.Context, *searchSuggestionsArgs) ([]*sear
 	return nil, nil
 }
 func (searchAlert) Stats(context.Context) (*searchResultsStats, error) { return nil, nil }
+
+func (searchAlert) SetStream(c SearchStream) {}
+func (searchAlert) Inputs() *SearchInputs {
+	return nil
+}


### PR DESCRIPTION
This prevents runtime bugs where NewSearchImplementer returns something
which doesn't implement SetStream. Going forward we should probably
rethink having searchAlert being a SearchImplementer.

Co-authored-by: @eseliger

Fixes https://github.com/sourcegraph/sourcegraph/issues/17703