### PR TITLE
graphql: Sync status messages are user specific

### DIFF
--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -11,12 +11,17 @@ import (
 )
 
 func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageResolver, error) {
-	// 🚨 SECURITY: Only site admins can see status messages.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	currentUser, err := backend.CurrentUser(ctx)
+	if err != nil {
 		return nil, err
 	}
+	if currentUser == nil {
+		return nil, backend.ErrNotAuthenticated
+	}
 
-	messages, err := repos.FetchStatusMessages(ctx, r.db)
+	// 🚨 SECURITY: Users will fetch status messages for any external services they
+	// own. In addition, site admins will also fetch site level external services.
+	messages, err := repos.FetchStatusMessages(ctx, r.db, currentUser)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/status_messages_test.go
+++ b/cmd/frontend/graphqlbackend/status_messages_test.go
@@ -48,28 +48,13 @@ func TestStatusMessages(t *testing.T) {
 		}
 	})
 
-	t.Run("authenticated as non-site-admin", func(t *testing.T) {
-		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
-			return &types.User{ID: 1, SiteAdmin: false}, nil
-		}
-		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
-
-		result, err := (&schemaResolver{}).StatusMessages(context.Background())
-		if want := backend.ErrMustBeSiteAdmin; err != want {
-			t.Errorf("got err %v, want %v", err, want)
-		}
-		if result != nil {
-			t.Errorf("got result %v, want nil", result)
-		}
-	})
-
 	t.Run("no messages", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
 			return &types.User{ID: 1, SiteAdmin: true}, nil
 		}
 		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
 
-		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
+		repos.MockStatusMessages = func(_ context.Context, _ *types.User) ([]repos.StatusMessage, error) {
 			return []repos.StatusMessage{}, nil
 		}
 		defer func() { repos.MockStatusMessages = nil }()
@@ -98,7 +83,7 @@ func TestStatusMessages(t *testing.T) {
 		}
 		defer func() { database.Mocks.ExternalServices.GetByID = nil }()
 
-		repos.MockStatusMessages = func(_ context.Context) ([]repos.StatusMessage, error) {
+		repos.MockStatusMessages = func(_ context.Context, _ *types.User) ([]repos.StatusMessage, error) {
 			res := []repos.StatusMessage{
 				{
 					Cloning: &repos.CloningProgress{

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -40,6 +40,16 @@ func TestStatusMessages(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	user1, err := database.Users(db).Create(ctx, database.NewUser{
+		Email:                 "a1@example.com",
+		Username:              "u1",
+		Password:              "p",
+		EmailVerificationCode: "c",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	testCases := []struct {
 		name            string
 		stored          types.Repos
@@ -211,7 +221,7 @@ func TestStatusMessages(t *testing.T) {
 				tc.err = "<nil>"
 			}
 
-			res, err := FetchStatusMessages(ctx, db)
+			res, err := FetchStatusMessages(ctx, db, user1)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("have err: %q, want: %q", have, want)
 			}


### PR DESCRIPTION
When fetching external service sync messages we now take into account
the current user.

We fetch sync errors for any services owned by the current user and if
they are site admins then additionally any site level external services.

Closes: https://github.com/sourcegraph/sourcegraph/issues/17688