### PR TITLE
doc(templates): add link to unversioned docs as fallback

### DIFF
--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -29,7 +29,8 @@
 		{{else}}
 			{{if .ContentVersionNotFoundError}}
 				<h1>Version not found</h1>
-				<p>The version <code>{{.ContentVersion}}</code> was not found.</p>
+                <p>The version <code>{{.ContentVersion}}</code> was not found.</p>
+                <p><a href="/{{.ContentPagePath}}">Click here</a> to view the latest version of this page instead.</p>
 			{{else if .ContentPageNotFoundError}}
 				<h1>Page not found</h1>
 				<p>The page <code>{{.ContentPagePath}}</code> was not found.</p>

--- a/doc/_resources/templates/document.html
+++ b/doc/_resources/templates/document.html
@@ -30,7 +30,10 @@
 			{{if .ContentVersionNotFoundError}}
 				<h1>Version not found</h1>
                 <p>The version <code>{{.ContentVersion}}</code> was not found.</p>
-                <p><a href="/{{.ContentPagePath}}">Click here</a> to view the latest version of this page instead.</p>
+                <p>
+                    <a href="javascript:window.location.assign(`/{{.ContentPagePath}}${window.location.hash}`)">Click here</a>
+                    to view the latest version of this page instead.
+                </p>
 			{{else if .ContentPageNotFoundError}}
 				<h1>Page not found</h1>
 				<p>The page <code>{{.ContentPagePath}}</code> was not found.</p>

--- a/doc/dev/how-to/documentation_implementation.md
+++ b/doc/dev/how-to/documentation_implementation.md
@@ -66,31 +66,6 @@ The [local documentation server](#previewing-changes-locally) on http://localhos
 
 In very rare cases, you may want to run a local documentation server with a different configuration (described in the following sections).
 
-<!-- TODO(ryan): Uncomment once https://github.com/sourcegraph/docsite/issues/13 is fixed.
-
-### Running multi-version support locally
-
-> NOTE: The below does not currently work due to an issue with docsite being unable to load a combination of content and templates/assets locally and over http.
-
-If you're working on a docs template change involving multiple content versions (i.e., doc site URL paths like `/@v1.2.3/my/doc/page`), then you must run a [docsite](https://github.com/sourcegraph/docsite) server that can read multiple content versions:
-
-``` shell
-DOCSITE_CONFIG=$(cat <<-'DOCSITE'
-{
-  "templates": "_resources/templates",
-  "content": "https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/$VERSION#*/doc/",
-  "baseURLPath": "/",
-  "assets": "_resources/assets",
-  "assetsBaseURLPath": "/assets/"
-}
-DOCSITE
-) docsite serve -http=localhost:5081
-
-```
-
-This runs a docsite server on http://localhost:5081 that reads templates and assets from disk (so yo can see your changes reflected immediately upon page reload) but reads content from the remote Git repository at any version (by default `master` if no version is given in the URL path, as in `/@v1.2.3/my/doc/page`).
--->
-
 ### Running a local server that mimics prod configuration
 
 If you want to run the doc site *exactly* as it's deployed (reading templates and assets from the remote Git repository, too), consult the current Kubernetes deployment spec and invoke `docsite serve` with the deployment's `DOCSITE_CONFIG` env var, the end result looking something like:
@@ -98,13 +73,15 @@ If you want to run the doc site *exactly* as it's deployed (reading templates an
 ```bash
 DOCSITE_CONFIG=$(cat <<-'DOCSITE'
 {
-  "templates": "https://codeload.github.com/sourcegraph/sourcegraph/zip/main#*/doc/_resources/templates/",
-  "assets": "https://codeload.github.com/sourcegraph/sourcegraph/zip/main#*/doc/_resources/assets/",
+  "templates": "https://codeload.github.com/sourcegraph/sourcegraph/zip/docsite-fallback#*/doc/_resources/templates/",
+  "assets": "https://codeload.github.com/sourcegraph/sourcegraph/zip/docsite-fallback#*/doc/_resources/assets/",
   "content": "https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/$VERSION#*/doc/",
-  "defaultContentBranch": "main",
+  "defaultContentBranch": "docsite-fallback",
   "baseURLPath": "/",
   "assetsBaseURLPath": "/assets/"
 }
 DOCSITE
 ) docsite serve -http=localhost:5081
 ```
+
+You can test your changes alongside prod configuration (including things like multi-version support, i.e. `/@version/content`) by pushing your changes to a branch (e.g. `my-branch`) and run the above command after replacing all instances of `main` with `my-branch`.


### PR DESCRIPTION
If a version is not found, provide a link to the default version of the page while preserving anchor links.

Required for https://github.com/sourcegraph/sourcegraph/issues/17598. Relevant: https://github.com/sourcegraph/docsite/pull/67

![version-fallback](https://user-images.githubusercontent.com/23356519/106246826-b0022f80-6249-11eb-99b0-a1b4f8291ff3.gif)

Also updates documentation for docsite dev with a note on how to test things like this. Try it out:

```sh
DOCSITE_CONFIG=$(cat <<-'DOCSITE'
{
  "templates": "https://codeload.github.com/sourcegraph/sourcegraph/zip/docsite-fallback#*/doc/_resources/templates/",
  "assets": "https://codeload.github.com/sourcegraph/sourcegraph/zip/docsite-fallback#*/doc/_resources/assets/",
  "content": "https://codeload.github.com/sourcegraph/sourcegraph/zip/refs/heads/$VERSION#*/doc/",
  "defaultContentBranch": "docsite-fallback",
  "baseURLPath": "/",
  "assetsBaseURLPath": "/assets/"
}
DOCSITE
) docsite serve -http=localhost:5081
```


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
