### PR TITLE
search: do not aggregate results if streaming

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1492,8 +1492,13 @@ func newAggregator(ctx context.Context, stream SearchStream, inputs *SearchInput
 			if event.Error != nil && isContextError(ctx, event.Error) {
 				event.Error = nil
 			}
+
+			// Do not aggregate results if we are streaming.
+			if stream == nil {
+				agg.results = append(agg.results, event.Results...)
+			}
+
 			agg.alert.Update(event)
-			agg.results = append(agg.results, event.Results...)
 			agg.common.Update(&event.Stats)
 			if stream != nil {
 				stream <- event


### PR DESCRIPTION
We don't need to build up the list of results in memory of we are
streaming them out. Previously alerts and filters depended on the list
of results. However, both have been changed to consume events.

Fixes https://github.com/sourcegraph/sourcegraph/issues/17767