### PR TITLE
saml: add config option "allowSignup"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - New site config option `"log": { "sentry": { "backendDSN": "<REDACTED>" } }` to use a separate Sentry project for backend errors. [#17363](https://github.com/sourcegraph/sourcegraph/pull/17363)
 - Structural search now supports searching indexed branches other than default. [#17726](https://github.com/sourcegraph/sourcegraph/pull/17726)
+- New site config option `"allowSignup"` for SAML authentication to determine if automatically create new users is allowed. [#17989](https://github.com/sourcegraph/sourcegraph/pull/17989)
 
 ### Changed
 

--- a/doc/admin/auth/saml/okta.md
+++ b/doc/admin/auth/saml/okta.md
@@ -30,7 +30,8 @@
  "auth.providers": [
    {
      "type": "saml",
-     "identityProviderMetadataURL": "https://okta.example.com/app/8VglnckX0yyhdkp0bk00/sso/saml/metadata"
+     "identityProviderMetadataURL": "https://okta.example.com/app/8VglnckX0yyhdkp0bk00/sso/saml/metadata",
+     "allowSignup": true 
    }
  ]
 }

--- a/enterprise/cmd/frontend/auth/saml/middleware.go
+++ b/enterprise/cmd/frontend/auth/saml/middleware.go
@@ -138,7 +138,8 @@ func samlSPHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		actor, safeErrMsg, err := getOrCreateUser(r.Context(), info)
+		allowSignup := p.config.AllowSignup == nil || *p.config.AllowSignup
+		actor, safeErrMsg, err := getOrCreateUser(r.Context(), allowSignup, info)
 		if err != nil {
 			log15.Error("Error looking up SAML-authenticated user.", "err", err, "userErr", safeErrMsg)
 			http.Error(w, safeErrMsg, http.StatusInternalServerError)

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -84,7 +84,7 @@ func readAuthnResponse(p *provider, encodedResp string) (*authnResponseInfo, err
 // getOrCreateUser gets or creates a user account based on the SAML claims. It returns the
 // authenticated actor if successful; otherwise it returns an friendly error message (safeErrMsg)
 // that is safe to display to users, and a non-nil err with lower-level error details.
-func getOrCreateUser(ctx context.Context, info *authnResponseInfo) (_ *actor.Actor, safeErrMsg string, err error) {
+func getOrCreateUser(ctx context.Context, allowSignup bool, info *authnResponseInfo) (_ *actor.Actor, safeErrMsg string, err error) {
 	var data extsvc.AccountData
 	data.SetAccountData(info.accountData)
 
@@ -103,7 +103,7 @@ func getOrCreateUser(ctx context.Context, info *authnResponseInfo) (_ *actor.Act
 		},
 		ExternalAccount:     info.spec,
 		ExternalAccountData: data,
-		CreateIfNotExist:    true,
+		CreateIfNotExist:    allowSignup,
 	})
 	if err != nil {
 		return nil, safeErrMsg, err

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1021,6 +1021,8 @@ type Responders struct {
 //
 // Note: if you are using IdP-initiated login, you must have *at most one* SAMLAuthProvider in the `auth.providers` array.
 type SAMLAuthProvider struct {
+	// AllowSignup description: Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.
+	AllowSignup *bool `json:"allowSignup,omitempty"`
 	// ConfigID description: An identifier that can be used to reference this authentication provider in other parts of the config. For example, in configuration for a code host, you may want to designate this authentication provider as the identity provider for the code host.
 	ConfigID    string `json:"configID,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1030,6 +1030,11 @@
           "description": "Whether the Service Provider should (insecurely) accept assertions from the Identity Provider without a valid signature.",
           "type": "boolean",
           "default": false
+        },
+        "allowSignup": {
+          "description": "Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.",
+          "type": "boolean",
+          "!go": { "pointer": true }
         }
       }
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -1035,6 +1035,11 @@ const SiteSchemaJSON = `{
           "description": "Whether the Service Provider should (insecurely) accept assertions from the Identity Provider without a valid signature.",
           "type": "boolean",
           "default": false
+        },
+        "allowSignup": {
+          "description": "Allows new visitors to sign up for accounts via SAML authentication. If false, users signing in via SAML must have an existing Sourcegraph account, which will be linked to their SAML identity after sign-in.",
+          "type": "boolean",
+          "!go": { "pointer": true }
         }
       }
     },


### PR DESCRIPTION
When the config option is absent, SAML authN preserves the current behavior (ie. allow sign up). Otherwise, SAML authN respects its value.

Fixes https://github.com/sourcegraph/customer/issues/194

Tested end-to-end.