### PR TITLE
codeintel: Add BulkMonikerResults to lsifstore

### DIFF
--- a/enterprise/internal/codeintel/stores/lsifstore/bundle.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle.go
@@ -394,7 +394,7 @@ func (s *Store) BulkMonikerResults(ctx context.Context, tableName string, upload
 	if totalCount > limit {
 		max = limit
 	}
-	
+
 	locations := make([]Location, 0, max)
 outer:
 	for _, monikerLocations := range locationData {

--- a/enterprise/internal/codeintel/stores/lsifstore/bundle.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle.go
@@ -390,7 +390,12 @@ func (s *Store) BulkMonikerResults(ctx context.Context, tableName string, upload
 		totalCount += len(monikerLocations.Locations)
 	}
 
-	var locations []Location
+	max := totalCount
+	if totalCount > limit {
+		max = limit
+	}
+	
+	locations := make([]Location, 0, max)
 outer:
 	for _, monikerLocations := range locationData {
 		for _, row := range monikerLocations.Locations {

--- a/enterprise/internal/codeintel/stores/lsifstore/bundle.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/keegancsmith/sqlf"
@@ -336,6 +337,86 @@ func (s *Store) MonikerResults(ctx context.Context, bundleID int, tableName, sch
 const monikerResultsQuery = `
 -- source: enterprise/internal/codeintel/stores/lsifstore/bundles.go:MonikerResults
 SELECT scheme, identifier, data FROM %s WHERE dump_id = %s AND scheme = %s AND identifier = %s
+`
+
+// BulkMonikerResults returns the locations within one of the given bundles that define or reference
+// one of the given monikers. This method also returns the size of the complete result set to aid in
+// pagination.
+func (s *Store) BulkMonikerResults(ctx context.Context, tableName string, uploadIDs []int, monikers []MonikerData, limit, offset int) (_ []Location, _ int, err error) {
+	strUploadIDs := make([]string, 0, len(uploadIDs))
+	for _, id := range uploadIDs {
+		strUploadIDs = append(strUploadIDs, strconv.Itoa(id))
+	}
+	strMonikers := make([]string, 0, len(monikers))
+	for _, arg := range monikers {
+		strMonikers = append(strMonikers, fmt.Sprintf("%s:%s", arg.Scheme, arg.Identifier))
+	}
+
+	ctx, endObservation := s.operations.bulkMonikerResults.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("tableName", tableName),
+		log.String("uploadIDs", strings.Join(strUploadIDs, ", ")),
+		log.String("monikers", strings.Join(strMonikers, ", ")),
+		log.Int("limit", limit),
+		log.Int("offset", offset),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	if len(uploadIDs) == 0 || len(monikers) == 0 {
+		return nil, 0, nil
+	}
+
+	idQueries := make([]*sqlf.Query, 0, len(uploadIDs))
+	for _, id := range uploadIDs {
+		idQueries = append(idQueries, sqlf.Sprintf("%s", id))
+	}
+
+	monikerQueries := make([]*sqlf.Query, 0, len(monikers))
+	for _, arg := range monikers {
+		monikerQueries = append(monikerQueries, sqlf.Sprintf("(%s, %s)", arg.Scheme, arg.Identifier))
+	}
+
+	locationData, err := s.scanQualifiedMonikerLocations(s.Store.Query(ctx, sqlf.Sprintf(
+		bulkMonikerResultsQuery,
+		sqlf.Sprintf(fmt.Sprintf("lsif_data_%s", tableName)),
+		sqlf.Join(idQueries, ", "),
+		sqlf.Join(monikerQueries, ", "),
+	)))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	totalCount := 0
+	for _, monikerLocations := range locationData {
+		totalCount += len(monikerLocations.Locations)
+	}
+
+	var locations []Location
+outer:
+	for _, monikerLocations := range locationData {
+		for _, row := range monikerLocations.Locations {
+			offset--
+			if offset >= 0 {
+				continue
+			}
+
+			locations = append(locations, Location{
+				DumpID: monikerLocations.DumpID,
+				Path:   row.URI,
+				Range:  newRange(row.StartLine, row.StartCharacter, row.EndLine, row.EndCharacter),
+			})
+
+			if len(locations) >= limit {
+				break outer
+			}
+		}
+	}
+
+	return locations, totalCount, nil
+}
+
+const bulkMonikerResultsQuery = `
+-- source: enterprise/internal/codeintel/stores/lsifstore/bundle.go:BulkMonikerResults
+SELECT dump_id, scheme, identifier, data FROM %s WHERE dump_id IN (%s) AND (scheme, identifier) IN (%s) ORDER BY (scheme, identifier, dump_id)
 `
 
 // PackageInformation looks up package information data by identifier.

--- a/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
@@ -2,11 +2,13 @@ package lsifstore
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -328,6 +330,88 @@ func TestDatabaseMonikerResults(t *testing.T) {
 				t.Errorf("unexpected moniker result locations for test case #%d (-want +got):\n%s", i, diff)
 			}
 		}
+	}
+}
+
+func TestDatabaseBulkMonikerResults(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	populateTestStore(t)
+	store := NewStore(dbconn.Global, &observation.TestContext)
+
+	edgeDefinitionLocations := []Location{
+		{DumpID: testBundleID, Path: "protocol/protocol.go", Range: newRange(410, 5, 410, 9)},
+		{DumpID: testBundleID, Path: "protocol/protocol.go", Range: newRange(411, 1, 411, 8)},
+	}
+
+	edgeReferenceLocations := []Location{
+		{DumpID: testBundleID, Path: "protocol/protocol.go", Range: newRange(507, 1, 507, 5)},
+		{DumpID: testBundleID, Path: "protocol/protocol.go", Range: newRange(530, 1, 530, 5)},
+		{DumpID: testBundleID, Path: "protocol/protocol.go", Range: newRange(516, 8, 516, 12)},
+		{DumpID: testBundleID, Path: "protocol/protocol.go", Range: newRange(410, 5, 410, 9)},
+		{DumpID: testBundleID, Path: "protocol/protocol.go", Range: newRange(470, 8, 470, 12)},
+		{DumpID: testBundleID, Path: "internal/index/helper.go", Range: newRange(78, 8, 78, 12)},
+	}
+
+	markdownReferenceLocations := []Location{
+		{DumpID: testBundleID, Path: "internal/index/helper.go", Range: newRange(78, 6, 78, 16)},
+	}
+
+	combinedReferences := append(markdownReferenceLocations, edgeReferenceLocations...)
+	edgeMoniker := MonikerData{Scheme: "gomod", Identifier: "github.com/sourcegraph/lsif-go/protocol:Edge"}
+	markdownMoniker := MonikerData{Scheme: "gomod", Identifier: "github.com/slimsag/godocmd:ToMarkdown"}
+
+	testCases := []struct {
+		tableName          string
+		uploadIDs          []int
+		monikers           []MonikerData
+		limit              int
+		offset             int
+		expectedLocations  []Location
+		expectedTotalCount int
+	}{
+		// empty cases
+		{"definitions", []int{}, []MonikerData{edgeMoniker}, 5, 0, nil, 0},
+		{"definitions", []int{testBundleID}, []MonikerData{}, 5, 0, nil, 0},
+
+		// single definitions
+		{"definitions", []int{testBundleID}, []MonikerData{edgeMoniker}, 5, 0, edgeDefinitionLocations, 2},
+		{"definitions", []int{testBundleID}, []MonikerData{edgeMoniker}, 1, 0, edgeDefinitionLocations[:1], 2},
+		{"definitions", []int{testBundleID}, []MonikerData{edgeMoniker}, 5, 1, edgeDefinitionLocations[1:], 2},
+
+		// single references
+		{"references", []int{testBundleID}, []MonikerData{edgeMoniker}, 5, 0, edgeReferenceLocations[:5], 29},
+		{"references", []int{testBundleID}, []MonikerData{edgeMoniker}, 2, 2, edgeReferenceLocations[2:4], 29},
+		{"references", []int{testBundleID}, []MonikerData{markdownMoniker}, 5, 0, markdownReferenceLocations, 1},
+
+		// multiple monikers
+		{"references", []int{testBundleID}, []MonikerData{edgeMoniker, markdownMoniker}, 5, 0, combinedReferences[:5], 30},
+		{"references", []int{testBundleID}, []MonikerData{edgeMoniker, markdownMoniker}, 5, 1, combinedReferences[1:6], 30},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
+			if actual, totalCount, err := store.BulkMonikerResults(
+				context.Background(),
+				testCase.tableName,
+				testCase.uploadIDs,
+				testCase.monikers,
+				testCase.limit,
+				testCase.offset,
+			); err != nil {
+				t.Fatalf("unexpected error for test case #%d: %s", i, err)
+			} else {
+				if totalCount != testCase.expectedTotalCount {
+					t.Errorf("unexpected moniker result total count for test case #%d. want=%d have=%d", i, testCase.expectedTotalCount, totalCount)
+				}
+
+				if diff := cmp.Diff(testCase.expectedLocations, actual); diff != "" {
+					t.Errorf("unexpected moniker result locations for test case #%d (-want +got):\n%s", i, diff)
+				}
+			}
+		})
 	}
 }
 

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -8,6 +8,7 @@ import (
 )
 
 type operations struct {
+	bulkMonikerResults *observation.Operation
 	clear              *observation.Operation
 	definitions        *observation.Operation
 	diagnostics        *observation.Operation
@@ -42,6 +43,7 @@ func newOperations(observationContext *observation.Context) *operations {
 	}
 
 	return &operations{
+		bulkMonikerResults: op("BulkMonikerResults"),
 		clear:              op("Clear"),
 		definitions:        op("Definitions"),
 		diagnostics:        op("Diagnostics"),


### PR DESCRIPTION
Helps https://github.com/sourcegraph/sourcegraph/pull/17964.

This adds `BulkMonikerResults`, which is a version of `MonikerResults` that can search over multiple indexes and monikers. This will be useful for fetching and deduplicating results without having to do it on the application side.