### PR TITLE
gitserver: add RPC endpoint to execute p4 commands

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -243,6 +243,7 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/archive", s.handleArchive)
 	mux.HandleFunc("/exec", s.handleExec)
+	mux.HandleFunc("/p4-exec", s.handleP4Exec)
 	mux.HandleFunc("/list", s.handleList)
 	mux.HandleFunc("/list-gitolite", s.handleListGitolite)
 	mux.HandleFunc("/is-repo-cloneable", s.handleIsRepoCloneable)
@@ -740,6 +741,167 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 
 	stderr := stderrBuf.String()
 	checkMaybeCorruptRepo(req.Repo, dir, stderr)
+
+	// write trailer
+	w.Header().Set("X-Exec-Error", errorString(execErr))
+	w.Header().Set("X-Exec-Exit-Status", status)
+	w.Header().Set("X-Exec-Stderr", stderr)
+}
+
+func (s *Server) handleP4Exec(w http.ResponseWriter, r *http.Request) {
+	var req protocol.P4ExecRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if len(req.Args) < 1 {
+		http.Error(w, "args must be greater than or equal to 1", http.StatusBadRequest)
+		return
+	}
+
+	// Make sure the subcommand is explicitly allowed
+	allowlist := []string{"protects", "groups", "users"}
+	allowed := false
+	for _, arg := range allowlist {
+		if req.Args[0] == arg {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		http.Error(w, fmt.Sprintf("subcommand %q is not allowed", req.Args[0]), http.StatusBadRequest)
+		return
+	}
+
+	// Make sure credentials are valid before heavier operation
+	err := p4pingWithLogin(r.Context(), req.P4Port, req.P4User, req.P4Passwd)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.p4exec(w, r, &req)
+}
+
+func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4ExecRequest) {
+	// Flush writes more aggressively than standard net/http so that clients
+	// with a context deadline see as much partial response body as possible.
+	if fw := newFlushingResponseWriter(w); fw != nil {
+		w = fw
+		defer fw.Close()
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), time.Minute)
+	defer cancel()
+
+	start := time.Now()
+	var cmdStart time.Time // set once we have ensured commit
+	exitStatus := -10810   // sentinel value to indicate not set
+	var stdoutN, stderrN int64
+	var status string
+	var execErr error
+
+	// Instrumentation
+	{
+		cmd := ""
+		if len(req.Args) > 0 {
+			cmd = req.Args[0]
+		}
+		args := strings.Join(req.Args, " ")
+
+		var tr *trace.Trace
+		tr, ctx = trace.New(ctx, "p4exec."+cmd, req.P4Port)
+		tr.LogFields(
+			otlog.Object("args", args),
+		)
+
+		execRunning.WithLabelValues(cmd, req.P4Port).Inc()
+		defer func() {
+			tr.LogFields(
+				otlog.String("status", status),
+				otlog.Int64("stdout", stdoutN),
+				otlog.Int64("stderr", stderrN),
+			)
+			tr.SetError(execErr)
+			tr.Finish()
+
+			duration := time.Since(start)
+			execRunning.WithLabelValues(cmd, req.P4Port).Dec()
+			execDuration.WithLabelValues(cmd, req.P4Port, status).Observe(duration.Seconds())
+
+			var cmdDuration time.Duration
+			if !cmdStart.IsZero() {
+				cmdDuration = time.Since(cmdStart)
+			}
+
+			isSlow := cmdDuration > 30*time.Second
+			if honey.Enabled() || traceLogs || isSlow {
+				ev := honey.Event("gitserver-p4exec")
+				ev.SampleRate = honeySampleRate(cmd)
+				ev.AddField("p4port", req.P4Port)
+				ev.AddField("cmd", cmd)
+				ev.AddField("args", args)
+				ev.AddField("actor", r.Header.Get("X-Sourcegraph-Actor"))
+				ev.AddField("client", r.UserAgent())
+				ev.AddField("duration_ms", duration.Seconds()*1000)
+				ev.AddField("stdout_size", stdoutN)
+				ev.AddField("stderr_size", stderrN)
+				ev.AddField("exit_status", exitStatus)
+				ev.AddField("status", status)
+				if execErr != nil {
+					ev.AddField("error", execErr.Error())
+				}
+				if !cmdStart.IsZero() {
+					ev.AddField("cmd_duration_ms", cmdDuration.Seconds()*1000)
+				}
+				if span := opentracing.SpanFromContext(ctx); span != nil {
+					spanURL := trace.SpanURL(span)
+					// URLs starting with # don't have a trace. eg
+					// "#tracer-not-enabled"
+					if !strings.HasPrefix(spanURL, "#") {
+						ev.AddField("trace", spanURL)
+					}
+				}
+
+				if honey.Enabled() {
+					_ = ev.Send()
+				}
+				if traceLogs {
+					log15.Debug("TRACE gitserver p4exec", mapToLog15Ctx(ev.Fields())...)
+				}
+				if isSlow {
+					log15.Warn("Long p4exec request", mapToLog15Ctx(ev.Fields())...)
+				}
+			}
+		}()
+	}
+
+	w.Header().Set("Trailer", "X-Exec-Error")
+	w.Header().Add("Trailer", "X-Exec-Exit-Status")
+	w.Header().Add("Trailer", "X-Exec-Stderr")
+	w.WriteHeader(http.StatusOK)
+
+	var stderrBuf bytes.Buffer
+	stdoutW := &writeCounter{w: w}
+	stderrW := &writeCounter{w: &limitWriter{W: &stderrBuf, N: 1024}}
+
+	cmdStart = time.Now()
+	cmd := exec.CommandContext(ctx, "p4", req.Args...)
+	cmd.Env = append(os.Environ(),
+		"P4PORT="+req.P4Port,
+		"P4USER="+req.P4User,
+	)
+	cmd.Stdout = stdoutW
+	cmd.Stderr = stderrW
+
+	exitStatus, execErr = runCommand(ctx, cmd)
+
+	status = strconv.Itoa(exitStatus)
+	stdoutN = stdoutW.n
+	stderrN = stderrW.n
+
+	stderr := stderrBuf.String()
 
 	// write trailer
 	w.Header().Set("X-Exec-Error", errorString(execErr))

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -619,7 +619,7 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 				ev.AddField("ensure_revision", req.EnsureRevision)
 				ev.AddField("ensure_revision_status", ensureRevisionStatus)
 				ev.AddField("client", r.UserAgent())
