### PR TITLE
Update Gerrit hover styling

### DIFF
--- a/client/browser/src/shared/code-hosts/gerrit/style.scss
+++ b/client/browser/src/shared/code-hosts/gerrit/style.scss
@@ -1,7 +1,7 @@
 .hover-overlay--gerrit {
     background-color: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.125);
-    box-shadow: 0 1px 5px rgb(0 0 0 / 30%);
+    box-shadow: 0 1px 5px rgba(0, 0, 0, 0.3);
 }
 
 .hover-overlay-mount__gerrit {

--- a/client/browser/src/shared/code-hosts/gerrit/style.scss
+++ b/client/browser/src/shared/code-hosts/gerrit/style.scss
@@ -35,8 +35,7 @@
         text-transform: uppercase;
 
         // Copied from Gerrit styles
-        font-family: Roboto, -apple-system, system-ui, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
-            'Segoe UI Emoji', 'Segoe UI Symbol', Roboto, Arial, sans-serif;
+        font-family: Roboto, -apple-system, system-ui, 'Segoe UI', Helvetica, Arial, sans-serif;
 
         &:hover {
             background-color: rgba(0, 0, 0, 0.12);

--- a/client/browser/src/shared/code-hosts/gerrit/style.scss
+++ b/client/browser/src/shared/code-hosts/gerrit/style.scss
@@ -1,24 +1,51 @@
 .hover-overlay--gerrit {
     background-color: #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.125);
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 1px 5px rgb(0 0 0 / 30%);
 }
 
 .hover-overlay-mount__gerrit {
-    // Styles for the overlay mount
-}
+    // Styles for the hover overlay
+    .hover-overlay__contents code {
+        font-family: 'Roboto Mono', 'SF Mono', 'Lucida Console', Monaco, monospace;
+        font-size: 12px;
+    }
+    .hover-overlay__close-button {
+        border: none;
+        background-color: transparent;
+        cursor: pointer;
 
-.hover-overlay__close-button {
-    border: none;
-    background-color: transparent;
-}
+        svg {
+            height: 14px;
+        }
+    }
 
-.hover-overlay__action {
-    color: rgba(42, 102, 217, 255);
-    padding: 6px;
-}
+    .hover-overlay__actions {
+        background-color: rgba(250, 250, 250, 255);
+        justify-content: space-around;
+        padding: 4px;
+    }
 
-.hover-overlay__action svg {
-    height: 14px;
-    width: 14px;
+    .hover-overlay__action {
+        color: rgba(42, 102, 217, 255);
+        padding: 5px 4px;
+        flex: none;
+
+        text-decoration: none;
+        text-transform: uppercase;
+
+        // Copied from Gerrit styles
+        font-family: Roboto, -apple-system, system-ui, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+            'Segoe UI Emoji', 'Segoe UI Symbol', Roboto, Arial, sans-serif;
+
+        &:hover {
+            background-color: rgba(0, 0, 0, 0.12);
+            border-radius: var(--border-radius);
+        }
+    }
+
+    .hover-overlay__action svg {
+        height: 12px;
+        width: 12px;
+    }
 }

--- a/client/browser/src/shared/code-hosts/shared/views.ts
+++ b/client/browser/src/shared/code-hosts/shared/views.ts
@@ -51,7 +51,6 @@ export interface ViewResolver<V extends View> {
 export function trackViews<V extends View>(
     viewResolvers: ViewResolver<V>[]
 ): OperatorFunction<MutationRecordLike[], ViewWithSubscriptions<V>> {
-    console.log('Sourcegraph: trackViews:', { viewResolvers })
     return mutations =>
         defer(() => {
             const viewStates = new Map<HTMLElement, ViewWithSubscriptions<V>>()


### PR DESCRIPTION
This change updates the CSS styles for the Gerrit code view hovers to:

- scope the styles to Gerrit hovers only (fixing an issue where styles got applied to other code hosts)
- update the visual style to be more consistent with the surrounding Gerrit UI.

![Screen Shot 2021-02-10 at 23 04 10](https://user-images.githubusercontent.com/602886/107601307-52c88f80-6bf4-11eb-88f2-3544de741246.png)
