### PR TITLE
search: store index: in TextPatternInfo

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1329,8 +1329,8 @@ func getPatternInfo(q query.QueryInfo, opts *getPatternInfoOptions) (*search.Tex
 	return patternInfo, nil
 }
 
-// indexValue parses index:yes (default), index:only, and index:no in the search
-// query.
+// indexValue converts the query index field to one of yes (default), only, or no
+// enum values.
 func indexValue(q query.QueryInfo) query.YesNoOnly {
 	indexParam := query.Yes
 	if index := q.Values(query.FieldIndex); len(index) > 0 {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1321,11 +1321,22 @@ func getPatternInfo(q query.QueryInfo, opts *getPatternInfoOptions) (*search.Tex
 		Languages:                    languages,
 		PathPatternsAreCaseSensitive: q.IsCaseSensitive(),
 		CombyRule:                    strings.Join(combyRule, ""),
+		Index:                        indexValue(q),
 	}
 	if len(excludePatterns) > 0 {
 		patternInfo.ExcludePattern = searchrepos.UnionRegExps(excludePatterns)
 	}
 	return patternInfo, nil
+}
+
+// indexValue parses index:yes (default), index:only, and index:no in the search
+// query.
+func indexValue(q query.QueryInfo) query.YesNoOnly {
+	indexParam := query.Yes
+	if index := q.Values(query.FieldIndex); len(index) > 0 {
+		indexParam = query.ParseYesNoOnly(index[0].ToString())
+	}
+	return indexParam
 }
 
 // langIncludeExcludePatterns returns regexps for the include/exclude path patterns given the lang:

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1310,6 +1310,49 @@ func TestEvaluateAnd(t *testing.T) {
 	}
 }
 
