### PR TITLE
code monitoring: action card button label from 'Done' to 'Continue'

### DIFF
--- a/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormActionArea.tsx
@@ -203,7 +203,7 @@ export const FormActionArea: React.FunctionComponent<ActionAreaProps> = ({
                             onClick={completeForm}
                             onSubmit={completeForm}
                         >
-                            Done
+                            Continue
                         </button>
                         <button type="button" className="btn btn-outline-secondary" onClick={cancelForm}>
                             Cancel

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -128,7 +128,7 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
         onSubmit={[Function]}
         type="submit"
       >
-        Done
+        Continue
       </button>
       <button
         className="btn btn-outline-secondary"


### PR DESCRIPTION
Fixes #17419

![image](https://user-images.githubusercontent.com/206864/106213433-87aefe00-6181-11eb-8af8-2653177deed2.png)
