### PR TITLE
codeintel: Expose commit graph metadata in GraphQL

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -22,6 +22,7 @@ type CodeIntelResolver interface {
 	DeleteLSIFIndex(ctx context.Context, id graphql.ID) (*EmptyResponse, error)
 	IndexConfiguration(ctx context.Context, id graphql.ID) (IndexConfigurationResolver, error) // TODO - rename ...ForRepo
 	UpdateRepositoryIndexConfiguration(ctx context.Context, args *UpdateRepositoryIndexConfigurationArgs) (*EmptyResponse, error)
+	CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error)
 	QueueAutoIndexJobForRepo(ctx context.Context, id graphql.ID) (*EmptyResponse, error)
 	GitBlobLSIFData(ctx context.Context, args *GitBlobLSIFDataArgs) (GitBlobLSIFDataResolver, error)
 }
@@ -69,6 +70,10 @@ func (defaultCodeIntelResolver) IndexConfiguration(ctx context.Context, id graph
 }
 
 func (defaultCodeIntelResolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args *UpdateRepositoryIndexConfigurationArgs) (*EmptyResponse, error) {
+	return nil, errCodeIntelOnlyInEnterprise
+}
+
+func (defaultCodeIntelResolver) CommitGraph(ctx context.Context, id graphql.ID) (CodeIntelligenceCommitGraphResolver, error) {
 	return nil, errCodeIntelOnlyInEnterprise
 }
 
