### PR TITLE
repo-updater: Remove syncErrors on syncer

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -708,7 +708,7 @@ func testServerStatusMessages(t *testing.T, store *repos.Store) func(t *testing.
 					Messages: []protocol.StatusMessage{
 						{
 							ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-								Message:           "github is down",
+								Message:           "1 error occurred:\n\t* github is down\n\n",
 								ExternalServiceId: githubService.ID,
 							},
 						},
@@ -721,8 +721,9 @@ func testServerStatusMessages(t *testing.T, store *repos.Store) func(t *testing.
 				res: &protocol.StatusMessagesResponse{
 					Messages: []protocol.StatusMessage{
 						{
-							SyncError: &protocol.SyncError{
-								Message: "syncer.sync.store.list-repos: could not connect to database",
+							ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
+								Message:           "syncer.sync.store.list-repos: could not connect to database",
+								ExternalServiceId: githubService.ID,
 							},
 						},
 					},
@@ -787,7 +788,21 @@ func testServerStatusMessages(t *testing.T, store *repos.Store) func(t *testing.
 					sourcer := repos.NewFakeSourcer(tc.sourcerErr, repos.NewFakeSource(githubService, nil))
 					// Run Sync so that possibly `LastSyncErrors` is set
 					syncer.Sourcer = sourcer
-					_ = syncer.SyncExternalService(ctx, store, githubService.ID, time.Millisecond)
+
+					err = syncer.SyncExternalService(ctx, store, githubService.ID, time.Millisecond)
+
+					// In prod, SyncExternalService is kicked off by a worker queue. Any error
+					// returned will be stored in the external_service_sync_jobs table so we fake
+					// that here.
+					if err != nil {
+						defer func() { database.Mocks.ExternalServices = database.MockExternalServices{} }()
+						database.Mocks.ExternalServices.ListSyncErrors = func(ctx context.Context) (map[int64]string, error) {
+							return map[int64]string{
+								githubService.ID: err.Error(),
+							}, nil
+						}
+					}
+
 				}
 
 				s := &Server{

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -708,7 +708,7 @@ func testServerStatusMessages(t *testing.T, store *repos.Store) func(t *testing.
 					Messages: []protocol.StatusMessage{
 						{
 							ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-								Message:           "1 error occurred:\n\t* github is down\n\n",
+								Message:           "fetching from code host: 1 error occurred:\n\t* github is down\n\n",
 								ExternalServiceId: githubService.ID,
 							},
 						},

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -814,6 +814,9 @@ LIMIT 1
 // service. If the latest run did not have an error, it will be excluded from the
 // map.
 func (e *ExternalServiceStore) ListSyncErrors(ctx context.Context) (map[int64]string, error) {
+	if Mocks.ExternalServices.ListSyncErrors != nil {
+		return Mocks.ExternalServices.ListSyncErrors(ctx)
+	}
 	q := `SELECT DISTINCT ON(external_service_id) external_service_id, failure_message 
 FROM external_service_sync_jobs
 WHERE state IN ('completed','errored','failed')
@@ -976,6 +979,7 @@ type MockExternalServices struct {
 	Delete           func(ctx context.Context, id int64) error
 	GetByID          func(id int64) (*types.ExternalService, error)
 	GetLastSyncError func(id int64) (string, error)
+	ListSyncErrors   func(ctx context.Context) (map[int64]string, error)
 	List             func(opt ExternalServicesListOptions) ([]*types.ExternalService, error)
 	Update           func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
 	Count            func(ctx context.Context, opt ExternalServicesListOptions) (int, error)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -801,13 +801,47 @@ func (e *ExternalServiceStore) GetLastSyncError(ctx context.Context, id int64) (
 	q := sqlf.Sprintf(`
 SELECT failure_message from external_service_sync_jobs
 WHERE external_service_id = %d
-AND state IN ('completed','errored')
+AND state IN ('completed','errored','failed')
 ORDER BY finished_at DESC
 LIMIT 1
 `, id)
 
 	lastError, _, err := basestore.ScanFirstNullString(e.Query(ctx, q))
 	return lastError, err
+}
+
+// ListSyncErrors returns the most recent failure message for each external
+// service. If the latest run did not have an error, it will be excluded from the
+// map.
+func (e *ExternalServiceStore) ListSyncErrors(ctx context.Context) (map[int64]string, error) {
+	q := `SELECT DISTINCT ON(external_service_id) external_service_id, failure_message 
+FROM external_service_sync_jobs
+WHERE state IN ('completed','errored','failed')
+AND finished_at IS NOT NULL
+ORDER BY external_service_id, finished_at DESC`
+
+	rows, err := e.Query(ctx, sqlf.Sprintf(q))
+	if err != nil {
+		return nil, err
+	}
+
+	messages := make(map[int64]string)
+
+	for rows.Next() {
+		var svcID int64
+		var message sql.NullString
+		if err := rows.Scan(&svcID, &message); err != nil {
+			return nil, err
+		}
+		if message.Valid {
+			messages[svcID] = message.String
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return messages, nil
 }
 
 // List returns external services under given namespace.

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -654,6 +654,108 @@ func TestExternalServicesStore_GetByID(t *testing.T) {
 	}
 }
 
+func TestListSyncErrors(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	db := dbtesting.GetDB(t)
+	ctx := context.Background()
+
+	// Create a new external service
+	confGet := func() *conf.Unified {
+		return &conf.Unified{}
+	}
+
+	svc1 := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GITHUB #1",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err := ExternalServices(db).Create(ctx, confGet, svc1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc2 := &types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GITHUB #2",
+		Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+	}
+	err = ExternalServices(db).Create(ctx, confGet, svc2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Listing errors now should return an empty map
+	failures, err := ExternalServices(db).ListSyncErrors(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) > 0 {
+		t.Fatal("Expected zero errors")
+	}
+
+	// Add failure
+	expectedFailure := "oops"
+	_, err = db.Exec(`
+INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
+VALUES ($1,'errored', now(), $2)
+`, svc1.ID, expectedFailure)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	failures, err = ExternalServices(db).ListSyncErrors(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) != 1 {
+		t.Fatal("Expected 1 failure")
+	}
+	failure := failures[svc1.ID]
+	if failure != expectedFailure {
+		t.Fatalf("Want %q, got %q", expectedFailure, failure)
+	}
+
+	// Add a later failure, we should get that instead
+	expectedFailure2 := "oops again"
+	_, err = db.Exec(`
+INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
+VALUES ($1,'errored', now(), $2)
+`, svc1.ID, expectedFailure2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failures, err = ExternalServices(db).ListSyncErrors(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) != 1 {
+		t.Fatal("Expected 1 failure")
+	}
+	failure = failures[svc1.ID]
+	if failure != expectedFailure2 {
+		t.Fatalf("Want %q, got %q", expectedFailure2, failure)
+	}
+
+	// Adding a second failing service
+	_, err = db.Exec(`
+INSERT INTO external_service_sync_jobs (external_service_id, state, finished_at, failure_message)
+VALUES ($1,'errored', now(), $2)
+`, svc2.ID, expectedFailure)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	failures, err = ExternalServices(db).ListSyncErrors(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failures) != 2 {
+		t.Fatal("Expected 2 failure")
+	}
+}
+
 func TestGetLastSyncError(t *testing.T) {
 	if testing.Short() {
 		t.Skip()

--- a/internal/repos/integration_test.go
+++ b/internal/repos/integration_test.go
@@ -61,7 +61,6 @@ func TestIntegration(t *testing.T) {
 		{"DBStore/SetClonedRepos", testStoreSetClonedRepos},
 		{"DBStore/CountNotClonedRepos", testStoreCountNotClonedRepos},
 		{"DBStore/Syncer/Sync", testSyncerSync},
-		{"DBStore/Syncer/SyncWithErrors", testSyncerSyncWithErrors},
 		{"DBStore/Syncer/SyncRepo", testSyncRepo},
 		{"DBStore/Syncer/SyncWorker", testSyncWorkerPlumbing(db)},
 		{"DBStore/Syncer/Run", testSyncRun(db)},

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -8,14 +8,15 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// A Sourcer converts the given ExternalServices to Sources
-// whose yielded Repos should be synced.
+// A Sourcer converts the given ExternalServices to Sources whose yielded Repos
+// should be synced.
 type Sourcer func(...*types.ExternalService) (Sources, error)
 
 // NewSourcer returns a Sourcer that converts the given ExternalServices

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -55,12 +55,6 @@ type Syncer struct {
 	// If zero, we'll read from config instead.
 	UserReposMaxPerSite int
 
-	// syncErrors contains the last error returned by the Sourcer during each
-	// sync per external service. It's reset with each service sync and if the sync produced no error, it's
-	// set to nil.
-	syncErrors   map[int64]error
-	syncErrorsMu sync.Mutex
-
 	enqueueSignal signal
 }
 
@@ -182,7 +176,6 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 
 	ctx, save := s.observe(ctx, "Syncer.SyncExternalService", "")
 	defer save(&diff, &err)
-	defer s.setOrResetLastSyncErr(externalServiceID, &err)
 
 	ids := []int64{externalServiceID}
 	// We don't use tx here as the sourcing process below can be slow and we don't
@@ -240,7 +233,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 
 	// Fetch repos from the source
 	var sourced types.Repos
-	if sourced, err = s.sourced(ctx, svcs, onSourced); err != nil {
+	if sourced, err = s.sourced(ctx, svc, onSourced); err != nil {
 		unauthorized = errcode.IsUnauthorized(err)
 		accountSuspended = errcode.IsAccountSuspended(err)
 
@@ -248,7 +241,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 		// should behave as if zero repos were found. This is so that revoked tokens
 		// cause repos to be removed correctly.
 		if !unauthorized && !accountSuspended {
-			return errors.Wrap(err, "syncer.sync.sourced")
+			return err
 		}
 		log15.Warn("Non fatal error during sync", "externalService", svc.ID, "unauthorized", unauthorized, "accountSuspended", accountSuspended)
 	}
@@ -817,8 +810,8 @@ func merge(o, n *types.Repo) {
 	o.Update(n)
 }
 
-func (s *Syncer) sourced(ctx context.Context, svcs []*types.ExternalService, onSourced ...func(*types.Repo) error) ([]*types.Repo, error) {
-	srcs, err := s.Sourcer(svcs...)
+func (s *Syncer) sourced(ctx context.Context, svc *types.ExternalService, onSourced ...func(*types.Repo) error) ([]*types.Repo, error) {
+	srcs, err := s.Sourcer(svc)
 	if err != nil {
 		return nil, err
 	}
@@ -852,47 +845,6 @@ func (s *Syncer) makeNewRepoInserter(ctx context.Context, store *Store, publicOn
 		}
 		return nil
 	}, nil
-}
-
-func (s *Syncer) setOrResetLastSyncErr(serviceID int64, perr *error) {
-	var err error
-	if perr != nil {
-		err = *perr
-	}
-
-	s.syncErrorsMu.Lock()
-	defer s.syncErrorsMu.Unlock()
-	if s.syncErrors == nil {
-		s.syncErrors = make(map[int64]error)
-	}
-
-	if err == nil {
-		delete(s.syncErrors, serviceID)
-		return
-	}
-	s.syncErrors[serviceID] = err
-}
-
-// SyncErrors returns all errors that were produced in the last Sync run per
-// external service. If no error was produced, this returns an empty slice.
-// Errors are sorted by external service id.
-func (s *Syncer) SyncErrors() []error {
-	s.syncErrorsMu.Lock()
-	defer s.syncErrorsMu.Unlock()
-
-	ids := make([]int, 0, len(s.syncErrors))
-
-	for id := range s.syncErrors {
-		ids = append(ids, int(id))
-	}
-	sort.Ints(ids)
-
-	sorted := make([]error, len(ids))
-	for i, id := range ids {
-		sorted[i] = s.syncErrors[int64(id)]
-	}
-
-	return sorted
 }
 
 func (s *Syncer) observe(ctx context.Context, family, title string) (context.Context, func(*Diff, *error)) {

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -241,7 +241,7 @@ func (s *Syncer) SyncExternalService(ctx context.Context, tx *Store, externalSer
 		// should behave as if zero repos were found. This is so that revoked tokens
 		// cause repos to be removed correctly.
 		if !unauthorized && !accountSuspended {
-			return err
+			return errors.Wrap(err, "fetching from code host")
 		}
 		log15.Warn("Non fatal error during sync", "externalService", svc.ID, "unauthorized", unauthorized, "accountSuspended", accountSuspended)
 	}


### PR DESCRIPTION
Instead of storing recent sync errors in memory we now rely on
workerutil to store them in `external_service_sync_jobs` in the
`failure_message` column.

When fetching errors to populate our StatusMessages we now fetch from
the database instead.

Part of https://github.com/sourcegraph/sourcegraph/issues/17688