### PR TITLE
search: remove use of query.Process

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	querytypes "github.com/sourcegraph/sourcegraph/internal/search/query/types"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -156,7 +155,8 @@ func queryForStableResults(args *SearchArgs, queryInfo query.QueryInfo) (*Search
 		// raise an error otherwise. If stable is explicitly set, this
 		// is implied. So, force this query to only return file content
 		// results.
-		queryInfo.Fields()["type"] = []*querytypes.Value{{String: &fileValue}}
+		nodes := queryInfo.(*query.AndOrQuery).Query
+		queryInfo.(*query.AndOrQuery).Query = query.OverrideField(nodes, "type", fileValue)
 	}
 	return args, queryInfo, nil
 }

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -349,7 +349,7 @@ func TestQuoteSuggestions(t *testing.T) {
 	})
 }
 
-func TestEueryForStableResults(t *testing.T) {
+func TestQueryForStableResults(t *testing.T) {
 	cases := []struct {
 		query           string
 		wantStableCount int32
@@ -370,7 +370,7 @@ func TestEueryForStableResults(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("query for stable results", func(t *testing.T) {
-			queryInfo, _ := query.Process(c.query, query.SearchTypeLiteral)
+			queryInfo, _ := query.ParseLiteral(c.query)
 			args, queryInfo, err := queryForStableResults(&SearchArgs{}, queryInfo)
 			if err != nil {
 				if !reflect.DeepEqual(err, c.wantError) {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -698,6 +698,14 @@ func ellipsesForHoles(nodes []Node) []Node {
 	})
 }
 
+func OverrideField(nodes []Node, field, value string) []Node {
+	// First remove any fields that exist.
+	nodes = MapField(nodes, field, func(_ string, _ bool) Node {
+		return nil
+	})
+	return newOperator(append(nodes, Parameter{Field: field, Value: value}), And)
+}
+
 // OmitQueryField removes all fields `field` from a query. The `field` string
 // should be the canonical name and not an alias ("repo", not "r").
 func OmitQueryField(q QueryInfo, field string) string {


### PR DESCRIPTION
Stacked on #18004.
Up the stack: #18008.

OK I have to get rid of one old `Process` call before removing a lot of things. See inline comment if you are curious about stuff.