### PR TITLE
search: remove all external uses of ParseAndCheck

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -195,7 +195,7 @@ func reposToAdd(ctx context.Context, args *search.TextParameters, repos []*searc
 	if len(args.PatternInfo.FilePatternsReposMustExclude) > 0 {
 		for _, pattern := range args.PatternInfo.FilePatternsReposMustExclude {
 			p := search.TextPatternInfo{IsRegExp: true, FileMatchLimit: math.MaxInt32, IncludePatterns: []string{pattern}, PathPatternsAreCaseSensitive: false, PatternMatchesContent: true, PatternMatchesPath: true}
-			q, err := query.ParseAndCheck("file:" + pattern)
+			q, err := query.ParseLiteral("file:" + pattern)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -313,10 +313,10 @@ func TestProcessSearchPattern(t *testing.T) {
 			Want:    "search me",
 		},
 		{
-			Name:    "Regexp with content field ignores default pattern",
-			Pattern: `content:"search me" ignored`,
+			Name:    "Regexp with content field sequences non-content pattern",
+			Pattern: `content:"search me" pattern`,
 			Opts:    &getPatternInfoOptions{},
-			Want:    "search me",
+			Want:    "(search me).*?(pattern)",
 		},
 		{
 			Name:    "Literal with quoted content field means double quotes are not part of the pattern",
@@ -333,7 +333,7 @@ func TestProcessSearchPattern(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
-			q, _ := query.ParseAndCheck(tt.Pattern)
+			q, _ := query.ParseRegexp(tt.Pattern)
 			got, _, _, _ := processSearchPattern(q, tt.Opts)
 			if got != tt.Want {
 				t.Fatalf("got %s\nwant %s", got, tt.Want)

--- a/cmd/frontend/graphqlbackend/search_structural_test.go
+++ b/cmd/frontend/graphqlbackend/search_structural_test.go
@@ -87,7 +87,7 @@ func TestStructuralSearchRepoFilter(t *testing.T) {
 
 	ctx := context.Background()
 
-	q, err := query.ParseAndCheck(`patterntype:structural index:only foo`)
+	q, err := query.ParseLiteral(`patterntype:structural index:only foo`)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -538,14 +538,14 @@ func TestVersionContext(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			qinfo, err := query.ParseAndCheck(tc.searchQuery)
+			q, err := query.ParseLiteral(tc.searchQuery)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			resolver := searchResolver{
 				SearchInputs: &SearchInputs{
-					Query:          qinfo,
+					Query:          q,
 					VersionContext: &tc.versionContext,
 					UserSettings:   &schema.Settings{},
 				},

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -282,7 +282,7 @@ func TestIndexedSearch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			q, err := query.ParseAndCheck(tt.args.query)
+			q, err := query.ParseLiteral(tt.args.query)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
As per title. Deleting old parser code.