### PR TITLE
code insights: add new GraphQL schema

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2426,9 +2426,54 @@ type ChangesetEventConnection {
 }
 
 """
-Insights about code.
+A list of insights.
 """
-type Insights {
+type InsightConnection {
+    """
+    A list of insights.
+    """
+    nodes: [Insight!]!
+
+    """
+    The total number of insights in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+An insight about code.
+"""
+type Insight {
+    """
+    The short title of the insight.
+    """
+    title: String!
+
+    """
+    The description of the insight.
+    """
+    description: String!
+
+    """
+    Data points over a time range (inclusive)
+    """
+    series: [InsightsSeries!]!
+}
+
+"""
+A series of data about a code insight.
+"""
+type InsightsSeries {
+    """
+    The label used to describe this series of data points.
+    """
+    label: String!
+
     """
     Data points over a time range (inclusive)
     """
@@ -2767,7 +2812,7 @@ type Query {
     """
     EXPERIMENTAL: Queries code insights
     """
-    insights: Insights
+    insights: InsightConnection
 
     """
     Looks up a repository by either name or cloneURL.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2419,9 +2419,54 @@ type ChangesetEventConnection {
 }
 
 """
-Insights about code.
+A list of insights.
 """
-type Insights {
+type InsightConnection {
+    """
+    A list of insights.
+    """
+    nodes: [Insight!]!
+
+    """
+    The total number of insights in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+An insight about code.
+"""
+type Insight {
+    """
+    The short title of the insight.
+    """
+    title: String!
+
+    """
+    The description of the insight.
+    """
+    description: String!
+
+    """
+    Data points over a time range (inclusive)
+    """
+    series: [InsightsSeries!]!
+}
+
+"""
+A series of data about a code insight.
+"""
+type InsightsSeries {
+    """
+    The label used to describe this series of data points.
+    """
+    label: String!
+
     """
     Data points over a time range (inclusive)
     """
@@ -2760,7 +2805,7 @@ type Query {
     """
     EXPERIMENTAL: Queries code insights
     """
-    insights: Insights
+    insights: InsightConnection
 
     """
     Looks up a repository by either name or cloneURL.

--- a/enterprise/internal/insights/resolvers/insight_connection_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_connection_resolver.go
@@ -1,0 +1,61 @@
+package resolvers
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+var _ graphqlbackend.InsightConnectionResolver = &insightConnectionResolver{}
+
+type insightConnectionResolver struct {
+	store        *store.Store
+	settingStore *database.SettingStore
+
+	// cache results because they are used by multiple fields
+	once     sync.Once
+	insights []graphqlbackend.InsightResolver
+	next     int64
+	err      error
+}
+
+func (r *insightConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.InsightResolver, error) {
+	nodes, _, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resolvers := make([]graphqlbackend.InsightResolver, 0, len(nodes))
+	for _, insight := range nodes {
+		resolvers = append(resolvers, &insightResolver{store: r.store, insight: insight})
+	}
+	return resolvers, nil
+}
+
+func (r *insightConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	return 0, errors.New("not yet implemented")
+}
+
+func (r *insightConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, next, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if next != 0 {
+		return graphqlutil.NextPageCursor(strconv.Itoa(int(next))), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
+}
+
+func (r *insightConnectionResolver) compute(ctx context.Context) ([]graphqlbackend.InsightResolver, int64, error) {
+	r.once.Do(func() {
+		// TODO: populate r.insights, r.next, r.err
+		// TODO: locate insights from user, org, global settings using r.settingStore.ListAll()
+	})
+	return r.insights, r.next, r.err
+}

--- a/enterprise/internal/insights/resolvers/insight_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_resolver.go
@@ -1,0 +1,22 @@
+package resolvers
+
+import (
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+)
+
+var _ graphqlbackend.InsightResolver = &insightResolver{}
+
+type insightResolver struct {
+	store   *store.Store
+	insight graphqlbackend.InsightResolver
+}
+
+func (r *insightResolver) Title() string { return r.insight.Title() }
+
+func (r *insightResolver) Description() string { return r.insight.Description() }
+
+func (r *insightResolver) Series() []graphqlbackend.InsightSeriesResolver {
+	// TODO: locate time series from r.store DB.
+	return nil
+}

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -1,0 +1,20 @@
+package resolvers
+
+import (
+	"context"
+	"errors"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+)
+
+var _ graphqlbackend.InsightSeriesResolver = &insightSeriesResolver{}
+
+type insightSeriesResolver struct {
+	label string
+}
+
+func (r *insightSeriesResolver) Label() string { return r.label }
+
+func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend.InsightsPointsArgs) ([]graphqlbackend.InsightsDataPointResolver, error) {
+	return nil, errors.New("not yet implemented")
+}

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -2,13 +2,14 @@ package resolvers
 
 import (
 	"context"
-	"errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
+
+var _ graphqlbackend.InsightsResolver = &Resolver{}
 
 // Resolver is the GraphQL resolver of all things related to Insights.
 type Resolver struct {
@@ -24,10 +25,9 @@ func New(timescale, postgres dbutil.DB) graphqlbackend.InsightsResolver {
 	}
 }
 
-func (r *Resolver) Insights(ctx context.Context) (graphqlbackend.InsightsResolver, error) {
-	return r, nil
-}
-
-func (r *Resolver) Points(ctx context.Context, args *graphqlbackend.InsightsPointsArgs) ([]graphqlbackend.InsightsDataPointResolver, error) {
-	return nil, errors.New("not yet implemented")
+func (r *Resolver) Insights(ctx context.Context) (graphqlbackend.InsightConnectionResolver, error) {
+	return &insightConnectionResolver{
+		store:        r.store,
+		settingStore: r.settingStore,
+	}, nil
 }


### PR DESCRIPTION
This PR updates the GraphQL schema for code insights. It doesn't implement the new backend for it, that will come in subsequent PRs.

* @felixfbecker to review/provide feedback on the GraphQL schema design
* @efritz to review backend stub implementation