### PR TITLE
search: do not report more than count MatchCount

### DIFF
--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -31,6 +31,11 @@ func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
 	for _, result := range event.Results {
 		p.MatchCount += int(result.ResultCount())
 	}
+
+	if p.MatchCount > p.Limit {
+		p.MatchCount = p.Limit
+		p.Stats.IsLimitHit = true
+	}
 }
 
 func (p *progressAggregator) currentStats() api.ProgressStats {


### PR DESCRIPTION
This is a change to improve user confidence in our search
system. Currently when you search when we hit our limits our search
counts fluctuate on numbers larger than our count. Instead we can return
exactly the count specified. This change only affects streaming search.

Part of https://github.com/sourcegraph/sourcegraph/issues/18076