### PR TITLE
search: remove alert dependency on ParseTree [2/2]

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -490,7 +490,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 			// add it to the user's query, but be smart. For example, if the user's
 			// query was "repo:foo" and the parent is "foobar/", then propose "repo:foobar/"
 			// not "repo:foo repo:foobar/" (which are equivalent, but shorter is better).
-			newExpr := query.AddRegexpField(r.Query.ParseTree(), query.FieldRepo, repoParentPattern)
+			newExpr := query.AddRegexpField(r.Query, query.FieldRepo, repoParentPattern)
 			proposedQueries = append(proposedQueries, &searchQueryDescription{
 				description: fmt.Sprintf("in repositories under %s %s", repoParent, more),
 				query:       newExpr,
@@ -509,7 +509,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 				if i >= maxReposToPropose {
 					break
 				}
-				newExpr := query.AddRegexpField(r.Query.ParseTree(), query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
+				newExpr := query.AddRegexpField(r.Query, query.FieldRepo, "^"+regexp.QuoteMeta(pathToPropose)+"$")
 				proposedQueries = append(proposedQueries, &searchQueryDescription{
 					description: fmt.Sprintf("in the repository %s", strings.TrimPrefix(pathToPropose, "github.com/")),
 					query:       newExpr,

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -85,70 +85,70 @@ func TestAddQueryRegexpField(t *testing.T) {
 			query:      "foo",
 			addField:   "repo",
 			addPattern: "p",
-			want:       "foo repo:p",
+			want:       "repo:p foo",
+		},
+		{
+			query:      "foo repo:p",
+			addField:   "repo",
+			addPattern: "p",
+			want:       "repo:p foo",
 		},
 		{
 			query:      "foo repo:q",
 			addField:   "repo",
 			addPattern: "p",
-			want:       "foo repo:q repo:p",
-		},
-		{
-			query:      "foo repo:p",
-			addField:   "repo",
-			addPattern: "p",
-			want:       "foo repo:p",
+			want:       "repo:q repo:p foo",
 		},
 		{
 			query:      "foo repo:p",
 			addField:   "repo",
 			addPattern: "pp",
-			want:       "foo repo:pp",
+			want:       "repo:pp foo",
 		},
 		{
 			query:      "foo repo:p",
 			addField:   "repo",
 			addPattern: "^p",
-			want:       "foo repo:^p",
+			want:       "repo:^p foo",
 		},
 		{
 			query:      "foo repo:p",
 			addField:   "repo",
 			addPattern: "p$",
-			want:       "foo repo:p$",
+			want:       "repo:p$ foo",
 		},
 		{
 			query:      "foo repo:^p",
 			addField:   "repo",
 			addPattern: "^pq",
-			want:       "foo repo:^pq",
+			want:       "repo:^pq foo",
 		},
 		{
 			query:      "foo repo:p$",
 			addField:   "repo",
 			addPattern: "qp$",
-			want:       "foo repo:qp$",
+			want:       "repo:qp$ foo",
 		},
 		{
 			query:      "foo repo:^p",
 			addField:   "repo",
 			addPattern: "x$",
-			want:       "foo repo:^p repo:x$",
+			want:       "repo:^p repo:x$ foo",
 		},
 		{
 			query:      "foo repo:p|q",
 			addField:   "repo",
 			addPattern: "pq",
-			want:       "foo repo:p|q repo:pq",
+			want:       "repo:p|q repo:pq foo",
 		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%s, add %s:%s", test.query, test.addField, test.addPattern), func(t *testing.T) {
-			parseTree, err := query.Parse(test.query)
+			q, err := query.ParseLiteral(test.query)
 			if err != nil {
 				t.Fatal(err)
 			}
-			got := query.AddRegexpField(parseTree, test.addField, test.addPattern)
+			got := query.AddRegexpField(q, test.addField, test.addPattern)
 			if got != test.want {
 				t.Errorf("got %q, want %q", got, test.want)
 			}
@@ -289,7 +289,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 				proposedQueries: []*searchQueryDescription{
 					{
 						"in the repository a/repoName0",
-						"foo repo:^a/repoName0$",
+						"repo:^a/repoName0$ foo",
 						query.SearchType(0),
 					},
 				},
@@ -320,7 +320,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 				proposedQueries: []*searchQueryDescription{
 					{
 						"in repositories under a (further filtering required)",
-						"foo repo:^a/",
+						"repo:^a/ foo",
 						query.SearchType(0),
 					},
 				},


### PR DESCRIPTION
Stacked on #17998.
Up the stack: #18004.

As per title, see inline comments.