### PR TITLE
search: pass stream in as part of search resolver constructor

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -41,7 +41,7 @@ type SearchArgs struct {
 	First          *int32
 	VersionContext *string
 
-	// Stream if non-nil will send all results down c.
+	// Stream if non-nil will stream all SearchEvents.
 	//
 	// This is how our streaming and our batch interface co-exist. When this
 	// is set, it exposes a way to stream out results as we collect them.

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -41,6 +41,17 @@ type SearchArgs struct {
 	First          *int32
 	VersionContext *string
 
+	// Stream if non-nil will send all results down c.
+	//
+	// This is how our streaming and our batch interface co-exist. When this
+	// is set, it exposes a way to stream out results as we collect them.
+	//
+	// TODO(keegan) This is not our final design. For example this doesn't
+	// allow us to stream out things like dynamic filters or take into account
+	// AND/OR. However, streaming is behind a feature flag for now, so this is
+	// to make it visible in the browser.
+	Stream Streamer
+
 	// For tests
 	Settings *schema.Settings
 }
@@ -51,7 +62,6 @@ type SearchImplementer interface {
 	//lint:ignore U1000 is used by graphql via reflection
 	Stats(context.Context) (*searchResultsStats, error)
 
-	SetStream(c Streamer)
 	Inputs() SearchInputs
 }
 
@@ -121,6 +131,9 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (_ SearchImplem
 			Pagination:     pagination,
 			PatternType:    searchType,
 		},
+
+		stream: args.Stream,
+
 		zoekt:        search.Indexed(),
 		searcherURLs: search.SearcherURLs(),
 		reposMu:      &sync.Mutex{},
@@ -257,8 +270,7 @@ type searchResolver struct {
 	*SearchInputs
 	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating search subexpressions.
 
-	// stream if non-nil will send all results we receive down it. See
-	// searchResolver.SetStream
+	// stream if non-nil will send all search events we receive down it.
 	stream Streamer
 
 	// Cached resolveRepositories results. We use a pointer to the mutex so that we
@@ -270,19 +282,6 @@ type searchResolver struct {
 
 	zoekt        *searchbackend.Zoekt
 	searcherURLs *endpoint.Map
-}
-
-// SetStream will send all results down c.
-//
-// This is how our streaming and our batch interface co-exist. When this is
-// set, it exposes a way to stream out results as we collect them.
-//
-// TODO(keegan) This is not our final design. For example this doesn't allow
-// us to stream out things like dynamic filters or take into account
-// AND/OR. However, streaming is behind a feature flag for now, so this is to
-// make it visible in the browser.
-func (r *searchResolver) SetStream(c Streamer) {
-	r.stream = c
 }
 
 func (r *searchResolver) Inputs() SearchInputs {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -621,7 +621,6 @@ func (searchAlert) Suggestions(context.Context, *searchSuggestionsArgs) ([]*sear
 	return nil, nil
 }
 func (searchAlert) Stats(context.Context) (*searchResultsStats, error) { return nil, nil }
-func (searchAlert) SetStream(c Streamer)                               {}
 func (searchAlert) Inputs() SearchInputs {
 	return SearchInputs{}
 }

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -214,6 +214,10 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan
 		Version:        a.Version,
 		PatternType:    strPtr(a.PatternType),
 		VersionContext: strPtr(a.VersionContext),
+
+		Stream: graphqlbackend.StreamFunc(func(event graphqlbackend.SearchEvent) {
+			eventsC <- event
+		}),
 	})
 	if err != nil {
 		close(eventsC)
@@ -231,10 +235,6 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan
 		defer close(final)
 		defer close(eventsC)
 
-		search.SetStream(graphqlbackend.StreamFunc(func(event graphqlbackend.SearchEvent) {
-			eventsC <- event
-		}))
-
 		r, err := search.Results(ctx)
 		final <- finalResult{resultsResolver: r, err: err}
 	}()
@@ -247,7 +247,6 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan
 
 type searchResolver interface {
 	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
-	SetStream(c graphqlbackend.Streamer)
 	Inputs() graphqlbackend.SearchInputs
 }
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -58,21 +58,11 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Log events to trace
 	eventWriter.StatHook = eventStreamOTHook(tr.LogFields)
 
-	search, err := h.newSearchResolver(ctx, &graphqlbackend.SearchArgs{
-		Query:          args.Query,
-		Version:        args.Version,
-		PatternType:    strPtr(args.PatternType),
-		VersionContext: strPtr(args.VersionContext),
-	})
-	if err != nil {
-		_ = eventWriter.Event("error", err.Error())
-		return
-	}
-	resultsStream, resultsStreamDone := newResultsStream(ctx, search)
+	events, inputs, results := h.startSearch(ctx, args)
 
 	progress := progressAggregator{
 		Start: time.Now(),
-		Limit: search.Inputs().MaxResults(),
+		Limit: inputs.MaxResults(),
 	}
 
 	sendProgress := func() {
@@ -109,7 +99,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		var event graphqlbackend.SearchEvent
 		var ok bool
 		select {
-		case event, ok = <-resultsStream:
+		case event, ok = <-events:
 		case <-flushTicker.C:
 			ok = true
 			flushMatchesBuf()
@@ -187,8 +177,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	final := <-resultsStreamDone
-	resultsResolver, err := final.resultsResolver, final.err
+	resultsResolver, err := results()
 	if err != nil {
 		_ = eventWriter.Event("error", err.Error())
 		return
@@ -214,6 +203,48 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_ = eventWriter.Event("progress", progress.Final())
 }
 
+// startSearch will start a search. It returns the events channel which
+// streams out search events. Once events is closed you can call results which
+// will return the results resolver and error.
+func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan graphqlbackend.SearchEvent, inputs graphqlbackend.SearchInputs, results func() (*graphqlbackend.SearchResultsResolver, error)) {
+	eventsC := make(chan graphqlbackend.SearchEvent)
+
+	search, err := h.newSearchResolver(ctx, &graphqlbackend.SearchArgs{
+		Query:          a.Query,
+		Version:        a.Version,
+		PatternType:    strPtr(a.PatternType),
+		VersionContext: strPtr(a.VersionContext),
+	})
+	if err != nil {
+		close(eventsC)
+		return eventsC, graphqlbackend.SearchInputs{}, func() (*graphqlbackend.SearchResultsResolver, error) {
+			return nil, err
+		}
+	}
+
+	type finalResult struct {
+		resultsResolver *graphqlbackend.SearchResultsResolver
+		err             error
+	}
+	final := make(chan finalResult, 1)
+	go func() {
+		defer close(final)
+		defer close(eventsC)
+
+		search.SetStream(graphqlbackend.StreamFunc(func(event graphqlbackend.SearchEvent) {
+			eventsC <- event
+		}))
+
+		r, err := search.Results(ctx)
+		final <- finalResult{resultsResolver: r, err: err}
+	}()
+
+	return eventsC, search.Inputs(), func() (*graphqlbackend.SearchResultsResolver, error) {
+		f := <-final
+		return f.resultsResolver, f.err
+	}
+}
+
 type searchResolver interface {
 	Results(context.Context) (*graphqlbackend.SearchResultsResolver, error)
 	SetStream(c graphqlbackend.Streamer)
@@ -221,15 +252,7 @@ type searchResolver interface {
 }
 
 func defaultNewSearchResolver(ctx context.Context, args *graphqlbackend.SearchArgs) (searchResolver, error) {
-	searchImpl, err := graphqlbackend.NewSearchImplementer(ctx, args)
-	if err != nil {
-		return nil, err
-	}
-	search, ok := searchImpl.(searchResolver)
-	if !ok {
-		return nil, errors.New("SearchImplementer does not support streaming")
-	}
-	return search, nil
+	return graphqlbackend.NewSearchImplementer(ctx, args)
 }
 
 type args struct {
@@ -274,35 +297,6 @@ func fromStrPtr(s *string) string {
 		return ""
 	}
 	return *s
-}
-
-type finalResult struct {
-	resultsResolver *graphqlbackend.SearchResultsResolver
-	err             error
-}
-
-// newResultsStream will return a channel which streams out the results found
-// by search.Results. Once done it will send the return value of
-// search.Results. Both channels need to be read until closed, otherwise
-// goroutines will be leaked.
-//
-//   - results is written to 0 or more times before closing.
-//   - final is written to once.
-func newResultsStream(ctx context.Context, search searchResolver) (results <-chan graphqlbackend.SearchEvent, final <-chan finalResult) {
-	resultsC := make(chan graphqlbackend.SearchEvent)
-	finalC := make(chan finalResult, 1)
-	go func() {
-		defer close(finalC)
-		defer close(resultsC)
-
-		search.SetStream(graphqlbackend.StreamFunc(func(event graphqlbackend.SearchEvent) {
-			resultsC <- event
-		}))
-
-		r, err := search.Results(ctx)
-		finalC <- finalResult{resultsResolver: r, err: err}
-	}()
-	return resultsC, finalC
 }
 
 func fromFileMatch(fm *graphqlbackend.FileMatchResolver) eventFileMatch {

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -66,9 +66,6 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 		}, nil
 	}
 }
-func (h *mockSearchResolver) SetStream(c graphqlbackend.Streamer) {
-	h.c = c
-}
 
 func (h *mockSearchResolver) Send(r []graphqlbackend.SearchResultResolver) {
 	h.c.Send(graphqlbackend.SearchEvent{Results: r})


### PR DESCRIPTION
We want the stream to be set as early as possible. This will also allow the
constructor to change the decisions it makes based on if it is streaming
mode or not.

Additionally we refactor how we setup the stream in the HTTP layer.

Can be reviewed commit by commit.