### PR TITLE
search: create a search result dedupper and update unionMerge

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -520,92 +520,77 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 	return rr, err
 }
 
+type searchResultDedupper struct {
+	seenFileMatches   map[string]struct{}
+	seenRepoMatches   map[string]struct{}
+	seenCommitMatches map[string]struct{}
+	seenDiffMatches   map[string]struct{}
+	initOnce          sync.Once
+}
+
+func (d *searchResultDedupper) init() {
+	d.initOnce.Do(func() {
+		d.seenFileMatches = make(map[string]struct{})
+		d.seenRepoMatches = make(map[string]struct{})
+		d.seenCommitMatches = make(map[string]struct{})
+		d.seenDiffMatches = make(map[string]struct{})
+	})
+}
+
+func (d *searchResultDedupper) Seen(r SearchResultResolver) bool {
+	d.init()
+
+	if fileMatch, ok := r.ToFileMatch(); ok {
+		if _, seen := d.seenFileMatches[fileMatch.uri]; seen {
+			return true
+		}
+		d.seenFileMatches[fileMatch.uri] = struct{}{}
+		return false
+	}
+
+	if repoMatch, ok := r.ToRepository(); ok {
+		if _, seen := d.seenRepoMatches[repoMatch.URL()]; seen {
+			return true
+		}
+		d.seenRepoMatches[repoMatch.URL()] = struct{}{}
+		return false
+	}
+
+	if commitMatch, ok := r.ToCommitSearchResult(); ok {
+		if commitMatch.DiffPreview() != nil {
+			if _, seen := d.seenDiffMatches[commitMatch.URL()]; seen {
+				return true
+			}
+			d.seenDiffMatches[commitMatch.URL()] = struct{}{}
+			return false
+		} else {
+			if _, seen := d.seenCommitMatches[commitMatch.URL()]; seen {
+				return true
+			}
+			d.seenCommitMatches[commitMatch.URL()] = struct{}{}
+			return false
+		}
+	}
+
+	return false
+}
+
 // unionMerge performs a merge of file match results, merging line matches when
 // they occur in the same file, and taking care to update match counts.
 func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
-	var count int // count non-overlapping files when we merge.
-	var merged []SearchResultResolver
-	rightFileMatches := make(map[string]*FileMatchResolver)
-	rightRepoMatches := make(map[string]*RepositoryResolver)
-	rightCommitMatches := make(map[string]*CommitSearchResultResolver)
-	rightDiffMatches := make(map[string]*CommitSearchResultResolver)
+	merged := make([]SearchResultResolver, 0, len(right.SearchResults))
 
-	// accumulate matches for the right subexpression in a lookup.
+	var dedup searchResultDedupper
 	for _, r := range right.SearchResults {
-		if fileMatch, ok := r.ToFileMatch(); ok {
-			rightFileMatches[fileMatch.uri] = fileMatch
-			continue
+		if seen := dedup.Seen(r); !seen {
+			merged = append(merged, r)
 		}
-		if repoMatch, ok := r.ToRepository(); ok {
-			rightRepoMatches[repoMatch.URL()] = repoMatch
-			continue
-		}
-		if commitMatch, ok := r.ToCommitSearchResult(); ok {
-			if commitMatch.DiffPreview() != nil {
-				rightDiffMatches[commitMatch.URL()] = commitMatch
-			} else {
-				rightCommitMatches[commitMatch.URL()] = commitMatch
-			}
-			continue
-		}
-		merged = append(merged, r)
 	}
 
-	for _, leftMatch := range left.SearchResults {
-		if leftFileMatch, ok := leftMatch.ToFileMatch(); ok {
-			rightFileMatch := rightFileMatches[leftFileMatch.uri]
-			if rightFileMatch == nil {
-				// no overlap with existing matches.
-				merged = append(merged, leftMatch)
-				count++
-				continue
-			}
-			// merge line matches with a file match that already exists.
-			rightFileMatch.appendMatches(leftFileMatch)
-			rightFileMatches[leftFileMatch.uri] = rightFileMatch
-			continue
+	for _, r := range left.SearchResults {
+		if seen := dedup.Seen(r); !seen {
+			merged = append(merged, r)
 		}
-
-		if leftRepoMatch, ok := leftMatch.ToRepository(); ok {
-			rightRepoMatch := rightRepoMatches[string(leftRepoMatch.URL())]
-			if rightRepoMatch == nil {
-				// no overlap with existing matches.
-				merged = append(merged, leftMatch)
-				count++
-			}
-			continue
-		}
-
-		if leftCommitMatch, ok := leftMatch.ToCommitSearchResult(); ok {
-			if leftCommitMatch.DiffPreview() != nil {
-				rightDiffMatch := rightDiffMatches[leftCommitMatch.URL()]
-				if rightDiffMatch == nil {
-					merged = append(merged, leftCommitMatch)
-					count++
-				}
-			} else {
-				rightCommitMatch := rightCommitMatches[leftCommitMatch.URL()]
-				if rightCommitMatch == nil {
-					merged = append(merged, leftCommitMatch)
-					count++
-				}
-			}
-			continue
-		}
-		merged = append(merged, leftMatch)
-	}
-
-	for _, v := range rightFileMatches {
-		merged = append(merged, v)
-	}
-	for _, v := range rightRepoMatches {
-		merged = append(merged, v)
-	}
-	for _, v := range rightCommitMatches {
-		merged = append(merged, v)
-	}
-	for _, v := range rightDiffMatches {
-		merged = append(merged, v)
 	}
 
 	left.SearchResults = merged


### PR DESCRIPTION
This creates the `searchResultDedupper` type, which facilitates
deduplicating search results by URL. It replaces the more complex logic
in `unionMerge` and will also be usable for deduplicating select
results since `unionMerge` is specific to two `SearchResultsResolver`s



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
