### PR TITLE
search: don't send repo count during search

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -74,7 +74,9 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sendProgress := func() {
-		_ = eventWriter.Event("progress", progress.Build())
+		pr := progress.Build()
+		pr.RepositoriesCount = nil // don't send repository counts during search.
+		_ = eventWriter.Event("progress", pr)
 	}
 
 	filters := &graphqlbackend.SearchFilters{


### PR DESCRIPTION
This effectively removes the repo count from the progress counter during
search. 

**before**
<img width="702" alt="Screenshot 2021-01-29 at 07 01 38" src="https://user-images.githubusercontent.com/26413131/106238972-1e230400-6202-11eb-86ba-736933676d87.png">

**after**
<img width="841" alt="image" src="https://user-images.githubusercontent.com/26413131/106238869-ea47de80-6201-11eb-8f3f-7d9b5a52cdd0.png">

We still send the repo count at the end of the search
<img width="631" alt="image" src="https://user-images.githubusercontent.com/26413131/106239183-7528d900-6202-11eb-8c3f-2800edf9f030.png">

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
