### PR TITLE
database: Don't batch default repo fetching

### DIFF
--- a/internal/database/default_repos.go
+++ b/internal/database/default_repos.go
@@ -114,7 +114,7 @@ func (s *DefaultRepoStore) refreshCache(ctx context.Context) ([]*types.RepoName,
 		return repos, nil
 	}
 
-	repos, err := ReposWith(s).ListAllDefaultRepos(ctx)
+	repos, err := ReposWith(s).ListDefaultRepos(ctx, ListDefaultReposOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "querying for default repos")
 	}


### PR DESCRIPTION
After digging into why ListDefaultRepos is slow and chatting through
different optimisation strategies we concluded that there's no need to
paginate our requests. Paginating leads to duplicate work in the database
since each page still needs to perform a lot of work to then throw
away the data that is not within range for the current page.

Postgres is smart enough to stream results back as they are requested
and we can limit memory usage in our Go code where necessary by using
rows.Next() to fetch data in chunks.
