### PR TITLE
Add how-to for using workspaces in campaign spec

### DIFF
--- a/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
+++ b/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
@@ -9,12 +9,9 @@
 
 ## Overview
 
-Large repositories often contain multiple projects.
+Large repositories often contain multiple projects and it can make sense to run the campaign spec [`steps`][steps] separately in each project and create one changeset per project.
 
-It often makes sense to run the campaign spec [`steps`][steps] in them separately and create one changeset per project.
-
-That can be done by using [`workspaces`][workspaces] in the campaign specs in
-two steps:
+That can be done by using [`workspaces`][workspaces] in the campaign specs in two steps:
 
 1. Define the project locations with the `workspaces` property
 2. Produce unique `changesetTemplate.branch` names

--- a/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
+++ b/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
@@ -1,4 +1,4 @@
-# Creating multiple changesets in large repositories
+# Creating changesets per project in monorepos
 
 <style>
 .markdown-body h2 { margin-top: 50px; }
@@ -9,7 +9,7 @@
 
 ## Overview
 
-Large repositories often contain multiple projects and it can make sense to run the campaign spec [`steps`][steps] separately in each project and create one changeset per project.
+Large repositories often contain multiple projects, making them so-called monorepos. It can make sense to run the campaign spec [`steps`][steps] separately in each project and create one changeset per project.
 
 That can be done by using [`workspaces`][workspaces] in the campaign specs in two steps:
 

--- a/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
+++ b/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
@@ -1,0 +1,140 @@
+# Creating multiple changesets in large repositories
+
+<style>
+.markdown-body h2 { margin-top: 50px; }
+.markdown-body pre.chroma { font-size: 0.75em; }
+</style>
+
+> NOTE: This feature is available in Sourcegraph 3.25 with <a href="https://github.com/sourcegraph/src-cli">Sourcegraph CLI</a> 3.25.0 and later.</p>
+
+## Overview
+
+Large repositories often contain multiple projects.
+
+It often makes sense to run the campaign spec [`steps`][steps] in them separately and create one changeset per project.
+
+That can be done by using [`workspaces`][workspaces] in the campaign specs in
+two steps:
+
+1. Define the project locations with the `workspaces` property
+2. Produce unique `changesetTemplate.branch` names
+
+## 1. Define project locations with `workspaces`
+
+Let's say we have a repository containing multiple TypeScript projects in which we want to update TypeScript by running the following command:
+
+```
+npm update typescript
+```
+
+The repository has the following directory and file structure:
+
+```
+README.md
+project1/package.json
+project1/src/...
+project2/package.json
+project2/src/...
+examples/project3/package.json
+examples/project3/src/...
+```
+
+The location of the `package.json` files tell us that the TypeScript projects are in `project1`, `project2` and `examples/project3`. In each of these we to run the `npm update` command and produce an individual changeset per project.
+
+The [`workspaces`][workspaces] property in campaign specs allows us to do that:
+
+```yaml
+name: update-typescript-monorepo
+description: This campaign updates the TypeScript dependency to the latest version
+
+on:
+  - repositoriesMatchingQuery: our-large-monorepo
+
+workspaces:
+  - rootAtLocationOf: package.json
+    in: github.com/our-org/our-large-monorepo
+
+steps:
+  - run: npm update typescript
+    container: node:14
+
+# [...]
+```
+
+The `workspaces` property here defines that in `github.com/our-org/our-large-monorepo` different `workspaces` exist and contain a `package.json` at their root.
+
+When executed with `src campaign [apply|preview]` this would produce up to 3 changesets in `github.com/our-org/our-large-monorepo`, one for each project.
+
+## 2. Produce unique `changesetTemplate.branch` names
+
+Since changesets are uniquely identified by their repository and branch, we **must** ensure that multiple changesets in the same repository will different branches.
+
+To do that, we make use of [templating][templating] in the [`changesetTemplate.branch`][branch] field
+
+```yaml
+# [...]
+changesetTemplate:
+  title: Update TypeScript
+  body: This updates TypeScript to the latest version
+  published: false
+  commit:
+    message: Update TypeScript
+  # Templating and helper functions allow us to get the `path` in which
+  # the `steps` executed and turn that into a branch name:
+  branch: campaigns/update-typescript-${{ replace steps.path "/" "-" }}
+```
+
+The `steps.path` [templating variable][templating] contains the path in which the `steps` were executed, relative to the root of the repository.
+
+With the file and directory structure above, that means we'd end up with the following branch names:
+
+- `campaigns/update-typescript-project1`
+- `campaigns/update-typescript-project2`
+- `campaigns/update-typescript-examples-project3`
+
+And with that, we're done and ready to produce multiple changesets in a single repository, with the full campaign spec looking like this:
+
+```yaml
+name: update-typescript-monorepo
+description: This campaign updates the TypeScript dependency to the latest version
+
+on:
+  - repository: github.com/sourcegraph/automation-testing
+
+workspaces:
+  - rootAtLocationOf: package.json
+    in: github.com/sourcegraph/automation-testing
+
+steps:
+  - run: npm update typescript
+    container: node:14
+
+changesetTemplate:
+  title: Update TypeScript
+  body: This updates TypeScript to the latest version
+  branch: campaigns/update-typescript-${{ replace steps.path "/" "-" }}
+  commit:
+    message: Update TypeScript
+  published: false
+```
+
+Now we only need to run `src campaign [apply|preview]` to execute our campaign spec.
+
+## Dynamic discovery of workspaces
+
+The `workspace` property leverages Sourcegraph search to find the location of the defined workspaces in the repositories yielded by the [`on`][on] property of the campaign spec.
+
+That has the advantage that it's _dynamic_: whenever `src campaign [apply|preview]` is re-executed, Sourcegraph search is used again to find workspaces, automatically picking up new ones and removing workspaces that no longer exist.
+
+## Learn more
+
+To learn more about `workspaces`, take a look at its entry in the "[Campaign Spec YAML reference][workspaces]".
+
+<!-- References for easier reading of text above: -->
+
+[cli]: ../cli/index.md
+[steps]: ../references/campaign_spec_yaml_reference.md#steps
+[workspaces]: ../references/campaign_spec_yaml_reference.md#workspaces
+[on]: ../references/campaign_spec_yaml_reference.md#on
+[branch]: ../references/campaign_spec_yaml_reference.md#changesettemplate-branch
+[templating]: ../references/campaign_spec_templating.md

