### PR TITLE
search: Add support for unindexed structural search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - New site config option `"log": { "sentry": { "backendDSN": "<REDACTED>" } }` to use a separate Sentry project for backend errors. [#17363](https://github.com/sourcegraph/sourcegraph/pull/17363)
 - Structural search now supports searching indexed branches other than default. [#17726](https://github.com/sourcegraph/sourcegraph/pull/17726)
+- Structural search now supports searching unindexed revisions. [#17928](https://github.com/sourcegraph/sourcegraph/pull/17928)
 
 ### Changed
 

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -49,6 +49,10 @@ type Request struct {
 	// Endpoint(s) for reaching Zoekt. See description in
 	// endpoint.go:Static(...)
 	IndexerEndpoints []string
+
+	// Whether the revision to be searched is indexed or unindexed. This matters for
+	// structural search because it will query Zoekt for indexed structural search.
+	Indexed bool
 }
 
 // PatternInfo describes a search request on a repo. Most of the fields

--- a/cmd/searcher/search/file_filter.go
+++ b/cmd/searcher/search/file_filter.go
@@ -1,0 +1,50 @@
+package search
+
+import (
+	"regexp"
+)
+
+type fileFilter struct {
+	includes []*regexp.Regexp
+	exclude  *regexp.Regexp
+}
+
+func (f *fileFilter) Match(filename string) bool {
+	if f.exclude != nil && f.exclude.MatchString(filename) {
+		return false
+	}
+
+	for _, include := range f.includes {
+		if !include.MatchString(filename) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func newFileFilter(includePatterns []string, excludePattern string) (*fileFilter, error) {
+	includes := make([]*regexp.Regexp, 0, len(includePatterns))
+	for _, pat := range includePatterns {
+		r, err := regexp.Compile(pat)
+		if err != nil {
+			return nil, err
+		}
+
+		includes = append(includes, r)
+	}
+
+	var exclude *regexp.Regexp
+	var err error
+	if excludePattern != "" {
+		exclude, err = regexp.Compile(excludePattern)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &fileFilter{
+		includes: includes,
+		exclude:  exclude,
+	}, nil
+}

--- a/cmd/searcher/search/file_filter_test.go
+++ b/cmd/searcher/search/file_filter_test.go
@@ -1,0 +1,38 @@
+package search
+
+import (
+	"testing"
+)
+
+func TestFileFilter(t *testing.T) {
+	cases := []struct {
+		include     []string
+		exclude     string
+		file        string
+		shouldMatch bool
+	}{
+		{[]string{}, "", "test.go", true},
+		{[]string{`.*\.go`}, "", "test.go", true},
+		{[]string{`.*\.go`}, "", "test.rb", false},
+		{[]string{`.*\.go`, `test.*`}, "", "test.go", true},
+		{[]string{`.*\.go`, `test.*`}, "", "foo.go", false},
+		{[]string{}, `.*`, "foo.go", false},
+		{[]string{}, `foo\.*`, "foo.go", false},
+		{[]string{`.*`}, `foo\.*`, "foo.go", false},
+		{[]string{`.*`}, `bar\.*`, "foo.go", true},
+	}
+
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			fm, err := newFileFilter(tc.include, tc.exclude)
+			if err != nil {
+				t.Fatalf("Unexpected error: %s", err)
+			}
+
+			matches := fm.Match(tc.file)
+			if matches != tc.shouldMatch {
+				t.Fatalf("Expect matches to be %v, but got %v", tc.shouldMatch, matches)
+			}
+		})
+	}
+}

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -191,7 +191,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		}
 	}(time.Now())
 
-	if p.IsStructuralPat && p.CombyRule != `where "backcompat" == "backcompat"` {
+	if p.IsStructuralPat && p.Indexed && p.CombyRule != `where "backcompat" == "backcompat"` {
 		// Execute the new structural search path that directly calls Zoekt.
 		return structuralSearchWithZoekt(ctx, p)
 	}
@@ -239,8 +239,10 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	archiveFiles.Observe(float64(nFiles))
 	archiveSize.Observe(float64(bytes))
 
-	if p.IsStructuralPat {
-		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, p.Repo)
+	if p.IsStructuralPat && p.CombyRule == `where "backcompat" == "backcompat"` {
+		matches, limitHit, err = structuralSearchBackcompat(ctx, zipPath, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, p.Repo)
+	} else if p.IsStructuralPat {
+		matches, limitHit, err = structuralSearchZip(ctx, zipPath, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, p.ExcludePattern, p.Repo)
 	} else {
 		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)
 	}

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -70,7 +70,7 @@ func foo(go string) {}
 	for _, tt := range cases {
 		t.Run(tt.Name, func(t *testing.T) {
 			p.Languages = tt.Languages
-			matches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "repo_foo")
+			matches, _, err := structuralSearchBackcompat(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "repo_foo")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -126,7 +126,7 @@ func foo(go.txt) {}
 		}
 
 		extension := filepath.Ext(filename)
-		matches, _, err := structuralSearch(context.Background(), zf, "foo(:[args])", "", extension, languages, []string{}, "repo_foo")
+		matches, _, err := structuralSearchBackcompat(context.Background(), zf, "foo(:[args])", "", extension, languages, []string{}, "repo_foo")
 		if err != nil {
 			return "ERROR"
 		}
@@ -180,7 +180,7 @@ func foo(real string) {}
 		Pattern:         pattern,
 		IncludePatterns: includePatterns,
 	}
-	m, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "foo")
+	m, _, err := structuralSearchBackcompat(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestIncludePatterns(t *testing.T) {
 		Pattern:         "",
 		IncludePatterns: includePatterns,
 	}
-	fileMatches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "foo")
+	fileMatches, _, err := structuralSearchBackcompat(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +321,7 @@ func TestRule(t *testing.T) {
 		CombyRule:       `where :[args] == "success"`,
 	}
 
-	got, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "repo")
+	got, _, err := structuralSearchBackcompat(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "repo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,7 +475,7 @@ func bar() {
 	defer cleanup()
 
 	t.Run("Strutural search match count", func(t *testing.T) {
-		matches, _, err := structuralSearch(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "repo_foo")
+		matches, _, err := structuralSearchBackcompat(context.Background(), zf, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, "repo_foo")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -693,7 +693,7 @@ func TestSearch(t *testing.T) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "Unable To Process Query",
-					Description: "Unbalanced expression: unmatched closing parenthesis )",
+					Description: "Unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses",
 				},
 			},
 			{
@@ -702,7 +702,7 @@ func TestSearch(t *testing.T) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "Unable To Process Query",
-					Description: "Unbalanced expression: unmatched closing parenthesis )",
+					Description: "Unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses",
 				},
 			},
 			{
@@ -711,7 +711,7 @@ func TestSearch(t *testing.T) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "Unable To Process Query",
-					Description: "Unbalanced expression: unmatched closing parenthesis )",
+					Description: "Unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses",
 				},
 			},
 			{
@@ -720,7 +720,7 @@ func TestSearch(t *testing.T) {
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:       "Unable To Process Query",
-					Description: "Unbalanced expression: unmatched closing parenthesis )",
+					Description: "Unsupported expression. The combination of parentheses in the query have an unclear meaning. Try using the content: filter to quote patterns that contain parentheses",
 				},
 			},
 			{

--- a/internal/comby/args.go
+++ b/internal/comby/args.go
@@ -45,5 +45,9 @@ func (args Args) String() string {
 		log15.Error("unrecognized input type: %T", i)
 	}
 
+	if args.Ripgrep {
+		s = append(s, "-rg", "")
+	}
+
 	return strings.Join(s, " ")
 }

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -64,6 +64,10 @@ func rawArgs(args Args) (rawArgs []string) {
 		panic("unreachable")
 	}
 
