### PR TITLE
search: fix intermittent integration test failure

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -298,7 +298,8 @@ describe('Search', () => {
 
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
             await driver.page.waitForSelector('.test-search-button', { visible: true })
-            await driver.page.keyboard.type(' hello')
+            // Note: Delay added because this test has been intermittently failing without it. Monaco search bar may drop events if it gets too many too fast.
+            await driver.page.keyboard.type(' hello', { delay: 50 })
             await driver.page.click('.test-search-button')
             await driver.assertWindowLocation('/search?q=test+hello&patternType=regexp')
         })


### PR DESCRIPTION
One of the search integration tests has been failing (Puppeteer types "hello" but test claims only "hllo" was typed). Adding a delay to this typing to hopefully avoid this test failing again. It's likely that Monaco drops keyboard events if it gets too many too fast.

Ran CI four times with this change so hopefully that's enough 🤞