### PR TITLE
code insights: add new user/org/global settings schema

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -741,6 +741,24 @@ type ImportChangesets struct {
 	// Repository description: The repository name as configured on your Sourcegraph instance.
 	Repository string `json:"repository"`
 }
+type Insight struct {
+	// Description description: The description of this insight
+	Description string `json:"description"`
+	// Series description: Series of data to show for this insight
+	Series []*InsightSeries `json:"series"`
+	// Title description: The short title of this insight
+	Title string `json:"title"`
+}
+type InsightSeries struct {
+	// Label description: The label to use for the series in the graph.
+	Label string `json:"label"`
+	// RepositoriesList description: Performs a search query and shows the number of results returned.
+	RepositoriesList []interface{} `json:"repositoriesList,omitempty"`
+	// Search description: Performs a search query and shows the number of results returned.
+	Search string `json:"search,omitempty"`
+	// Webhook description: (not yet supported) Fetch data from a webhook URL.
+	Webhook string `json:"webhook,omitempty"`
+}
 
 // Log description: Configuration for logging and alerting, including to external services.
 type Log struct {
@@ -1099,6 +1117,8 @@ type Settings struct {
 	ExperimentalFeatures *SettingsExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: The Sourcegraph extensions to use. Enable an extension by adding a property `"my/extension": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.
 	Extensions map[string]bool `json:"extensions,omitempty"`
+	// Insights description: EXPERIMENTAL: Code Insights
+	Insights []*Insight `json:"insights,omitempty"`
 	// Motd description: DEPRECATED: Use `notices` instead.
 	//
 	// An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -321,9 +321,61 @@
       "!go": {
         "pointer": true
       }
+    },
+    "insights": {
+      "description": "EXPERIMENTAL: Code Insights",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Insight"
+      }
     }
   },
   "definitions": {
+    "Insight": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "description", "series"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "The short title of this insight"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of this insight"
+        },
+        "series": {
+          "type": "array",
+          "description": "Series of data to show for this insight",
+          "items": {
+            "$ref": "#/definitions/InsightSeries"
+          }
+        }
+      }
+    },
+    "InsightSeries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label to use for the series in the graph."
+        },
+        "repositoriesList": {
+          "type": "array",
+          "description": "Performs a search query and shows the number of results returned."
+        },
+        "search": {
+          "type": "string",
+          "description": "Performs a search query and shows the number of results returned."
+        },
+        "webhook": {
+          "type": "string",
+          "description": "(not yet supported) Fetch data from a webhook URL."
+        }
+      }
+    },
     "SearchScope": {
       "type": "object",
       "additionalProperties": false,

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -326,9 +326,61 @@ const SettingsSchemaJSON = `{
       "!go": {
         "pointer": true
       }
+    },
+    "insights": {
+      "description": "EXPERIMENTAL: Code Insights",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Insight"
+      }
     }
   },
   "definitions": {
+    "Insight": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "description", "series"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "The short title of this insight"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of this insight"
+        },
+        "series": {
+          "type": "array",
+          "description": "Series of data to show for this insight",
+          "items": {
+            "$ref": "#/definitions/InsightSeries"
+          }
+        }
+      }
+    },
+    "InsightSeries": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label"],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label to use for the series in the graph."
+        },
+        "repositoriesList": {
+          "type": "array",
+          "description": "Performs a search query and shows the number of results returned."
+        },
+        "search": {
+          "type": "string",
+          "description": "Performs a search query and shows the number of results returned."
+        },
+        "webhook": {
+          "type": "string",
+          "description": "(not yet supported) Fetch data from a webhook URL."
+        }
+      }
+    },
     "SearchScope": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
This adds a schema definition for code insights to be stored in user/org/global settings.

I drew inspiration from the current schema the frontend uses, and also ensured this aligns closely with the GraphQL schema #17842 

Example which describes an insight with two series from search results:

```
  "insights": [
    {
      "title": "fmt usage",
      "description": "fmt.Errorf/fmt.Printf usage",
      "series": [
        {
          "label": "fmt.Errorf",
          "search": "errorf",
        },
        {
          "label": "printf",
          "search": "fmt.Printf",
        }
      ]
    }
  ]
```

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
