### PR TITLE
rename types.RedactedSecret to not use a zero width space character

### DIFF
--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -24,9 +24,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
-// redacted strings are zero width spaces, so we can detect any redacted fields when validating on the way back in to
-// the database
-const RedactedSecret = string('\u200B')
+// RedactedSecret is used as a placeholder for secret fields when reading external service config
+const RedactedSecret = "REDACTED"
 
 // RedactConfig replaces any secret fields in the Config field with RedactedSecret, be sure to call
 // UnRedactExternalServiceConfig before writing back to the database, otherwise validation will throw errors.


### PR DESCRIPTION
@unknwon made a good point in a comment on my previous PR https://github.com/sourcegraph/sourcegraph/pull/17775#discussion_r567397405
> FYI zero-length characters have caused confusions and days of debugging time for at least one customer's PoC
so instead i'll use the explicit string "REDACTED"
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
