### PR TITLE
Reference managed instances in installation docs

### DIFF
--- a/doc/admin/install/index.md
+++ b/doc/admin/install/index.md
@@ -1,5 +1,12 @@
 # Installing Sourcegraph
 
+You can opt to use Sourcegraph as a [self-hosted](#self-hosted) deployment or [managed instance](#managed-instances).
+## Managed instances
+
+The Sourcegraph team can host and manage a Sourcegraph instance for you. This makes them a simple choice for customers that want to utilize Sourcegraph but do not wish to manage its deployment and maintenance. You can find more details in its [installation page](managed.md).
+
+## Self-hosted
+
 | Deployment Type                                       | Suggested for                                       | Setup time | Multi-machine? | Auto healing? | Monitoring? |
 |-------------------------------------------------------|-----------------------------------------------------|------------|----------------|---------------|-------------|
 | [Single-container server](../install/docker/index.md) | Local testing                                       | 60 seconds | No             | No            | No          |
@@ -10,6 +17,6 @@
 * If you're just starting out, we recommend [running Sourcegraph locally](docker/index.md). It takes only a few minutes and lets you try out all of the features.
 * If you need scalability and high-availability beyond what a single-node [Docker Compose](https://docs.docker.com/compose/) can offer, use the [Kubernetes cluster deployment option](https://github.com/sourcegraph/deploy-sourcegraph), instead.
 
-## Resource estimator
+### Resource estimator
 
 Use the [resource estimator](resource_estimator.md) to find a good starting point for your deployment.

--- a/doc/admin/install/managed.md
+++ b/doc/admin/install/managed.md
@@ -10,7 +10,7 @@ Please [contact us](https://about.sourcegraph.com/contact/sales) to discuss [pri
 
 ## Scaling
 
-Managed instances support most small to large enterprises well. Please [contact us](https://about.sourcegraph.com/contact/sales) to discuss options.
+Managed instances can be used by most enterprises of any size. Please [contact us](https://about.sourcegraph.com/contact/sales) to discuss options.
 
 # Service
 

--- a/doc/admin/install/managed.md
+++ b/doc/admin/install/managed.md
@@ -1,6 +1,6 @@
 # Managed Sourcegraph instances
 
-Managed instances are provision and managed by the Sourcegraph team, making them a simple choice for customers to deploy Sourcegraph without having to worry about managing it.
+Managed instances are provisioned and managed by the Sourcegraph team, making them a simple choice for customers to deploy Sourcegraph without having to worry about managing it.
 
 Sourcegraph provisions your instance in a completely isolated and secure cloud infrastructure. It will be restricted to only your organization through your enterprise VPN and/or SSO provider of choice.
 

--- a/doc/admin/install/managed.md
+++ b/doc/admin/install/managed.md
@@ -1,26 +1,22 @@
 # Managed Sourcegraph instances
 
-The Sourcegraph team can host and manage a Sourcegraph instance for you on our Google Cloud infrastructure at e.g. https://example.sourcegraph.com.
+Managed instances are provision and managed by the Sourcegraph team, making them a simple choice for customers to deploy Sourcegraph without having to worry about managing it.
 
-If you are interested in this service, please [contact us](https://about.sourcegraph.com/contact/sales) to start a trial or discuss [pricing](https://about.sourcegraph.com/pricing) and requirements.
+Sourcegraph provisions your instance in a completely isolated and secure cloud infrastructure. It will be restricted to only your organization through your enterprise VPN and/or SSO provider of choice.
 
-## Overview
-
-The Sourcegraph team will provision and manage a Sourcegraph deployment for you in completely isolated and secure cloud infrastructure. It will be restricted to only your organization through your enterprise VPN and/or SSO provider of choice.
-
-### Costs
+## Costs
 
 Please [contact us](https://about.sourcegraph.com/contact/sales) to discuss [pricing](https://about.sourcegraph.com/pricing) and to start a trial.
 
-### Scaling
+## Scaling
 
-Managed instances support most small to large enterprises well, but due to technical limitations cannot support extra-large organizations requiring a cluster deployment. Please [contact us](https://about.sourcegraph.com/contact/sales) to discuss options.
+Managed instances support most small to large enterprises well. Please [contact us](https://about.sourcegraph.com/contact/sales) to discuss options.
 
-## Service
+# Service
 
 As part of this service you will receive a number of benefits from our team, including:
 
-### Initial setup, configuration, and cost estimation
+## Initial setup, configuration, and cost estimation
 
 - Advising if managed instances are right for your organization.
 - Initial resource estimations based on your organization & code size.
@@ -32,22 +28,22 @@ As part of this service you will receive a number of benefits from our team, inc
   - [Integrating your single sign-on provider with Sourcegraph](../auth/index.md)
   - [Configuring Sourcegraph](../config/index.md)
 
-### Access restrictions
+## Access restrictions
 
 - Granting your team application-level admin access to the instance.
 - Configuring any IP-restrictions (e.g. VPN) and/or SSO restrictions to the instance.
 
-### Monthly upgrades and maintenance
+## Monthly upgrades and maintenance
 
 - Automatic monthly [upgrades](../updates.md) and maintenance.
 - Regular reassessment of resource utilization based on your organization's unique usage to determine if costs can be reduced without impact to service. Additionally, you will automatically benefit from any committed use cloud provider discounts we receive.
 
-### Health monitoring, support, and SLAs
+## Health monitoring, support, and SLAs
 
 - Instance performance and health [monitored](../observability/index.md) by our team's on-call engineers.
 - [Responding to support requests and maintaining SLAs](https://about.sourcegraph.com/handbook/ce/support#for-customers-with-managed-instances)
 
-### Training, feedback, and engagement
+## Training, feedback, and engagement
 
 As with any Sourcegraph enterprise customer, you will also receive support from us with:
 
@@ -60,22 +56,22 @@ As with any Sourcegraph enterprise customer, you will also receive support from 
   - Holding ongoing brown bag lunches to introduce new feature releases
   - Advice and templates on how to introduce Sourcegraph to your engineering organization
 
-## Requirements
+# Requirements
 
-### Business
+## Business
 
 - A dedicated project manager point of contact for the rollout process
 - A mutual non-disclosure agreement, and any additional approvals or special status required to allow Sourcegraph to manage infrastructure access tokens (listed below)
 - Acceptance of our [Terms of Service for private instances](https://about.sourcegraph.com/terms-private) or an enterprise contract
 
-### Technical
+## Technical
 
-- A dedicated technical point of contact for the installation process
+- A dedicated technical point of contact for the installation process.
 - [Tokens with read access to your code hosts](../external_service/index.md) (we will direct you on how to enter them)
 - [Keys, access tokens, or any other setup required to integrate your SSO (single sign-on) provider with Sourcegraph](../auth/index.md), as well as support from a member of your team with administrator access to your SSO provider to help set up and test the integration.
 - If you desire VPN/IP-restricted access, we will need to know the IP/CIDR source ranges of your enterprise VPN to allow access to the instance.
 
-## Security
+# Security
 
 Your managed instance will be accessible over HTTPS/TLS, provide storage volumes that are encrypted at rest, and would have access restricted to only your team through your enterprise VPN and/or internal [SSO (single sign-on provider)](../auth/index.md) of choice.
 
@@ -83,6 +79,6 @@ It will be hosted in completely isolated Google Cloud infrastructure, with minim
 
 Only essential Sourcegraph personnel will have access to the instance, server, code, and any other sensitive materials, such as tokens or keys. The employees or contractors with access would be bound by the same terms as Sourcegraph itself. Learn more in our [network security policies for Sourcegraph Cloud](https://about.sourcegraph.com/security) or [contact us](https://about.sourcegraph.com/contact/sales) with any questions/concerns.
 
-## Accommodating special requirements
+# Accommodating special requirements
 
 We may be able to support special requests (network access policies, infrastructure requirements, custom version control systems, etc.) with additional time, support, and fees. [Contact us](https://about.sourcegraph.com/contact/sales) to discuss any special requirements you may have.

--- a/doc/index.md
+++ b/doc/index.md
@@ -58,7 +58,7 @@ running Sourcegraph 3.1 and want to upgrade to 3.3, you should upgrade to 3.2 an
 
 ### Core documentation
 
-- [Install](admin/install/index.md) or [update](admin/updates.md) Sourcegraph 
+- [Install](admin/install/index.md) or [update](admin/updates.md) Sourcegraph
 - [Using Sourcegraph](getting-started/index.md)
 - [Administration](admin/index.md)
 - [Extensions](extensions/index.md)
@@ -74,9 +74,10 @@ running Sourcegraph 3.1 and want to upgrade to 3.3, you should upgrade to 3.2 an
 
 ## Sourcegraph subscriptions
 
-You can use Sourcegraph in 2 ways:
+You can use Sourcegraph in 3 ways:
 
 - [Self-hosted](admin/install/index.md): Deploy and manage your own Sourcegraph instance.
+- [Managed instance](admin/install/managed.md): A private Sourcegraph deployment managed by Sourcegraph.
 - [Sourcegraph Cloud](https://sourcegraph.com/search): For public code only. No signup or installation required.
 
 For self-hosted Sourcegraph instances, you run a Docker image or Kubernetes cluster on-premises or on your preferred cloud provider. There are [3 tiers](https://about.sourcegraph.com/pricing): Core, Team, and Enterprise. Team and Enterprise features require a [Sourcegraph subscription](https://about.sourcegraph.com/contact/sales).


### PR DESCRIPTION
Managed instances are a bit hidden in our docs at the moment, we would like to bring them to the main page so they get more visibility.