### PR TITLE
search contexts: allow searching in context dropdown

### DIFF
--- a/client/web/src/search/input/SearchContextMenu.scss
+++ b/client/web/src/search/input/SearchContextMenu.scss
@@ -19,7 +19,7 @@
     }
 
     &__list {
-        max-width: 30rem;
+        width: 30rem;
         padding: 0.25rem 0;
     }
 

--- a/client/web/src/search/input/SearchContextMenu.story.tsx
+++ b/client/web/src/search/input/SearchContextMenu.story.tsx
@@ -48,3 +48,9 @@ const defaultProps: SearchContextMenuProps = {
 }
 
 add('default', () => <WebStory>{() => <SearchContextMenu {...defaultProps} />}</WebStory>, {})
+
+add(
+    'empty',
+    () => <WebStory>{() => <SearchContextMenu {...defaultProps} availableSearchContexts={[]} />}</WebStory>,
+    {}
+)

--- a/client/web/src/search/input/SearchContextMenu.test.tsx
+++ b/client/web/src/search/input/SearchContextMenu.test.tsx
@@ -1,5 +1,5 @@
 import { mount } from 'enzyme'
-import React from 'react'
+import React, { ChangeEvent } from 'react'
 import { DropdownItem, DropdownMenu, UncontrolledDropdown } from 'reactstrap'
 import sinon from 'sinon'
 import { SearchContextMenu, SearchContextMenuProps } from './SearchContextMenu'
@@ -75,5 +75,57 @@ describe('SearchContextMenu', () => {
         sinon.assert.calledWithExactly(setSelectedSearchContextSpec, 'global')
 
         sinon.assert.calledOnce(closeMenu)
+    })
+
+    it('should filter list when searching', () => {
+        const root = mount(
+            <UncontrolledDropdown>
+                <DropdownMenu>
+                    <SearchContextMenu {...defaultProps} />
+                </DropdownMenu>
+            </UncontrolledDropdown>
+        )
+
+        const searchInput = root.find('input')
+
+        // Search by spec
+        searchInput.invoke('onInput')?.({
+            currentTarget: { value: '@user' },
+        } as ChangeEvent<HTMLInputElement>)
+
+        let items = root.find(DropdownItem)
+        expect(items.length).toBe(2)
+        expect(items.at(0).text()).toBe('@usernameYour repositories on Sourcegraph')
+        expect(items.at(1).text()).toBe('@username/test-version-1.5Only code in version 1.5')
+
+        // Search by description
+        searchInput.invoke('onInput')?.({
+            currentTarget: { value: 'version 1.5' },
+        } as ChangeEvent<HTMLInputElement>)
+
+        items = root.find(DropdownItem)
+        expect(items.length).toBe(1)
+        expect(items.at(0).text()).toBe('@username/test-version-1.5Only code in version 1.5')
+    })
+
+    it('should show message if search does not find anything', () => {
+        const root = mount(
+            <UncontrolledDropdown>
+                <DropdownMenu>
+                    <SearchContextMenu {...defaultProps} />
+                </DropdownMenu>
+            </UncontrolledDropdown>
+        )
+
+        const searchInput = root.find('input')
+
+        // Search by spec
+        searchInput.invoke('onInput')?.({
+            currentTarget: { value: 'nothing' },
+        } as ChangeEvent<HTMLInputElement>)
+
+        const items = root.find(DropdownItem)
+        expect(items.length).toBe(1)
+        expect(items.at(0).text()).toBe('No contexts found')
     })
 })

--- a/client/web/src/search/input/SearchContextMenu.test.tsx
+++ b/client/web/src/search/input/SearchContextMenu.test.tsx
@@ -77,7 +77,7 @@ describe('SearchContextMenu', () => {
         sinon.assert.calledOnce(closeMenu)
     })
 
