### PR TITLE
insights: skip integration tests if DB unavailable in dev environments

### DIFF
--- a/enterprise/internal/insights/store/integration_test.go
+++ b/enterprise/internal/insights/store/integration_test.go
@@ -39,7 +39,12 @@ func TestIntegration(t *testing.T) {
 			t.Log("")
 			t.Log("Or skip them with 'go test -short'")
 			t.Log("")
-			t.Fatalf("Failed to connect to codeinsights database: %s", err)
+			t.Logf("Failed to connect to codeinsights database: %s", err)
+			if os.Getenv("CI") == "" {
+				t.Skip()
+			} else {
+				t.Fail()
+			}
 		}
 		if err := dbconn.MigrateDB(db, dbconn.CodeInsights); err != nil {
 			t.Fatalf("Failed to perform codeinsights database migration: %s", err)


### PR DESCRIPTION
If a dev isn't running the code insights' TimescaleDB, and is trying to `go test` other code, it's nicer to skip these tests than to fail.

See https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/database/dbtesting/dbtesting.go#L73 for where we do this elsewhere.

Thanks @rvantonder for the idea: https://sourcegraph.slack.com/archives/C07KZF47K/p1611966174165500

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
