### PR TITLE
insights: add very basic GraphQL resolver integration test

### DIFF
--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -2,11 +2,13 @@ package resolvers
 
 import (
 	"context"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 var _ graphqlbackend.InsightsResolver = &Resolver{}
@@ -19,8 +21,14 @@ type Resolver struct {
 
 // New returns a new Resolver whose store uses the given Timescale and Postgres DBs.
 func New(timescale, postgres dbutil.DB) graphqlbackend.InsightsResolver {
+	return newWithClock(timescale, postgres, timeutil.Now)
+}
+
+// newWithClock returns a new Resolver whose store uses the given Timescale and Postgres DBs, and the given
+// clock for timestamps.
+func newWithClock(timescale, postgres dbutil.DB, clock func() time.Time) graphqlbackend.InsightsResolver {
 	return &Resolver{
-		store:        store.New(timescale),
+		store:        store.NewWithClock(timescale, clock),
 		settingStore: database.Settings(postgres),
 	}
 }

--- a/enterprise/internal/insights/resolvers/resolver_test.go
+++ b/enterprise/internal/insights/resolvers/resolver_test.go
@@ -1,0 +1,40 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	insightsdbtesting "github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+)
+
+func init() {
+	dbtesting.DBNameSuffix = "insightsresolvers"
+}
+
+// TestResolver_Insights just checks that root resolver setup and getting an insights connection
+// does not result in any errors. It is a pretty minimal test.
+func TestResolver_Insights(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	ctx := backend.WithAuthzBypass(context.Background())
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	clock := func() time.Time { return now }
+	timescale, cleanup := insightsdbtesting.TimescaleDB(t)
+	defer cleanup()
+	postgres := dbtesting.GetDB(t)
+	resolver := newWithClock(timescale, postgres, clock)
+
+	insightsConnection, err := resolver.Insights(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if insightsConnection == nil {
+		t.Fatal("got nil")
+	}
+}


### PR DESCRIPTION
This is mostly just spec'cing out how other GraphQL resolver integration tests in this package will work.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