--- a/doc/campaigns/how-tos/index.md
+++ b/doc/campaigns/how-tos/index.md
@@ -10,5 +10,6 @@ The following is a list of how-tos that show how to use [Sourcegraph campaigns](
 - [Closing or deleting a campaign](closing_or_deleting_a_campaign.md)
 - [Site admin configuration for campaigns](site_admin_configuration.md)
 - [Configuring user credentials for campaigns](configuring_user_credentials.md)
-- <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
 - [Handling errored changesets](handling_errored_changesets.md)
+- <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
+- [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)

--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -89,6 +89,7 @@ Create a campaign by specifying a search query to get a list of repositories and
 - [Configuring user credentials for campaigns](how-tos/configuring_user_credentials.md)
 - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
 - [Handling errored changesets](how-tos/handling_errored_changesets.md)
+- [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)
 
 ## Tutorials
 

--- a/doc/campaigns/references/campaign_spec_yaml_reference.md
+++ b/doc/campaigns/references/campaign_spec_yaml_reference.md
@@ -658,9 +658,9 @@ changesetTemplate:
   # Since a changeset is uniquely identified by its repository and its
   # branch we need to ensure that each changesets has a unique branch name.
 
-  # We can use templating and helper functions for to use the `path` in which
+  # We can use templating and helper functions get the `path` in which
   # the `steps` executed and turn that into a branch name:
-  branch: ${{ join "-" "my-multi-workspace-campaign" (replace steps.path "/" "-") }}
+  branch: my-multi-workspace-campaign-${{ replace steps.path "/" "-" }}
 ```
 
 Using templating to produce a unique branch name in repositories _with_ workspaces and repositories without workspaces:
@@ -682,7 +682,6 @@ changesetTemplate:
   # if it's a blank string:
   branch: ${{ join_if "-" "my-multi-workspace-campaign" (replace steps.path "/" "-") }}
 ```
-
 
 Defining where Go, JavaScript, and Rust projects live in multiple repositories:
 


### PR DESCRIPTION
This adds a how-to that explains how to use the new `workspaces` feature (added in https://github.com/sourcegraph/src-cli/pull/442) in campaign specs.

Click [here for the preview](https://docs.sourcegraph.com/@mrn-how-to-dynamic-workspaces/campaigns/how-tos/creating_changesets_per_project_in_monorepos).

---

I know that this kinda blurs the line between how-to and tutorial, but I have to say that I found it hard to explain how to use this feature without making it more concrete. And since we have our campaign spec YAML reference, I think it's okay to get a bit more concrete here.