### PR TITLE
search: return early from evaluateAnd if no results

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -650,10 +650,6 @@ func TestSearch(t *testing.T) {
 				name:       `Mixed regexp and quoted literal`,
 				query:      `repo:^github\.com/sgtest/go-diff$ "*" and cert.*Load count:1 stable:yes type:file`,
 				zeroResult: true,
-				wantAlert: &gqltestutil.SearchAlert{
-					Title:       "Too many files to search for and-expression",
-					Description: "One and-expression in the query requires a lot of work! Try using the 'repo:' or 'file:' filters to narrow your search. We're working on improving this experience in https://github.com/sourcegraph/sourcegraph/issues/9824",
-				},
 			},
 			{
 				name:  `Escape sequences`,


### PR DESCRIPTION
currently, we do too much work when evaluating AND expressions.
We evaluate all terms even if some terms return no results. Since we
are only interested in the intersection we can return as soon as
the search returns 0 results for 1 term.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
