### PR TITLE
search: return early if time left for zoekt is <0

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -260,7 +260,9 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
 		searchOpts.MaxWallTime = time.Until(deadline)
-
+		if searchOpts.MaxWallTime < 0 {
+			return ctx.Err()
+		}
 		// We don't want our context's deadline to cut off zoekt so that we can get the results
 		// found before the deadline.
 		//

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -113,12 +113,7 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: true,
 				since:           func(time.Time) time.Duration { return 0 },
 			},
-			wantCommon: streaming.Stats{
-				Status: mkStatusMap(map[string]search.RepoStatus{
-					"foo/bar":    search.RepoStatusIndexed | search.RepoStatusTimedout,
-					"foo/foobar": search.RepoStatusIndexed | search.RepoStatusTimedout,
-				}),
-			},
+			wantErr: true,
 		},
 		{
 			name: "results",


### PR DESCRIPTION
It was possible that we start calling zoekt with a negative wall time
left on the clock. This didn't cause any issues, because the zoekt
client would return early. However, by moving repo resolution before the
first call to zoekt, we waited endlessly if the deadline had already
exceed because the context we hand to getRepo never expires.

This little change makes sure we have at least some time left on the
clock before we call zoekt.

In a follow-up PR I will move repo resolution to before this block.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
