### PR TITLE
Preserve formatting and comments when redacting secrets, test all external service kinds

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -190,10 +190,15 @@ func (e *ExternalServiceStore) ValidateConfig(ctx context.Context, opt ValidateE
 		return nil, errors.Wrapf(err, "unable to normalize JSON")
 	}
 
+	// Check for any redacted secrets, in graphqlbackend/external_service.go:externalServiceByID() we call
+	// svc.RedactConfig() replacing any secret fields in the JSON with types.RedactedSecret, this is to
+	// prevent us leaking tokens that users add. Here we check that the config we've been passed doesn't
+	// contain any redacted secrets in order to avoid breaking configs by writing the redacted version to
+	// the database. we should have called svc.UnredactConfig(oldSvc) before this point, eg in the Update
+	// method of the ExternalServiceStore. talk to @arussellsaw or the cloud team if you have any questions
 	if bytes.Contains(normalized, []byte(types.RedactedSecret)) {
 		return nil, errors.Errorf(
-			"found unexpected Redacted string: %q, has ExternalService.UnredactConfig been called before attempting to write?",
-			types.RedactedSecret,
+			"unable to write external service config as it contains redacted fields, this is likely a bug rather than a problem with your config",
 		)
 	}
 
@@ -666,6 +671,15 @@ func (e *ExternalServiceStore) Update(ctx context.Context, ps []schema.AuthProvi
 		if err != nil {
 			return err
 		}
+		newSvc := types.ExternalService{
+			Kind:   externalService.Kind,
+			Config: *update.Config,
+		}
+		err = newSvc.UnredactConfig(externalService)
+		if err != nil {
+			return errors.Wrapf(err, "error unredacting config")
+		}
+		update.Config = &newSvc.Config
 
 		normalized, err = e.ValidateConfig(ctx, ValidateExternalServiceConfigOptions{
 			ExternalServiceID: id,

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -229,19 +229,13 @@ func TestExternalServicesStore_ValidateConfig(t *testing.T) {
 			name:    "1 errors - GitHub.com",
 			kind:    extsvc.KindGitHub,
 			config:  `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "` + types.RedactedSecret + `"}`,
-			wantErr: "found unexpected Redacted string: \"" + types.RedactedSecret + "\", has ExternalService.UnredactConfig been called before attempting to write?",
+			wantErr: "unable to write external service config as it contains redacted fields, this is likely a bug rather than a problem with your config",
 		},
 		{
 			name:    "1 errors - GitLab.com",
 			kind:    extsvc.KindGitLab,
 			config:  `{"url": "https://github.com", "projectQuery": ["none"], "token": "` + types.RedactedSecret + `"}`,
-			wantErr: "found unexpected Redacted string: \"" + types.RedactedSecret + "\", has ExternalService.UnredactConfig been called before attempting to write?",
-		},
-		{
-			name:    "0 errors - potentially redacted string",
-			kind:    extsvc.KindGitHub,
-			config:  `{"url": "https://github.com", "repositoryQuery": ["github.com/srcgraph_redacted"], "token": "abc"}`,
-			wantErr: "<nil>",
+			wantErr: "unable to write external service config as it contains redacted fields, this is likely a bug rather than a problem with your config",
 		},
 	}
 	for _, test := range tests {

--- a/internal/jsonc/jsonc.go
+++ b/internal/jsonc/jsonc.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/jsonx"
 )
 
@@ -69,6 +71,17 @@ func Edit(input string, v interface{}, path ...string) (string, error) {
 	}
 
 	return jsonx.ApplyEdits(input, edits...)
+}
+
+// ReadProperty attempts to read the value of the specified path, ignoring parse errors. it will only error if the path
+// doesn't exist
+func ReadProperty(input, path string) (interface{}, error) {
+	root, _ := jsonx.ParseTree(input, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
+	node := jsonx.FindNodeAtLocation(root, jsonx.PropertyPath(path))
+	if node == nil {
+		return nil, errors.Errorf("couldn't find node: %s", path)
+	}
+	return node.Value, nil
 }
 
 // Format returns the input JSON formatted with the given options.

--- a/internal/types/secret_test.go
+++ b/internal/types/secret_test.go
@@ -4,81 +4,188 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
+var newValue = "a different value"
+
 func TestRoundTripRedactExternalServiceConfig(t *testing.T) {
-	// this test simulates the round trip of a user editing external service config via our APIs
 	someSecret := "this is a secret, i hope no one steals it"
-	cfg := schema.GitHubConnection{
+	githubConfig := schema.GitHubConnection{
 		Token: someSecret,
-		Repos: []string{
-			"foo",
-			"bar",
+		Url:   "https://github.com",
+	}
+	gitlabConfig := schema.GitLabConnection{
+		Token: someSecret,
+		Url:   "https://gitlab.com",
+	}
+	bitbucketCloudConfig := schema.BitbucketCloudConnection{
+		AppPassword: someSecret,
+		Url:         "https://bitbucket.com",
+	}
+	bitbucketServerConfig := schema.BitbucketServerConnection{
+		Password: someSecret,
+		Token:    someSecret,
+		Url:      "https://bitbucket.com",
+	}
+	awsCodeCommitConfig := schema.AWSCodeCommitConnection{
+		SecretAccessKey: someSecret,
+		Region:          "us-east-9000z",
+	}
+	phabricatorConfig := schema.PhabricatorConnection{
+		Token: someSecret,
+		Url:   "https://phabricator.biz",
+	}
+	perforceConfig := schema.PerforceConnection{
+		P4Passwd: someSecret,
+		P4User:   "admin",
+	}
+	otherConfig := schema.OtherExternalServiceConnection{
+		Url:                   someSecret,
+		RepositoryPathPattern: "foo",
+	}
+	var tc = []struct {
+		kind        string
+		config      interface{} // the config for the service kind
+		editField   *string     // a pointer to a field on the config we can edit to simulate the user using the API
+		secretField *string     // a pointer to the field we expect to be obfuscated
+	}{
+		{
+			kind:        extsvc.KindGitHub,
+			config:      &githubConfig,
+			editField:   &githubConfig.Url,
+			secretField: &githubConfig.Token,
+		},
+		{
+			kind:        extsvc.KindGitLab,
+			config:      &gitlabConfig,
+			editField:   &gitlabConfig.Url,
+			secretField: &gitlabConfig.Token,
+		},
+		{
+			kind:        extsvc.KindBitbucketCloud,
+			config:      &bitbucketCloudConfig,
+			editField:   &bitbucketCloudConfig.Url,
+			secretField: &bitbucketCloudConfig.AppPassword,
+		},
+		{
+			kind:        extsvc.KindBitbucketServer,
+			config:      &bitbucketServerConfig,
+			editField:   &bitbucketServerConfig.Url,
+			secretField: &bitbucketServerConfig.Password,
+		},
+		{
+			kind:        extsvc.KindBitbucketServer,
+			config:      &bitbucketServerConfig,
+			editField:   &bitbucketServerConfig.Url,
+			secretField: &bitbucketServerConfig.Token, // call bitbucket twice to check both secrets
+		},
+		{
+			kind:        extsvc.KindAWSCodeCommit,
+			config:      &awsCodeCommitConfig,
+			editField:   &awsCodeCommitConfig.Region,
+			secretField: &awsCodeCommitConfig.SecretAccessKey,
+		},
+		{
+			kind:        extsvc.KindPhabricator,
+			config:      &phabricatorConfig,
+			editField:   &phabricatorConfig.Url,
+			secretField: &phabricatorConfig.Token,
+		},
+		{
+			kind:        extsvc.KindPerforce,
+			config:      &perforceConfig,
+			editField:   &perforceConfig.P4User,
+			secretField: &perforceConfig.P4Passwd,
+		},
+		{
+			kind:        extsvc.KindOther,
+			config:      &otherConfig,
+			editField:   &otherConfig.RepositoryPathPattern,
+			secretField: &otherConfig.Url,
 		},
 	}
-	buf, err := json.Marshal(cfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	old := string(buf)
-	// first we redact the config as it was received from the DB, then write the redacted form to the user
-	svc := ExternalService{
-		Kind:   extsvc.KindGitHub,
-		Config: old,
-	}
-	if err := svc.RedactConfig(); err != nil {
-		t.Fatalf("unexpected error: %s", err)
+	for _, c := range tc {
+		t.Run(c.kind, func(t *testing.T) {
+			// reset all fields on the config struct to prevent stale data
+			if err := zeroFields(c.config); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			// this test simulates the round trip of a user editing external service config via our APIs
+			buf, err := json.Marshal(c.config)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			old := string(buf)
+
+			// capture the field before redacting
+			unredactedField := *c.secretField
+
+			// first we redact the config as it was received from the DB, then write the redacted form to the user
+			svc := ExternalService{
+				Kind:   c.kind,
+				Config: old,
+			}
+			if err := svc.RedactConfig(); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			// reset all fields on the config struct to prevent stale data
+			if err := zeroFields(c.config); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			if err := json.Unmarshal([]byte(svc.Config), &c.config); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if want, got := RedactedSecret, *c.secretField; want != got {
+				t.Errorf("want: %q, got: %q", want, got)
+			}
+
+			// now we simulate a user updating their config, and writing it back to the API containing redacted secrets
+			oldSvc := ExternalService{
+				Kind:   c.kind,
+				Config: old,
+			}
+			// edit a field
+			*c.editField = newValue
+			buf, err = json.Marshal(c.config)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			// this config now contains a redacted token
+			newSvc := ExternalService{
+				Kind:   c.kind,
+				Config: string(buf),
+			}
+			// unredact fields in newSvc config
+			if err := newSvc.UnredactConfig(&oldSvc); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			// reset all fields on the config struct to prevent stale data
+			if err := zeroFields(c.config); err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+
+			// the config is now safe to write to the DB, let's unmarshal it again to make sure that no fields are redacted
+			// still, and that our updated fields are there
+			if err := json.Unmarshal([]byte(newSvc.Config), &c.config); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			// our updated fields are still here
+			if *c.editField != newValue {
+				t.Errorf("expected %s got %s", newValue, *c.editField)
+			}
+			// and the secret is no longer redacted
+			if want, got := unredactedField, *c.secretField; want != got {
+				t.Errorf("want: %q, got %q", want, got)
+			}
+		})
 	}
 
-	// now we have the redacted form, we check that the relevant fields are correctly redacted
-	newCfg := schema.GitHubConnection{}
-	if err := json.Unmarshal([]byte(svc.Config), &newCfg); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	if want, got := RedactedSecret, newCfg.Token; want != got {
-		t.Errorf("want: %q, got: %q", want, got)
-	}
-
-	// now we simulate a user updating their config, and writing it back to the API containing redacted secrets
-	oldSvc := ExternalService{
-		Kind:   extsvc.KindGitHub,
-		Config: old,
-	}
-	// the user added a new repo
-	newCfg.Repos = append(newCfg.Repos, "baz")
-	buf, err = json.Marshal(newCfg)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// this config now contains a redacted token
-	newSvc := ExternalService{
-		Kind:   extsvc.KindGitHub,
-		Config: string(buf),
-	}
-	// unredact fields in newSvc config
-	if err := newSvc.UnredactConfig(&oldSvc); err != nil {
-		t.Errorf("unexpected error: %s", err)
-	}
-
-	// the config is now safe to write to the DB, let's unmarshal it again to make sure that no fields are redacted
-	// still, and that our updated fields are there
-	finalCfg := schema.GitHubConnection{}
-	if err := json.Unmarshal([]byte(newSvc.Config), &finalCfg); err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
-	// our updated fields are still here
-	if diff := cmp.Diff(finalCfg.Repos, newCfg.Repos); diff != "" {
-		t.Errorf("unexpected diff: %s", diff)
-	}
-	// and the secret is no longer redacted
-	if want, got := someSecret, finalCfg.Token; want != got {
-		t.Errorf("want: %q, got %q", want, got)
-	}
 }


### PR DESCRIPTION
I realised that because i was roundtrip marshaling JSON in the previous implementation we'd lose comments and formatting, this approach instead uses jsonc.Edit to replace the fields in the json string itself, avoiding the marshal and preserving formatting. The downside to this is now we hardcode path strings to find those fields in the jsonc.Edit calls, this means the already brittle code feels even more brittle. To combat this i've made the testing far more thorough by roundtrip testing all external services.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