+	if args.Ripgrep {
+		rawArgs = append(rawArgs, "-rg", "")
+	}
+
 	return rawArgs
 }
 
@@ -119,6 +123,9 @@ func PipeTo(ctx context.Context, args Args, w io.Writer) (err error) {
 	cmd := exec.Command(combyPath, rawArgs...)
 	// Ensure forked child processes are killed
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if dir, ok := args.Input.(DirPath); ok {
+		cmd.Dir = string(dir)
+	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/comby/types.go
+++ b/internal/comby/types.go
@@ -34,6 +34,9 @@ type Args struct {
 
 	// NumWorkers is the number of worker processes to fork in parallel
 	NumWorkers int
+
+	// Use ripgrep to pre-filter to a set of files
+	Ripgrep bool
 }
 
 // Location is the location in a file

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -43,7 +43,7 @@ var (
 var MockSearch func(ctx context.Context, repo api.RepoName, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*protocol.FileMatch, limitHit bool, err error)
 
 // Search searches repo@commit with p.
-func Search(ctx context.Context, searcherURLs *endpoint.Map, repo api.RepoName, branch string, commit api.CommitID, p *search.TextPatternInfo, fetchTimeout time.Duration, indexerEndpoints []string) (matches []*protocol.FileMatch, limitHit bool, err error) {
+func Search(ctx context.Context, searcherURLs *endpoint.Map, repo api.RepoName, branch string, commit api.CommitID, indexed bool, p *search.TextPatternInfo, fetchTimeout time.Duration, indexerEndpoints []string) (matches []*protocol.FileMatch, limitHit bool, err error) {
 	if MockSearch != nil {
 		return MockSearch(ctx, repo, commit, p, fetchTimeout)
 	}
@@ -81,6 +81,9 @@ func Search(ctx context.Context, searcherURLs *endpoint.Map, repo api.RepoName, 
 	}
 	if p.IsStructuralPat {
 		q.Set("IsStructuralPat", "true")
+	}
+	if indexed {
+		q.Set("Indexed", "true")
 	}
 	if p.IsWordMatch {
 		q.Set("IsWordMatch", "true")


### PR DESCRIPTION
This adds support for searching unindexed revisions with a structural
search.

~~Depends on #17924~~
~~Depends on #17930~~
Fixes #8164 

General flow:
- Frontend sends searcher a repo/revision to search with `indexed ==
  false`
- Searcher retrieves a zip of that revision from gitserver or from its
  cache as normal (no change here)
- Searcher unzips the zip, skipping any files that do not match filters
  - We unzip because ripgrep is used to pre-filter the list of files for
    comby, and it doesn't support searching a zip file.
  - We skip files that don't match filters because ripgrep only supports
    glob patterns, and our filters are regex patterns. Additionally,
    this keeps us from having to extract huge archives when we're only
    interested in a couple of files.
- Comby searches the unzipped directory, pre-filtering with ripgrep for
  the sake of performance
- Clean up the unzipped directory
- Matches are returned as normal
