### PR TITLE
search: create a search result dedupper and update unionMerge

### DIFF
--- a/cmd/frontend/graphqlbackend/result_deduper.go
+++ b/cmd/frontend/graphqlbackend/result_deduper.go
@@ -53,9 +53,9 @@ func (d *searchResultDeduper) Add(r SearchResultResolver) {
 	}
 }
 
-// Dedupe returns a slice of SearchResultResolvers, deduplicated from
+// Results returns a slice of SearchResultResolvers, deduplicated from
 // the SearchResultResolvers that were added with Add
-func (d *searchResultDeduper) Dedupe() []SearchResultResolver {
+func (d *searchResultDeduper) Results() []SearchResultResolver {
 	total := len(d.seenFileMatches) + len(d.seenRepoMatches) + len(d.seenCommitMatches) + len(d.seenDiffMatches)
 	r := make([]SearchResultResolver, 0, total)
 	for _, v := range d.seenFileMatches {

--- a/cmd/frontend/graphqlbackend/result_deduper.go
+++ b/cmd/frontend/graphqlbackend/result_deduper.go
@@ -1,0 +1,74 @@
+package graphqlbackend
+
+type searchResultDeduper struct {
+	seenFileMatches   map[string]*FileMatchResolver
+	seenRepoMatches   map[string]*RepositoryResolver
+	seenCommitMatches map[string]*CommitSearchResultResolver
+	seenDiffMatches   map[string]*CommitSearchResultResolver
+}
+
+func NewDeduper() *searchResultDeduper {
+	return &searchResultDeduper{
+		seenFileMatches:   make(map[string]*FileMatchResolver),
+		seenRepoMatches:   make(map[string]*RepositoryResolver),
+		seenCommitMatches: make(map[string]*CommitSearchResultResolver),
+		seenDiffMatches:   make(map[string]*CommitSearchResultResolver),
+	}
+}
+
+// Add adds a SearchResultResolver to the deduper, merging it into
+// a previously added SearchResultResolver if the URL has already been seen
+func (d *searchResultDeduper) Add(r SearchResultResolver) {
+	if fileMatch, ok := r.ToFileMatch(); ok {
+		if prev, seen := d.seenFileMatches[fileMatch.uri]; seen {
+			prev.appendMatches(fileMatch)
+			return
+		}
+		d.seenFileMatches[fileMatch.uri] = fileMatch
+		return
+	}
+
+	if repoMatch, ok := r.ToRepository(); ok {
+		if _, seen := d.seenRepoMatches[repoMatch.URL()]; seen {
+			return
+		}
+		d.seenRepoMatches[repoMatch.URL()] = repoMatch
+		return
+	}
+
+	if commitMatch, ok := r.ToCommitSearchResult(); ok {
+		if commitMatch.DiffPreview() != nil {
+			if _, seen := d.seenDiffMatches[commitMatch.URL()]; seen {
+				return
+			}
+			d.seenDiffMatches[commitMatch.URL()] = commitMatch
+			return
+		}
+
+		if _, seen := d.seenCommitMatches[commitMatch.URL()]; seen {
+			return
+		}
+		d.seenCommitMatches[commitMatch.URL()] = commitMatch
+		return
+	}
+}
+
+// Dedupe returns a slice of SearchResultResolvers, deduplicated from
+// the SearchResultResolvers that were added with Add
+func (d *searchResultDeduper) Dedupe() []SearchResultResolver {
+	total := len(d.seenFileMatches) + len(d.seenRepoMatches) + len(d.seenCommitMatches) + len(d.seenDiffMatches)
+	r := make([]SearchResultResolver, 0, total)
+	for _, v := range d.seenFileMatches {
+		r = append(r, v)
+	}
+	for _, v := range d.seenRepoMatches {
+		r = append(r, v)
+	}
+	for _, v := range d.seenCommitMatches {
+		r = append(r, v)
+	}
+	for _, v := range d.seenDiffMatches {
+		r = append(r, v)
+	}
+	return r
+}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -520,98 +520,20 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 	return rr, err
 }
 
-type searchResultDeduper struct {
-	seenFileMatches   map[string]*FileMatchResolver
-	seenRepoMatches   map[string]*RepositoryResolver
-	seenCommitMatches map[string]*CommitSearchResultResolver
-	seenDiffMatches   map[string]*CommitSearchResultResolver
-}
-
-func (d *searchResultDeduper) init() {
-	if d.seenFileMatches == nil {
-		d.seenFileMatches = make(map[string]*FileMatchResolver)
-		d.seenRepoMatches = make(map[string]*RepositoryResolver)
-		d.seenCommitMatches = make(map[string]*CommitSearchResultResolver)
-		d.seenDiffMatches = make(map[string]*CommitSearchResultResolver)
-	}
-}
-
-// Add adds a SearchResultResolver to the deduper, merging it into
-// a previously added SearchResultResolver if the URL has already been seen
-func (d *searchResultDeduper) Add(r SearchResultResolver) {
-	d.init()
-
-	if fileMatch, ok := r.ToFileMatch(); ok {
-		if prev, seen := d.seenFileMatches[fileMatch.uri]; seen {
-			prev.appendMatches(fileMatch)
-			return
-		}
-		d.seenFileMatches[fileMatch.uri] = fileMatch
-		return
-	}
-
-	if repoMatch, ok := r.ToRepository(); ok {
-		if _, seen := d.seenRepoMatches[repoMatch.URL()]; seen {
-			return
-		}
-		d.seenRepoMatches[repoMatch.URL()] = repoMatch
-		return
-	}
-
-	if commitMatch, ok := r.ToCommitSearchResult(); ok {
-		if commitMatch.DiffPreview() != nil {
-			if _, seen := d.seenDiffMatches[commitMatch.URL()]; seen {
-				return
-			}
-			d.seenDiffMatches[commitMatch.URL()] = commitMatch
-			return
-		} else {
-			if _, seen := d.seenCommitMatches[commitMatch.URL()]; seen {
-				return
-			}
-			d.seenCommitMatches[commitMatch.URL()] = commitMatch
-			return
-		}
-	}
-
-	return
-}
-
-// Deduped returns a slice of SearchResultResolvers, deduplicated from
-// the SearchResultResolvers that were added with Add
-func (d *searchResultDeduper) Deduped() []SearchResultResolver {
-	total := len(d.seenFileMatches) + len(d.seenRepoMatches) + len(d.seenCommitMatches) + len(d.seenDiffMatches)
-	r := make([]SearchResultResolver, 0, total)
-	for _, v := range d.seenFileMatches {
-		r = append(r, v)
-	}
-	for _, v := range d.seenRepoMatches {
-		r = append(r, v)
-	}
-	for _, v := range d.seenCommitMatches {
-		r = append(r, v)
-	}
-	for _, v := range d.seenDiffMatches {
-		r = append(r, v)
-	}
-	return r
-}
-
 // unionMerge performs a merge of file match results, merging line matches when
 // they occur in the same file.
 func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
-	var dedup searchResultDeduper
+	dedup := NewDeduper()
 
-	// Register all the left results in the dedupper
+	// Add results to maps for deduping
 	for _, leftResult := range left.SearchResults {
 		dedup.Add(leftResult)
 	}
-
 	for _, rightResult := range right.SearchResults {
 		dedup.Add(rightResult)
 	}
 
-	left.SearchResults = dedup.Deduped()
+	left.SearchResults = dedup.Dedupe()
 	left.Stats.Update(&right.Stats)
 	return left
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -533,7 +533,7 @@ func unionMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 		dedup.Add(rightResult)
 	}
 
-	left.SearchResults = dedup.Dedupe()
+	left.SearchResults = dedup.Results()
 	left.Stats.Update(&right.Stats)
 	return left
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1444,6 +1444,38 @@ func fileResult(uri string, lineMatches []*lineMatch, symbolMatches []*searchSym
 	}
 }
 
