### PR TITLE
codeintel: Add PagedReferences to lsifstore

### DIFF
--- a/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
@@ -244,7 +244,7 @@ func TestDatabasePagedReferences(t *testing.T) {
 		{5, 0, expected},
 		{2, 0, expected[:2]},
 		{2, 1, expected[1:]},
-		{5, 5, nil},
+		{5, 5, expected[:0]},
 	}
 
 	for i, testCase := range testCases {

--- a/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
@@ -2,11 +2,13 @@ package lsifstore
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -208,6 +210,57 @@ func TestDatabaseReferences(t *testing.T) {
 		if diff := cmp.Diff(expected, actual); diff != "" {
 			t.Errorf("unexpected reference locations (-want +got):\n%s", diff)
 		}
+	}
+}
+
+func TestDatabasePagedReferences(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	populateTestStore(t)
+	store := NewStore(dbconn.Global, &observation.TestContext)
+
+	// `func (w *Writer) EmitRange(start, end Pos) (string, error) {`
+	//                   ^^^^^^^^^
+	//
+	// -> `\t\trangeID, err := i.w.EmitRange(lspRange(ipos, ident.Name, isQuotedPkgName))`
+	//                             ^^^^^^^^^
+	//
+	// -> `\t\t\trangeID, err = i.w.EmitRange(lspRange(ipos, ident.Name, false))`
+	//                              ^^^^^^^^^
+
+	expected := []Location{
+		{DumpID: testBundleID, Path: "internal/index/indexer.go", Range: newRange(380, 22, 380, 31)},
+		{DumpID: testBundleID, Path: "internal/index/indexer.go", Range: newRange(529, 22, 529, 31)},
+		{DumpID: testBundleID, Path: "protocol/writer.go", Range: newRange(85, 17, 85, 26)},
+	}
+
+	testCases := []struct {
+		limit    int
+		offset   int
+		expected []Location
+	}{
+		{5, 0, expected},
+		{2, 0, expected[:2]},
+		{2, 1, expected[1:]},
+		{5, 5, nil},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
+			if actual, totalCount, err := store.PagedReferences(context.Background(), testBundleID, "protocol/writer.go", 85, 20, testCase.limit, testCase.offset); err != nil {
+				t.Fatalf("unexpected error %s", err)
+			} else {
+				if totalCount != 3 {
+					t.Errorf("unexpected count. want=%d have=%d", 3, totalCount)
+				}
+
+				if diff := cmp.Diff(testCase.expected, actual); diff != "" {
+					t.Errorf("unexpected reference locations (-want +got):\n%s", diff)
+				}
+			}
+		})
 	}
 }
 

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -16,6 +16,7 @@ type operations struct {
 	monikerResults     *observation.Operation
 	monikersByPosition *observation.Operation
 	packageInformation *observation.Operation
+	pagedReferences    *observation.Operation
 	ranges             *observation.Operation
 	references         *observation.Operation
 	writeDefinitions   *observation.Operation
@@ -50,6 +51,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		monikerResults:     op("MonikerResults"),
 		monikersByPosition: op("MonikersByPosition"),
 		packageInformation: op("PackageInformation"),
+		pagedReferences:    op("PagedReferences"),
 		ranges:             op("Ranges"),
 		references:         op("References"),
 		writeDefinitions:   op("WriteDefinitions"),


### PR DESCRIPTION
Helps https://github.com/sourcegraph/sourcegraph/pull/17964.

This adds `PagedReferences`, which is a version of `References` that supports limit/offset pagination (admittedly a very gross version). We'll be putting effort into paginating efficiently here without fully decoding an unbounded set of LSIF payloads.