### PR TITLE
Remove stopgap code for broken version upgrade from 3.17

### DIFF
--- a/cmd/frontend/backend/versions.go
+++ b/cmd/frontend/backend/versions.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
@@ -82,11 +83,6 @@ WHERE versions.version = %s`
 func IsValidUpgrade(previous, latest *semver.Version) bool {
 	switch {
 	case previous == nil || latest == nil:
-		return true
-	case previous.Major() == 0 && previous.Minor() == 0 && previous.Patch() == 0:
-		// https://github.com/sourcegraph/sourcegraph/issues/11666
-		//
-		// TODO(slimsag): Remove this switch case Oct, 1st 2020
 		return true
 	case previous.Major() > latest.Major():
 		return true

--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
@@ -126,12 +127,6 @@ func TestIsValidUpgrade(t *testing.T) {
 		name:     "patch rollback",
 		previous: "v4.1.4",
 		latest:   "v4.1.3",
-		want:     true,
-	}, {
-		// https://github.com/sourcegraph/sourcegraph/issues/11666
-		name:     "issue 11666",
-		previous: "v0.0.0+dev",
-		latest:   "v3.17.1",
 		want:     true,
 	},
 	} {


### PR DESCRIPTION
While looking around, I've found this line with a TODO comment next to it that it can be removed after Oct 1, 2020. As far as I understand it, it was used as a stopgap to fix the 3.17 version of Sourcegraph not properly updating to a newer version, because we forgot to bake in the correct version string (was `v0.0.0+dev`, instead of `v3.17.0`).