### PR TITLE
Split web team notifications by function area

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -11,7 +11,8 @@ jobs:
         - uses: jenschelkopf/issue-label-notification-action@f7d2363e5efa18b8aeea671ca8093e183ae8f218 # 1.3
           with:
              recipients: |
-                  team/web=@joelkw @felixfbecker @jeanduplessis
+                  team/extensibility=@joelkw @jeanduplessis
+                  team/frontend-platform=@jeanduplessis @alicjasuska
                   team/cloud=@tsenart
                   team/search=@lguychard
                   team/code-intelligence=@macraig

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -11,8 +11,8 @@ jobs:
         - uses: jenschelkopf/issue-label-notification-action@f7d2363e5efa18b8aeea671ca8093e183ae8f218 # 1.3
           with:
              recipients: |
-                  team/extensibility=@joelkw @jeanduplessis
-                  team/frontend-platform=@jeanduplessis @alicjasuska
+                  team/extensibility=@joelkw @jeanduplessis @felixfbecker
+                  team/frontend-platform=@jeanduplessis @alicjasuska @felixfbecker
                   team/cloud=@tsenart
                   team/search=@lguychard
                   team/code-intelligence=@macraig


### PR DESCRIPTION
Are these the labels we'd like to use? (Originally had `team/web/extensibility` but given Jean's company meeting update perhaps it's better to just switch fully.) 

@felixfbecker noting that I have now removed you from both but if you think it's helpful or relevant to still get these pings, feel free to add yourself back in. 