### PR TITLE
add /ping-from-self-hosted and fire ping on /site-admin/init submission

### DIFF
--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -9,6 +9,16 @@ import { AuthenticatedUser } from '../../auth'
 import { SourcegraphContext } from '../../jscontext'
 
 const initSite = async (args: SignUpArguments): Promise<void> => {
+    let pingUrl = new URL('https://sourcegraph.com/ping-from-self-hosted')
+    pingUrl.searchParams.set('email', args.email)
+    pingUrl.searchParams.set('hostname', window.location.hostname)
+
+    fetch(pingUrl.toString()).then(res => {
+        if (res.status !== 200) {
+            // non-blocking error, just mention something in the console
+            console.error(res.text())
+        }
+    })
     const response = await fetch('/-/site-init', {
         credentials: 'same-origin',
         method: 'POST',

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -9,16 +9,15 @@ import { AuthenticatedUser } from '../../auth'
 import { SourcegraphContext } from '../../jscontext'
 
 const initSite = async (args: SignUpArguments): Promise<void> => {
-    let pingUrl = new URL('https://sourcegraph.com/ping-from-self-hosted')
+    const pingUrl = new URL('https://sourcegraph.com/ping-from-self-hosted')
     pingUrl.searchParams.set('email', args.email)
     pingUrl.searchParams.set('hostname', window.location.hostname)
 
-    fetch(pingUrl.toString()).then(res => {
-        if (res.status !== 200) {
-            // non-blocking error, just mention something in the console
-            console.error(res.text())
-        }
-    })
+    fetch(pingUrl.toString())
+        .then() // no op
+        .catch((error): void => {
+            console.error(error)
+        })
     const response = await fetch('/-/site-init', {
         credentials: 'same-origin',
         method: 'POST',

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -30,45 +30,46 @@ import (
 )
 
 const (
-	routeHome           = "home"
-	routeSearch         = "search"
-	routeSearchBadge    = "search-badge"
-	routeRepo           = "repo"
-	routeRepoSettings   = "repo-settings"
-	routeRepoCommit     = "repo-commit"
-	routeRepoBranches   = "repo-branches"
-	routeRepoCommits    = "repo-commits"
-	routeRepoTags       = "repo-tags"
-	routeRepoCompare    = "repo-compare"
-	routeRepoStats      = "repo-stats"
-	routeInsights       = "insights"
-	routeCampaigns      = "campaigns"
-	routeCodeMonitoring = "code-monitoring"
-	routeThreads        = "threads"
-	routeTree           = "tree"
-	routeBlob           = "blob"
-	routeRaw            = "raw"
-	routeOrganizations  = "org"
-	routeSettings       = "settings"
-	routeSiteAdmin      = "site-admin"
-	routeAPIConsole     = "api-console"
-	routeUser           = "user"
-	routeUserSettings   = "user-settings"
-	routeUserRedirect   = "user-redirect"
-	routeAboutSubdomain = "about-subdomain"
-	aboutRedirectScheme = "https"
-	aboutRedirectHost   = "about.sourcegraph.com"
-	routeSurvey         = "survey"
-	routeSurveyScore    = "survey-score"
-	routeRegistry       = "registry"
-	routeExtensions     = "extensions"
-	routeHelp           = "help"
-	routeRepoGroups     = "repo-groups"
-	routeCncf           = "repo-groups.cncf"
-	routeSnippets       = "snippets"
-	routeSubscriptions  = "subscriptions"
-	routeStats          = "stats"
-	routeViews          = "views"
+	routeHome               = "home"
+	routeSearch             = "search"
+	routeSearchBadge        = "search-badge"
+	routeRepo               = "repo"
+	routeRepoSettings       = "repo-settings"
+	routeRepoCommit         = "repo-commit"
+	routeRepoBranches       = "repo-branches"
+	routeRepoCommits        = "repo-commits"
+	routeRepoTags           = "repo-tags"
+	routeRepoCompare        = "repo-compare"
+	routeRepoStats          = "repo-stats"
+	routeInsights           = "insights"
+	routeCampaigns          = "campaigns"
+	routeCodeMonitoring     = "code-monitoring"
+	routeThreads            = "threads"
+	routeTree               = "tree"
+	routeBlob               = "blob"
+	routeRaw                = "raw"
+	routeOrganizations      = "org"
+	routeSettings           = "settings"
+	routeSiteAdmin          = "site-admin"
+	routeAPIConsole         = "api-console"
+	routeUser               = "user"
+	routeUserSettings       = "user-settings"
+	routeUserRedirect       = "user-redirect"
+	routeAboutSubdomain     = "about-subdomain"
+	aboutRedirectScheme     = "https"
+	aboutRedirectHost       = "about.sourcegraph.com"
+	routeSurvey             = "survey"
+	routeSurveyScore        = "survey-score"
+	routeRegistry           = "registry"
+	routeExtensions         = "extensions"
+	routeHelp               = "help"
+	routeRepoGroups         = "repo-groups"
+	routeCncf               = "repo-groups.cncf"
+	routeSnippets           = "snippets"
+	routeSubscriptions      = "subscriptions"
+	routeStats              = "stats"
+	routeViews              = "views"
+	routePingFromSelfHosted = "ping-from-self-hosted"
 
 	routeSearchQueryBuilder = "search.query-builder"
 	routeSearchStream       = "search.stream"
@@ -147,6 +148,7 @@ func newRouter() *mux.Router {
 	r.PathPrefix("/subscriptions").Methods("GET").Name(routeSubscriptions)
 	r.PathPrefix("/stats").Methods("GET").Name(routeStats)
 	r.PathPrefix("/views").Methods("GET").Name(routeViews)
+	r.Path("/ping-from-self-hosted").Methods("GET", "OPTIONS").Name(routePingFromSelfHosted)
 
 	// Repogroup pages. Must mirror web/src/Layout.tsx
 	if envvar.SourcegraphDotComMode() {
@@ -230,6 +232,7 @@ func initRouter(router *mux.Router) {
 	router.Get(routeSubscriptions).Handler(handler(serveBrandedPageString("Subscriptions", nil)))
 	router.Get(routeStats).Handler(handler(serveBrandedPageString("Stats", nil)))
 	router.Get(routeViews).Handler(handler(serveBrandedPageString("View", nil)))
+	router.Get(routePingFromSelfHosted).Handler(handler(servePingFromSelfHosted))
 
 	router.Get(routeUserSettings).Handler(handler(serveBrandedPageString("User settings", nil)))
 	router.Get(routeUserRedirect).Handler(handler(serveBrandedPageString("User", nil)))

--- a/internal/hubspot/contacts.go
+++ b/internal/hubspot/contacts.go
@@ -37,11 +37,12 @@ func (c *Client) baseContactURL(email string) *url.URL {
 
 // ContactProperties represent HubSpot user properties
 type ContactProperties struct {
-	UserID          string `json:"user_id"`
-	IsServerAdmin   bool   `json:"is_server_admin"`
-	LatestPing      int64  `json:"latest_ping"`
-	AnonymousUserID string `json:"anonymous_user_id"`
-	FirstSourceURL  string `json:"first_source_url"`
+	UserID               string `json:"user_id"`
+	IsServerAdmin        bool   `json:"is_server_admin"`
+	LatestPing           int64  `json:"latest_ping"`
+	AnonymousUserID      string `json:"anonymous_user_id"`
+	FirstSourceURL       string `json:"first_source_url"`
+	InstallationHostname string `json:"installation_hostname"`
 }
 
 // ContactResponse represents HubSpot user properties returned

--- a/internal/hubspot/hubspotutil/hubspotutil.go
+++ b/internal/hubspot/hubspotutil/hubspotutil.go
@@ -25,6 +25,9 @@ var TrialFormID = "0bbc9f90-3741-4c7a-b5f5-6c81f130ea9d"
 // https://app.hubspot.com/reports/2762526/events
 var SignupEventID = "000001776813"
 
+// SelfHostedSiteInitEventID is the Hubstpot Event ID for when a new site is created in /site-admin/sites
+var SelfHostedSiteInitEventID = "000010399089"
+
 var client *hubspot.Client
 
 // HasAPIKey returns true if a HubspotAPI key is present. A subset of requests require a HubSpot API key.


### PR DESCRIPTION
I don't think i can test this without it going to prod 🤔  but it's a pretty low consequence change.

this change adds a new endpoint /ping-from-self-hosted to track attribution on signup for self hosted instances. It also updates /site-admin/init to hit the ping endpoint on form submission.

ref: #18088 

ref [RFC 296](https://docs.google.com/document/d/1LjogYGRd8lp_pIBp_uXLPBOAdGnMvpvNo-RojjHwvwc/edit#)
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
