### PR TITLE
Add tooltip to redacted fields in settings editor

### DIFF
--- a/client/web/src/settings/MonacoSettingsEditor.tsx
+++ b/client/web/src/settings/MonacoSettingsEditor.tsx
@@ -73,8 +73,6 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
         this.subscriptions.add(
             componentUpdates.pipe(distinctUntilKeyChanged('jsonSchema')).subscribe(props => {
                 if (this.monaco) {
-                    registerRedactedHover(this.monaco)
-
                     setDiagnosticsOptions(this.monaco, props.jsonSchema)
                 }
             })
@@ -144,6 +142,8 @@ export class MonacoSettingsEditor extends React.PureComponent<Props, State> {
                 }
             })
         }
+
+        this.disposables.push(registerRedactedHover(monaco))
 
         setDiagnosticsOptions(monaco, this.props)
 
@@ -295,8 +295,8 @@ function toMonacoEdits(
     }))
 }
 
-function registerRedactedHover(editor: typeof monaco): void {
-    editor.languages.registerHoverProvider('json', {
+function registerRedactedHover(editor: typeof monaco): monaco.IDisposable {
+    return editor.languages.registerHoverProvider('json', {
         provideHover(model, position, token): monaco.languages.ProviderResult<monaco.languages.Hover> {
             if (model.getWordAtPosition(position)?.word === 'REDACTED') {
                 return {


### PR DESCRIPTION
now that we're redacting secrets in config https://github.com/sourcegraph/sourcegraph/pull/17872 we need to make sure that users know not to mess with redacted fields, or their config will break. 
![Screenshot 2021-02-01 at 14 57 58](https://user-images.githubusercontent.com/5236823/106475484-e1733900-649d-11eb-871d-1defa672fbf8.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

closes #17261 