### PR TITLE
Hide campaigns in deleted namespaces

### DIFF
--- a/enterprise/internal/campaigns/background/main_test.go
+++ b/enterprise/internal/campaigns/background/main_test.go
@@ -1,0 +1,7 @@
+package background
+
+import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+
+func init() {
+	dbtesting.DBNameSuffix = "campaignsbackgrounddb"
+}

--- a/enterprise/internal/campaigns/background/spec_expire.go
+++ b/enterprise/internal/campaigns/background/spec_expire.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )

--- a/enterprise/internal/campaigns/background/workers.go
+++ b/enterprise/internal/campaigns/background/workers.go
@@ -73,6 +73,7 @@ func createDBWorkerStore(s *store.Store) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
 		Name:                 "campaigns_reconciler_worker_store",
 		TableName:            "changesets",
+		ViewName:             "reconciler_changesets",
 		AlternateColumnNames: map[string]string{"state": "reconciler_state"},
 		ColumnExpressions:    store.ChangesetColumns,
 		Scan:                 scanFirstChangesetRecord,

--- a/enterprise/internal/campaigns/background/workers.go
+++ b/enterprise/internal/campaigns/background/workers.go
@@ -73,7 +73,7 @@ func createDBWorkerStore(s *store.Store) dbworkerstore.Store {
 	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
 		Name:                 "campaigns_reconciler_worker_store",
 		TableName:            "changesets",
-		ViewName:             "reconciler_changesets",
+		ViewName:             "reconciler_changesets c",
 		AlternateColumnNames: map[string]string{"state": "reconciler_state"},
 		ColumnExpressions:    store.ChangesetColumns,
 		Scan:                 scanFirstChangesetRecord,
@@ -81,7 +81,7 @@ func createDBWorkerStore(s *store.Store) dbworkerstore.Store {
 		// Order changesets by state, so that freshly enqueued changesets have
 		// higher priority.
 		// If state is equal, prefer the newer ones.
-		OrderByExpression: sqlf.Sprintf("reconciler_state = 'errored', changesets.updated_at DESC"),
+		OrderByExpression: sqlf.Sprintf("c.reconciler_state = 'errored', c.updated_at DESC"),
 
 		StalledMaxAge: 60 * time.Second,
 		MaxNumResets:  reconcilerMaxNumResets,

--- a/enterprise/internal/campaigns/background/workers_test.go
+++ b/enterprise/internal/campaigns/background/workers_test.go
@@ -1,0 +1,176 @@
+package background
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+)
+
+func TestWorkerView(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	ctx := context.Background()
+	dbtesting.SetupGlobalTestDB(t)
+
+	now := timeutil.Now()
+	clock := func() time.Time { return now }
+	cstore := store.NewWithClock(dbconn.Global, clock)
+
+	user := ct.CreateTestUser(t, true)
+	spec := ct.CreateCampaignSpec(t, ctx, cstore, "test-campaign", user.ID)
+	campaign := ct.CreateCampaign(t, ctx, cstore, "test-campaign", user.ID, spec.ID)
+	repos, _ := ct.CreateTestRepos(t, ctx, cstore.DB(), 2)
+	repo := repos[0]
+	deletedRepo := repos[1]
+	if err := cstore.Repos().Delete(ctx, deletedRepo.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("Queued changeset", func(t *testing.T) {
+		c := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+			Repo:            repo.ID,
+			Campaign:        campaign.ID,
+			ReconcilerState: campaigns.ReconcilerStateQueued,
+		})
+		t.Cleanup(func() {
+			if err := cstore.DeleteChangeset(ctx, c.ID); err != nil {
+				t.Fatal(err)
+			}
+		})
+		assertReturnedChangesetIDs(t, ctx, cstore.DB(), []int{int(c.ID)})
+	})
+	t.Run("Not in campaign", func(t *testing.T) {
+		c := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+			Repo:            repo.ID,
+			Campaign:        0,
+			ReconcilerState: campaigns.ReconcilerStateQueued,
+		})
+		t.Cleanup(func() {
+			if err := cstore.DeleteChangeset(ctx, c.ID); err != nil {
+				t.Fatal(err)
+			}
+		})
+		assertReturnedChangesetIDs(t, ctx, cstore.DB(), []int{})
+	})
+	t.Run("In campaign with deleted user namespace", func(t *testing.T) {
+		deletedUser := ct.CreateTestUser(t, true)
+		if err := database.UsersWith(cstore).Delete(ctx, deletedUser.ID); err != nil {
+			t.Fatal(err)
+		}
+		userCampaign := ct.CreateCampaign(t, ctx, cstore, "test-user-namespace", deletedUser.ID, spec.ID)
+		c := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+			Repo:            repo.ID,
+			Campaign:        userCampaign.ID,
+			ReconcilerState: campaigns.ReconcilerStateQueued,
+		})
+		t.Cleanup(func() {
+			if err := cstore.DeleteChangeset(ctx, c.ID); err != nil {
+				t.Fatal(err)
+			}
+		})
+		assertReturnedChangesetIDs(t, ctx, cstore.DB(), []int{})
+	})
+	t.Run("In campaign with deleted org namespace", func(t *testing.T) {
+		orgID := ct.InsertTestOrg(t, "deleted-org")
+		if err := database.OrgsWith(cstore).Delete(ctx, orgID); err != nil {
+			t.Fatal(err)
+		}
+		orgCampaign := ct.BuildCampaign(cstore, "test-user-namespace", 0, spec.ID)
+		orgCampaign.NamespaceOrgID = orgID
+		if err := cstore.CreateCampaign(ctx, orgCampaign); err != nil {
+			t.Fatal(err)
+		}
+		c := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+			Repo:            repo.ID,
+			Campaign:        orgCampaign.ID,
+			ReconcilerState: campaigns.ReconcilerStateQueued,
+		})
+		t.Cleanup(func() {
+			if err := cstore.DeleteChangeset(ctx, c.ID); err != nil {
+				t.Fatal(err)
+			}
+		})
+		assertReturnedChangesetIDs(t, ctx, cstore.DB(), []int{})
+	})
+	t.Run("In campaign with deleted namespace but another campaign with an existing one", func(t *testing.T) {
+		deletedUser := ct.CreateTestUser(t, true)
+		if err := database.UsersWith(cstore).Delete(ctx, deletedUser.ID); err != nil {
+			t.Fatal(err)
+		}
+		userCampaign := ct.CreateCampaign(t, ctx, cstore, "test-user-namespace", deletedUser.ID, spec.ID)
+		c := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+			Repo:            repo.ID,
+			Campaign:        userCampaign.ID,
+			ReconcilerState: campaigns.ReconcilerStateQueued,
+		})
+		// Attach second campaign
+		c.Attach(campaign.ID)
+		if err := cstore.UpdateChangeset(ctx, c); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if err := cstore.DeleteChangeset(ctx, c.ID); err != nil {
+				t.Fatal(err)
+			}
+		})
+		assertReturnedChangesetIDs(t, ctx, cstore.DB(), []int{int(c.ID)})
+	})
+	t.Run("In deleted repo", func(t *testing.T) {
+		c := ct.CreateChangeset(t, ctx, cstore, ct.TestChangesetOpts{
+			Repo:            deletedRepo.ID,
+			Campaign:        campaign.ID,
+			ReconcilerState: campaigns.ReconcilerStateQueued,
+		})
+		t.Cleanup(func() {
+			if err := cstore.DeleteChangeset(ctx, c.ID); err != nil {
+				t.Fatal(err)
+			}
+		})
+		assertReturnedChangesetIDs(t, ctx, cstore.DB(), []int{})
+	})
+}
+
+func assertReturnedChangesetIDs(t *testing.T, ctx context.Context, db dbutil.DB, want []int) {
+	t.Helper()
+
+	have := make([]int, 0)
+
+	q := sqlf.Sprintf("SELECT id FROM reconciler_changesets")
+	rows, err := db.QueryContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
+	for rows.Next() {
+		var id int
+		err = rows.Scan(&id)
+		have = append(have, id)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rows.Err() != nil {
+		t.Fatal(err)
+	}
+	if rows.Close() != nil {
+		t.Fatal(err)
+	}
+
+	sort.Ints(have)
+	sort.Ints(want)
+
+	if diff := cmp.Diff(have, want); diff != "" {
+		t.Fatalf("invalid IDs returned: diff = %s", diff)
+	}
+}

--- a/enterprise/internal/campaigns/store/campaigns.go
+++ b/enterprise/internal/campaigns/store/campaigns.go
@@ -163,8 +163,14 @@ WHERE %s
 `
 
 func countCampaignsQuery(opts *CountCampaignsOpts) *sqlf.Query {
-	joins := []*sqlf.Query{}
-	preds := []*sqlf.Query{}
+	joins := []*sqlf.Query{
+		sqlf.Sprintf("LEFT JOIN users namespace_user ON campaigns.namespace_user_id = namespace_user.id"),
+		sqlf.Sprintf("LEFT JOIN orgs namespace_org ON campaigns.namespace_org_id = namespace_org.id"),
+	}
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("namespace_user.deleted_at IS NULL"),
+		sqlf.Sprintf("namespace_org.deleted_at IS NULL"),
+	}
 
 	if opts.ChangesetID != 0 {
 		joins = append(joins, sqlf.Sprintf("INNER JOIN changesets ON changesets.campaign_ids ? campaigns.id::TEXT"))
@@ -230,12 +236,17 @@ func (s *Store) GetCampaign(ctx context.Context, opts GetCampaignOpts) (*campaig
 var getCampaignsQueryFmtstr = `
 -- source: enterprise/internal/campaigns/store.go:GetCampaign
 SELECT %s FROM campaigns
+LEFT JOIN users namespace_user ON campaigns.namespace_user_id = namespace_user.id
+LEFT JOIN orgs  namespace_org  ON campaigns.namespace_org_id = namespace_org.id
 WHERE %s
 LIMIT 1
 `
 
 func getCampaignQuery(opts *GetCampaignOpts) *sqlf.Query {
-	var preds []*sqlf.Query
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("namespace_user.deleted_at IS NULL"),
+		sqlf.Sprintf("namespace_org.deleted_at IS NULL"),
+	}
 	if opts.ID != 0 {
 		preds = append(preds, sqlf.Sprintf("campaigns.id = %s", opts.ID))
 	}
@@ -354,8 +365,14 @@ ORDER BY id DESC
 `
 
 func listCampaignsQuery(opts *ListCampaignsOpts) *sqlf.Query {
-	joins := []*sqlf.Query{}
-	preds := []*sqlf.Query{}
+	joins := []*sqlf.Query{
+		sqlf.Sprintf("LEFT JOIN users namespace_user ON campaigns.namespace_user_id = namespace_user.id"),
+		sqlf.Sprintf("LEFT JOIN orgs namespace_org ON campaigns.namespace_org_id = namespace_org.id"),
+	}
+	preds := []*sqlf.Query{
+		sqlf.Sprintf("namespace_user.deleted_at IS NULL"),
+		sqlf.Sprintf("namespace_org.deleted_at IS NULL"),
+	}
 
 	if opts.Cursor != 0 {
 		preds = append(preds, sqlf.Sprintf("campaigns.id <= %s", opts.Cursor))

--- a/enterprise/internal/campaigns/testing/campaign.go
+++ b/enterprise/internal/campaigns/testing/campaign.go
@@ -13,9 +13,7 @@ type CreateCampaigner interface {
 	Clock() func() time.Time
 }
 
-func CreateCampaign(t *testing.T, ctx context.Context, store CreateCampaigner, name string, userID int32, spec int64) *campaigns.Campaign {
-	t.Helper()
-
+func BuildCampaign(store CreateCampaigner, name string, userID int32, spec int64) *campaigns.Campaign {
 	c := &campaigns.Campaign{
 		InitialApplierID: userID,
 		LastApplierID:    userID,
@@ -25,6 +23,13 @@ func CreateCampaign(t *testing.T, ctx context.Context, store CreateCampaigner, n
 		Name:             name,
 		Description:      "campaign description",
 	}
+	return c
+}
+
+func CreateCampaign(t *testing.T, ctx context.Context, store CreateCampaigner, name string, userID int32, spec int64) *campaigns.Campaign {
+	t.Helper()
+
+	c := BuildCampaign(store, name, userID, spec)
 
 	if err := store.CreateCampaign(ctx, c); err != nil {
 		t.Fatal(err)

--- a/enterprise/internal/campaigns/testing/repos.go
+++ b/enterprise/internal/campaigns/testing/repos.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -53,7 +54,7 @@ func TestRepo(t *testing.T, store *database.ExternalServiceStore, serviceKind st
 	}
 }
 
-func CreateTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count int) ([]*types.Repo, *types.ExternalService) {
+func CreateTestRepos(t *testing.T, ctx context.Context, db dbutil.DB, count int) ([]*types.Repo, *types.ExternalService) {
 	t.Helper()
 
 	repoStore := database.Repos(db)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1809,6 +1809,91 @@ Indexes:
   WHERE (r.deleted_at IS NULL);
 ```
 
+# View "public.reconciler_changesets"
+```
+        Column         |           Type           | Modifiers 
+-----------------------+--------------------------+-----------
+ id                    | bigint                   | 
+ campaign_ids          | jsonb                    | 
+ repo_id               | integer                  | 
+ created_at            | timestamp with time zone | 
+ updated_at            | timestamp with time zone | 
+ metadata              | jsonb                    | 
+ external_id           | text                     | 
+ external_service_type | text                     | 
+ external_deleted_at   | timestamp with time zone | 
+ external_branch       | text                     | 
+ external_updated_at   | timestamp with time zone | 
+ external_state        | text                     | 
+ external_review_state | text                     | 
+ external_check_state  | text                     | 
+ diff_stat_added       | integer                  | 
+ diff_stat_changed     | integer                  | 
+ diff_stat_deleted     | integer                  | 
+ sync_state            | jsonb                    | 
+ current_spec_id       | bigint                   | 
+ previous_spec_id      | bigint                   | 
+ publication_state     | text                     | 
+ owned_by_campaign_id  | bigint                   | 
+ reconciler_state      | text                     | 
+ failure_message       | text                     | 
+ started_at            | timestamp with time zone | 
+ finished_at           | timestamp with time zone | 
+ process_after         | timestamp with time zone | 
+ num_resets            | integer                  | 
+ closing               | boolean                  | 
+ num_failures          | integer                  | 
+ log_contents          | text                     | 
+ execution_logs        | json[]                   | 
+ syncer_error          | text                     | 
+
+```
+
+## View query:
+
+```sql
+ SELECT c.id,
+    c.campaign_ids,
+    c.repo_id,
+    c.created_at,
+    c.updated_at,
+    c.metadata,
+    c.external_id,
+    c.external_service_type,
+    c.external_deleted_at,
+    c.external_branch,
+    c.external_updated_at,
+    c.external_state,
+    c.external_review_state,
+    c.external_check_state,
+    c.diff_stat_added,
+    c.diff_stat_changed,
+    c.diff_stat_deleted,
+    c.sync_state,
+    c.current_spec_id,
+    c.previous_spec_id,
+    c.publication_state,
+    c.owned_by_campaign_id,
+    c.reconciler_state,
+    c.failure_message,
+    c.started_at,
+    c.finished_at,
+    c.process_after,
+    c.num_resets,
+    c.closing,
+    c.num_failures,
+    c.log_contents,
+    c.execution_logs,
+    c.syncer_error
+   FROM (changesets c
+     JOIN repo r ON ((r.id = c.repo_id)))
+  WHERE ((r.deleted_at IS NULL) AND (EXISTS ( SELECT 1
+           FROM ((campaigns
+             LEFT JOIN users namespace_user ON ((campaigns.namespace_user_id = namespace_user.id)))
+             LEFT JOIN orgs namespace_org ON ((campaigns.namespace_org_id = namespace_org.id)))
+          WHERE ((c.campaign_ids ? (campaigns.id)::text) AND (namespace_user.deleted_at IS NULL) AND (namespace_org.deleted_at IS NULL)))));
+```
+
 # View "public.site_config"
 ```
    Column    |  Type   | Modifiers 

--- a/migrations/frontend/1528395787_reconciler_changesets_view.down.sql
+++ b/migrations/frontend/1528395787_reconciler_changesets_view.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP VIEW IF EXISTS reconciler_changesets;
+
+COMMIT;

--- a/migrations/frontend/1528395787_reconciler_changesets_view.up.sql
+++ b/migrations/frontend/1528395787_reconciler_changesets_view.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+CREATE VIEW reconciler_changesets AS
+    SELECT c.* FROM changesets c
+    INNER JOIN repo r on r.id = c.repo_id
+    WHERE
+        r.deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM campaigns
+            LEFT JOIN users namespace_user ON campaigns.namespace_user_id = namespace_user.id
+            LEFT JOIN orgs namespace_org ON campaigns.namespace_org_id = namespace_org.id
+            WHERE
+                c.campaign_ids ? campaigns.id::text AND
+                namespace_user.deleted_at IS NULL AND
+                namespace_org.deleted_at IS NULL
+        )
+;
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -108,6 +108,8 @@
 // 1528395785_out_of_band_migration_table.up.sql (3.838kB)
 // 1528395786_diagnostic_counts_migration.down.sql (16B)
 // 1528395786_diagnostic_counts_migration.up.sql (277B)
+// 1528395787_reconciler_changesets_view.down.sql (60B)
+// 1528395787_reconciler_changesets_view.up.sql (598B)
 
 package migrations
 
@@ -2336,6 +2338,46 @@ func _1528395786_diagnostic_counts_migrationUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395787_reconciler_changesets_viewDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\x08\xf3\x74\x0d\x57\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x28\x4a\x4d\xce\xcf\x4b\xce\xcc\x49\x2d\x8a\x4f\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x29\xb6\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xa9\x6f\xfd\xd6\x3c\x00\x00\x00")
+
+func _1528395787_reconciler_changesets_viewDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395787_reconciler_changesets_viewDownSql,
+		"1528395787_reconciler_changesets_view.down.sql",
+	)
+}
+
+func _1528395787_reconciler_changesets_viewDownSql() (*asset, error) {
+	bytes, err := _1528395787_reconciler_changesets_viewDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395787_reconciler_changesets_view.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x9, 0x47, 0x77, 0x5d, 0xe6, 0xb3, 0xe1, 0x8c, 0xb3, 0xf2, 0x7a, 0x9c, 0xd6, 0xd1, 0x94, 0xe4, 0x2a, 0xa9, 0x59, 0x60, 0xc4, 0x86, 0x12, 0x29, 0x2a, 0x70, 0x88, 0xed, 0x3c, 0xf9, 0xb0, 0xe1}}
+	return a, nil
+}
+
+var __1528395787_reconciler_changesets_viewUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x84\x92\x5f\x4b\xc3\x30\x14\xc5\xdf\xfb\x29\xce\xa3\xfa\x10\xf0\x75\x43\x64\xce\x4c\x23\x5d\x0a\x6d\x75\xbe\x85\x90\x5c\x62\x60\x6b\x46\x52\xc1\x8f\x2f\xad\xdb\xec\x1f\xc4\xfb\x94\xdc\x9c\x73\xf2\xcb\x25\x0f\xfc\x49\xc8\x65\x96\xad\x4b\xbe\xaa\x39\xde\x04\xdf\x21\x92\x09\x8d\xf1\x7b\x8a\xca\x7c\xe8\xc6\x51\xa2\x36\x61\x55\x65\x00\x50\xf1\x9c\xaf\x6b\x18\x76\x83\x4d\x59\x6c\x31\x50\x98\x5e\x20\xa4\xe4\x25\x5e\x0a\x21\x11\xe9\x18\x10\x11\x1a\x44\xe6\x2d\xee\x60\x58\xd7\x52\xde\xf6\xca\xdd\x33\x2f\x79\xbf\xea\x2a\x32\x4b\x7b\x6a\xc9\x2a\xdd\x42\x54\x90\xaf\x79\x8e\x95\x7c\xbc\x08\xf8\xbb\xa8\xea\x0a\x57\x97\xc6\x00\xe7\xf6\x04\xa3\x0f\x47\xed\x5d\x93\x46\x9a\x9c\x6f\xea\x1f\xa0\xcf\x44\x31\xa1\xd1\x07\x4a\x47\x6d\x48\x75\x7b\x14\xf2\xd7\xc7\xc6\x67\xaa\xa7\x1e\xf7\xd8\x89\x7e\x9e\x1e\xa2\x1b\x86\x87\xe8\xfe\xca\x0e\xd1\x4d\xa3\x43\x74\xd3\xe4\xf1\x7c\xce\x65\xd8\x39\x51\x79\x9b\x70\x3f\xb8\xc0\xdb\xc5\xa2\xa5\xaf\x76\x34\xb6\x73\x4d\x5e\xf1\xcf\xb0\xe7\xae\x0e\x70\x6e\xba\x18\xae\xb3\xee\x17\x15\xdb\xad\xa8\x97\xd9\x77\x00\x00\x00\xff\xff\x33\xc1\xde\xae\x56\x02\x00\x00")
+
+func _1528395787_reconciler_changesets_viewUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395787_reconciler_changesets_viewUpSql,
+		"1528395787_reconciler_changesets_view.up.sql",
+	)
+}
+
+func _1528395787_reconciler_changesets_viewUpSql() (*asset, error) {
+	bytes, err := _1528395787_reconciler_changesets_viewUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395787_reconciler_changesets_view.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x7a, 0x7e, 0x4e, 0x87, 0xa6, 0x39, 0x45, 0x4d, 0x4a, 0xe8, 0x44, 0x41, 0xda, 0xf7, 0x80, 0xb9, 0xd8, 0xc0, 0x71, 0xd5, 0x49, 0x40, 0xa, 0x18, 0xd0, 0x4a, 0xdf, 0x7c, 0x44, 0x88, 0x3, 0xa2}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2535,6 +2577,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395785_out_of_band_migration_table.up.sql":                                          _1528395785_out_of_band_migration_tableUpSql,
 	"1528395786_diagnostic_counts_migration.down.sql":                                        _1528395786_diagnostic_counts_migrationDownSql,
 	"1528395786_diagnostic_counts_migration.up.sql":                                          _1528395786_diagnostic_counts_migrationUpSql,
