### PR TITLE
dont use wildcard allow origin header, allow credentials & send credentials on fetch

### DIFF
--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -13,7 +13,9 @@ const initSite = async (args: SignUpArguments): Promise<void> => {
     pingUrl.searchParams.set('email', args.email)
     pingUrl.searchParams.set('hostname', window.location.hostname)
 
-    await fetch(pingUrl.toString())
+    await fetch(pingUrl.toString(), {
+        credentials: 'include'
+    })
         .then() // no op
         .catch((error): void => {
             console.error(error)

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -14,7 +14,7 @@ const initSite = async (args: SignUpArguments): Promise<void> => {
     pingUrl.searchParams.set('hostname', window.location.hostname)
 
     await fetch(pingUrl.toString(), {
-        credentials: 'include'
+        credentials: 'include',
     })
         .then() // no op
         .catch((error): void => {

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -11,7 +11,6 @@ import { SourcegraphContext } from '../../jscontext'
 const initSite = async (args: SignUpArguments): Promise<void> => {
     const pingUrl = new URL('https://sourcegraph.com/ping-from-self-hosted')
     pingUrl.searchParams.set('email', args.email)
-    pingUrl.searchParams.set('hostname', window.location.hostname)
 
     await fetch(pingUrl.toString(), {
         credentials: 'include',

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -392,7 +392,6 @@ func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 		w.WriteHeader(http.StatusNoContent)
 		return nil
 	}
-	hostname := r.URL.Query().Get("hostname")
 	email := r.URL.Query().Get("email")
 	cookie, err := r.Cookie("sourcegraphSourceUrl")
 	var sourceURL string
@@ -400,8 +399,7 @@ func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 		sourceURL = cookie.Value
 	}
 	hubspotutil.SyncUser(email, hubspotutil.SelfHostedSiteInitEventID, &hubspot.ContactProperties{
-		FirstSourceURL:       sourceURL,
-		InstallationHostname: hostname,
+		FirstSourceURL: sourceURL,
 	})
 	return nil
 }

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -385,7 +385,8 @@ func searchBadgeHandler() *httputil.ReverseProxy {
 
 func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 	// CORS to allow request from anywhere
-	w.Header().Add("Access-Control-Allow-Origin", "*")
+	w.Header().Add("Access-Control-Allow-Origin", r.Host)
+	w.Header().Add("Access-Control-Allow-Credentials", "true")
 	if r.Method == http.MethodOptions {
 		// CORS preflight request, respond 204 and allow origin header
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/hubspot/contacts.go
+++ b/internal/hubspot/contacts.go
@@ -61,6 +61,7 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("latest_ping", h.LatestPing)
 	apiProps.set("anonymous_user_id", h.AnonymousUserID)
 	apiProps.set("first_source_url", h.FirstSourceURL)
+	apiProps.set("installation_hostname", h.InstallationHostname)
 	return apiProps
 }
 

--- a/internal/hubspot/contacts.go
+++ b/internal/hubspot/contacts.go
@@ -37,12 +37,11 @@ func (c *Client) baseContactURL(email string) *url.URL {
 
 // ContactProperties represent HubSpot user properties
 type ContactProperties struct {
-	UserID               string `json:"user_id"`
-	IsServerAdmin        bool   `json:"is_server_admin"`
-	LatestPing           int64  `json:"latest_ping"`
-	AnonymousUserID      string `json:"anonymous_user_id"`
-	FirstSourceURL       string `json:"first_source_url"`
-	InstallationHostname string `json:"installation_hostname"`
+	UserID          string `json:"user_id"`
+	IsServerAdmin   bool   `json:"is_server_admin"`
+	LatestPing      int64  `json:"latest_ping"`
+	AnonymousUserID string `json:"anonymous_user_id"`
+	FirstSourceURL  string `json:"first_source_url"`
 }
 
 // ContactResponse represents HubSpot user properties returned
@@ -61,7 +60,6 @@ func newAPIValues(h *ContactProperties) *apiProperties {
 	apiProps.set("latest_ping", h.LatestPing)
 	apiProps.set("anonymous_user_id", h.AnonymousUserID)
 	apiProps.set("first_source_url", h.FirstSourceURL)
-	apiProps.set("installation_hostname", h.InstallationHostname)
 	return apiProps
 }
 


### PR DESCRIPTION
This should be the final change, it's actually working already, but the browser still complains about CORS because of the headers returned. Specifically it doesn't like allowing a wildcard origin.

The reason it works is that we only really need the headers sent in the request, which are sent before it can determine if it's happy about CORS 😄 

we now use r.Host as the allowed origin, and include credentials on the request.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
