### PR TITLE
search frontend: static suggestion order derives from list order, not alphabetically

### DIFF
--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -321,6 +321,21 @@ describe('getCompletionItems()', () => {
         ])
     })
 
+    test('returns completions in order of discrete value definition, not alphabetically', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    toSuccess(scanSearchQuery('select:')),
+                    {
+                        column: 8,
+                    },
+                    of([]),
+                    false
+                )
+            )?.suggestions.map(({ label }) => label)
+        ).toStrictEqual(['repo', 'file', 'content', 'symbol', 'commit'])
+    })
+
     test('returns dynamically fetched completions', async () => {
         expect(
             (

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -307,8 +307,9 @@ export async function getCompletionItems(
         if (resolvedFilter.definition.discreteValues) {
             return {
                 suggestions: resolvedFilter.definition.discreteValues.map(
-                    (label): Monaco.languages.CompletionItem => ({
+                    (label, index): Monaco.languages.CompletionItem => ({
                         label,
+                        sortText: index.toString(), // suggestions sort by order in the list, not alphabetically.
                         kind: Monaco.languages.CompletionItemKind.Value,
                         insertText: `${label} `,
                         filterText: label,


### PR DESCRIPTION
Stacked on #18125.

It's better to give ourselves control over static suggestion order, rather than use Monaco's default (alphabetical). When we do want an alphabetic static suggestions, we simply define it alphabetically.

Important for `select` suggestions, where `repo` should in general take precedence over other kinds. 

![Screen Shot 2021-02-11 at 4 47 58 PM](https://user-images.githubusercontent.com/888624/107714088-dd0f0300-6c89-11eb-898f-37c4b920948e.png)

A nice idea later could be to dynamically reorder the suggestion based on the kind of search, but I'm not sure that's super useful right now, there are just 5 values right now.
