### PR TITLE
search: filters for excluding minified JS and JS maps

### DIFF
--- a/cmd/frontend/graphqlbackend/search_filters.go
+++ b/cmd/frontend/graphqlbackend/search_filters.go
@@ -53,6 +53,18 @@ var commonFileFilters = []struct {
 		regexFilter: `-file:(^|/)node_modules/`,
 		globFilter:  `-file:node_modules/** -file:**/node_modules/**`,
 	},
+	// Exclude minified javascript
+	{
+		regexp:      lazyregexp.New(`\.min\.js$`),
+		regexFilter: `-file:\.min\.js$`,
+		globFilter:  `-file:**.min.js`,
+	},
+	// Exclude javascript maps
+	{
+		regexp:      lazyregexp.New(`\.js\.map$`),
+		regexFilter: `-file:\.js\.map$`,
+		globFilter:  `-file:**.js.map`,
+	},
 }
 
 // Update internal state for the results in event.

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -660,6 +660,27 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 			},
 		},
 
+		{
+			descr: "javascript filters",
+			searchResults: []SearchResultResolver{
+				fileMatch("/jsrender.min.js.map"),
+				fileMatch("playground/react/lib/app.js.map"),
+				fileMatch("assets/javascripts/bootstrap.min.js"),
+			},
+			expectedDynamicFilterStrsRegexp: map[string]struct{}{
+				`repo:^testRepo$`:  {},
+				`-file:\.min\.js$`: {},
+				`-file:\.js\.map$`: {},
+				`lang:javascript`:  {},
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]struct{}{
+				`repo:testRepo`:   {},
+				`-file:**.min.js`: {},
+				`-file:**.js.map`: {},
+				`lang:javascript`: {},
+			},
+		},
+
 		// If there are no search results, no filters should be displayed.
 		{
 			descr:                             "no results",


### PR DESCRIPTION
I was doing some testing of search and was annoyed at results from
minified javascript files as well as javascript maps. These are both
autogenerated files that get checked in, so seemed useful to suggest
excluding them.