### PR TITLE
fix /ping-from-self-hosted (hopefully)

### DIFF
--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -13,7 +13,7 @@ const initSite = async (args: SignUpArguments): Promise<void> => {
     pingUrl.searchParams.set('email', args.email)
     pingUrl.searchParams.set('hostname', window.location.hostname)
 
-    fetch(pingUrl.toString())
+    await fetch(pingUrl.toString())
         .then() // no op
         .catch((error): void => {
             console.error(error)

--- a/cmd/frontend/auth/non_public.go
+++ b/cmd/frontend/auth/non_public.go
@@ -71,9 +71,10 @@ var (
 		router.CheckUsernameTaken: {},
 	}
 	anonymousAccessibleUIRoutes = map[string]struct{}{
-		uirouter.RouteSignIn:        {},
-		uirouter.RouteSignUp:        {},
-		uirouter.RoutePasswordReset: {},
+		uirouter.RouteSignIn:             {},
+		uirouter.RouteSignUp:             {},
+		uirouter.RoutePasswordReset:      {},
+		uirouter.RoutePingFromSelfHosted: {},
 	}
 	// Some routes return non-standard HTTP responses when a user is not
 	// signed in.

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -30,46 +30,45 @@ import (
 )
 
 const (
-	routeHome               = "home"
-	routeSearch             = "search"
-	routeSearchBadge        = "search-badge"
-	routeRepo               = "repo"
-	routeRepoSettings       = "repo-settings"
-	routeRepoCommit         = "repo-commit"
-	routeRepoBranches       = "repo-branches"
-	routeRepoCommits        = "repo-commits"
-	routeRepoTags           = "repo-tags"
-	routeRepoCompare        = "repo-compare"
-	routeRepoStats          = "repo-stats"
-	routeInsights           = "insights"
-	routeCampaigns          = "campaigns"
-	routeCodeMonitoring     = "code-monitoring"
-	routeThreads            = "threads"
-	routeTree               = "tree"
-	routeBlob               = "blob"
-	routeRaw                = "raw"
-	routeOrganizations      = "org"
-	routeSettings           = "settings"
-	routeSiteAdmin          = "site-admin"
-	routeAPIConsole         = "api-console"
-	routeUser               = "user"
-	routeUserSettings       = "user-settings"
-	routeUserRedirect       = "user-redirect"
-	routeAboutSubdomain     = "about-subdomain"
-	aboutRedirectScheme     = "https"
-	aboutRedirectHost       = "about.sourcegraph.com"
-	routeSurvey             = "survey"
-	routeSurveyScore        = "survey-score"
-	routeRegistry           = "registry"
-	routeExtensions         = "extensions"
-	routeHelp               = "help"
-	routeRepoGroups         = "repo-groups"
-	routeCncf               = "repo-groups.cncf"
-	routeSnippets           = "snippets"
-	routeSubscriptions      = "subscriptions"
-	routeStats              = "stats"
-	routeViews              = "views"
-	routePingFromSelfHosted = "ping-from-self-hosted"
+	routeHome           = "home"
+	routeSearch         = "search"
+	routeSearchBadge    = "search-badge"
+	routeRepo           = "repo"
+	routeRepoSettings   = "repo-settings"
+	routeRepoCommit     = "repo-commit"
+	routeRepoBranches   = "repo-branches"
+	routeRepoCommits    = "repo-commits"
+	routeRepoTags       = "repo-tags"
+	routeRepoCompare    = "repo-compare"
+	routeRepoStats      = "repo-stats"
+	routeInsights       = "insights"
+	routeCampaigns      = "campaigns"
+	routeCodeMonitoring = "code-monitoring"
+	routeThreads        = "threads"
+	routeTree           = "tree"
+	routeBlob           = "blob"
+	routeRaw            = "raw"
+	routeOrganizations  = "org"
+	routeSettings       = "settings"
+	routeSiteAdmin      = "site-admin"
+	routeAPIConsole     = "api-console"
+	routeUser           = "user"
+	routeUserSettings   = "user-settings"
+	routeUserRedirect   = "user-redirect"
+	routeAboutSubdomain = "about-subdomain"
+	aboutRedirectScheme = "https"
+	aboutRedirectHost   = "about.sourcegraph.com"
+	routeSurvey         = "survey"
+	routeSurveyScore    = "survey-score"
+	routeRegistry       = "registry"
+	routeExtensions     = "extensions"
+	routeHelp           = "help"
+	routeRepoGroups     = "repo-groups"
+	routeCncf           = "repo-groups.cncf"
+	routeSnippets       = "snippets"
+	routeSubscriptions  = "subscriptions"
+	routeStats          = "stats"
+	routeViews          = "views"
 
 	routeSearchQueryBuilder = "search.query-builder"
 	routeSearchStream       = "search.stream"
@@ -148,7 +147,7 @@ func newRouter() *mux.Router {
 	r.PathPrefix("/subscriptions").Methods("GET").Name(routeSubscriptions)
 	r.PathPrefix("/stats").Methods("GET").Name(routeStats)
 	r.PathPrefix("/views").Methods("GET").Name(routeViews)
-	r.Path("/ping-from-self-hosted").Methods("GET", "OPTIONS").Name(routePingFromSelfHosted)
+	r.Path("/ping-from-self-hosted").Methods("GET", "OPTIONS").Name(uirouter.RoutePingFromSelfHosted)
 
 	// Repogroup pages. Must mirror web/src/Layout.tsx
 	if envvar.SourcegraphDotComMode() {
@@ -232,7 +231,7 @@ func initRouter(router *mux.Router) {
 	router.Get(routeSubscriptions).Handler(handler(serveBrandedPageString("Subscriptions", nil)))
 	router.Get(routeStats).Handler(handler(serveBrandedPageString("Stats", nil)))
 	router.Get(routeViews).Handler(handler(serveBrandedPageString("View", nil)))
-	router.Get(routePingFromSelfHosted).Handler(handler(servePingFromSelfHosted))
+	router.Get(uirouter.RoutePingFromSelfHosted).Handler(handler(servePingFromSelfHosted))
 
 	router.Get(routeUserSettings).Handler(handler(serveBrandedPageString("User settings", nil)))
 	router.Get(routeUserRedirect).Handler(handler(serveBrandedPageString("User", nil)))

--- a/cmd/frontend/internal/app/ui/router/exported_router.go
+++ b/cmd/frontend/internal/app/ui/router/exported_router.go
@@ -11,8 +11,9 @@ var Router *mux.Router
 // These route names are used by other packages that can't import the ../ui package without creating
 // an import cycle.
 const (
-	RouteSignIn        = "sign-in"
-	RouteSignUp        = "sign-up"
-	RoutePasswordReset = "password-reset"
-	RouteRaw           = "raw"
+	RouteSignIn             = "sign-in"
+	RouteSignUp             = "sign-up"
+	RoutePasswordReset      = "password-reset"
+	RouteRaw                = "raw"
+	RoutePingFromSelfHosted = "ping-from-self-hosted"
 )


### PR DESCRIPTION
this fixes two issues:
• not awaiting the request means we'd cancel when navigating away, so now we await.
• the /ping-from-self-hosted endpoint wasn't on the list of public endpoints, so middleware was trying to redirect to sign in.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