+func resultToString(r SearchResultResolver) string {
+	switch v := r.(type) {
+	case *FileMatchResolver:
+		return fmt.Sprintf("File:%s", v.uri)
+	case *RepositoryResolver:
+		return fmt.Sprintf("Repository:%s", v.URL())
+	case *CommitSearchResultResolver:
+		if v.diffPreview != nil {
+			return fmt.Sprintf("Diff:%s", v.url)
+		}
+		return fmt.Sprintf("Commit:%s", v.url)
+	}
+	return "unknown"
+}
+
+func sortResultResolvers(rs []SearchResultResolver) {
+	sort.Slice(rs, func(i, j int) bool {
+		return resultToString(rs[i]) < resultToString(rs[j])
+	})
+
+	for _, res := range rs {
+		if fm, ok := res.(*FileMatchResolver); ok {
+			sort.Slice(fm.JLineMatches, func(i, j int) bool {
+				return fm.JLineMatches[i].JPreview < fm.JLineMatches[j].JPreview
+			})
+			sort.Slice(fm.symbols, func(i, j int) bool {
+				return fm.symbols[i].symbol.Name < fm.symbols[j].symbol.Name
+			})
+		}
+	}
+}
+
 func TestUnionMerge(t *testing.T) {
 	cases := []struct {
 		left  SearchResultsResolver
@@ -1618,45 +1650,98 @@ func TestUnionMerge(t *testing.T) {
 			}}},
 	}
 
