### PR TITLE
search: only send repositoriesCount in final event

### DIFF
--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -66,7 +66,7 @@ func (p *progressAggregator) Final() api.Progress {
 
 	// We only send RepositoriesCount at the end because the number is
 	// confusing to users to see while searching.
-	s.RepositoriesCount = len(p.Stats.Repos)
+	s.RepositoriesCount = intPtr(len(p.Stats.Repos))
 
 	event := api.BuildProgressEvent(s)
 	event.Done = true
@@ -89,4 +89,8 @@ func getNames(stats streaming.Stats, status searchshared.RepoStatus) []api.Namer
 		}
 	})
 	return names
+}
+
+func intPtr(i int) *int {
+	return &i
 }

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -17,7 +17,7 @@ func BuildProgressEvent(stats ProgressStats) Progress {
 	}
 
 	return Progress{
-		RepositoriesCount: intPtr(stats.RepositoriesCount),
+		RepositoriesCount: stats.RepositoriesCount,
 		MatchCount:        stats.MatchCount,
 		DurationMs:        stats.ElapsedMilliseconds,
 		Skipped:           skipped,
@@ -31,7 +31,7 @@ type Namer interface {
 type ProgressStats struct {
 	MatchCount          int
 	ElapsedMilliseconds int
-	RepositoriesCount   int
+	RepositoriesCount   *int
 	ExcludedArchived    int
 	ExcludedForks       int
 
@@ -172,10 +172,6 @@ var skippedHandlers = []func(stats ProgressStats) (Skipped, bool){
 	shardTimeoutHandler,
 	excludedForkHandler,
 	excludedArchiveHandler,
-}
-
-func intPtr(i int) *int {
-	return &i
 }
 
 func number(i int) string {

--- a/internal/search/streaming/api/progress_test.go
+++ b/internal/search/streaming/api/progress_test.go
@@ -18,10 +18,13 @@ func TestSearchProgress(t *testing.T) {
 	}
 	cases := map[string]ProgressStats{
 		"empty": {},
+		"zeroresults": {
+			RepositoriesCount: intPtr(0),
+		},
 		"timedout100": {
 			MatchCount:          0,
 			ElapsedMilliseconds: 0,
-			RepositoriesCount:   100,
+			RepositoriesCount:   intPtr(100),
 			ExcludedArchived:    0,
 			ExcludedForks:       0,
 			Timedout:            timedout100,
@@ -32,7 +35,7 @@ func TestSearchProgress(t *testing.T) {
 		"all": {
 			MatchCount:          1,
 			ElapsedMilliseconds: 0,
-			RepositoriesCount:   5,
+			RepositoriesCount:   intPtr(5),
 			ExcludedArchived:    1,
 			ExcludedForks:       5,
 			Timedout:            []Namer{repo{"timedout-1"}},
@@ -58,4 +61,8 @@ type repo struct {
 
 func (r repo) Name() string {
 	return r.name
+}
+
+func intPtr(i int) *int {
+	return &i
 }

--- a/internal/search/streaming/api/testdata/golden/TestSearchProgress/zeroresults.json
+++ b/internal/search/streaming/api/testdata/golden/TestSearchProgress/zeroresults.json
@@ -1,5 +1,6 @@
 {
   "done": false,
+  "repositoriesCount": 0,
   "matchCount": 0,
   "durationMs": 0,
   "skipped": []

--- a/internal/search/streaming/api/types.go
+++ b/internal/search/streaming/api/types.go
@@ -7,7 +7,7 @@ type Progress struct {
 
 	// RepositoriesCount is the number of repositories being searched. It is
 	// non-nil once the set of repositories has been resolved.
-	RepositoriesCount *int `json:"repositoriesCount"`
+	RepositoriesCount *int `json:"repositoriesCount,omitempty"`
 
 	// MatchCount is number of non-overlapping matches. If skipped is
 	// non-empty, then this is a lower bound.


### PR DESCRIPTION
We needed to make RepositoriesCount a pointer with "omitempty" option so
we only send the value when the pointer is set.

Co-authored-by: @stefanhengl 