-				ev.AddField("duration_ms", duration.Seconds()*1000)
+				ev.AddField("duration_ms", duration.Milliseconds())
 				ev.AddField("stdout_size", stdoutN)
 				ev.AddField("stderr_size", stderrN)
 				ev.AddField("exit_status", exitStatus)
@@ -628,8 +628,8 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 					ev.AddField("error", execErr.Error())
 				}
 				if !cmdStart.IsZero() {
-					ev.AddField("cmd_duration_ms", cmdDuration.Seconds()*1000)
-					ev.AddField("fetch_duration_ms", fetchDuration.Seconds()*1000)
+					ev.AddField("cmd_duration_ms", cmdDuration.Milliseconds())
+					ev.AddField("fetch_duration_ms", fetchDuration.Milliseconds())
 				}
 				if span := opentracing.SpanFromContext(ctx); span != nil {
 					spanURL := trace.SpanURL(span)
@@ -844,7 +844,7 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 				ev.AddField("args", args)
 				ev.AddField("actor", r.Header.Get("X-Sourcegraph-Actor"))
 				ev.AddField("client", r.UserAgent())
-				ev.AddField("duration_ms", duration.Seconds()*1000)
+				ev.AddField("duration_ms", duration.Milliseconds())
 				ev.AddField("stdout_size", stdoutN)
 				ev.AddField("stderr_size", stderrN)
 				ev.AddField("exit_status", exitStatus)
@@ -853,7 +853,7 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 					ev.AddField("error", execErr.Error())
 				}
 				if !cmdStart.IsZero() {
-					ev.AddField("cmd_duration_ms", cmdDuration.Seconds()*1000)
+					ev.AddField("cmd_duration_ms", cmdDuration.Milliseconds())
 				}
 				if span := opentracing.SpanFromContext(ctx); span != nil {
 					spanURL := trace.SpanURL(span)

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -123,8 +123,8 @@ func decomposePerforceCloneURL(cloneURL string) (username, password, host, depot
 	return url.User.Username(), password, url.Host, url.Path, nil
 }
 
-// ping sends one message to the Perforce Server to check connectivity.
-func (s *PerforceDepotSyncer) ping(ctx context.Context, host, username string) error {
+// p4ping sends one message to the Perforce Server to check connectivity.
+func p4ping(ctx context.Context, host, username string) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -147,8 +147,8 @@ func (s *PerforceDepotSyncer) ping(ctx context.Context, host, username string) e
 	return nil
 }
 
-// login performs a "p4 login" operation against the Perforce Server to obtain a session.
-func (s *PerforceDepotSyncer) login(ctx context.Context, host, username, password string) error {
+// p4login performs a login operation against the Perforce Server to obtain a session.
+func p4login(ctx context.Context, host, username, password string) error {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -192,10 +192,10 @@ func (s *PerforceDepotSyncer) login(ctx context.Context, host, username, passwor
 	return err
 }
 
-// pingWithLogin attempts to ping the Perforce Server and performs a login operation when needed.
-func (s *PerforceDepotSyncer) pingWithLogin(ctx context.Context, host, username, password string) error {
+// p4pingWithLogin attempts to ping the Perforce Server and performs a login operation when needed.
+func p4pingWithLogin(ctx context.Context, host, username, password string) error {
 	// Attempt to check connectivity, may be prompted to login (again)
-	err := s.ping(ctx, host, username)
+	err := p4ping(ctx, host, username)
 	if err == nil {
 		return nil // The ping worked, session still validate for the user
 	} else if !strings.Contains(err.Error(), "Your session has expired, please login again.") &&
@@ -203,7 +203,7 @@ func (s *PerforceDepotSyncer) pingWithLogin(ctx context.Context, host, username,
 		return errors.Wrap(err, "ping")
 	}
 
-	err = s.login(ctx, host, username, password)
+	err = p4login(ctx, host, username, password)
 	if err != nil {
 		return errors.Wrap(err, "login")
 	}
@@ -218,7 +218,7 @@ func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error
 	}
 
 	// FIXME: Need to find a way to determine if depot exists instead of a general ping to the Perforce server.
-	return s.pingWithLogin(ctx, host, username, password)
+	return p4pingWithLogin(ctx, host, username, password)
 }
 
 // CloneCommand returns the command to be executed for cloning a Perforce depot as a Git repository.
@@ -228,7 +228,7 @@ func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, url, tmpPath str
 		return nil, errors.Wrap(err, "decompose")
 	}
 
-	err = s.pingWithLogin(ctx, host, username, password)
+	err = p4pingWithLogin(ctx, host, username, password)
 	if err != nil {
 		return nil, errors.Wrap(err, "ping with login")
 	}
@@ -256,7 +256,7 @@ func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, url string) (cmd
 		return nil, false, errors.Wrap(err, "decompose")
 	}
 
-	err = s.pingWithLogin(ctx, host, username, password)
+	err = p4pingWithLogin(ctx, host, username, password)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "ping with login")
 	}

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -19,6 +19,18 @@ type ExecRequest struct {
 	Opt            *RemoteOpts `json:"opt"`
 }
 
+// P4ExecRequest is a request to execute a p4 command with given arguments.
+//
+// Note that this request is deserialized by both gitserver and the frontend's
+// internal proxy route and any major change to this structure will need to be
+// reconciled in both places.
+type P4ExecRequest struct {
+	P4Port   string   `json:"p4port"`
+	P4User   string   `json:"p4user"`
+	P4Passwd string   `json:"p4passwd"`
+	Args     []string `json:"args"`
+}
+
 // RemoteOpts configures interactions with a remote repository.
 type RemoteOpts struct {
 	SSH   *SSHConfig   `json:"ssh"`   // SSH configuration for communication with the remote


### PR DESCRIPTION
This PR adds a new gitserver endpoint `/p4-exec` for executing `p4` CLI commands. Currently only three subcommands are allowed: 

- `users` for listing user catalog
- `protects` for listing ACL
- `groups` for listing group memberships

Fixes #16704