-	resultToString := func(r SearchResultResolver) string {
+	for _, tc := range cases {
+		t.Run("", func(t *testing.T) {
+			got := unionMerge(&tc.left, &tc.right)
+			sortResultResolvers(got.SearchResults)
+			if !reflect.DeepEqual(got.SearchResults, tc.want.SearchResults) {
+				t.Fatal(cmp.Diff(got.SearchResults, tc.want.SearchResults))
+			}
+		})
+	}
+}
+
+func TestSearchResultDeduper(t *testing.T) {
+	url := func(r SearchResultResolver) string {
 		switch v := r.(type) {
 		case *FileMatchResolver:
-			return fmt.Sprintf("File:%s", v.uri)
-		case *RepositoryResolver:
-			return fmt.Sprintf("Repository:%s", v.URL())
+			return v.uri
 		case *CommitSearchResultResolver:
-			if v.diffPreview != nil {
-				return fmt.Sprintf("Diff:%s", v.url)
-			}
-			return fmt.Sprintf("Commit:%s", v.url)
+			return v.url
+		case *RepositoryResolver:
+			return v.URL()
 		}
-		return "unknown"
+		return ""
 	}
 
-	sortResultsResolver := func(r *SearchResultsResolver) {
-		sort.Slice(r.SearchResults, func(i, j int) bool {
-			return resultToString(r.SearchResults[i]) < resultToString(r.SearchResults[j])
-		})
-
-		for _, res := range r.SearchResults {
-			if fm, ok := res.(*FileMatchResolver); ok {
-				sort.Slice(fm.JLineMatches, func(i, j int) bool {
-					return fm.JLineMatches[i].JPreview < fm.JLineMatches[j].JPreview
-				})
-				sort.Slice(fm.symbols, func(i, j int) bool {
-					return fm.symbols[i].symbol.Name < fm.symbols[j].symbol.Name
-				})
+	resultType := func(r SearchResultResolver) string {
+		switch v := r.(type) {
+		case *FileMatchResolver:
+			return "File"
+		case *CommitSearchResultResolver:
+			if v.diffPreview != nil {
+				return "Diff"
 			}
+			return "Commit"
+		case *RepositoryResolver:
+			return "Repo"
 		}
+		return ""
+	}
+
+	cases := []struct {
+		input []SearchResultResolver
+		want  autogold.Value
+	}{
+		{
+			[]SearchResultResolver{},
+			autogold.Want("Empty", ""),
+		},
+		{
+			[]SearchResultResolver{commitResult("a")},
+			autogold.Want("SingleCommit", "Commit:a"),
+		},
+		{
+			[]SearchResultResolver{commitResult("a"), commitResult("a")},
+			autogold.Want("DuplicateCommits", "Commit:a"),
+		},
+		{
+			[]SearchResultResolver{commitResult("a"), diffResult("a")},
+			autogold.Want("SharedURLCommitDiff", "Commit:a, Diff:a"),
+		},
+		{
+			[]SearchResultResolver{commitResult("a"), diffResult("b")},
+			autogold.Want("DifferentURLCommitDiff", "Commit:a, Diff:b"),
+		},
+		{
+			[]SearchResultResolver{commitResult("a"), diffResult("a"), repoResult("a"), fileResult("a", nil, nil)},
+			autogold.Want("EachTypeSameURL", "Commit:a, Diff:a, File:a, Repo:/a"),
+		},
+		{
+			[]SearchResultResolver{commitResult("a"), commitResult("b"), commitResult("a"), commitResult("b")},
+			autogold.Want("FourCommitsTwoURLs", "Commit:a, Commit:b"),
+		},
+	}
+
+	toString := func(srrs []SearchResultResolver) string {
+		var searchResultStrings []string
+		for _, srr := range srrs {
+			searchResultStrings = append(searchResultStrings, fmt.Sprintf("%s:%s", resultType(srr), url(srr)))
+		}
+		return strings.Join(searchResultStrings, ", ")
 	}
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			got := unionMerge(&tc.left, &tc.right)
-			sortResultsResolver(got)
-			if !reflect.DeepEqual(got.SearchResults, tc.want.SearchResults) {
-				t.Fatal(cmp.Diff(got.SearchResults, tc.want.SearchResults))
+			var dedup searchResultDeduper
+			for _, r := range tc.input {
+				dedup.Add(r)
 			}
+
+			deduped := dedup.Deduped()
+			sortResultResolvers(deduped)
+
+			tc.want.Equal(t, toString(deduped))
 		})
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1733,12 +1733,12 @@ func TestSearchResultDeduper(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
-			var dedup searchResultDeduper
+			dedup := NewDeduper()
 			for _, r := range tc.input {
 				dedup.Add(r)
 			}
 
-			deduped := dedup.Deduped()
+			deduped := dedup.Dedupe()
 			sortResultResolvers(deduped)
 
 			tc.want.Equal(t, toString(deduped))

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1738,7 +1738,7 @@ func TestSearchResultDeduper(t *testing.T) {
 				dedup.Add(r)
 			}
 
-			deduped := dedup.Dedupe()
+			deduped := dedup.Results()
 			sortResultResolvers(deduped)
 
 			tc.want.Equal(t, toString(deduped))


### PR DESCRIPTION
Stacked on: #18191 
Reopened from the reverted #18148 

This creates the `searchResultDedupper` type, which facilitates
deduplicating search results by URL. It replaces the more complex logic
in `unionMerge` and will also be usable for deduplicating select
results.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
