### PR TITLE
search: streaming progress handles 0 repositories

### DIFF
--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -14,6 +14,17 @@ describe('StreamingProgressCount', () => {
         expect(mount(<StreamingProgressCount state="loading" progress={progress} />)).toMatchSnapshot()
     })
 
+    it('should render correctly for 0 repositories', () => {
+        const progress: Progress = {
+            durationMs: 0,
+            matchCount: 0,
+            repositoriesCount: 0,
+            skipped: [],
+        }
+
+        expect(mount(<StreamingProgressCount state="loading" progress={progress} />)).toMatchSnapshot()
+    })
+
     it('should render correctly for 1 item complete', () => {
         const progress: Progress = {
             durationMs: 1250,

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -29,7 +29,7 @@ export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgr
         <CalculatorIcon className="mr-2 icon-inline" />
         {abbreviateNumber(progress.matchCount)} {pluralize('result', progress.matchCount)} in{' '}
         {(progress.durationMs / 1000).toFixed(2)}s
-        {progress.repositoriesCount && (
+        {progress.repositoriesCount !== undefined && (
             <>
                 {' '}
                 from {abbreviateNumber(progress.repositoriesCount)}{' '}

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -28,6 +28,40 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
 </StreamingProgressCount>
 `;
 
+exports[`StreamingProgressCount should render correctly for 0 repositories 1`] = `
+<StreamingProgressCount
+  progress={
+    Object {
+      "durationMs": 0,
+      "matchCount": 0,
+      "repositoriesCount": 0,
+      "skipped": Array [],
+    }
+  }
+  state="loading"
+>
+  <div
+    className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
+  >
+    <Memo(CalculatorIcon)
+      className="mr-2 icon-inline"
+    />
+    0
+     
+    results
+     in
+     
+    0.00
+    s
+     
+    from 
+    0
+     
+    repositories
+  </div>
+</StreamingProgressCount>
+`;
+
 exports[`StreamingProgressCount should render correctly for 1 item complete 1`] = `
 <StreamingProgressCount
   progress={


### PR DESCRIPTION
Previously we used a truthy check on "progress.repositoriesCount". So
when 0 we would render a 0. 0 is a valid value, so instead of using !!
we check if the field is undefined.

See https://github.com/sourcegraph/sourcegraph/issues/17558#issuecomment-769592791