### PR TITLE
search: Make new structural search code path default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixes an issue that prevented the hard deletion of a user if they had saved searches. [#17461](https://github.com/sourcegraph/sourcegraph/pull/17461)
 - Fixes an issue that caused some missing results for `type:commit` when a pattern was used instead of the `message` field. [#17490](https://github.com/sourcegraph/sourcegraph/pull/17490#issuecomment-764004758)
 - Fixes an issue where cAdvisor-based alerts would not fire correctly for services with multiple replicas. [#17600](https://github.com/sourcegraph/sourcegraph/pull/17600)
-- Significantly improved performance of structural search on large repositories [#17846](https://github.com/sourcegraph/sourcegraph/pull/17846)
+- Significantly improved performance of structural search on monorepo deployments [#17846](https://github.com/sourcegraph/sourcegraph/pull/17846)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Fixes an issue that prevented the hard deletion of a user if they had saved searches. [#17461](https://github.com/sourcegraph/sourcegraph/pull/17461)
 - Fixes an issue that caused some missing results for `type:commit` when a pattern was used instead of the `message` field. [#17490](https://github.com/sourcegraph/sourcegraph/pull/17490#issuecomment-764004758)
 - Fixes an issue where cAdvisor-based alerts would not fire correctly for services with multiple replicas. [#17600](https://github.com/sourcegraph/sourcegraph/pull/17600)
+- Significantly improved performance of structural search on large repositories [#17846](https://github.com/sourcegraph/sourcegraph/pull/17846)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - New site config option `"log": { "sentry": { "backendDSN": "<REDACTED>" } }` to use a separate Sentry project for backend errors. [#17363](https://github.com/sourcegraph/sourcegraph/pull/17363)
+- Structural search now supports searching indexed branches other than default. [#17726](https://github.com/sourcegraph/sourcegraph/pull/17726)
 
 ### Changed
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -605,7 +605,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}()
 	}
 
-	if isStructuralSearch && args.PatternInfo.CombyRule == `where "zoekt" == "zoekt"` {
+	if isStructuralSearch && args.PatternInfo.CombyRule != `where "zoekt" == "zoekt"` {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -605,7 +605,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 		}()
 	}
 
-	if isStructuralSearch && args.PatternInfo.CombyRule != `where "zoekt" == "zoekt"` {
+	if isStructuralSearch && args.PatternInfo.CombyRule != `where "backcompat" == "backcompat"` {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -176,7 +176,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 	// We do not support non-head searches for the old structural search code path.
 	// Once the new code path (triggered by the CombyRule below) is default, this can be removed.
 	// https://github.com/sourcegraph/sourcegraph/issues/17616
-	if typ == fileRequest && indexed.NotHEADOnlySearch && args.PatternInfo.CombyRule != `where "zoekt" == "zoekt"` {
+	if typ == fileRequest && indexed.NotHEADOnlySearch && args.PatternInfo.CombyRule == `where "zoekt" == "zoekt"` {
 		return nil, errors.New("structural search only supports searching the default branch https://github.com/sourcegraph/sourcegraph/issues/11906")
 	}
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -176,7 +176,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 	// We do not support non-head searches for the old structural search code path.
 	// Once the new code path (triggered by the CombyRule below) is default, this can be removed.
 	// https://github.com/sourcegraph/sourcegraph/issues/17616
-	if typ == fileRequest && indexed.NotHEADOnlySearch && args.PatternInfo.CombyRule == `where "zoekt" == "zoekt"` {
+	if typ == fileRequest && indexed.NotHEADOnlySearch && args.PatternInfo.CombyRule == `where "backcompat" == "backcompat"` {
 		return nil, errors.New("structural search only supports searching the default branch https://github.com/sourcegraph/sourcegraph/issues/11906")
 	}
 

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -114,8 +114,8 @@ type PatternInfo struct {
 	// CombyRule is a rule that constrains matching for structural search.
 	// It only applies when IsStructuralPat is true.
 	// As a temporary measure, the expression `where "zoekt" == "zoekt"` acts as
-	// a flag to activate a new structural search path to directly query
-	// Zoekt for file contents.
+	// a flag to activate the old structural search path, which queries zoekt for the
+	// file list in the frontend and passes it to searcher.
 	CombyRule string
 }
 

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -113,7 +113,7 @@ type PatternInfo struct {
 
 	// CombyRule is a rule that constrains matching for structural search.
 	// It only applies when IsStructuralPat is true.
-	// As a temporary measure, the expression `where "zoekt" == "zoekt"` acts as
+	// As a temporary measure, the expression `where "backcompat" == "backcompat"` acts as
 	// a flag to activate the old structural search path, which queries zoekt for the
 	// file list in the frontend and passes it to searcher.
 	CombyRule string

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -191,7 +191,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		}
 	}(time.Now())
 
-	if p.IsStructuralPat && p.CombyRule == `where "zoekt" == "zoekt"` {
+	if p.IsStructuralPat && p.CombyRule != `where "zoekt" == "zoekt"` {
 		// Execute the new structural search path that directly calls Zoekt.
 		return structuralSearchWithZoekt(ctx, p)
 	}

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -191,7 +191,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		}
 	}(time.Now())
 
-	if p.IsStructuralPat && p.CombyRule != `where "zoekt" == "zoekt"` {
+	if p.IsStructuralPat && p.CombyRule != `where "backcompat" == "backcompat"` {
 		// Execute the new structural search path that directly calls Zoekt.
 		return structuralSearchWithZoekt(ctx, p)
 	}

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -407,6 +407,7 @@ func doSearch(u string, p *protocol.Request) ([]protocol.FileMatch, error) {
 		"FetchTimeout":    []string{p.FetchTimeout},
 		"IncludePatterns": p.IncludePatterns,
 		"ExcludePattern":  []string{p.ExcludePattern},
+		"CombyRule":       []string{p.CombyRule},
 	}
 	if p.IsRegExp {
 		form.Set("IsRegExp", "true")

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -186,6 +186,7 @@ main.go:7:}
 			IncludePatterns: []string{"file++.plus"},
 			IsStructuralPat: true,
 			IsRegExp:        true, // To test for a regression, imply that IsStructuralPat takes precedence.
+			CombyRule:       `where "backcompat" == "backcompat"`,
 		}, `
 file++.plus:1:filename contains regex metachars
 `},


### PR DESCRIPTION
This switches over to using the new structural code search path by
default, so now searcher will query zoekt for the file contents directly
rather than copying over a full repository archive from gitserver.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
