### PR TITLE
frontend: Handle renamed GitHub repos on Cloud

### DIFF
--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -86,7 +86,7 @@ func TestRepos_Add(t *testing.T) {
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 
-	if err := s.Add(ctx, repoName); err != nil {
+	if _, err := s.Add(ctx, repoName); err != nil {
 		t.Fatal(err)
 	}
 	if !calledRepoLookup {

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -73,6 +73,7 @@ func TestRepos_Add(t *testing.T) {
 	ctx := testContext()
 
 	const repoName = "my/repo"
+	const newName = "my/repo2"
 
 	calledRepoLookup := false
 	repoupdater.MockRepoLookup = func(args protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error) {
@@ -81,13 +82,18 @@ func TestRepos_Add(t *testing.T) {
 			t.Errorf("got %q, want %q", args.Repo, repoName)
 		}
 		return &protocol.RepoLookupResult{
-			Repo: &protocol.RepoInfo{Name: repoName, Description: "d"},
+			Repo: &protocol.RepoInfo{Name: newName, Description: "d"},
 		}, nil
 	}
 	defer func() { repoupdater.MockRepoLookup = nil }()
 
-	if _, err := s.Add(ctx, repoName); err != nil {
+	// The repoName could change if it has been renamed on the code host
+	addedName, err := s.Add(ctx, repoName)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if addedName != newName {
+		t.Fatalf("Want %q, got %q", newName, addedName)
 	}
 	if !calledRepoLookup {
 		t.Error("!calledRepoLookup")

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -144,7 +144,7 @@ func DeployType() string {
 	if e := os.Getenv("DEPLOY_TYPE"); e != "" {
 		return e
 	}
-	// Default to Kubernetes cluster so that every Kubernetes c
+	// Default to Kubernetes cluster so that every Kubernetes
 	// cluster deployment doesn't need to be configured with DEPLOY_TYPE.
 	return DeployKubernetes
 }


### PR DESCRIPTION
When browsing to a repo on Cloud we perform an on demand fetch if the
repo could not be found. In the case of a repo being renamed on the code
host we should instead return the new name and redirect there.

Closes: https://github.com/sourcegraph/sourcegraph/issues/17978