### PR TITLE
search: Fix getting results for non-existant files

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -289,7 +289,11 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			Languages:                    p.Languages,
 		}
 
-	repoBranches := map[string][]string{string(p.Repo): {string(p.Branch)}}
+	branch := p.Branch
+	if branch == "" {
+		branch = "HEAD"
+	}
+	repoBranches := map[string][]string{string(p.Repo): {branch}}
 	useFullDeadline := false
 	zoektMatches, limitHit, _, err := zoektSearch(ctx, patternInfo, repoBranches, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -289,11 +289,10 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			Languages:                    p.Languages,
 		}
 
-	branch := p.Branch
-	if branch == "" {
-		branch = "HEAD"
+	if p.Branch == "" {
+		p.Branch = "HEAD"
 	}
-	repoBranches := map[string][]string{string(p.Repo): {branch}}
+	repoBranches := map[string][]string{string(p.Repo): {p.Branch}}
 	useFullDeadline := false
 	zoektMatches, limitHit, _, err := zoektSearch(ctx, patternInfo, repoBranches, time.Since, p.IndexerEndpoints, useFullDeadline, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes #17907 

Fixes an issue where results were being returned for branches other than the default branch when no revision was specified, causing `git ls-tree` errors in the frontend. 

The issue is that when we don't specify a revision, we were passing `branch == ""` to searcher, causing results to be returned from multiple branches (if there are multiple branches indexed for a repo). 

I think this solution should be fine (it's certainly better than what it was), but it's unclear to me if there is any situation where an empty revision means something other than just "search HEAD". It feels funny to not be using a specific revision name when we already queried Zoekt for indexed revisions, but every time I went down that path, it broke something else, so this feels like the safest option. 