### PR TITLE
ci: add a codecov project for search

### DIFF
--- a/dev/codecov.yml
+++ b/dev/codecov.yml
@@ -18,6 +18,16 @@ coverage:
           - internal/campaigns
           - enterprise/internal/campaigns
           - client/web/src/enterprise/campaigns
+      search:
+        informational: true
+        paths:
+          - client/shared/src/search
+          - client/web/src/enterprise/search
+          - client/web/src/search
+          - cmd/frontend/graphqlbackend/*search*
+          - cmd/frontend/internal/search
+          - cmd/searcher
+          - internal/search
       typescript:
         informational: true
         flags:


### PR DESCRIPTION
Allows the search team to track code coverage just for search
code. Note: our coverage numbers are under-reported since go coverage
doesn't track cross pkg coverage.