### PR TITLE
frontend: Add the CreatePassword mutation

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -236,6 +236,11 @@ type Mutation {
     """
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse
     """
+    Creates a password for the current user. It is only permitted if the user has never had a password and
+    they don't have any login connections.
+    """
+    createPassword(newPassword: String!): EmptyResponse
+    """
     Creates an access token that grants the privileges of the specified user (referred to as the access token's
     "subject" user after token creation). The result is the access token value, which the caller is responsible
     for storing (it is not accessible by Sourcegraph after creation).

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -236,7 +236,7 @@ type Mutation {
     """
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse
     """
-    Creates a password for the current user. It is only permitted if the user has never had a password and
+    Creates a password for the current user. It is only permitted if the user does not have a password and
     they don't have any login connections.
     """
     createPassword(newPassword: String!): EmptyResponse

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -229,7 +229,7 @@ type Mutation {
     """
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse
     """
-    Creates a password for the current user. It is only permitted if the user has never had a password and
+    Creates a password for the current user. It is only permitted if the user does not have a password and
     they don't have any login connections.
     """
     createPassword(newPassword: String!): EmptyResponse

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -229,6 +229,11 @@ type Mutation {
     """
     updatePassword(oldPassword: String!, newPassword: String!): EmptyResponse
     """
+    Creates a password for the current user. It is only permitted if the user has never had a password and
+    they don't have any login connections.
+    """
+    createPassword(newPassword: String!): EmptyResponse
+    """
     Creates an access token that grants the privileges of the specified user (referred to as the access token's
     "subject" user after token creation). The result is the access token value, which the caller is responsible
     for storing (it is not accessible by Sourcegraph after creation).

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -320,6 +320,30 @@ func (r *schemaResolver) UpdatePassword(ctx context.Context, args *struct {
 	return &EmptyResponse{}, nil
 }
 
+func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
+	NewPassword string
+}) (*EmptyResponse, error) {
+	// 🚨 SECURITY: A user can only create their own password.
+	user, err := database.GlobalUsers.GetByCurrentAuthUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, errors.New("no authenticated user")
+	}
+
+	if err := database.GlobalUsers.CreatePassword(ctx, user.ID, args.NewPassword); err != nil {
+		return nil, err
+	}
+
+	if conf.CanSendEmail() {
+		if err := backend.UserEmails.SendUserEmailOnFieldUpdate(ctx, user.ID, "created a password"); err != nil {
+			log15.Warn("Failed to send email to inform user of password creation", "error", err)
+		}
+	}
+	return &EmptyResponse{}, nil
+}
+
 // ViewerCanChangeUsername returns if the current user can change the username of the user.
 func (r *UserResolver) ViewerCanChangeUsername(ctx context.Context) bool {
 	return viewerCanChangeUsername(ctx, r.user.ID)

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -331,7 +331,6 @@ func (r *schemaResolver) CreatePassword(ctx context.Context, args *struct {
 	if user == nil {
 		return nil, errors.New("no authenticated user")
 	}
-
 	if err := database.GlobalUsers.CreatePassword(ctx, user.ID, args.NewPassword); err != nil {
 		return nil, err
 	}

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -905,6 +905,9 @@ func (u *UserStore) SetPassword(ctx context.Context, id int32, resetCode, newPas
 	if newPassword == "" {
 		return false, errors.New("new password was empty")
 	}
+	if err := CheckPasswordLength(newPassword); err != nil {
+		return false, err
+	}
 
 	resetLinkExpiryDuration := conf.AuthPasswordResetLinkExpiry()
 
@@ -974,8 +977,8 @@ func (u *UserStore) UpdatePassword(ctx context.Context, id int32, oldPassword, n
 	return nil
 }
 
-// CreatePassword creates a user's password iff they have never had one set and
-// they don't have any other valid login connections.
+// CreatePassword creates a user's password iff don't have a password and they
+// don't have any valid login connections.
 func (u *UserStore) CreatePassword(ctx context.Context, id int32, password string) error {
 	u.ensureStore()
 

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -198,6 +198,9 @@ const maxPasswordRunes = 256
 
 // CheckPasswordLength returns an error if the length of the password is not in the required range.
 func CheckPasswordLength(pw string) error {
+	if pw == "" {
+		return errors.New("password empty")
+	}
 	pwLen := utf8.RuneCountInString(pw)
 	minPasswordRunes := conf.AuthMinPasswordLength()
 	if pwLen < minPasswordRunes ||
@@ -902,9 +905,6 @@ func (u *UserStore) SetPassword(ctx context.Context, id int32, resetCode, newPas
 	u.ensureStore()
 
 	// 🚨 SECURITY: no empty passwords
-	if newPassword == "" {
-		return false, errors.New("new password was empty")
-	}
 	if err := CheckPasswordLength(newPassword); err != nil {
 		return false, err
 	}
@@ -983,9 +983,6 @@ func (u *UserStore) CreatePassword(ctx context.Context, id int32, password strin
 	u.ensureStore()
 
 	// 🚨 SECURITY: Check min and max password length
-	if password == "" {
-		return errors.New("new password was empty")
-	}
 	if err := CheckPasswordLength(password); err != nil {
 		return err
 	}


### PR DESCRIPTION
Only for users that initially signed up with OAuth and subsequently
removed all their OAuth connections.

It can only create a new password where the current password 
is null and the user doesn't have any external login connections.

Closes: https://github.com/sourcegraph/sourcegraph/issues/17729