### PR TITLE
search: remove useless old parser tests

### DIFF
--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -338,51 +338,13 @@ func TestExactlyOneRepo(t *testing.T) {
 func TestQuoteSuggestions(t *testing.T) {
 	t.Run("regex error", func(t *testing.T) {
 		raw := "*"
-		_, err := query.Process(raw, query.SearchTypeRegex)
+		_, err := query.ParseRegexp(raw)
 		if err == nil {
-			t.Fatalf("error returned from query.Process(%q) is nil", raw)
+			t.Fatalf("error returned from query.ParseRegexp(%q) is nil", raw)
 		}
 		alert := alertForQuery(raw, err)
-		if !strings.Contains(strings.ToLower(alert.title), "regexp") {
-			t.Errorf("title is '%s', want it to contain 'regexp'", alert.title)
-		}
-		if !strings.Contains(alert.description, "regular expression") {
-			t.Errorf("description is '%s', want it to contain 'regular expression'", alert.description)
-		}
-	})
-
-	t.Run("type error that is not a regex error should show a suggestion", func(t *testing.T) {
-		raw := "-foobar"
-		_, alert := query.Process(raw, query.SearchTypeRegex)
-		if alert == nil {
-			t.Fatalf("alert returned from query.Process(%q) is nil", raw)
-		}
-	})
-
-	t.Run("query parse error", func(t *testing.T) {
-		raw := ":"
-		_, err := query.Process(raw, query.SearchTypeRegex)
-		if err == nil {
-			t.Fatalf("error returned from query.Process(%q) is nil", raw)
-		}
-		alert := alertForQuery(raw, err)
-		if strings.Contains(strings.ToLower(alert.title), "regexp") {
-			t.Errorf("title is '%s', want it not to contain 'regexp'", alert.title)
-		}
-		if strings.Contains(alert.description, "regular expression") {
-			t.Errorf("description is '%s', want it not to contain 'regular expression'", alert.description)
-		}
-	})
-
-	t.Run("negated file field with an invalid regex", func(t *testing.T) {
-		raw := "-f:(a"
-		_, err := query.Process(raw, query.SearchTypeRegex)
-		if err == nil {
-			t.Fatal("query.Process failed to detect the invalid regex in the f: field")
-		}
-		alert := alertForQuery(raw, err)
-		if len(alert.proposedQueries) != 1 {
-			t.Fatalf("got %d proposed queries (%v), want exactly 1", len(alert.proposedQueries), alert.proposedQueries)
+		if !strings.Contains(alert.description, "regexp") {
+			t.Errorf("description is '%s', want it to contain 'regexp'", alert.description)
 		}
 	})
 }


### PR DESCRIPTION
Stacked on #17862.

I'm removing dependencies on `Process`, an old parser function. These tests use it, but they are not useful any longer. These tests checked that we reject queries like `:` and `-foobar` as invalid queries, rather than just search terms. We've established since that it's much better to be less strict about the input format.

There's one test here that I'm updating that is "arguably" useful, at least until we can do this validation in the frontend going forward.
