### PR TITLE
search: unify code for missing status on unindexed repos

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -301,7 +301,7 @@ func TestIndexedSearch(t *testing.T) {
 				},
 			}
 
-			indexed, err := newIndexedSearchRequest(context.Background(), args, textRequest)
+			indexed, err := newIndexedSearchRequest(context.Background(), args, textRequest, StreamFunc(func(SearchEvent) {}))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
We had duplicated code between symbols and text search. Additionally it
was tricky in searchFilesInRepos since you had to use the searcherRepos
variable, not the "indexed.Unindexed" variable. Now there is only
indexed.Unindexed.

Previously we would log to the tracer about missing vs not. This has
been removed. The information is not that valuable these days.