### PR TITLE
search: remove ParseTree from query interface

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -57,7 +57,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 
 	args.applyDefaultsAndConstraints()
 
-	if len(r.Query.ParseTree()) == 0 {
+	if len(r.Query.(*query.AndOrQuery).Query) == 0 {
 		return nil, nil
 	}
 

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -46,7 +46,6 @@ type QueryInfo interface {
 	Fields() map[string][]*types.Value
 	BoolValue(field string) bool
 	IsCaseSensitive() bool
-	ParseTree() syntax.ParseTree
 }
 
 // An ordinary query (not containing and/or expressions).


### PR DESCRIPTION
Stacked on #18003.
Up the stack: #18006.

`ParseTree` is gone 🦀 

This is actually the thing that will let me nuke basically everything else.