### PR TITLE
search: don't run global search path if index:no

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1772,9 +1772,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return false
 	}
 
+	isIndexedSearch := args.PatternInfo.Index != query.No
+
 	// performance optimization: call zoekt early, resolve repos concurrently, filter
 	// search results with resolved repos.
-	if r.isGlobalSearch() && isFileOrPath() {
+	if r.isGlobalSearch() && isIndexedSearch && isFileOrPath() {
 		argsIndexed := args
 		argsIndexed.Mode = search.ZoektGlobalSearch
 		wg := waitGroup(true)


### PR DESCRIPTION
This fixes a bug that was uncovered by a seemingly unrelated integration test:

```
	t.Run("timeout search options", func(t *testing.T) {
		results, err := client.SearchFiles(`router index:no timeout:1ns`)
                ...
	})
```

We ran the perf optimized global search path even if `index:no` was specified
by the user. The bug revealed itself once we changed things around context handling
in zoekt.go (addressed in #17977).



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
