### PR TITLE
search: remove FileMatch.MatchCount

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -40,7 +40,6 @@ type FileMatch struct {
 	JPath        string       `json:"Path"`
 	JLineMatches []*lineMatch `json:"LineMatches"`
 	JLimitHit    bool         `json:"LimitHit"`
-	MatchCount   int          // Number of matches. Different from len(JLineMatches), as multiple lines may correspond to one logical match.
 	symbols      []*searchSymbolResult
 	uri          string
 	Repo         *types.RepoName
@@ -130,16 +129,18 @@ func (fm *FileMatchResolver) path() string {
 func (fm *FileMatchResolver) appendMatches(src *FileMatchResolver) {
 	fm.JLineMatches = append(fm.JLineMatches, src.JLineMatches...)
 	fm.symbols = append(fm.symbols, src.symbols...)
-	fm.MatchCount += src.MatchCount
 	fm.JLimitHit = fm.JLimitHit || src.JLimitHit
 }
 
 func (fm *FileMatchResolver) ResultCount() int32 {
-	rc := len(fm.symbols) + fm.MatchCount
-	if rc > 0 {
-		return int32(rc)
+	rc := len(fm.symbols)
+	for _, m := range fm.JLineMatches {
+		rc += len(m.JOffsetAndLengths)
 	}
-	return 1 // 1 to count "empty" results like type:path results
+	if rc == 0 {
+		return 1 // 1 to count "empty" results like type:path results
+	}
+	return int32(rc)
 }
 
 // lineMatch is the struct used by vscode to receive search results for a line
@@ -232,7 +233,6 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 				JPath:        fm.Path,
 				JLineMatches: lineMatches,
 				JLimitHit:    fm.LimitHit,
-				MatchCount:   fm.MatchCount,
 				Repo:         repo,
 				uri:          workspace + fm.Path,
 				CommitID:     commit,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -365,9 +365,8 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 			}
 
 			var lines []*lineMatch
-			var matchCount int
 			if typ != symbolRequest {
-				lines, matchCount = zoektFileMatchToLineMatches(maxLineFragmentMatches, &file)
+				lines = zoektFileMatchToLineMatches(maxLineFragmentMatches, &file)
 			}
 
 			for _, inputRev := range inputRevs {
@@ -382,7 +381,6 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 						JPath:        file.FileName,
 						JLineMatches: lines,
 						JLimitHit:    fileLimitHit,
-						MatchCount:   matchCount, // We do not use resp.MatchCount because it counts the number of lines matched, not the number of fragments.
 						uri:          fileMatchURI(repo.Name, inputRev, file.FileName),
 						symbols:      symbols,
 						Repo:         repo,
@@ -423,8 +421,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	return nil
 }
 
-func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) ([]*lineMatch, int) {
-	var matchCount int
+func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) []*lineMatch {
 	lines := make([]*lineMatch, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {
@@ -441,7 +438,6 @@ func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMat
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 			offsets[k] = [2]int32{int32(offset), int32(length)}
 		}
-		matchCount += len(offsets)
 		lines = append(lines, &lineMatch{
 			JPreview:          string(l.Line),
 			JLineNumber:       int32(l.LineNumber - 1),
@@ -449,7 +445,7 @@ func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMat
 		})
 	}
 
-	return lines, matchCount
+	return lines
 }
 
 func escape(s string) string {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -199,6 +199,7 @@ func TestIndexedSearch(t *testing.T) {
 				},
 				since: func(time.Time) time.Duration { return 0 },
 			},
+			wantMatchCount: 3,
 			wantCommon: streaming.Stats{
 				Status: mkStatusMap(map[string]search.RepoStatus{
 					"foo/bar": search.RepoStatusSearched | search.RepoStatusIndexed,
@@ -243,6 +244,7 @@ func TestIndexedSearch(t *testing.T) {
 			wantMatchURLs: []string{
 				"git://foo/bar?HEAD#baz.go",
 			},
+			wantMatchCount:     1,
 			wantMatchInputRevs: []string{"HEAD"},
 		},
 		{
@@ -330,7 +332,7 @@ func TestIndexedSearch(t *testing.T) {
 			var gotMatchURLs []string
 			var gotMatchInputRevs []string
 			for _, m := range gotFm {
-				gotMatchCount += m.MatchCount
+				gotMatchCount += int(m.ResultCount())
 				gotMatchURLs = append(gotMatchURLs, m.Resource())
 				if m.InputRev != nil {
 					gotMatchInputRevs = append(gotMatchInputRevs, *m.InputRev)


### PR DESCRIPTION
The value of MatchCount is computed as the number of line fragments for
both indexed and unindexed search. Instead we can just compute that
number in the resolver.

Part of https://github.com/sourcegraph/sourcegraph/issues/18076