### PR TITLE
Fix query input focus on search homepage

### DIFF
--- a/client/web/src/search/input/SearchOnboardingTour.ts
+++ b/client/web/src/search/input/SearchOnboardingTour.ts
@@ -447,7 +447,8 @@ export const useSearchOnboardingTour = ({
             tour.start()
         }
     }, [shouldShowTour, tour, inputLocation])
-    const shouldFocusQueryInput = useMemo(() => shouldShowTour && inputLocation !== 'search-homepage', [
+    // If we're showing the onboarding tour, do not focus the query input by default on the search homepage.
+    const shouldFocusQueryInput = useMemo(() => (shouldShowTour ? inputLocation !== 'search-homepage' : true), [
         shouldShowTour,
         inputLocation,
     ])


### PR DESCRIPTION
While cleaning up some search onboarding code, I introduced a bug that would cause the search homepage query input to never be enabled.

- [ ] add integration test.