### PR TITLE
graphql: Fetch status messages from db

### DIFF
--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -2,11 +2,13 @@ package graphqlbackend
 
 import (
 	"context"
-	"errors"
+	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 )
 
@@ -18,7 +20,7 @@ func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageRe
 		return nil, err
 	}
 
-	result, err := repoupdater.DefaultClient.StatusMessages(ctx)
+	result, err := fetchStatusMessages(ctx, r.db)
 	if err != nil {
 		return nil, err
 	}
@@ -28,6 +30,49 @@ func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageRe
 	}
 
 	return messages, nil
+}
+
+var MockStatusMessages func(context.Context) (*protocol.StatusMessagesResponse, error)
+
+// TODO: Move this somewhere better
+// TODO: No need for protocol.StatusMessageResponse
+func fetchStatusMessages(ctx context.Context, db dbutil.DB) (*protocol.StatusMessagesResponse, error) {
+	if MockStatusMessages != nil {
+		return MockStatusMessages(ctx)
+	}
+
+	resp := protocol.StatusMessagesResponse{
+		Messages: []protocol.StatusMessage{},
+	}
+
+	notCloned, err := database.Repos(db).Count(ctx, database.ReposListOptions{NoCloned: true})
+	if err != nil {
+		return nil, errors.Wrap(err, "counting uncloned repos")
+	}
+
+	if notCloned != 0 {
+		resp.Messages = append(resp.Messages, protocol.StatusMessage{
+			Cloning: &protocol.CloningProgress{
+				Message: fmt.Sprintf("%d repositories enqueued for cloning...", notCloned),
+			},
+		})
+	}
+
+	syncErrors, err := database.ExternalServices(db).ListSyncErrors(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching sync errors")
+	}
+
+	for id, failure := range syncErrors {
+		resp.Messages = append(resp.Messages, protocol.StatusMessage{
+			ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
+				Message:           failure,
+				ExternalServiceId: id,
+			},
+		})
+	}
+
+	return &resp, nil
 }
 
 type statusMessageResolver struct {

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -69,11 +69,10 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
 
-		MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
-			res := &protocol.StatusMessagesResponse{Messages: []protocol.StatusMessage{}}
-			return res, nil
+		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
+			return []repos.StatusMessage{}, nil
 		}
-		defer func() { MockStatusMessages = nil }()
+		defer func() { repos.MockStatusMessages = nil }()
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
@@ -99,28 +98,28 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { database.Mocks.ExternalServices.GetByID = nil }()
 
-		MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
-			res := &protocol.StatusMessagesResponse{Messages: []protocol.StatusMessage{
+		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
+			res := []repos.StatusMessage{
 				{
-					Cloning: &protocol.CloningProgress{
+					Cloning: &repos.CloningProgress{
 						Message: "Currently cloning 5 repositories in parallel...",
 					},
 				},
 				{
-					ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
+					ExternalServiceSyncError: &repos.ExternalServiceSyncError{
 						Message:           "Authentication failed. Please check credentials.",
 						ExternalServiceId: 1,
 					},
 				},
 				{
-					SyncError: &protocol.SyncError{
+					SyncError: &repos.SyncError{
 						Message: "Could not save to database",
 					},
 				},
-			}}
+			}
 			return res, nil
 		}
-		defer func() { MockStatusMessages = nil }()
+		defer func() { repos.MockStatusMessages = nil }()
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -70,11 +69,11 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
 
-		repoupdater.MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
+		MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
 			res := &protocol.StatusMessagesResponse{Messages: []protocol.StatusMessage{}}
 			return res, nil
 		}
