### PR TITLE
search: one query type

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -98,7 +98,7 @@ func (*schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	}
 
 	var jsons []interface{}
-	for _, node := range q.(*query.AndOrQuery).Query {
+	for _, node := range q {
 		jsons = append(jsons, toJSON(node))
 	}
 	json, err := json.Marshal(jsons)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -884,7 +884,7 @@ func (r *searchResolver) setQuery(q []query.Node) {
 		r.resolved.MissingRepoRevs = nil
 		r.repoErr = nil
 	}
-	r.Query.(*query.AndOrQuery).Query = q
+	r.Query = q
 }
 
 // evaluatePatternExpression evaluates a search pattern containing and/or expressions.
@@ -909,7 +909,7 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, scopePar
 }
 
 // evaluate evaluates all expressions of a search query.
-func (r *searchResolver) evaluate(ctx context.Context, q []query.Node) (*SearchResultsResolver, error) {
+func (r *searchResolver) evaluate(ctx context.Context, q query.Query) (*SearchResultsResolver, error) {
 	scopeParameters, pattern, err := query.PartitionSearchPattern(q)
 	if err != nil {
 		return alertForQuery("", err).wrap(), nil
@@ -954,42 +954,36 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	switch q := r.Query.(type) {
-	case *query.AndOrQuery:
-		var countStr string
-		wantCount := defaultMaxSearchResults
-		query.VisitField(q.Query, "count", func(value string, _ bool, _ query.Annotation) {
-			countStr = value
-		})
-		if countStr != "" {
-			wantCount, _ = strconv.Atoi(countStr) // Invariant: count is validated.
-		}
+	var countStr string
+	wantCount := defaultMaxSearchResults
+	query.VisitField(r.Query, "count", func(value string, _ bool, _ query.Annotation) {
+		countStr = value
+	})
+	if countStr != "" {
+		wantCount, _ = strconv.Atoi(countStr) // Invariant: count is validated.
+	}
 
-		if invalidateRepoCache(q.Query) {
-			r.invalidateRepoCache = true
+	if invalidateRepoCache(r.Query) {
+		r.invalidateRepoCache = true
+	}
+	for _, disjunct := range query.Dnf(r.Query) {
+		disjunct = query.ConcatRevFilters(disjunct)
+		newResult, err := r.evaluate(ctx, disjunct)
+		if err != nil {
+			// Fail if any subquery fails.
+			return nil, err
 		}
-		for _, disjunct := range query.Dnf(q.Query) {
-			disjunct = query.ConcatRevFilters(disjunct)
-			newResult, err := r.evaluate(ctx, disjunct)
-			if err != nil {
-				// Fail if any subquery fails.
-				return nil, err
+		if newResult != nil {
+			srr = union(srr, newResult)
+			if len(srr.SearchResults) > wantCount {
+				srr.SearchResults = srr.SearchResults[:wantCount]
+				break
 			}
-			if newResult != nil {
-				srr = union(srr, newResult)
-				if len(srr.SearchResults) > wantCount {
-					srr.SearchResults = srr.SearchResults[:wantCount]
-					break
-				}
 
-			}
 		}
-		if srr != nil {
-			r.sortResults(ctx, srr.SearchResults)
-		}
-	default:
-		// Unreachable.
-		return nil, fmt.Errorf("unrecognized type %T in searchResolver Results", r.Query)
+	}
+	if srr != nil {
+		r.sortResults(ctx, srr.SearchResults)
 	}
 	// copy userSettings from searchResolver to SearchResultsResolver
 	if srr != nil {
@@ -1215,7 +1209,7 @@ func isPatternNegated(q []query.Node) bool {
 
 // processSearchPattern processes the search pattern for a query. It handles the interpretation of search patterns
 // as literal, regex, or structural patterns, and applies fuzzy regex matching if applicable.
-func processSearchPattern(q query.QueryInfo, opts *getPatternInfoOptions) (string, bool, bool, bool) {
+func processSearchPattern(q query.Query, opts *getPatternInfoOptions) (string, bool, bool, bool) {
 	var pattern string
 	var pieces []string
 	var contentFieldSet bool
@@ -1223,11 +1217,7 @@ func processSearchPattern(q query.QueryInfo, opts *getPatternInfoOptions) (strin
 	isStructuralPat := false
 
 	patternValues := q.Values(query.FieldDefault)
-
-	isNegated := false
-	if andOrQuery, ok := q.(*query.AndOrQuery); ok {
-		isNegated = isPatternNegated(andOrQuery.Query)
-	}
+	isNegated := isPatternNegated(q)
 
 	if overridePattern := q.Values(query.FieldContent); len(overridePattern) > 0 {
 		patternValues = overridePattern
@@ -1278,7 +1268,7 @@ func processSearchPattern(q query.QueryInfo, opts *getPatternInfoOptions) (strin
 }
 
 // getPatternInfo gets the search pattern info for q
-func getPatternInfo(q query.QueryInfo, opts *getPatternInfoOptions) (*search.TextPatternInfo, error) {
+func getPatternInfo(q query.Query, opts *getPatternInfoOptions) (*search.TextPatternInfo, error) {
 	pattern, isRegExp, isStructuralPat, isNegated := processSearchPattern(q, opts)
 
 	// Handle file: and -file: filters.
@@ -2008,7 +1998,7 @@ func (r *searchResolver) sortResults(ctx context.Context, results []SearchResult
 func (r *searchResolver) getExactFilePatterns() map[string]struct{} {
 	m := map[string]struct{}{}
 	query.VisitField(
-		r.Query.(*query.AndOrQuery).Query,
+		r.Query,
 		query.FieldFile,
 		func(value string, negated bool, annotation query.Annotation) {
 			originalValue := r.OriginalQuery[annotation.Range.Start.Column+len(query.FieldFile)+1 : annotation.Range.End.Column]

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -379,7 +379,7 @@ func TestIsPatternNegated(t *testing.T) {
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
-			got := isPatternNegated(q.(*query.AndOrQuery).Query)
+			got := isPatternNegated(q)
 			if got != tt.want {
 				t.Fatalf("got %t\nwant %t", got, tt.want)
 			}
@@ -960,7 +960,7 @@ func TestCheckDiffCommitSearchLimits(t *testing.T) {
 			context.Background(),
 			&search.TextParameters{
 				RepoPromise: (&search.Promise{}).Resolve(repoRevs),
-				Query:       &query.AndOrQuery{Query: test.fields},
+				Query:       test.fields,
 			},
 			test.resultType)
 
@@ -1062,8 +1062,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 func TestSearchResolver_evaluateWarning(t *testing.T) {
 	q, _ := query.ProcessAndOr("file:foo or file:bar", query.ParserOptions{SearchType: query.SearchTypeRegex, Globbing: false})
 	wantPrefix := "I'm having trouble understanding that query."
-	andOrQuery, _ := q.(*query.AndOrQuery)
-	got, _ := (&searchResolver{}).evaluate(context.Background(), andOrQuery.Query)
+	got, _ := (&searchResolver{}).evaluate(context.Background(), q)
 	t.Run("warn for unsupported and/or query", func(t *testing.T) {
 		if !strings.HasPrefix(got.alert.description, wantPrefix) {
 			t.Fatalf("got alert description %s, want %s", got.alert.description, wantPrefix)

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -51,13 +51,13 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 	if getBoolPtr(r.UserSettings.SearchGlobbing, false) {
 		globbing = true
 	}
-	if AndOrQuery, isAndOr := r.Query.(*query.AndOrQuery); globbing && isAndOr {
-		AndOrQuery.Query = query.FuzzifyRegexPatterns(AndOrQuery.Query)
+	if globbing {
+		r.Query = query.FuzzifyRegexPatterns(r.Query)
 	}
 
 	args.applyDefaultsAndConstraints()
 
-	if len(r.Query.(*query.AndOrQuery).Query) == 0 {
+	if len(r.Query) == 0 {
 		return nil, nil
 	}
 

--- a/internal/search/query/alert.go
+++ b/internal/search/query/alert.go
@@ -16,10 +16,9 @@ import (
 // a query like "x:foo", if given a field "x" with pattern "foobar" to add,
 // it will return a query "x:foobar" instead of "x:foo x:foobar". It is not
 // guaranteed to always return the simplest query.
-func AddRegexpField(q QueryInfo, field, pattern string) string {
+func AddRegexpField(q Query, field, pattern string) string {
 	var modified bool
-	nodes := q.(*AndOrQuery).Query
-	nodes = MapParameter(nodes, func(gotField, value string, negated bool, annotation Annotation) Node {
+	q = MapParameter(q, func(gotField, value string, negated bool, annotation Annotation) Node {
 		if field == gotField && strings.Contains(pattern, value) {
 			value = pattern
 			modified = true
@@ -34,9 +33,9 @@ func AddRegexpField(q QueryInfo, field, pattern string) string {
 
 	if !modified {
 		// use newOperator to reduce And nodes when adding a parameter to the query toplevel.
-		nodes = newOperator(append(nodes, Parameter{Field: field, Value: pattern}), And)
+		q = newOperator(append(q, Parameter{Field: field, Value: pattern}), And)
 	}
-	return StringHuman(nodes)
+	return StringHuman(q)
 }
 
 type ProposedQuery struct {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1060,7 +1060,7 @@ type ParserOptions struct {
 }
 
 // ProcessAndOr query parses and validates an and/or query for a given search type.
-func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
+func ProcessAndOr(in string, options ParserOptions) (Query, error) {
 	var query []Node
 	var err error
 
@@ -1092,13 +1092,13 @@ func ProcessAndOr(in string, options ParserOptions) (QueryInfo, error) {
 			return nil, err
 		}
 	}
-	return &AndOrQuery{Query: query}, nil
+	return query, nil
 }
 
-func ParseLiteral(in string) (QueryInfo, error) {
+func ParseLiteral(in string) (Query, error) {
 	return ProcessAndOr(in, ParserOptions{SearchType: SearchTypeLiteral})
 }
 
-func ParseRegexp(in string) (QueryInfo, error) {
+func ParseRegexp(in string) (Query, error) {
 	return ProcessAndOr(in, ParserOptions{SearchType: SearchTypeRegex})
 }

--- a/internal/search/query/printer_test.go
+++ b/internal/search/query/printer_test.go
@@ -9,7 +9,7 @@ import (
 func TestStringHuman(t *testing.T) {
 	test := func(input string) string {
 		q, _ := ParseLiteral(input)
-		return StringHuman(q.(*AndOrQuery).Query)
+		return StringHuman(q)
 	}
 
 	autogold.Want("00", "a b c").Equal(t, test("a b c"))

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -708,8 +708,8 @@ func OverrideField(nodes []Node, field, value string) []Node {
 
 // OmitQueryField removes all fields `field` from a query. The `field` string
 // should be the canonical name and not an alias ("repo", not "r").
-func OmitQueryField(q QueryInfo, field string) string {
-	return StringHuman(MapField(q.(*AndOrQuery).Query, field, func(_ string, _ bool) Node {
+func OmitQueryField(q Query, field string) string {
+	return StringHuman(MapField(q, field, func(_ string, _ bool) Node {
 		return nil
 	}))
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -109,7 +109,7 @@ func TestSubstituteAliases(t *testing.T) {
 	for _, c := range cases {
 		t.Run("substitute alises", func(t *testing.T) {
 			query, _ := ProcessAndOr(c.input, ParserOptions{SearchType: c.searchType})
-			if diff := cmp.Diff(nodesToJSON(query.(*AndOrQuery).Query), c.want); diff != "" {
+			if diff := cmp.Diff(nodesToJSON(query), c.want); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -383,7 +383,7 @@ func TestEllipsesForHoles(t *testing.T) {
 	want := `"if :[_] { :[_] }"`
 	t.Run("Ellipses for holes", func(t *testing.T) {
 		query, _ := ProcessAndOr(input, ParserOptions{SearchType: SearchTypeStructural})
-		got := prettyPrint(query.(*AndOrQuery).Query)
+		got := prettyPrint(query)
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatal(diff)
 		}

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -104,7 +104,7 @@ type TextParameters struct {
 	// Query is the parsed query from the user. You should be using Pattern
 	// instead, but Query is useful for checking extra fields that are set and
 	// ignored by Pattern, such as index:no
-	Query query.QueryInfo
+	Query query.Query
 
 	// UseFullDeadline indicates that the search should try do as much work as
 	// it can within context.Deadline. If false the search should try and be


### PR DESCRIPTION
Stacked on #18009.

- No more `QueryInfo`, no more `AndOrQuery`.
- Removes all the `*query.AndOrQuery` assertions.
- Only `type Query []Node`