### PR TITLE
enterprise: Pass down db connection instead of using global variable

### DIFF
--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -118,7 +118,7 @@ func InitDB() (*sql.DB, error) {
 }
 
 // Main is the main entrypoint for the frontend server program.
-func Main(enterpriseSetupHook func() enterprise.Services) error {
+func Main(enterpriseSetupHook func(db dbutil.DB) enterprise.Services) error {
 	log.SetFlags(0)
 	log.SetPrefix("")
 
@@ -147,7 +147,7 @@ func Main(enterpriseSetupHook func() enterprise.Services) error {
 	trace.Init(true)
 
 	// Run enterprise setup hook
-	enterprise := enterpriseSetupHook()
+	enterprise := enterpriseSetupHook(db)
 
 	if len(os.Args) >= 2 {
 		switch os.Args[1] {

--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/assets"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/shared"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // Note: All frontend code should be added to shared.Main, not here. See that
@@ -15,7 +16,7 @@ func main() {
 	// See https://github.com/sourcegraph/sourcegraph/issues/3847 for details.
 	authz.SetProviders(true, []authz.Provider{})
 
-	shared.Main(func() enterprise.Services {
+	shared.Main(func(db dbutil.DB) enterprise.Services {
 		return enterprise.DefaultServices()
 	})
 }

--- a/cmd/frontend/shared/frontend.go
+++ b/cmd/frontend/shared/frontend.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/cli"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 
 	_ "github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
@@ -17,7 +18,7 @@ import (
 // It is exposed as function in a package so that it can be called by other
 // main package implementations such as Sourcegraph Enterprise, which import
 // proprietary/private code.
-func Main(enterpriseSetupHook func() enterprise.Services) {
+func Main(enterpriseSetupHook func(db dbutil.DB) enterprise.Services) {
 	env.Lock()
 	err := cli.Main(enterpriseSetupHook)
 	if err != nil {

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -11,12 +11,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
-func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
-	eauthz.Init(dbconn.Global, timeutil.Now)
+func Init(ctx context.Context, db dbutil.DB, enterpriseServices *enterprise.Services) error {
+	eauthz.Init(db, timeutil.Now)
 
 	go func() {
 		t := time.NewTicker(5 * time.Second)
@@ -27,7 +27,7 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 		}
 	}()
 
-	enterpriseServices.AuthzResolver = resolvers.NewResolver(dbconn.Global, timeutil.Now)
+	enterpriseServices.AuthzResolver = resolvers.NewResolver(db, timeutil.Now)
 
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/init.go
+++ b/enterprise/cmd/frontend/internal/codeintel/init.go
@@ -18,13 +18,14 @@ import (
 	codeintelresolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	codeintelgqlresolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
-	if err := initServices(ctx); err != nil {
+func Init(ctx context.Context, db dbutil.DB, enterpriseServices *enterprise.Services) error {
+	if err := initServices(ctx, db); err != nil {
 		return err
 	}
 
@@ -39,7 +40,7 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 		return err
 	}
 
-	uploadHandler, err := newUploadHandler(ctx)
+	uploadHandler, err := newUploadHandler(ctx, db)
 	if err != nil {
 		return err
 	}
@@ -81,13 +82,13 @@ func newResolver(ctx context.Context, observationContext *observation.Context) (
 	return resolver, err
 }
 
-func newUploadHandler(ctx context.Context) (func(internal bool) http.Handler, error) {
-	internalHandler, err := NewCodeIntelUploadHandler(ctx, true)
+func newUploadHandler(ctx context.Context, db dbutil.DB) (func(internal bool) http.Handler, error) {
+	internalHandler, err := NewCodeIntelUploadHandler(ctx, db, true)
 	if err != nil {
 		return nil, err
 	}
 
-	externalHandler, err := NewCodeIntelUploadHandler(ctx, false)
+	externalHandler, err := NewCodeIntelUploadHandler(ctx, db, false)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/services.go
+++ b/enterprise/cmd/frontend/internal/codeintel/services.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -36,7 +37,7 @@ var services struct {
 
 var once sync.Once
 
-func initServices(ctx context.Context) error {
+func initServices(ctx context.Context, db dbutil.DB) error {
 	once.Do(func() {
 		if err := config.UploadStoreConfig.Validate(); err != nil {
 			services.err = fmt.Errorf("failed to load config: %s", err)
@@ -54,7 +55,7 @@ func initServices(ctx context.Context) error {
 		codeIntelDB := mustInitializeCodeIntelDB()
 
 		// Initialize stores
-		dbStore := store.NewWithDB(dbconn.Global, observationContext)
+		dbStore := store.NewWithDB(db, observationContext)
 		lsifStore := lsifstore.NewStore(codeIntelDB, observationContext)
 		uploadStore, err := uploadstore.CreateLazy(context.Background(), config.UploadStoreConfig, observationContext)
 		if err != nil {

--- a/enterprise/cmd/frontend/internal/codeintel/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/upload_handler.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/httpapi"
 	codeintelhttpapi "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/httpapi"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // NewCodeIntelUploadHandler creates a new code intel LSIF upload HTTP handler. This is used
 // by both the enterprise frontend codeintel init code to install handlers in the frontend API
 // as well as the the enterprise frontend executor init code to install handlers in the proxy.
-func NewCodeIntelUploadHandler(ctx context.Context, internal bool) (http.Handler, error) {
-	if err := initServices(ctx); err != nil {
+func NewCodeIntelUploadHandler(ctx context.Context, db dbutil.DB, internal bool) (http.Handler, error) {
+	if err := initServices(ctx, db); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/codemonitors/init.go
+++ b/enterprise/cmd/frontend/internal/codemonitors/init.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codemonitors/resolvers"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
-	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(dbconn.Global)
+func Init(ctx context.Context, db dbutil.DB, enterpriseServices *enterprise.Services) error {
+	enterpriseServices.CodeMonitorsResolver = resolvers.NewResolver(db)
 	return nil
 }

--- a/enterprise/cmd/frontend/internal/executor/init.go
+++ b/enterprise/cmd/frontend/internal/executor/init.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
-	handler, err := codeintel.NewCodeIntelUploadHandler(ctx, true)
+func Init(ctx context.Context, db dbutil.DB, enterpriseServices *enterprise.Services) error {
+	handler, err := codeintel.NewCodeIntelUploadHandler(ctx, db, true)
 	if err != nil {
 		return err
 	}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -17,12 +17,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 
 // TODO(efritz) - de-globalize assignments in this function
 // TODO(efritz) - refactor licensing packages - this is a huge mess!
-func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
+func Init(ctx context.Context, db dbutil.DB, enterpriseServices *enterprise.Services) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
 	database.GlobalUsers.BeforeCreateUser = enforcement.NewBeforeCreateUserHook(&usersStore{})

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -21,6 +21,7 @@ import (
 	licensing "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/licensing/init"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth"
 	_ "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/graphqlbackend"
@@ -31,7 +32,7 @@ func main() {
 	shared.Main(enterpriseSetupHook)
 }
 
-var initFunctions = map[string]func(ctx context.Context, enterpriseServices *enterprise.Services) error{
+var initFunctions = map[string]func(ctx context.Context, db dbutil.DB, enterpriseServices *enterprise.Services) error{
 	"authz":        authz.Init,
 	"licensing":    licensing.Init,
 	"executor":     executor.Init,
@@ -41,7 +42,7 @@ var initFunctions = map[string]func(ctx context.Context, enterpriseServices *ent
 	"codemonitors": codemonitors.Init,
 }
 
-func enterpriseSetupHook() enterprise.Services {
+func enterpriseSetupHook(db dbutil.DB) enterprise.Services {
 	debug, _ := strconv.ParseBool(os.Getenv("DEBUG"))
 	if debug {
 		log.Println("enterprise edition")
@@ -51,7 +52,7 @@ func enterpriseSetupHook() enterprise.Services {
 	enterpriseServices := enterprise.DefaultServices()
 
 	for name, fn := range initFunctions {
-		if err := fn(ctx, &enterpriseServices); err != nil {
+		if err := fn(ctx, db, &enterpriseServices); err != nil {
 			log.Fatal(fmt.Sprintf("failed to initialize %s: %s", name, err))
 		}
 	}

--- a/enterprise/internal/campaigns/frontend.go
+++ b/enterprise/internal/campaigns/frontend.go
@@ -7,19 +7,19 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/resolvers"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/webhooks"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/database/globalstatedb"
 )
 
 // InitFrontend initializes the given enterpriseServices to include the required resolvers for campaigns
 // and sets up webhook handlers for changeset events.
-func InitFrontend(ctx context.Context, enterpriseServices *enterprise.Services) error {
+func InitFrontend(ctx context.Context, db dbutil.DB, enterpriseServices *enterprise.Services) error {
 	globalState, err := globalstatedb.Get(ctx)
 	if err != nil {
 		return err
 	}
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	enterpriseServices.CampaignsResolver = resolvers.New(cstore)
 	enterpriseServices.GitHubWebhook = webhooks.NewGitHubWebhook(cstore)

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -12,10 +12,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // Init initializes the given enterpriseServices to include the required resolvers for insights.
-func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
+func Init(ctx context.Context, postgres dbutil.DB, enterpriseServices *enterprise.Services) error {
 	if !conf.IsDev(conf.DeployType()) {
 		// Code Insights is not yet deployed to non-dev/testing instances. We don't yet have
 		// TimescaleDB in those deployments. https://github.com/sourcegraph/sourcegraph/issues/17218
@@ -34,7 +35,6 @@ func Init(ctx context.Context, enterpriseServices *enterprise.Services) error {
 	if err != nil {
 		return err
 	}
-	postgres := dbconn.Global
 	enterpriseServices.InsightsResolver = resolvers.New(timescale, postgres)
 	return nil
 }


### PR DESCRIPTION
This PR refactors the enterprise codebase to accept a db to be passed down, instead of using the `dbconn.Global`. 