### PR TITLE
dev: fix typo in alpine guard check

### DIFF
--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -18,7 +18,7 @@ ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e
   ':(exclude)docker-images/alpine' \
   ':(exclude)doc/campaigns/' \
   ':(exclude)web/src/enterprise/campaigns/create/CreateCampaignPage.tsx' \
-  ':(exclude)vendor' \
+  ':(exclude)*vendor*' \
   ':(exclude)testdata')
 set -e
 

--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -19,7 +19,7 @@ ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e
   ':(exclude)doc/campaigns/' \
   ':(exclude)web/src/enterprise/campaigns/create/CreateCampaignPage.tsx' \
   ':(exclude)*vendor*' \
-  ':(exclude)testdata')
+  ':(exclude)*testdata*')
 set -e
 
 if [ -n "$ALPINE_MATCHES" ]; then

--- a/dev/check/no-alpine-guard.sh
+++ b/dev/check/no-alpine-guard.sh
@@ -19,7 +19,7 @@ ALPINE_MATCHES=$(git grep -e '\salpine\:' --and --not -e '^\s*//' --and --not -e
   ':(exclude)doc/campaigns/' \
   ':(exclude)web/src/enterprise/campaigns/create/CreateCampaignPage.tsx' \
   ':(exclude)vendor' \
-  ':(eclude)testdata')
+  ':(exclude)testdata')
 set -e
 
 if [ -n "$ALPINE_MATCHES" ]; then


### PR DESCRIPTION

![](https://media3.giphy.com/media/5t9wJjyHAOxvnxcPNk/giphy.gif?cid=5a38a5a2czk2hal3mj9vnid9qp4jpzxydfzg5qtj7au6i31i&rid=giphy.gif)

Spotted this when I saw a [`Misc Linters` job failing](https://buildkite.com/sourcegraph/sourcegraph/builds/86725#a5b89b64-00d7-4237-a632-72409a88678d/1364-1365) (doesn't affect green build?)