### PR TITLE
search: choose matcher from filename result

### DIFF
--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -240,7 +240,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	archiveSize.Observe(float64(bytes))
 
 	if p.IsStructuralPat {
-		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, p.Languages, p.IncludePatterns, p.Repo)
+		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, p.Repo)
 	} else {
 		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
 	}

--- a/internal/comby/args.go
+++ b/internal/comby/args.go
@@ -12,9 +12,13 @@ func (args Args) String() string {
 	s := []string{
 		args.MatchTemplate,
 		args.RewriteTemplate,
-		fmt.Sprintf("-f (%d file patterns)", len(args.FilePatterns)),
 		"-json-lines",
 	}
+
+	if len(args.FilePatterns) > 0 {
+		s = append(s, fmt.Sprintf("-f (%d file patterns)", len(args.FilePatterns)))
+	}
+
 	if args.MatchOnly {
 		s = append(s, "-match-only")
 	} else {


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/17569. See https://github.com/sourcegraph/sourcegraph/issues/17569#issuecomment-765610246

Previous code:

- Get filepaths we need to search with comby, let comby figure out which matcher to use based on file extension if there is no `lang:...`. Poor part of this: we invoke comby on the command line with lots of filepaths to search.

Now:

- Extract file extension from first filepath result and use that to define comby matcher if there is no `lang:...`. Improvement: we no longer set a list of long filepaths in the comby command line to search.


Master dry run build: https://buildkite.com/sourcegraph/sourcegraph/builds/86034