### PR TITLE
search: calculate repo map outside event loop

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -300,6 +300,18 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		}
 	)
 
+	var repoRevMap map[string]*search.RepositoryRevisions
+	if args.Mode == search.ZoektGlobalSearch {
+		repos, err := getRepos(ctx, args.RepoPromise)
+		if err != nil {
+			return err
+		}
+		repoRevMap = make(map[string]*search.RepositoryRevisions, len(repos))
+		for _, r := range repos {
+			repoRevMap[string(r.Repo.Name)] = r
+		}
+	}
+
 	for event := range events {
 		if event.Error != nil {
 			return event.Error
@@ -323,27 +335,11 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 		var getRepoInputRev zoektutil.RepoRevFunc
 
 		if args.Mode == search.ZoektGlobalSearch {
-			m := map[string]*search.RepositoryRevisions{}
-			for _, file := range files {
-				m[file.Repository] = nil
-			}
-			repos, err := getRepos(ctx, args.RepoPromise)
-			if err != nil {
-				return err
-			}
-
-			for _, repo := range repos {
-				if _, ok := m[string(repo.Repo.Name)]; !ok {
-					continue
-				}
-				m[string(repo.Repo.Name)] = repo
-			}
 			getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
-				repoRev := m[file.Repository]
-				if repoRev == nil {
-					return nil, nil, false
+				if repoRev, ok := repoRevMap[file.Repository]; ok {
+					return repoRev.Repo, repoRev.RevSpecs(), true
 				}
-				return repoRev.Repo, repoRev.RevSpecs(), true
+				return nil, nil, false
 			}
 		} else {
 			getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {


### PR DESCRIPTION
I had to revert this PR previously in #17956 because it broke the CI pipeline. The root cause was that in zoekt.go we swap a context (with a deadline) with a context that never expires. However, if the original context expires before we resolve repos then the underlying promise will never get resolved and we wait forever in getRepos. The issue is resolved by moving the repo resolution to above the block in which we replace the context.

original PR description:
We trade memory against performance by calculating a map of repo
names to revisions once per global search request. This should improve
performance for medium to large result sets.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
