### PR TITLE
search: remove zoekt.MatchLimiter

### DIFF
--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -5,7 +5,6 @@ import (
 	"regexp/syntax"
 	"time"
 
-	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
 
 	searcherzoekt "github.com/sourcegraph/sourcegraph/cmd/searcher/search"
@@ -14,7 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func buildQuery(args *search.TextParameters, repos *indexedRepoRevs, filePathPatterns zoektquery.Q, shortcircuit bool) (zoektquery.Q, error) {
@@ -47,7 +45,6 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	var (
 		err       error
 		limitHit  bool
-		partial   map[api.RepoID]struct{}
 		statusMap search.RepoStatusMap
 	)
 
@@ -125,23 +122,6 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 	if len(resp.Files) == 0 {
 		return nil
 	}
-
-	matchLimiter := zoektutil.MatchLimiter{Limit: int(args.PatternInfo.FileMatchLimit)}
-	repoRevFunc := func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
-		repo, inputRevs := repos.GetRepoInputRev(file)
-		return repo, inputRevs, true
-	}
-
-	var files []zoekt.FileMatch
-	partial, files = matchLimiter.Slice(resp.Files, repoRevFunc)
-	// Partial is populated with repositories we may have not fully
-	// searched due to limits.
-	for r := range partial {
-		statusMap.Update(r, search.RepoStatusLimitHit)
-	}
-
-	limitHit = limitHit || len(partial) > 0
-	resp.Files = files
 
 	maxLineMatches := 25 + k
 	matches := make([]SearchResultResolver, len(resp.Files))

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -24,7 +24,6 @@ import (
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 var zoektOnce sync.Once
@@ -219,16 +218,6 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, repoBranches
 	if len(resp.Files) == 0 {
 		return nil, false, nil, nil
 	}
-
-	matchLimiter := zoektutil.MatchLimiter{Limit: int(args.FileMatchLimit)}
-	repoRevFunc := func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
-		return repo, revs, false
-	}
-
-	var files []zoekt.FileMatch
-	partial, files = matchLimiter.Slice(resp.Files, repoRevFunc)
-	limitHit = limitHit || len(partial) > 0
-	resp.Files = files
 
 	maxLineMatches := 25 + k
 	for _, file := range resp.Files {


### PR DESCRIPTION
Rather than limiting the response we get back from Zoekt, we just ask
not to send more than our limit in results. We still calculate
limit hit correctly.

This has two user visible changes. The first is we can receive upto
"len(zoektsReplicas) * limit" results. For graphql we limit before
sending to the user. For streaming we just send down the results
anyways. This seems like fine behaviour, especially given our default
limit is so low and we have computed the information anyways. If we want
to change that behaviour, we need to introduce limiting at the top level
for streaming anyways since we need to limit between backends.

The other user visible change is we now no longer compute the partial
sets. If a repo appeared in partial, we would show a "+" next to the
dynamic filter count for that repo. This is the most contentious part of
the change. The previous implementation was pretty hacky and not
necessarily correct. This is something we could maybe add back when we
create a streaming RPC for zoekt. Or we could not do this change now.