### PR TITLE
Update browserslist to support last 2 major versions of Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "not dead",
     "not <0.25%",
     "last 1 Chrome versions",
+    "last 2 Safari major versions",
     "not IE > 0"
   ],
   "nyc": {


### PR DESCRIPTION
Fixes #17606

```
yarn browserslist

and_chr 87
and_ff 83
and_uc 12.12
chrome 87
chrome 86
edge 87
firefox 84
firefox 83
ios_saf 14.0-14.3
ios_saf 13.4-13.7
ios_saf 12.2-12.4
op_mini all
opera 72
safari 14
safari 13.1
safari 13
samsung 13.0
```