### PR TITLE
Change file tree trigger icons

### DIFF
--- a/client/branded/src/components/tooltip/Tooltip.tsx
+++ b/client/branded/src/components/tooltip/Tooltip.tsx
@@ -10,6 +10,7 @@ interface State {
     lastEventTarget?: HTMLElement
     content?: string
     placement?: string
+    delay?: number
 }
 
 /**
@@ -79,6 +80,7 @@ export class Tooltip extends React.PureComponent<Props, State> {
                         boundariesElement: 'window',
                     },
                 }}
+                delay={this.state.delay}
             >
                 {this.state.content}
             </BootstrapTooltip>
@@ -106,6 +108,7 @@ export class Tooltip extends React.PureComponent<Props, State> {
             subjectSeq: previousState.subject === subject ? previousState.subjectSeq : previousState.subjectSeq + 1,
             content: subject ? this.getContent(subject) : undefined,
             placement: subject ? this.getPlacement(subject) : undefined,
+            delay: subject ? this.getDelay(subject) : 0,
         }))
     }
 
@@ -141,6 +144,14 @@ export class Tooltip extends React.PureComponent<Props, State> {
             return undefined
         }
         return subject.getAttribute('data-placement') || undefined
+    }
+
+    private getDelay = (subject: HTMLElement): number | undefined => {
+        if (!document.body.contains(subject)) {
+            return undefined
+        }
+        const dataDelay = subject.getAttribute('data-delay')
+        return dataDelay ? parseInt(dataDelay, 10) : undefined
     }
 }
 

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -19,8 +19,8 @@
         background: var(--color-bg-2);
 
         &-toggle {
-            background: var(--color-bg-3);
-            color: var(--text-muted);
+            background: var(--color-bg-2);
+            color: var(--link-color);
 
             position: absolute;
             top: 0;

--- a/client/web/src/repo/RepoRevisionSidebar.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.scss
@@ -19,8 +19,8 @@
     }
 
     &-toggle {
-        width: 1.25rem;
-        height: 1.25rem;
+        width: 2.5rem;
+        height: 2.5rem;
         margin-right: -1.25rem;
 
         .icon {
@@ -30,7 +30,5 @@
 
         display: flex;
         justify-content: center;
-
-        border-radius: 0 0 0.25rem;
     }
 }

--- a/client/web/src/repo/RepoRevisionSidebar.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.scss
@@ -18,7 +18,7 @@
         width: 0;
     }
 
-    &-toggle {
+    &__toggle {
         width: 2.5rem;
         height: 2.5rem;
         margin-right: -1.25rem;
@@ -30,5 +30,12 @@
 
         display: flex;
         justify-content: center;
+    }
+
+    &__close-button {
+        color: var(--link-color);
+        &:hover {
+            color: var(--link-hover-color);
+        }
     }
 }

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -76,7 +76,7 @@ export class RepoRevisionSidebar extends React.PureComponent<Props, State> {
                     type="button"
                     className={classNames(
                         'btn btn-icon border-right border-bottom rounded-0',
-                        'repo-revision-sidebar-toggle',
+                        'repo-revision-sidebar__toggle',
                         this.props.className && `${this.props.className}-toggle`
                     )}
                     onClick={this.onSidebarToggle}
@@ -106,8 +106,9 @@ export class RepoRevisionSidebar extends React.PureComponent<Props, State> {
                                 <button
                                     type="button"
                                     onClick={this.onSidebarToggle}
-                                    className={`btn btn-icon tab_bar__close-button ${TabBorderClassName}`}
-                                    title="Collapse panel (Alt+S/Opt+S)"
+                                    className={`btn btn-icon pr-1 repo-revision-sidebar__close-button ${TabBorderClassName}`}
+                                    data-tooltip="Collapse panel (Alt+S/Opt+S)"
+                                    data-placement="right"
                                 >
                                     <ChevronDoubleLeftIcon className="icon-inline" />
                                 </button>

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -1,9 +1,7 @@
 import * as H from 'history'
-import CloseIcon from 'mdi-react/CloseIcon'
 import * as React from 'react'
 import { fromEvent, Subscription } from 'rxjs'
 import { filter } from 'rxjs/operators'
-import { FormatListBulletedIcon } from '../../../shared/src/components/icons'
 import { Resizable } from '../../../shared/src/components/Resizable'
 import {
     Spacer,
@@ -18,6 +16,9 @@ import { Tree } from '../tree/Tree'
 import { RepoRevisionSidebarSymbols } from './RepoRevisionSidebarSymbols'
 import { ThemeProps } from '../../../shared/src/theme'
 import { Scalars } from '../../../shared/src/graphql-operations'
+import ChevronDoubleLeftIcon from 'mdi-react/ChevronDoubleLeftIcon'
+import FileTreeIcon from 'mdi-react/FileTreeIcon'
+import classNames from 'classnames'
 
 type SidebarTabID = 'files' | 'symbols' | 'history'
 
@@ -73,11 +74,16 @@ export class RepoRevisionSidebar extends React.PureComponent<Props, State> {
             return (
                 <button
                     type="button"
-                    className={`btn btn-icon repo-revision-sidebar-toggle ${this.props.className}-toggle`}
+                    className={classNames(
+                        'btn btn-icon border-right border-bottom rounded-0',
+                        'repo-revision-sidebar-toggle',
+                        this.props.className && `${this.props.className}-toggle`
+                    )}
                     onClick={this.onSidebarToggle}
-                    data-tooltip="Show sidebar (Alt+S/Opt+S)"
+                    data-tooltip="Open file tree (Alt+S/Opt+S)"
+                    data-delay="1000"
                 >
-                    <FormatListBulletedIcon className="icon-inline" />
+                    <FileTreeIcon className="icon-inline" />
                 </button>
             )
         }
@@ -101,9 +107,9 @@ export class RepoRevisionSidebar extends React.PureComponent<Props, State> {
                                     type="button"
                                     onClick={this.onSidebarToggle}
                                     className={`btn btn-icon tab_bar__close-button ${TabBorderClassName}`}
-                                    data-tooltip="Close sidebar (Alt+S/Opt+S)"
+                                    title="Collapse panel (Alt+S/Opt+S)"
                                 >
-                                    <CloseIcon className="icon-inline" />
+                                    <ChevronDoubleLeftIcon className="icon-inline" />
                                 </button>
                             </>
                         }


### PR DESCRIPTION
## Overview

Addresses #16947, part of the greater RFC 250 Action Items Bar project (#16165)

### Open

#### Before

![open-before](https://user-images.githubusercontent.com/37420160/106964727-8eed8300-6710-11eb-9a50-b74393c53b2a.png)

#### After
![open-after](https://user-images.githubusercontent.com/37420160/106964743-96149100-6710-11eb-9796-4cf4e17369ee.png)

### Close

#### Before

![close-before](https://user-images.githubusercontent.com/37420160/106964812-b47a8c80-6710-11eb-981c-fb66343de63e.png)

#### After

![close-after](https://user-images.githubusercontent.com/37420160/106964814-b6dce680-6710-11eb-931d-e30f6dcd9fb6.png)

### Limitations

- Collapse icon tooltip doesn't work, so I kept the title attribute. I suspect that the original authors ran into the same problem. I believe it has to do with the `<Spacer>` element, but I couldn't find a quick fix. We should refactor the `<Tabs>` component when we improve panel styles (it's the parent of both the sidebar and the panel)
- Tooltip delay doesn't work. I added logic in our `<Tooltip>` component to read `data-delay` from elements with `data-tooltip`, but [Reactstrap doesn't seem to respect the `delay` prop](https://github.com/reactstrap/reactstrap/issues/520#issuecomment-632970952)

## Progress
- [x] Implementation progress milestones
  - [x] Replace open icon
    - [x] Update sidebar toggle styles  
  - [x] Replace close icon
- [ ] Approved by a frontend engineer 
- [ ] Approved by a designer (approve on Percy as well)