-		defer func() { repoupdater.MockStatusMessages = nil }()
+		defer func() { MockStatusMessages = nil }()
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{
@@ -100,7 +99,7 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { database.Mocks.ExternalServices.GetByID = nil }()
 
-		repoupdater.MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
+		MockStatusMessages = func(_ context.Context) (*protocol.StatusMessagesResponse, error) {
 			res := &protocol.StatusMessagesResponse{Messages: []protocol.StatusMessage{
 				{
 					Cloning: &protocol.CloningProgress{
@@ -121,7 +120,7 @@ func TestStatusMessages(t *testing.T) {
 			}}
 			return res, nil
 		}
-		defer func() { repoupdater.MockStatusMessages = nil }()
+		defer func() { MockStatusMessages = nil }()
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 
@@ -65,7 +64,6 @@ func TestIntegration(t *testing.T) {
 		{"Server/SetRepoEnabled", testServerSetRepoEnabled},
 		{"Server/EnqueueRepoUpdate", testServerEnqueueRepoUpdate},
 		{"Server/RepoExternalServices", testServerRepoExternalServices},
-		{"Server/StatusMessages", testServerStatusMessages},
 		{"Server/RepoLookup", testRepoLookup(db)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -602,236 +600,6 @@ func testServerRepoExternalServices(t *testing.T, store *repos.Store) func(t *te
 	}
 }
 
-func testServerStatusMessages(t *testing.T, store *repos.Store) func(t *testing.T) {
-	return func(t *testing.T) {
-		ctx := context.Background()
-
-		githubService := &types.ExternalService{
-			ID:          1,
-			Config:      `{}`,
-			Kind:        extsvc.KindGitHub,
-			DisplayName: "github.com - test",
-		}
-
-		err := store.ExternalServiceStore.Upsert(ctx, githubService)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		testCases := []struct {
-			name            string
-			stored          types.Repos
-			gitserverCloned []string
-			sourcerErr      error
-			listRepoErr     error
-			res             *protocol.StatusMessagesResponse
-			err             string
-		}{
-			{
-				name:            "all cloned",
-				gitserverCloned: []string{"foobar"},
-				stored:          []*types.Repo{{Name: "foobar", Cloned: true}},
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{},
-				},
-			},
-			{
-				name:            "nothing cloned",
-				stored:          []*types.Repo{{Name: "foobar"}},
-				gitserverCloned: []string{},
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{
-						{
-							Cloning: &protocol.CloningProgress{
-								Message: "1 repositories enqueued for cloning...",
-							},
-						},
-					},
-				},
-			},
-			{
-				name:            "subset cloned",
-				stored:          []*types.Repo{{Name: "foobar", Cloned: true}, {Name: "barfoo"}},
-				gitserverCloned: []string{"foobar"},
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{
-						{
-							Cloning: &protocol.CloningProgress{
-								Message: "1 repositories enqueued for cloning...",
-							},
-						},
-					},
-				},
-			},
-			{
-				name:            "more cloned than stored",
-				stored:          []*types.Repo{{Name: "foobar", Cloned: true}},
-				gitserverCloned: []string{"foobar", "barfoo"},
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{},
-				},
-			},
-			{
-				name:            "cloned different than stored",
-				stored:          []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
-				gitserverCloned: []string{"one", "two", "three"},
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{
-						{
-							Cloning: &protocol.CloningProgress{
-								Message: "2 repositories enqueued for cloning...",
-							},
-						},
-					},
-				},
-			},
-			{
-				name:            "case insensitivity",
-				gitserverCloned: []string{"foobar"},
-				stored:          []*types.Repo{{Name: "FOOBar", Cloned: true}},
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{},
-				},
-			},
-			{
-				name:            "case insensitivity to gitserver names",
-				gitserverCloned: []string{"FOOBar"},
-				stored:          []*types.Repo{{Name: "FOOBar", Cloned: true}},
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{},
-				},
-			},
-			{
-				name:       "one external service syncer err",
-				sourcerErr: errors.New("github is down"),
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{
-						{
-							ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-								Message:           "fetching from code host: 1 error occurred:\n\t* github is down\n\n",
-								ExternalServiceId: githubService.ID,
-							},
-						},
-					},
-				},
-			},
-			{
-				name:        "one syncer err",
-				listRepoErr: errors.New("could not connect to database"),
-				res: &protocol.StatusMessagesResponse{
-					Messages: []protocol.StatusMessage{
-						{
-							ExternalServiceSyncError: &protocol.ExternalServiceSyncError{
-								Message:           "syncer.sync.store.list-repos: could not connect to database",
-								ExternalServiceId: githubService.ID,
-							},
-						},
-					},
-				},
-			},
-		}
-
-		for _, tc := range testCases {
-			tc := tc
-			ctx := context.Background()
-
-			t.Run(tc.name, func(t *testing.T) {
-				gitserverClient := &fakeGitserverClient{listClonedResponse: tc.gitserverCloned}
-
-				stored := tc.stored.Clone()
-				var cloned []string
-				for _, r := range stored {
-					r.ExternalRepo = api.ExternalRepoSpec{
-						ID:          uuid.New().String(),
-						ServiceType: extsvc.TypeGitHub,
-						ServiceID:   "https://github.com/",
-					}
-					if r.Cloned {
-						cloned = append(cloned, string(r.Name))
-					}
-				}
-
-				err := store.RepoStore.Create(ctx, stored...)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				t.Cleanup(func() {
-					ids := make([]api.RepoID, 0, len(stored))
-					for _, r := range stored {
-						ids = append(ids, r.ID)
-					}
-					err := store.RepoStore.Delete(ctx, ids...)
-					if err != nil {
-						t.Fatal(err)
-					}
-				})
-
-				err = store.SetClonedRepos(ctx, cloned...)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				clock := timeutil.NewFakeClock(time.Now(), 0)
-				syncer := &repos.Syncer{
-					Store: store,
-					Now:   clock.Now,
-				}
-
-				if tc.sourcerErr != nil || tc.listRepoErr != nil {
-					database.Mocks.Repos.List = func(v0 context.Context, v1 database.ReposListOptions) ([]*types.Repo, error) {
-						return nil, tc.listRepoErr
-					}
-					defer func() {
-						database.Mocks.Repos.List = nil
-					}()
-					sourcer := repos.NewFakeSourcer(tc.sourcerErr, repos.NewFakeSource(githubService, nil))
-					// Run Sync so that possibly `LastSyncErrors` is set
-					syncer.Sourcer = sourcer
-
-					err = syncer.SyncExternalService(ctx, store, githubService.ID, time.Millisecond)
-
-					// In prod, SyncExternalService is kicked off by a worker queue. Any error
-					// returned will be stored in the external_service_sync_jobs table so we fake
-					// that here.
-					if err != nil {
-						defer func() { database.Mocks.ExternalServices = database.MockExternalServices{} }()
-						database.Mocks.ExternalServices.ListSyncErrors = func(ctx context.Context) (map[int64]string, error) {
-							return map[int64]string{
-								githubService.ID: err.Error(),
-							}, nil
-						}
-					}
-
-				}
-
-				s := &Server{
-					Syncer:          syncer,
-					Store:           store,
-					GitserverClient: gitserverClient,
-				}
-
-				srv := httptest.NewServer(s.Handler())
-				defer srv.Close()
-				cli := repoupdater.Client{URL: srv.URL}
-
-				if tc.err == "" {
-					tc.err = "<nil>"
-				}
-
-				res, err := cli.StatusMessages(ctx)
-				if have, want := fmt.Sprint(err), tc.err; have != want {
-					t.Errorf("have err: %q, want: %q", have, want)
-				}
-
-				if have, want := res, tc.res; !reflect.DeepEqual(have, want) {
-					t.Errorf("response: %s", cmp.Diff(have, want))
-				}
-			})
-		}
-	}
-}
-
 func apiExternalServices(es ...*types.ExternalService) []api.ExternalService {
 	if len(es) == 0 {
 		return nil
@@ -1325,14 +1093,6 @@ type fakeScheduler struct{}
 func (s *fakeScheduler) UpdateOnce(_ api.RepoID, _ api.RepoName) {}
 func (s *fakeScheduler) ScheduleInfo(id api.RepoID) *protocol.RepoUpdateSchedulerInfoResult {
 	return &protocol.RepoUpdateSchedulerInfoResult{}
-}
-
-type fakeGitserverClient struct {
-	listClonedResponse []string
-}
-
-func (g *fakeGitserverClient) ListCloned(ctx context.Context) ([]string, error) {
-	return g.listClonedResponse, nil
 }
 
 type fakePermsSyncer struct{}

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -1,0 +1,69 @@
+package repos
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+var MockStatusMessages func(context.Context) ([]StatusMessage, error)
+
+func FetchStatusMessages(ctx context.Context, db dbutil.DB) ([]StatusMessage, error) {
+	if MockStatusMessages != nil {
+		return MockStatusMessages(ctx)
+	}
+
+	var messages []StatusMessage
+
+	notCloned, err := database.Repos(db).Count(ctx, database.ReposListOptions{NoCloned: true})
+	if err != nil {
+		return nil, errors.Wrap(err, "counting uncloned repos")
+	}
+
+	if notCloned != 0 {
+		messages = append(messages, StatusMessage{
+			Cloning: &CloningProgress{
+				Message: fmt.Sprintf("%d repositories enqueued for cloning...", notCloned),
+			},
+		})
+	}
+
+	syncErrors, err := database.ExternalServices(db).ListSyncErrors(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetching sync errors")
+	}
+
+	for id, failure := range syncErrors {
+		messages = append(messages, StatusMessage{
+			ExternalServiceSyncError: &ExternalServiceSyncError{
+				Message:           failure,
+				ExternalServiceId: id,
+			},
+		})
+	}
+
+	return messages, nil
+}
+
+type CloningProgress struct {
+	Message string
+}
+
+type ExternalServiceSyncError struct {
+	Message           string
+	ExternalServiceId int64
+}
+
+type SyncError struct {
+	Message string
+}
+
+type StatusMessage struct {
+	Cloning                  *CloningProgress          `json:"cloning"`
+	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
+	SyncError                *SyncError                `json:"sync_error"`
+}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -1,0 +1,224 @@
+package repos
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestStatusMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := context.Background()
+	db := dbtest.NewDB(t, "")
+	store := NewStore(db, sql.TxOptions{})
+
+	githubService := &types.ExternalService{
+		ID:          1,
+		Config:      `{}`,
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "github.com - test",
+	}
+
+	err := database.ExternalServices(db).Upsert(ctx, githubService)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		name            string
+		stored          types.Repos
+		gitserverCloned []string
+		sourcerErr      error
+		listRepoErr     error
+		res             []StatusMessage
+		err             string
+	}{
+		{
+			name:            "all cloned",
+			gitserverCloned: []string{"foobar"},
+			stored:          []*types.Repo{{Name: "foobar", Cloned: true}},
+			res:             nil,
+		},
+		{
+			name:            "nothing cloned",
+			stored:          []*types.Repo{{Name: "foobar"}},
+			gitserverCloned: []string{},
+			res: []StatusMessage{
+				{
+					Cloning: &CloningProgress{
+						Message: "1 repositories enqueued for cloning...",
+					},
+				},
+			},
+		},
+		{
+			name:            "subset cloned",
+			stored:          []*types.Repo{{Name: "foobar", Cloned: true}, {Name: "barfoo"}},
+			gitserverCloned: []string{"foobar"},
+			res: []StatusMessage{
+				{
+					Cloning: &CloningProgress{
+						Message: "1 repositories enqueued for cloning...",
+					},
+				},
+			},
+		},
+		{
+			name:            "more cloned than stored",
+			stored:          []*types.Repo{{Name: "foobar", Cloned: true}},
+			gitserverCloned: []string{"foobar", "barfoo"},
+			res:             nil,
+		},
+		{
+			name:            "cloned different than stored",
+			stored:          []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
+			gitserverCloned: []string{"one", "two", "three"},
+			res: []StatusMessage{
+				{
+					Cloning: &CloningProgress{
+						Message: "2 repositories enqueued for cloning...",
+					},
+				},
+			},
+		},
+		{
+			name:            "case insensitivity",
+			gitserverCloned: []string{"foobar"},
+			stored:          []*types.Repo{{Name: "FOOBar", Cloned: true}},
+			res:             nil,
+		},
+		{
+			name:            "case insensitivity to gitserver names",
+			gitserverCloned: []string{"FOOBar"},
+			stored:          []*types.Repo{{Name: "FOOBar", Cloned: true}},
+			res:             nil,
+		},
+		{
+			name:       "one external service syncer err",
+			sourcerErr: errors.New("github is down"),
+			res: []StatusMessage{
+				{
+					ExternalServiceSyncError: &ExternalServiceSyncError{
+						Message:           "fetching from code host: 1 error occurred:\n\t* github is down\n\n",
+						ExternalServiceId: githubService.ID,
+					},
+				},
+			},
+		},
+		{
+			name:        "one syncer err",
+			listRepoErr: errors.New("could not connect to database"),
+			res: []StatusMessage{
+				{
+					ExternalServiceSyncError: &ExternalServiceSyncError{
+						Message:           "syncer.sync.store.list-repos: could not connect to database",
+						ExternalServiceId: githubService.ID,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		ctx := context.Background()
+
+		t.Run(tc.name, func(t *testing.T) {
+			stored := tc.stored.Clone()
+			var cloned []string
+			for _, r := range stored {
+				r.ExternalRepo = api.ExternalRepoSpec{
+					ID:          uuid.New().String(),
+					ServiceType: extsvc.TypeGitHub,
+					ServiceID:   "https://github.com/",
+				}
+				if r.Cloned {
+					cloned = append(cloned, string(r.Name))
+				}
+			}
+
+			err := database.Repos(db).Create(ctx, stored...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Cleanup(func() {
+				ids := make([]api.RepoID, 0, len(stored))
+				for _, r := range stored {
+					ids = append(ids, r.ID)
+				}
+				err := database.Repos(db).Delete(ctx, ids...)
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+
+			err = store.SetClonedRepos(ctx, cloned...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			clock := timeutil.NewFakeClock(time.Now(), 0)
+			syncer := &Syncer{
+				Store: store,
+				Now:   clock.Now,
+			}
+
+			if tc.sourcerErr != nil || tc.listRepoErr != nil {
+				database.Mocks.Repos.List = func(v0 context.Context, v1 database.ReposListOptions) ([]*types.Repo, error) {
+					return nil, tc.listRepoErr
+				}
+				defer func() {
+					database.Mocks.Repos.List = nil
+				}()
+				sourcer := NewFakeSourcer(tc.sourcerErr, NewFakeSource(githubService, nil))
+				// Run Sync so that possibly `LastSyncErrors` is set
+				syncer.Sourcer = sourcer
+
+				err = syncer.SyncExternalService(ctx, store, githubService.ID, time.Millisecond)
+
+				// In prod, SyncExternalService is kicked off by a worker queue. Any error
+				// returned will be stored in the external_service_sync_jobs table so we fake
+				// that here.
+				if err != nil {
+					defer func() { database.Mocks.ExternalServices = database.MockExternalServices{} }()
+					database.Mocks.ExternalServices.ListSyncErrors = func(ctx context.Context) (map[int64]string, error) {
+						return map[int64]string{
+							githubService.ID: err.Error(),
+						}, nil
+					}
+				}
+
+			}
+
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			res, err := FetchStatusMessages(ctx, db)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("have err: %q, want: %q", have, want)
+			}
+
+			if have, want := res, tc.res; !reflect.DeepEqual(have, want) {
+				t.Errorf("response: %s", cmp.Diff(have, want))
+			}
+		})
+	}
+}

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
@@ -306,15 +307,8 @@ func (c *Client) ExcludeRepo(ctx context.Context, id api.RepoID) (*protocol.Excl
 	return &res, nil
 }
 
-// MockStatusMessages mocks (*Client).StatusMessages for tests.
-var MockStatusMessages func(context.Context) (*protocol.StatusMessagesResponse, error)
-
 // StatusMessages returns an array of status messages
 func (c *Client) StatusMessages(ctx context.Context) (*protocol.StatusMessagesResponse, error) {
-	if MockStatusMessages != nil {
-		return MockStatusMessages(ctx)
-	}
-
 	resp, err := c.httpGet(ctx, "status-messages")
 	if err != nil {
 		return nil, err

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -307,28 +307,6 @@ func (c *Client) ExcludeRepo(ctx context.Context, id api.RepoID) (*protocol.Excl
 	return &res, nil
 }
 
-// StatusMessages returns an array of status messages
-func (c *Client) StatusMessages(ctx context.Context) (*protocol.StatusMessagesResponse, error) {
-	resp, err := c.httpGet(ctx, "status-messages")
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	bs, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read response body")
-	}
-
-	var res protocol.StatusMessagesResponse
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		return nil, errors.New(string(bs))
-	} else if err = json.Unmarshal(bs, &res); err != nil {
-		return nil, err
-	}
-	return &res, nil
-}
-
 func (c *Client) httpPost(ctx context.Context, method string, payload interface{}) (resp *http.Response, err error) {
 	reqBody, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -321,15 +321,6 @@ func (c *Client) httpPost(ctx context.Context, method string, payload interface{
 	return c.do(ctx, req)
 }
 
-func (c *Client) httpGet(ctx context.Context, method string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", c.URL+"/"+method, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.do(ctx, req)
-}
-
 func (c *Client) do(ctx context.Context, req *http.Request) (_ *http.Response, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Client.do")
 	defer func() {

--- a/internal/repoupdater/protocol/repoupdater.go
+++ b/internal/repoupdater/protocol/repoupdater.go
@@ -189,26 +189,3 @@ type ExternalServiceSyncResult struct {
 	ExternalService api.ExternalService
 	Error           string
 }
-
-type CloningProgress struct {
-	Message string
-}
-
-type ExternalServiceSyncError struct {
-	Message           string
-	ExternalServiceId int64
-}
-
-type SyncError struct {
-	Message string
-}
-
-type StatusMessage struct {
-	Cloning                  *CloningProgress          `json:"cloning"`
-	ExternalServiceSyncError *ExternalServiceSyncError `json:"external_service_sync_error"`
-	SyncError                *SyncError                `json:"sync_error"`
-}
-
-type StatusMessagesResponse struct {
-	Messages []StatusMessage `json:"messages"`
-}


### PR DESCRIPTION
We now fetch status messages directly from the database
rather than going via repo-updater.

The logic was moved to the `internal/repos` package. 

Part of: https://github.com/sourcegraph/sourcegraph/issues/17688