### PR TITLE
add a11y properties for tabs

### DIFF
--- a/client/branded/src/components/Tabs.test.tsx
+++ b/client/branded/src/components/Tabs.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { TabsWithLocalStorageViewStatePersistence } from './Tabs'
+import { mount } from 'enzyme'
+import sinon from 'sinon'
+
+describe('Tab', () => {
+    test('Tabs with local storage persistenc', () => {
+        expect(
+            mount(
+                <TabsWithLocalStorageViewStatePersistence
+                    tabs={[{ id: 'files', label: 'Files' }]}
+                    storageKey="repo-revision-sidebar-last-tab"
+                    tabBarEndFragment={
+                        <>
+                            <div>fragment</div>
+                        </>
+                    }
+                    id="tab"
+                    className="tab-bar"
+                    tabClassName="tab-bar__tab--h5like"
+                    onSelectTab={() => null}
+                >
+                    <div>Panel 1</div>
+                    <div>Panel 2</div>
+                </TabsWithLocalStorageViewStatePersistence>
+            )
+        ).toMatchSnapshot()
+    })
+})

--- a/client/branded/src/components/Tabs.test.tsx
+++ b/client/branded/src/components/Tabs.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { TabsWithLocalStorageViewStatePersistence } from './Tabs'
 import { mount } from 'enzyme'
-import sinon from 'sinon'
 
 describe('Tab', () => {
     test('Tabs with local storage persistenc', () => {

--- a/client/branded/src/components/Tabs.tsx
+++ b/client/branded/src/components/Tabs.tsx
@@ -36,7 +36,7 @@ interface TabBarProps<ID extends string, T extends Tab<ID>> {
     endFragment?: React.ReactFragment
 
     /** The component used to render the tab (in the tab bar, not the active tab's content area). */
-    tabComponent: React.ComponentType<{ tab: T; className: string; role: string }>
+    tabComponent: React.ComponentType<{ tab: T; className: string; role: string; selected: boolean; tabIndex: number }>
 
     tabClassName?: string
 }
@@ -70,6 +70,8 @@ class TabBar<ID extends string, T extends Tab<ID>> extends React.PureComponent<T
                                 this.props.tabClassName
                             )}
                             role="tab"
+                            selected={this.props.activeTab === tab.id}
+                            tabIndex={this.props.activeTab === tab.id ? 0 : -1}
                         />
                     ))}
                 {this.props.endFragment}
@@ -132,7 +134,13 @@ class Tabs<ID extends string, T extends Tab<ID>> extends React.PureComponent<
         activeTab: ID | undefined
 
         /** The component used to render the tab (in the tab bar, not the active tab's content area). */
-        tabComponent: React.ComponentType<{ tab: T; className: string; role: string }>
+        tabComponent: React.ComponentType<{
+            tab: T
+            className: string
+            role: string
+            selected: boolean
+            tabIndex: number
+        }>
     }
 > {
     public render(): JSX.Element | null {
@@ -219,11 +227,23 @@ export class TabsWithLocalStorageViewStatePersistence<ID extends string, T exten
         )
     }
 
