### PR TITLE
ci: remove codecov comments on PRs

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -30,10 +30,7 @@ coverage:
       default:
         only_pulls: true
         target: 5%
-comment:
-  require_changes: yes
-  layout: 'diff, flags, files'
-  show_carryforward_flags: true
+comment: false
 ignore:
   - '**/bindata.go'
 


### PR DESCRIPTION
We had a discussion in slack asking if people found the comments
useful. We had 2 vote yes, while 10 voted no. This removes the
comments. Note we still have the status check.

Thread: https://sourcegraph.slack.com/archives/C07KZF47K/p1612508512242400