### PR TITLE
campaigns: Don't use global database anymore

### DIFF
--- a/enterprise/internal/campaigns/background.go
+++ b/enterprise/internal/campaigns/background.go
@@ -2,14 +2,13 @@ package campaigns
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/background"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/syncer"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	ossDB "github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
@@ -18,7 +17,7 @@ import (
 // repo-updater and in the future will be the main entry point for the campaigns worker.
 func InitBackgroundJobs(
 	ctx context.Context,
-	db *sql.DB,
+	db dbutil.DB,
 	cf *httpcli.Factory,
 	// TODO(eseliger): Remove this parameter as the sunset of repo-updater is approaching.
 	// We should switch to our own polling mechanism instead of using repo-updaters.
@@ -26,8 +25,8 @@ func InitBackgroundJobs(
 ) {
 	cstore := store.New(db)
 
-	repoStore := ossDB.ReposWith(cstore)
-	esStore := ossDB.ExternalServicesWith(cstore)
+	repoStore := cstore.Repos()
+	esStore := cstore.ExternalServices()
 
 	// We use an internal actor so that we can freely load dependencies from
 	// the database without repository permissions being enforced.
@@ -41,5 +40,5 @@ func InitBackgroundJobs(
 		server.ChangesetSyncRegistry = syncRegistry
 	}
 
-	go goroutine.MonitorBackgroundRoutines(ctx, background.Routines(ctx, db, cstore, cf)...)
+	go goroutine.MonitorBackgroundRoutines(ctx, background.Routines(ctx, cstore, cf)...)
 }

--- a/enterprise/internal/campaigns/background/background.go
+++ b/enterprise/internal/campaigns/background/background.go
@@ -2,7 +2,6 @@ package background
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -11,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
 
-func Routines(ctx context.Context, db *sql.DB, campaignsStore *store.Store, cf *httpcli.Factory) []goroutine.BackgroundRoutine {
+func Routines(ctx context.Context, campaignsStore *store.Store, cf *httpcli.Factory) []goroutine.BackgroundRoutine {
 	sourcer := repos.NewSourcer(cf)
 
 	metrics := newMetrics()

--- a/enterprise/internal/campaigns/frontend.go
+++ b/enterprise/internal/campaigns/frontend.go
@@ -7,10 +7,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/globalstatedb"
-	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 // InitFrontend initializes the given enterpriseServices to include the required resolvers for campaigns
@@ -21,18 +19,15 @@ func InitFrontend(ctx context.Context, enterpriseServices *enterprise.Services) 
 		return err
 	}
 
-	cstore := store.NewWithClock(dbconn.Global, timeutil.Now)
-	esStore := database.ExternalServices(dbconn.Global)
+	cstore := store.New(dbconn.Global)
 
-	enterpriseServices.CampaignsResolver = resolvers.New(dbconn.Global)
-	enterpriseServices.GitHubWebhook = webhooks.NewGitHubWebhook(cstore, esStore, timeutil.Now)
+	enterpriseServices.CampaignsResolver = resolvers.New(cstore)
+	enterpriseServices.GitHubWebhook = webhooks.NewGitHubWebhook(cstore)
 	enterpriseServices.BitbucketServerWebhook = webhooks.NewBitbucketServerWebhook(
 		cstore,
-		esStore,
-		timeutil.Now,
 		"sourcegraph-"+globalState.SiteID,
 	)
-	enterpriseServices.GitLabWebhook = webhooks.NewGitLabWebhook(cstore, esStore, timeutil.Now)
+	enterpriseServices.GitLabWebhook = webhooks.NewGitLabWebhook(cstore)
 
 	return nil
 }

--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -63,14 +63,12 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 		return nil
 	}
 
-	reposStore := database.ReposWith(e.tx)
-
-	e.repo, err = reposStore.Get(ctx, e.ch.RepoID)
+	e.repo, err = e.tx.Repos().Get(ctx, e.ch.RepoID)
 	if err != nil {
 		return errors.Wrap(err, "failed to load repository")
 	}
 
-	esStore := database.ExternalServicesWith(e.tx)
+	esStore := e.tx.ExternalServices()
 
 	e.extSvc, err = loadExternalService(ctx, esStore, e.repo)
 	if err != nil {
@@ -134,7 +132,7 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 	}
 
 	events := e.ch.Events()
-	state.SetDerivedState(ctx, e.ch, events)
+	state.SetDerivedState(ctx, e.tx.Repos(), e.ch, events)
 
 	if err := e.tx.UpsertChangesetEvents(ctx, events...); err != nil {
 		log15.Error("UpsertChangesetEvents", "err", err)
@@ -196,14 +194,19 @@ func (e *executor) loadAuthenticator(ctx context.Context) (auth.Authenticator, e
 		return nil, errors.Wrap(err, "failed to load owning campaign")
 	}
 
-	cred, err := loadUserCredential(ctx, campaign.LastApplierID, e.repo)
+	cred, err := e.tx.UserCredentials().GetByScope(ctx, database.UserCredentialScope{
+		Domain:              database.UserCredentialDomainCampaigns,
+		UserID:              campaign.LastApplierID,
+		ExternalServiceType: e.repo.ExternalRepo.ServiceType,
+		ExternalServiceID:   e.repo.ExternalRepo.ServiceID,
+	})
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			// We need to check if the user is an admin: if they are, then
 			// we can use the nil return from loadUserCredential() to fall
 			// back to the global credentials used for the code host. If
 			// not, then we need to error out.
-			user, err := loadUser(ctx, campaign.LastApplierID)
+			user, err := database.UsersWith(e.tx).GetByID(ctx, campaign.LastApplierID)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to load user applying the campaign")
 			}
@@ -257,7 +260,7 @@ func (e *executor) publishChangeset(ctx context.Context, asDraft bool) (err erro
 
 	// Depending on the changeset, we may want to add to the body (for example,
 	// to add a backlink to Sourcegraph).
-	if err := decorateChangesetBody(ctx, e.tx, cs); err != nil {
+	if err := decorateChangesetBody(ctx, e.tx, database.NamespacesWith(e.tx), cs); err != nil {
 		return errors.Wrapf(err, "decorating body for changeset %d", e.ch.ID)
 	}
 
@@ -344,7 +347,7 @@ func (e *executor) updateChangeset(ctx context.Context) (err error) {
 
 	// Depending on the changeset, we may want to add to the body (for example,
 	// to add a backlink to Sourcegraph).
-	if err := decorateChangesetBody(ctx, e.tx, &cs); err != nil {
+	if err := decorateChangesetBody(ctx, e.tx, database.NamespacesWith(e.tx), &cs); err != nil {
 		return errors.Wrapf(err, "decorating body for changeset %d", e.ch.ID)
 	}
 
@@ -607,20 +610,11 @@ func loadCampaign(ctx context.Context, tx getCampaigner, id int64) (*campaigns.C
 	return campaign, nil
 }
 
-func loadUser(ctx context.Context, id int32) (*types.User, error) {
-	return database.GlobalUsers.GetByID(ctx, id)
+type getNamespacer interface {
+	GetByID(ctx context.Context, orgID, userID int32) (*database.Namespace, error)
 }
 
-func loadUserCredential(ctx context.Context, userID int32, repo *types.Repo) (*database.UserCredential, error) {
-	return database.GlobalUserCredentials.GetByScope(ctx, database.UserCredentialScope{
-		Domain:              database.UserCredentialDomainCampaigns,
-		UserID:              userID,
-		ExternalServiceType: repo.ExternalRepo.ServiceType,
-		ExternalServiceID:   repo.ExternalRepo.ServiceID,
-	})
-}
-
-func decorateChangesetBody(ctx context.Context, tx getCampaigner, cs *repos.Changeset) error {
+func decorateChangesetBody(ctx context.Context, tx getCampaigner, nsStore getNamespacer, cs *repos.Changeset) error {
 	campaign, err := loadCampaign(ctx, tx, cs.OwnedByCampaignID)
 	if err != nil {
 		return errors.Wrap(err, "failed to load campaign")
@@ -628,7 +622,7 @@ func decorateChangesetBody(ctx context.Context, tx getCampaigner, cs *repos.Chan
 
 	// We need to get the namespace, since external campaign URLs are
 	// namespaced.
-	ns, err := database.GlobalNamespaces.GetByID(ctx, campaign.NamespaceOrgID, campaign.NamespaceUserID)
+	ns, err := nsStore.GetByID(ctx, campaign.NamespaceOrgID, campaign.NamespaceUserID)
 	if err != nil {
 		return errors.Wrap(err, "retrieving namespace")
 	}

--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -900,7 +900,7 @@ func TestDecorateChangesetBody(t *testing.T) {
 
 	body := "body"
 	rcs := &repos.Changeset{Body: body, Changeset: cs}
-	if err := decorateChangesetBody(context.Background(), fs, rcs); err != nil {
+	if err := decorateChangesetBody(context.Background(), fs, database.GlobalNamespaces, rcs); err != nil {
 		t.Errorf("unexpected non-nil error: %v", err)
 	}
 	if want := body + "\n\n[_Created by Sourcegraph campaign `my-user/reconciler-test-campaign`._](https://sourcegraph.test/users/my-user/campaigns/reconciler-test-campaign)"; rcs.Body != want {

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/syncer"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -101,7 +100,7 @@ func (r *changesetsConnectionResolver) compute(ctx context.Context) (allChangese
 
 		// 🚨 SECURITY: database.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		r.reposByID, err = database.GlobalRepos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
+		r.reposByID, err = r.store.Repos().GetReposSetByIDs(ctx, cs.RepoIDs()...)
 		if err != nil {
 			r.err = err
 			return

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -44,7 +43,7 @@ func NewChangesetSpecResolver(ctx context.Context, store *store.Store, changeset
 	// filters out repositories that the user doesn't have access to.
 	// In case we don't find a repository, it might be because it's deleted
 	// or because the user doesn't have access.
-	rs, err := database.GlobalRepos.GetByIDs(ctx, changesetSpec.RepoID)
+	rs, err := store.Repos().GetByIDs(ctx, changesetSpec.RepoID)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -86,7 +85,7 @@ func (r *changesetSpecConnectionResolver) compute(ctx context.Context) (campaign
 
 		// 🚨 SECURITY: database.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 		// filters out repositories that the user doesn't have access to.
-		r.reposByID, r.err = database.GlobalRepos.GetReposSetByIDs(ctx, r.changesetSpecs.RepoIDs()...)
+		r.reposByID, r.err = r.store.Repos().GetReposSetByIDs(ctx, r.changesetSpecs.RepoIDs()...)
 	})
 
 	return r.changesetSpecs, r.reposByID, r.next, r.err

--- a/enterprise/internal/campaigns/resolvers/code_host_connection.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection.go
@@ -79,7 +79,7 @@ func (c *campaignsCodeHostConnectionResolver) compute(ctx context.Context) (all,
 		}
 
 		// Fetch all user credentials to avoid N+1 per credential resolver.
-		creds, _, err := database.GlobalUserCredentials.List(ctx, database.UserCredentialsListOpts{Scope: database.UserCredentialScope{Domain: database.UserCredentialDomainCampaigns, UserID: c.userID}})
+		creds, _, err := c.store.UserCredentials().List(ctx, database.UserCredentialsListOpts{Scope: database.UserCredentialScope{Domain: database.UserCredentialDomainCampaigns, UserID: c.userID}})
 		if err != nil {
 			c.chsErr = err
 			return

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -34,8 +33,8 @@ type Resolver struct {
 }
 
 // New returns a new Resolver whose store uses the given database
-func New(db *sql.DB) graphqlbackend.CampaignsResolver {
-	return &Resolver{store: store.New(db)}
+func New(store *store.Store) graphqlbackend.CampaignsResolver {
+	return &Resolver{store: store}
 }
 
 func campaignsEnabled(ctx context.Context) error {
@@ -110,7 +109,7 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 
 	// 🚨 SECURITY: database.Repos.Get uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
-	repo, err := database.GlobalRepos.Get(ctx, changeset.RepoID)
+	repo, err := r.store.Repos().Get(ctx, changeset.RepoID)
 	if err != nil && !errcode.IsNotFound(err) {
 		return nil, err
 	}
@@ -232,7 +231,7 @@ func (r *Resolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (
 		return nil, nil
 	}
 
-	cred, err := database.GlobalUserCredentials.GetByID(ctx, dbID)
+	cred, err := r.store.UserCredentials().GetByID(ctx, dbID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return nil, nil
@@ -847,7 +846,7 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 	}
 
 	// Throw error documented in schema.graphql.
-	existing, err := database.GlobalUserCredentials.GetByScope(ctx, scope)
+	existing, err := r.store.UserCredentials().GetByScope(ctx, scope)
 	if err != nil && !errcode.IsNotFound(err) {
 		return nil, err
 	}
@@ -867,7 +866,7 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 		a = &auth.OAuthBearerToken{Token: args.Credential}
 	}
 
-	cred, err := database.GlobalUserCredentials.Create(ctx, scope, a)
+	cred, err := r.store.UserCredentials().Create(ctx, scope, a)
 	if err != nil {
 		return nil, err
 	}
@@ -895,7 +894,7 @@ func (r *Resolver) DeleteCampaignsCredential(ctx context.Context, args *graphqlb
 	}
 
 	// Get existing credential.
-	cred, err := database.GlobalUserCredentials.GetByID(ctx, dbID)
+	cred, err := r.store.UserCredentials().GetByID(ctx, dbID)
 	if err != nil {
 		return nil, err
 	}
@@ -906,7 +905,7 @@ func (r *Resolver) DeleteCampaignsCredential(ctx context.Context, args *graphqlb
 	}
 
 	// This also fails if the credential was not found.
-	if err := database.GlobalUserCredentials.Delete(ctx, dbID); err != nil {
+	if err := r.store.UserCredentials().Delete(ctx, dbID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/campaigns/service/service.go
+++ b/enterprise/internal/campaigns/service/service.go
@@ -93,7 +93,7 @@ func (s *Service) CreateCampaignSpec(ctx context.Context, opts CreateCampaignSpe
 
 	// 🚨 SECURITY: database.Repos.GetRepoIDsSet uses the authzFilter under the hood and
 	// filters out repositories that the user doesn't have access to.
-	accessibleReposByID, err := database.GlobalRepos.GetReposSetByIDs(ctx, cs.RepoIDs()...)
+	accessibleReposByID, err := s.store.Repos().GetReposSetByIDs(ctx, cs.RepoIDs()...)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (s *Service) CreateChangesetSpec(ctx context.Context, rawSpec string, userI
 
 	// 🚨 SECURITY: We use database.Repos.Get to check whether the user has access to
 	// the repository or not.
-	if _, err = database.GlobalRepos.Get(ctx, spec.RepoID); err != nil {
+	if _, err = s.store.Repos().Get(ctx, spec.RepoID); err != nil {
 		return nil, err
 	}
 
@@ -382,7 +382,7 @@ func (s *Service) EnqueueChangesetSync(ctx context.Context, id int64) (err error
 
 	// 🚨 SECURITY: We use database.Repos.Get to check whether the user has access to
 	// the repository or not.
-	if _, err = database.GlobalRepos.Get(ctx, changeset.RepoID); err != nil {
+	if _, err = s.store.Repos().Get(ctx, changeset.RepoID); err != nil {
 		return err
 	}
 
@@ -436,7 +436,7 @@ func (s *Service) ReenqueueChangeset(ctx context.Context, id int64) (changeset *
 
 	// 🚨 SECURITY: We use database.Repos.Get to check whether the user has access to
 	// the repository or not.
-	repo, err = database.ReposWith(s.store).Get(ctx, changeset.RepoID)
+	repo, err = s.store.Repos().Get(ctx, changeset.RepoID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -521,8 +521,7 @@ func (s *Service) FetchUsernameForBitbucketServerToken(ctx context.Context, exte
 		return "", err
 	}
 
-	esStore := database.ExternalServicesWith(s.store)
-	externalService, err := esStore.GetByID(ctx, extSvcID)
+	externalService, err := s.store.ExternalServices().GetByID(ctx, extSvcID)
 	if err != nil {
 		if errcode.IsNotFound(err) {
 			return "", errors.New("no external service found for repo")

--- a/enterprise/internal/campaigns/store/changeset_specs.go
+++ b/enterprise/internal/campaigns/store/changeset_specs.go
@@ -441,7 +441,7 @@ func (rm RewirerMappings) Hydrate(ctx context.Context, store *Store) error {
 		}
 	}
 
-	accessibleReposByID, err := database.GlobalRepos.GetReposSetByIDs(ctx, rm.RepoIDs()...)
+	accessibleReposByID, err := store.Repos().GetReposSetByIDs(ctx, rm.RepoIDs()...)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/campaigns/store/store.go
+++ b/enterprise/internal/campaigns/store/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -72,6 +73,21 @@ func (s *Store) Transact(ctx context.Context) (*Store, error) {
 		return nil, err
 	}
 	return &Store{Store: txBase, now: s.now}, nil
+}
+
+// Repos returns a database.RepoStore using the same connection as this store.
+func (s *Store) Repos() *database.RepoStore {
+	return database.ReposWith(s)
+}
+
+// ExternalServices returns a database.ExternalServiceStore using the same connection as this store.
+func (s *Store) ExternalServices() *database.ExternalServiceStore {
+	return database.ExternalServicesWith(s)
+}
+
+// UserCredentials returns a database.UserCredentialsStore using the same connection as this store.
+func (s *Store) UserCredentials() *database.UserCredentialsStore {
+	return database.UserCredentialsWith(s)
 }
 
 func (s *Store) query(ctx context.Context, q *sqlf.Query, sc scanFunc) error {

--- a/enterprise/internal/campaigns/syncer/syncer.go
+++ b/enterprise/internal/campaigns/syncer/syncer.go
@@ -275,6 +275,7 @@ type SyncStore interface {
 	UpdateChangeset(ctx context.Context, cs *campaigns.Changeset) error
 	UpsertChangesetEvents(ctx context.Context, cs ...*campaigns.ChangesetEvent) error
 	Transact(context.Context) (*store.Store, error)
+	Repos() *database.RepoStore
 }
 
 // Run will start the process of changeset syncing. It is long running
@@ -467,7 +468,7 @@ func SyncChangeset(ctx context.Context, syncStore SyncStore, source repos.Change
 	}
 
 	events := c.Events()
-	state.SetDerivedState(ctx, c, events)
+	state.SetDerivedState(ctx, syncStore.Repos(), c, events)
 
 	tx, err := syncStore.Transact(ctx)
 	if err != nil {

--- a/enterprise/internal/campaigns/syncer/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer/syncer_test.go
@@ -450,6 +450,10 @@ func (m MockSyncStore) Transact(ctx context.Context) (*store.Store, error) {
 	return m.transact(ctx)
 }
 
+func (m MockSyncStore) Repos() *database.RepoStore {
+	return database.GlobalRepos
+}
+
 type MockRepoStore struct {
 	get func(ctx context.Context, id api.RepoID) (*types.Repo, error)
 }

--- a/enterprise/internal/campaigns/webhooks/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks.go
@@ -64,8 +64,7 @@ func (h Webhook) getRepoForPR(
 	pr PR,
 	externalServiceID string,
 ) (*types.Repo, error) {
-	reposTx := database.ReposWith(tx)
-	rs, err := reposTx.List(ctx, database.ReposListOptions{
+	rs, err := tx.Repos().List(ctx, database.ReposListOptions{
 		ExternalRepos: []api.ExternalRepoSpec{
 			{
 				ID:          pr.RepoExternalID,
@@ -189,7 +188,7 @@ func (h Webhook) upsertChangesetEvent(
 	events, _, err := tx.ListChangesetEvents(ctx, store.ListChangesetEventsOpts{
 		ChangesetIDs: []int64{cs.ID},
 	})
-	state.SetDerivedState(ctx, cs, events)
+	state.SetDerivedState(ctx, tx.Repos(), cs, events)
 	if err := tx.UpdateChangeset(ctx, cs); err != nil {
 		return err
 	}
@@ -213,8 +212,8 @@ type BitbucketServerWebhook struct {
 	configCache map[int64]*schema.BitbucketServerConnection
 }
 
-func NewGitHubWebhook(store *store.Store, externalServices *database.ExternalServiceStore, now func() time.Time) *GitHubWebhook {
-	return &GitHubWebhook{&Webhook{store, externalServices, now, extsvc.TypeGitHub}}
+func NewGitHubWebhook(store *store.Store) *GitHubWebhook {
+	return &GitHubWebhook{&Webhook{store, store.ExternalServices(), store.Clock(), extsvc.TypeGitHub}}
 }
 
 // Register registers this webhook handler to handle events with the passed webhook router
@@ -769,9 +768,9 @@ func (*GitHubWebhook) checkRunEvent(cr *gh.CheckRun) *github.CheckRun {
 	}
 }
 
-func NewBitbucketServerWebhook(store *store.Store, externalServices *database.ExternalServiceStore, now func() time.Time, name string) *BitbucketServerWebhook {
+func NewBitbucketServerWebhook(store *store.Store, name string) *BitbucketServerWebhook {
 	return &BitbucketServerWebhook{
-		Webhook:     &Webhook{store, externalServices, now, extsvc.TypeBitbucketServer},
+		Webhook:     &Webhook{store, store.ExternalServices(), store.Clock(), extsvc.TypeBitbucketServer},
 		Name:        name,
 		configCache: make(map[int64]*schema.BitbucketServerConnection),
 	}

--- a/enterprise/internal/campaigns/webhooks/webhooks_gitlab.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_gitlab.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
@@ -24,8 +23,8 @@ import (
 
 type GitLabWebhook struct{ *Webhook }
 
-func NewGitLabWebhook(store *store.Store, externalServices *database.ExternalServiceStore, now func() time.Time) *GitLabWebhook {
-	return &GitLabWebhook{&Webhook{store, externalServices, now, extsvc.TypeGitLab}}
+func NewGitLabWebhook(store *store.Store) *GitLabWebhook {
+	return &GitLabWebhook{&Webhook{store, store.ExternalServices(), store.Clock(), extsvc.TypeGitLab}}
 }
 
 // ServeHTTP implements the http.Handler interface.

--- a/enterprise/internal/campaigns/webhooks/webhooks_gitlab_test.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_gitlab_test.go
@@ -37,8 +37,8 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 
 		t.Run("ServeHTTP", func(t *testing.T) {
 			t.Run("missing external service", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
 
 				u := extsvc.WebhookURL(extsvc.TypeGitLab, 12345, "https://example.com/")
 				req, err := http.NewRequest("POST", u, nil)
@@ -55,8 +55,8 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("invalid external service", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
 
 				u := strings.ReplaceAll(extsvc.WebhookURL(extsvc.TypeGitLab, 12345, "https://example.com/"), "12345", "foo")
 				req, err := http.NewRequest("POST", u, nil)
@@ -75,12 +75,12 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("malformed external service", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				es.Config = "invalid JSON"
-				if err := esStore.Upsert(ctx, es); err != nil {
+				if err := store.ExternalServices().Upsert(ctx, es); err != nil {
 					t.Fatal(err)
 				}
 
@@ -102,9 +102,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("missing secret", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, "https://example.com/")
 				req, err := http.NewRequest("POST", u, nil)
@@ -123,9 +123,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("incorrect secret", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, "https://example.com/")
 				req, err := http.NewRequest("POST", u, nil)
@@ -145,9 +145,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("missing body", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, "https://example.com/")
 				req, err := http.NewRequest("POST", u, nil)
@@ -167,9 +167,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("unreadable body", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, "https://example.com/")
 				req, err := http.NewRequest("POST", u, nil)
@@ -190,9 +190,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("malformed body", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, "https://example.com/")
 				req, err := http.NewRequest("POST", u, bytes.NewBufferString("invalid JSON"))
@@ -212,9 +212,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("invalid body", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				u := extsvc.WebhookURL(extsvc.TypeGitLab, es.ID, "https://example.com/")
 				body := ct.MarshalJSON(t, &webhooks.EventCommon{
@@ -236,10 +236,10 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("error from handleEvent", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
+				store := gitLabTestSetup(t, db)
 				repoStore := database.ReposWith(store)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 				repo := createGitLabRepo(t, ctx, repoStore, es)
 				changeset := createGitLabChangeset(t, ctx, store, repo)
 				body := createMergeRequestPayload(t, repo, changeset, "close")
@@ -252,7 +252,7 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				conn := cfg.(*schema.GitLabConnection)
 				conn.Url = ""
 				es.Config = ct.MarshalJSON(t, conn)
-				if err := esStore.Upsert(ctx, es); err != nil {
+				if err := store.ExternalServices().Upsert(ctx, es); err != nil {
 					t.Fatal(err)
 				}
 
@@ -283,10 +283,10 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			t.Run("valid merge request approval events", func(t *testing.T) {
 				for _, action := range []string{"approved", "unapproved"} {
 					t.Run(action, func(t *testing.T) {
-						store, esStore, clock := gitLabTestSetup(t, db)
+						store := gitLabTestSetup(t, db)
 						repoStore := database.ReposWith(store)
-						h := NewGitLabWebhook(store, esStore, clock.Now)
-						es := createGitLabExternalService(t, ctx, esStore)
+						h := NewGitLabWebhook(store)
+						es := createGitLabExternalService(t, ctx, store.ExternalServices())
 						repo := createGitLabRepo(t, ctx, repoStore, es)
 						changeset := createGitLabChangeset(t, ctx, store, repo)
 						body := createMergeRequestPayload(t, repo, changeset, "approved")
@@ -329,10 +329,10 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					"reopen": campaigns.ChangesetEventKindGitLabReopened,
 				} {
 					t.Run(action, func(t *testing.T) {
-						store, esStore, clock := gitLabTestSetup(t, db)
+						store := gitLabTestSetup(t, db)
 						repoStore := database.ReposWith(store)
-						h := NewGitLabWebhook(store, esStore, clock.Now)
-						es := createGitLabExternalService(t, ctx, esStore)
+						h := NewGitLabWebhook(store)
+						es := createGitLabExternalService(t, ctx, store.ExternalServices())
 						repo := createGitLabRepo(t, ctx, repoStore, es)
 						changeset := createGitLabChangeset(t, ctx, store, repo)
 						body := createMergeRequestPayload(t, repo, changeset, action)
@@ -359,10 +359,10 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("valid pipeline events", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
+				store := gitLabTestSetup(t, db)
 				repoStore := database.ReposWith(store)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 				repo := createGitLabRepo(t, ctx, repoStore, es)
 				changeset := createGitLabChangeset(t, ctx, store, repo)
 				body := createPipelinePayload(t, repo, changeset, gitlab.Pipeline{
@@ -392,17 +392,17 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		t.Run("getExternalServiceFromRawID", func(t *testing.T) {
 			// Since these tests don't write to the database, we can just share
 			// the same database setup.
-			store, esStore, clock := gitLabTestSetup(t, db)
-			h := NewGitLabWebhook(store, esStore, clock.Now)
+			store := gitLabTestSetup(t, db)
+			h := NewGitLabWebhook(store)
 
 			// Set up two GitLab external services.
-			a := createGitLabExternalService(t, ctx, esStore)
-			b := createGitLabExternalService(t, ctx, esStore)
+			a := createGitLabExternalService(t, ctx, store.ExternalServices())
+			b := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 			// Set up a GitHub external service.
-			github := createGitLabExternalService(t, ctx, esStore)
+			github := createGitLabExternalService(t, ctx, store.ExternalServices())
 			github.Kind = extsvc.KindGitHub
-			if err := esStore.Upsert(ctx, github); err != nil {
+			if err := store.ExternalServices().Upsert(ctx, github); err != nil {
 				t.Fatal(err)
 			}
 
@@ -456,13 +456,19 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 		})
 
-		t.Run("broken repo store", func(t *testing.T) {
+		t.Run("broken external services store", func(t *testing.T) {
 			// This test is separate from the other unit tests for this
 			// function above because it needs to set up a bad database
 			// connection on the repo store.
-			store, _, clock := gitLabTestSetup(t, db)
-			esStore := database.ExternalServices(&brokenDB{errors.New("foo")})
-			h := NewGitLabWebhook(store, esStore, clock.Now)
+			store := gitLabTestSetup(t, db)
+			database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+				return nil, errors.New("foo")
+			}
+			defer func() {
+				database.Mocks.ExternalServices.List = nil
+			}()
+
+			h := NewGitLabWebhook(store)
 
 			_, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if err == nil {
@@ -472,9 +478,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 
 		t.Run("broken campaign store", func(t *testing.T) {
 			// We can induce an error with a broken database connection.
-			s, esStore, clock := gitLabTestSetup(t, db)
-			h := NewGitLabWebhook(s, esStore, clock.Now)
-			h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, clock.Now)
+			s := gitLabTestSetup(t, db)
+			h := NewGitLabWebhook(s)
+			h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, s.Clock())
 
 			es, err := h.getExternalServiceFromRawID(ctx, "12345")
 			if es != nil {
@@ -491,9 +497,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			// in the gaps as best we can.
 
 			t.Run("unknown event type", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				err := h.handleEvent(ctx, es, nil)
 				if err != nil {
@@ -502,9 +508,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("error from enqueueChangesetSyncFromEvent", func(t *testing.T) {
-				store, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(store, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				store := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(store)
+				es := createGitLabExternalService(t, ctx, store.ExternalServices())
 
 				// We can induce an error with an incomplete merge request
 				// event that's missing a project.
@@ -523,9 +529,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("error from handleMergeRequestStateEvent", func(t *testing.T) {
-				s, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(s, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				s := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(s)
+				es := createGitLabExternalService(t, ctx, s.ExternalServices())
 
 				event := &webhooks.MergeRequestCloseEvent{
 					MergeRequestEventCommon: webhooks.MergeRequestEventCommon{
@@ -534,7 +540,7 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, clock.Now)
+				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -545,16 +551,16 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			})
 
 			t.Run("error from handlePipelineEvent", func(t *testing.T) {
-				s, esStore, clock := gitLabTestSetup(t, db)
-				h := NewGitLabWebhook(s, esStore, clock.Now)
-				es := createGitLabExternalService(t, ctx, esStore)
+				s := gitLabTestSetup(t, db)
+				h := NewGitLabWebhook(s)
+				es := createGitLabExternalService(t, ctx, s.ExternalServices())
 
 				event := &webhooks.PipelineEvent{
 					MergeRequest: &gitlab.MergeRequest{IID: 42},
 				}
 
 				// We can induce an error with a broken database connection.
-				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, clock.Now)
+				h.Store = store.NewWithClock(&brokenDB{errors.New("foo")}, s.Clock())
 
 				err := h.handleEvent(ctx, es, event)
 				if err == nil {
@@ -568,10 +574,10 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		t.Run("enqueueChangesetSyncFromEvent", func(t *testing.T) {
 			// Since these tests don't write to the database, we can just share
 			// the same database setup.
-			store, esStore, clock := gitLabTestSetup(t, db)
+			store := gitLabTestSetup(t, db)
 			repoStore := database.ReposWith(store)
-			h := NewGitLabWebhook(store, esStore, clock.Now)
-			es := createGitLabExternalService(t, ctx, esStore)
+			h := NewGitLabWebhook(store)
+			es := createGitLabExternalService(t, ctx, store.ExternalServices())
 			repo := createGitLabRepo(t, ctx, repoStore, es)
 			changeset := createGitLabChangeset(t, ctx, store, repo)
 
@@ -663,9 +669,9 @@ func testGitLabWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			//
 			// Again, we're going to set up a poisoned store database that will
 			// error if a transaction is started.
-			s, esStore, clock := gitLabTestSetup(t, db)
-			s = store.NewWithClock(&noNestingTx{s.DB()}, clock.Now)
-			h := NewGitLabWebhook(s, esStore, clock.Now)
+			s := gitLabTestSetup(t, db)
+			store := store.NewWithClock(&noNestingTx{s.DB()}, s.Clock())
+			h := NewGitLabWebhook(store)
 
 			t.Run("missing merge request", func(t *testing.T) {
 				event := &webhooks.PipelineEvent{}
@@ -822,13 +828,13 @@ func (nntx *noNestingTx) BeginTx(ctx context.Context, opts *sql.TxOptions) error
 // gitLabTestSetup instantiates the stores and a clock for use within tests.
 // Any changes made to the stores will be rolled back after the test is
 // complete.
-func gitLabTestSetup(t *testing.T, db *sql.DB) (*store.Store, *database.ExternalServiceStore, ct.Clock) {
+func gitLabTestSetup(t *testing.T, db *sql.DB) *store.Store {
 	c := &ct.TestClock{Time: timeutil.Now()}
 	tx := dbtest.NewTx(t, db)
 
 	// Note that tx is wrapped in nestedTx to effectively neuter further use of
 	// transactions within the test.
-	return store.NewWithClock(&nestedTx{tx}, c.Now), database.ExternalServices(tx), c
+	return store.NewWithClock(&nestedTx{tx}, c.Now)
 }
 
 // assertBodyIncludes checks for a specific substring within the given response

--- a/enterprise/internal/campaigns/webhooks/webhooks_test.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_test.go
@@ -141,7 +141,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			t.Fatal(err)
 		}
 
-		hook := NewGitHubWebhook(s, esStore, clock)
+		hook := NewGitHubWebhook(s)
 
 		fixtureFiles, err := filepath.Glob("testdata/fixtures/webhooks/github/*.json")
 		if err != nil {
@@ -328,7 +328,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			}
 		}
 
-		hook := NewBitbucketServerWebhook(s, esStore, clock, "testhook")
+		hook := NewBitbucketServerWebhook(s, "testhook")
 
 		fixtureFiles, err := filepath.Glob("testdata/fixtures/webhooks/bitbucketserver/*.json")
 		if err != nil {


### PR DESCRIPTION
Since using global stores is discouraged, I've switched usage of those to be derived from out store.