### PR TITLE
Remove orphan comment

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -33,9 +33,6 @@ const maxUnindexedRepoRevSearchesPerQuery = 200
 // A global limiter on number of concurrent searcher searches.
 var textSearchLimiter = mutablelimiter.New(32)
 
-// A light wrapper around the search service. We implement the service here so
-// that we can unmarshal the result directly into graphql resolvers.
-
 type FileMatch struct {
 	JPath        string       `json:"Path"`
 	JLineMatches []*lineMatch `json:"LineMatches"`


### PR DESCRIPTION
Removes a comment that appears to be left over from a previous refactor. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
