### PR TITLE
Change font-size measurement unit from px to rem

### DIFF
--- a/client/branded/src/components/Tabs.scss
+++ b/client/branded/src/components/Tabs.scss
@@ -58,7 +58,7 @@
 
         &--h5like {
             // Mimic h5 style.
-            font-size: 12px;
+            font-size: 0.75rem;
             letter-spacing: 1px;
             text-transform: uppercase;
             color: var(--body-color);

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -24,7 +24,7 @@ code,
 kbd {
     font-family: SFMono-Regular, Consolas, Menlo, DejaVu Sans Mono, monospace;
     display: inline-block;
-    line-height: 1.25;
+    line-height: (16/12);
     height: 1.125rem;
     font-size: $code-font-size;
     padding: 0 0.25rem;

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -1,5 +1,5 @@
 $code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
-$code-font-size: 0.92582em;
+$code-font-size: (12/14)em;
 
 .theme-dark {
     --code-bg: var(--color-bg-2);

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -1,5 +1,5 @@
 $code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
-$code-font-size: (12/14)em;
+$code-font-size: (12/14) em;
 
 .theme-dark {
     --code-bg: var(--color-bg-2);

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -26,7 +26,7 @@ kbd {
     display: inline-block;
     line-height: 16px;
     height: 1.125rem;
-    font-size: 12px;
+    font-size: 0.75rem;
     padding: 0 0.25rem;
     margin: 0 0.125rem;
     vertical-align: middle;

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -1,5 +1,5 @@
 $code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
-$code-font-size: 12px;
+$code-font-size: 0.92582em;
 
 .theme-dark {
     --code-bg: var(--color-bg-2);
@@ -13,7 +13,7 @@ code,
 .code {
     font-family: $code-font-family;
     font-size: $code-font-size;
-    line-height: 16px;
+    line-height: 1.25;
     white-space: pre;
 }
 
@@ -24,9 +24,9 @@ code,
 kbd {
     font-family: SFMono-Regular, Consolas, Menlo, DejaVu Sans Mono, monospace;
     display: inline-block;
-    line-height: 16px;
+    line-height: 1.25;
     height: 1.125rem;
-    font-size: 0.75rem;
+    font-size: $code-font-size;
     padding: 0 0.25rem;
     margin: 0 0.125rem;
     vertical-align: middle;

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -13,7 +13,7 @@ code,
 .code {
     font-family: $code-font-family;
     font-size: $code-font-size;
-    line-height: 1.25;
+    line-height: (16/12);
     white-space: pre;
 }
 

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -145,7 +145,7 @@ $hr-margin-y: 0.25rem;
 
 html {
     // Base for layout rem values
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 // Our simple popovers only need these styles. We don't want the caret or special font sizes from

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -143,11 +143,6 @@ $hr-margin-y: 0.25rem;
     box-sizing: border-box;
 }
 
-html {
-    // Base for layout rem values
-    font-size: 1rem;
-}
-
 // Our simple popovers only need these styles. We don't want the caret or special font sizes from
 // Bootstrap's popover CSS.
 .popover-inner {

--- a/client/branded/src/global-styles/type.scss
+++ b/client/branded/src/global-styles/type.scss
@@ -2,26 +2,22 @@
 
 h1 {
     font-size: 1.75rem;
-    line-height: 40px;
     font-weight: 500;
     margin: 0 0 1rem;
 }
 
 h2 {
     font-size: 1.5rem;
-    line-height: 32px;
     font-weight: 500;
 }
 
 h3 {
     font-size: 1rem;
-    line-height: 24px;
     font-weight: 600;
 }
 
 h4 {
     font-size: 0.875rem;
-    line-height: 20px;
     font-weight: 600;
 }
 

--- a/client/branded/src/global-styles/type.scss
+++ b/client/branded/src/global-styles/type.scss
@@ -1,32 +1,32 @@
 @import 'bootstrap/scss/type';
 
 h1 {
-    font-size: 28px;
+    font-size: 1.75rem;
     line-height: 40px;
     font-weight: 500;
     margin: 0 0 1rem;
 }
 
 h2 {
-    font-size: 24px;
+    font-size: 1.5rem;
     line-height: 32px;
     font-weight: 500;
 }
 
 h3 {
-    font-size: 16px;
+    font-size: 1rem;
     line-height: 24px;
     font-weight: 600;
 }
 
 h4 {
-    font-size: 14px;
+    font-size: 0.875rem;
     line-height: 20px;
     font-weight: 600;
 }
 
 h5 {
-    font-size: 14px;
+    font-size: 0.875rem;
     letter-spacing: 0.05em;
     font-weight: normal;
     text-transform: uppercase;
@@ -34,12 +34,12 @@ h5 {
 }
 
 h6 {
-    font-size: 12px;
+    font-size: 0.75rem;
     font-weight: 600;
 }
 
 small {
-    font-size: 12px;
+    font-size: 0.75rem;
 }
 
 sup,

--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.scss
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.scss
@@ -7,6 +7,6 @@
         width: 2rem !important;
     }
     &__code-host-titles {
-        line-height: 2rem;
+        line-height: 2;
     }
 }

--- a/client/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/client/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -1,7 +1,7 @@
 // Command palette
 .command-palette-button--bitbucket-server {
     z-index: 3000;
-    font-size: 13px;
+    font-size: 0.8125rem;
     svg {
         // The icon we use is taller than the other items' font size, so make it a bit shorter.
         height: 13px;
@@ -119,7 +119,7 @@
         font-weight: normal;
         font-style: normal;
         content: '\f15b';
-        font-size: 16px;
+        font-size: 1rem;
         height: 16px;
         line-height: 1;
         margin-top: -8px;

--- a/client/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/client/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -100,6 +100,7 @@
     background: transparent !important;
     border: none !important;
     height: 16px !important;
+    // stylelint-disable-next-line declaration-property-unit-whitelist
     line-height: 16px !important;
 
     &:hover {

--- a/client/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/client/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -1,7 +1,6 @@
 // Command palette
 .command-palette-button--bitbucket-server {
     z-index: 3000;
-    // stylelint-disable-next-line declaration-property-unit-whitelist
     font-size: 13px;
     svg {
         // The icon we use is taller than the other items' font size, so make it a bit shorter.
@@ -100,7 +99,6 @@
     background: transparent !important;
     border: none !important;
     height: 16px !important;
-    // stylelint-disable-next-line declaration-property-unit-whitelist
     line-height: 16px !important;
 
     &:hover {
@@ -121,7 +119,6 @@
         font-weight: normal;
         font-style: normal;
         content: '\f15b';
-        // stylelint-disable-next-line declaration-property-unit-whitelist
         font-size: 16px;
         height: 16px;
         line-height: 1;

--- a/client/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/client/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -1,6 +1,7 @@
 // Command palette
 .command-palette-button--bitbucket-server {
     z-index: 3000;
+    // stylelint-disable-next-line declaration-property-unit-whitelist
     font-size: 13px;
     svg {
         // The icon we use is taller than the other items' font size, so make it a bit shorter.
@@ -119,6 +120,7 @@
         font-weight: normal;
         font-style: normal;
         content: '\f15b';
+        // stylelint-disable-next-line declaration-property-unit-whitelist
         font-size: 16px;
         height: 16px;
         line-height: 1;

--- a/client/browser/src/shared/code-hosts/bitbucket/style.scss
+++ b/client/browser/src/shared/code-hosts/bitbucket/style.scss
@@ -1,7 +1,7 @@
 // Command palette
 .command-palette-button--bitbucket-server {
     z-index: 3000;
-    font-size: 0.8125rem;
+    font-size: 13px;
     svg {
         // The icon we use is taller than the other items' font size, so make it a bit shorter.
         height: 13px;
@@ -119,7 +119,7 @@
         font-weight: normal;
         font-style: normal;
         content: '\f15b';
-        font-size: 1rem;
+        font-size: 16px;
         height: 16px;
         line-height: 1;
         margin-top: -8px;

--- a/client/shared/src/commandPalette/EmptyCommandList.scss
+++ b/client/shared/src/commandPalette/EmptyCommandList.scss
@@ -9,7 +9,7 @@
     }
 
     &__text {
-        line-height: 150%;
+        line-height: 1.5;
         margin-bottom: 2rem;
     }
 

--- a/client/shared/src/notifications/NotificationItem.scss
+++ b/client/shared/src/notifications/NotificationItem.scss
@@ -37,7 +37,7 @@
         flex: 0 0;
         // stylelint-disable-next-line declaration-property-unit-whitelist
         font-size: 1.25rem;
-        line-height: 1.25rem;
+        line-height: 1;
         background-color: transparent;
         border-width: 0;
         outline: 0 !important;

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -46,7 +46,7 @@ $popover-item-padding-v: 0.325rem;
         border: none;
         border-radius: 0;
         text-align: left;
-        font-size: 12px;
+        font-size: 0.75rem;
         padding: $popover-item-padding-v $popover-item-padding-h;
     }
 }

--- a/client/web/src/components/HeroPage.scss
+++ b/client/web/src/components/HeroPage.scss
@@ -36,9 +36,9 @@
     }
 
     &__title {
-        font-size: 2em;
+        font-size: 2rem;
         margin-top: 1rem;
-        line-height: 2.5rem;
+        line-height: 1.1111111111;
     }
 
     &__subtitle {

--- a/client/web/src/components/HeroPage.scss
+++ b/client/web/src/components/HeroPage.scss
@@ -38,7 +38,7 @@
     &__title {
         font-size: 2rem;
         margin-top: 1rem;
-        line-height: 1.1111111111;
+        line-height: 1.5;
     }
 
     &__subtitle {

--- a/client/web/src/components/d3/BarChart.scss
+++ b/client/web/src/components/d3/BarChart.scss
@@ -5,7 +5,7 @@
     text,
     tspan {
         fill: currentColor;
-        font-size: 9px;
+        font-size: 0.5625rem;
         font-family: inherit;
     }
 

--- a/client/web/src/components/diff/FileDiffHunks.scss
+++ b/client/web/src/components/diff/FileDiffHunks.scss
@@ -15,7 +15,7 @@
         min-width: 2.5rem;
         padding: 0 0.75rem;
         font-size: 0.75rem;
-        line-height: 1.25rem;
+        line-height: 1.6666666667;
         white-space: nowrap;
         text-align: right;
         user-select: none;

--- a/client/web/src/components/diff/FileDiffHunks.scss
+++ b/client/web/src/components/diff/FileDiffHunks.scss
@@ -15,7 +15,7 @@
         min-width: 2.5rem;
         padding: 0 0.75rem;
         font-size: 0.75rem;
-        line-height: 1.6666666667;
+        line-height: (20/12);
         white-space: nowrap;
         text-align: right;
         user-select: none;

--- a/client/web/src/components/diff/FileDiffHunks.scss
+++ b/client/web/src/components/diff/FileDiffHunks.scss
@@ -14,7 +14,7 @@
         width: 1%;
         min-width: 2.5rem;
         padding: 0 0.75rem;
-        font-size: 12px;
+        font-size: 0.75rem;
         line-height: 1.25rem;
         white-space: nowrap;
         text-align: right;
@@ -37,7 +37,7 @@
         padding-right: 0.5rem;
         font-family: $code-font-family;
         white-space: pre;
-        font-size: 12px;
+        font-size: 0.75rem;
         &::before {
             padding-right: 0.5rem;
             content: attr(data-diff-marker);

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
@@ -8,7 +8,7 @@
         @include media-breakpoint-down(xs) {
             // Emulate h4 size on xs devices.
             font-size: 0.875rem;
-            line-height: 1.4285714286;
+            line-height: (20/14);
         }
     }
     &__state-badge {

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
@@ -8,14 +8,14 @@
         @include media-breakpoint-down(xs) {
             // Emulate h4 size on xs devices.
             font-size: 0.875rem;
-            line-height: 20px;
+            line-height: 1.4285714286;
         }
     }
     &__state-badge {
         @include media-breakpoint-down(sm) {
             // Emulate h4 on sm and xs devices.
             font-size: 0.875rem;
-            line-height: 20px;
+            line-height: 1.4285714286;
             font-weight: 600;
         }
     }

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
@@ -15,7 +15,7 @@
         @include media-breakpoint-down(sm) {
             // Emulate h4 on sm and xs devices.
             font-size: 0.875rem;
-            line-height: 1.4285714286;
+            line-height: (20/14);
             font-weight: 600;
         }
     }

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.scss
@@ -7,14 +7,14 @@
     &__completeness {
         @include media-breakpoint-down(xs) {
             // Emulate h4 size on xs devices.
-            font-size: 14px;
+            font-size: 0.875rem;
             line-height: 20px;
         }
     }
     &__state-badge {
         @include media-breakpoint-down(sm) {
             // Emulate h4 on sm and xs devices.
-            font-size: 14px;
+            font-size: 0.875rem;
             line-height: 20px;
             font-weight: 600;
         }

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.scss
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.scss
@@ -11,7 +11,7 @@
         @include media-breakpoint-down(sm) {
             // Emulate h4 on sm and xs devices.
             font-size: 0.875rem;
-            line-height: 20px;
+            line-height: 1.4285714286;
             font-weight: 600;
         }
     }

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.scss
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.scss
@@ -10,7 +10,7 @@
     &__title {
         @include media-breakpoint-down(sm) {
             // Emulate h4 on sm and xs devices.
-            font-size: 14px;
+            font-size: 0.875rem;
             line-height: 20px;
             font-weight: 600;
         }

--- a/client/web/src/enterprise/campaigns/list/CampaignNode.scss
+++ b/client/web/src/enterprise/campaigns/list/CampaignNode.scss
@@ -11,7 +11,7 @@
         @include media-breakpoint-down(sm) {
             // Emulate h4 on sm and xs devices.
             font-size: 0.875rem;
-            line-height: 1.4285714286;
+            line-height: (20/14);
             font-weight: 600;
         }
     }

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.scss
@@ -18,7 +18,7 @@
 
     &__start {
         &-subheading {
-            font-size: 16px;
+            font-size: 1rem;
         }
 
         &-button {

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -5,7 +5,7 @@
 
         &-preview-link {
             white-space: nowrap;
-            font-size: 12px;
+            font-size: 0.75rem;
             background-color: var(--color-bg-2);
             border: 1px solid var(--input-border-color);
             border-top-right-radius: 2px;
@@ -25,7 +25,7 @@
         }
 
         &-error-message {
-            font-size: 12px;
+            font-size: 0.75rem;
         }
 
         &-field {

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -14,7 +14,7 @@
             &-text {
                 display: flex;
                 align-items: center;
-                line-height: 1rem;
+                line-height: 1.3333333333;
                 height: 1rem;
             }
 

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -14,7 +14,7 @@
             &-text {
                 display: flex;
                 align-items: center;
-                line-height: 1.3333333333;
+                line-height: (1/0.75);
                 height: 1rem;
             }
 

--- a/client/web/src/nav/VersionContextDropdown.scss
+++ b/client/web/src/nav/VersionContextDropdown.scss
@@ -17,7 +17,7 @@
         border-radius: 0;
 
         &-text {
-            font-size: 10px;
+            font-size: 0.625rem;
         }
     }
 
@@ -29,7 +29,7 @@
 
     &__info {
         padding: 0.5rem 0.5rem;
-        font-size: 12px;
+        font-size: 0.75rem;
         border: none;
 
         &-dismiss {
@@ -53,7 +53,7 @@
     }
 
     &__option {
-        font-size: 12px;
+        font-size: 0.75rem;
         display: grid;
         grid-template-columns: 0.5fr 4fr 5fr 0.5fr;
         cursor: pointer;

--- a/client/web/src/repo/commits/GitCommitNode.scss
+++ b/client/web/src/repo/commits/GitCommitNode.scss
@@ -23,7 +23,7 @@
         }
         &-toggle {
             flex: none;
-            font-size: 9px;
+            font-size: 0.5625rem;
             padding: 0 0.175rem;
             margin-right: 0.5rem;
         }
@@ -35,7 +35,7 @@
         &-body {
             margin-top: 0.25rem;
             margin-bottom: 0.75rem;
-            font-size: 12px;
+            font-size: 0.75rem;
             overflow: visible;
             max-width: 100%;
             word-wrap: break-word;
@@ -68,7 +68,7 @@
             margin-right: 2rem;
         }
         &-copy {
-            font-size: 11px;
+            font-size: 0.6875rem;
             padding: 0.25rem;
             &:not(:hover) {
                 opacity: 0.8;

--- a/client/web/src/repogroups/RepogroupPage.scss
+++ b/client/web/src/repogroups/RepogroupPage.scss
@@ -37,7 +37,7 @@
 
         &-description {
             max-width: 60rem;
-            font-size: 16px;
+            font-size: 1rem;
             line-height: 150%;
         }
     }

--- a/client/web/src/repogroups/RepogroupPage.scss
+++ b/client/web/src/repogroups/RepogroupPage.scss
@@ -38,7 +38,7 @@
         &-description {
             max-width: 60rem;
             font-size: 1rem;
-            line-height: 150%;
+            line-height: 1.5;
         }
     }
 

--- a/client/web/src/search/input/SearchContextDropdown.scss
+++ b/client/web/src/search/input/SearchContextDropdown.scss
@@ -5,7 +5,7 @@
         margin-left: 0.25rem;
         margin-right: 0.25rem;
         padding: 0.125rem 0.25rem;
-        line-height: 1rem;
+        line-height: 1.3333333333;
         border-radius: 0.25rem;
         border: 2px solid transparent;
         box-sizing: border-box;

--- a/client/web/src/search/input/SearchContextDropdown.scss
+++ b/client/web/src/search/input/SearchContextDropdown.scss
@@ -5,7 +5,7 @@
         margin-left: 0.25rem;
         margin-right: 0.25rem;
         padding: 0.125rem 0.25rem;
-        line-height: 1.3333333333;
+        line-height: (16/12);
         border-radius: 0.25rem;
         border: 2px solid transparent;
         box-sizing: border-box;

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -7,7 +7,7 @@
     overflow: auto;
     white-space: pre;
     line-height: 20px;
-    font-size: 14px;
+    font-size: 0.875rem;
 
     user-select: none;
 

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -6,7 +6,7 @@
     width: 100%;
     overflow: auto;
     white-space: pre;
-    line-height: 20px;
+    line-height: 1.4285714286;
     font-size: 0.875rem;
 
     user-select: none;

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -6,7 +6,7 @@
     width: 100%;
     overflow: auto;
     white-space: pre;
-    line-height: 1.4285714286;
+    line-height: (20/14);
     font-size: 0.875rem;
 
     user-select: none;

--- a/client/web/src/user/area/UserAreaHeader.scss
+++ b/client/web/src/user/area/UserAreaHeader.scss
@@ -8,7 +8,7 @@
 
         &-subtitle {
             opacity: 0.75;
-            font-size: 20px;
+            font-size: 1.25rem;
         }
     }
 

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.scss
@@ -56,7 +56,7 @@
         margin-bottom: 0.25rem;
         width: 1.5rem;
         height: 1.5rem;
-        font-size: 12px;
+        font-size: 0.75rem;
         &--active {
             background-color: inherit;
         }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@sourcegraph/babel-plugin-transform-react-hot-loader-wrapper": "^1.0.0",
     "@sourcegraph/eslint-config": "^0.20.19",
     "@sourcegraph/prettierrc": "^3.0.3",
-    "@sourcegraph/stylelint-config": "^1.1.9",
+    "@sourcegraph/stylelint-config": "^1.2.0",
     "@sourcegraph/tsconfig": "^4.0.1",
     "@storybook/addon-actions": "^6.1.11",
     "@storybook/addon-console": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,10 +2715,10 @@
   resolved "https://registry.npmjs.org/@sourcegraph/react-loading-spinner/-/react-loading-spinner-0.0.7.tgz#e1d0bb1c13e6e8051cf3e0471c6aee0ca24dec45"
   integrity sha512-F4GMp+8XhlRQzEngc+CwbalT8zy8vXMxMrUjhm2cslTjWgWuSft0vSNCmCJDVPshpG/B+Ehb/OzpLLAzsG2JKg==
 
-"@sourcegraph/stylelint-config@^1.1.9":
-  version "1.1.9"
-  resolved "https://registry.npmjs.org/@sourcegraph/stylelint-config/-/stylelint-config-1.1.9.tgz#12c7d6476a6074c170a5e945e3bdf43f7b0711cf"
-  integrity sha512-g+NZstXoNO6XT3041gVB9shmaIOD74hgZ67Vr05APcID0vmdQ9eiefvwvNz1OGH1vVV5su9QuYLu0gynUpAaMg==
+"@sourcegraph/stylelint-config@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/stylelint-config/-/stylelint-config-1.2.0.tgz#b2b8c5091c4104de82842f30f34b50954b4bf5bf"
+  integrity sha512-0AZSnuY4nzRolTO6QYb4xlMwwkg/1WgpHm15a9gsk4i6yA8wVHakFdyP05Y2gXBkkI4LazzsKeGxGyieu0Q/Qw==
   dependencies:
     stylelint-config-prettier "^8.0.1"
     stylelint-config-standard "^20.0.0"


### PR DESCRIPTION

<!-- Describe the purpose of the PR so that if you looked at it in 6 ,months it would be clear from the overview why this was created -->
## Overview
The script posted below is one of the approaches that I found helpful to perform this change. This process has some advantages, like avoiding typing and make manual calculations.

The change only affects `font-size` property. In case any additional property needs to be updated, this script can do it.
```js
const fs = require('fs');
const path = require('path');
const postcss = require('postcss');
const sass = require('sass');
const sassSyntax = require('postcss-scss')
const pxtorem = require('postcss-pxtorem');
const scss = fs.readFileSync('client/browser/src/app.scss', 'utf8');

const options = {
  propWhiteList: ['font', 'font-size'],
};

function rempixer(startPath, filter) {
  if (!fs.existsSync(startPath)) {
    console.log("❌ Directory not found", startPath);
    return;
  }

  var files = fs.readdirSync(startPath);
  for (var i = 0; i < files.length; i++) {
    var filename = path.join(startPath, files[i]);
    var stat = fs.lstatSync(filename);
    if (stat.isDirectory()) {
      rempixer(filename, filter);
    }
    else if (filename.indexOf(filter) >= 0) {
      console.log('👀 scss file found: ', filename);
      const el = fs.readFileSync(filename, 'utf8')
      const processedCss = postcss([pxtorem(options)]).process(el, { syntax: sassSyntax }).css;
      fs.writeFile(filename, processedCss, error => {
        if (error) {
          throw error;
        }
        console.log(`💄 ${filename} font-size replaced from px to rem`);
      });
    };
  };
};

rempixer('client/', '.scss');

```

This approach uses a [postCSS plugin](https://github.com/cuth/postcss-pxtorem) that replaces those `px` to the equivalent `rem` value on compile time.

### Example Before
![Screen Shot 2021-02-02 at 1 39 12 PM](https://user-images.githubusercontent.com/989826/106647081-7b99b680-655c-11eb-816d-61b302d5bdfa.png)

### Example After
![Screen Shot 2021-02-02 at 1 41 17 PM](https://user-images.githubusercontent.com/989826/106647135-8d7b5980-655c-11eb-97ab-530e6a429274.png)

<!-- Update the implementation steps that should be completed to implement the feature/bugfix/tech debt cleanup -->
## Progress
- [x] Approved by a frontend engineer
- [x] Approved by a designer

<!-- Add a reference to the issue that this PR addresses if relevant -->
Closes https://github.com/sourcegraph/sourcegraph/issues/16602