### PR TITLE
add postcss rule to transform px to rem

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "postcss": "^8.2.4",
     "postcss-focus-visible": "^5.0.0",
     "postcss-loader": "^4.1.0",
+    "postcss-pxtorem": "^5.1.1",
     "prettier": "^2.2.1",
     "puppeteer": "5.5.0",
     "puppeteer-firefox": "^0.5.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  plugins: [require('autoprefixer'), require('postcss-focus-visible'), require('postcss-pxtorem')({ propWhiteList: [] })],
+  plugins: [
+    require('autoprefixer'),
+    require('postcss-focus-visible'),
+    require('postcss-pxtorem')({ propWhiteList: [] }),
+  ],
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require('autoprefixer'), require('postcss-focus-visible')],
+  plugins: [require('autoprefixer'), require('postcss-focus-visible'), require('postcss-pxtorem')({ propWhiteList: [] })],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17110,6 +17110,13 @@ postcss-ordered-values@^4.1.2:
     postcss "^7.0.0"
     postcss-value-parser "^3.0.0"
 
+postcss-pxtorem@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.npmjs.org/postcss-pxtorem/-/postcss-pxtorem-5.1.1.tgz#198a68c10f9ad2d42370ef66299d7b3168f8cffa"
+  integrity sha512-uvgIujL/pn0GbZ+rczESD2orHsbXrrCqi+q9wJO8PCk3ZGCoVVtu5hZTbtk+tbZHZP5UkTfCvqOrTZs9Ncqfsg==
+  dependencies:
+    postcss "^7.0.27"
+
 postcss-reduce-initial@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz#7fd42ebea5e9c814609639e2c2e84ae270ba48df"


### PR DESCRIPTION

<!-- Describe the purpose of the PR so that if you looked at it in 6 ,months it would be clear from the overview why this was created -->
## Overview
Currently, **94 .scss files** on our codebase are using `px` as the unit of measurement. The `px` units do not scale according to the width of the browser window. Our focus is to convert all those px to their `rem` equivalent.

This approach uses a [postCSS plugin](https://github.com/cuth/postcss-pxtorem) that replaces those `px` to the equivalent `rem` value on compile time.

### Example Before
![Screen Shot 2021-02-02 at 1 39 12 PM](https://user-images.githubusercontent.com/989826/106647081-7b99b680-655c-11eb-816d-61b302d5bdfa.png)

### Example After
![Screen Shot 2021-02-02 at 1 41 17 PM](https://user-images.githubusercontent.com/989826/106647135-8d7b5980-655c-11eb-97ab-530e6a429274.png)

<!-- Update the implementation steps that should be completed to implement the feature/bugfix/tech debt cleanup -->
## Progress
- [ ] Approved by a frontend engineer
- [ ] Approved by a designer

<!-- Add a reference to the issue that this PR addresses if relevant -->
Closes https://github.com/sourcegraph/sourcegraph/issues/16602