### PR TITLE
search: return after sending error on channel

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -114,13 +114,16 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		q, err = buildQuery(args, repos, filePathPatterns, false)
 		if err != nil {
 			c <- SearchEvent{Error: err}
+			return
 		}
 		resp, err = args.Zoekt.Client.Search(ctx, q, &searchOpts)
 		if err != nil {
 			c <- SearchEvent{Error: err}
+			return
 		}
 		if since(t0) >= searchOpts.MaxWallTime {
 			c <- SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout | search.RepoStatusIndexed)}}
+			return
 		}
 		// This is the only place limitHit can be set false, meaning we covered everything.
 		limitHit = resp.FilesSkipped+resp.ShardsSkipped > 0

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -123,7 +123,6 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		}
 		if since(t0) >= searchOpts.MaxWallTime {
 			c <- SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout | search.RepoStatusIndexed)}}
-			return
 		}
 		// This is the only place limitHit can be set false, meaning we covered everything.
 		limitHit = resp.FilesSkipped+resp.ShardsSkipped > 0


### PR DESCRIPTION
This fixes a bug we introduced when we updated zoektSearchHEADOnlyFiles
to be stream-based.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
