### PR TITLE
codeintel: Add DefinitionDumps and ReferenceIDsAndFilters to dbstore

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/helpers_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/helpers_test.go
@@ -393,3 +393,23 @@ func scanStates(rows *sql.Rows, queryErr error) (_ map[int]string, err error) {
 
 	return states, nil
 }
+
+func dumpToUpload(expected Dump) Upload {
+	return Upload{
+		ID:                expected.ID,
+		Commit:            expected.Commit,
+		Root:              expected.Root,
+		UploadedAt:        expected.UploadedAt,
+		State:             expected.State,
+		FailureMessage:    expected.FailureMessage,
+		StartedAt:         expected.StartedAt,
+		FinishedAt:        expected.FinishedAt,
+		ProcessAfter:      expected.ProcessAfter,
+		NumResets:         expected.NumResets,
+		NumFailures:       expected.NumFailures,
+		RepositoryID:      expected.RepositoryID,
+		RepositoryName:    expected.RepositoryName,
+		Indexer:           expected.Indexer,
+		AssociatedIndexID: expected.AssociatedIndexID,
+	}
+}

--- a/enterprise/internal/codeintel/stores/dbstore/observability.go
+++ b/enterprise/internal/codeintel/stores/dbstore/observability.go
@@ -10,8 +10,11 @@ import (
 type operations struct {
 	addUploadPart                          *observation.Operation
 	calculateVisibleUploads                *observation.Operation
+	commitGraphMetadata                    *observation.Operation
+	definitionDumps                        *observation.Operation
 	deleteIndexByID                        *observation.Operation
 	deleteIndexesWithoutRepository         *observation.Operation
+	deleteOldIndexes                       *observation.Operation
 	deleteOverlappingDumps                 *observation.Operation
 	deleteUploadByID                       *observation.Operation
 	deleteUploadsStuckUploading            *observation.Operation
@@ -19,7 +22,6 @@ type operations struct {
 	dequeue                                *observation.Operation
 	dequeueIndex                           *observation.Operation
 	dirtyRepositories                      *observation.Operation
-	commitGraphMetadata                    *observation.Operation
 	findClosestDumps                       *observation.Operation
 	findClosestDumpsFromGraphFragment      *observation.Operation
 	getDumpByID                            *observation.Operation
@@ -48,6 +50,7 @@ type operations struct {
 	markRepositoryAsDirty                  *observation.Operation
 	packageReferencePager                  *observation.Operation
 	queueSize                              *observation.Operation
+	referenceIDsAndFilters                 *observation.Operation
 	repoName                               *observation.Operation
 	repoUsageStatistics                    *observation.Operation
 	requeue                                *observation.Operation
@@ -55,7 +58,6 @@ type operations struct {
 	resetIndexableRepositories             *observation.Operation
 	sameRepoPager                          *observation.Operation
 	softDeleteOldUploads                   *observation.Operation
-	deleteOldIndexes                       *observation.Operation
 	updateIndexableRepository              *observation.Operation
 	updateIndexConfigurationByRepositoryID *observation.Operation
 	updatePackageReferences                *observation.Operation
@@ -81,8 +83,11 @@ func newOperations(observationContext *observation.Context) *operations {
 	return &operations{
 		addUploadPart:                          op("AddUploadPart"),
 		calculateVisibleUploads:                op("CalculateVisibleUploads"),
+		commitGraphMetadata:                    op("CommitGraphMetadata"),
+		definitionDumps:                        op("DefinitionDumps"),
 		deleteIndexByID:                        op("DeleteIndexByID"),
 		deleteIndexesWithoutRepository:         op("DeleteIndexesWithoutRepository"),
+		deleteOldIndexes:                       op("DeleteOldIndexes"),
 		deleteOverlappingDumps:                 op("DeleteOverlappingDumps"),
 		deleteUploadByID:                       op("DeleteUploadByID"),
 		deleteUploadsStuckUploading:            op("DeleteUploadsStuckUploading"),
@@ -90,7 +95,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		dequeue:                                op("Dequeue"),
 		dequeueIndex:                           op("DequeueIndex"),
 		dirtyRepositories:                      op("DirtyRepositories"),
-		commitGraphMetadata:                    op("CommitGraphMetadata"),
 		findClosestDumps:                       op("FindClosestDumps"),
 		findClosestDumpsFromGraphFragment:      op("FindClosestDumpsFromGraphFragment"),
 		getDumpByID:                            op("GetDumpByID"),
@@ -119,6 +123,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		markRepositoryAsDirty:                  op("MarkRepositoryAsDirty"),
 		packageReferencePager:                  op("PackageReferencePager"),
 		queueSize:                              op("QueueSize"),
+		referenceIDsAndFilters:                 op("ReferenceIDsAndFilters"),
 		repoName:                               op("RepoName"),
 		repoUsageStatistics:                    op("RepoUsageStatistics"),
 		requeue:                                op("Requeue"),
@@ -126,7 +131,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		resetIndexableRepositories:             op("ResetIndexableRepositories"),
 		sameRepoPager:                          op("SameRepoPager"),
 		softDeleteOldUploads:                   op("SoftDeleteOldUploads"),
-		deleteOldIndexes:                       op("DeleteOldIndexes"),
 		updateIndexableRepository:              op("UpdateIndexableRepository"),
 		updateIndexConfigurationByRepositoryID: op("UpdateIndexConfigurationByRepositoryID"),
 		updatePackageReferences:                op("UpdatePackageReferences"),

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
 
-// definitionsLimit is the maximum number of records that can be returned from DefinitionDumps.
+// DefinitionDumpsLimit is the maximum number of records that can be returned from DefinitionDumps.
 const DefinitionDumpsLimit = 10
 
 // DefinitionDumps returns the set of dumps that define at least one of the given monikers.

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo.go
@@ -1,0 +1,149 @@
+package dbstore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+// definitionsLimit is the maximum number of records that can be returned from DefinitionDumps.
+const DefinitionDumpsLimit = 10
+
+// DefinitionDumps returns the set of dumps that define at least one of the given monikers.
+func (s *Store) DefinitionDumps(ctx context.Context, monikers []lsifstore.QualifiedMonikerData) (dumps []Dump, err error) {
+	strMonikers := make([]string, 0, len(monikers))
+	for _, moniker := range monikers {
+		strMonikers = append(strMonikers, fmt.Sprintf("%s:%s:%s", moniker.Scheme, moniker.Name, moniker.Version))
+	}
+
+	ctx, endObservation := s.operations.definitionDumps.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.String("monikers", strings.Join(strMonikers, ", ")),
+	}})
+	defer endObservation(1, observation.Args{LogFields: []log.Field{
+		log.Int("numDumps", len(dumps)),
+	}})
+
+	if len(monikers) == 0 {
+		return nil, nil
+	}
+
+	qs := make([]*sqlf.Query, 0, len(monikers))
+	for _, moniker := range monikers {
+		qs = append(qs, sqlf.Sprintf("(%s, %s, %s)", moniker.Scheme, moniker.Name, moniker.Version))
+	}
+
+	return scanDumps(s.Query(ctx, sqlf.Sprintf(definitionDumpsQuery, sqlf.Join(qs, ", "), DefinitionDumpsLimit)))
+}
+
+const definitionDumpsQuery = `
+-- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:DefinitionDumps
+SELECT
+	d.id,
+	d.commit,
+	d.root,
+	` + visibleAtTipFragment + ` AS visible_at_tip,
+	d.uploaded_at,
+	d.state,
+	d.failure_message,
+	d.started_at,
+	d.finished_at,
+	d.process_after,
+	d.num_resets,
+	d.num_failures,
+	d.repository_id,
+	d.repository_name,
+	d.indexer,
+	d.associated_index_id
+FROM lsif_dumps_with_repository_name d WHERE d.id IN (
+	SELECT MAX(p.dump_id) FROM lsif_packages p WHERE (p.scheme, p.name, p.version) IN (%s) GROUP BY p.scheme, p.name, p.version LIMIT %s
+)
+`
+
+// ReferenceIDsAndFilters returns the total count of visible uploads that may refer to one of the given
+// monikers. Each upload identifier in the result set is paired with one or more compressed bloom filters
+// that encode more precisely the set of identifiers imported from dependent packages.
+//
+// Visibility is determined in two parts: if the index belongs to the given repository, it is visible if
+// it can be seen from the given index; otherwise, an index is visible if it can be seen from the tip of
+// the default branch of its own repository.
+func (s *Store) ReferenceIDsAndFilters(ctx context.Context, repositoryID int, commit string, monikers []lsifstore.QualifiedMonikerData, limit, offset int) (_ PackageReferenceScanner, _ int, err error) {
+	strMonikers := make([]string, 0, len(monikers))
+	for _, moniker := range monikers {
+		strMonikers = append(strMonikers, fmt.Sprintf("%s:%s:%s", moniker.Scheme, moniker.Name, moniker.Version))
+	}
+
+	ctx, endObservation := s.operations.referenceIDsAndFilters.With(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("repositoryID", repositoryID),
+		log.String("commit", commit),
+		log.String("monikers", strings.Join(strMonikers, ", ")),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	if len(monikers) == 0 {
+		return nil, 0, nil
+	}
+
+	qs := make([]*sqlf.Query, 0, len(monikers))
+	for _, moniker := range monikers {
+		qs = append(qs, sqlf.Sprintf("(%s, %s, %s)", moniker.Scheme, moniker.Name, moniker.Version))
+	}
+
+	visibleUploadsQuery := makeVisibleUploadsQuery(repositoryID, commit)
+
+	totalCount, _, err := basestore.ScanFirstInt(s.Query(ctx, sqlf.Sprintf(
+		referenceIDsAndFiltersCountQuery,
+		visibleUploadsQuery,
+		repositoryID,
+		sqlf.Join(qs, ", "),
+	)))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := s.Query(ctx, sqlf.Sprintf(
+		referenceIDsAndFiltersQuery,
+		visibleUploadsQuery,
+		repositoryID,
+		sqlf.Join(qs, ", "),
+		limit,
+		offset,
+	))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return &packageReferenceScanner{rows}, totalCount, nil
+}
+
+const referenceIDsAndFiltersCTEDefinitions = `
+-- source: enterprise/internal/codeintel/stores/dbstore/xrepo.go:ReferenceIDsAndFilters
+WITH visible_uploads AS (
+	(%s)
+	UNION
+	(SELECT uvt.upload_id FROM lsif_uploads_visible_at_tip uvt WHERE uvt.repository_id != %s)
+)
+`
+
+const referenceIDsAndFiltersBaseQuery = `
+FROM lsif_references r
+LEFT JOIN lsif_dumps d ON d.id = r.dump_id
+WHERE (r.scheme, r.name, r.version) IN (%s) AND r.dump_id IN (SELECT * FROM visible_uploads)
+`
+
+const referenceIDsAndFiltersQuery = referenceIDsAndFiltersCTEDefinitions + `
+SELECT r.dump_id, r.filter
+` + referenceIDsAndFiltersBaseQuery + `
+ORDER BY dump_id
+LIMIT %s OFFSET %s
+`
+
+const referenceIDsAndFiltersCountQuery = referenceIDsAndFiltersCTEDefinitions + `
+SELECT COUNT(distinct r.dump_id)
+` + referenceIDsAndFiltersBaseQuery

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo_scanner.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo_scanner.go
@@ -1,0 +1,44 @@
+package dbstore
+
+import (
+	"database/sql"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+)
+
+// PackageReferenceScanner allows for on-demand scanning of PackageReference values.
+//
+// A scanner for this type was introduced as a memory optimization. Instead of reading a
+// large number of large byte arrays into memory at once, we allow the user to request
+// the next filter value when they are ready to process it. This allows us to hold only
+// a single bloom filter in memory at any give time during reference requests.
+type PackageReferenceScanner interface {
+	// Next reads the next package reference value from the database cursor.
+	Next() (lsifstore.PackageReference, bool, error)
+
+	// Close the underlying row object.
+	Close() error
+}
+
+type packageReferenceScanner struct {
+	rows *sql.Rows
+}
+
+// Next reads the next package reference value from the database cursor.
+func (s *packageReferenceScanner) Next() (reference lsifstore.PackageReference, _ bool, _ error) {
+	if !s.rows.Next() {
+		return lsifstore.PackageReference{}, false, nil
+	}
+
+	if err := s.rows.Scan(&reference.DumpID, &reference.Filter); err != nil {
+		return lsifstore.PackageReference{}, false, err
+	}
+
+	return reference, true, nil
+}
+
+// Close the underlying row object.
+func (s *packageReferenceScanner) Close() error {
+	return basestore.CloseRows(s.rows, nil)
+}

--- a/enterprise/internal/codeintel/stores/dbstore/xrepo_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/xrepo_test.go
@@ -1,0 +1,373 @@
+package dbstore
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/commitgraph"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+)
+
+func TestDefinitionDumps(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	moniker1 := lsifstore.QualifiedMonikerData{
+		MonikerData: lsifstore.MonikerData{
+			Scheme: "gomod",
+		},
+		PackageInformationData: lsifstore.PackageInformationData{
+			Name:    "leftpad",
+			Version: "0.1.0",
+		},
+	}
+
+	moniker2 := lsifstore.QualifiedMonikerData{
+		MonikerData: lsifstore.MonikerData{
+			Scheme: "npm",
+		},
+		PackageInformationData: lsifstore.PackageInformationData{
+			Name:    "north-pad",
+			Version: "0.2.0",
+		},
+	}
+
+	// Package does not exist initially
+	if dumps, err := store.DefinitionDumps(context.Background(), []lsifstore.QualifiedMonikerData{moniker1}); err != nil {
+		t.Fatalf("unexpected error getting package: %s", err)
+	} else if len(dumps) != 0 {
+		t.Fatal("unexpected record")
+	}
+
+	uploadedAt := time.Unix(1587396557, 0).UTC()
+	startedAt := uploadedAt.Add(time.Minute)
+	finishedAt := uploadedAt.Add(time.Minute * 2)
+	expected1 := Dump{
+		ID:             1,
+		Commit:         makeCommit(1),
+		Root:           "sub/",
+		VisibleAtTip:   true,
+		UploadedAt:     uploadedAt,
+		State:          "completed",
+		FailureMessage: nil,
+		StartedAt:      &startedAt,
+		FinishedAt:     &finishedAt,
+		RepositoryID:   50,
+		RepositoryName: "n-50",
+		Indexer:        "lsif-go",
+	}
+	expected2 := Dump{
+		ID:                2,
+		Commit:            makeCommit(2),
+		Root:              "other/",
+		VisibleAtTip:      false,
+		UploadedAt:        uploadedAt,
+		State:             "completed",
+		FailureMessage:    nil,
+		StartedAt:         &startedAt,
+		FinishedAt:        &finishedAt,
+		RepositoryID:      50,
+		RepositoryName:    "n-50",
+		Indexer:           "lsif-tsc",
+		AssociatedIndexID: nil,
+	}
+
+	insertUploads(t, dbconn.Global, dumpToUpload(expected1), dumpToUpload(expected2))
+	insertVisibleAtTip(t, dbconn.Global, 50, 1)
+
+	if err := store.UpdatePackages(context.Background(), []lsifstore.Package{
+		{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"},
+		{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0"},
+		{DumpID: 2, Scheme: "npm", Name: "north-pad", Version: "0.2.0"},
+	}); err != nil {
+		t.Fatalf("unexpected error updating packages: %s", err)
+	}
+
+	if dumps, err := store.DefinitionDumps(context.Background(), []lsifstore.QualifiedMonikerData{moniker1}); err != nil {
+		t.Fatalf("unexpected error getting package: %s", err)
+	} else if len(dumps) != 1 {
+		t.Fatal("expected one record")
+	} else if diff := cmp.Diff(expected1, dumps[0]); diff != "" {
+		t.Errorf("unexpected dump (-want +got):\n%s", diff)
+	}
+
+	if dumps, err := store.DefinitionDumps(context.Background(), []lsifstore.QualifiedMonikerData{moniker1, moniker2}); err != nil {
+		t.Fatalf("unexpected error getting package: %s", err)
+	} else if len(dumps) != 2 {
+		t.Fatal("expected two records")
+	} else if diff := cmp.Diff(expected1, dumps[0]); diff != "" {
+		t.Errorf("unexpected dump (-want +got):\n%s", diff)
+	} else if diff := cmp.Diff(expected2, dumps[1]); diff != "" {
+		t.Errorf("unexpected dump (-want +got):\n%s", diff)
+	}
+}
+
+func TestReferenceIDsAndFilters(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	insertUploads(t, dbconn.Global,
+		Upload{ID: 1, Commit: makeCommit(2), Root: "sub1/"},
+		Upload{ID: 2, Commit: makeCommit(3), Root: "sub2/"},
+		Upload{ID: 3, Commit: makeCommit(4), Root: "sub3/"},
+		Upload{ID: 4, Commit: makeCommit(3), Root: "sub4/"},
+		Upload{ID: 5, Commit: makeCommit(2), Root: "sub5/"},
+	)
+
+	insertNearestUploads(t, dbconn.Global, 50, map[string][]commitgraph.UploadMeta{
+		makeCommit(1): {
+			{UploadID: 1, Distance: 1},
+			{UploadID: 2, Distance: 2},
+			{UploadID: 3, Distance: 3},
+			{UploadID: 4, Distance: 2},
+			{UploadID: 5, Distance: 1},
+		},
+		makeCommit(2): {
+			{UploadID: 1, Distance: 0},
+			{UploadID: 2, Distance: 1},
+			{UploadID: 3, Distance: 2},
+			{UploadID: 4, Distance: 1},
+			{UploadID: 5, Distance: 0},
+		},
+		makeCommit(3): {
+			{UploadID: 1, Distance: 1},
+			{UploadID: 2, Distance: 0},
+			{UploadID: 3, Distance: 1},
+			{UploadID: 4, Distance: 0},
+			{UploadID: 5, Distance: 1},
+		},
+		makeCommit(4): {
+			{UploadID: 1, Distance: 2},
+			{UploadID: 2, Distance: 1},
+			{UploadID: 3, Distance: 0},
+			{UploadID: 4, Distance: 1},
+			{UploadID: 5, Distance: 2},
+		},
+	})
+
+	insertPackageReferences(t, store, []lsifstore.PackageReference{
+		{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f1")},
+		{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f2")},
+		{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f3")},
+		{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f4")},
+		{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f5")},
+	})
+
+	moniker := lsifstore.QualifiedMonikerData{
+		MonikerData: lsifstore.MonikerData{
+			Scheme: "gomod",
+		},
+		PackageInformationData: lsifstore.PackageInformationData{
+			Name:    "leftpad",
+			Version: "0.1.0",
+		},
+	}
+
+	refs := []lsifstore.PackageReference{
+		{DumpID: 1, Filter: []byte("f1")},
+		{DumpID: 2, Filter: []byte("f2")},
+		{DumpID: 3, Filter: []byte("f3")},
+		{DumpID: 4, Filter: []byte("f4")},
+		{DumpID: 5, Filter: []byte("f5")},
+	}
+
+	testCases := []struct {
+		limit    int
+		offset   int
+		expected []lsifstore.PackageReference
+	}{
+		{5, 0, refs},
+		{5, 2, refs[2:]},
+		{2, 1, refs[1:3]},
+		{5, 5, nil},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
+			scanner, totalCount, err := store.ReferenceIDsAndFilters(context.Background(), 50, makeCommit(1), []lsifstore.QualifiedMonikerData{moniker}, testCase.limit, testCase.offset)
+			if err != nil {
+				t.Fatalf("unexpected error getting filters: %s", err)
+			}
+
+			if totalCount != 5 {
+				t.Errorf("unexpected count. want=%d have=%d", 5, totalCount)
+			}
+
+			filters, err := consumeScanner(scanner)
+			if err != nil {
+				t.Fatalf("unexpected error from scanner: %s", err)
+			}
+
+			if diff := cmp.Diff(testCase.expected, filters); diff != "" {
+				t.Errorf("unexpected filters (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReferenceIDsAndFiltersVisibility(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	insertUploads(t, dbconn.Global,
+		Upload{ID: 1, Commit: makeCommit(1), Root: "sub1/"}, // not visible
+		Upload{ID: 2, Commit: makeCommit(2), Root: "sub2/"}, // not visible
+		Upload{ID: 3, Commit: makeCommit(3), Root: "sub1/"},
+		Upload{ID: 4, Commit: makeCommit(4), Root: "sub2/"},
+		Upload{ID: 5, Commit: makeCommit(5), Root: "sub5/"},
+	)
+
+	insertNearestUploads(t, dbconn.Global, 50, map[string][]commitgraph.UploadMeta{
+		makeCommit(1): {{UploadID: 1, Distance: 0}},
+		makeCommit(2): {{UploadID: 2, Distance: 0}},
+		makeCommit(3): {{UploadID: 3, Distance: 0}},
+		makeCommit(4): {{UploadID: 4, Distance: 0}},
+		makeCommit(5): {{UploadID: 5, Distance: 0}},
+		makeCommit(6): {{UploadID: 3, Distance: 3}, {UploadID: 4, Distance: 2}, {UploadID: 5, Distance: 1}},
+	})
+
+	insertPackageReferences(t, store, []lsifstore.PackageReference{
+		{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f1")},
+		{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f2")},
+		{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f3")},
+		{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f4")},
+		{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f5")},
+	})
+
+	moniker := lsifstore.QualifiedMonikerData{
+		MonikerData: lsifstore.MonikerData{
+			Scheme: "gomod",
+		},
+		PackageInformationData: lsifstore.PackageInformationData{
+			Name:    "leftpad",
+			Version: "0.1.0",
+		},
+	}
+
+	scanner, totalCount, err := store.ReferenceIDsAndFilters(context.Background(), 50, makeCommit(6), []lsifstore.QualifiedMonikerData{moniker}, 5, 0)
+	if err != nil {
+		t.Fatalf("unexpected error getting filters: %s", err)
+	}
+
+	if totalCount != 3 {
+		t.Errorf("unexpected count. want=%d have=%d", 3, totalCount)
+	}
+
+	filters, err := consumeScanner(scanner)
+	if err != nil {
+		t.Fatalf("unexpected error from scanner: %s", err)
+	}
+
+	expected := []lsifstore.PackageReference{
+		{DumpID: 3, Filter: []byte("f3")},
+		{DumpID: 4, Filter: []byte("f4")},
+		{DumpID: 5, Filter: []byte("f5")},
+	}
+	if diff := cmp.Diff(expected, filters); diff != "" {
+		t.Errorf("unexpected filters (-want +got):\n%s", diff)
+	}
+}
+
+func TestReferenceIDsAndFiltersRemoteVisibility(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore()
+
+	insertUploads(t, dbconn.Global,
+		Upload{ID: 1, Commit: makeCommit(1)},
+		Upload{ID: 2, Commit: makeCommit(2), RepositoryID: 51},
+		Upload{ID: 3, Commit: makeCommit(3), RepositoryID: 52},
+		Upload{ID: 4, Commit: makeCommit(4), RepositoryID: 53},
+		Upload{ID: 5, Commit: makeCommit(5), RepositoryID: 54},
+		Upload{ID: 6, Commit: makeCommit(6), RepositoryID: 55},
+		Upload{ID: 7, Commit: makeCommit(6), RepositoryID: 56},
+	)
+	insertVisibleAtTip(t, dbconn.Global, 50, 1)
+	insertVisibleAtTip(t, dbconn.Global, 51, 2)
+	insertVisibleAtTip(t, dbconn.Global, 52, 3)
+	insertVisibleAtTip(t, dbconn.Global, 53, 4)
+	insertVisibleAtTip(t, dbconn.Global, 54, 5)
+	insertVisibleAtTip(t, dbconn.Global, 56, 7)
+
+	insertPackageReferences(t, store, []lsifstore.PackageReference{
+		{DumpID: 1, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f1")}, // same repo, not visible in git
+		{DumpID: 2, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f2")},
+		{DumpID: 3, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f3")},
+		{DumpID: 4, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f4")},
+		{DumpID: 5, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f5")},
+		{DumpID: 6, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f6")}, // remote repo not visible at tip
+		{DumpID: 7, Scheme: "gomod", Name: "leftpad", Version: "0.1.0", Filter: []byte("f7")},
+	})
+
+	moniker := lsifstore.QualifiedMonikerData{
+		MonikerData: lsifstore.MonikerData{
+			Scheme: "gomod",
+		},
+		PackageInformationData: lsifstore.PackageInformationData{
+			Name:    "leftpad",
+			Version: "0.1.0",
+		},
+	}
+
+	scanner, totalCount, err := store.ReferenceIDsAndFilters(context.Background(), 50, makeCommit(6), []lsifstore.QualifiedMonikerData{moniker}, 5, 0)
+	if err != nil {
+		t.Fatalf("unexpected error getting filters: %s", err)
+	}
+
+	if totalCount != 5 {
+		t.Errorf("unexpected count. want=%d have=%d", 5, totalCount)
+	}
+
+	filters, err := consumeScanner(scanner)
+	if err != nil {
+		t.Fatalf("unexpected error from scanner: %s", err)
+	}
+
+	expected := []lsifstore.PackageReference{
+		{DumpID: 2, Filter: []byte("f2")},
+		{DumpID: 3, Filter: []byte("f3")},
+		{DumpID: 4, Filter: []byte("f4")},
+		{DumpID: 5, Filter: []byte("f5")},
+		{DumpID: 7, Filter: []byte("f7")},
+	}
+	if diff := cmp.Diff(expected, filters); diff != "" {
+		t.Errorf("unexpected filters (-want +got):\n%s", diff)
+	}
+}
+
+// consumeScanner reads all values from the scanner into memory.
+func consumeScanner(scanner PackageReferenceScanner) (references []lsifstore.PackageReference, _ error) {
+	for {
+		reference, exists, err := scanner.Next()
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			break
+		}
+
+		references = append(references, reference)
+	}
+	if err := scanner.Close(); err != nil {
+		return nil, err
+	}
+
+	return references, nil
+}

--- a/enterprise/internal/codeintel/stores/lsifstore/types.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/types.go
@@ -50,6 +50,12 @@ type PackageInformationData struct {
 	Version string
 }
 
+// QualifiedMonikerData pairs a moniker with its package information.
+type QualifiedMonikerData struct {
+	MonikerData
+	PackageInformationData
+}
+
 // DiagnosticData carries diagnostic information attached to a range within its
 // containing document.
 type DiagnosticData struct {


### PR DESCRIPTION
Helps https://github.com/sourcegraph/sourcegraph/pull/17964.

The new `DefinitionDumps` method will replace `Packages`, and `ReferenceIDsAndFilters` will replace the reference paginating methods. The query strategy for the new methods mirror the old one, so there should be no huge surprises.