### PR TITLE
search: move fields out of searchquery.go

### DIFF
--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -2,6 +2,41 @@ package query
 
 var empty = struct{}{}
 
+// All field names.
+const (
+	FieldDefault            = ""
+	FieldCase               = "case"
+	FieldRepo               = "repo"
+	FieldRepoGroup          = "repogroup"
+	FieldFile               = "file"
+	FieldFork               = "fork"
+	FieldArchived           = "archived"
+	FieldLang               = "lang"
+	FieldType               = "type"
+	FieldRepoHasFile        = "repohasfile"
+	FieldRepoHasCommitAfter = "repohascommitafter"
+	FieldPatternType        = "patterntype"
+	FieldContent            = "content"
+	FieldVisibility         = "visibility"
+	FieldRev                = "rev"
+	FieldContext            = "context"
+
+	// For diff and commit search only:
+	FieldBefore    = "before"
+	FieldAfter     = "after"
+	FieldAuthor    = "author"
+	FieldCommitter = "committer"
+	FieldMessage   = "message"
+
+	// Temporary experimental fields:
+	FieldIndex     = "index"
+	FieldCount     = "count"  // Searches that specify `count:` will fetch at least that number of results, or the full result set
+	FieldStable    = "stable" // Forces search to return a stable result ordering (currently limited to file content matches).
+	FieldMax       = "max"    // Deprecated alias for count
+	FieldTimeout   = "timeout"
+	FieldCombyRule = "rule"
+)
+
 var allFields = map[string]struct{}{
 	FieldCase:               empty,
 	FieldRepo:               empty,

--- a/internal/search/query/searchquery.go
+++ b/internal/search/query/searchquery.go
@@ -10,41 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query/types"
 )
 
-// All field names.
-const (
-	FieldDefault            = ""
-	FieldCase               = "case"
-	FieldRepo               = "repo"
-	FieldRepoGroup          = "repogroup"
-	FieldFile               = "file"
-	FieldFork               = "fork"
-	FieldArchived           = "archived"
-	FieldLang               = "lang"
-	FieldType               = "type"
-	FieldRepoHasFile        = "repohasfile"
-	FieldRepoHasCommitAfter = "repohascommitafter"
-	FieldPatternType        = "patterntype"
-	FieldContent            = "content"
-	FieldVisibility         = "visibility"
-	FieldRev                = "rev"
-	FieldContext            = "context"
-
-	// For diff and commit search only:
-	FieldBefore    = "before"
-	FieldAfter     = "after"
-	FieldAuthor    = "author"
-	FieldCommitter = "committer"
-	FieldMessage   = "message"
-
-	// Temporary experimental fields:
-	FieldIndex     = "index"
-	FieldCount     = "count"  // Searches that specify `count:` will fetch at least that number of results, or the full result set
-	FieldStable    = "stable" // Forces search to return a stable result ordering (currently limited to file content matches).
-	FieldMax       = "max"    // Deprecated alias for count
-	FieldTimeout   = "timeout"
-	FieldCombyRule = "rule"
-)
-
 var (
 	regexpNegatableFieldType = types.FieldType{Literal: types.RegexpType, Quoted: types.RegexpType, Negatable: true}
 	stringFieldType          = types.FieldType{Literal: types.StringType, Quoted: types.StringType}


### PR DESCRIPTION
Stacked on #18006.
Up the stack: #18009.

These field definitions are actually useful and still used, unlike the rest of `searchquery.go`. Prep for removal of `searchquery.go`