### PR TITLE
database: Improve performance of ListDefaultRepos

### DIFF
--- a/internal/database/default_repos_test.go
+++ b/internal/database/default_repos_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -50,15 +53,37 @@ func TestListDefaultRepos(t *testing.T) {
 		},
 	}
 
+	createExternalService := func(ctx context.Context, db dbutil.DB) *types.ExternalService {
+		confGet := func() *conf.Unified {
+			return &conf.Unified{}
+		}
+		es := &types.ExternalService{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "GITHUB #1",
+			Config:      `{"url": "https://github.com", "repositoryQuery": ["none"], "token": "abc"}`,
+		}
+		err := ExternalServices(db).Create(ctx, confGet, es)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return es
+	}
+
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			db := dbtesting.GetDB(t)
 			ctx := context.Background()
+
+			es := createExternalService(ctx, db)
+
 			for _, r := range tc.repos {
 				if _, err := db.ExecContext(ctx, `INSERT INTO repo(id, name) VALUES ($1, $2)`, r.ID, r.Name); err != nil {
 					t.Fatal(err)
 				}
 				if _, err := db.ExecContext(ctx, `INSERT INTO default_repos(repo_id) VALUES ($1)`, r.ID); err != nil {
+					t.Fatal(err)
+				}
+				if _, err := db.ExecContext(ctx, `INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES ($1, $2, 'example.com')`, r.ID, es.ID); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -71,7 +96,7 @@ func TestListDefaultRepos(t *testing.T) {
 
 			sort.Sort(types.RepoNames(repos))
 			sort.Sort(types.RepoNames(tc.repos))
-			if diff := cmp.Diff(repos, tc.repos, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.repos, repos, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -80,21 +105,26 @@ func TestListDefaultRepos(t *testing.T) {
 	t.Run("user-added repos", func(t *testing.T) {
 		db := dbtesting.GetDB(t)
 		ctx := context.Background()
+
+		es := createExternalService(ctx, db)
+		if es.ID != 1 {
+			// Since we depend on this in the test below
+			t.Fatal("id should be 1")
+		}
 		_, err := db.ExecContext(ctx, `
 			-- insert one user-added repo, i.e. a repo added by an external service owned by a user
 			INSERT INTO users(id, username) VALUES (1, 'foo');
 			INSERT INTO repo(id, name) VALUES (10, 'github.com/foo/bar10');
 			INSERT INTO external_services(id, kind, display_name, config, namespace_user_id) VALUES (100, 'github', 'github', '{}', 1);
 			INSERT INTO external_service_repos VALUES (100, 10, 'https://github.com/foo/bar10');
+			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES (10, 1, 'example.com');
 
 			-- insert one repo referenced in the default repo table
 			INSERT INTO repo(id, name) VALUES (11, 'github.com/foo/bar11');
 			INSERT INTO default_repos(repo_id) VALUES(11);
+			INSERT INTO external_service_repos(repo_id, external_service_id, clone_url) VALUES (11, 1, 'example.com');
 
-			-- insert one repo not referenced in the default repo table;
-			INSERT INTO repo(id, name) VALUES (12, 'github.com/foo/bar12');
-
-			-- insert a repo only references by a cloud_default external service
+			-- insert a repo only referenced by a cloud_default external service
 			INSERT INTO repo(id, name) VALUES (13, 'github.com/foo/bar13');
 			INSERT INTO external_services(id, kind, display_name, config, cloud_default) VALUES (101, 'github', 'github', '{}', true);
 			INSERT INTO external_service_repos VALUES (101, 13, 'https://github.com/foo/bar13');
@@ -149,11 +179,20 @@ func TestListDefaultReposInBatches(t *testing.T) {
 
 	db := dbtesting.GetDB(t)
 	ctx := context.Background()
+
+	// Add an external service
+	_, err := db.ExecContext(ctx, `INSERT INTO external_services(id, kind, display_name, config, cloud_default) VALUES (1, 'github', 'github', '{}', true);`)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, r := range reposToAdd {
 		if _, err := db.ExecContext(ctx, `INSERT INTO repo(id, name) VALUES ($1, $2)`, r.ID, r.Name); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := db.ExecContext(ctx, `INSERT INTO default_repos(repo_id) VALUES ($1)`, r.ID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO external_service_repos VALUES (1, $1, 'https://github.com/foo/bar13');`, r.ID); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -192,12 +231,20 @@ func TestListDefaultReposUncloned(t *testing.T) {
 
 	db := dbtesting.GetDB(t)
 	ctx := context.Background()
+	// Add an external service
+	_, err := db.ExecContext(ctx, `INSERT INTO external_services(id, kind, display_name, config, cloud_default) VALUES (1, 'github', 'github', '{}', true);`)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for _, r := range reposToAdd {
 		cloned := int(r.ID) > 1
 		if _, err := db.ExecContext(ctx, `INSERT INTO repo(id, name, cloned) VALUES ($1, $2, $3)`, r.ID, r.Name, cloned); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := db.ExecContext(ctx, `INSERT INTO default_repos(repo_id) VALUES ($1)`, r.ID); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := db.ExecContext(ctx, `INSERT INTO external_service_repos VALUES (1, $1, 'https://github.com/foo/bar13');`, r.ID); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
In testing this appears to improve the performance of the query by
about 20x.

Tests needed to be updated since the new query assumes all valid repos
exist in our external_service_repos table which is correct but the old
tests didn't set this up.

Co-authored-by: Tomás Senart <tomas@sourcegraph.com>
