### PR TITLE
frontend: make ExtensionRegistry a function

### DIFF
--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 
@@ -67,7 +68,7 @@ func (r *defaultSettingsResolver) LatestSettings(ctx context.Context) (*settings
 	for id := range builtinExtensions {
 		extensionIDs = append(extensionIDs, id)
 	}
-	extensionIDs = ExtensionRegistry.FilterRemoteExtensions(extensionIDs)
+	extensionIDs = ExtensionRegistry().FilterRemoteExtensions(extensionIDs)
 	extensions := map[string]bool{}
 	for _, id := range extensionIDs {
 		extensions[id] = true

--- a/cmd/frontend/graphqlbackend/extension_registry.go
+++ b/cmd/frontend/graphqlbackend/extension_registry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 )
@@ -12,8 +13,9 @@ import (
 var ErrExtensionsDisabled = errors.New("extensions are disabled in site configuration (contact the site admin to enable extensions)")
 
 func (r *schemaResolver) ExtensionRegistry(ctx context.Context) (ExtensionRegistryResolver, error) {
+	reg := ExtensionRegistry()
 	if conf.Extensions() == nil {
-		if !ExtensionRegistry.ImplementsLocalExtensionRegistry() {
+		if !reg.ImplementsLocalExtensionRegistry() {
 			// The OSS build doesn't implement a local extension registry, so the reason for
 			// extensions being disabled is probably that the OSS build is in use.
 			return nil, errors.New("no extension registry is available (use Sourcegraph Free or Sourcegraph Enterprise to access the Sourcegraph extension registry and/or to host a private internal extension registry)")
@@ -21,12 +23,12 @@ func (r *schemaResolver) ExtensionRegistry(ctx context.Context) (ExtensionRegist
 
 		return nil, ErrExtensionsDisabled
 	}
-	return ExtensionRegistry, nil
+	return reg, nil
 }
 
 // ExtensionRegistry is the implementation of the GraphQL types ExtensionRegistry and
 // ExtensionRegistryMutation.
-var ExtensionRegistry ExtensionRegistryResolver
+var ExtensionRegistry func() ExtensionRegistryResolver
 
 // ExtensionRegistryResolver is the interface for the GraphQL types ExtensionRegistry and
 // ExtensionRegistryMutation.

--- a/cmd/frontend/registry/registry_graphql.go
+++ b/cmd/frontend/registry/registry_graphql.go
@@ -11,7 +11,9 @@ import (
 )
 
 func init() {
-	graphqlbackend.ExtensionRegistry = &ExtensionRegistry
+	graphqlbackend.ExtensionRegistry = func() graphqlbackend.ExtensionRegistryResolver {
+		return &ExtensionRegistry
+	}
 }
 
 // ExtensionRegistry is the implementation of the GraphQL types ExtensionRegistry and


### PR DESCRIPTION
This changes the global ExtensionRegistry variable into a function to simplify dependency injection in further PRs.
