### PR TITLE
Linking to docker compose instructions

### DIFF
--- a/doc/admin/install/docker/aws.md
+++ b/doc/admin/install/docker/aws.md
@@ -2,7 +2,7 @@
 
 This tutorial shows you how to deploy Sourcegraph to a single EC2 instance on AWS.
 
-> NOTE: Trying to decide how to deploy Sourcegraph? See [our recommendations](../index.md) for how to chose a deployment type that suits your needs.
+> NOTE: We *do not* recommend using this method for a production instance. If deploying a production instance, see [our recommendations](../index.md) for how to chose a deployment type that suits your needs. We recommend [Docker Compose](../docker-compose/aws.md) for most initial production deployments.
 
 ---
 


### PR DESCRIPTION
Changes suggested at https://sourcegraph.slack.com/archives/C07KZF47K/p1612810956316100. Does this seem like it hits the points we want to?