### PR TITLE
code insights: improve backend testing experience

### DIFF
--- a/enterprise/internal/insights/store/integration_test.go
+++ b/enterprise/internal/insights/store/integration_test.go
@@ -22,6 +22,9 @@ func TestIntegration(t *testing.T) {
 
 	getTimescaleDB := func(t testing.TB) *sql.DB {
 		// Setup TimescaleDB for testing.
+		if os.Getenv("CODEINSIGHTS_PGDATASOURCE") == "" {
+			os.Setenv("CODEINSIGHTS_PGDATASOURCE", "postgres://postgres:password@127.0.0.1:5435/postgres")			
+		}
 		username := ""
 		if user, err := user.Current(); err == nil {
 			username = user.Username
@@ -33,7 +36,6 @@ func TestIntegration(t *testing.T) {
 			t.Log("README: To run these tests you need to have the codeinsights TimescaleDB running:")
 			t.Log("")
 			t.Log("$ ./dev/codeinsights-db.sh &")
-			t.Log("$ export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres")
 			t.Log("")
 			t.Log("Or skip them with 'go test -short'")
 			t.Log("")

--- a/enterprise/internal/insights/store/integration_test.go
+++ b/enterprise/internal/insights/store/integration_test.go
@@ -23,7 +23,7 @@ func TestIntegration(t *testing.T) {
 	getTimescaleDB := func(t testing.TB) *sql.DB {
 		// Setup TimescaleDB for testing.
 		if os.Getenv("CODEINSIGHTS_PGDATASOURCE") == "" {
-			os.Setenv("CODEINSIGHTS_PGDATASOURCE", "postgres://postgres:password@127.0.0.1:5435/postgres")			
+			os.Setenv("CODEINSIGHTS_PGDATASOURCE", "postgres://postgres:password@127.0.0.1:5435/postgres")
 		}
 		username := ""
 		if user, err := user.Current(); err == nil {


### PR DESCRIPTION
This improves the backend testing experience for code insights. The way this previously worked meant that if you _didn't_ have `CODEINSIGHTS_PGDATASOURCE` set you would likely get accidentally connected to the main app DB due to #17739 and get a confusing migration error.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
