### PR TITLE
dbconn: stop leaking DB connections everytime we migrate

### DIFF
--- a/internal/database/dbconn/migration.go
+++ b/internal/database/dbconn/migration.go
@@ -59,7 +59,11 @@ func MigrateDB(db *sql.DB, database *Database) error {
 	if err != nil {
 		return err
 	}
-	defer m.Close()
+	defer func() {
+		if err := m.Close(); err != nil {
+			log15.Error("MigrateDB closing", "err", err, "database", database.Name)
+		}
+	}()
 	if err := DoMigrate(m); err != nil {
 		return errors.Wrap(err, "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
 	}

--- a/internal/database/dbconn/migration.go
+++ b/internal/database/dbconn/migration.go
@@ -60,8 +60,8 @@ func MigrateDB(db *sql.DB, database *Database) error {
 		return err
 	}
 	defer func() {
-		if err := m.Close(); err != nil {
-			log15.Error("MigrateDB closing", "err", err, "database", database.Name)
+		if srcErr, dbErr := m.Close(); srcErr != nil || dbErr != nil {
+			log15.Error("MigrateDB closing", "srcErr", srcErr, "dbErr", dbErr, "database", database.Name)
 		}
 	}()
 	if err := DoMigrate(m); err != nil {

--- a/internal/database/dbconn/migration.go
+++ b/internal/database/dbconn/migration.go
@@ -59,6 +59,7 @@ func MigrateDB(db *sql.DB, database *Database) error {
 	if err != nil {
 		return err
 	}
+	defer m.Close()
 	if err := DoMigrate(m); err != nil {
 		return errors.Wrap(err, "Failed to migrate the DB. Please contact support@sourcegraph.com for further assistance")
 	}


### PR DESCRIPTION
This will probably help a bit with our "DB connections is too low" issue...

![](https://media3.giphy.com/media/RKZJ7hsNjdb3ICpZbo/giphy.gif)

Prior to this change, any call to `dbconn.MigrateDB` would leak a DB
connection. This is because `dbconn.NewMigrate` duplicates the connection:

```
	driver, err := postgres.WithInstance(db, &postgres.Config{
		MigrationsTable: database.MigrationsTable,
	})
```

I only caught this because I was writing test code which tried to migrate
the code insights database, and then drop the database I created for a
test. It always failed, despite my cleanup code working correctly:

```
dropping test database ERROR: database "insights_test_testresolver_insights" is being accessed by other users (SQLSTATE 55006)
```

It turned out that commenting out `dbconn.MigrateDB` fixed it - leading me
to find this bug.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>