### PR TITLE
search: Remove outdated comment

### DIFF
--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -152,9 +152,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, repoBranches
 		return nil, false, nil, nil
 	}
 
-	// TODO(@camdencheek) TODO(@rvantonder). repoBranches is currently
-	// hardcoded to HEAD. Choose sensible values for k when we generalize
-	// this.
+	// Choose sensible values for k when we generalize this.
 	k := zoektutil.ResultCountFactor(len(repoBranches), args.FileMatchLimit, false)
 	searchOpts := zoektutil.SearchOpts(ctx, k, args)
 	searchOpts.Whole = true


### PR DESCRIPTION
The TODO about hardcoding to HEAD is no longer accurate since the
changes to structural search that enable non-HEAD searching.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
