### PR TITLE
search: propose count when limit hit

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -619,8 +619,8 @@ func (searchAlert) Suggestions(context.Context, *searchSuggestionsArgs) ([]*sear
 }
 func (searchAlert) Stats(context.Context) (*searchResultsStats, error) { return nil, nil }
 func (searchAlert) SetStream(c SearchStream)                           {}
-func (searchAlert) Inputs() *SearchInputs {
-	return nil
+func (searchAlert) Inputs() SearchInputs {
+	return SearchInputs{}
 }
 
 func alertForError(err error, inputs *SearchInputs) *searchAlert {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1189,7 +1189,7 @@ func (r *searchResolver) getPatternInfo(opts *getPatternInfoOptions) (*search.Te
 	}
 
 	if opts.fileMatchLimit == 0 {
-		opts.fileMatchLimit = r.maxResults()
+		opts.fileMatchLimit = int32(r.Limit)
 	}
 
 	return getPatternInfo(r.Query, opts)
@@ -1820,14 +1820,14 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 			wg.Add(1)
 			goroutine.Go(func() {
 				defer wg.Done()
-				agg.doRepoSearch(ctx, &args, r.maxResults())
+				agg.doRepoSearch(ctx, &args, int32(r.Limit))
 			})
 		case "symbol":
 			wg := waitGroup(len(resultTypes) == 1)
 			wg.Add(1)
 			goroutine.Go(func() {
 				defer wg.Done()
-				agg.doSymbolSearch(ctx, &args, int(r.maxResults()))
+				agg.doSymbolSearch(ctx, &args, r.Limit)
 			})
 		case "file", "path":
 			if searchedFileContentsOrPaths || args.Mode == search.NoFilePath {
@@ -1886,7 +1886,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		start:         start,
 		Stats:         common,
 		SearchResults: results,
-		limit:         int(r.maxResults()),
+		limit:         r.Limit,
 		alert:         alert,
 	}
 	return &resultsResolver, err

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -833,6 +833,7 @@ func TestSearchResultsHydration(t *testing.T) {
 		SearchInputs: &SearchInputs{
 			Query:        q,
 			UserSettings: &schema.Settings{},
+			Limit:        defaultMaxSearchResults,
 		},
 		zoekt:    z,
 		reposMu:  &sync.Mutex{},
@@ -1268,7 +1269,7 @@ func TestEvaluateAnd(t *testing.T) {
 				t.Fatal(err)
 			}
 			resolver := &searchResolver{
-				SearchInputs: &SearchInputs{Query: q, UserSettings: &schema.Settings{}},
+				SearchInputs: &SearchInputs{Query: q, UserSettings: &schema.Settings{}, Limit: 100},
 				zoekt:        z,
 				reposMu:      &sync.Mutex{},
 				resolved:     &searchrepos.Resolved{},

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -96,6 +96,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 			Query:        q,
 			PatternType:  query.SearchTypeStructural,
 			UserSettings: &schema.Settings{},
+			Limit:        defaultMaxSearchResults,
 		},
 		zoekt:        z,
 		searcherURLs: endpoint.Static("test"),

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -15,6 +15,7 @@ type progressAggregator struct {
 	Start      time.Time
 	MatchCount int
 	Stats      streaming.Stats
+	Limit      int
 }
 
 func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
@@ -29,6 +30,9 @@ func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
 }
 
 func (p *progressAggregator) Build() api.Progress {
+	// Suggest the next 1000 after rounding off.
+	suggestedLimit := (p.Limit + 1500) / 1000 * 1000
+
 	return api.BuildProgressEvent(api.ProgressStats{
 		MatchCount:          p.MatchCount,
 		ElapsedMilliseconds: int(time.Since(p.Start).Milliseconds()),
@@ -39,6 +43,7 @@ func (p *progressAggregator) Build() api.Progress {
 		Missing:             getNames(p.Stats, searchshared.RepoStatusMissing),
 		Cloning:             getNames(p.Stats, searchshared.RepoStatusCloning),
 		LimitHit:            p.Stats.IsLimitHit,
+		SuggestedLimit:      suggestedLimit,
 	})
 }
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -70,6 +70,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	progress := progressAggregator{
 		Start: time.Now(),
+		Limit: search.Inputs().Limit,
 	}
 
 	sendProgress := func() {
@@ -216,7 +217,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 type searchResolver interface {
 	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
 	SetStream(c graphqlbackend.SearchStream)
-	Inputs() *graphqlbackend.SearchInputs
+	Inputs() graphqlbackend.SearchInputs
 }
 
 func defaultNewSearchResolver(ctx context.Context, args *graphqlbackend.SearchArgs) (searchResolver, error) {

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -78,6 +78,6 @@ func (h *mockSearchResolver) Close() {
 	close(h.done)
 }
 
-func (h *mockSearchResolver) Inputs() *graphqlbackend.SearchInputs {
-	return &graphqlbackend.SearchInputs{}
+func (h *mockSearchResolver) Inputs() graphqlbackend.SearchInputs {
+	return graphqlbackend.SearchInputs{}
 }

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -40,6 +40,9 @@ type ProgressStats struct {
 	Cloning  []Namer
 
 	LimitHit bool
+
+	// SuggestedLimit is what to suggest to the user for count if needed.
+	SuggestedLimit int
 }
 
 func skippedReposHandler(repos []Namer, titleVerb, messageReason string, base Skipped) (Skipped, bool) {
@@ -104,11 +107,20 @@ func shardMatchLimitHandler(resultsResolver ProgressStats) (Skipped, bool) {
 		return Skipped{}, false
 	}
 
+	var suggest *SkippedSuggested
+	if resultsResolver.SuggestedLimit > 0 {
+		suggest = &SkippedSuggested{
+			Title:           "increase limit",
+			QueryExpression: fmt.Sprintf("count:%d", resultsResolver.SuggestedLimit),
+		}
+	}
+
 	return Skipped{
-		Reason:   ShardMatchLimit,
-		Title:    "result limit hit",
-		Message:  "Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.",
-		Severity: SeverityInfo,
+		Reason:    ShardMatchLimit,
+		Title:     "result limit hit",
+		Message:   "Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.",
+		Severity:  SeverityInfo,
+		Suggested: suggest,
 	}, true
 }
 

--- a/internal/search/streaming/api/progress_test.go
+++ b/internal/search/streaming/api/progress_test.go
@@ -39,6 +39,7 @@ func TestSearchProgress(t *testing.T) {
 			Missing:             []Namer{repo{"missing-1"}, repo{"missing-2"}},
 			Cloning:             []Namer{repo{"cloning-1"}},
 			LimitHit:            true,
+			SuggestedLimit:      1000,
 		},
 	}
 

--- a/internal/search/streaming/api/testdata/golden/TestSearchProgress/all.json
+++ b/internal/search/streaming/api/testdata/golden/TestSearchProgress/all.json
@@ -20,7 +20,11 @@
     "reason": "shard-match-limit",
     "title": "result limit hit",
     "message": "Not all results have been returned due to hitting a match limit. Sourcegraph has limits for the number of results returned from a line, document and repository.",
-    "severity": "info"
+    "severity": "info",
+    "suggested": {
+     "title": "increase limit",
+     "queryExpression": "count:1000"
+    }
    },
    {
     "reason": "shard-timeout",


### PR DESCRIPTION
In streaming we don't have a nice way to educate the user to increase
the limit when they hit them. This adds a proposed query for increasing
the count.

To achieve this we needed to know what the current limit is. This was
hidden as an implementation detail of SearchResults. It is now promoted
to the field Limit in SearchInputs.

![image](https://user-images.githubusercontent.com/187831/106169878-8b01b400-6198-11eb-95ca-d30b8334a4dc.png)

![image](https://user-images.githubusercontent.com/187831/106169905-948b1c00-6198-11eb-9dc5-97f33454c15a.png)

Downside: the webapp doesn't merge in, it naively just appends it to the query. @lguychard @limitedmage I'm not sure if the webapp should know how to update the query, or our query language takes the largest count, or suggested query returns the whole query. WDYT?

![image](https://user-images.githubusercontent.com/187831/106169824-79b8a780-6198-11eb-8522-1b9791a7e868.png)


Fixes https://github.com/sourcegraph/sourcegraph/issues/17773