### PR TITLE
search: do not include + suffix in progress count

### DIFF
--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -9,12 +9,12 @@ const abbreviateNumber = (number: number): string => {
         return number.toString()
     }
     if (number >= 1e3 && number < 1e6) {
-        return (number / 1e3).toFixed(1) + 'k+'
+        return (number / 1e3).toFixed(1) + 'k'
     }
     if (number >= 1e6 && number < 1e9) {
-        return (number / 1e6).toFixed(1) + 'm+'
+        return (number / 1e6).toFixed(1) + 'm'
     }
-    return (number / 1e9).toFixed(1) + 'b+'
+    return (number / 1e9).toFixed(1) + 'b'
 }
 
 export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgressProps, 'progress' | 'state'>> = ({

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -148,7 +148,7 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
     <Memo(CalculatorIcon)
       className="mr-2 icon-inline"
     />
-    1.2m+
+    1.2m
      
     results
      in
@@ -157,7 +157,7 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
     s
      
     from 
-    8.9k+
+    8.9k
      
     repositories
   </div>


### PR DESCRIPTION
We use + in other parts of our UI to indicate a limit was hit.

Part of https://github.com/sourcegraph/sourcegraph/issues/18076