### PR TITLE
search: remove error from SearchEvent

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -9,6 +9,7 @@ import (
 	rxsyntax "regexp/syntax"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
@@ -683,10 +684,13 @@ type alertObserver struct {
 	// Inputs are used to generate alert messages based on the query.
 	Inputs *SearchInputs
 
-	// alert is the current alert to show.
-	alert      *searchAlert
-	err        error
+	// Update state.
 	hasResults bool
+
+	// Error state. Can be called concurrently.
+	mu    sync.Mutex
+	alert *searchAlert
+	err   error
 }
 
 // Update AlertObserver's state based on event.
@@ -694,19 +698,28 @@ func (o *alertObserver) Update(event SearchEvent) {
 	if len(event.Results) > 0 {
 		o.hasResults = true
 	}
+}
 
-	if event.Error == nil {
+func (o *alertObserver) Error(ctx context.Context, err error) {
+	// Timeouts are reported through Stats so don't report an error for them.
+	if err == nil || isContextError(ctx, err) {
 		return
 	}
 
+	// We can compute the alert outside of the critical section.
+	alert := alertForError(err, o.Inputs)
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	// The error can be converted into an alert.
-	if alert := alertForError(event.Error, o.Inputs); alert != nil {
+	if alert != nil {
 		o.update(alert)
 		return
 	}
 
 	// Track the unexpected error for reporting when calling Done.
-	o.err = multierror.Append(o.err, event.Error)
+	o.err = multierror.Append(o.err, err)
 }
 
 // update to alert if it is more important than our current alert.

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -526,8 +526,7 @@ type searchCommitsInReposParameters struct {
 	ResultChannel SearchStream
 }
 
-func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) {
-	var err error
+func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) (err error) {
 	tr, ctx := trace.New(ctx, params.TraceName, fmt.Sprintf("query: %+v, numRepoRevs: %d", args.PatternInfo, len(args.Repos)))
 	defer func() {
 		tr.SetError(err)
@@ -608,16 +607,12 @@ func searchCommitsInRepos(ctx context.Context, args *search.TextParametersForCom
 	}
 	wg.Wait()
 
-	if err != nil {
-		params.ResultChannel <- SearchEvent{
-			Error: err,
-		}
-	}
+	return err
 }
 
 // searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel SearchStream) {
-	searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
+func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel SearchStream) error {
+	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
 		TraceName:     "searchCommitDiffsInRepos",
 		ErrorName:     "diffs",
 		ResultChannel: resultChannel,
@@ -630,13 +625,13 @@ func searchCommitDiffsInRepos(ctx context.Context, args *search.TextParametersFo
 }
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel SearchStream) {
+func searchCommitLogInRepos(ctx context.Context, args *search.TextParametersForCommitParameters, resultChannel SearchStream) error {
 	var terms []string
 	if args.PatternInfo.Pattern != "" {
 		terms = append(terms, args.PatternInfo.Pattern)
 	}
 
-	searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
+	return searchCommitsInRepos(ctx, args, searchCommitsInReposParameters{
 		TraceName:     "searchCommitLogsInRepos",
 		ErrorName:     "commits",
 		ResultChannel: resultChannel,

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -43,7 +43,7 @@ func buildQuery(args *search.TextParameters, repos *indexedRepoRevs, filePathPat
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, _ indexedRequestType, since func(t time.Time) time.Duration, c SearchStream) error {
+func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, _ indexedRequestType, since func(t time.Time) time.Duration, c chan<- SearchEvent) error {
 	var (
 		err       error
 		limitHit  bool

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -43,7 +43,7 @@ func buildQuery(args *search.TextParameters, repos *indexedRepoRevs, filePathPat
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, _ indexedRequestType, since func(t time.Time) time.Duration, c chan<- SearchEvent) error {
+func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, _ indexedRequestType, since func(t time.Time) time.Duration, c SearchStream) error {
 	var (
 		err       error
 		limitHit  bool

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -103,8 +103,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		run = parallel.NewRun(conf.SearchSymbolsParallelism())
 		mu  sync.Mutex
 
-		aggMatches        []*FileMatchResolver
-		overLimitCanceled bool
+		aggMatches []*FileMatchResolver
 	)
 
 	addMatches := func(matches []*FileMatchResolver) {
@@ -112,7 +111,6 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 			aggMatches = append(aggMatches, matches...)
 			if len(aggMatches) > int(args.PatternInfo.FileMatchLimit) {
 				tr.LazyPrintf("cancel due to result size: %d > %d", len(aggMatches), args.PatternInfo.FileMatchLimit)
-				overLimitCanceled = true
 				common.IsLimitHit = true
 				cancelAll()
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -142,7 +142,10 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 
 		if err := <-e; err != nil {
 			tr.LogFields(otlog.Error(err))
-			run.Error(err)
+			if ctx.Err() == nil || errors.Cause(err) != ctx.Err() {
+				// Only record error if it's not directly caused by a context error.
+				run.Error(err)
+			}
 		}
 	})
 

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -128,14 +128,14 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		}()
 		for event := range c {
 			func() {
-				mu.Lock()
-				defer mu.Unlock()
-				common.Update(&event.Stats)
-
 				fms := make([]*FileMatchResolver, 0, len(event.Results))
 				for _, match := range event.Results {
 					fms = append(fms, match.(*FileMatchResolver))
 				}
+
+				mu.Lock()
+				defer mu.Unlock()
+				common.Update(&event.Stats)
 				addMatches(fms)
 			}()
 		}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -124,7 +124,7 @@ func searchSymbols(ctx context.Context, args *search.TextParameters, limit int) 
 		e := make(chan error, 1)
 		go func() {
 			defer close(c)
-			e <- indexed.doSearch(ctx, c)
+			e <- indexed.Search(ctx, c)
 		}()
 		for event := range c {
 			func() {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -343,7 +343,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 		mu                sync.Mutex
 		searchErr         error
-		resultCount       int
 		overLimitCanceled bool // canceled because we were over the limit
 	)
 	if mockSearchFilesInRepos != nil {
@@ -461,28 +460,6 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}
 	}
 
-	// send assumes the caller does not hold mu.
-	send := func(event SearchEvent) {
-		stream <- event
-
-		// Stop searching if we have found enough results.
-		mu.Lock()
-		resultCount += len(event.Results)
-		if limit := int(args.PatternInfo.FileMatchLimit); resultCount > limit && !overLimitCanceled {
-			cancel()
-			tr.LazyPrintf("cancel due to result size: %d > %d", resultCount, limit)
-			overLimitCanceled = true
-
-			// Inform stream we have found more than limit results
-			stream <- SearchEvent{
-				Stats: streaming.Stats{
-					IsLimitHit: true,
-				},
-			}
-		}
-		mu.Unlock()
-	}
-
 	// callSearcherOverRepos calls searcher on a set of repos.
 	// searcherReposFilteredFiles is an optional map of {repo name => file list}
 	// that forces the searcher to only include the file list in the
@@ -563,10 +540,10 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
 					repoCommon, fatalErr := handleRepoSearchResult(repoRev, repoLimitHit, false, err)
-					send(SearchEvent{
+					stream <- SearchEvent{
 						Results: fileMatchResultsToSearchResults(matches),
 						Stats:   repoCommon,
-					})
+					}
 					setError(ctx, repoRev, fatalErr)
 				}(limitCtx, limitDone) // ends the Go routine for a call to searcher for a repo
 			} // ends the for loop iterating over repo's revs
@@ -584,11 +561,8 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		go func() {
 			// TODO limitHit, handleRepoSearchResult
 			defer wg.Done()
-			for event := range indexed.Search(ctx) {
-				tr.LogFields(otlog.Int("matches.len", len(event.Results)), otlog.Error(event.Error))
-				send(event.SearchEvent)
-				setError(ctx, stringerFunc("indexed"), event.Error)
-			}
+			err := indexed.doSearch(ctx, stream)
+			setError(ctx, stringerFunc("indexed"), err)
 		}()
 	}
 
@@ -614,9 +588,9 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 			source := stringerFunc("structural-indexed")
 			for event := range indexed.Search(ctx) {
 				tr.LogFields(otlog.Int("matches.len", len(event.Results)), otlog.Error(event.Error))
-				send(SearchEvent{
+				stream <- SearchEvent{
 					Stats: event.Stats,
-				})
+				}
 				setError(ctx, source, event.Error)
 
 				// For structural search, we run callSearcherOverRepos

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -327,17 +327,17 @@ func searchResultsToFileMatchResults(results []SearchResultResolver) ([]*FileMat
 // which collects the results from the stream.
 func searchFilesInReposBatch(ctx context.Context, args *search.TextParameters) ([]*FileMatchResolver, streaming.Stats, error) {
 	ctx, stream, done := collectStream(ctx)
-	searchFilesInRepos(ctx, args, stream)
+	searchErr := searchFilesInRepos(ctx, args, stream)
 	agg := done()
 	results, err := searchResultsToFileMatchResults(agg.Results)
-	if err != nil {
-		agg.Error = errors.Wrap(err, "searchFilesInReposBatch failed to convert results")
+	if err != nil && searchErr == nil {
+		searchErr = errors.Wrap(err, "searchFilesInReposBatch failed to convert results")
 	}
-	return results, agg.Stats, agg.Error
+	return results, agg.Stats, searchErr
 }
 
 // searchFilesInRepos searches a set of repos for a pattern.
-func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream SearchStream) {
+func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream SearchStream) (finalErr error) {
 	var (
 		wg sync.WaitGroup
 
@@ -351,22 +351,14 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		stream <- SearchEvent{
 			Results: fileMatchResultsToSearchResults(results),
 			Stats:   statsDeref(mockStats),
-			Error:   err,
 		}
-		return
+		return err
 	}
 
 	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %s", args.PatternInfo.Pattern))
 	defer func() {
-		mu.Lock()
-		if searchErr != nil {
-			stream <- SearchEvent{
-				Error: searchErr,
-			}
-		}
-		tr.SetError(searchErr)
+		tr.SetError(finalErr)
 		tr.Finish()
-		mu.Unlock()
 	}()
 	fields := querytypes.Fields(args.Query.Fields())
 	tr.LogFields(
@@ -397,25 +389,19 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		var err error
 		indexed, err = newIndexedSearchRequest(ctx, args, indexedTyp)
 		if err != nil {
-			mu.Lock()
-			searchErr = err
-			mu.Unlock()
-			return
+			return err
 		}
 	}
 
 	// if there are no indexed repos and this is a structural search
 	// query, there will be no results. Raise a friendly alert.
 	if args.PatternInfo.IsStructuralPat && len(indexed.Repos()) == 0 {
-		mu.Lock()
-		searchErr = errors.New("no indexed repositories for structural search")
-		mu.Unlock()
-		return
+		return errors.New("no indexed repositories for structural search")
 	}
 
 	if args.PatternInfo.IsEmpty() {
 		// Empty query isn't an error, but it has no results.
-		return
+		return nil
 	}
 
 	tr.LazyPrintf("%d indexed repos, %d unindexed repos", len(indexed.Repos()), len(indexed.Unindexed))
@@ -452,31 +438,31 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}
 	}
 
-	// send assumes the caller does not hold mu.
-	send := func(ctx context.Context, source fmt.Stringer, event SearchEvent) {
-		// Do not pass on errors yet.
-		if event.Error != nil {
-			if ctx.Err() == context.Canceled {
-				// Our request has been canceled (another backend had a fatal
-				// error, or otherwise), so we can just ignore these
-				// results.
-				return
-			}
-
-			// Check if we are the first error found.
-			mu.Lock()
-			if searchErr == nil && !overLimitCanceled {
-				searchErr = errors.Wrapf(event.Error, "failed to search %s", source.String())
-				tr.LazyPrintf("cancel due to error: %v", searchErr)
-				cancel()
-			}
-			mu.Unlock()
-
-			// Do not report the error now on the stream. We report a final
-			// error (searchErr) once all backends have finished running.
+	setError := func(ctx context.Context, source fmt.Stringer, err error) {
+		if err == nil {
 			return
 		}
 
+		if ctx.Err() == context.Canceled {
+			// Our request has been canceled (another backend had a fatal
+			// error, or otherwise), so we can just ignore these
+			// results.
+			return
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		// Check if we are the first error found.
+		if searchErr == nil && !overLimitCanceled {
+			searchErr = errors.Wrapf(err, "failed to search %s", source.String())
+			tr.LazyPrintf("cancel due to error: %v", searchErr)
+			cancel()
+		}
+	}
+
+	// send assumes the caller does not hold mu.
+	send := func(event SearchEvent) {
 		stream <- event
 
 		// Stop searching if we have found enough results.
@@ -577,11 +563,11 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
 					repoCommon, fatalErr := handleRepoSearchResult(repoRev, repoLimitHit, false, err)
-					send(ctx, repoRev, SearchEvent{
+					send(SearchEvent{
 						Results: fileMatchResultsToSearchResults(matches),
 						Stats:   repoCommon,
-						Error:   fatalErr,
 					})
+					setError(ctx, repoRev, fatalErr)
 				}(limitCtx, limitDone) // ends the Go routine for a call to searcher for a repo
 			} // ends the for loop iterating over repo's revs
 		} // ends the for loop iterating over repos
@@ -600,7 +586,8 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 			defer wg.Done()
 			for event := range indexed.Search(ctx) {
 				tr.LogFields(otlog.Int("matches.len", len(event.Results)), otlog.Error(event.Error))
-				send(ctx, stringerFunc("indexed"), event)
+				send(event.SearchEvent)
+				setError(ctx, stringerFunc("indexed"), event.Error)
 			}
 		}()
 	}
@@ -617,21 +604,20 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 			err := callSearcherOverRepos(repos, nil)
 			if err != nil {
-				mu.Lock()
-				searchErr = err
-				mu.Unlock()
+				setError(ctx, stringerFunc("structural-zoekt"), err)
 			}
 		}()
 	} else if isStructuralSearch {
 		wg.Add(1)
 		go func() {
-			// TODO limitHit, handleRepoSearchResult
 			defer wg.Done()
+			source := stringerFunc("structural-indexed")
 			for event := range indexed.Search(ctx) {
 				tr.LogFields(otlog.Int("matches.len", len(event.Results)), otlog.Error(event.Error))
-				send(ctx, stringerFunc("structural-indexed"), SearchEvent{
+				send(SearchEvent{
 					Stats: event.Stats,
 				})
+				setError(ctx, source, event.Error)
 
 				// For structural search, we run callSearcherOverRepos
 				// over the set of repos and files known to contain
@@ -644,10 +630,8 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 				for _, m := range event.Results {
 					fm, ok := m.ToFileMatch()
 					if !ok {
-						mu.Lock()
-						searchErr = fmt.Errorf("structual search: Events from indexed.Search could not be converted to FileMatch")
-						mu.Unlock()
-						return
+						setError(ctx, source, fmt.Errorf("structual search: Events from indexed.Search could not be converted to FileMatch"))
+						continue
 					}
 					name := string(fm.Repo.Name)
 					partition[name] = append(partition[name], fm.JPath)
@@ -664,9 +648,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 				err := callSearcherOverRepos(repos, partition)
 				if err != nil {
-					mu.Lock()
-					searchErr = err
-					mu.Unlock()
+					setError(ctx, source, err)
 				}
 			}
 		}()
@@ -677,13 +659,13 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 	// - unindexed search of negated content
 	if !args.PatternInfo.IsStructuralPat {
 		if err := callSearcherOverRepos(searcherRepos, nil); err != nil {
-			mu.Lock()
-			searchErr = err
-			mu.Unlock()
+			setError(ctx, stringerFunc("searcher"), err)
 		}
 	}
 
 	wg.Wait()
+
+	return searchErr
 }
 
 // limitSearcherRepos limits the number of repo@revs searched by the unindexed searcher codepath.

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -588,7 +588,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 			e := make(chan error, 1)
 			go func() {
 				defer close(c)
-				e <- indexed.doSearch(ctx, c)
+				e <- indexed.Search(ctx, c)
 			}()
 			for event := range c {
 				tr.LogFields(otlog.Int("matches.len", len(event.Results)))
@@ -626,7 +626,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 			e := make(chan error, 1)
 			go func() {
 				defer close(c)
-				e <- indexed.doSearch(ctx, c)
+				e <- indexed.Search(ctx, c)
 			}()
 			for event := range c {
 				tr.LogFields(otlog.Int("matches.len", len(event.Results)))

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -200,7 +200,7 @@ func (s *indexedSearchRequest) Repos() map[string]*search.RepositoryRevisions {
 	return s.repos.repoRevs
 }
 
-func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- SearchEvent) error {
+func (s *indexedSearchRequest) doSearch(ctx context.Context, c SearchStream) error {
 	if s.args == nil {
 		return nil
 	}
@@ -213,7 +213,7 @@ func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- SearchEven
 		since = s.since
 	}
 
-	var zoektStream func(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration, c chan<- SearchEvent) error
+	var zoektStream func(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration, c SearchStream) error
 	switch s.typ {
 	case textRequest, symbolRequest:
 		zoektStream = zoektSearch
@@ -233,7 +233,7 @@ func (s *indexedSearchRequest) doSearch(ctx context.Context, c chan<- SearchEven
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration, c chan<- SearchEvent) error {
+func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration, c SearchStream) error {
 	if args == nil {
 		return nil
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -200,7 +200,8 @@ func (s *indexedSearchRequest) Repos() map[string]*search.RepositoryRevisions {
 	return s.repos.repoRevs
 }
 
-func (s *indexedSearchRequest) doSearch(ctx context.Context, c SearchStream) error {
+// Search streams 0 or more events to c.
+func (s *indexedSearchRequest) Search(ctx context.Context, c SearchStream) error {
 	if s.args == nil {
 		return nil
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -221,9 +221,7 @@ func (s *indexedSearchRequest) Search(ctx context.Context, c SearchStream) error
 	case fileRequest:
 		zoektStream = zoektSearchHEADOnlyFiles
 	default:
-		err := fmt.Errorf("unexpected indexedSearchRequest type: %q", s.typ)
-		c <- SearchEvent{Stats: streaming.Stats{}, Results: nil}
-		return err
+		return fmt.Errorf("unexpected indexedSearchRequest type: %q", s.typ)
 	}
 
 	return zoektStream(ctx, s.args, s.repos, s.typ, since, c)

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -319,18 +319,19 @@ func TestIndexedSearch(t *testing.T) {
 				gotCommon streaming.Stats
 				gotFm     []*FileMatchResolver
 			)
-			for event := range indexed.Search(tt.args.ctx) {
-				if (event.Error != nil) != tt.wantErr {
-					t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
-					return
-				}
-				gotCommon.Update(&event.Stats)
-				fms := make([]*FileMatchResolver, 0, len(event.Results))
-				for _, r := range event.Results {
-					fms = append(fms, r.(*FileMatchResolver))
-				}
-				gotFm = append(gotFm, fms...)
+			ctx, stream, done := collectStream(tt.args.ctx)
+			err = indexed.doSearch(ctx, stream)
+			agg := done()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
+				return
 			}
+			gotCommon.Update(&agg.Stats)
+			fms, err := searchResultsToFileMatchResults(agg.Results)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotFm = append(gotFm, fms...)
 
 			if diff := cmp.Diff(&tt.wantCommon, &gotCommon, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("common mismatch (-want +got):\n%s", diff)

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -320,7 +320,7 @@ func TestIndexedSearch(t *testing.T) {
 				gotFm     []*FileMatchResolver
 			)
 			ctx, stream, done := collectStream(tt.args.ctx)
-			err = indexed.doSearch(ctx, stream)
+			err = indexed.Search(ctx, stream)
 			agg := done()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -70,10 +69,10 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resultsStream, resultsStreamDone := newResultsStream(ctx, search)
-	limit := search.Inputs().MaxResults()
+
 	progress := progressAggregator{
 		Start: time.Now(),
-		Limit: limit,
+		Limit: search.Inputs().MaxResults(),
 	}
 
 	sendProgress := func() {
@@ -106,8 +105,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	first := true
 
-	var resultCount int
-	var overLimitCanceled bool
 	for {
 		var event graphqlbackend.SearchEvent
 		var ok bool
@@ -128,17 +125,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		progress.Update(event)
 		filters.Update(event)
 
-		resultCount += len(event.Results)
-		if resultCount > limit && !overLimitCanceled {
-			progress.Update(graphqlbackend.SearchEvent{
-				Stats: streaming.Stats{
-					IsLimitHit: true,
-				},
-			})
-			cancel()
-			overLimitCanceled = true
-			tr.LazyPrintf("cancel due to result size: %d > %d", resultCount, limit)
-		}
 		for _, result := range event.Results {
 			if fm, ok := result.ToFileMatch(); ok {
 				if syms := fm.Symbols(); len(syms) > 0 {


### PR DESCRIPTION
We expected once a search stream returned an error event, it would stop. Additionally we expected once a function returned that took a stream, it would stop writing to the stream. This assumption could lead to bugs if broken. By removing error from the event, we more clearly force the above.