### PR TITLE
Link campaign doc to cli reference

### DIFF
--- a/doc/campaigns/index.md
+++ b/doc/campaigns/index.md
@@ -104,3 +104,4 @@ Create a campaign by specifying a search query to get a list of repositories and
 - [Campaign spec YAML reference](references/campaign_spec_yaml_reference.md)
 - [Campaign spec templating](references/campaign_spec_templating.md)
 - [Troubleshooting](references/troubleshooting.md)
+- [CLI](../cli/references/campaigns/index.md)

--- a/doc/campaigns/references/index.md
+++ b/doc/campaigns/references/index.md
@@ -4,3 +4,4 @@
 - [Campaign spec templating](campaign_spec_templating.md)
 - [Troubleshooting](troubleshooting.md)
 - [Requirements](requirements.md)
+- [CLI](../../cli/references/campaigns/index.md)


### PR DESCRIPTION
It is hard for a user to find what they can do with the campaigns CLI. For example, users have trouble finding the `-ski-errors command`.