### PR TITLE
search: remove alert dependency on ParseTree [1/2]

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -118,7 +118,7 @@ func alertForTimeout(usedTime time.Duration, suggestTime time.Duration, r *searc
 		proposedQueries: []*searchQueryDescription{
 			{
 				description: "query with longer timeout",
-				query:       fmt.Sprintf("timeout:%v %s", suggestTime, query.OmitQueryField(r.Query.ParseTree(), query.FieldTimeout)),
+				query:       fmt.Sprintf("timeout:%v %s", suggestTime, query.OmitQueryField(r.Query, query.FieldTimeout)),
 				patternType: r.PatternType,
 			},
 		},
@@ -180,7 +180,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 
 	// TODO(sqs): handle -repo:foo fields.
 
-	withoutRepoFields := query.OmitQueryField(r.Query.ParseTree(), query.FieldRepo)
+	withoutRepoFields := query.OmitQueryField(r.Query, query.FieldRepo)
 
 	switch {
 	case len(repoGroupFilters) > 1:
@@ -210,7 +210,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			proposedQueries = []*searchQueryDescription{
 				{
 					description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
-					query:       query.OmitQueryField(r.Query.ParseTree(), query.FieldRepoGroup),
+					query:       query.OmitQueryField(r.Query, query.FieldRepoGroup),
 					patternType: r.PatternType,
 				},
 			}
@@ -265,7 +265,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 			proposedQueries = []*searchQueryDescription{
 				{
 					description: fmt.Sprintf("include repositories outside of repogroup:%s", repoGroupFilters[0]),
-					query:       query.OmitQueryField(r.Query.ParseTree(), query.FieldRepoGroup),
+					query:       query.OmitQueryField(r.Query, query.FieldRepoGroup),
 					patternType: r.PatternType,
 				},
 			}

--- a/internal/search/query/alert.go
+++ b/internal/search/query/alert.go
@@ -8,16 +8,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query/syntax"
 )
 
-func OmitQueryField(p syntax.ParseTree, field string) string {
-	omitField := func(e syntax.Expr) *syntax.Expr {
-		if e.Field == field {
-			return nil
-		}
-		return &e
-	}
-	return syntax.Map(p, omitField).String()
-}
-
 // addRegexpField adds a new expr to the query with the given field
 // and pattern value. The field is assumed to be a regexp.
 //

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -697,3 +697,11 @@ func ellipsesForHoles(nodes []Node) []Node {
 		}
 	})
 }
+
+// OmitQueryField removes all fields `field` from a query. The `field` string
+// should be the canonical name and not an alias ("repo", not "r").
+func OmitQueryField(q QueryInfo, field string) string {
+	return StringHuman(MapField(q.(*AndOrQuery).Query, field, func(_ string, _ bool) Node {
+		return nil
+	}))
+}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hexops/autogold"
 )
 
 func toJSON(node Node) interface{} {
@@ -1012,4 +1013,14 @@ func TestConcatRevFiltersTopLevelAnd(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOmitQueryField(t *testing.T) {
+	test := func(input, field string) string {
+		q, _ := ParseLiteral(input)
+		return OmitQueryField(q, field)
+	}
+
+	autogold.Want("omit repo", "pattern").Equal(t, test("repo:stuff pattern", "repo"))
+	autogold.Want("omit repo alias", "alias-pattern").Equal(t, test("r:stuff alias-pattern", "repo"))
 }


### PR DESCRIPTION
Stacked on #17935.
Up the stack: #18003.

Breaks the dependency on `ParseTree()` by updating `OmitQueryField`. This function wasn't tested previously, and probably never worked with field aliases. I added a test, but it feels a bit like polishing a ---- so just want to get to the point where we can remove the other stuff.