### PR TITLE
UI: Fix cache key for document highlights

### DIFF
--- a/client/web/src/repo/backend.ts
+++ b/client/web/src/repo/backend.ts
@@ -210,9 +210,9 @@ export const fetchHighlightedFileLineRanges = memoizeObservable(
         ),
     context =>
         makeRepoURI(context) +
-        `?disableTimeout=${String(context.disableTimeout)}&isLightTheme=${String(context.isLightTheme)}&ranges=${String(
-            context.ranges
-        )}`
+        `?disableTimeout=${String(context.disableTimeout)}&isLightTheme=${String(
+            context.isLightTheme
+        )}&ranges=${context.ranges.map(range => `${range.startLine}:${range.endLine}`).join(',')}`
 )
 
 export const fetchFileExternalLinks = memoizeObservable(


### PR DESCRIPTION
Fixes #17231. The issue was in the usage of [`memoizeObservable`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@v3.24.1/-/blob/client/shared/src/util/memoizeObservable.ts#L37), which was producing cache keys such as 

```
git://...schema_validator.go?disableTimeout=false&isLightTheme=true&ranges=[Object object],[Object object],[Object object]
```

This means that we were caching results regardless of the range values (as long as it had the same _number_ of ranges for a past query. That's why it was so flaky to reproduce. Now, the cache key has the following format:

```
git://...schema_validator.go?disableTimeout=false&isLightTheme=true&ranges=64:67,88:91,99:102
```
