### PR TITLE
codeintel: Standardize limit/offset parameters in lsifstore

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/api/diagnostics.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/diagnostics.go
@@ -7,6 +7,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -36,7 +37,7 @@ func (api *CodeIntelAPI) Diagnostics(ctx context.Context, prefix string, uploadI
 	}
 
 	pathInBundle := strings.TrimPrefix(prefix, dump.Root)
-	diagnostics, totalCount, err := api.lsifStore.Diagnostics(ctx, dump.ID, pathInBundle, offset, limit)
+	diagnostics, totalCount, err := api.lsifStore.Diagnostics(ctx, dump.ID, pathInBundle, limit, offset)
 	if err != nil {
 		if err == lsifstore.ErrNotFound {
 			log15.Warn("Bundle does not exist")

--- a/enterprise/cmd/frontend/internal/codeintel/api/diagnostics_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/diagnostics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
@@ -58,7 +59,7 @@ func TestDiagnostics(t *testing.T) {
 	}
 
 	setMockDBStoreGetDumpByID(t, mockDBStore, map[int]store.Dump{42: testDump1})
-	setmockLSIFStoreDiagnostics(t, mockLSIFStore, 42, "sub1", 1, 3, sourceDiagnostics, 5)
+	setmockLSIFStoreDiagnostics(t, mockLSIFStore, 42, "sub1", 3, 1, sourceDiagnostics, 5)
 
 	api := New(mockDBStore, mockLSIFStore, mockGitserverClient, &observation.TestContext)
 	diagnostics, _, err := api.Diagnostics(context.Background(), "sub1", 42, 3, 1)

--- a/enterprise/cmd/frontend/internal/codeintel/api/helpers_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/helpers_test.go
@@ -321,19 +321,19 @@ func setMultimockLSIFStoreHover(t testing.TB, mockLSIFStore *MockLSIFStore, spec
 	})
 }
 
-func setmockLSIFStoreDiagnostics(t testing.TB, mockLSIFStore *MockLSIFStore, expectedDumpID int, expectedPrefix string, expectedSkip, expectedTake int, diagnostics []lsifstore.Diagnostic, totalCount int) {
-	mockLSIFStore.DiagnosticsFunc.SetDefaultHook(func(ctx context.Context, dumpID int, prefix string, skip, take int) ([]lsifstore.Diagnostic, int, error) {
+func setmockLSIFStoreDiagnostics(t testing.TB, mockLSIFStore *MockLSIFStore, expectedDumpID int, expectedPrefix string, expectedLimit, expectedOffset int, diagnostics []lsifstore.Diagnostic, totalCount int) {
+	mockLSIFStore.DiagnosticsFunc.SetDefaultHook(func(ctx context.Context, dumpID int, prefix string, limit, offset int) ([]lsifstore.Diagnostic, int, error) {
 		if dumpID != expectedDumpID {
 			t.Errorf("unexpected id for Diagnostics. want=%d have=%d", expectedDumpID, dumpID)
 		}
 		if prefix != expectedPrefix {
 			t.Errorf("unexpected prefix for Diagnostics. want=%s have=%s", expectedPrefix, prefix)
 		}
-		if skip != expectedSkip {
-			t.Errorf("unexpected skip for Diagnostics. want=%d have=%d", expectedSkip, skip)
+		if limit != expectedLimit {
+			t.Errorf("unexpected limit for Diagnostics. want=%d have=%d", expectedLimit, limit)
 		}
-		if take != expectedTake {
-			t.Errorf("unexpected take for Diagnostics. want=%d have=%d", expectedTake, take)
+		if offset != expectedOffset {
+			t.Errorf("unexpected take for Diagnostics. want=%d have=%d", expectedOffset, offset)
 		}
 		return diagnostics, totalCount, nil
 	})

--- a/enterprise/cmd/frontend/internal/codeintel/api/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/api/iface.go
@@ -57,7 +57,7 @@ type LSIFStore interface {
 	Definitions(ctx context.Context, bundleID int, path string, line, character int) ([]lsifstore.Location, error)
 	References(ctx context.Context, bundleID int, path string, line, character int) ([]lsifstore.Location, error)
 	Hover(ctx context.Context, bundleID int, path string, line, character int) (string, lsifstore.Range, bool, error)
-	Diagnostics(ctx context.Context, bundleID int, prefix string, skip, take int) ([]lsifstore.Diagnostic, int, error)
+	Diagnostics(ctx context.Context, bundleID int, prefix string, limit, offset int) ([]lsifstore.Diagnostic, int, error)
 	MonikersByPosition(ctx context.Context, bundleID int, path string, line, character int) ([][]lsifstore.MonikerData, error)
 	MonikerResults(ctx context.Context, bundleID int, tableName, scheme, identifier string, skip, take int) ([]lsifstore.Location, int, error)
 	PackageInformation(ctx context.Context, bundleID int, path string, packageInformationID string) (lsifstore.PackageInformationData, bool, error)

--- a/enterprise/internal/codeintel/stores/lsifstore/bundle.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle.go
@@ -202,13 +202,13 @@ func (s *Store) Hover(ctx context.Context, bundleID int, path string, line, char
 }
 
 // Diagnostics returns the diagnostics for the documents that have the given path prefix. This method
-// also returns the size of the complete result set to aid in pagination (along with skip and take).
-func (s *Store) Diagnostics(ctx context.Context, bundleID int, prefix string, skip, take int) (_ []Diagnostic, _ int, err error) {
+// also returns the size of the complete result set to aid in pagination.
+func (s *Store) Diagnostics(ctx context.Context, bundleID int, prefix string, limit, offset int) (_ []Diagnostic, _ int, err error) {
 	ctx, endObservation := s.operations.diagnostics.With(ctx, &err, observation.Args{LogFields: []log.Field{
 		log.Int("bundleID", bundleID),
 		log.String("prefix", prefix),
-		log.Int("skip", skip),
-		log.Int("take", take),
+		log.Int("limit", limit),
+		log.Int("offset", offset),
 	}})
 	defer endObservation(1, observation.Args{})
 
@@ -217,19 +217,17 @@ func (s *Store) Diagnostics(ctx context.Context, bundleID int, prefix string, sk
 		return nil, 0, err
 	}
 
-	// TODO(efritz) - this is inefficient for large documents. We need to store the total number of diagnostics
-	// along-side the document so that we can determine which documents to skip and how many to retrieve. Right
-	// now we pull back every matching document, which can be large in large indexes.
 	totalCount := 0
-
-	diagnostics := make([]Diagnostic, 0, take)
 	for _, documentData := range documentData {
 		totalCount += len(documentData.Document.Diagnostics)
+	}
 
+	diagnostics := make([]Diagnostic, 0, limit)
+	for _, documentData := range documentData {
 		for _, diagnostic := range documentData.Document.Diagnostics {
-			skip--
+			offset--
 
-			if skip < 0 && len(diagnostics) < take {
+			if offset < 0 && len(diagnostics) < limit {
 				diagnostics = append(diagnostics, Diagnostic{
 					DumpID:         bundleID,
 					Path:           documentData.Path,


### PR DESCRIPTION
Ensure names and orders of parameters are consistent (use limit/offset in that order, never take/skip).