### PR TITLE
search: always send done event at end of stream

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -49,6 +49,10 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Always send a final done event so clients know the stream is shutting
+	// down.
+	defer eventWriter.Event("done", map[string]interface{}{})
+
 	// Log events to trace
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
@@ -193,9 +197,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	pr := progress.Build()
 	pr.Done = true
 	_ = eventWriter.Event("progress", pr)
-
-	// TODO done event includes progress
-	_ = eventWriter.Event("done", map[string]interface{}{})
 }
 
 type searchResolver interface {


### PR DESCRIPTION
Right now the webapp client expects the last event to be done. Right now
if we return an error we don't send done, leading to the webapp
reporting the connection failed rather than the error. Done always being
sent feels like the right thing since SSE doesn't have a way to signal a
clean shutdown.

Co-authored-by: @eseliger 

Part of https://github.com/sourcegraph/sourcegraph/issues/17703