### PR TITLE
codeintel: don't run autoindexer on repositories with recent manual uploads

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/iface.go
@@ -14,6 +14,7 @@ type DBStore interface {
 	RepoUsageStatistics(ctx context.Context) ([]dbstore.RepoUsageStatistics, error)
 	ResetIndexableRepositories(ctx context.Context, lastUpdatedBefore time.Time) error
 	UpdateIndexableRepository(ctx context.Context, indexableRepository dbstore.UpdateableIndexableRepository, now time.Time) error
+	GetUploads(ctx context.Context, opts dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error)
 }
 
 type GitserverClient interface {

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater.go
@@ -123,12 +123,12 @@ func (u *IndexabilityUpdater) queueRepository(ctx context.Context, repoUsageStat
 
 	oneDayAgo := time.Now().Add(time.Hour * 24)
 	uploads, count, err := u.dbStore.GetUploads(ctx, store.GetUploadsOptions{
-		RepositoryID:   repoUsageStatistics.RepositoryID,
-		VisibleAtTip:   true,
-		OldestFirst:    false,
-		Limit:          1,
-		Offset:         0,
-		UploadedAfter:  &oneDayAgo,
+		RepositoryID:  repoUsageStatistics.RepositoryID,
+		VisibleAtTip:  true,
+		OldestFirst:   false,
+		Limit:         1,
+		Offset:        0,
+		UploadedAfter: &oneDayAgo,
 	})
 	if err != nil {
 		return errors.Wrap(err, "dbstore.GetUploads")

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/indexability_updater_test.go
@@ -96,10 +96,10 @@ func TestSkipManualUploads(t *testing.T) {
 		{RepositoryID: 1, SearchCount: 200, PreciseCount: 50},
 	}, nil)
 	mockDBStore.GetUploadsFunc.SetDefaultReturn([]store.Upload{
-		store.Upload{AssociatedIndexID: nil},
+		{AssociatedIndexID: nil},
 	}, 1, nil)
 	mockDBStore.UpdateIndexableRepositoryFunc.SetDefaultHook(func(_ context.Context, _ dbstore.UpdateableIndexableRepository, _ time.Time) error {
-		t.Fatal("should skip manual uploads")
+		t.Fatal("IndexabilityUpdater tried to queue index for repo with recent manual upload")
 		return nil
 	})
 	mockGitserverClient := NewMockGitserverClient()

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/mock_iface_test.go
@@ -19,6 +19,9 @@ type MockDBStore struct {
 	// function object controlling the behavior of the method
 	// GetRepositoriesWithIndexConfiguration.
 	GetRepositoriesWithIndexConfigurationFunc *DBStoreGetRepositoriesWithIndexConfigurationFunc
+	// GetUploadsFunc is an instance of a mock function object controlling
+	// the behavior of the method GetUploads.
+	GetUploadsFunc *DBStoreGetUploadsFunc
 	// IndexableRepositoriesFunc is an instance of a mock function object
 	// controlling the behavior of the method IndexableRepositories.
 	IndexableRepositoriesFunc *DBStoreIndexableRepositoriesFunc
@@ -42,6 +45,11 @@ func NewMockDBStore() *MockDBStore {
 		GetRepositoriesWithIndexConfigurationFunc: &DBStoreGetRepositoriesWithIndexConfigurationFunc{
 			defaultHook: func(context.Context) ([]int, error) {
 				return nil, nil
+			},
+		},
+		GetUploadsFunc: &DBStoreGetUploadsFunc{
+			defaultHook: func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error) {
+				return nil, 0, nil
 			},
 		},
 		IndexableRepositoriesFunc: &DBStoreIndexableRepositoriesFunc{
@@ -73,6 +81,9 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 	return &MockDBStore{
 		GetRepositoriesWithIndexConfigurationFunc: &DBStoreGetRepositoriesWithIndexConfigurationFunc{
 			defaultHook: i.GetRepositoriesWithIndexConfiguration,
+		},
+		GetUploadsFunc: &DBStoreGetUploadsFunc{
+			defaultHook: i.GetUploads,
 		},
 		IndexableRepositoriesFunc: &DBStoreIndexableRepositoriesFunc{
 			defaultHook: i.IndexableRepositories,
@@ -198,6 +209,117 @@ func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Args() []interface
 // invocation.
 func (c DBStoreGetRepositoriesWithIndexConfigurationFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
+}
+
+// DBStoreGetUploadsFunc describes the behavior when the GetUploads method
+// of the parent MockDBStore instance is invoked.
+type DBStoreGetUploadsFunc struct {
+	defaultHook func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error)
+	hooks       []func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error)
+	history     []DBStoreGetUploadsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetUploads delegates to the next hook function in the queue and stores
+// the parameter and result values of this invocation.
+func (m *MockDBStore) GetUploads(v0 context.Context, v1 dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error) {
+	r0, r1, r2 := m.GetUploadsFunc.nextHook()(v0, v1)
+	m.GetUploadsFunc.appendCall(DBStoreGetUploadsFuncCall{v0, v1, r0, r1, r2})
+	return r0, r1, r2
+}
+
+// SetDefaultHook sets function that is called when the GetUploads method of
+// the parent MockDBStore instance is invoked and the hook queue is empty.
+func (f *DBStoreGetUploadsFunc) SetDefaultHook(hook func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetUploads method of the parent MockDBStore instance inovkes the hook at
+// the front of the queue and discards it. After the queue is empty, the
+// default hook function is invoked for any future action.
+func (f *DBStoreGetUploadsFunc) PushHook(hook func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DBStoreGetUploadsFunc) SetDefaultReturn(r0 []dbstore.Upload, r1 int, r2 error) {
+	f.SetDefaultHook(func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error) {
+		return r0, r1, r2
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DBStoreGetUploadsFunc) PushReturn(r0 []dbstore.Upload, r1 int, r2 error) {
+	f.PushHook(func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error) {
+		return r0, r1, r2
+	})
+}
+
+func (f *DBStoreGetUploadsFunc) nextHook() func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreGetUploadsFunc) appendCall(r0 DBStoreGetUploadsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreGetUploadsFuncCall objects
+// describing the invocations of this function.
+func (f *DBStoreGetUploadsFunc) History() []DBStoreGetUploadsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreGetUploadsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreGetUploadsFuncCall is an object that describes an invocation of
+// method GetUploads on an instance of MockDBStore.
+type DBStoreGetUploadsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is the value of the 2nd argument passed to this method
+	// invocation.
+	Arg1 dbstore.GetUploadsOptions
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []dbstore.Upload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 int
+	// Result2 is the value of the 3rd result returned from this method
+	// invocation.
+	Result2 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation.
+func (c DBStoreGetUploadsFuncCall) Args() []interface{} {
+	return []interface{}{c.Arg0, c.Arg1}
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
 // DBStoreIndexableRepositoriesFunc describes the behavior when the

--- a/enterprise/cmd/frontend/internal/codeintel/config.go
+++ b/enterprise/cmd/frontend/internal/codeintel/config.go
@@ -10,18 +10,19 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	UploadStoreConfig             *uploadstore.Config
-	CommitGraphUpdateTaskInterval time.Duration
-	CleanupTaskInterval           time.Duration
-	AutoIndexingTaskInterval      time.Duration
-	HunkCacheSize                 int
-	DataTTL                       time.Duration
-	UploadTimeout                 time.Duration
-	IndexBatchSize                int
-	MinimumTimeSinceLastEnqueue   time.Duration
-	MinimumSearchCount            int
-	MinimumSearchRatio            int
-	MinimumPreciseCount           int
+	UploadStoreConfig              *uploadstore.Config
+	CommitGraphUpdateTaskInterval  time.Duration
+	CleanupTaskInterval            time.Duration
+	AutoIndexingTaskInterval       time.Duration
+	AutoIndexingSkipManualInterval time.Duration
+	HunkCacheSize                  int
+	DataTTL                        time.Duration
+	UploadTimeout                  time.Duration
+	IndexBatchSize                 int
+	MinimumTimeSinceLastEnqueue    time.Duration
+	MinimumSearchCount             int
+	MinimumSearchRatio             int
+	MinimumPreciseCount            int
 }
 
 var config = &Config{}
@@ -37,6 +38,7 @@ func init() {
 	config.CommitGraphUpdateTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_COMMIT_GRAPH_UPDATE_TASK_INTERVAL", "10s", "The frequency with which to run periodic codeintel commit graph update tasks.")
 	config.CleanupTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_CLEANUP_TASK_INTERVAL", "1m", "The frequency with which to run periodic codeintel cleanup tasks.")
 	config.AutoIndexingTaskInterval = config.GetInterval("PRECISE_CODE_INTEL_AUTO_INDEXING_TASK_INTERVAL", "10m", "The frequency with which to run periodic codeintel auto-indexing tasks.")
+	config.AutoIndexingSkipManualInterval = config.GetInterval("PRECISE_CODE_INTEL_AUTO_INDEXING_SKIP_MANUAL", "24h", "The duration the auto-indexer will wait after a manual upload to a repository before it starts auto-indexing again. Manually queueing an auto-index run will cancel this waiting period.")
 	config.IndexBatchSize = config.GetInt("PRECISE_CODE_INTEL_INDEX_BATCH_SIZE", "100", "The number of indexable repositories to schedule at a time.")
 	config.MinimumTimeSinceLastEnqueue = config.GetInterval("PRECISE_CODE_INTEL_MINIMUM_TIME_SINCE_LAST_ENQUEUE", "24h", "The minimum time between auto-index enqueues for the same repository.")
 	config.MinimumSearchCount = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_SEARCH_COUNT", "50", "The minimum number of search-based code intel events that triggers auto-indexing on a repository.")

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -140,6 +140,7 @@ func newIndexingRoutines(observationContext *observation.Context) []goroutine.Ba
 			config.MinimumSearchCount,
 			float64(config.MinimumSearchRatio)/100,
 			config.MinimumPreciseCount,
+			config.AutoIndexingSkipManualInterval,
 			config.AutoIndexingTaskInterval,
 			observationContext,
 		),

--- a/enterprise/internal/codeintel/stores/dbstore/uploads.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads.go
@@ -180,6 +180,7 @@ type GetUploadsOptions struct {
 	Term           string
 	VisibleAtTip   bool
 	UploadedBefore *time.Time
+	UploadedAfter  *time.Time
 	OldestFirst    bool
 	Limit          int
 	Offset         int
@@ -243,6 +244,9 @@ func (s *Store) GetUploads(ctx context.Context, opts GetUploadsOptions) (_ []Upl
 	}
 	if opts.UploadedBefore != nil {
 		conds = append(conds, sqlf.Sprintf("u.uploaded_at < %s", *opts.UploadedBefore))
+	}
+	if opts.UploadedAfter != nil {
+		conds = append(conds, sqlf.Sprintf("u.uploaded_at > %s", *opts.UploadedAfter))
 	}
 
 	count, _, err := basestore.ScanFirstInt(tx.Store.Query(

--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -250,6 +250,7 @@ func TestGetUploads(t *testing.T) {
 		term           string
 		visibleAtTip   bool
 		uploadedBefore *time.Time
+		uploadedAfter  *time.Time
 		oldestFirst    bool
 		expectedIDs    []int
 	}{
@@ -265,6 +266,7 @@ func TestGetUploads(t *testing.T) {
 		{term: "bAr", expectedIDs: []int{4, 6}},              // search repo names
 		{visibleAtTip: true, expectedIDs: []int{2, 5, 7, 8}},
 		{uploadedBefore: &t5, expectedIDs: []int{6, 7, 8, 9, 10}},
+		{uploadedAfter: &t4, expectedIDs: []int{1, 2, 3}},
 	}
 
 	for _, testCase := range testCases {
@@ -290,6 +292,7 @@ func TestGetUploads(t *testing.T) {
 					Term:           testCase.term,
 					VisibleAtTip:   testCase.visibleAtTip,
 					UploadedBefore: testCase.uploadedBefore,
+					UploadedAfter:  testCase.uploadedAfter,
 					OldestFirst:    testCase.oldestFirst,
 					Limit:          3,
 					Offset:         lo,


### PR DESCRIPTION
@efritz does this logic seem like what we want? if the most recent upload is manual and happened in the last day, then we don't autoindex

closes #14572 