### PR TITLE
search: apply limit across backends in streaming

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1741,9 +1741,9 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	// defaults.
 	stream := r.stream
 	if stream != nil {
-		var cancel2 context.CancelFunc
-		ctx, stream, cancel2 = WithLimit(ctx, stream, limit)
-		defer cancel2()
+		var cancelOnLimit context.CancelFunc
+		ctx, stream, cancelOnLimit = WithLimit(ctx, stream, limit)
+		defer cancelOnLimit()
 	}
 
 	agg := newAggregator(stream, r.SearchInputs)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1746,7 +1746,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		defer cancel2()
 	}
 
-	agg := newAggregator(r.stream, r.SearchInputs)
+	agg := newAggregator(stream, r.SearchInputs)
 
 	// This ensures we properly cleanup in the case of an early return. In
 	// particular we want to cancel global searches before returning early.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1736,6 +1736,16 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return &optionalWg
 	}
 
+	// For streaming search we want to limit based on all results, not just
+	// per backend. This works better than batch based since we have higher
+	// defaults.
+	stream := r.stream
+	if stream != nil {
+		var cancel2 context.CancelFunc
+		ctx, stream, cancel2 = WithLimit(ctx, stream, limit)
+		defer cancel2()
+	}
+
 	agg := newAggregator(r.stream, r.SearchInputs)
 
 	// This ensures we properly cleanup in the case of an early return. In


### PR DESCRIPTION
Now that streaming has higher defaults we can apply the limit across
backends. Previously the default limit was 30 so we didn't want one
search type to dominate results. Now that the limit is 500 we can be
more aggressive with cancellation. This is an effort to increase
confidence in result counts.

Part of #18076