### PR TITLE
search contexts: remove Manage contexts button

### DIFF
--- a/client/web/src/search/input/SearchContextMenu.tsx
+++ b/client/web/src/search/input/SearchContextMenu.tsx
@@ -75,9 +75,6 @@ export const SearchContextMenu: React.FunctionComponent<SearchContextMenuProps> 
                     Reset
                 </button>
                 <span className="flex-grow-1" />
-                <button type="button" className="btn btn-link btn-sm search-context-menu__footer-button">
-                    Manage contexts
-                </button>
             </div>
         </div>
     )


### PR DESCRIPTION
We don't need it for now, so removing it until we have a page this can go to.