### PR TITLE
search: Convert struct field accesses to method calls

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -97,6 +97,8 @@ func (r *GitCommitResolver) Repository() *RepositoryResolver { return r.repoReso
 
 func (r *GitCommitResolver) OID() GitObjectID { return r.oid }
 
+func (r *GitCommitResolver) InputRev() *string { return r.inputRev }
+
 func (r *GitCommitResolver) AbbreviatedOID() string {
 	return string(r.oid)[:7]
 }

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -368,7 +368,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			// equal.
 			k.file = s.Path()
 		case *searchSymbolResult:
-			k.repoName = s.commit.repoResolver.innerRepo.Name
+			k.repoName = api.RepoName(s.commit.Repository().Name())
 			k.symbol = s.symbol.Name + s.symbol.Parent
 		case *languageResolver:
 			k.lang = s.name

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -217,13 +217,11 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 		} else {
 			fileMatch := &FileMatchResolver{
 				FileMatch: FileMatch{
-					JPath:   symbolRes.symbol.Path,
-					symbols: []*searchSymbolResult{symbolRes},
-					uri:     uri,
-					Repo:    repoRevs.Repo,
-					// Don't get commit from GitCommitResolver.OID() because we don't want to
-					// slow search results down when they are coming from zoekt.
-					CommitID: api.CommitID(symbolRes.commit.oid),
+					JPath:    symbolRes.symbol.Path,
+					symbols:  []*searchSymbolResult{symbolRes},
+					uri:      uri,
+					Repo:     repoRevs.Repo,
+					CommitID: api.CommitID(symbolRes.commit.OID()),
 				},
 				RepoResolver: repoResolver,
 			}
@@ -237,7 +235,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 // makeFileMatchURIFromSymbol makes a git://repo?rev#path URI from a symbol
 // search result to use in a fileMatchResolver
 func makeFileMatchURIFromSymbol(symbolResult *searchSymbolResult, inputRev string) string {
-	uri := "git:/" + string(symbolResult.commit.repoResolver.URL())
+	uri := "git:/" + string(symbolResult.commit.Repository().URL())
 	if inputRev != "" {
 		uri += "?" + inputRev
 	}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1041,13 +1041,13 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		if got, want := res.baseURI.URL.String(), "git://foo?master"; got != want {
 			t.Fatalf("baseURI: got %q want %q", got, want)
 		}
-		if got, want := string(res.commit.repoResolver.innerRepo.Name), "foo"; got != want {
+		if got, want := string(res.commit.Repository().Name()), "foo"; got != want {
 			t.Fatalf("reporesolver: got %q want %q", got, want)
 		}
-		if got, want := string(res.commit.oid), "deadbeef"; got != want {
+		if got, want := string(res.commit.OID()), "deadbeef"; got != want {
 			t.Fatalf("oid: got %q want %q", got, want)
 		}
-		if got, want := *res.commit.inputRev, "master"; got != want {
+		if got, want := *res.commit.InputRev(), "master"; got != want {
 			t.Fatalf("inputRev: got %q want %q", got, want)
 		}
 


### PR DESCRIPTION
This converts all struct field accesses of GitCommitResolver from
searchSymbolResult.commit into method calls so that
searchSymbolResult.commit can be converted to an interface to aid in the
disentangling of resolvers from search results.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
