### PR TITLE
Add a draft of code insights docs pages [Discussion]

### DIFF
--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,0 +1,48 @@
+# Code insights [Prototype]
+
+<style>
+
+.markdown-body h2 {
+  margin-top: 2em;
+}
+
+.markdown-body ul {
+  list-style:none;
+  padding-left: 1em;
+}
+
+.markdown-body ul li {
+  margin: 0.5em 0;
+}
+
+.markdown-body ul li:before {
+  content: '';
+  display: inline-block;
+  height: 1.2em;
+  width: 1em;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-image: url(campaigns/file-icon.svg);
+  margin-right: 0.5em;
+  margin-bottom: -0.29em;
+}
+
+body.theme-dark .markdown-body ul li:before {
+  filter: invert(50%);
+}
+
+</style>
+
+<p class="subtitle">Answer and track high-level questions about your code</p>
+
+> NOTE: Code insights is a prototype feature. This documentation exists to help users experiment with it for the purpose of giving our product team feedback. 
+
+<p class="lead">
+Code insights dashboards will answer questions like “How is a migration progressing?”, “What areas of the code are most vulnerable to bugs?”, and “How many developers are using a specific API?” Code insights will also incorporate third-party data like code coverage or static analysis metrics to deliver on the promise of aggregating everything you can know about your code.
+</p>
+
+![Code Insights Splash](https://drive.google.com/uc?id=1legWJ9JY4QuYEcV4NFH8ZWPRvvche3oI)
+
+<div class="cta-group">
+<a class="btn btn-primary" href="quickstart">★ Prototype Quickstart Guide</a>
+</div>

--- a/doc/code_insights/quickstart.md
+++ b/doc/code_insights/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart for Code Insights [Prototype]
+
+> ## _This is a prototype_ (Considerations)
+>
+> This is a prototype, and it's not yet optimized. 
+>
+> For example, a search insight runs all the search queries on the frontend and tries to cache them – it may take awhile on first view but less time on subsequent views. The number of queries to run is (number of repos in your repo list) x (number of steps). The number of steps is currently hardcoded to 7. If you're running into loading time issues, first try limiting the number of repos.
+>
+> Please do slack/email Joel Kwartler (@joel slack; @joelkw github; joel@sourcegraph.com) with feedback, bugs, and feature requests. 
+
+
+
+## 1. Enable the experimental feature flag
+
+Add the following to your Sourcegraph user `/users/[username]/settings` or organization `/organizations/[your_org]/settings` settings: 
+
+```jsx
+"experimentalFeatures": { "codeInsights": true }
+```
+
+## 2. Enable the extension
+ 
+Visit the [search insights extension page](https://sourcegraph.com/extensions/sourcegraph/search-insights) and enable it.
+
+## 3. Configure your first insight
+
+Configure the insight by adding the following structure to your user, org, or global settings: 
+
+```jsx
+// Choose any name - only the prefix "searchInsights.insight." is mandatory.
+"searchInsights.insight.uniqueNameForYourInsight": {
+
+  // Shown as the title of the insight.
+  "title": "Migration to React function components",
+
+  // a list of repositories to run the search over
+  "repositories": ["github.com/sourcegraph/sourcegraph"],
+
+  // The lines of the chart.
+  "series": [
+    {
+      // Name shown in the legend and tooltip.
+      "name": "Function components",
+
+      // The search query that will be run for the interval defined in "step".
+      // Do not include the "repo:" filter as it will be added automatically for the current repository. Example query
+      "query": "patternType:regexp const\\s\\w+:\\s(React\\.)?FunctionComponent",
+
+      // An optional color for the line.
+      // Can be any hex color code, rgb(), hsl(),
+      // or reference color variables from the OpenColor palette (recommended): https://yeun.github.io/open-color/
+      // The semantic colors var(--danger), var(--warning) and var(--info) are also available.
+      "stroke": "var(--oc-teal-7)"
+    },
+    {
+      // this is a second series on the same chart 
+      "name": "Class components",
+      "query": "patternType:regexp extends\\s(React\\.)?(Pure)?Component",
+      "stroke": "var(--oc-indigo-7)"
+    }
+  ],
+  // The step between two data points. Supports days, months, hours, etc.
+  "step": {
+    "weeks": 2
+  }
+}
+```
+
+## 4. View your insight
+
+The insight will appear on your insights page (`YourSourcegraphUrl.com/insights`) as well as below the search bar on the home page. 
+
+Regardless of whether you define a repo, the insight will show up on every directory page (and run for that directory). With repos listed, it will also show up on the /insights and search pages. Without listing repos, it will show nothing on those two pages. 
+
+If you put these settings in your org settings, everyone will see them on the /insights page. If you put them in your personal settings, only you will see them there. 
+
+## 5. Configure additional insights
+
+Multiple search insights can be defined by adding more objects under different keys, as long as they are prefixed with `searchInsights.insight.` .
+
+## 6. Other insights
+
+Sourcegraph also has [language usage insights](https://sourcegraph.com/extensions/sourcegraph/code-stats-insights), which adds a pie chart of lines of code by language to your directory and insights page. 
+
+The setup is similar, and you enable [the extension](https://sourcegraph.com/extensions/sourcegraph/code-stats-insights) and then add to your user or global settings: 
+
+```json
+// Title
+"codeStatsInsights.title": "Language usage",
+
+// The file query to limit the global insights page to (here it's limited to a repo)
+"codeStatsInsights.query": "repo:^github\\.com/sourcegraph/sourcegraph$",
+
+// The threshold for grouping all other languages into an "other" category
+"codeStatsInsights.otherThreshold": 0.02,
+```
+> Please do slack/email Joel Kwartler (@joel slack; @joelkw github; joel@sourcegraph.com) with any feedback, bugs, and feature requests! 

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -23,6 +23,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
   - [How-to guides](code_intelligence/how-to/index.md)
   - [Explanations](code_intelligence/explanations/index.md)
   - [Reference](code_intelligence/references/index.md)
+- [Code insights](code_insights/index.md)
 - [Campaigns](campaigns/index.md)
   - [Quickstart](campaigns/quickstart.md)
   - [Explanations](campaigns/explanations/index.md)


### PR DESCRIPTION
The catalyst for this was @nicksnyder's [slack message here](https://sourcegraph.slack.com/archives/C014ZCKMCAV/p1612217701041300).

I'm putting up this draft PR for discussion rather than as evidence of WIP (though it contains a WIP we can take next steps on depending on the discussion). In starting this, two questions came up that I think we should align on before continuing down this path. 

Questions for @nicksnyder or @felixfbecker, with my answers inline below. You're welcome to leave a full response or just a quick topline "I think we should do it / I think we should wait" 

- Does it make sense to start adding code insights documentation to our official docs?

> I don't think so. While [we have "documentation"](https://gist.github.com/Joelkw/f0582b164578aabc3ac936dee43f23e0), this is not final (the ultimate code insights UI won't be in settings like this) nor is the code insights product quite at a level of "self-discovery." By that I mean that we don't have a working backend – so your average code insight attempt will just timeout if you use it on a lot of your code – and a user is likely to get frustrated with the feature, and less likely to try in the future, if they discover it on their own rather than with the high-touch expectation-setting of a CE or PM. We are intentionally keeping code insights less discoverable until it enters a "beta:" roughly -- working backend, v1 UI, clear what it does and works for the primary use cases. 

But, if you think we should add it to docs: 

- How do we best communicate that insights are still very much a prototype? Can we leave it out of the sidebar (make it less discoverable to a "browsing" user)? 

> We can add some quick treatment to the basic [Prototype] labels I have in the title as well. Are there other things we've done int he past? I would prefer to leave it out of the sidebar until it's a beta for the same reasoning in the prior answer. 

**Other considerationsIthat would convince me this is a good idea to do *now*:** this would help us with hiring; this would let us capture insights as we build it (at the moment, though, the work is backend and the documention is more oriented towards a Sourcegraph engineer than a user). 

**This update is a failure if:** it makes people annoyed that code insights doesn't work even if it's in the docs, or if people try it, see that there isn't much there yet, and decide not to return to using code insights when it actually launches. 

**This update is a success if:** it gets people excited about code insights and creates an active inbound feedback pipeline. I think this is entirely possible, but I would prefer to wait until we reach our "beta" milestone (to paraphrase from [the goals](https://about.sourcegraph.com/handbook/engineering/code-insights/goals), this means it has a UI, scales to all repos, and is primarily supported by the CE team. We've reached none of these points yet, though we should get to the backend one by 3.25) 