### PR TITLE
insights: split out DB testing setup code into separate package

### DIFF
--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -1,11 +1,15 @@
 package dbtesting
 
 import (
+	"context"
 	"database/sql"
+	"net/url"
 	"os"
 	"os/user"
 	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v4"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -15,7 +19,8 @@ import (
 //
 // The returned DB handle is initialized with a unique database just for the specified test, with
 // all migrations applied.
-func TimescaleDB(t testing.TB) *sql.DB {
+func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
+	ctx := context.Background()
 	// Setup TimescaleDB for testing.
 	if os.Getenv("CODEINSIGHTS_PGDATASOURCE") == "" {
 		os.Setenv("CODEINSIGHTS_PGDATASOURCE", "postgres://postgres:password@127.0.0.1:5435/postgres")
@@ -24,8 +29,9 @@ func TimescaleDB(t testing.TB) *sql.DB {
 	if user, err := user.Current(); err == nil {
 		username = user.Username
 	}
+
 	timescaleDSN := dbutil.PostgresDSN("codeinsights", username, os.Getenv)
-	db, err := dbconn.New(timescaleDSN, "insights-test-"+strings.Replace(t.Name(), "/", "_", -1))
+	initConn, err := pgx.Connect(ctx, timescaleDSN)
 	if err != nil {
 		t.Log("")
 		t.Log("README: To run these tests you need to have the codeinsights TimescaleDB running:")
@@ -41,8 +47,52 @@ func TimescaleDB(t testing.TB) *sql.DB {
 			t.Fail()
 		}
 	}
+
+	// Create database just for this test.
+	dbname := "insights_test_" + strings.ToLower(strings.Replace(t.Name(), "/", "_", -1))
+	_, err = initConn.Exec(ctx, "DROP DATABASE IF EXISTS "+dbname+";")
+	if err != nil {
+		t.Fatal("dropping test database", err)
+	}
+	_, err = initConn.Exec(ctx, "CREATE DATABASE "+dbname+";")
+	if err != nil {
+		t.Fatal("creating test database", err)
+	}
+
+	// Connect to the new DB.
+	u, err := url.Parse(timescaleDSN)
+	if err != nil {
+		t.Fatal("parsing Timescale DSN", err)
+	}
+	u.Path = dbname
+	timescaleDSN = u.String()
+	db, err = dbconn.New(timescaleDSN, dbname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Perform DB migrations.
 	if err := dbconn.MigrateDB(db, dbconn.CodeInsights); err != nil {
 		t.Fatalf("Failed to perform codeinsights database migration: %s", err)
 	}
-	return db
+	cleanup = func() {
+		if err := db.Close(); err != nil {
+			t.Log(err)
+		}
+		defer initConn.Close(ctx)
+		// It would be nice to cleanup by dropping the test DB we just created. But we can't:
+		//
+		// 	dropping test database ERROR: database "insights_test_testresolver_insights" is being accessed by other users (SQLSTATE 55006)
+		//
+		// This is because dbconn.MigrateDB leaks DB connections: https://github.com/sourcegraph/sourcegraph/pull/18033
+		//
+		// But, as you'll find there, we cannot have nice things because OF COURSE the fix somehow
+		// passes all tests locally but not on our CI system. 💩💩💩
+		//_, err = initConn.Exec(ctx, "DROP DATABASE "+dbname+";")
+		//if err != nil {
+		//	t.Fatal("dropping test database", err)
+		//}
+	}
+	cleanup()
+	return db, cleanup
 }

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -1,0 +1,48 @@
+package dbtesting
+
+import (
+	"database/sql"
+	"os"
+	"os/user"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+// TimescaleDB returns a handle to the Code Insights TimescaleDB instance.
+//
+// The returned DB handle is initialized with a unique database just for the specified test, with
+// all migrations applied.
+func TimescaleDB(t testing.TB) *sql.DB {
+	// Setup TimescaleDB for testing.
+	if os.Getenv("CODEINSIGHTS_PGDATASOURCE") == "" {
+		os.Setenv("CODEINSIGHTS_PGDATASOURCE", "postgres://postgres:password@127.0.0.1:5435/postgres")
+	}
+	username := ""
+	if user, err := user.Current(); err == nil {
+		username = user.Username
+	}
+	timescaleDSN := dbutil.PostgresDSN("codeinsights", username, os.Getenv)
+	db, err := dbconn.New(timescaleDSN, "insights-test-"+strings.Replace(t.Name(), "/", "_", -1))
+	if err != nil {
+		t.Log("")
+		t.Log("README: To run these tests you need to have the codeinsights TimescaleDB running:")
+		t.Log("")
+		t.Log("$ ./dev/codeinsights-db.sh &")
+		t.Log("")
+		t.Log("Or skip them with 'go test -short'")
+		t.Log("")
+		t.Logf("Failed to connect to codeinsights database: %s", err)
+		if os.Getenv("CI") == "" {
+			t.Skip()
+		} else {
+			t.Fail()
+		}
+	}
+	if err := dbconn.MigrateDB(db, dbconn.CodeInsights); err != nil {
+		t.Fatalf("Failed to perform codeinsights database migration: %s", err)
+	}
+	return db
+}

--- a/enterprise/internal/insights/store/integration_test.go
+++ b/enterprise/internal/insights/store/integration_test.go
@@ -2,14 +2,9 @@ package store
 
 import (
 	"context"
-	"database/sql"
-	"os"
-	"os/user"
-	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -20,42 +15,10 @@ func TestIntegration(t *testing.T) {
 
 	t.Parallel()
 
-	getTimescaleDB := func(t testing.TB) *sql.DB {
-		// Setup TimescaleDB for testing.
-		if os.Getenv("CODEINSIGHTS_PGDATASOURCE") == "" {
-			os.Setenv("CODEINSIGHTS_PGDATASOURCE", "postgres://postgres:password@127.0.0.1:5435/postgres")
-		}
-		username := ""
-		if user, err := user.Current(); err == nil {
-			username = user.Username
-		}
-		timescaleDSN := dbutil.PostgresDSN("codeinsights", username, os.Getenv)
-		db, err := dbconn.New(timescaleDSN, "insights-test-"+strings.Replace(t.Name(), "/", "_", -1))
-		if err != nil {
-			t.Log("")
-			t.Log("README: To run these tests you need to have the codeinsights TimescaleDB running:")
-			t.Log("")
-			t.Log("$ ./dev/codeinsights-db.sh &")
-			t.Log("")
-			t.Log("Or skip them with 'go test -short'")
-			t.Log("")
-			t.Logf("Failed to connect to codeinsights database: %s", err)
-			if os.Getenv("CI") == "" {
-				t.Skip()
-			} else {
-				t.Fail()
-			}
-		}
-		if err := dbconn.MigrateDB(db, dbconn.CodeInsights); err != nil {
-			t.Fatalf("Failed to perform codeinsights database migration: %s", err)
-		}
-		return db
-	}
-
 	t.Run("Integration", func(t *testing.T) {
 		ctx := context.Background()
 		clock := timeutil.Now
-		store := NewWithClock(getTimescaleDB(t), clock)
+		store := NewWithClock(dbtesting.TimescaleDB(t), clock)
 		t.Run("Insights", func(t *testing.T) { testInsights(t, ctx, store, clock) })
 	})
 }

--- a/enterprise/internal/insights/store/integration_test.go
+++ b/enterprise/internal/insights/store/integration_test.go
@@ -18,7 +18,9 @@ func TestIntegration(t *testing.T) {
 	t.Run("Integration", func(t *testing.T) {
 		ctx := context.Background()
 		clock := timeutil.Now
-		store := NewWithClock(dbtesting.TimescaleDB(t), clock)
+		timescale, cleanup := dbtesting.TimescaleDB(t)
+		defer cleanup()
+		store := NewWithClock(timescale, clock)
 		t.Run("Insights", func(t *testing.T) { testInsights(t, ctx, store, clock) })
 	})
 }


### PR DESCRIPTION
I am going to reuse this code for setting up DB tests for GraphQL resolvers, so putting it into a new package.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>