+	"1528395787_reconciler_changesets_view.down.sql":                                         _1528395787_reconciler_changesets_viewDownSql,
+	"1528395787_reconciler_changesets_view.up.sql":                                           _1528395787_reconciler_changesets_viewUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2689,6 +2733,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395785_out_of_band_migration_table.up.sql":                                          {_1528395785_out_of_band_migration_tableUpSql, map[string]*bintree{}},
 	"1528395786_diagnostic_counts_migration.down.sql":                                        {_1528395786_diagnostic_counts_migrationDownSql, map[string]*bintree{}},
 	"1528395786_diagnostic_counts_migration.up.sql":                                          {_1528395786_diagnostic_counts_migrationUpSql, map[string]*bintree{}},
+	"1528395787_reconciler_changesets_view.down.sql":                                         {_1528395787_reconciler_changesets_viewDownSql, map[string]*bintree{}},
+	"1528395787_reconciler_changesets_view.up.sql":                                           {_1528395787_reconciler_changesets_viewUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This fixes breaking the API and hence the global list of campaigns, when a campaign in a deleted namespace exists in the database.
In order to not pick those changesets up in the reconciler, I added a view that filters those out. It also fixes the reconciler picking up changesets in deleted repos.

Note that hiding may not be the final behavior we want here, but if fixes the bug, so it's a good stopgap for now, I think. 