### PR TITLE
repos: Update cloning repo count for users

### DIFF
--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -38,10 +38,9 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 	}
 
 	if notCloned != 0 {
-		text := fmt.Sprintf("%d repositories enqueued for cloning...", notCloned)
 		messages = append(messages, StatusMessage{
 			Cloning: &CloningProgress{
-				Message: text,
+				Message: fmt.Sprintf("%d repositories enqueued for cloning...", notCloned),
 			},
 		})
 	}

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
@@ -28,24 +27,43 @@ func TestStatusMessages(t *testing.T) {
 	db := dbtest.NewDB(t, "")
 	store := NewStore(db, sql.TxOptions{})
 
-	githubService := &types.ExternalService{
-		ID:          1,
-		Config:      `{}`,
-		Kind:        extsvc.KindGitHub,
-		DisplayName: "github.com - test",
-	}
-
-	err := database.ExternalServices(db).Upsert(ctx, githubService)
+	admin, err := database.Users(db).Create(ctx, database.NewUser{
+		Email:                 "a1@example.com",
+		Username:              "a1",
+		Password:              "p",
+		EmailVerificationCode: "c",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	user1, err := database.Users(db).Create(ctx, database.NewUser{
-		Email:                 "a1@example.com",
+	nonAdmin, err := database.Users(db).Create(ctx, database.NewUser{
+		Email:                 "u1@example.com",
 		Username:              "u1",
 		Password:              "p",
 		EmailVerificationCode: "c",
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	siteLevelService := &types.ExternalService{
+		ID:          1,
+		Config:      `{}`,
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "github.com - site",
+	}
+	err = database.ExternalServices(db).Upsert(ctx, siteLevelService)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userService := &types.ExternalService{
+		ID:              2,
+		Config:          `{}`,
+		Kind:            extsvc.KindGitHub,
+		DisplayName:     "github.com - user",
+		NamespaceUserID: nonAdmin.ID,
+	}
+	err = database.ExternalServices(db).Upsert(ctx, userService)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,17 +75,22 @@ func TestStatusMessages(t *testing.T) {
 		sourcerErr      error
 		listRepoErr     error
 		res             []StatusMessage
-		err             string
+		user            *types.User
+		// maps repoName to external service id
+		repoOwner map[api.RepoName]int64
+		err       string
 	}{
 		{
 			name:            "all cloned",
 			gitserverCloned: []string{"foobar"},
 			stored:          []*types.Repo{{Name: "foobar", Cloned: true}},
+			user:            admin,
 			res:             nil,
 		},
 		{
 			name:            "nothing cloned",
 			stored:          []*types.Repo{{Name: "foobar"}},
+			user:            admin,
 			gitserverCloned: []string{},
 			res: []StatusMessage{
 				{
@@ -80,7 +103,23 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:            "subset cloned",
 			stored:          []*types.Repo{{Name: "foobar", Cloned: true}, {Name: "barfoo"}},
+			user:            admin,
 			gitserverCloned: []string{"foobar"},
+			res: []StatusMessage{
+				{
+					Cloning: &CloningProgress{
+						Message: "1 repositories enqueued for cloning...",
+					},
+				},
+			},
+		},
+		{
+			name:   "non admin users should only count their own non cloned repos",
+			stored: []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
+			repoOwner: map[api.RepoName]int64{
+				"foobar": userService.ID,
+			},
+			user: nonAdmin,
 			res: []StatusMessage{
 				{
 					Cloning: &CloningProgress{
@@ -92,12 +131,14 @@ func TestStatusMessages(t *testing.T) {
 		{
 			name:            "more cloned than stored",
 			stored:          []*types.Repo{{Name: "foobar", Cloned: true}},
+			user:            admin,
 			gitserverCloned: []string{"foobar", "barfoo"},
 			res:             nil,
 		},
 		{
 			name:            "cloned different than stored",
 			stored:          []*types.Repo{{Name: "foobar"}, {Name: "barfoo"}},
+			user:            admin,
 			gitserverCloned: []string{"one", "two", "three"},
 			res: []StatusMessage{
 				{
@@ -111,34 +152,38 @@ func TestStatusMessages(t *testing.T) {
 			name:            "case insensitivity",
 			gitserverCloned: []string{"foobar"},
 			stored:          []*types.Repo{{Name: "FOOBar", Cloned: true}},
+			user:            admin,
 			res:             nil,
 		},
 		{
 			name:            "case insensitivity to gitserver names",
 			gitserverCloned: []string{"FOOBar"},
 			stored:          []*types.Repo{{Name: "FOOBar", Cloned: true}},
+			user:            admin,
 			res:             nil,
 		},
 		{
 			name:       "one external service syncer err",
+			user:       admin,
 			sourcerErr: errors.New("github is down"),
 			res: []StatusMessage{
 				{
 					ExternalServiceSyncError: &ExternalServiceSyncError{
 						Message:           "fetching from code host: 1 error occurred:\n\t* github is down\n\n",
-						ExternalServiceId: githubService.ID,
+						ExternalServiceId: siteLevelService.ID,
 					},
 				},
 			},
 		},
 		{
 			name:        "one syncer err",
+			user:        admin,
 			listRepoErr: errors.New("could not connect to database"),
 			res: []StatusMessage{
 				{
 					ExternalServiceSyncError: &ExternalServiceSyncError{
 						Message:           "syncer.sync.store.list-repos: could not connect to database",
-						ExternalServiceId: githubService.ID,
+						ExternalServiceId: siteLevelService.ID,
 					},
 				},
 			},
@@ -167,7 +212,6 @@ func TestStatusMessages(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
 			t.Cleanup(func() {
 				ids := make([]api.RepoID, 0, len(stored))
 				for _, r := range stored {
@@ -178,6 +222,26 @@ func TestStatusMessages(t *testing.T) {
 					t.Fatal(err)
 				}
 			})
+
+			// Set up ownership of repos
+			if tc.repoOwner != nil {
+				for _, repo := range stored {
+					svcID, ok := tc.repoOwner[repo.Name]
+					if !ok {
+						continue
+					}
+					_, err = db.ExecContext(ctx, `INSERT INTO external_service_repos VALUES ($1, $2, 'example.com')`, svcID, repo.ID)
+					if err != nil {
+						t.Fatal(err)
+					}
+					t.Cleanup(func() {
+						_, err = db.ExecContext(ctx, `DELETE FROM external_service_repos WHERE external_service_id = $1`, svcID)
+						if err != nil {
+							t.Fatal(err)
+						}
+					})
+				}
+			}
 
 			err = store.SetClonedRepos(ctx, cloned...)
 			if err != nil {
@@ -197,12 +261,10 @@ func TestStatusMessages(t *testing.T) {
 				defer func() {
 					database.Mocks.Repos.List = nil
 				}()
-				sourcer := NewFakeSourcer(tc.sourcerErr, NewFakeSource(githubService, nil))
-				// Run Sync so that possibly `LastSyncErrors` is set
+				sourcer := NewFakeSourcer(tc.sourcerErr, NewFakeSource(siteLevelService, nil))
 				syncer.Sourcer = sourcer
 
-				err = syncer.SyncExternalService(ctx, store, githubService.ID, time.Millisecond)
-
+				err = syncer.SyncExternalService(ctx, store, siteLevelService.ID, time.Millisecond)
 				// In prod, SyncExternalService is kicked off by a worker queue. Any error
 				// returned will be stored in the external_service_sync_jobs table so we fake
 				// that here.
@@ -210,24 +272,23 @@ func TestStatusMessages(t *testing.T) {
 					defer func() { database.Mocks.ExternalServices = database.MockExternalServices{} }()
 					database.Mocks.ExternalServices.ListSyncErrors = func(ctx context.Context) (map[int64]string, error) {
 						return map[int64]string{
-							githubService.ID: err.Error(),
+							siteLevelService.ID: err.Error(),
 						}, nil
 					}
 				}
-
 			}
 
 			if tc.err == "" {
 				tc.err = "<nil>"
 			}
 
-			res, err := FetchStatusMessages(ctx, db, user1)
+			res, err := FetchStatusMessages(ctx, db, tc.user)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("have err: %q, want: %q", have, want)
 			}
 
-			if have, want := res, tc.res; !reflect.DeepEqual(have, want) {
-				t.Errorf("response: %s", cmp.Diff(have, want))
+			if diff := cmp.Diff(tc.res, res); diff != "" {
+				t.Error(diff)
 			}
 		})
 	}


### PR DESCRIPTION
Only return repos they've added, not site wide. Site admins will contiue
to see a count of ALL uncloned repos.

Once this is merged we can re-enable the status message indicator on Cloud.