### PR TITLE
set access-control-allow-origin to referrer host

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -385,7 +385,11 @@ func searchBadgeHandler() *httputil.ReverseProxy {
 
 func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 	// CORS to allow request from anywhere
-	w.Header().Add("Access-Control-Allow-Origin", r.Host)
+	u, err := url.Parse(r.Referer())
+	if err != nil {
+		return err
+	}
+	w.Header().Add("Access-Control-Allow-Origin", u.Host)
 	w.Header().Add("Access-Control-Allow-Credentials", "true")
 	if r.Method == http.MethodOptions {
 		// CORS preflight request, respond 204 and allow origin header


### PR DESCRIPTION
it turns out using prod to test this was a really dumb idea, the feedback loop is so wide, i could have probably sorted this in a single PR if i wasn't so lazy.

using r.Host was never gonna work, as that's the request host not the site requesting it 🙄 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
