### PR TITLE
search: send progress event when changed

### DIFF
--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -34,8 +34,6 @@ func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
 }
 
 func (p *progressAggregator) currentStats() api.ProgressStats {
-	p.Dirty = false
-
 	// Suggest the next 1000 after rounding off.
 	suggestedLimit := (p.Limit + 1500) / 1000 * 1000
 
@@ -54,12 +52,16 @@ func (p *progressAggregator) currentStats() api.ProgressStats {
 
 // Current returns the current progress event.
 func (p *progressAggregator) Current() api.Progress {
+	p.Dirty = false
+
 	return api.BuildProgressEvent(p.currentStats())
 }
 
 // Final returns the current progress event, but with final fields set to
 // indicate it is the last progress event.
 func (p *progressAggregator) Final() api.Progress {
+	p.Dirty = false
+
 	s := p.currentStats()
 
 	// We only send RepositoriesCount at the end because the number is

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -92,7 +92,9 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			matchesBuf = matchesBuf[:0]
+		}
 
+		if progress.Dirty {
 			sendProgress()
 		}
 	}

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -63,6 +63,21 @@ func (c *Stats) Update(other *Stats) {
 	c.ExcludedArchived = c.ExcludedArchived + other.ExcludedArchived
 }
 
+// Zero returns true if stats is empty. IE calling Update will result in no
+// change.
+func (c *Stats) Zero() bool {
+	if c == nil {
+		return true
+	}
+
+	return !(c.IsLimitHit ||
+		len(c.Repos) > 0 ||
+		c.Status.Len() > 0 ||
+		c.ExcludedForks > 0 ||
+		c.ExcludedArchived > 0 ||
+		c.IsIndexUnavailable)
+}
+
 func (c *Stats) String() string {
 	if c == nil {
 		return "Stats{}"


### PR DESCRIPTION
Previously we would only send progress updates if we found new
results. Now also send them if progress has changed (even if results
have not been found). They will be sent as often as we previously called
flush, which is every 100ms or every 1000 results.