### PR TITLE
search: prevent sharing of statusmap map

### DIFF
--- a/internal/search/repo_status.go
+++ b/internal/search/repo_status.go
@@ -99,9 +99,8 @@ func (m *RepoStatusMap) Update(id api.RepoID, status RepoStatus) {
 // Union is a fast path for calling m.Update on all entries in o.
 func (m *RepoStatusMap) Union(o *RepoStatusMap) {
 	m.status |= o.status
-	if m.m == nil {
-		m.m = o.m
-		return
+	if m.m == nil && len(o.m) > 0 {
+		m.m = make(map[api.RepoID]RepoStatus, len(o.m))
 	}
 	for id, status := range o.m {
 		m.m[id] |= status

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -46,6 +46,10 @@ func (c *Stats) Update(other *Stats) {
 	c.IsIndexUnavailable = c.IsIndexUnavailable || other.IsIndexUnavailable
 
 	if c.Repos == nil {
+		// PERF: use other's map assuming it will never be concurrently
+		// written/read to in the future. This is the sort of assumption that
+		// will break, but we are doing it for now since this map is very
+		// large.
 		c.Repos = other.Repos
 	} else {
 		for id, r := range other.Repos {


### PR DESCRIPTION
This was a performance optimization which leads to concurrent
reads/writes. Technically there is also streaming.Stats.Repos map.
However, that is currently only written to once and can be large. So
will prefer to avoid future proofing that just yet.