### PR TITLE
perforce: support repositoryPathPattern

### DIFF
--- a/internal/conf/reposource/perforce.go
+++ b/internal/conf/reposource/perforce.go
@@ -1,0 +1,17 @@
+package reposource
+
+import (
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+)
+
+func PerforceRepoName(repositoryPathPattern, depot string) api.RepoName {
+	if repositoryPathPattern == "" {
+		repositoryPathPattern = "{depot}"
+	}
+
+	return api.RepoName(strings.NewReplacer(
+		"{depot}", depot,
+	).Replace(repositoryPathPattern))
+}

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -68,8 +69,14 @@ func (s PerforceSource) makeRepo(depot string) *types.Repo {
 	cloneURL := composePerforceCloneURL(s.config.P4User, s.config.P4Passwd, s.config.P4Port, depot)
 
 	return &types.Repo{
-		Name: api.RepoName(name),
-		URI:  name,
+		Name: reposource.PerforceRepoName(
+			s.config.RepositoryPathPattern,
+			name,
+		),
+		URI: string(reposource.PerforceRepoName(
+			"",
+			name,
+		)),
 		ExternalRepo: api.ExternalRepoSpec{
 			ID:          depot,
 			ServiceType: extsvc.TypePerforce,

--- a/internal/repos/perforce_test.go
+++ b/internal/repos/perforce_test.go
@@ -104,6 +104,14 @@ func TestPerforceSource_makeRepo(t *testing.T) {
 				P4User:   "admin",
 				P4Passwd: "pa$$word",
 			},
+		}, {
+			name: "path-pattern",
+			schmea: &schema.PerforceConnection{
+				P4Port:                "ssl:111.222.333.444:1666",
+				P4User:                "admin",
+				P4Passwd:              "pa$$word",
+				RepositoryPathPattern: "perforce/{depot}",
+			},
 		},
 	}
 	for _, test := range tests {

--- a/internal/repos/testdata/golden/PerforceSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/PerforceSource_makeRepo_path-pattern
@@ -1,0 +1,56 @@
+[
+  {
+   "ID": 0,
+   "Name": "perforce/Sourcegraph",
+   "URI": "Sourcegraph",
+   "Description": "",
+   "Fork": false,
+   "Archived": false,
+   "Private": true,
+   "Cloned": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "//Sourcegraph/",
+    "ServiceType": "perforce",
+    "ServiceID": "ssl:111.222.333.444:1666"
+   },
+   "Sources": {
+    "extsvc:perforce:1": {
+     "ID": "extsvc:perforce:1",
+     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Sourcegraph/"
+    }
+   },
+   "Metadata": {
+    "depot": "//Sourcegraph/"
+   }
+  },
+  {
+   "ID": 0,
+   "Name": "perforce/Engineering/Cloud",
+   "URI": "Engineering/Cloud",
+   "Description": "",
+   "Fork": false,
+   "Archived": false,
+   "Private": true,
+   "Cloned": false,
+   "CreatedAt": "0001-01-01T00:00:00Z",
+   "UpdatedAt": "0001-01-01T00:00:00Z",
+   "DeletedAt": "0001-01-01T00:00:00Z",
+   "ExternalRepo": {
+    "ID": "//Engineering/Cloud/",
+    "ServiceType": "perforce",
+    "ServiceID": "ssl:111.222.333.444:1666"
+   },
+   "Sources": {
+    "extsvc:perforce:1": {
+     "ID": "extsvc:perforce:1",
+     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Engineering/Cloud/"
+    }
+   },
+   "Metadata": {
+    "depot": "//Engineering/Cloud/"
+   }
+  }
+ ]

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -39,6 +39,11 @@
       "description": "If non-null, enforces Perforce depot permissions.",
       "type": "object",
       "properties": {}
+    },
+    "repositoryPathPattern": {
+      "description": "The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable \"{depot}\" is replaced with the Perforce depot's path.\n\nFor example, if your Perforce depot path is \"//Sourcegraph/\" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of \"perforce/{depot}\" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.",
+      "type": "string",
+      "default": "{depot}"
     }
   }
 }

--- a/schema/perforce_stringdata.go
+++ b/schema/perforce_stringdata.go
@@ -44,6 +44,11 @@ const PerforceSchemaJSON = `{
       "description": "If non-null, enforces Perforce depot permissions.",
       "type": "object",
       "properties": {}
+    },
+    "repositoryPathPattern": {
+      "description": "The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable \"{depot}\" is replaced with the Perforce depot's path.\n\nFor example, if your Perforce depot path is \"//Sourcegraph/\" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of \"perforce/{depot}\" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.",
+      "type": "string",
+      "default": "{depot}"
     }
   }
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -943,6 +943,12 @@ type PerforceConnection struct {
 	P4Port string `json:"p4.port"`
 	// P4User description: The user to be authenticated for p4 CLI (P4USER).
 	P4User string `json:"p4.user"`
+	// RepositoryPathPattern description: The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable "{depot}" is replaced with the Perforce depot's path.
+	//
+	// For example, if your Perforce depot path is "//Sourcegraph/" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of "perforce/{depot}" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.
+	//
+	// It is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.
+	RepositoryPathPattern string `json:"repositoryPathPattern,omitempty"`
 }
 
 // PermissionsUserMapping description: Settings for Sourcegraph permissions, which allow the site admin to explicitly manage repository permissions via the GraphQL API. This setting cannot be enabled if repository permissions for any specific external service are enabled (i.e., when the external service's `authorization` field is set).


### PR DESCRIPTION
Help admin to group Perforce depots since raw depot paths are looking quite unorganized when use with other Git code hosts. 

Fixes #17697