### PR TITLE
Append em without whitespace to code-font-size

### DIFF
--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -10,7 +10,7 @@ $code-font-size: (12/14) + em;
 }
 
 code,
-.code {
+.codelike {
     font-family: $code-font-family;
     font-size: $code-font-size;
     line-height: (16/12);

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -10,7 +10,7 @@ $code-font-size: (12/14) + em;
 }
 
 code,
-.codelike {
+.text-code {
     font-family: $code-font-family;
     font-size: $code-font-size;
     line-height: (16/12);

--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -1,5 +1,5 @@
 $code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
-$code-font-size: (12/14) em;
+$code-font-size: (12/14) + em;
 
 .theme-dark {
     --code-bg: var(--color-bg-2);

--- a/client/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/client/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -26,7 +26,7 @@ export const PlainQueryInput: React.FunctionComponent<MonacoQueryInputProps> = (
             <input
                 type="text"
                 autoFocus={autoFocus}
-                className="form-control code lazy-monaco-query-input--intermediate-input"
+                className="form-control codelike lazy-monaco-query-input--intermediate-input"
                 value={queryState.query}
                 onChange={onInputChange}
                 spellCheck={false}

--- a/client/web/src/search/input/LazyMonacoQueryInput.tsx
+++ b/client/web/src/search/input/LazyMonacoQueryInput.tsx
@@ -26,7 +26,7 @@ export const PlainQueryInput: React.FunctionComponent<MonacoQueryInputProps> = (
             <input
                 type="text"
                 autoFocus={autoFocus}
-                className="form-control codelike lazy-monaco-query-input--intermediate-input"
+                className="form-control text-code lazy-monaco-query-input--intermediate-input"
                 value={queryState.query}
                 onChange={onInputChange}
                 spellCheck={false}

--- a/client/web/src/search/input/__snapshots__/LazyMonacoQueryInput.test.tsx.snap
+++ b/client/web/src/search/input/__snapshots__/LazyMonacoQueryInput.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`PlainQueryInput empty 1`] = `
   className="query-input2 d-flex"
 >
   <input
-    className="form-control code lazy-monaco-query-input--intermediate-input"
+    className="form-control text-code lazy-monaco-query-input--intermediate-input"
     onChange={[Function]}
     spellCheck={false}
     type="text"
@@ -93,7 +93,7 @@ exports[`PlainQueryInput with query 1`] = `
   className="query-input2 d-flex"
 >
   <input
-    className="form-control code lazy-monaco-query-input--intermediate-input"
+    className="form-control text-code lazy-monaco-query-input--intermediate-input"
     onChange={[Function]}
     spellCheck={false}
     type="text"


### PR DESCRIPTION
Sass takes whitespace literally here, we have to use the + operator to actually append the unit

![image](https://user-images.githubusercontent.com/9516420/107227020-c7dc6f00-6a12-11eb-920f-cfba80f29b6a.png)