-    it('should filter list when searching', () => {
+    it('should filter list by spec when searching', () => {
         const root = mount(
             <UncontrolledDropdown>
                 <DropdownMenu>
@@ -93,19 +93,10 @@ describe('SearchContextMenu', () => {
             currentTarget: { value: '@user' },
         } as ChangeEvent<HTMLInputElement>)
 
-        let items = root.find(DropdownItem)
+        const items = root.find(DropdownItem)
         expect(items.length).toBe(2)
         expect(items.at(0).text()).toBe('@usernameYour repositories on Sourcegraph')
         expect(items.at(1).text()).toBe('@username/test-version-1.5Only code in version 1.5')
-
-        // Search by description
-        searchInput.invoke('onInput')?.({
-            currentTarget: { value: 'version 1.5' },
-        } as ChangeEvent<HTMLInputElement>)
-
-        items = root.find(DropdownItem)
-        expect(items.length).toBe(1)
-        expect(items.at(0).text()).toBe('@username/test-version-1.5Only code in version 1.5')
     })
 
     it('should show message if search does not find anything', () => {
@@ -122,6 +113,26 @@ describe('SearchContextMenu', () => {
         // Search by spec
         searchInput.invoke('onInput')?.({
             currentTarget: { value: 'nothing' },
+        } as ChangeEvent<HTMLInputElement>)
+
+        const items = root.find(DropdownItem)
+        expect(items.length).toBe(1)
+        expect(items.at(0).text()).toBe('No contexts found')
+    })
+
+    it('should not search by description', () => {
+        const root = mount(
+            <UncontrolledDropdown>
+                <DropdownMenu>
+                    <SearchContextMenu {...defaultProps} />
+                </DropdownMenu>
+            </UncontrolledDropdown>
+        )
+
+        const searchInput = root.find('input')
+
+        searchInput.invoke('onInput')?.({
+            currentTarget: { value: 'version 1.5' },
         } as ChangeEvent<HTMLInputElement>)
 
         const items = root.find(DropdownItem)

--- a/client/web/src/search/input/SearchContextMenu.tsx
+++ b/client/web/src/search/input/SearchContextMenu.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
-import React, { useCallback } from 'react'
+import React, { FormEvent, useCallback, useMemo, useState } from 'react'
 import { DropdownItem } from 'reactstrap'
 import { SearchContextProps } from '..'
 
@@ -46,16 +46,37 @@ export const SearchContextMenu: React.FunctionComponent<SearchContextMenuProps> 
         closeMenu()
     }, [closeMenu, defaultSearchContextSpec, setSelectedSearchContextSpec])
 
+    const [searchFilter, setSearchFilter] = useState('')
+    const onSearchFilterChanged = useCallback(
+        (event: FormEvent<HTMLInputElement>) => setSearchFilter(event ? event.currentTarget.value : ''),
+        []
+    )
+
+    const filteredList = useMemo(
+        () =>
+            availableSearchContexts.filter(
+                context =>
+                    context.spec.toLowerCase().includes(searchFilter.toLowerCase()) ||
+                    context.description.toLowerCase().includes(searchFilter.toLowerCase())
+            ),
+        [availableSearchContexts, searchFilter]
+    )
+
     return (
         <div className="search-context-menu">
             <div className="search-context-menu__header d-flex">
                 <span aria-hidden="true" className="search-context-menu__header-prompt">
                     <ChevronRightIcon className="icon-inline" />
                 </span>
-                <input type="search" placeholder="Find a context" className="search-context-menu__header-input" />
+                <input
+                    onInput={onSearchFilterChanged}
+                    type="search"
+                    placeholder="Find a context"
+                    className="search-context-menu__header-input"
+                />
             </div>
             <div className="search-context-menu__list">
-                {availableSearchContexts.map(context => (
+                {filteredList.map(context => (
                     <SearchContextMenuItem
                         key={context.id}
                         spec={context.spec}
@@ -65,6 +86,11 @@ export const SearchContextMenu: React.FunctionComponent<SearchContextMenuProps> 
                         setSelectedSearchContextSpec={setSelectedSearchContextSpec}
                     />
                 ))}
+                {filteredList.length === 0 && (
+                    <DropdownItem className="search-context-menu__item" disabled={true}>
+                        No contexts found
+                    </DropdownItem>
+                )}
             </div>
             <div className="search-context-menu__footer">
                 <button

--- a/client/web/src/search/input/SearchContextMenu.tsx
+++ b/client/web/src/search/input/SearchContextMenu.tsx
@@ -54,11 +54,7 @@ export const SearchContextMenu: React.FunctionComponent<SearchContextMenuProps> 
 
     const filteredList = useMemo(
         () =>
-            availableSearchContexts.filter(
-                context =>
-                    context.spec.toLowerCase().includes(searchFilter.toLowerCase()) ||
-                    context.description.toLowerCase().includes(searchFilter.toLowerCase())
-            ),
+            availableSearchContexts.filter(context => context.spec.toLowerCase().includes(searchFilter.toLowerCase())),
         [availableSearchContexts, searchFilter]
     )
 


### PR DESCRIPTION
Fixes #18114

Users can search via either spec (fully qualified name) or description. Search is case insensitive.
Also fixed with width of the dropdown so it doesn't resize randomly while you search.

https://user-images.githubusercontent.com/206864/107677767-779e2080-6c4f-11eb-9b44-cc9f6cfae4b4.mov

