### PR TITLE
codeintel: Break out WAU counts in pings

### DIFF
--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -411,9 +411,14 @@ func reserializeNewCodeIntelUsage(payload json.RawMessage) (json.RawMessage, err
 	}
 
 	return json.Marshal(jsonCodeIntelUsage{
-		StartOfWeek:    codeIntelUsage.StartOfWeek,
-		WAUs:           &codeIntelUsage.WAUs,
-		EventSummaries: eventSummaries,
+		StartOfWeek:                    codeIntelUsage.StartOfWeek,
+		WAUs:                           codeIntelUsage.WAUs,
+		PreciseWAUs:                    codeIntelUsage.PreciseWAUs,
+		SearchBasedWAUs:                codeIntelUsage.SearchBasedWAUs,
+		CrossRepositoryWAUs:            codeIntelUsage.CrossRepositoryWAUs,
+		PreciseCrossRepositoryWAUs:     codeIntelUsage.PreciseCrossRepositoryWAUs,
+		SearchBasedCrossRepositoryWAUs: codeIntelUsage.SearchBasedCrossRepositoryWAUs,
+		EventSummaries:                 eventSummaries,
 	})
 }
 
@@ -439,8 +444,13 @@ func reserializeOldCodeIntelUsage(payload json.RawMessage) (json.RawMessage, err
 	references := week.References
 
 	return json.Marshal(jsonCodeIntelUsage{
-		StartOfWeek: week.StartTime,
-		WAUs:        nil,
+		StartOfWeek:                    week.StartTime,
+		WAUs:                           nil,
+		PreciseWAUs:                    nil,
+		SearchBasedWAUs:                nil,
+		CrossRepositoryWAUs:            nil,
+		PreciseCrossRepositoryWAUs:     nil,
+		SearchBasedCrossRepositoryWAUs: nil,
 		EventSummaries: []jsonEventSummary{
 			{Action: "hover", Source: "precise", WAUs: hover.LSIF.UsersCount, TotalActions: unwrap(hover.LSIF.EventsCount)},
 			{Action: "hover", Source: "search", WAUs: hover.Search.UsersCount, TotalActions: unwrap(hover.Search.EventsCount)},
@@ -453,9 +463,14 @@ func reserializeOldCodeIntelUsage(payload json.RawMessage) (json.RawMessage, err
 }
 
 type jsonCodeIntelUsage struct {
-	StartOfWeek    time.Time          `json:"start_time"`
-	WAUs           *int32             `json:"waus"`
-	EventSummaries []jsonEventSummary `json:"event_summaries"`
+	StartOfWeek                    time.Time          `json:"start_time"`
+	WAUs                           *int32             `json:"waus"`
+	PreciseWAUs                    *int32             `json:"precise_waus"`
+	SearchBasedWAUs                *int32             `json:"search_waus"`
+	CrossRepositoryWAUs            *int32             `json:"xrepo_waus"`
+	PreciseCrossRepositoryWAUs     *int32             `json:"precise_xrepo_waus"`
+	SearchBasedCrossRepositoryWAUs *int32             `json:"search_xrepo_waus"`
+	EventSummaries                 []jsonEventSummary `json:"event_summaries"`
 }
 
 type jsonEventSummary struct {

--- a/cmd/frontend/internal/app/updatecheck/handler_test.go
+++ b/cmd/frontend/internal/app/updatecheck/handler_test.go
@@ -324,10 +324,15 @@ func TestSerializeAutomationUsage(t *testing.T) {
 
 func TestSerializeCodeIntelUsage(t *testing.T) {
 	now := time.Unix(1587396557, 0).UTC()
+	waus1 := int32(25)
+	waus2 := int32(10)
+	waus3 := int32(40)
 
 	testUsage, err := json.Marshal(types.NewCodeIntelUsageStatistics{
-		StartOfWeek: now,
-		WAUs:        25,
+		StartOfWeek:                now,
+		WAUs:                       &waus1,
+		SearchBasedWAUs:            &waus2,
+		PreciseCrossRepositoryWAUs: &waus3,
 		EventSummaries: []types.CodeIntelEventSummary{
 			{
 				Action:          types.HoverAction,
@@ -427,6 +432,11 @@ func TestSerializeCodeIntelUsage(t *testing.T) {
 		"new_code_intel_usage": {
 			"start_time": "2020-04-20T15:29:17Z",
 			"waus": 25,
+			"precise_waus": null,
+			"search_waus": 10,
+			"xrepo_waus": null,
+			"precise_xrepo_waus": 40,
+			"search_xrepo_waus": null,
 			"event_summaries": [
 				{
 					"action": "hover",
@@ -571,6 +581,11 @@ func TestSerializeOldCodeIntelUsage(t *testing.T) {
 		"new_code_intel_usage": {
 			"start_time": "2020-04-20T15:29:17Z",
 			"waus": null,
+			"precise_waus": null,
+			"search_waus": null,
+			"xrepo_waus": null,
+			"precise_xrepo_waus": null,
+			"search_xrepo_waus": null,
 			"event_summaries": [
 				{
 					"action": "hover",

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -651,19 +651,83 @@ FROM (
 GROUP BY current_month, current_week, current_day
 `
 
-// CodeIntelligenceCombinedWAU returns the WAU (current week) with any code intelligence event.
-func (l *EventLogStore) CodeIntelligenceCombinedWAU(ctx context.Context) (int, error) {
-	return l.codeIntelligenceCombinedWAU(ctx, time.Now().UTC())
+// CodeIntelligencePreciseWAUs returns the WAU (current week) with precise-based code intelligence events.
+func (l *EventLogStore) CodeIntelligencePreciseWAUs(ctx context.Context) (int, error) {
+	eventNames := []string{
+		"codeintel.lsifHover",
+		"codeintel.lsifDefinitions",
+		"codeintel.lsifReferences",
+	}
+
+	return l.codeIntelligenceWeeklyUsersCount(ctx, eventNames, time.Now().UTC())
 }
 
-func (l *EventLogStore) codeIntelligenceCombinedWAU(ctx context.Context, now time.Time) (wau int, _ error) {
+// CodeIntelligenceSearchBasedWAUs returns the WAU (current week) with searched-base code intelligence events.
+func (l *EventLogStore) CodeIntelligenceSearchBasedWAUs(ctx context.Context) (int, error) {
+	eventNames := []string{
+		"codeintel.searchHover",
+		"codeintel.searchDefinitions",
+		"codeintel.searchReferences",
+	}
+
+	return l.codeIntelligenceWeeklyUsersCount(ctx, eventNames, time.Now().UTC())
+}
+
+// CodeIntelligenceWAUs returns the WAU (current week) with any (precise or search-based) code intelligence event.
+func (l *EventLogStore) CodeIntelligenceWAUs(ctx context.Context) (int, error) {
+	eventNames := []string{
+		"codeintel.lsifHover",
+		"codeintel.lsifDefinitions",
+		"codeintel.lsifReferences",
+		"codeintel.searchHover",
+		"codeintel.searchDefinitions",
+		"codeintel.searchReferences",
+	}
+
+	return l.codeIntelligenceWeeklyUsersCount(ctx, eventNames, time.Now().UTC())
+}
+
+// CodeIntelligenceCrossRepositoryWAUs returns the WAU (current week) with any (precise or search-based) cross-repository code intelligence event.
+func (l *EventLogStore) CodeIntelligenceCrossRepositoryWAUs(ctx context.Context) (int, error) {
+	eventNames := []string{
+		"codeintel.lsifDefinitions.xrepo",
+		"codeintel.lsifReferences.xrepo",
+		"codeintel.searchDefinitions.xrepo",
+		"codeintel.searchReferences.xrepo",
+	}
+
+	return l.codeIntelligenceWeeklyUsersCount(ctx, eventNames, time.Now().UTC())
+}
+
+// CodeIntelligencePreciseCrossRepositoryWAUs returns the WAU (current week) with precise-based cross-repository code intelligence events.
+func (l *EventLogStore) CodeIntelligencePreciseCrossRepositoryWAUs(ctx context.Context) (int, error) {
+	eventNames := []string{
+		"codeintel.lsifDefinitions.xrepo",
+		"codeintel.lsifReferences.xrepo",
+	}
+
+	return l.codeIntelligenceWeeklyUsersCount(ctx, eventNames, time.Now().UTC())
+}
+
+// CodeIntelligenceSearchBasedCrossRepositoryWAUs returns the WAU (current week) with searched-base cross-repository code intelligence events.
+func (l *EventLogStore) CodeIntelligenceSearchBasedCrossRepositoryWAUs(ctx context.Context) (int, error) {
+	eventNames := []string{
+		"codeintel.searchDefinitions.xrepo",
+		"codeintel.searchReferences.xrepo",
+	}
+
+	return l.codeIntelligenceWeeklyUsersCount(ctx, eventNames, time.Now().UTC())
+}
+
+func (l *EventLogStore) codeIntelligenceWeeklyUsersCount(ctx context.Context, eventNames []string, now time.Time) (wau int, _ error) {
 	l.ensureStore()
 
-	query := sqlf.Sprintf(codeIntelWeeklyUsersQuery, now)
+	var names []*sqlf.Query
+	for _, name := range eventNames {
+		names = append(names, sqlf.Sprintf("%s", name))
+	}
 
-	if err := l.QueryRow(ctx, query).Scan(
-		&wau,
-	); err != nil {
+	if err := l.QueryRow(ctx, sqlf.Sprintf(codeIntelWeeklyUsersQuery, now, sqlf.Join(names, ", "))).Scan(&wau); err != nil {
 		return 0, err
 	}
 
@@ -671,12 +735,12 @@ func (l *EventLogStore) codeIntelligenceCombinedWAU(ctx context.Context, now tim
 }
 
 var codeIntelWeeklyUsersQuery = `
--- source: internal/database/event_logs.go:CodeIntelligenceCombinedWAU
+-- source: internal/database/event_logs.go:codeIntelligenceWAU
 SELECT COUNT(DISTINCT ` + userIDQueryFragment + `)
 FROM event_logs
 WHERE
   timestamp >= ` + makeDateTruncExpression("week", "%s::timestamp") + `
-  AND name IN (` + strings.Join(codeIntelEventNames, ", ") + `);
+  AND name IN (%s);
 `
 
 // AggregatedCodeIntelEvents calculates AggregatedEvent for each every unique event type related to code intel.
@@ -687,7 +751,25 @@ func (l *EventLogStore) AggregatedCodeIntelEvents(ctx context.Context) ([]types.
 func (l *EventLogStore) aggregatedCodeIntelEvents(ctx context.Context, now time.Time) (events []types.CodeIntelAggregatedEvent, err error) {
 	l.ensureStore()
 
-	query := sqlf.Sprintf(aggregatedCodeIntelEventsQuery, now, now)
+	var eventNames = []string{
+		"codeintel.lsifHover",
+		"codeintel.lsifDefinitions",
+		"codeintel.lsifDefinitions.xrepo",
+		"codeintel.lsifReferences",
+		"codeintel.lsifReferences.xrepo",
+		"codeintel.searchHover",
+		"codeintel.searchDefinitions",
+		"codeintel.searchDefinitions.xrepo",
+		"codeintel.searchReferences",
+		"codeintel.searchReferences.xrepo",
+	}
+
+	var eventNameQueries []*sqlf.Query
+	for _, name := range eventNames {
+		eventNameQueries = append(eventNameQueries, sqlf.Sprintf("%s", name))
+	}
+
+	query := sqlf.Sprintf(aggregatedCodeIntelEventsQuery, now, now, sqlf.Join(eventNameQueries, ", "))
 
 	rows, err := l.Query(ctx, query)
 	if err != nil {
@@ -718,19 +800,6 @@ func (l *EventLogStore) aggregatedCodeIntelEvents(ctx context.Context, now time.
 	return events, nil
 }
 
-var codeIntelEventNames = []string{
-	"'codeintel.lsifHover'",
-	"'codeintel.searchHover'",
-	"'codeintel.lsifDefinitions'",
-	"'codeintel.lsifDefinitions.xrepo'",
-	"'codeintel.searchDefinitions'",
-	"'codeintel.searchDefinitions.xrepo'",
-	"'codeintel.lsifReferences'",
-	"'codeintel.lsifReferences.xrepo'",
-	"'codeintel.searchReferences'",
-	"'codeintel.searchReferences.xrepo'",
-}
-
 var aggregatedCodeIntelEventsQuery = `
 -- source: internal/database/event_logs.go:aggregatedCodeIntelEvents
 WITH events AS (
@@ -742,7 +811,7 @@ WITH events AS (
   FROM event_logs
   WHERE
     timestamp >= ` + makeDateTruncExpression("week", "%s::timestamp") + `
-    AND name IN (` + strings.Join(codeIntelEventNames, ", ") + `)
+    AND name IN (%s)
 )
 SELECT
   name,

--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -735,7 +735,7 @@ func (l *EventLogStore) codeIntelligenceWeeklyUsersCount(ctx context.Context, ev
 }
 
 var codeIntelWeeklyUsersQuery = `
--- source: internal/database/event_logs.go:codeIntelligenceWAU
+-- source: internal/database/event_logs.go:codeIntelligenceWeeklyUsersCount
 SELECT COUNT(DISTINCT ` + userIDQueryFragment + `)
 FROM event_logs
 WHERE

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -277,14 +277,14 @@ func TestEventLogs_SiteUsage(t *testing.T) {
 	}
 }
 
-func TestEventLogs_CodeIntelligenceCombinedWAU(t *testing.T) {
+func TestEventLogs_codeIntelligenceWeeklyUsersCount(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
 	db := dbtesting.GetDB(t)
 	ctx := context.Background()
 
-	names := []string{"codeintel.lsifHover", "codeintel.searchReferences.xrepo", "unknown event"}
+	names := []string{"codeintel.lsifHover", "codeintel.searchReferences", "unknown event"}
 	users1 := []uint32{10, 20, 30, 40, 50, 60, 70, 80}
 	users2 := []uint32{15, 25, 35, 45, 55, 65, 75, 85}
 
@@ -323,7 +323,12 @@ func TestEventLogs_CodeIntelligenceCombinedWAU(t *testing.T) {
 		}
 	}
 
-	count, err := EventLogs(db).codeIntelligenceCombinedWAU(ctx, now)
+	eventNames := []string{
+		"codeintel.lsifHover",
+		"codeintel.searchReferences",
+	}
+
+	count, err := EventLogs(db).codeIntelligenceWeeklyUsersCount(ctx, eventNames, now)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/types/codeintel.go
+++ b/internal/types/codeintel.go
@@ -18,9 +18,14 @@ type CodeIntelAggregatedEvent struct {
 // This is sent from private instances to the cloud frontends, where it is further
 // massaged and inserted into a BigQuery.
 type NewCodeIntelUsageStatistics struct {
-	StartOfWeek    time.Time
-	WAUs           int32
-	EventSummaries []CodeIntelEventSummary
+	StartOfWeek                    time.Time
+	WAUs                           *int32
+	PreciseWAUs                    *int32
+	SearchBasedWAUs                *int32
+	CrossRepositoryWAUs            *int32
+	PreciseCrossRepositoryWAUs     *int32
+	SearchBasedCrossRepositoryWAUs *int32
+	EventSummaries                 []CodeIntelEventSummary
 }
 
 type CodeIntelEventSummary struct {


### PR DESCRIPTION
We send back the number of weekly active users that have had _any_ code intel event (precise or search-based). This sends additional counts for weekly active users getting precise events, search-based events, precise xrepo events, and search-based xrepo events.

Fixes https://github.com/sourcegraph/sourcegraph/issues/17923. Sister commit that updates the BigQuery schema in https://github.com/sourcegraph/analytics/pull/96.