### PR TITLE
search: trace global search mode

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1551,6 +1551,7 @@ func (a *aggregator) doSymbolSearch(ctx context.Context, args *search.TextParame
 
 func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextParameters) (err error) {
 	tr, ctx := trace.New(ctx, "doFilePathSearch", "")
+	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {
 		a.error(ctx, err)
 		tr.SetError(err)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -354,6 +354,7 @@ func searchFilesInRepos(ctx context.Context, args *search.TextParameters, stream
 	tr.LogFields(
 		trace.Stringer("query", args.Query),
 		trace.Stringer("info", args.PatternInfo),
+		trace.Stringer("global_search_mode", args.Mode),
 	)
 
 	indexedTyp := textRequest

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -86,6 +86,7 @@ func containsRefGlobs(q query.QueryInfo) bool {
 
 func newIndexedSearchRequest(ctx context.Context, args *search.TextParameters, typ indexedRequestType, stream Streamer) (_ *indexedSearchRequest, err error) {
 	tr, ctx := trace.New(ctx, "newIndexedSearchRequest", string(typ))
+	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -84,7 +84,7 @@ type SymbolsParameters struct {
 
 type GlobalSearchMode int
 
-// keep the order in sync with func (m GlobalSearchMode) String() string
+// Keep the order in sync with func (m GlobalSearchMode) String() string.
 const (
 	ZoektGlobalSearch GlobalSearchMode = iota + 1
 	SearcherOnly

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -84,11 +84,16 @@ type SymbolsParameters struct {
 
 type GlobalSearchMode int
 
+// keep the order in sync with func (m GlobalSearchMode) String() string
 const (
 	ZoektGlobalSearch GlobalSearchMode = iota + 1
 	SearcherOnly
 	NoFilePath
 )
+
+func (m GlobalSearchMode) String() string {
+	return []string{"None", "ZoektGlobalSearch", "SearcherOnly", "NoFilePath"}[m]
+}
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern
 // to search for, as well as the hydrated list of repository revisions to


### PR DESCRIPTION
we didn't trace the global search mode yet. Let's add it to the 
trace to better track down regressions.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
