### PR TITLE
insights: store: add support for recording data points

### DIFF
--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -110,6 +110,6 @@ func TestResolver_InsightSeries(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Want("insights[0][0].Points mocked", "[{p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:1}} {p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:2}} {p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:3}}]").Equal(t, fmt.Sprintf("%+v", points))
+		autogold.Want("insights[0][0].Points mocked", "[{p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:1 Metadata:[]}} {p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:2 Metadata:[]}} {p:{Time:{wall:0 ext:63271811045 loc:<nil>} Value:3 Metadata:[]}}]").Equal(t, fmt.Sprintf("%+v", points))
 	})
 }

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -221,6 +221,7 @@ func (s *Store) RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) 
 }
 
 const upsertRepoNameFmtStr = `
+-- source: enterprise/internal/insights/store/store.go:RecordSeriesPoint
 WITH e AS(
 	INSERT INTO repo_names(name)
 	VALUES (%s)
@@ -233,6 +234,7 @@ UNION
 `
 
 const upsertMetadataFmtStr = `
+-- source: enterprise/internal/insights/store/store.go:RecordSeriesPoint
 WITH e AS(
     INSERT INTO metadata(metadata)
     VALUES (%s)

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -3,11 +3,14 @@ package store
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -17,6 +20,7 @@ import (
 // for actual API usage.
 type Interface interface {
 	SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error)
+	RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) error
 }
 
 var _ Interface = &Store{}
@@ -139,6 +143,119 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 		sqlf.Join(preds, "\n AND "),
 	)
 }
+
+// RecordSeriesPointArgs describes arguments for the RecordSeriesPoint method.
+type RecordSeriesPointArgs struct {
+	// SeriesID is the unique series ID to query. It should describe the series of data uniquely,
+	// but is not a DB table primary key ID.
+	SeriesID string
+
+	// Point is the actual data point recorded and at what time.
+	Point SeriesPoint
+
+	// Repository name and DB ID to associate with this data point, if any.
+	//
+	// Both must be specified if one is specified.
+	RepoName *string
+	RepoID   *api.RepoID
+
+	// Metadata contains arbitrary JSON metadata to associate with the data point, if any.
+	//
+	// See the DB schema comments for intended use cases. This should generally be small,
+	// low-cardinality data to avoid inflating the table.
+	Metadata interface{}
+}
+
+// RecordSeriesPoint records a data point for the specfied series ID (which is a unique ID for the
+// series, not a DB table primary key ID).
+func (s *Store) RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) (err error) {
+	// Start transaction.
+	var txStore *basestore.Store
+	txStore, err = s.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = txStore.Done(err) }()
+
+	if (v.RepoName != nil && v.RepoID == nil) || (v.RepoID != nil && v.RepoName == nil) {
+		return errors.New("RepoName and RepoID must be mutually specified")
+	}
+
+	// Upsert the repository name into a separate table, so we get a small ID we can reference
+	// many times from the series_points table without storing the repo name multiple times.
+	var repoNameID *int32
+	if v.RepoName != nil {
+		row := txStore.QueryRow(ctx, sqlf.Sprintf(upsertRepoNameFmtStr, *v.RepoName, *v.RepoName))
+		repoNameID = new(int32)
+		if err := row.Scan(repoNameID); err != nil {
+			return errors.Wrap(err, "upserting repo name ID")
+		}
+	}
+
+	// Upsert the metadata into a separate table, so we get a small ID we can reference many times
+	// from the series_points table without storing the metadata multiple times.
+	var metadataID *int32
+	if v.Metadata != nil {
+		jsonMetadata, err := json.Marshal(v.Metadata)
+		if err != nil {
+			return errors.Wrap(err, "upserting>encoding metadata")
+		}
+		row := txStore.QueryRow(ctx, sqlf.Sprintf(upsertMetadataFmtStr, jsonMetadata, jsonMetadata))
+		metadataID = new(int32)
+		if err := row.Scan(metadataID); err != nil {
+			return errors.Wrap(err, "upserting metadata ID")
+		}
+	}
+
+	// Insert the actual data point.
+	return txStore.Exec(ctx, sqlf.Sprintf(
+		recordSeriesPointFmtstr,
+		v.SeriesID,    // series_id
+		v.Point.Time,  // time
+		v.Point.Value, // value
+		metadataID,    // metadata_id
+		v.RepoID,      // repo_id
+		repoNameID,    // repo_name_id
+		repoNameID,    // original_repo_name_id
+	))
+}
+
+const upsertRepoNameFmtStr = `
+WITH e AS(
+	INSERT INTO repo_names(name)
+	VALUES (%s)
+	ON CONFLICT DO NOTHING
+	RETURNING id
+)
+SELECT * FROM e
+UNION
+	SELECT id FROM repo_names WHERE name = %s;
+`
+
+const upsertMetadataFmtStr = `
+WITH e AS(
+    INSERT INTO metadata(metadata)
+    VALUES (%s)
+    ON CONFLICT DO NOTHING
+    RETURNING id
+)
+SELECT * FROM e
+UNION
+	SELECT id FROM metadata WHERE metadata = %s;
+`
+
+const recordSeriesPointFmtstr = `
+-- source: enterprise/internal/insights/store/store.go:RecordSeriesPoint
+INSERT INTO series_points(
+	series_id,
+	time,
+	value,
+	metadata_id,
+	repo_id,
+	repo_name_id,
+	original_repo_name_id)
+VALUES (%s, %s, %s, %s, %s, %s, %s);
+`
 
 func (s *Store) query(ctx context.Context, q *sqlf.Query, sc scanFunc) error {
 	rows, err := s.Store.Query(ctx, q)

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -198,7 +198,7 @@ func (s *Store) RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) 
 	if v.Metadata != nil {
 		jsonMetadata, err := json.Marshal(v.Metadata)
 		if err != nil {
-			return errors.Wrap(err, "upserting>encoding metadata")
+			return errors.Wrap(err, "upserting: encoding metadata")
 		}
 		row := txStore.QueryRow(ctx, sqlf.Sprintf(upsertMetadataFmtStr, jsonMetadata, jsonMetadata))
 		metadataID = new(int32)

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -73,8 +72,8 @@ SELECT time,
 			t.Fatal(err)
 		}
 		autogold.Want("SeriesPoints(2).len", int(913)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(2)[len()-1]", "{Time:2020-01-01 00:00:00 +0000 UTC Value:-20.00716650672132}").Equal(t, fmt.Sprintf("%+v", points[len(points)-1]))
-		autogold.Want("SeriesPoints(2)[0]", "{Time:2020-06-01 00:00:00 +0000 UTC Value:-37.8750440811433}").Equal(t, fmt.Sprintf("%+v", points[0]))
+		autogold.Want("SeriesPoints(2)[len()-1].String()", `SeriesPoint{Time: "2020-01-01 00:00:00 +0000 UTC", Value: -20.00716650672132, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
+		autogold.Want("SeriesPoints(2)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
 	})
 
 	t.Run("subset of data", func(t *testing.T) {
@@ -87,8 +86,8 @@ SELECT time,
 			t.Fatal(err)
 		}
 		autogold.Want("SeriesPoints(3).len", int(551)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(3)[0]", "{Time:2020-05-31 20:00:00 +0000 UTC Value:-11.269436460802638}").Equal(t, fmt.Sprintf("%+v", points[0]))
-		autogold.Want("SeriesPoints(3)[len()-1]", "{Time:2020-03-01 04:00:00 +0000 UTC Value:35.85710033014749}").Equal(t, fmt.Sprintf("%+v", points[len(points)-1]))
+		autogold.Want("SeriesPoints(3)[0].String()", `SeriesPoint{Time: "2020-05-31 20:00:00 +0000 UTC", Value: -11.269436460802638, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
+		autogold.Want("SeriesPoints(3)[len()-1].String()", `SeriesPoint{Time: "2020-03-01 04:00:00 +0000 UTC", Value: 35.85710033014749, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
 	})
 
 	t.Run("latest 3 points", func(t *testing.T) {
@@ -100,9 +99,9 @@ SELECT time,
 			t.Fatal(err)
 		}
 		autogold.Want("SeriesPoints(4).len", int(3)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(4)[0]", "{Time:2020-06-01 00:00:00 +0000 UTC Value:-37.8750440811433}").Equal(t, fmt.Sprintf("%+v", points[0]))
-		autogold.Want("SeriesPoints(4)[1]", "{Time:2020-05-31 20:00:00 +0000 UTC Value:-11.269436460802638}").Equal(t, fmt.Sprintf("%+v", points[1]))
-		autogold.Want("SeriesPoints(4)[2]", "{Time:2020-05-31 16:00:00 +0000 UTC Value:17.838503552871998}").Equal(t, fmt.Sprintf("%+v", points[2]))
+		autogold.Want("SeriesPoints(4)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
+		autogold.Want("SeriesPoints(4)[1].String()", `SeriesPoint{Time: "2020-05-31 20:00:00 +0000 UTC", Value: -11.269436460802638, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[1].String())
+		autogold.Want("SeriesPoints(4)[2].String()", `SeriesPoint{Time: "2020-05-31 16:00:00 +0000 UTC", Value: 17.838503552871998, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[2].String())
 	})
 
 }

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hexops/autogold"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -104,4 +105,59 @@ SELECT time,
 		autogold.Want("SeriesPoints(4)[2].String()", `SeriesPoint{Time: "2020-05-31 16:00:00 +0000 UTC", Value: 17.838503552871998, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[2].String())
 	})
 
+}
+
+func TestRecordSeriesPoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	t.Parallel()
+
+	ctx := context.Background()
+	clock := timeutil.Now
+	timescale, cleanup := dbtesting.TimescaleDB(t)
+	defer cleanup()
+	store := NewWithClock(timescale, clock)
+
+	time := func(s string) time.Time {
+		v, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return v
+	}
+	optionalString := func(v string) *string { return &v }
+	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
+
+	// Record some data points.
+	for _, record := range []RecordSeriesPointArgs{
+		{
+			SeriesID: "one",
+			Point:    SeriesPoint{Time: time("2020-03-01T00:00:00Z"), Value: 1.1},
+			RepoName: optionalString("repo1"),
+			RepoID:   optionalRepoID(3),
+			Metadata: map[string]interface{}{"some": "data"},
+		},
+		{
+			SeriesID: "two",
+			Point:    SeriesPoint{Time: time("2020-03-02T00:00:00Z"), Value: 2.2},
+			Metadata: []interface{}{"some", "data", "two"},
+		},
+	} {
+		if err := store.RecordSeriesPoint(ctx, record); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Confirm we get the expected data back.
+	points, err := store.SeriesPoints(ctx, SeriesPointsOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	autogold.Want("len(points)", 0).Equal(t, len(points))
+	autogold.Want("points[0].String()", 0).Equal(t, points[0].String())
+	autogold.Want("points[1].String()", 0).Equal(t, points[1].String())
+
+	// Confirm the data point with repository name got recorded correctly.
+	// TODO(slimsag): future: once we support querying by repo ID/names, add tests to ensure that information is inserted properly here.
 }

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -154,9 +154,9 @@ func TestRecordSeriesPoints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	autogold.Want("len(points)", 0).Equal(t, len(points))
-	autogold.Want("points[0].String()", 0).Equal(t, points[0].String())
-	autogold.Want("points[1].String()", 0).Equal(t, points[1].String())
+	autogold.Want("len(points)", int(2)).Equal(t, len(points))
+	autogold.Want("points[0].String()", `SeriesPoint{Time: "2020-03-02 00:00:00 +0000 UTC", Value: 2.2, Metadata: ["some", "data", "two"]}`).Equal(t, points[0].String())
+	autogold.Want("points[1].String()", `SeriesPoint{Time: "2020-03-01 00:00:00 +0000 UTC", Value: 1.1, Metadata: {"some": "data"}}`).Equal(t, points[1].String())
 
 	// Confirm the data point with repository name got recorded correctly.
 	// TODO(slimsag): future: once we support querying by repo ID/names, add tests to ensure that information is inserted properly here.


### PR DESCRIPTION
This PR adds support for the store to record data points.

Stacked on top of #18254

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>