### PR TITLE
search: only send limit hit if we exceed limit

### DIFF
--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -41,7 +41,9 @@ func (s *limitStream) Send(event SearchEvent) {
 	// Only send IsLimitHit once. Can race with other sends and be sent
 	// multiple times, but this is fine. Want to avoid lots of noop events
 	// after the first IsLimitHit.
-	if old >= 0 && s.remaining.Load() < 0 {
+	//
+	// We send after -1 to ensure we have passed the limit.
+	if old >= 0 && s.remaining.Load() < -1 {
 		s.s.Send(SearchEvent{Stats: streaming.Stats{IsLimitHit: true}})
 		s.cancel()
 	}


### PR DESCRIPTION
If we have 10 results for a search and specify count:10 then we
shouldn't show to the user limithit. So instead we search for 11
results. This is work towards improving how we communicate limit and
result counts.

Part of https://github.com/sourcegraph/sourcegraph/issues/18076