### PR TITLE
Debounce extensions query

### DIFF
--- a/client/shared/src/api/client/services/contribution.ts
+++ b/client/shared/src/api/client/services/contribution.ts
@@ -104,6 +104,8 @@ export class ContributionRegistry {
         logWarning = (...args: any[]) => console.log(...args)
     ): Observable<Evaluated<Contributions>> {
         return combineLatest([
+            // TODO: Don't unsubscribe from existing entries when new entries are registered.
+            // This could retrigger side effects (e.g. GQL query) unnecessarily
             entries.pipe(
                 switchMap(entries =>
                     combineLatestOrDefault(

--- a/client/shared/src/extensions/helpers.ts
+++ b/client/shared/src/extensions/helpers.ts
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash'
 import { from, Observable, of, throwError } from 'rxjs'
-import { catchError, distinctUntilChanged, map, publishReplay, refCount, switchMap } from 'rxjs/operators'
+import { catchError, distinctUntilChanged, map, shareReplay, switchMap } from 'rxjs/operators'
 import { gql } from '../graphql/graphql'
 import * as GQL from '../graphql/schema'
 import { PlatformContext } from '../platform/context'
@@ -20,8 +20,10 @@ export function viewerConfiguredExtensions({
         distinctUntilChanged((a, b) => isEqual(a, b)),
         switchMap(extensionIDs => queryConfiguredRegistryExtensions({ requestGraphQL }, extensionIDs)),
         catchError(error => throwError(asError(error))),
-        publishReplay(),
-        refCount()
+        // TODO: Restore reference counter after refactoring contributions service
+        // to not unsubscribe from existing entries when new entries are registered,
+        // in order to ensure that the source is unsubscribed from.
+        shareReplay(1)
     )
 }
 


### PR DESCRIPTION
On webapp initialization, settings are updated in rapid succession. We fetch enabled extensions on each settings update, so this results in network console spam. Debounce settings changes to reduce spam.