### PR TITLE
db: add a dev script to renumber migrations

### DIFF
--- a/dev/db/rebase_migration.sh
+++ b/dev/db/rebase_migration.sh
@@ -66,6 +66,13 @@ for migration; do
 done
 
 # Find the highest version, relying on ls's default sorting behaviour.
+#
+# Disable shellcheck: it doesn't like the ls | grep construction, and honestly
+# nor do I, but the alternatives (using a glob with ./, or find | sort) involve
+# more string munging due to including preceding path elements in the output.
+# (This is one of the exceptions noted in the relevant shellcheck page.)
+#
+# shellcheck disable=SC2010
 version="$(ls -1 | grep '\.sql$' | tail -1 | cut -d _ -f 1)"
 
 # Now we'll go through and rename the files.

--- a/dev/db/rebase_migration.sh
+++ b/dev/db/rebase_migration.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# This script attempts to help when rebasing a branch with one or more
+# migrations by renumbering a database migration to a non-conflicting number.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../migrations"
+
+if [ $# -lt 2 ]; then
+  echo "USAGE: $0 <db_name> <migration_to_rebase...>"
+  echo
+  echo "NOTE: <migration_to_rebase> can be either an up or down migration file."
+  exit 1
+fi
+
+if [ ! -d "$1" ]; then
+  echo "Unknown database '$1'"
+  exit 1
+fi
+database="$1"
+pushd "$database" >/dev/null || exit 1
+
+cat <<EOF
+SOURCERER WARNING
+
+Assuming your migration is the latest one, it's a lot easier to migrate down
+before rebasing. If you're in the middle of a rebase, we can't migrate down now
+because the migrate command will get confused by the duplicate migrations we're
+about to fix.
+
+If you haven't already migrated down, you may want to consider aborting your
+rebase, migrating down, then re-running this script:
+
+    git rebase --abort
+    ./dev/db/migrate.sh down $(($# - 1))
+    git rebase origin/main          # or whatever you're rebasing on
+    $0 $@
+
+EOF
+
+read -p 'Do you want to continue? [y/N] ' -n 1 -r
+echo
+case "$REPLY" in
+  Y | y) ;;
+  *)
+    echo 'No problemo! This script will still be here when you need it.'
+    exit 0
+    ;;
+esac
+
+# OK. Let's figure out what we're renaming.
+shift 1
+migrations=()
+for migration; do
+  migration="$(echo "$migration" | sed -E -e 's/^.*\///' -e 's/\.sql$//' -e 's/\.(down|up)$//')"
+
+  for suffix in .down.sql .up.sql; do
+    if [ ! -f "$migration$suffix" ]; then
+      echo "ERROR: cannot find migration file $migration"
+      exit 1
+    fi
+  done
+
+  migrations+=("$migration")
+done
+
+# Find the highest version, relying on ls's default sorting behaviour.
+version="$(ls -1 | grep '\.sql$' | tail -1 | cut -d _ -f 1)"
+
+# Now we'll go through and rename the files.
+for migration in "${migrations[@]}"; do
+  name="$(echo "$migration" | cut -d _ -f 2-)"
+  version=$((version + 1))
+  echo "Renumbering $migration to $version..."
+  git mv "${migration}.down.sql" "${version}_${name}.down.sql"
+  git mv "${migration}.up.sql" "${version}_${name}.up.sql"
+done
+
+cat <<EOF
+Done!
+
+Don't forget to regenerate the bindata and schema before continuing your
+rebase:
+
+    rm migrations/$database/bindata.go
+    go generate ./migrations/$database
+    ./dev/db/migrate.sh $database up
+    go generate ./internal/database
+
+Then git add everything and continue the rebase.
+EOF

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -65,6 +65,40 @@ For example, a non-nullable column can be added to an existing table with the fo
 
 We have a hard requirement (enforced by CI) that rolling upgrades are always possible on Sourcegraph.com. When possible, this same standard should be kept between minor release versions to ensure a smooth upgrade process for private instances (although there will be exceptions due to feature velocity and a monthly release cadence).
 
+### Rebasing a migration
+
+On longer running branches, you might find that your migration now conflicts with another migration added while you were working on your branch. Don't despair! Here are some handy tips when rebasing a branch on `main` that has a migration conflict:
+
+1. It's usually easiest to separate out your migration into a separate commit, with nothing else in it. (You probably want this to be the first commit on your branch, for rebasing simplicity.)
+2. Before you rebase, you should migrate down to the version before your migration. `./dev/db/migrate.sh <database> down 1` will usually take care of this for you.
+3. Once you start rebasing, you'll get an error like this on your migration commit:
+
+   ```
+   Auto-merging migrations/frontend/bindata.go
+   CONFLICT (content): Merge conflict in migrations/frontend/bindata.go
+   Auto-merging internal/database/schema.md
+   error: could not apply 4931031d10... Add migrations.
+   Resolve all conflicts manually, mark them as resolved with
+   "git add/rm <conflicted_files>", then run "git rebase --continue".
+   You can instead skip this commit: run "git rebase --skip".
+   To abort and get back to the state before "git rebase", run "git rebase --abort".
+   Could not apply 4931031d10... Add migrations.
+   ```
+
+   We need to renumber your migration, and regenerate the generated files.
+
+4. You can renumber your migration by `git mv`-ing the relevant up and down files, or with this script: `./dev/db/rebase_migration.sh <database> <either your up or down file>`
+5. Once done, you need to regenerate the schema and bindata. If you use `rebase_migration.sh`, it will suggest what to do, but it's roughly:
+
+   ```bash
+   rm migrations/<database>/bindata.go
+   go generate ./migrations/<database>
+   ./dev/db/migrate.sh <database> up
+   go generate ./internal/<database>
+   ```
+
+6. From there, `git add` your updated files, and you should be able to continue your rebase.
+
 ## Customer rollbacks
 
 Running down migrations in a rollback **should NOT** be necessary if all migrations are backward-compatible. In case the customer must run a down migration, they will need perform do the following steps.


### PR DESCRIPTION
When I'm working on feature branches that take more than a day or two to finish, review, and merge, I find that my migrations often end up conflicting with other people's migrations that have been merged in the interim. This adds instructions on how to deal with this, based on what I personally do, and (probably more usefully) bundles the core of the process into a script that can do most of the dirty work.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
