### PR TITLE
search: factor out most functionality in searchFilesInRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -527,10 +527,8 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 
 				// Filter Zoekt repos that didn't contain matches
 				for _, repo := range indexed.Repos() {
-					for key := range partition {
-						if string(repo.Repo.Name) == key {
-							repos = append(repos, repo)
-						}
+					if _, ok := partition[string(repo.Repo.Name)]; ok {
+						repos = append(repos, repo)
 					}
 				}
 


### PR DESCRIPTION
This function has long since been confusing to use due to the size of it, and quite a few special cases around structural and searcher. This PR pulls out most of the logic into separate functions. This leads to a much easier to navigation function which is mainly responsible for calling out to zoekt/searcher/etc.

One of the main things done here is a switch to using errgroup more. Please review commit by commit.