+func TestIndexValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		want    query.YesNoOnly
+	}{
+		{
+			name:    "yes",
+			pattern: "foo index:yes",
+			want:    query.Yes,
+		},
+		{
+			name:    "no",
+			pattern: "foo index:no",
+			want:    query.No,
+		},
+		{
+			name:    "only",
+			pattern: "foo index:only",
+			want:    query.Only,
+		},
+		{
+			name:    "default",
+			pattern: "foo",
+			want:    query.Yes,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			q, err := query.ProcessAndOr(tt.pattern,
+				query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: false})
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			got := indexValue(q)
+			if got != tt.want {
+				t.Fatalf("got %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSearchContext(t *testing.T) {
 	orig := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -461,59 +461,76 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 		"p": {
 			Pattern:  "p",
 			IsRegExp: true,
+			Index:    query.Yes,
 		},
 		"p1 p2": {
 			Pattern:  "(p1).*?(p2)",
 			IsRegExp: true,
+			Index:    query.Yes,
 		},
 		"p case:yes": {
 			Pattern:                      "p",
 			IsRegExp:                     true,
 			IsCaseSensitive:              true,
 			PathPatternsAreCaseSensitive: true,
+			Index:                        query.Yes,
 		},
 		"p file:f": {
 			Pattern:         "p",
 			IsRegExp:        true,
 			IncludePatterns: []string{"f"},
+			Index:           query.Yes,
 		},
 		"p file:f1 file:f2": {
 			Pattern:         "p",
 			IsRegExp:        true,
 			IncludePatterns: []string{"f1", "f2"},
+			Index:           query.Yes,
 		},
 		"p -file:f": {
 			Pattern:        "p",
 			IsRegExp:       true,
 			ExcludePattern: "f",
+			Index:          query.Yes,
+		},
+		"p -file:f index:no": {
+			Pattern:        "p",
+			IsRegExp:       true,
+			ExcludePattern: "f",
+			Index:          query.No,
 		},
 		"p -file:f1 -file:f2": {
 			Pattern:        "p",
 			IsRegExp:       true,
 			ExcludePattern: "f1|f2",
+			Index:          query.Yes,
 		},
 		"p lang:graphql": {
 			Pattern:         "p",
 			IsRegExp:        true,
 			IncludePatterns: []string{`\.graphql$|\.gql$|\.graphqls$`},
 			Languages:       []string{"graphql"},
+			Index:           query.Yes,
 		},
 		"p lang:graphql file:f": {
 			Pattern:         "p",
 			IsRegExp:        true,
 			IncludePatterns: []string{"f", `\.graphql$|\.gql$|\.graphqls$`},
 			Languages:       []string{"graphql"},
+			Index:           query.Yes,
 		},
 		"p -lang:graphql file:f": {
 			Pattern:         "p",
 			IsRegExp:        true,
 			IncludePatterns: []string{"f"},
 			ExcludePattern:  `\.graphql$|\.gql$|\.graphqls$`,
+			Index:           query.Yes,
 		},
 		"p -lang:graphql -file:f": {
 			Pattern:        "p",
 			IsRegExp:       true,
 			ExcludePattern: `f|(\.graphql$|\.gql$|\.graphqls$)`,
+			Index:          query.Yes,
 		},
 	}
 	for queryStr, want := range tests {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
+	"github.com/hexops/autogold"
 	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -1328,46 +1329,14 @@ func TestEvaluateAnd(t *testing.T) {
 }
 
 func TestIndexValue(t *testing.T) {
-	cases := []struct {
-		name    string
-		pattern string
-		want    query.YesNoOnly
-	}{
-		{
-			name:    "yes",
-			pattern: "foo index:yes",
-			want:    query.Yes,
-		},
-		{
-			name:    "no",
-			pattern: "foo index:no",
-			want:    query.No,
-		},
-		{
-			name:    "only",
-			pattern: "foo index:only",
-			want:    query.Only,
-		},
-		{
-			name:    "default",
-			pattern: "foo",
-			want:    query.Yes,
-		},
+	test := func(input string) query.YesNoOnly {
+		q, _ := query.ParseLiteral(input)
+		return indexValue(q)
 	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			q, err := query.ProcessAndOr(tt.pattern,
-				query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: false})
-			if err != nil {
-				t.Fatalf(err.Error())
-			}
-			got := indexValue(q)
-			if got != tt.want {
-				t.Fatalf("got %s\nwant %s", got, tt.want)
-			}
-		})
-	}
+	autogold.Want("yes", query.YesNoOnly("yes")).Equal(t, test("foo index:yes"))
+	autogold.Want("no", query.YesNoOnly("no")).Equal(t, test("foo index:no"))
+	autogold.Want("only", query.YesNoOnly("only")).Equal(t, test("foo index:only"))
+	autogold.Want("default", query.YesNoOnly("yes")).Equal(t, test("foo"))
 }
 
 func TestSearchContext(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -170,7 +170,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 	}
 
 	// Disable unindexed search
-	if indexParam == query.Only {
+	if args.PatternInfo.Index == query.Only {
 		searcherRepos = limitUnindexedRepos(searcherRepos, 0, stream)
 	}
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -95,20 +95,10 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		return nil, err
 	}
 
-	// Parse index:yes (default), index:only, and index:no in search query.
-	indexParam := query.Yes
-	if index, _ := args.Query.StringValues(query.FieldIndex); len(index) > 0 {
-		index := index[len(index)-1]
-		indexParam = query.ParseYesNoOnly(index)
-		if indexParam == query.Invalid {
-			return nil, fmt.Errorf("invalid index:%q (valid values are: yes, only, no)", index)
-		}
-	}
-
 	// If Zoekt is disabled just fallback to Unindexed.
 	if !args.Zoekt.Enabled() {
-		if indexParam == query.Only {
-			return nil, fmt.Errorf("invalid index:%q (indexed search is not enabled)", indexParam)
+		if args.PatternInfo.Index == query.Only {
+			return nil, fmt.Errorf("invalid index:%q (indexed search is not enabled)", args.PatternInfo.Index)
 		}
 
 		return &indexedSearchRequest{
@@ -119,8 +109,8 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 
 	// Fallback to Unindexed if the query contains ref-globs
 	if containsRefGlobs(args.Query) {
-		if indexParam == query.Only {
-			return nil, fmt.Errorf("invalid index:%q (revsions with glob pattern cannot be resolved for indexed searches)", indexParam)
+		if args.PatternInfo.Index == query.Only {
+			return nil, fmt.Errorf("invalid index:%q (revsions with glob pattern cannot be resolved for indexed searches)", args.PatternInfo.Index)
 		}
 		return &indexedSearchRequest{
 			Unindexed: limitUnindexedRepos(repos, maxUnindexedRepoRevSearchesPerQuery, stream),
@@ -128,7 +118,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 	}
 
 	// Fallback to Unindexed if index:no
-	if indexParam == query.No {
+	if args.PatternInfo.Index == query.No {
 		return &indexedSearchRequest{
 			Unindexed: limitUnindexedRepos(repos, maxUnindexedRepoRevSearchesPerQuery, stream),
 		}, nil
@@ -149,7 +139,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 	if err != nil {
 		if ctx.Err() == nil {
 			// Only hard fail if the user specified index:only
-			if indexParam == query.Only {
+			if args.PatternInfo.Index == query.Only {
 				return nil, errors.New("index:only failed since indexed search is not available yet")
 			}
 
@@ -191,7 +181,7 @@ func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, t
 		Unindexed: limitUnindexedRepos(searcherRepos, maxUnindexedRepoRevSearchesPerQuery, stream),
 		repos:     indexed,
 
-		DisableUnindexedSearch: indexParam == query.Only,
+		DisableUnindexedSearch: args.PatternInfo.Index == query.Only,
 	}, nil
 }
 

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -140,6 +140,7 @@ type TextPatternInfo struct {
 	IsWordMatch     bool
 	IsCaseSensitive bool
 	FileMatchLimit  int32
+	Index           query.YesNoOnly
 
 	// We do not support IsMultiline
 	// IsMultiline     bool


### PR DESCRIPTION
Initially, I wanted to store `index` in `SearchInput` but given where
similar information resides right now and based on the discussion in
[#17958](https://github.com/sourcegraph/sourcegraph/pull/17958) I think TextPatternInfo might be the better place after all.

Even though the docstring of TextPatternInfo says otherwise

> TextPatternInfo is the struct used by vscode pass on search queries. Keep it in
> sync with pkg/searcher/protocol.PatternInfo.

I think in this particular case, it makes sense not to pass index to searcher?



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