@@ -216,6 +221,11 @@ type QueueAutoIndexJobArgs struct {
 
 type GitTreeLSIFDataResolver interface {
 	Diagnostics(ctx context.Context, args *LSIFDiagnosticsArgs) (DiagnosticConnectionResolver, error)
+}
+
+type CodeIntelligenceCommitGraphResolver interface {
+	Stale(ctx context.Context) (bool, error)
+	UpdatedAt(ctx context.Context) (*DateTime, error)
 }
 
 type GitBlobLSIFDataResolver interface {

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -333,6 +333,10 @@ func (r *RepositoryResolver) IndexConfiguration(ctx context.Context) (IndexConfi
 	return EnterpriseResolvers.codeIntelResolver.IndexConfiguration(ctx, r.ID())
 }
 
+func (r *RepositoryResolver) CodeIntelligenceCommitGraph(ctx context.Context) (CodeIntelligenceCommitGraphResolver, error) {
+	return EnterpriseResolvers.codeIntelResolver.CommitGraph(ctx, r.ID())
+}
+
 type AuthorizedUserArgs struct {
 	RepositoryID graphql.ID
 	Permission   string

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -4555,7 +4555,7 @@ type Repository implements Node & GenericSearchResultInterface {
     Information and status related to the commit graph of this repository calculated
     for use by code intelligence features.
     """
-    codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph
+    codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph!
 
     """
     A list of authorized users to access this repository with the given permission.

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -4552,6 +4552,12 @@ type Repository implements Node & GenericSearchResultInterface {
     indexConfiguration: IndexConfiguration
 
     """
+    Information and status related to the commit graph of this repository calculated
+    for use by code intelligence features.
+    """
+    codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph
+
+    """
     A list of authorized users to access this repository with the given permission.
     This API currently only returns permissions from the Sourcegraph provider, i.e.
     "permissions.userMapping" in site configuration.
@@ -4576,6 +4582,22 @@ type Repository implements Node & GenericSearchResultInterface {
     It is null when there is no permissions data stored for the repository.
     """
     permissionsInfo: PermissionsInfo
+}
+
+"""
+Information and status related to the commit graph of this repository calculated
+for use by code intelligence features.
+"""
+type CodeIntelligenceCommitGraph {
+    """
+    Whether or not the commit graph needs to be updated.
+    """
+    stale: Boolean!
+
+    """
+    When, if ever, the commit graph was last refreshed.
+    """
+    updatedAt: DateTime
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4548,7 +4548,7 @@ type Repository implements Node & GenericSearchResultInterface {
     Information and status related to the commit graph of this repository calculated
     for use by code intelligence features.
     """
-    codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph
+    codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph!
 
     """
     A list of authorized users to access this repository with the given permission.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4545,6 +4545,12 @@ type Repository implements Node & GenericSearchResultInterface {
     indexConfiguration: IndexConfiguration
 
     """
+    Information and status related to the commit graph of this repository calculated
+    for use by code intelligence features.
+    """
+    codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph
+
+    """
     A list of authorized users to access this repository with the given permission.
     This API currently only returns permissions from the Sourcegraph provider, i.e.
     "permissions.userMapping" in site configuration.
@@ -4569,6 +4575,22 @@ type Repository implements Node & GenericSearchResultInterface {
     It is null when there is no permissions data stored for the repository.
     """
     permissionsInfo: PermissionsInfo
+}
+
+"""
+Information and status related to the commit graph of this repository calculated
+for use by code intelligence features.
+"""
+type CodeIntelligenceCommitGraph {
+    """
+    Whether or not the commit graph needs to be updated.
+    """
+    stale: Boolean!
+
+    """
+    When, if ever, the commit graph was last refreshed.
+    """
+    updatedAt: DateTime
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/iface.go
@@ -12,7 +12,7 @@ type DBStore interface {
 	Lock(ctx context.Context, key int, blocking bool) (bool, dbstore.UnlockFunc, error)
 	GetUploads(ctx context.Context, opts dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error)
 	DirtyRepositories(ctx context.Context) (map[int]int, error)
-	CalculateVisibleUploads(ctx context.Context, repositoryID int, graph *gitserver.CommitGraph, tipCommit string, dirtyToken int) error
+	CalculateVisibleUploads(ctx context.Context, repositoryID int, graph *gitserver.CommitGraph, tipCommit string, dirtyToken int, now time.Time) error
 }
 
 type GitserverClient interface {

--- a/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/mock_iface_test.go
@@ -34,7 +34,7 @@ type MockDBStore struct {
 func NewMockDBStore() *MockDBStore {
 	return &MockDBStore{
 		CalculateVisibleUploadsFunc: &DBStoreCalculateVisibleUploadsFunc{
-			defaultHook: func(context.Context, int, *gitserver.CommitGraph, string, int) error {
+			defaultHook: func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error {
 				return nil
 			},
 		},
@@ -79,24 +79,24 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 // CalculateVisibleUploads method of the parent MockDBStore instance is
 // invoked.
 type DBStoreCalculateVisibleUploadsFunc struct {
-	defaultHook func(context.Context, int, *gitserver.CommitGraph, string, int) error
-	hooks       []func(context.Context, int, *gitserver.CommitGraph, string, int) error
+	defaultHook func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error
+	hooks       []func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error
 	history     []DBStoreCalculateVisibleUploadsFuncCall
 	mutex       sync.Mutex
 }
 
 // CalculateVisibleUploads delegates to the next hook function in the queue
 // and stores the parameter and result values of this invocation.
-func (m *MockDBStore) CalculateVisibleUploads(v0 context.Context, v1 int, v2 *gitserver.CommitGraph, v3 string, v4 int) error {
-	r0 := m.CalculateVisibleUploadsFunc.nextHook()(v0, v1, v2, v3, v4)
-	m.CalculateVisibleUploadsFunc.appendCall(DBStoreCalculateVisibleUploadsFuncCall{v0, v1, v2, v3, v4, r0})
+func (m *MockDBStore) CalculateVisibleUploads(v0 context.Context, v1 int, v2 *gitserver.CommitGraph, v3 string, v4 int, v5 time.Time) error {
+	r0 := m.CalculateVisibleUploadsFunc.nextHook()(v0, v1, v2, v3, v4, v5)
+	m.CalculateVisibleUploadsFunc.appendCall(DBStoreCalculateVisibleUploadsFuncCall{v0, v1, v2, v3, v4, v5, r0})
 	return r0
 }
 
 // SetDefaultHook sets function that is called when the
 // CalculateVisibleUploads method of the parent MockDBStore instance is
 // invoked and the hook queue is empty.
-func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultHook(hook func(context.Context, int, *gitserver.CommitGraph, string, int) error) {
+func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultHook(hook func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error) {
 	f.defaultHook = hook
 }
 
@@ -104,7 +104,7 @@ func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultHook(hook func(context.Co
 // CalculateVisibleUploads method of the parent MockDBStore instance inovkes
 // the hook at the front of the queue and discards it. After the queue is
 // empty, the default hook function is invoked for any future action.
-func (f *DBStoreCalculateVisibleUploadsFunc) PushHook(hook func(context.Context, int, *gitserver.CommitGraph, string, int) error) {
+func (f *DBStoreCalculateVisibleUploadsFunc) PushHook(hook func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -113,7 +113,7 @@ func (f *DBStoreCalculateVisibleUploadsFunc) PushHook(hook func(context.Context,
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
 func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultReturn(r0 error) {
-	f.SetDefaultHook(func(context.Context, int, *gitserver.CommitGraph, string, int) error {
+	f.SetDefaultHook(func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error {
 		return r0
 	})
 }
@@ -121,12 +121,12 @@ func (f *DBStoreCalculateVisibleUploadsFunc) SetDefaultReturn(r0 error) {
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
 func (f *DBStoreCalculateVisibleUploadsFunc) PushReturn(r0 error) {
-	f.PushHook(func(context.Context, int, *gitserver.CommitGraph, string, int) error {
+	f.PushHook(func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error {
 		return r0
 	})
 }
 
-func (f *DBStoreCalculateVisibleUploadsFunc) nextHook() func(context.Context, int, *gitserver.CommitGraph, string, int) error {
+func (f *DBStoreCalculateVisibleUploadsFunc) nextHook() func(context.Context, int, *gitserver.CommitGraph, string, int, time.Time) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -175,6 +175,9 @@ type DBStoreCalculateVisibleUploadsFuncCall struct {
 	// Arg4 is the value of the 5th argument passed to this method
 	// invocation.
 	Arg4 int
+	// Arg5 is the value of the 6th argument passed to this method
+	// invocation.
+	Arg5 time.Time
 	// Result0 is the value of the 1st result returned from this method
 	// invocation.
 	Result0 error
@@ -183,7 +186,7 @@ type DBStoreCalculateVisibleUploadsFuncCall struct {
 // Args returns an interface slice containing the arguments of this
 // invocation.
 func (c DBStoreCalculateVisibleUploadsFuncCall) Args() []interface{} {
-	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4}
+	return []interface{}{c.Arg0, c.Arg1, c.Arg2, c.Arg3, c.Arg4, c.Arg5}
 }
 
 // Results returns an interface slice containing the results of this

--- a/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/updater.go
@@ -116,7 +116,7 @@ func (u *Updater) update(ctx context.Context, repositoryID, dirtyToken int) (err
 	// Decorate the commit graph with the set of processed uploads are visible from each commit,
 	// then bulk update the denormalized view in Postgres. We call this with an empty graph as well
 	// so that we end up clearing the stale data and bulk inserting nothing.
-	if err := u.dbStore.CalculateVisibleUploads(ctx, repositoryID, commitGraph, tipCommit, dirtyToken); err != nil {
+	if err := u.dbStore.CalculateVisibleUploads(ctx, repositoryID, commitGraph, tipCommit, dirtyToken, time.Now()); err != nil {
 		return errors.Wrap(err, "store.CalculateVisibleUploads")
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/commit_graph.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/commit_graph.go
@@ -1,0 +1,28 @@
+package resolvers
+
+import (
+	"context"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+type CommitGraphResolver struct {
+	stale     bool
+	updatedAt *time.Time
+}
+
+func NewCommitGraphResolver(stale bool, updatedAt *time.Time) *CommitGraphResolver {
+	return &CommitGraphResolver{
+		stale:     stale,
+		updatedAt: updatedAt,
+	}
+}
+
+func (r *CommitGraphResolver) Stale(ctx context.Context) (bool, error) {
+	return r.stale, nil
+}
+
+func (r *CommitGraphResolver) UpdatedAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+	return graphqlbackend.DateTimeOrNil(r.updatedAt), nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -188,6 +188,15 @@ func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args 
 	return &gql.EmptyResponse{}, nil
 }
 
+func (r *Resolver) CommitGraph(ctx context.Context, id graphql.ID) (gql.CodeIntelligenceCommitGraphResolver, error) {
+	repositoryID, err := gql.UnmarshalRepositoryID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.resolver.CommitGraph(ctx, int(repositoryID))
+}
+
 func (r *Resolver) QueueAutoIndexJobForRepo(ctx context.Context, id graphql.ID) (*gql.EmptyResponse, error) {
 	if !autoIndexingEnabled() {
 		return nil, errAutoIndexingNotEnabled

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/api"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
@@ -34,6 +35,7 @@ type DBStore interface {
 	HasRepository(ctx context.Context, repositoryID int) (bool, error)
 	HasCommit(ctx context.Context, repositoryID int, commit string) (bool, error)
 	MarkRepositoryAsDirty(ctx context.Context, repositoryID int) error
+	CommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, _ error)
 	GetIndexByID(ctx context.Context, id int) (dbstore.Index, bool, error)
 	GetIndexes(ctx context.Context, opts dbstore.GetIndexesOptions) ([]dbstore.Index, int, error)
 	DeleteIndexByID(ctx context.Context, id int) (bool, error)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -9,6 +9,7 @@ import (
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"sync"
+	"time"
 )
 
 // MockCodeIntelAPI is a mock implementation of the CodeIntelAPI interface
@@ -896,8 +897,8 @@ type MockDBStore struct {
 func NewMockDBStore() *MockDBStore {
 	return &MockDBStore{
 		CommitGraphMetadataFunc: &DBStoreCommitGraphMetadataFunc{
-			defaultHook: func(context.Context, int) (bool, error) {
-				return false, nil
+			defaultHook: func(context.Context, int) (bool, *time.Time, error) {
+				return false, nil, nil
 			},
 		},
 		DeleteIndexByIDFunc: &DBStoreDeleteIndexByIDFunc{
@@ -1060,24 +1061,24 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 // DBStoreCommitGraphMetadataFunc describes the behavior when the
 // CommitGraphMetadata method of the parent MockDBStore instance is invoked.
 type DBStoreCommitGraphMetadataFunc struct {
-	defaultHook func(context.Context, int) (bool, error)
-	hooks       []func(context.Context, int) (bool, error)
+	defaultHook func(context.Context, int) (bool, *time.Time, error)
+	hooks       []func(context.Context, int) (bool, *time.Time, error)
 	history     []DBStoreCommitGraphMetadataFuncCall
 	mutex       sync.Mutex
 }
 
 // CommitGraphMetadata delegates to the next hook function in the queue and
 // stores the parameter and result values of this invocation.
-func (m *MockDBStore) CommitGraphMetadata(v0 context.Context, v1 int) (bool, error) {
-	r0, r1 := m.CommitGraphMetadataFunc.nextHook()(v0, v1)
-	m.CommitGraphMetadataFunc.appendCall(DBStoreCommitGraphMetadataFuncCall{v0, v1, r0, r1})
-	return r0, r1
+func (m *MockDBStore) CommitGraphMetadata(v0 context.Context, v1 int) (bool, *time.Time, error) {
+	r0, r1, r2 := m.CommitGraphMetadataFunc.nextHook()(v0, v1)
+	m.CommitGraphMetadataFunc.appendCall(DBStoreCommitGraphMetadataFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
 }
 
 // SetDefaultHook sets function that is called when the CommitGraphMetadata
 // method of the parent MockDBStore instance is invoked and the hook queue
 // is empty.
-func (f *DBStoreCommitGraphMetadataFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+func (f *DBStoreCommitGraphMetadataFunc) SetDefaultHook(hook func(context.Context, int) (bool, *time.Time, error)) {
 	f.defaultHook = hook
 }
 
@@ -1085,7 +1086,7 @@ func (f *DBStoreCommitGraphMetadataFunc) SetDefaultHook(hook func(context.Contex
 // CommitGraphMetadata method of the parent MockDBStore instance inovkes the
 // hook at the front of the queue and discards it. After the queue is empty,
 // the default hook function is invoked for any future action.
-func (f *DBStoreCommitGraphMetadataFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+func (f *DBStoreCommitGraphMetadataFunc) PushHook(hook func(context.Context, int) (bool, *time.Time, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -1093,21 +1094,21 @@ func (f *DBStoreCommitGraphMetadataFunc) PushHook(hook func(context.Context, int
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DBStoreCommitGraphMetadataFunc) SetDefaultReturn(r0 bool, r1 error) {
-	f.SetDefaultHook(func(context.Context, int) (bool, error) {
-		return r0, r1
+func (f *DBStoreCommitGraphMetadataFunc) SetDefaultReturn(r0 bool, r1 *time.Time, r2 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, *time.Time, error) {
+		return r0, r1, r2
 	})
 }
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DBStoreCommitGraphMetadataFunc) PushReturn(r0 bool, r1 error) {
-	f.PushHook(func(context.Context, int) (bool, error) {
-		return r0, r1
+func (f *DBStoreCommitGraphMetadataFunc) PushReturn(r0 bool, r1 *time.Time, r2 error) {
+	f.PushHook(func(context.Context, int) (bool, *time.Time, error) {
+		return r0, r1, r2
 	})
 }
 
-func (f *DBStoreCommitGraphMetadataFunc) nextHook() func(context.Context, int) (bool, error) {
+func (f *DBStoreCommitGraphMetadataFunc) nextHook() func(context.Context, int) (bool, *time.Time, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -1151,7 +1152,10 @@ type DBStoreCommitGraphMetadataFuncCall struct {
 	Result0 bool
 	// Result1 is the value of the 2nd result returned from this method
 	// invocation.
-	Result1 error
+	Result1 *time.Time
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
 }
 
 // Args returns an interface slice containing the arguments of this
@@ -1163,7 +1167,7 @@ func (c DBStoreCommitGraphMetadataFuncCall) Args() []interface{} {
 // Results returns an interface slice containing the results of this
 // invocation.
 func (c DBStoreCommitGraphMetadataFuncCall) Results() []interface{} {
-	return []interface{}{c.Result0, c.Result1}
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreDeleteIndexByIDFunc describes the behavior when the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -829,6 +829,9 @@ func (c CodeIntelAPIReferencesFuncCall) Results() []interface{} {
 // github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers)
 // used for unit testing.
 type MockDBStore struct {
+	// CommitGraphMetadataFunc is an instance of a mock function object
+	// controlling the behavior of the method CommitGraphMetadata.
+	CommitGraphMetadataFunc *DBStoreCommitGraphMetadataFunc
 	// DeleteIndexByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteIndexByID.
 	DeleteIndexByIDFunc *DBStoreDeleteIndexByIDFunc
@@ -892,6 +895,11 @@ type MockDBStore struct {
 // return zero values for all results, unless overwritten.
 func NewMockDBStore() *MockDBStore {
 	return &MockDBStore{
+		CommitGraphMetadataFunc: &DBStoreCommitGraphMetadataFunc{
+			defaultHook: func(context.Context, int) (bool, error) {
+				return false, nil
+			},
+		},
 		DeleteIndexByIDFunc: &DBStoreDeleteIndexByIDFunc{
 			defaultHook: func(context.Context, int) (bool, error) {
 				return false, nil
@@ -989,6 +997,9 @@ func NewMockDBStore() *MockDBStore {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 	return &MockDBStore{
+		CommitGraphMetadataFunc: &DBStoreCommitGraphMetadataFunc{
+			defaultHook: i.CommitGraphMetadata,
+		},
 		DeleteIndexByIDFunc: &DBStoreDeleteIndexByIDFunc{
 			defaultHook: i.DeleteIndexByID,
 		},
@@ -1044,6 +1055,115 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 			defaultHook: i.UpdateIndexConfigurationByRepositoryID,
 		},
 	}
+}
+
+// DBStoreCommitGraphMetadataFunc describes the behavior when the
+// CommitGraphMetadata method of the parent MockDBStore instance is invoked.
+type DBStoreCommitGraphMetadataFunc struct {
+	defaultHook func(context.Context, int) (bool, error)
+	hooks       []func(context.Context, int) (bool, error)
+	history     []DBStoreCommitGraphMetadataFuncCall
+	mutex       sync.Mutex
+}
+
+// CommitGraphMetadata delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDBStore) CommitGraphMetadata(v0 context.Context, v1 int) (bool, error) {
+	r0, r1 := m.CommitGraphMetadataFunc.nextHook()(v0, v1)
+	m.CommitGraphMetadataFunc.appendCall(DBStoreCommitGraphMetadataFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the CommitGraphMetadata
+// method of the parent MockDBStore instance is invoked and the hook queue
+// is empty.
+func (f *DBStoreCommitGraphMetadataFunc) SetDefaultHook(hook func(context.Context, int) (bool, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// CommitGraphMetadata method of the parent MockDBStore instance inovkes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *DBStoreCommitGraphMetadataFunc) PushHook(hook func(context.Context, int) (bool, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DBStoreCommitGraphMetadataFunc) SetDefaultReturn(r0 bool, r1 error) {
+	f.SetDefaultHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DBStoreCommitGraphMetadataFunc) PushReturn(r0 bool, r1 error) {
+	f.PushHook(func(context.Context, int) (bool, error) {
+		return r0, r1
+	})
+}
+
+func (f *DBStoreCommitGraphMetadataFunc) nextHook() func(context.Context, int) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreCommitGraphMetadataFunc) appendCall(r0 DBStoreCommitGraphMetadataFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreCommitGraphMetadataFuncCall objects
+// describing the invocations of this function.
+func (f *DBStoreCommitGraphMetadataFunc) History() []DBStoreCommitGraphMetadataFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreCommitGraphMetadataFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreCommitGraphMetadataFuncCall is an object that describes an
+// invocation of method CommitGraphMetadata on an instance of MockDBStore.
+type DBStoreCommitGraphMetadataFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 bool
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBStoreCommitGraphMetadataFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreCommitGraphMetadataFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // DBStoreDeleteIndexByIDFunc describes the behavior when the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -15,10 +15,9 @@ import (
 // github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers)
 // used for unit testing.
 type MockResolver struct {
-	// CodeIntelligenceCommitGraphFunc is an instance of a mock function
-	// object controlling the behavior of the method
-	// CodeIntelligenceCommitGraph.
-	CodeIntelligenceCommitGraphFunc *ResolverCodeIntelligenceCommitGraphFunc
+	// CommitGraphFunc is an instance of a mock function object controlling
+	// the behavior of the method CommitGraph.
+	CommitGraphFunc *ResolverCommitGraphFunc
 	// DeleteIndexByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method DeleteIndexByID.
 	DeleteIndexByIDFunc *ResolverDeleteIndexByIDFunc
@@ -56,7 +55,7 @@ type MockResolver struct {
 // return zero values for all results, unless overwritten.
 func NewMockResolver() *MockResolver {
 	return &MockResolver{
-		CodeIntelligenceCommitGraphFunc: &ResolverCodeIntelligenceCommitGraphFunc{
+		CommitGraphFunc: &ResolverCommitGraphFunc{
 			defaultHook: func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
 				return nil, nil
 			},
@@ -118,8 +117,8 @@ func NewMockResolver() *MockResolver {
 // methods delegate to the given implementation, unless overwritten.
 func NewMockResolverFrom(i resolvers.Resolver) *MockResolver {
 	return &MockResolver{
-		CodeIntelligenceCommitGraphFunc: &ResolverCodeIntelligenceCommitGraphFunc{
-			defaultHook: i.CodeIntelligenceCommitGraph,
+		CommitGraphFunc: &ResolverCommitGraphFunc{
+			defaultHook: i.CommitGraph,
 		},
 		DeleteIndexByIDFunc: &ResolverDeleteIndexByIDFunc{
 			defaultHook: i.DeleteIndexByID,
@@ -154,37 +153,35 @@ func NewMockResolverFrom(i resolvers.Resolver) *MockResolver {
 	}
 }
 
-// ResolverCodeIntelligenceCommitGraphFunc describes the behavior when the
-// CodeIntelligenceCommitGraph method of the parent MockResolver instance is
-// invoked.
-type ResolverCodeIntelligenceCommitGraphFunc struct {
+// ResolverCommitGraphFunc describes the behavior when the CommitGraph
+// method of the parent MockResolver instance is invoked.
+type ResolverCommitGraphFunc struct {
 	defaultHook func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error)
 	hooks       []func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error)
-	history     []ResolverCodeIntelligenceCommitGraphFuncCall
+	history     []ResolverCommitGraphFuncCall
 	mutex       sync.Mutex
 }
 
-// CodeIntelligenceCommitGraph delegates to the next hook function in the
-// queue and stores the parameter and result values of this invocation.
-func (m *MockResolver) CodeIntelligenceCommitGraph(v0 context.Context, v1 int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
-	r0, r1 := m.CodeIntelligenceCommitGraphFunc.nextHook()(v0, v1)
-	m.CodeIntelligenceCommitGraphFunc.appendCall(ResolverCodeIntelligenceCommitGraphFuncCall{v0, v1, r0, r1})
+// CommitGraph delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockResolver) CommitGraph(v0 context.Context, v1 int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
+	r0, r1 := m.CommitGraphFunc.nextHook()(v0, v1)
+	m.CommitGraphFunc.appendCall(ResolverCommitGraphFuncCall{v0, v1, r0, r1})
 	return r0, r1
 }
 
-// SetDefaultHook sets function that is called when the
-// CodeIntelligenceCommitGraph method of the parent MockResolver instance is
-// invoked and the hook queue is empty.
-func (f *ResolverCodeIntelligenceCommitGraphFunc) SetDefaultHook(hook func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error)) {
+// SetDefaultHook sets function that is called when the CommitGraph method
+// of the parent MockResolver instance is invoked and the hook queue is
+// empty.
+func (f *ResolverCommitGraphFunc) SetDefaultHook(hook func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// CodeIntelligenceCommitGraph method of the parent MockResolver instance
-// inovkes the hook at the front of the queue and discards it. After the
-// queue is empty, the default hook function is invoked for any future
-// action.
-func (f *ResolverCodeIntelligenceCommitGraphFunc) PushHook(hook func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error)) {
+// CommitGraph method of the parent MockResolver instance inovkes the hook
+// at the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *ResolverCommitGraphFunc) PushHook(hook func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -192,7 +189,7 @@ func (f *ResolverCodeIntelligenceCommitGraphFunc) PushHook(hook func(context.Con
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *ResolverCodeIntelligenceCommitGraphFunc) SetDefaultReturn(r0 graphqlbackend.CodeIntelligenceCommitGraphResolver, r1 error) {
+func (f *ResolverCommitGraphFunc) SetDefaultReturn(r0 graphqlbackend.CodeIntelligenceCommitGraphResolver, r1 error) {
 	f.SetDefaultHook(func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
 		return r0, r1
 	})
@@ -200,13 +197,13 @@ func (f *ResolverCodeIntelligenceCommitGraphFunc) SetDefaultReturn(r0 graphqlbac
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *ResolverCodeIntelligenceCommitGraphFunc) PushReturn(r0 graphqlbackend.CodeIntelligenceCommitGraphResolver, r1 error) {
+func (f *ResolverCommitGraphFunc) PushReturn(r0 graphqlbackend.CodeIntelligenceCommitGraphResolver, r1 error) {
 	f.PushHook(func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
 		return r0, r1
 	})
 }
 
-func (f *ResolverCodeIntelligenceCommitGraphFunc) nextHook() func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
+func (f *ResolverCommitGraphFunc) nextHook() func(context.Context, int) (graphqlbackend.CodeIntelligenceCommitGraphResolver, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -219,27 +216,26 @@ func (f *ResolverCodeIntelligenceCommitGraphFunc) nextHook() func(context.Contex
 	return hook
 }
 
-func (f *ResolverCodeIntelligenceCommitGraphFunc) appendCall(r0 ResolverCodeIntelligenceCommitGraphFuncCall) {
+func (f *ResolverCommitGraphFunc) appendCall(r0 ResolverCommitGraphFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of ResolverCodeIntelligenceCommitGraphFuncCall
-// objects describing the invocations of this function.
-func (f *ResolverCodeIntelligenceCommitGraphFunc) History() []ResolverCodeIntelligenceCommitGraphFuncCall {
+// History returns a sequence of ResolverCommitGraphFuncCall objects
+// describing the invocations of this function.
+func (f *ResolverCommitGraphFunc) History() []ResolverCommitGraphFuncCall {
 	f.mutex.Lock()
-	history := make([]ResolverCodeIntelligenceCommitGraphFuncCall, len(f.history))
+	history := make([]ResolverCommitGraphFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// ResolverCodeIntelligenceCommitGraphFuncCall is an object that describes
-// an invocation of method CodeIntelligenceCommitGraph on an instance of
-// MockResolver.
-type ResolverCodeIntelligenceCommitGraphFuncCall struct {
+// ResolverCommitGraphFuncCall is an object that describes an invocation of
+// method CommitGraph on an instance of MockResolver.
+type ResolverCommitGraphFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -256,13 +252,13 @@ type ResolverCodeIntelligenceCommitGraphFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c ResolverCodeIntelligenceCommitGraphFuncCall) Args() []interface{} {
+func (c ResolverCommitGraphFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0, c.Arg1}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c ResolverCodeIntelligenceCommitGraphFuncCall) Results() []interface{} {
+func (c ResolverCommitGraphFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -26,6 +26,7 @@ type Resolver interface {
 	DeleteIndexByID(ctx context.Context, id int) error
 	IndexConfiguration(ctx context.Context, repositoryID int) (store.IndexConfiguration, error)
 	UpdateIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int, configuration string) error
+	CommitGraph(ctx context.Context, repositoryID int) (gql.CodeIntelligenceCommitGraphResolver, error)
 	QueueAutoIndexJobForRepo(ctx context.Context, repositoryID int) error
 	QueryResolver(ctx context.Context, args *gql.GitBlobLSIFDataArgs) (QueryResolver, error)
 }
@@ -99,6 +100,15 @@ func (r *resolver) UpdateIndexConfigurationByRepositoryID(ctx context.Context, r
 	}
 
 	return r.dbStore.UpdateIndexConfigurationByRepositoryID(ctx, repositoryID, []byte(configuration))
+}
+
+func (r *resolver) CommitGraph(ctx context.Context, repositoryID int) (gql.CodeIntelligenceCommitGraphResolver, error) {
+	stale, updatedAt, err := r.dbStore.CommitGraphMetadata(ctx, repositoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCommitGraphResolver(stale, updatedAt), nil
 }
 
 func (r *resolver) QueueAutoIndexJobForRepo(ctx context.Context, repositoryID int) error {

--- a/enterprise/internal/codeintel/stores/dbstore/commits_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits_test.go
@@ -13,8 +13,11 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/commitgraph"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
@@ -119,6 +122,51 @@ func TestMarkRepositoryAsDirty(t *testing.T) {
 	}
 }
 
+func TestCommitGraphMetadata(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	if err := store.MarkRepositoryAsDirty(context.Background(), 50); err != nil {
+		t.Errorf("unexpected error marking repository as dirty: %s", err)
+	}
+
+	updatedAt := time.Unix(1587396557, 0).UTC()
+	query := sqlf.Sprintf("INSERT INTO lsif_dirty_repositories VALUES (%s, %s, %s, %s)", 51, 10, 10, updatedAt)
+	if _, err := dbconn.Global.ExecContext(context.Background(), query.Query(sqlf.PostgresBindVar), query.Args()...); err != nil {
+		t.Fatalf("unexpected error inserting commit graph metadata: %s", err)
+	}
+
+	testCases := []struct {
+		RepositoryID int
+		Stale        bool
+		UpdatedAt    *time.Time
+	}{
+		{50, true, nil},
+		{51, false, &updatedAt},
+		{52, false, nil},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(fmt.Sprintf("repositoryID=%d", testCase.RepositoryID), func(t *testing.T) {
+			stale, updatedAt, err := store.CommitGraphMetadata(context.Background(), testCase.RepositoryID)
+			if err != nil {
+				t.Fatalf("unexpected error getting commit graph metadata: %s", err)
+			}
+
+			if stale != testCase.Stale {
+				t.Errorf("unexpected value for stale. want=%v have=%v", testCase.Stale, stale)
+			}
+
+			if diff := cmp.Diff(testCase.UpdatedAt, updatedAt); diff != "" {
+				t.Errorf("unexpected value for uploadedAt (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestCalculateVisibleUploads(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -150,7 +198,7 @@ func TestCalculateVisibleUploads(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(8), 0); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(8), 0, time.Time{}); err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 
@@ -204,7 +252,7 @@ func TestCalculateVisibleUploadsAlternateCommitGraph(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 0); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 0, time.Time{}); err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 
@@ -243,7 +291,7 @@ func TestCalculateVisibleUploadsDistinctRoots(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(2), 0); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(2), 0, time.Time{}); err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 
@@ -308,7 +356,7 @@ func TestCalculateVisibleUploadsOverlappingRoots(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(6), 0); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(6), 0, time.Time{}); err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 
@@ -360,7 +408,7 @@ func TestCalculateVisibleUploadsIndexerName(t *testing.T) {
 		strings.Join([]string{makeCommit(1)}, " "),
 	})
 
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(5), 0); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(5), 0, time.Time{}); err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 
@@ -407,32 +455,41 @@ func TestCalculateVisibleUploadsResetsDirtyFlag(t *testing.T) {
 		}
 	}
 
+	now := time.Unix(1587396557, 0).UTC()
+
 	// Non-latest dirty token - should not clear flag
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 2); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 2, now); err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
-
 	repositoryIDs, err := store.DirtyRepositories(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error listing dirty repositories: %s", err)
 	}
-
 	if len(repositoryIDs) == 0 {
 		t.Errorf("did not expect repository to be unmarked")
 	}
 
 	// Latest dirty token - should clear flag
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 3); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 3, now); err != nil {
 		t.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
-
 	repositoryIDs, err = store.DirtyRepositories(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error listing dirty repositories: %s", err)
 	}
-
 	if len(repositoryIDs) != 0 {
 		t.Errorf("expected repository to be unmarked")
+	}
+
+	stale, updatedAt, err := store.CommitGraphMetadata(context.Background(), 50)
+	if err != nil {
+		t.Fatalf("unexpected error getting commit graph metadata: %s", err)
+	}
+	if stale {
+		t.Errorf("unexpected value for stale. want=%v have=%v", false, stale)
+	}
+	if diff := cmp.Diff(&now, updatedAt); diff != "" {
+		t.Errorf("unexpected value for uploadedAt (-want +got):\n%s", diff)
 	}
 }
 
@@ -466,7 +523,7 @@ func BenchmarkCalculateVisibleUploads(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 2); err != nil {
+	if err := store.CalculateVisibleUploads(context.Background(), 50, graph, makeCommit(3), 0, time.Time{}); err != nil {
 		b.Fatalf("unexpected error while calculating visible uploads: %s", err)
 	}
 }

--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -19,6 +19,7 @@ type operations struct {
 	dequeue                                *observation.Operation
 	dequeueIndex                           *observation.Operation
 	dirtyRepositories                      *observation.Operation
+	commitGraphMetadata                    *observation.Operation
 	findClosestDumps                       *observation.Operation
 	findClosestDumpsFromGraphFragment      *observation.Operation
 	getDumpByID                            *observation.Operation
@@ -89,6 +90,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		dequeue:                                op("Dequeue"),
 		dequeueIndex:                           op("DequeueIndex"),
 		dirtyRepositories:                      op("DirtyRepositories"),
+		commitGraphMetadata:                    op("CommitGraphMetadata"),
 		findClosestDumps:                       op("FindClosestDumps"),
 		findClosestDumpsFromGraphFragment:      op("FindClosestDumpsFromGraphFragment"),
 		getDumpByID:                            op("GetDumpByID"),

--- a/internal/database/basestore/rows.go
+++ b/internal/database/basestore/rows.go
@@ -170,14 +170,13 @@ func ScanBools(rows *sql.Rows, queryErr error) (_ []bool, err error) {
 
 // ScanFirstBool reads bool values from the given row object and returns the first one.
 // If no rows match the query, a false-valued flag is returned.
-func ScanFirstBool(rows *sql.Rows, queryErr error) (_ bool, _ bool, err error) {
+func ScanFirstBool(rows *sql.Rows, queryErr error) (value bool, exists bool, err error) {
 	if queryErr != nil {
 		return false, false, queryErr
 	}
 	defer func() { err = CloseRows(rows, err) }()
 
 	if rows.Next() {
-		var value bool
 		if err := rows.Scan(&value); err != nil {
 			return false, false, err
 		}

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -568,11 +568,12 @@ Indexes:
 
 # Table "public.lsif_dirty_repositories"
 ```
-    Column     |  Type   | Modifiers 
----------------+---------+-----------
- repository_id | integer | not null
- dirty_token   | integer | not null
- update_token  | integer | not null
+    Column     |           Type           | Modifiers 
+---------------+--------------------------+-----------
+ repository_id | integer                  | not null
+ dirty_token   | integer                  | not null
+ update_token  | integer                  | not null
+ updated_at    | timestamp with time zone | 
 Indexes:
     "lsif_dirty_repositories_pkey" PRIMARY KEY, btree (repository_id)
 
@@ -583,6 +584,8 @@ Stores whether or not the nearest upload data for a repository is out of date (w
 **dirty_token**: Set to the value of update_token visible to the transaction that updates the commit graph. Updates of dirty_token during this time will cause a second update.
 
 **update_token**: This value is incremented on each request to update the commit graph for the repository.
+
+**updated_at**: The time the update_token value was last updated.
 
 # Table "public.lsif_index_configuration"
 ```

--- a/migrations/frontend/1528395779_dirty_repositories_updated_at.down.sql
+++ b/migrations/frontend/1528395779_dirty_repositories_updated_at.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE lsif_dirty_repositories DROP COLUMN updated_at;
+
+COMMIT;

--- a/migrations/frontend/1528395779_dirty_repositories_updated_at.up.sql
+++ b/migrations/frontend/1528395779_dirty_repositories_updated_at.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE lsif_dirty_repositories ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE;
+COMMENT ON COLUMN lsif_dirty_repositories.updated_at IS 'The time the update_token value was last updated.';
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -92,6 +92,8 @@
 // 1528395777_lsif_uploads_associated_index.up.sql (791B)
 // 1528395778_add_syncer_error.down.sql (76B)
 // 1528395778_add_syncer_error.up.sql (84B)
+// 1528395779_dirty_repositories_updated_at.down.sql (77B)
+// 1528395779_dirty_repositories_updated_at.up.sql (210B)
 
 package migrations
 
@@ -2000,6 +2002,46 @@ func _1528395778_add_syncer_errorUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395779_dirty_repositories_updated_atDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\xf4\x09\x71\x0d\x52\x08\x71\x74\xf2\x71\x55\xc8\x29\xce\x4c\x8b\x4f\xc9\x2c\x2a\xa9\x8c\x2f\x4a\x2d\xc8\x2f\xce\x2c\xc9\x2f\xca\x4c\x2d\x56\x70\x09\xf2\x0f\x50\x70\xf6\xf7\x09\xf5\xf5\x53\x28\x2d\x48\x49\x2c\x49\x4d\x89\x4f\x2c\xb1\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\x5f\xbe\x72\x40\x4d\x00\x00\x00")
+
+func _1528395779_dirty_repositories_updated_atDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395779_dirty_repositories_updated_atDownSql,
+		"1528395779_dirty_repositories_updated_at.down.sql",
+	)
+}
+
+func _1528395779_dirty_repositories_updated_atDownSql() (*asset, error) {
+	bytes, err := _1528395779_dirty_repositories_updated_atDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395779_dirty_repositories_updated_at.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9f, 0xdc, 0x4b, 0xef, 0xb8, 0xa6, 0x6b, 0xe2, 0x3d, 0xbe, 0x41, 0x29, 0x4c, 0x90, 0xe, 0x1d, 0x55, 0xef, 0xbe, 0xb6, 0x27, 0xc2, 0x37, 0x1c, 0x98, 0x9f, 0x62, 0x61, 0xdf, 0x46, 0xa, 0x29}}
+	return a, nil
+}
+
+var __1528395779_dirty_repositories_updated_atUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x74\x8e\xc1\x8a\x83\x30\x14\x45\xf7\xf9\x8a\xb7\x73\xe7\x0f\x64\x15\x35\xcc\x04\x4c\x32\x8c\xaf\x14\xba\x09\x01\x5f\x31\xd4\x56\x31\xcf\x96\xfe\x7d\x41\x2a\x74\xd3\xe5\x5d\xdc\x73\x4e\xa5\x7f\x8c\x93\x42\xa8\x16\xf5\x3f\xa0\xaa\x5a\x0d\x63\x4e\xe7\xd0\xa7\x85\x9f\x61\xa1\x79\xca\x89\xa7\x25\x51\x06\xd5\x34\x50\xfb\xf6\x60\x1d\xac\x73\x1f\x99\xfa\x10\x19\xd0\x58\xdd\xa1\xb2\x7f\x70\x34\xf8\xbb\x4d\x38\x79\xa7\xa5\xa8\xbd\xb5\xda\x21\x78\xb7\xdf\xbe\x90\xcb\x0f\x9c\xe9\xa0\xc0\x81\x80\xd3\x95\x80\x07\x7a\xab\x02\x4f\x17\xba\xc1\x3d\x8e\x2b\xc1\x23\x66\x18\x63\xe6\x3d\xa3\x2c\xa4\xd8\x6c\x06\xa5\x78\x05\x00\x00\xff\xff\x94\x2b\xa8\x0c\xd2\x00\x00\x00")
+
+func _1528395779_dirty_repositories_updated_atUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395779_dirty_repositories_updated_atUpSql,
+		"1528395779_dirty_repositories_updated_at.up.sql",
+	)
+}
+
+func _1528395779_dirty_repositories_updated_atUpSql() (*asset, error) {
+	bytes, err := _1528395779_dirty_repositories_updated_atUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395779_dirty_repositories_updated_at.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0xd3, 0x66, 0xc4, 0xa8, 0x5, 0x44, 0xe5, 0x95, 0x17, 0x34, 0xdb, 0x4e, 0x9a, 0xc0, 0x82, 0x22, 0xa1, 0x8a, 0xfc, 0x0, 0xa4, 0xe8, 0xa5, 0xc, 0xb4, 0x2c, 0xc8, 0xd9, 0x3, 0x44, 0xa5, 0x38}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2183,6 +2225,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395777_lsif_uploads_associated_index.up.sql":                                        _1528395777_lsif_uploads_associated_indexUpSql,
 	"1528395778_add_syncer_error.down.sql":                                                   _1528395778_add_syncer_errorDownSql,
 	"1528395778_add_syncer_error.up.sql":                                                     _1528395778_add_syncer_errorUpSql,
+	"1528395779_dirty_repositories_updated_at.down.sql":                                      _1528395779_dirty_repositories_updated_atDownSql,
+	"1528395779_dirty_repositories_updated_at.up.sql":                                        _1528395779_dirty_repositories_updated_atUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2321,6 +2365,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395777_lsif_uploads_associated_index.up.sql":                                        {_1528395777_lsif_uploads_associated_indexUpSql, map[string]*bintree{}},
 	"1528395778_add_syncer_error.down.sql":                                                   {_1528395778_add_syncer_errorDownSql, map[string]*bintree{}},
 	"1528395778_add_syncer_error.up.sql":                                                     {_1528395778_add_syncer_errorUpSql, map[string]*bintree{}},
+	"1528395779_dirty_repositories_updated_at.down.sql":                                      {_1528395779_dirty_repositories_updated_atDownSql, map[string]*bintree{}},
+	"1528395779_dirty_repositories_updated_at.up.sql":                                        {_1528395779_dirty_repositories_updated_atUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
The commit graph calculation is necessary for precise code intelligence to work correctly. We have recently had issues in customer instances due to lack of visibility into this status, and our current code intelligence integration tests are flaky because we don't have a way to check when this process has run (so we currently resort to a `sleep 10` between uploading and querying, which sometimes isn't enough.

This is the first step to exposing this data to the API layer for use from the UI as well as integration testing utilities.