### PR TITLE
Link list of extensions repos to architecture overview

### DIFF
--- a/doc/dev/background-information/architecture/index.md
+++ b/doc/dev/background-information/architecture/index.md
@@ -141,6 +141,7 @@ Some core features of Sourcegraph, like displaying code intelligence hover toolt
 If you want to learn more about our extension API:
 
 - [Sourcegraph extension architecture](sourcegraph-extensions.md)
+- [Repository list of Sourcegraph-maintained extensions](https://docs.google.com/document/d/1zxrDabs9bEgGENuDPF8Zb6zYvxNASxnKnUKOfk_Yv1o/edit?usp=sharing)
 
 ## src-cli
 


### PR DESCRIPTION
Link a list of Sourcegraph-maintained extensions repos (not all of them are owned by Sourcegraph). 

Is there a better place for this info? I notice we don't have a "Developing extensions" section [on this page ](https://docs.sourcegraph.com/dev/background-information) (perhaps we should eventually make one cc @jeanduplessis ? Or is this information well-covered in other sections?)  