### PR TITLE
search: add function to convert query tree to string

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -621,14 +621,14 @@ func (p *parser) TryParseDelimiter() (string, rune, bool) {
 // ParseFieldValue parses a value after a field like "repo:". If the value
 // starts with a recognized quoting delimiter but does not close it, an error is
 // returned.
-func (p *parser) ParseFieldValue() (string, error) {
-	delimited := func(delimiter rune) (string, error) {
+func (p *parser) ParseFieldValue() (string, bool, error) {
+	delimited := func(delimiter rune) (string, bool, error) {
 		value, advance, err := ScanDelimited(p.buf[p.pos:], true, delimiter)
 		if err != nil {
-			return "", err
+			return "", false, err
 		}
 		p.pos += advance
-		return value, nil
+		return value, true, nil
 	}
 	if p.match(SQUOTE) {
 		return delimited('\'')
@@ -644,7 +644,7 @@ func (p *parser) ParseFieldValue() (string, error) {
 		value, advance = ScanValue(p.buf[p.pos:], false)
 	}
 	p.pos += advance
-	return value, nil
+	return value, false, nil
 }
 
 // Try parse a delimited pattern, quoted as "...", '...', or /.../.
@@ -728,15 +728,19 @@ func (p *parser) ParseParameter() (Parameter, bool, error) {
 	}
 
 	p.pos += advance
-	value, err := p.ParseFieldValue()
+	value, quoted, err := p.ParseFieldValue()
 	if err != nil {
 		return Parameter{}, false, err
+	}
+	var labels labels
+	if quoted {
+		labels.set(Quoted)
 	}
 	return Parameter{
 		Field:      field,
 		Value:      value,
 		Negated:    negated,
-		Annotation: Annotation{Range: newRange(start, p.pos)},
+		Annotation: Annotation{Range: newRange(start, p.pos), Labels: labels},
 	}, true, nil
 }
 

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -618,9 +618,9 @@ func (p *parser) TryParseDelimiter() (string, rune, bool) {
 	return "", 0, false
 }
 
-// ParseFieldValue parses a value after a field like "repo:". If the value
-// starts with a recognized quoting delimiter but does not close it, an error is
-// returned.
+// ParseFieldValue parses a value after a field like "repo:". It returns the
+// parsed value and whether it was quoted. If the value starts with a recognized
+// quoting delimiter but does not close it, an error is returned.
 func (p *parser) ParseFieldValue() (string, bool, error) {
 	delimited := func(delimiter rune) (string, bool, error) {
 		value, advance, err := ScanDelimited(p.buf[p.pos:], true, delimiter)

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -40,8 +40,7 @@ func stringHumanPattern(nodes []Node) string {
 func stringHumanParameters(nodes []Node) string {
 	var result []string
 	for _, node := range nodes {
-		switch n := node.(type) {
-		case Parameter:
+		if n, ok := node.(Parameter); ok {
 			v := n.Value
 			if n.Annotation.Labels.isSet(Quoted) {
 				v = strconv.Quote(v)

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -1,0 +1,99 @@
+package query
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func stringHumanPattern(nodes []Node) string {
+	var result []string
+	for _, node := range nodes {
+		switch n := node.(type) {
+		case Pattern:
+			v := n.Value
+			if n.Annotation.Labels.isSet(Quoted) {
+				v = strconv.Quote(v)
+			}
+			if n.Negated {
+				v = fmt.Sprintf("(not %s)", v)
+			}
+			result = append(result, v)
+		case Operator:
+			var nested []string
+			for _, operand := range n.Operands {
+				nested = append(nested, stringHumanPattern([]Node{operand}))
+			}
+			var separator string
+			switch n.Kind {
+			case Or:
+				separator = " or "
+			case And:
+				separator = " and "
+			}
+			result = append(result, "("+strings.Join(nested, separator)+")")
+		}
+	}
+	return strings.Join(result, "")
+}
+
+func stringHumanParameters(nodes []Node) string {
+	var result []string
+	for _, node := range nodes {
+		switch n := node.(type) {
+		case Parameter:
+			v := n.Value
+			if n.Annotation.Labels.isSet(Quoted) {
+				v = strconv.Quote(v)
+			}
+			if n.Negated {
+				return fmt.Sprintf("-%s:%s", n.Field, v)
+			}
+			result = append(result, fmt.Sprintf("%s:%s", n.Field, v))
+		}
+	}
+	return strings.Join(result, " ")
+}
+
+// StringHuman creates a valid query string from a parsed query. It is used in
+// contexts like query suggestions where we take the original query string of a
+// user, parse it to a tree, modify the tree, and return a valid string
+// representation. To faithfully preserve the meaning of the original tree,
+// we need to consider whether to add operators like "and" contextually and must
+// process the tree as a whole:
+//
+// repo:foo file:bar a and b -> preserve 'and', but do not insert 'and' between 'repo:foo file:bar'.
+// repo:foo file:bar a b     -> do not insert any 'and', especially not between 'a b'.
+//
+// It strives to be syntax preserving, but may in some cases affect whitespace,
+// operator capitalization, or parenthesized groupings. In very complex queries,
+// additional 'and' operators may be inserted to segment parameters
+// from patterns to preserve the original meaning.
+func StringHuman(nodes []Node) string {
+	parameters, pattern, err := PartitionSearchPattern(nodes)
+	if err != nil {
+		// We couldn't partition at this level in the tree, so recurse on operators until we can.
+		var v []string
+		for _, node := range nodes {
+			if term, ok := node.(Operator); ok {
+				var s []string
+				for _, operand := range term.Operands {
+					s = append(s, StringHuman([]Node{operand}))
+				}
+				if term.Kind == Or {
+					v = append(v, "("+strings.Join(s, " or ")+")")
+				} else if term.Kind == And {
+					v = append(v, "("+strings.Join(s, " and ")+")")
+				}
+			}
+		}
+		return strings.Join(v, "")
+	}
+	if pattern == nil {
+		return stringHumanParameters(parameters)
+	}
+	if len(parameters) == 0 {
+		return stringHumanPattern([]Node{pattern})
+	}
+	return stringHumanParameters(parameters) + " " + stringHumanPattern([]Node{pattern})
+}

--- a/internal/search/query/printer_test.go
+++ b/internal/search/query/printer_test.go
@@ -1,0 +1,28 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/hexops/autogold"
+)
+
+func TestStringHuman(t *testing.T) {
+	test := func(input string) string {
+		q, _ := ParseLiteral(input)
+		return StringHuman(q.(*AndOrQuery).Query)
+	}
+
+	autogold.Want("00", "a b c").Equal(t, test("a b c"))
+	autogold.Want("01", "(this or that)").Equal(t, test("this or that"))
+	autogold.Want("02", "(this or (that and here) or there)").Equal(t, test("this or that and here or there"))
+	autogold.Want("03", "((not x) and y)").Equal(t, test("not x and y"))
+	autogold.Want("04", "repo:foo (a and b)").Equal(t, test("repo:foo a and b"))
+	autogold.Want("05", `repo:"quoted\""`).Equal(t, test(`repo:"quoted\""`))
+	autogold.Want("06", `repo:"quoted"`).Equal(t, test(`repo:'quoted'`))
+	autogold.Want("07", `"ab\"cd"`).Equal(t, test(`"ab\"cd"`))
+	autogold.Want("08", "repo:foo file:bar (baz and qux)").Equal(t, test(`repo:foo file:bar baz and qux`))
+	autogold.Want("09", "patterntype:regexp /abcd\\//").Equal(t, test(`/abcd\// patterntype:regexp`))
+	autogold.Want("10", "repo:foo file:bar").Equal(t, test("repo:foo file:bar"))
+	autogold.Want("11", "((repo:foo or repo:bar) or ((repo:baz or repo:qux) and (a or b)))").Equal(t, test("(repo:foo or repo:bar) or (repo:baz or repo:qux) (a or b)"))
+	autogold.Want("12", "((repo:foo or repo:bar file:a) or ((repo:baz or repo:qux file:b) and a and b))").Equal(t, test("(repo:foo or repo:bar file:a) or (repo:baz or repo:qux and file:b) a and b"))
+}


### PR DESCRIPTION
Up the stack: #17998

A blocking thing from removing old parser code is that we don't have a human-representable toString function for new queries. E.g., we manipulate the old tree and then [return a string representation of it](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/query/alert.go#L28) in suggestions. I need to replace this to get rid of things.

This PR adds a function to generate a human-representable string. It's more difficult to add a human-representation of the parse tree for expressions, especially if it should be faithful to the original syntax. This is actually a low-value addition and I'm not going overboard here because the cases where we need this (in suggestions) is rare, and we will preserve syntax for common, simple (flat) queries. I would much rather focus on preserving syntax faithfully in frontend suggestions. Copying doc comment:

```
// StringHuman creates a valid query string from a parsed query. It is used in
// contexts like query suggestions where we take the original query string of a
// user, parse it to a tree, modify the tree, and return a valid string
// representation. To faithfully preserve the meaning of the original tree,
// we need to consider whether to add operators like "and" contextually and must
// process the tree as a whole:
//
// repo:foo file:bar a and b -> preserve 'and', but do not insert 'and' between 'repo:foo file:bar'.
// repo:foo file:bar a b     -> do not insert any 'and', especially not between 'a b'.
//
// It strives to be syntax preserving, but may in some cases affect whitespace,
// operator capitalization, or parenthesized groupings. In very complex queries,
// additional 'and' operators may be inserted to segment parameters
// from patterns to preserve the original meaning.
```

Because of ^ it doesn't make sense to define `HumanString` on each of the tree's terms (`Operator`, `Parameter`, `Pattern`) because printing a human representation of `Operator` nodes depends contextually on whether we can partition a query to `(parameters, pattern expression)` which is the ground truth meaning (i.e., how we evaluate queries in general).