### PR TITLE
codeintel: Ensure txn is used for bulk inserts

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/commits.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits.go
@@ -222,7 +222,7 @@ func (s *Store) CalculateVisibleUploads(ctx context.Context, repositoryID int, c
 	// Update the set of uploads that are visible from each commit for a given repository.
 	nearestUploadsInserter := batch.NewBatchInserter(
 		ctx,
-		s.Store.Handle().DB(),
+		tx.Handle().DB(),
 		"lsif_nearest_uploads",
 		"repository_id",
 		"commit_bytea",
@@ -235,7 +235,7 @@ func (s *Store) CalculateVisibleUploads(ctx context.Context, repositoryID int, c
 	// graph AND the number of unique roots.
 	nearestUploadsLinksInserter := batch.NewBatchInserter(
 		ctx,
-		s.Store.Handle().DB(),
+		tx.Handle().DB(),
 		"lsif_nearest_uploads_links",
 		"repository_id",
 		"commit_bytea",
@@ -291,7 +291,7 @@ func (s *Store) CalculateVisibleUploads(ctx context.Context, repositoryID int, c
 	// find references query.
 	uploadsVisibleAtTipInserter := batch.NewBatchInserter(
 		ctx,
-		s.Store.Handle().DB(),
+		tx.Handle().DB(),
 		"lsif_uploads_visible_at_tip",
 		"repository_id",
 		"upload_id",


### PR DESCRIPTION
When we recalculate the commit graph for a repository, we (were supposed to) delete all the existing records for that repository and bulk insert the new rows within a transaction. It turns out only the deletion was in a transaction and the uploads happened outside of the transaction.

This caused an issue at a [customer](https://github.com/sourcegraph/customer/issues/196) to have 2x the number of records than expected in the lsif_nearest_uploads table. It looks like the deletion got rolled back but the insertions still succeeded at least once.

Not sure if it solves the linked issue completely, but it should help it from recurring.