### PR TITLE
WIP: move LineMatch from graphqlbackend to internal/search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	searchresults "github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -56,9 +57,9 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	defer git.ResetMocks()
 
 	fileMatch := func(path string, lineNumbers ...int32) *FileMatchResolver {
-		var lines []*lineMatch
+		var lines []*searchresults.LineMatch
 		for _, n := range lineNumbers {
-			lines = append(lines, &lineMatch{JLineNumber: n})
+			lines = append(lines, &searchresults.LineMatch{LineNumber: n})
 		}
 		return mkFileMatchResolver(FileMatch{
 			JPath:        path,

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -58,7 +58,7 @@ func TestSearchResults(t *testing.T) {
 			case *RepositoryResolver:
 				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.innerRepo.Name)
 			case *FileMatchResolver:
-				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.JPath, m.JLineMatches[0].JLineNumber)
+				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.JPath, m.JLineMatches[0].LineNumber)
 			default:
 				t.Fatal("unexpected result type", result)
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	searchresults "github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -548,9 +549,9 @@ func mkFileMatch(repo *types.RepoName, path string, lineNumbers ...int32) *FileM
 			Name: "repo",
 		}
 	}
-	var lines []*lineMatch
+	var lines []*searchresults.LineMatch
 	for _, n := range lineNumbers {
-		lines = append(lines, &lineMatch{JLineNumber: n})
+		lines = append(lines, &searchresults.LineMatch{LineNumber: n})
 	}
 	return mkFileMatchResolver(FileMatch{
 		uri:          fileMatchURI(repo.Name, "", path),

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	searchresults "github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
@@ -364,7 +365,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 				repoResolvers[repo.Name] = repoResolver
 			}
 
-			var lines []*lineMatch
+			var lines []*searchresults.LineMatch
 			var matchCount int
 			if typ != symbolRequest {
 				lines, matchCount = zoektFileMatchToLineMatches(maxLineFragmentMatches, &file)
@@ -423,9 +424,9 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	return nil
 }
 
-func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) ([]*lineMatch, int) {
+func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) ([]*searchresults.LineMatch, int) {
 	var matchCount int
-	lines := make([]*lineMatch, 0, len(file.LineMatches))
+	lines := make([]*searchresults.LineMatch, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {
 		if l.FileName {
@@ -442,10 +443,10 @@ func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMat
 			offsets[k] = [2]int32{int32(offset), int32(length)}
 		}
 		matchCount += len(offsets)
-		lines = append(lines, &lineMatch{
-			JPreview:          string(l.Line),
-			JLineNumber:       int32(l.LineNumber - 1),
-			JOffsetAndLengths: offsets,
+		lines = append(lines, &searchresults.LineMatch{
+			Preview:          string(l.Line),
+			LineNumber:       int32(l.LineNumber - 1),
+			OffsetAndLengths: offsets,
 		})
 	}
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -304,9 +304,9 @@ func fromFileMatch(fm *graphqlbackend.FileMatchResolver) eventFileMatch {
 	lineMatches := make([]eventLineMatch, 0, len(fm.JLineMatches))
 	for _, lm := range fm.JLineMatches {
 		lineMatches = append(lineMatches, eventLineMatch{
-			Line:             lm.JPreview,
-			LineNumber:       lm.JLineNumber,
-			OffsetAndLengths: lm.JOffsetAndLengths,
+			Line:             lm.Preview,
+			LineNumber:       lm.LineNumber,
+			OffsetAndLengths: lm.OffsetAndLengths,
 		})
 	}
 

--- a/internal/search/results/line_match.go
+++ b/internal/search/results/line_match.go
@@ -1,0 +1,8 @@
+package results
+
+type LineMatch struct {
+	Preview          string
+	OffsetAndLengths [][2]int32
+	LineNumber       int32
+	LimitHit         bool
+}


### PR DESCRIPTION
As part of implementing select (#18002), @rvantonder mentioned potentially moving the result types from `graphqlbackend` into `internal/search`. This PR was an attempt at an exploratory change to see how much effort that would take. This PR specifically just moves the `LineMatch` type into `internal/search/results`, and creates a new `LineMatchResolver` that implements the same necessary graphql interfaces as a wrapper around `LineMatch`. 

Right now, I'm mostly looking for opinions on whether this is a high enough priority refactor that I should slot it in now. For estimation purposes, this PR took me about an hour. If this is something worth tackling, I'll convert this to a real PR and ask for a closer review of the changes. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
