### PR TITLE
search: resolve repos after starting zoekt stream

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -252,29 +252,8 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	k := zoektutil.ResultCountFactor(len(repos.repoBranches), args.PatternInfo.FileMatchLimit, args.Mode == search.ZoektGlobalSearch)
 	searchOpts := zoektutil.SearchOpts(ctx, k, args.PatternInfo)
 
-	var getRepoInputRev zoektutil.RepoRevFunc
-	if args.Mode == search.ZoektGlobalSearch {
-		repos, err := getRepos(ctx, args.RepoPromise)
-		if err != nil {
-			return err
-		}
-		repoRevMap := make(map[string]*search.RepositoryRevisions, len(repos))
-		for _, r := range repos {
-			repoRevMap[string(r.Repo.Name)] = r
-		}
-		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
-			if repoRev, ok := repoRevMap[file.Repository]; ok {
-				return repoRev.Repo, repoRev.RevSpecs(), true
-			}
-			return nil, nil, false
-		}
-	} else {
-		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
-			repo, inputRevs := repos.GetRepoInputRev(file)
-			return repo, inputRevs, true
-		}
-	}
-
+	// Make a copy of the original context so that we can respect deadlines during repo resolution.
+	originalCtx := ctx
 	if deadline, ok := ctx.Deadline(); ok {
 		// If the user manually specified a timeout, allow zoekt to use all of the remaining timeout.
 		searchOpts.MaxWallTime = time.Until(deadline)
@@ -295,9 +274,32 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Start event stream
+	// Start event stream before resolving repositories.
 	t0 := time.Now()
 	events := args.Zoekt.Client.StreamSearch(ctx, finalQuery, &searchOpts)
+
+	var getRepoInputRev zoektutil.RepoRevFunc
+	if args.Mode == search.ZoektGlobalSearch {
+		repos, err := getRepos(originalCtx, args.RepoPromise)
+		if err != nil {
+			return err
+		}
+		repoRevMap := make(map[string]*search.RepositoryRevisions, len(repos))
+		for _, r := range repos {
+			repoRevMap[string(r.Repo.Name)] = r
+		}
+		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
+			if repoRev, ok := repoRevMap[file.Repository]; ok {
+				return repoRev.Repo, repoRev.RevSpecs(), true
+			}
+			return nil, nil, false
+		}
+	} else {
+		getRepoInputRev = func(file *zoekt.FileMatch) (repo *types.RepoName, revs []string, ok bool) {
+			repo, inputRevs := repos.GetRepoInputRev(file)
+			return repo, inputRevs, true
+		}
+	}
 
 	// Ensure we always drain events
 	defer func() {


### PR DESCRIPTION
fixes: #18103

This fixes a regression introduced last week. We accidentally resolved
repos before starting the zoekt event stream. Once zoekt supports
streaming we will get rid of the suspended-deadline logic and simplify
the code in `zoektSearch`.

Before fix:
<img width="2558" alt="image" src="https://user-images.githubusercontent.com/26413131/107397385-e6b82f80-6afe-11eb-8325-42b904f90f3d.png">

After fix:
<img width="2560" alt="image" src="https://user-images.githubusercontent.com/26413131/107397482-f9caff80-6afe-11eb-95b2-2ef0ec7eaa11.png">



Co-authored-by: Keegan Carruthers-Smith <keegan.csmith@gmail.com>

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
