### PR TITLE
Add hideActions flag to the code view toolbar

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -602,6 +602,7 @@ export interface HandleCodeHostOptions extends CodeIntelligenceProps {
     sourcegraphURL: string
     render: typeof reactDOMRender
     minimalUI: boolean
+    hideActions?: boolean
     background: Pick<BackgroundPageApi, 'notifyPrivateRepository' | 'openOptionsPage'>
 }
 
@@ -615,6 +616,7 @@ export function handleCodeHost({
     telemetryService,
     render,
     minimalUI,
+    hideActions,
     background,
 }: HandleCodeHostOptions): Subscription {
     const history = H.createBrowserHistory()
@@ -1075,6 +1077,7 @@ export function handleCodeHost({
                 render(
                     <CodeViewToolbar
                         {...codeHost.codeViewToolbarClassProps}
+                        hideActions={hideActions}
                         fileInfoOrError={diffOrBlobInfo}
                         sourcegraphURL={sourcegraphURL}
                         telemetryService={telemetryService}
@@ -1172,6 +1175,8 @@ export function injectCodeIntelligenceToCodeHost(
     const minimalUIStorageFlag = localStorage.getItem('sourcegraphMinimalUI')
     const minimalUI =
         minimalUIStorageFlag !== null ? minimalUIStorageFlag === 'true' : codeHost.type === 'gitlab' && !isExtension
+    // Flag to hide the actions in the code view toolbar (hide ActionNavItems) leaving only the "Open on Sourcegraph" button in the toolbar.
+    const hideActions = codeHost.type === 'gerrit'
     subscriptions.add(
         extensionDisabled.subscribe(disableExtension => {
             if (disableExtension) {
@@ -1191,6 +1196,7 @@ export function injectCodeIntelligenceToCodeHost(
                     telemetryService,
                     render: reactDOMRender,
                     minimalUI,
+                    hideActions,
                     background,
                 })
                 subscriptions.add(codeHostSubscription)

--- a/client/browser/src/shared/components/CodeViewToolbar.tsx
+++ b/client/browser/src/shared/components/CodeViewToolbar.tsx
@@ -46,19 +46,22 @@ export interface CodeViewToolbarProps
     buttonProps?: ButtonProps
     onSignInClose: () => void
     location: H.Location
+    hideActions?: boolean
 }
 
 export const CodeViewToolbar: React.FunctionComponent<CodeViewToolbarProps> = props => (
     <ul className={classNames('code-view-toolbar', props.className)}>
-        <ActionsNavItems
-            {...props}
-            listItemClass={classNames('code-view-toolbar__item', props.listItemClass)}
-            menu={ContributableMenu.EditorTitle}
-            extensionsController={props.extensionsController}
-            platformContext={props.platformContext}
-            location={props.location}
-            scope={props.scope}
-        />{' '}
+        {!props.hideActions && (
+            <ActionsNavItems
+                {...props}
+                listItemClass={classNames('code-view-toolbar__item', props.listItemClass)}
+                menu={ContributableMenu.EditorTitle}
+                extensionsController={props.extensionsController}
+                platformContext={props.platformContext}
+                location={props.location}
+                scope={props.scope}
+            />
+        )}{' '}
         {isErrorLike(props.fileInfoOrError) ? (
             isHTTPAuthError(props.fileInfoOrError) ? (
                 <SignInButton


### PR DESCRIPTION
This adds a `hideActions` flags to `CodeViewToolbar` which makes the toolbar hide action buttons (by hiding `ActionNavItems`).

For now the flag is enabled on Gerrit because there is additional work needed to make extension-contributed action buttons work in the code view toolbar.
