### PR TITLE
search: Add spans for zip writing and comby

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 // The Sourcegraph frontend and interface only allow LineMatches (matches on a
@@ -211,9 +210,6 @@ func structuralSearch(ctx context.Context, zipPath, pattern, rule string, langua
 		Rule:          rule,
 		NumWorkers:    numWorkers,
 	}
-
-	span, ctx := ot.StartSpanFromContext(ctx, "Comby")
-	defer span.Finish()
 
 	combyMatches, err := comby.Matches(ctx, args)
 	if err != nil {

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/inconshreveable/log15"
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 const combyPath = "comby"
@@ -157,6 +158,9 @@ func PipeTo(ctx context.Context, args Args, w io.Writer) (err error) {
 
 // Matches returns all matches in all files for which comby finds matches.
 func Matches(ctx context.Context, args Args) (matches []FileMatch, err error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "Comby.Matches")
+	defer span.Finish()
+
 	b := new(bytes.Buffer)
 	w := bufio.NewWriter(b)
 


### PR DESCRIPTION
Adds a span for `writeZip` operation during structural search, as well
as a span for the comby subprocess.

Sample result from Jaeger:
<img width="1307" alt="image" src="https://user-images.githubusercontent.com/12631702/106315943-35291c80-6229-11eb-868c-3e09da9cdacb.png">

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
