### PR TITLE
frontend: Add optional sampling of GraphQL requests in Honeycomb 

### DIFF
--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -9,6 +9,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Included in tracing so that we can differentiate different costs as we tweak
+// the algorithm
+const costEstimateVersion = 1
+
 // estimateQueryCost estimates the cost of the query based on the method used by GitHub as described here:
 // https://developer.github.com/v4/guides/resource-limitations/#calculating-a-rate-limit-score-before-running-the-call
 func estimateQueryCost(query string) (int, error) {

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -1,0 +1,107 @@
+package graphqlbackend
+
+import (
+	"strconv"
+
+	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/parser"
+	"github.com/graphql-go/graphql/language/visitor"
+	"github.com/pkg/errors"
+)
+
+// estimateQueryCost estimates the cost of the query based on the method used by GitHub as described here:
+// https://developer.github.com/v4/guides/resource-limitations/#calculating-a-rate-limit-score-before-running-the-call
+func estimateQueryCost(query string) (int, error) {
+	doc, err := parser.Parse(parser.ParseParams{
+		Source: query,
+	})
+	if err != nil {
+		return 0, errors.Wrap(err, "parsing query")
+	}
+
+	var totalCost int
+	for _, def := range doc.Definitions {
+		cost := calcDefinitionCost(def)
+		totalCost += cost
+	}
+
+	// As per the calculation spec, cost should be divided by 100
+	totalCost /= 100
+	if totalCost < 1 {
+		return 1, nil
+	}
+	return totalCost, nil
+}
+
+type limitDepth struct {
+	// The 'first' or 'last' limit
+	limit int
+	// The depth at which it was added
+	depth int
+}
+
+func calcDefinitionCost(def ast.Node) int {
+	var cost int
+	limitStack := make([]limitDepth, 0)
+
+	v := &visitor.VisitorOptions{
+		Enter: func(p visitor.VisitFuncParams) (string, interface{}) {
+			switch node := p.Node.(type) {
+			case *ast.IntValue:
+				// We're looking for a 'first' or 'last' param indicating a limit
+				parent, ok := p.Parent.(*ast.Argument)
+				if !ok {
+					return visitor.ActionNoChange, nil
+				}
+				if parent.Name == nil {
+					return visitor.ActionNoChange, nil
+				}
+				if parent.Name.Value != "first" && parent.Name.Value != "last" {
+					return visitor.ActionNoChange, nil
+				}
+
+				// Prune anything above our current depth as we may have started walking
+				// back down the tree
+				currentDepth := len(p.Ancestors)
+				limitStack = filterInPlace(limitStack, currentDepth)
+
+				limit, err := strconv.Atoi(node.Value)
+				if err != nil {
+					return "", errors.Wrap(err, "parsing limit")
+				}
+				limitStack = append(limitStack, limitDepth{limit: limit, depth: currentDepth})
+				// The first item in the tree is always worth 1
+				if len(limitStack) == 1 {
+					cost++
+					return visitor.ActionNoChange, nil
+				}
+				// The cost of the current item is calculated using the limits of
+				// its children
+				children := limitStack[:len(limitStack)-1]
+				product := 1
+				// Multiply them all together
+				for _, n := range children {
+					product = n.limit * product
+				}
+				cost += product
+			}
+			return visitor.ActionNoChange, nil
+		},
+	}
+
+	_ = visitor.Visit(def, v, nil)
+
+	return cost
+}
+
+func filterInPlace(limitStack []limitDepth, depth int) []limitDepth {
+	n := 0
+	for _, x := range limitStack {
+		if depth > x.depth {
+			limitStack[n] = x
+			n++
+		}
+	}
+	limitStack = limitStack[:n]
+	return limitStack
+}

--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -1,0 +1,147 @@
+package graphqlbackend
+
+import "testing"
+
+func TestEstimateQueryCost(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  int
+	}{
+		{
+			name: "Canonical example",
+			query: `query {
+  viewer {
+    login
+    repositories(first: 100) {
+      edges {
+        node {
+          id
+          issues(first: 50) {
+            edges {
+              node {
+                id
+                labels(first: 60) {
+                  edges {
+                    node {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`,
+			want: 51,
+		},
+		{
+			name: "simple query",
+			query: `
+query {
+  viewer {
+    repositories(first: 50) {
+      edges {
+        repository:node {
+          name
+          issues(first: 10) {
+            totalCount
+            edges {
+              node {
+                title
+                bodyHTML
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`,
+			want: 1,
+		},
+		{
+			name: "complex query",
+			query: `query {
+  viewer {
+    repositories(first: 50) {
+      edges {
+        repository:node {
+          name
+
+          pullRequests(first: 20) {
+            edges {
+              pullRequest:node {
+                title
+
+                comments(first: 10) {
+                  edges {
+                    comment:node {
+                      bodyHTML
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          issues(first: 20) {
+            totalCount
+            edges {
+              issue:node {
+                title
+                bodyHTML
+
+                comments(first: 10) {
+                  edges {
+                    comment:node {
+                      bodyHTML
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    followers(first: 10) {
+      edges {
+        follower:node {
+          login
+        }
+      }
+    }
+  }
+}`,
+			want: 21,
+		},
+		{
+			name: "Multiple top level queries",
+			query: `query {
+  thing
+}
+query{
+  thing
+}
+`,
+			want: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			have, err := estimateQueryCost(tc.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if have != tc.want {
+				t.Fatalf("have %d, want %d", have, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-func serveGraphQL(schema *graphql.Schema) func(w http.ResponseWriter, r *http.Request) (err error) {
+func serveGraphQL(schema *graphql.Schema, isInternal bool) func(w http.ResponseWriter, r *http.Request) (err error) {
 	relayHandler := &relay.Handler{Schema: schema}
 	return func(w http.ResponseWriter, r *http.Request) (err error) {
 		if r.Method != "POST" {
@@ -27,8 +28,8 @@ func serveGraphQL(schema *graphql.Schema) func(w http.ResponseWriter, r *http.Re
 			requestName = r.URL.RawQuery
 		}
 		r = r.WithContext(trace.WithGraphQLRequestName(r.Context(), requestName))
-
 		r = r.WithContext(trace.WithRequestSource(r.Context(), guessSource(r)))
+		r = r.WithContext(trace.WithIsInternal(r.Context(), isInternal))
 
 		if r.Header.Get("Content-Encoding") == "gzip" {
 			gzipReader, err := gzip.NewReader(r.Body)

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -74,7 +74,7 @@ func NewHandler(m *mux.Router, schema *graphql.Schema, githubWebhook webhooks.Re
 		m.Path("/updates").Methods("GET", "POST").Name("updatecheck").Handler(trace.TraceRoute(http.HandlerFunc(updatecheck.Handler)))
 	}
 
-	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
+	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema, false))))
 
 	m.Get(apirouter.SearchStream).Handler(trace.TraceRoute(frontendsearch.StreamHandler()))
 
@@ -141,7 +141,7 @@ func NewInternalHandler(m *mux.Router, schema *graphql.Schema, newCodeIntelUploa
 	m.Get(apirouter.GitInfoRefs).Handler(trace.TraceRoute(http.HandlerFunc(gitService.serveInfoRefs)))
 	m.Get(apirouter.GitUploadPack).Handler(trace.TraceRoute(http.HandlerFunc(gitService.serveGitUploadPack)))
 	m.Get(apirouter.Telemetry).Handler(trace.TraceRoute(telemetryHandler))
-	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema))))
+	m.Get(apirouter.GraphQL).Handler(trace.TraceRoute(handler(serveGraphQL(schema, true))))
 	m.Get(apirouter.Configuration).Handler(trace.TraceRoute(handler(serveConfiguration)))
 	m.Get(apirouter.SearchConfiguration).Handler(trace.TraceRoute(handler(serveSearchConfiguration)))
 	m.Path("/ping").Methods("GET").Name("ping").HandlerFunc(handlePing)

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -16,6 +16,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/repotrackutil"
@@ -32,6 +33,7 @@ const (
 	graphQLRequestNameKey
 	originKey
 	sourceKey
+	isInternalKey
 )
 
 // trackOrigin specifies a URL value. When an incoming request has the request header "Origin" set
@@ -41,13 +43,13 @@ const (
 var trackOrigin = "https://gitlab.com"
 
 var metricLabels = []string{"route", "method", "code", "repo", "origin"}
-var requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+var requestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Name:    "src_http_request_duration_seconds",
 	Help:    "The HTTP request latencies in seconds.",
 	Buckets: UserLatencyBuckets,
 }, metricLabels)
 
-var requestHeartbeat = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+var requestHeartbeat = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "src_http_requests_last_timestamp_unixtime",
 	Help: "Last time a request finished for a http endpoint.",
 }, metricLabels)
@@ -56,9 +58,6 @@ func Init(shouldInitSentry bool) {
 	if origin := os.Getenv("METRICS_TRACK_ORIGIN"); origin != "" {
 		trackOrigin = origin
 	}
-
-	prometheus.MustRegister(requestDuration)
-	prometheus.MustRegister(requestHeartbeat)
 
 	if shouldInitSentry {
 		sentry.Init()
@@ -79,6 +78,18 @@ func GraphQLRequestName(ctx context.Context) string {
 // WithGraphQLRequestName sets the GraphQL request name in the context.
 func WithGraphQLRequestName(ctx context.Context, name string) context.Context {
 	return context.WithValue(ctx, graphQLRequestNameKey, name)
+}
+
+// IsInternalRequest returns true if the request was handled by our internal API
+// handler.
+func IsInternalRequest(ctx context.Context) bool {
+	return ctx.Value(isInternalKey).(bool)
+}
+
+// WithIsInternal sets whether or not the request was handled by our internal or
+// external API handler.
+func WithIsInternal(ctx context.Context, isInternal bool) context.Context {
+	return context.WithValue(ctx, isInternalKey, isInternal)
 }
 
 // RequestOrigin returns the request origin (the value of the request header "Origin") for a request context.


### PR DESCRIPTION
We optionally sample the following data for GraphQL requests:

* Query
* Query cost estimate
* Query cost version, so that we can tweak the algorithm
* Whether the user is anonymous
* GraphQL operation name
* Was the request was handled by our internal or external handler

Closes: https://github.com/sourcegraph/sourcegraph/issues/18099