### PR TITLE
label-notify: change label team/cloud to team/core-application & notify the whole core-application team

### DIFF
--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -13,8 +13,8 @@ jobs:
              recipients: |
                   team/extensibility=@joelkw @jeanduplessis @felixfbecker
                   team/frontend-platform=@jeanduplessis @alicjasuska @felixfbecker
-                  team/core-application=@core-application
-                  team/backend-platform=@core-application
+                  team/core-application=@sourcegraph/core-application
+                  team/backend-platform=@sourcegraph/core-application
                   team/search=@lguychard
                   team/code-intelligence=@macraig
                   team/code-insights=@joelkw @felixfbecker

--- a/.github/workflows/label-notify.yml
+++ b/.github/workflows/label-notify.yml
@@ -13,7 +13,8 @@ jobs:
              recipients: |
                   team/extensibility=@joelkw @jeanduplessis @felixfbecker
                   team/frontend-platform=@jeanduplessis @alicjasuska @felixfbecker
-                  team/cloud=@tsenart
+                  team/core-application=@core-application
+                  team/backend-platform=@core-application
                   team/search=@lguychard
                   team/code-intelligence=@macraig
                   team/code-insights=@joelkw @felixfbecker


### PR DESCRIPTION
instead of Tomás handling it all, now we route these mentions to @sourcegraph/core-application 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