-    private renderTab = ({ tab, className, role }: { tab: T; className: string; role: string }): JSX.Element => (
+    private renderTab = ({
+        tab,
+        className,
+        role,
+        selected,
+    }: {
+        tab: T
+        className: string
+        role: string
+        selected: boolean
+    }): JSX.Element => (
         <button
             type="button"
             className={className}
             role={role}
+            aria-selected={selected}
+            aria-controls={tab.id}
             data-test-tab={tab.id}
             onClick={() => this.onSelectTab(tab.id)}
         >

--- a/client/branded/src/components/__snapshots__/Tabs.test.tsx.snap
+++ b/client/branded/src/components/__snapshots__/Tabs.test.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tab Tabs with local storage persistenc 1`] = `
+<TabsWithLocalStorageViewStatePersistence
+  className="tab-bar"
+  id="tab"
+  onSelectTab={[Function]}
+  storageKey="repo-revision-sidebar-last-tab"
+  tabBarEndFragment={
+    <React.Fragment>
+      <div>
+        fragment
+      </div>
+    </React.Fragment>
+  }
+  tabClassName="tab-bar__tab--h5like"
+  tabs={
+    Array [
+      Object {
+        "id": "files",
+        "label": "Files",
+      },
+    ]
+  }
+>
+  <Tabs
+    activeTab="files"
+    className="tab-bar"
+    id="tab"
+    onSelectTab={[Function]}
+    storageKey="repo-revision-sidebar-last-tab"
+    tabBarEndFragment={
+      <React.Fragment>
+        <div>
+          fragment
+        </div>
+      </React.Fragment>
+    }
+    tabClassName="tab-bar__tab--h5like"
+    tabComponent={[Function]}
+    tabs={
+      Array [
+        Object {
+          "id": "files",
+          "label": "Files",
+        },
+      ]
+    }
+  >
+    <div
+      className="tabs tab-bar"
+      id="tab"
+    >
+      <TabBar
+        activeTab="files"
+        endFragment={
+          <React.Fragment>
+            <div>
+              fragment
+            </div>
+          </React.Fragment>
+        }
+        tabClassName="tab-bar__tab--h5like"
+        tabComponent={[Function]}
+        tabs={
+          Array [
+            Object {
+              "id": "files",
+              "label": "Files",
+            },
+          ]
+        }
+      >
+        <div
+          className="tab-bar "
+          role="tablist"
+        >
+          <Component
+            className="btn btn-link btn-sm tab-bar__tab tab-bar__tab--active tab-bar__tab--h5like"
+            key="files"
+            role="tab"
+            selected={true}
+            tab={
+              Object {
+                "id": "files",
+                "label": "Files",
+              }
+            }
+            tabIndex={0}
+          >
+            <button
+              aria-controls="files"
+              aria-selected={true}
+              className="btn btn-link btn-sm tab-bar__tab tab-bar__tab--active tab-bar__tab--h5like"
+              data-test-tab="files"
+              onClick={[Function]}
+              role="tab"
+              type="button"
+            >
+              Files
+            </button>
+          </Component>
+          <div>
+            fragment
+          </div>
+        </div>
+      </TabBar>
+    </div>
+  </Tabs>
+</TabsWithLocalStorageViewStatePersistence>
+`;

--- a/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarSymbols.tsx
@@ -81,19 +81,21 @@ export class RepoRevisionSidebarSymbols extends React.PureComponent<Props> {
 
     public render(): JSX.Element | null {
         return (
-            <FilteredSymbolsConnection
-                className="repo-revision-sidebar-symbols"
-                compact={true}
-                noun="symbol"
-                pluralNoun="symbols"
-                queryConnection={this.fetchSymbols}
-                nodeComponent={SymbolNode}
-                nodeComponentProps={{ location: this.props.location }}
-                defaultFirst={100}
-                useURLQuery={false}
-                history={this.props.history}
-                location={this.props.location}
-            />
+            <div id="symbols" role="tabpanel" tabIndex={0} aria-labelledby="symbols" hidden={false}>
+                <FilteredSymbolsConnection
+                    className="repo-revision-sidebar-symbols"
+                    compact={true}
+                    noun="symbol"
+                    pluralNoun="symbols"
+                    queryConnection={this.fetchSymbols}
+                    nodeComponent={SymbolNode}
+                    nodeComponentProps={{ location: this.props.location }}
+                    defaultFirst={100}
+                    useURLQuery={false}
+                    history={this.props.history}
+                    location={this.props.location}
+                />
+            </div>
         )
     }
 

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -294,7 +294,15 @@ export class Tree extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         return (
-            <div className="tree" tabIndex={1} onKeyDown={this.onKeyDown} ref={this.setTreeElement}>
+            <div
+                className="tree"
+                id="files"
+                role="tabpanel"
+                aria-labelledby="Tree"
+                tabIndex={0}
+                onKeyDown={this.onKeyDown}
+                ref={this.setTreeElement}
+            >
                 <TreeRoot
                     ref={reference => {
                         if (reference) {


### PR DESCRIPTION
<!-- Describe the purpose of the PR so that if you looked at it in 6 months, it would be clear from the overview why this was created -->
## Overview
Tabs are not using proper a11y properties. The addition of these new attributes allows more control towards better navigation.

<!-- Update the implementation steps that should be completed to implement the feature/bug fix/tech debt cleanup -->
## Progress
- [x] aria attributes on Tabs 
- [x] aria attributes on Tab Panels


- [ ] Approved by a frontend engineer
<!-- Add a reference to the issue that this PR addresses if relevant -->
Closes #15403 