### PR TITLE
search contexts: reset context

### DIFF
--- a/client/web/src/search/input/MonacoQueryInput.story.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.story.tsx
@@ -50,7 +50,7 @@ const defaultProps: MonacoQueryInputProps = {
         },
         {
             __typename: 'SearchContext',
-            id: '2',
+            id: '3',
             spec: '@username/test-version-1.5',
             autoDefined: true,
             description: 'Only code in version 1.5',

--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -52,7 +52,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
                     </code>
                 </DropdownToggle>
                 <DropdownMenu>
-                    <SearchContextMenu {...props} />
+                    <SearchContextMenu {...props} closeMenu={toggleOpen} />
                 </DropdownMenu>
             </ButtonDropdown>
             <div className="search-context-dropdown__separator" />

--- a/client/web/src/search/input/SearchContextMenu.story.tsx
+++ b/client/web/src/search/input/SearchContextMenu.story.tsx
@@ -1,8 +1,7 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
-import { SearchContextProps } from '..'
 import { WebStory } from '../../components/WebStory'
-import { SearchContextMenu } from './SearchContextMenu'
+import { SearchContextMenu, SearchContextMenuProps } from './SearchContextMenu'
 
 const { add } = storiesOf('web/search/input/SearchContextMenu', module)
     .addParameters({
@@ -18,7 +17,7 @@ const { add } = storiesOf('web/search/input/SearchContextMenu', module)
         </div>
     ))
 
-const defaultProps: Omit<SearchContextProps, 'showSearchContext'> = {
+const defaultProps: SearchContextMenuProps = {
     availableSearchContexts: [
         {
             __typename: 'SearchContext',
@@ -36,7 +35,7 @@ const defaultProps: Omit<SearchContextProps, 'showSearchContext'> = {
         },
         {
             __typename: 'SearchContext',
-            id: '2',
+            id: '3',
             spec: '@username/test-version-1.5',
             autoDefined: true,
             description: 'Only code in version 1.5',
@@ -45,6 +44,7 @@ const defaultProps: Omit<SearchContextProps, 'showSearchContext'> = {
     defaultSearchContextSpec: 'global',
     selectedSearchContextSpec: 'global',
     setSelectedSearchContextSpec: () => {},
+    closeMenu: () => {},
 }
 
 add('default', () => <WebStory>{() => <SearchContextMenu {...defaultProps} />}</WebStory>, {})

--- a/client/web/src/search/input/SearchContextMenu.test.tsx
+++ b/client/web/src/search/input/SearchContextMenu.test.tsx
@@ -1,0 +1,79 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import { DropdownItem, DropdownMenu, UncontrolledDropdown } from 'reactstrap'
+import sinon from 'sinon'
+import { SearchContextMenu, SearchContextMenuProps } from './SearchContextMenu'
+
+describe('SearchContextMenu', () => {
+    const defaultProps: SearchContextMenuProps = {
+        availableSearchContexts: [
+            {
+                __typename: 'SearchContext',
+                id: '1',
+                spec: 'global',
+                autoDefined: true,
+                description: 'All repositories on Sourcegraph',
+            },
+            {
+                __typename: 'SearchContext',
+                id: '2',
+                spec: '@username',
+                autoDefined: true,
+                description: 'Your repositories on Sourcegraph',
+            },
+            {
+                __typename: 'SearchContext',
+                id: '3',
+                spec: '@username/test-version-1.5',
+                autoDefined: true,
+                description: 'Only code in version 1.5',
+            },
+        ],
+        defaultSearchContextSpec: 'global',
+        selectedSearchContextSpec: 'global',
+        setSelectedSearchContextSpec: () => {},
+        closeMenu: () => {},
+    }
+
+    it('should select item when clicking on it', () => {
+        const setSelectedSearchContextSpec = sinon.spy()
+
+        const root = mount(
+            <UncontrolledDropdown>
+                <DropdownMenu>
+                    <SearchContextMenu {...defaultProps} setSelectedSearchContextSpec={setSelectedSearchContextSpec} />
+                </DropdownMenu>
+            </UncontrolledDropdown>
+        )
+        const item = root.find(DropdownItem).at(1)
+        item.simulate('click')
+
+        sinon.assert.calledOnce(setSelectedSearchContextSpec)
+        sinon.assert.calledWithExactly(setSelectedSearchContextSpec, '@username')
+    })
+
+    it('should reset back to default when clicking on Reset button', () => {
+        const setSelectedSearchContextSpec = sinon.spy()
+        const closeMenu = sinon.spy()
+
+        const root = mount(
+            <UncontrolledDropdown>
+                <DropdownMenu>
+                    <SearchContextMenu
+                        {...defaultProps}
+                        setSelectedSearchContextSpec={setSelectedSearchContextSpec}
+                        selectedSearchContextSpec="@username"
+                        closeMenu={closeMenu}
+                    />
+                </DropdownMenu>
+            </UncontrolledDropdown>
+        )
+        const button = root.find('.search-context-menu__footer-button').at(0)
+        button.simulate('click')
+
+        sinon.assert.calledOnce(setSelectedSearchContextSpec)
+        sinon.assert.calledWithExactly(setSelectedSearchContextSpec, 'global')
+
+        sinon.assert.calledOnce(closeMenu)
+    })
+})

--- a/client/web/src/search/input/SearchContextMenu.tsx
+++ b/client/web/src/search/input/SearchContextMenu.tsx
@@ -11,7 +11,9 @@ const SearchContextMenuItem: React.FunctionComponent<{
     isDefault: boolean
     setSelectedSearchContextSpec: (spec: string) => void
 }> = ({ spec, description, selected, isDefault, setSelectedSearchContextSpec }) => {
-    const setContext = useCallback(() => setSelectedSearchContextSpec(spec), [spec, setSelectedSearchContextSpec])
+    const setContext = useCallback(() => {
+        setSelectedSearchContextSpec(spec)
+    }, [setSelectedSearchContextSpec, spec])
     return (
         <DropdownItem
             className={classNames('search-context-menu__item', { 'search-context-menu__item--selected': selected })}
@@ -28,39 +30,55 @@ const SearchContextMenuItem: React.FunctionComponent<{
     )
 }
 
-export const SearchContextMenu: React.FunctionComponent<Omit<SearchContextProps, 'showSearchContext'>> = ({
+export interface SearchContextMenuProps extends Omit<SearchContextProps, 'showSearchContext'> {
+    closeMenu: () => void
+}
+
+export const SearchContextMenu: React.FunctionComponent<SearchContextMenuProps> = ({
     availableSearchContexts,
     selectedSearchContextSpec,
     defaultSearchContextSpec,
     setSelectedSearchContextSpec,
-}) => (
-    <div className="search-context-menu">
-        <div className="search-context-menu__header d-flex">
-            <span aria-hidden="true" className="search-context-menu__header-prompt">
-                <ChevronRightIcon className="icon-inline" />
-            </span>
-            <input type="search" placeholder="Find a context" className="search-context-menu__header-input" />
+    closeMenu,
+}) => {
+    const reset = useCallback(() => {
+        setSelectedSearchContextSpec(defaultSearchContextSpec)
+        closeMenu()
+    }, [closeMenu, defaultSearchContextSpec, setSelectedSearchContextSpec])
+
+    return (
+        <div className="search-context-menu">
+            <div className="search-context-menu__header d-flex">
+                <span aria-hidden="true" className="search-context-menu__header-prompt">
+                    <ChevronRightIcon className="icon-inline" />
+                </span>
+                <input type="search" placeholder="Find a context" className="search-context-menu__header-input" />
+            </div>
+            <div className="search-context-menu__list">
+                {availableSearchContexts.map(context => (
+                    <SearchContextMenuItem
+                        key={context.id}
+                        spec={context.spec}
+                        description={context.description}
+                        isDefault={context.spec === defaultSearchContextSpec}
+                        selected={context.spec === selectedSearchContextSpec}
+                        setSelectedSearchContextSpec={setSelectedSearchContextSpec}
+                    />
+                ))}
+            </div>
+            <div className="search-context-menu__footer">
+                <button
+                    type="button"
+                    onClick={reset}
+                    className="btn btn-link btn-sm search-context-menu__footer-button"
+                >
+                    Reset
+                </button>
+                <span className="flex-grow-1" />
+                <button type="button" className="btn btn-link btn-sm search-context-menu__footer-button">
+                    Manage contexts
+                </button>
+            </div>
         </div>
-        <div className="search-context-menu__list">
-            {availableSearchContexts.map(context => (
-                <SearchContextMenuItem
-                    key={context.id}
-                    spec={context.spec}
-                    description={context.description}
-                    isDefault={context.spec === defaultSearchContextSpec}
-                    selected={context.spec === selectedSearchContextSpec}
-                    setSelectedSearchContextSpec={setSelectedSearchContextSpec}
-                />
-            ))}
-        </div>
-        <div className="search-context-menu__footer">
-            <button type="button" className="btn btn-link btn-sm search-context-menu__footer-button">
-                Reset
-            </button>
-            <span className="flex-grow-1" />
-            <button type="button" className="btn btn-link btn-sm search-context-menu__footer-button">
-                Manage contexts
-            </button>
-        </div>
-    </div>
-)
+    )
+}


### PR DESCRIPTION
Stacked on #18161

Allows users to reset context by clicking on the button in the footer of the context dropdown menu