### PR TITLE
uniform prometheus job label for dev env

### DIFF
--- a/dev/prometheus/all/prometheus_targets.yml
+++ b/dev/prometheus/all/prometheus_targets.yml
@@ -1,6 +1,6 @@
 ---
 - labels:
-    job: frontend
+    job: sourcegraph-frontend
   targets:
     # frontend
     - host.docker.internal:6063

--- a/dev/prometheus/linux/prometheus_targets.yml
+++ b/dev/prometheus/linux/prometheus_targets.yml
@@ -1,6 +1,6 @@
 ---
 - labels:
-    job: frontend
+    job: sourcegraph-frontend
   targets:
     # frontend
     - 127.0.0.1:6063


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/16552 for local dev.

![image](https://user-images.githubusercontent.com/534011/107555567-2a0caf80-6b8c-11eb-9b3f-bffe4f9e01f4.png)

(we decided on "sourcegraph-frontend" because it matches the deployment label in k8s and seems more informative)