### PR TITLE
search: streaming symbol backend

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1543,17 +1543,7 @@ func (a *aggregator) doSymbolSearch(ctx context.Context, args *search.TextParame
 		tr.Finish()
 	}()
 
-	symbolFileMatches, stats, err := searchSymbols(ctx, args, limit)
-
-	results := make([]SearchResultResolver, len(symbolFileMatches))
-	for i := range symbolFileMatches {
-		results[i] = symbolFileMatches[i]
-	}
-
-	a.Send(SearchEvent{
-		Results: results,
-		Stats:   statsDeref(stats),
-	})
+	err = searchSymbols(ctx, args, limit, a)
 	return errors.Wrap(err, "symbol search failed")
 }
 


### PR DESCRIPTION
We convert searchSymbols into a streaming function. Additionally we
cleanup the logic in the function and end up with something minimal.