### PR TITLE
frontend: replace global handler variables by functions

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -370,11 +370,13 @@ func serveRepoOrBlob(routeName string, title func(c *Common, r *http.Request) st
 
 // searchBadgeHandler serves the search readme badges from the search-badger service
 // https://github.com/sourcegraph/search-badger
-var searchBadgeHandler = &httputil.ReverseProxy{
-	Director: func(r *http.Request) {
-		r.URL.Scheme = "http"
-		r.URL.Host = "search-badger"
-		r.URL.Path = "/"
-	},
-	ErrorLog: log.New(env.DebugOut, "search-badger proxy: ", log.LstdFlags),
+func searchBadgeHandler() *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Director: func(r *http.Request) {
+			r.URL.Scheme = "http"
+			r.URL.Host = "search-badger"
+			r.URL.Path = "/"
+		},
+		ErrorLog: log.New(env.DebugOut, "search-badger proxy: ", log.LstdFlags),
+	}
 }

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -260,10 +260,10 @@ func initRouter(router *mux.Router) {
 	}, nil)))
 
 	// streaming search
-	router.Get(routeSearchStream).Handler(search.StreamHandler)
+	router.Get(routeSearchStream).Handler(search.StreamHandler())
 
 	// search badge
-	router.Get(routeSearchBadge).Handler(searchBadgeHandler)
+	router.Get(routeSearchBadge).Handler(searchBadgeHandler())
 
 	if envvar.SourcegraphDotComMode() {
 		// about subdomain

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -76,7 +76,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook webhooks.Re
 
 	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
 
-	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(frontendsearch.StreamHandler))
+	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(frontendsearch.StreamHandler()))
 
 	// Return the minimum src-cli version that's compatible with this instance
 	m.Get(apirouter.SrcCliVersion).Handler(trace.TraceRoute(handler(srcCliVersionServe)))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -15,8 +15,10 @@ import (
 )
 
 // StreamHandler is an http handler which streams back search results.
-var StreamHandler http.Handler = &streamHandler{
-	newSearchResolver: defaultNewSearchResolver,
+func StreamHandler() http.Handler {
+	return &streamHandler{
+		newSearchResolver: defaultNewSearchResolver,
+	}
 }
 
 type streamHandler struct {


### PR DESCRIPTION
This changes global handler variables into functions to simplify dependency injection in further PRs.

