### PR TITLE
Distinguish permission errors from 404 deleted when loading changesets

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -860,7 +860,7 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(
 						Repo: api.RepoName("github.com/foo/bar"),
 					},
 					githubDotComSource: &fakeRepoSource{
-						err: github.ErrNotFound,
+						err: github.ErrRepoNotFound,
 					},
 					result: &protocol.RepoLookupResult{ErrorNotFound: true},
 					err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName("github.com/foo/bar"), true),
@@ -973,7 +973,7 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(
 						Repo: api.RepoName(githubRepository.Name),
 					},
 					githubDotComSource: &fakeRepoSource{
-						err: github.ErrNotFound,
+						err: github.ErrRepoNotFound,
 					},
 					stored: []*types.Repo{githubRepository},
 					result: &protocol.RepoLookupResult{Repo: &protocol.RepoInfo{

--- a/internal/authz/gitlab/common_test.go
+++ b/internal/authz/gitlab/common_test.go
@@ -138,7 +138,7 @@ func (m *mockGitLab) GetProject(c *gitlab.Client, ctx context.Context, op gitlab
 
 	proj, ok := m.projs[op.ID]
 	if !ok {
-		return nil, gitlab.ErrNotFound
+		return nil, gitlab.ErrProjectNotFound
 	}
 	if proj.Visibility == gitlab.Public {
 		return proj, nil
@@ -154,7 +154,7 @@ func (m *mockGitLab) GetProject(c *gitlab.Client, ctx context.Context, op gitlab
 		}
 	}
 
-	return nil, gitlab.ErrNotFound
+	return nil, gitlab.ErrProjectNotFound
 }
 
 func (m *mockGitLab) ListProjects(c *gitlab.Client, ctx context.Context, urlStr string) (projs []*gitlab.Project, nextPageURL *string, err error) {
@@ -228,7 +228,7 @@ func (m *mockGitLab) ListTree(c *gitlab.Client, ctx context.Context, op gitlab.L
 
 	proj, ok := m.projs[op.ProjID]
 	if !ok {
-		return nil, gitlab.ErrNotFound
+		return nil, gitlab.ErrProjectNotFound
 	}
 	if proj.Visibility == gitlab.Public {
 		return ret, nil
@@ -244,7 +244,7 @@ func (m *mockGitLab) ListTree(c *gitlab.Client, ctx context.Context, op gitlab.L
 		}
 	}
 
-	return nil, gitlab.ErrNotFound
+	return nil, gitlab.ErrProjectNotFound
 }
 
 // isClientAuthenticated returns true if the client is authenticated. User is authenticated if OAuth

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -21,9 +21,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
 	"github.com/sergi/go-diff/diffmatchpatch"
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/time/rate"
 )
 
 var update = flag.Bool("update", false, "update testdata")
@@ -375,7 +376,7 @@ func TestClient_LoadPullRequest(t *testing.T) {
 				pr.ToRef.Repository.Project.Key = "SOUR"
 				return pr
 			},
-			err: "Bitbucket API HTTP error: code=404 url=\"${INSTANCEURL}/rest/api/1.0/projects/SOUR/repos/vegeta/pull-requests/9999\" body=\"{\\\"errors\\\":[{\\\"context\\\":null,\\\"message\\\":\\\"Pull request 9999 does not exist in SOUR/vegeta.\\\",\\\"exceptionName\\\":\\\"com.atlassian.bitbucket.pull.NoSuchPullRequestException\\\"}]}\"",
+			err: "pull request not found",
 		},
 		{
 			name: "non existing repo",

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -115,13 +115,13 @@ func urlIsGitHubDotCom(apiURL *url.URL) bool {
 	return hostname == "api.github.com" || hostname == "github.com" || hostname == "www.github.com" || apiURL.String() == githubProxyURL.String()
 }
 
-// ErrNotFound is when the requested GitHub repository is not found.
-var ErrNotFound = errors.New("GitHub repository not found")
+// ErrRepoNotFound is when the requested GitHub repository is not found.
+var ErrRepoNotFound = errors.New("GitHub repository not found")
 
 // IsNotFound reports whether err is a GitHub API error of type NOT_FOUND, the equivalent cached
 // response error, or HTTP 404.
 func IsNotFound(err error) bool {
-	if err == ErrNotFound || errors.Cause(err) == ErrNotFound {
+	if err == ErrRepoNotFound || errors.Cause(err) == ErrRepoNotFound {
 		return true
 	}
 	if _, ok := err.(ErrPullRequestNotFound); ok {

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -830,7 +830,7 @@ query($owner: String!, $name: String!, $number: Int!) {
 						continue
 					}
 					if len(err2.Path) == 1 {
-						return ErrNotFound
+						return ErrRepoNotFound
 					}
 					if prPath, ok := err2.Path[1].(string); !ok || prPath != "pullRequest" {
 						continue

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -76,7 +76,7 @@ func (c *V3Client) cachedGetRepository(ctx context.Context, key string, getRepos
 		if cached := c.getRepositoryFromCache(ctx, key); cached != nil {
 			reposGitHubCacheCounter.WithLabelValues("hit").Inc()
 			if cached.NotFound {
-				return nil, ErrNotFound
+				return nil, ErrRepoNotFound
 			}
 			return &cached.Repository, nil
 		}
@@ -181,7 +181,7 @@ func (c *V3Client) getRepositoryFromAPI(ctx context.Context, owner, name string)
 	var result restRepository
 	if err := c.requestGet(ctx, fmt.Sprintf("/repos/%s/%s", owner, name), &result); err != nil {
 		if HTTPErrorCode(err) == http.StatusNotFound {
-			return nil, ErrNotFound
+			return nil, ErrRepoNotFound
 		}
 		return nil, err
 	}
@@ -491,7 +491,7 @@ func (c *V3Client) ListTopicsOnRepository(ctx context.Context, ownerAndName stri
 	var result restTopicsResponse
 	if err := c.requestGet(ctx, fmt.Sprintf("/repos/%s/%s/topics", owner, name), &result); err != nil {
 		if HTTPErrorCode(err) == http.StatusNotFound {
-			return nil, ErrNotFound
+			return nil, ErrRepoNotFound
 		}
 		return nil, err
 	}

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -135,7 +135,7 @@ func TestClient_GetRepository_nonexistent(t *testing.T) {
 	if !IsNotFound(err) {
 		t.Errorf("got err == %v, want IsNotFound(err) == true", err)
 	}
-	if err != ErrNotFound {
+	if err != ErrRepoNotFound {
 		t.Errorf("got err == %q, want ErrNotFound", err)
 	}
 	if repo != nil {

--- a/internal/extsvc/gitlab/projects.go
+++ b/internal/extsvc/gitlab/projects.go
@@ -98,7 +98,7 @@ func (c *Client) cachedGetProject(ctx context.Context, key string, forceFetch bo
 		if cached := c.getProjectFromCache(ctx, key); cached != nil {
 			projectsGitLabCacheCounter.WithLabelValues("hit").Inc()
 			if cached.NotFound {
-				return nil, ErrNotFound
+				return nil, ErrProjectNotFound
 			}
 			return &cached.Project, nil
 		}

--- a/internal/extsvc/gitlab/resource_state_events.go
+++ b/internal/extsvc/gitlab/resource_state_events.go
@@ -47,7 +47,10 @@ func (c *Client) GetMergeRequestResourceStateEvents(ctx context.Context, project
 
 		header, _, err := c.do(ctx, req, &page)
 		if err != nil {
-			if e, ok := err.(HTTPError); ok && e.Code() == http.StatusNotFound {
+			// If this endpoint is not found, the GitLab instance doesn't support these events yet.
+			// This is okay and we can't do anything about it, but as GitLab <13.2 ages, we should
+			// remove this stopgap.
+			if e, ok := errors.Cause(err).(HTTPError); ok && e.Code() == http.StatusNotFound {
 				return []*ResourceStateEvent{}, nil
 			}
 			return nil, errors.Wrap(err, "requesting rse page")

--- a/internal/extsvc/gitlab/resource_state_events.go
+++ b/internal/extsvc/gitlab/resource_state_events.go
@@ -47,7 +47,7 @@ func (c *Client) GetMergeRequestResourceStateEvents(ctx context.Context, project
 
 		header, _, err := c.do(ctx, req, &page)
 		if err != nil {
-			if errors.Is(err, HTTPError(404)) {
+			if e, ok := err.(HTTPError); ok && e.Code() == http.StatusNotFound {
 				return []*ResourceStateEvent{}, nil
 			}
 			return nil, errors.Wrap(err, "requesting rse page")

--- a/internal/httptestutil/recorder.go
+++ b/internal/httptestutil/recorder.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
@@ -25,6 +26,8 @@ func NewRecorder(file string, record bool, filters ...cassette.Filter) (*recorde
 
 	filters = append(filters, func(i *cassette.Interaction) error {
 		delete(i.Request.Headers, "Authorization")
+		// This is used for GitLab.
+		delete(i.Request.Headers, "Private-Token")
 		delete(i.Response.Headers, "Set-Cookie")
 		return nil
 	})

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -175,7 +176,7 @@ func (s BitbucketServerSource) LoadChangeset(ctx context.Context, cs *Changeset)
 
 	err = s.client.LoadPullRequest(ctx, pr)
 	if err != nil {
-		if bitbucketserver.IsNotFound(err) {
+		if err == bitbucketserver.ErrPullRequestNotFound {
 			return ChangesetNotFoundError{Changeset: cs}
 		}
 

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -461,7 +461,7 @@ func (s *GitLabSource) LoadChangeset(ctx context.Context, cs *Changeset) error {
 
 	mr, err := s.client.GetMergeRequest(ctx, project, gitlab.ID(iid))
 	if err != nil {
-		if gitlab.IsNotFound(err) {
+		if errors.Cause(err) == gitlab.ErrMergeRequestNotFound {
 			return ChangesetNotFoundError{Changeset: cs}
 		}
 		return errors.Wrapf(err, "retrieving merge request %d", iid)

--- a/internal/repos/gitlab_test.go
+++ b/internal/repos/gitlab_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -537,12 +539,98 @@ func TestGitLabSource_ChangesetSource(t *testing.T) {
 			p := newGitLabChangesetSourceTestProvider(t)
 			p.changeset.Changeset.ExternalID = "43"
 			p.changeset.Changeset.Metadata = p.mr
-			p.mockGetMergeRequest(43, nil, gitlab.HTTPError(404))
+			p.mockGetMergeRequest(43, nil, gitlab.ErrMergeRequestNotFound)
 
 			if err := p.source.LoadChangeset(p.ctx, p.changeset); err == nil {
 				t.Fatal("unexpectedly no error for not found changeset")
 			} else if err.Error() != (ChangesetNotFoundError{Changeset: &Changeset{Changeset: &campaigns.Changeset{ExternalID: "43"}}}).Error() {
 				t.Fatalf("unexpected error: %+v", err)
+			}
+		})
+
+		t.Run("integration", func(t *testing.T) {
+			testCases := []struct {
+				name string
+				cs   *Changeset
+				err  string
+			}{
+				{
+					name: "found",
+					cs: &Changeset{
+						Repo: &types.Repo{Metadata: &gitlab.Project{
+							// sourcegraph/sourcegraph
+							ProjectCommon: gitlab.ProjectCommon{ID: 16606088},
+						}},
+						Changeset: &campaigns.Changeset{ExternalID: "2"},
+					},
+				},
+				{
+					name: "not-found",
+					cs: &Changeset{
+						Repo: &types.Repo{Metadata: &gitlab.Project{
+							// sourcegraph/sourcegraph
+							ProjectCommon: gitlab.ProjectCommon{ID: 16606088},
+						}},
+						Changeset: &campaigns.Changeset{ExternalID: "100000"},
+					},
+					err: "Changeset with external ID 100000 not found",
+				},
+				{
+					name: "project-not-found",
+					cs: &Changeset{
+						Repo: &types.Repo{Metadata: &gitlab.Project{
+							ProjectCommon: gitlab.ProjectCommon{ID: 999999999999},
+						}},
+						Changeset: &campaigns.Changeset{ExternalID: "100000"},
+					},
+					// Not a changeset not found error. This is important so we don't set
+					// a changeset as deleted, when the token scope cannot view the project
+					// the MR lives in.
+					err: "retrieving merge request 100000: sending request to get a merge request: GitLab project not found",
+				},
+			}
+
+			for _, tc := range testCases {
+				tc := tc
+				tc.name = "GitlabSource_LoadChangeset_" + tc.name
+
+				t.Run(tc.name, func(t *testing.T) {
+					cf, save := newClientFactory(t, tc.name)
+					defer save(t)
+
+					lg := log15.New()
+					lg.SetHandler(log15.DiscardHandler())
+
+					svc := &types.ExternalService{
+						Kind: extsvc.KindGitLab,
+						Config: marshalJSON(t, &schema.GitLabConnection{
+							Url:   "https://gitlab.com",
+							Token: os.Getenv("GITLAB_TOKEN"),
+						}),
+					}
+
+					gitlabSource, err := NewGitLabSource(svc, cf)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					ctx := context.Background()
+					if tc.err == "" {
+						tc.err = "<nil>"
+					}
+
+					err = gitlabSource.LoadChangeset(ctx, tc.cs)
+					if have, want := fmt.Sprint(err), tc.err; have != want {
+						t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+					}
+
+					if err != nil {
+						return
+					}
+
+					meta := tc.cs.Changeset.Metadata.(*gitlab.MergeRequest)
+					testutil.AssertGolden(t, "testdata/golden/"+tc.name, update(tc.name), meta)
+				})
 			}
 		})
 

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -152,7 +152,10 @@ func newUnsupportedAuthenticatorError(source string, a auth.Authenticator) Unsup
 }
 
 // ChangesetNotFoundError is returned by LoadChangeset if the changeset
-// could not be found on the codehost.
+// could not be found on the codehost. This is only returned, if the
+// changeset is actually not found. Other not found errors, such as
+// repo not found should NOT raise this error, since it will cause
+// the changeset to be marked as deleted.
 type ChangesetNotFoundError struct {
 	Changeset *Changeset
 }

--- a/internal/repos/testdata/golden/GitlabSource_LoadChangeset_found
+++ b/internal/repos/testdata/golden/GitlabSource_LoadChangeset_found
@@ -1,0 +1,36 @@
+{
+  "id": 48629396,
+  "iid": 2,
+  "project_id": 16606088,
+  "title": "a8n: Allow filtering campaigns based on their state",
+  "description": "",
+  "state": "opened",
+  "created_at": "2020-01-30T13:04:48.674Z",
+  "updated_at": "2020-01-30T13:04:48.674Z",
+  "merged_at": null,
+  "closed_at": null,
+  "head_pipeline": null,
+  "labels": [],
+  "source_branch": "a8n/campaign-list-filter",
+  "target_branch": "master",
+  "web_url": "https://gitlab.com/sourcegraph/sourcegraph/-/merge_requests/2",
+  "work_in_progress": false,
+  "author": {
+   "id": 3294801,
+   "name": "Ryan Blunden",
+   "username": "ryan-blunden",
+   "email": "",
+   "state": "active",
+   "avatar_url": "https://assets.gitlab-static.net/uploads/-/system/user/avatar/3294801/avatar.png",
+   "web_url": "https://gitlab.com/ryan-blunden",
+   "identities": null
+  },
+  "diff_refs": {
+   "base_sha": "743138714c8d9ec92ee96d9f200729814de7d2fb",
+   "head_sha": "02cf15ec43a2e8818a1e0cac2da5ca9766ce1cdc",
+   "start_sha": "c4f4bea6111b65a362e7ec529e4b1879e774e522"
+  },
+  "Notes": null,
+  "Pipelines": null,
+  "ResourceStateEvents": null
+ }

--- a/internal/repos/testdata/sources/GitlabSource_LoadChangeset_found.yaml
+++ b/internal/repos/testdata/sources/GitlabSource_LoadChangeset_found.yaml
@@ -1,0 +1,268 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/16606088/merge_requests/2
+    method: GET
+  response:
+    body: '{"id":48629396,"iid":2,"project_id":16606088,"title":"a8n: Allow filtering
+      campaigns based on their state","description":"","state":"opened","created_at":"2020-01-30T13:04:48.674Z","updated_at":"2020-01-30T13:04:48.674Z","merged_by":null,"merged_at":null,"closed_by":null,"closed_at":null,"target_branch":"master","source_branch":"a8n/campaign-list-filter","user_notes_count":0,"upvotes":0,"downvotes":0,"author":{"id":3294801,"name":"Ryan
+      Blunden","username":"ryan-blunden","state":"active","avatar_url":"https://assets.gitlab-static.net/uploads/-/system/user/avatar/3294801/avatar.png","web_url":"https://gitlab.com/ryan-blunden"},"assignees":[],"assignee":null,"reviewers":[],"source_project_id":16606088,"target_project_id":16606088,"labels":[],"work_in_progress":false,"milestone":null,"merge_when_pipeline_succeeds":false,"merge_status":"cannot_be_merged","sha":"02cf15ec43a2e8818a1e0cac2da5ca9766ce1cdc","merge_commit_sha":null,"squash_commit_sha":null,"discussion_locked":null,"should_remove_source_branch":null,"force_remove_source_branch":false,"reference":"!2","references":{"short":"!2","relative":"!2","full":"sourcegraph/sourcegraph!2"},"web_url":"https://gitlab.com/sourcegraph/sourcegraph/-/merge_requests/2","time_stats":{"time_estimate":0,"total_time_spent":0,"human_time_estimate":null,"human_total_time_spent":null},"squash":false,"task_completion_status":{"count":0,"completed_count":0},"has_conflicts":true,"blocking_discussions_resolved":true,"approvals_before_merge":null,"subscribed":false,"changes_count":"9","head_pipeline":null,"diff_refs":{"base_sha":"743138714c8d9ec92ee96d9f200729814de7d2fb","head_sha":"02cf15ec43a2e8818a1e0cac2da5ca9766ce1cdc","start_sha":"c4f4bea6111b65a362e7ec529e4b1879e774e522"},"merge_error":null,"first_contribution":true,"user":{"can_merge":false}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 620a4c179f3bacdc-OTP
+      Cf-Request-Id:
+      - 083a4de2bf0000acdcffbcb000000001
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Feb 2021 00:05:21 GMT
+      Etag:
+      - W/"c62181a60a1e024fa9e3cb5a5df10f40"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-06-lb-gprd
+      Gitlab-Sv:
+      - api-12-sv-gprd
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Feature-Category:
+      - code_review
+      X-Request-Id:
+      - 01EYCB9JS7ZVSNQWDA70NTC01S
+      X-Runtime:
+      - "0.160821"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/16606088/merge_requests/2/notes?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 620a4c1a4847acdc-OTP
+      Cf-Request-Id:
+      - 083a4de46d0000acdc293aa000000001
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Feb 2021 00:05:21 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-06-lb-gprd
+      Gitlab-Sv:
+      - api-06-sv-gprd
+      Link:
+      - <https://gitlab.com/api/v4/projects/16606088/merge_requests/2/notes?activity_filter=all_notes&id=16606088&noteable_id=2&order_by=created_at&page=1&per_page=20&sort=desc>;
+        rel="first", <https://gitlab.com/api/v4/projects/16606088/merge_requests/2/notes?activity_filter=all_notes&id=16606088&noteable_id=2&order_by=created_at&page=1&per_page=20&sort=desc>;
+        rel="last"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Feature-Category:
+      - code_review
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "20"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - 01EYCB9K6MYXMFWAZBT3WSQ8WA
+      X-Runtime:
+      - "0.072246"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/16606088/merge_requests/2/resource_state_events?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 620a4c1c08f7acdc-OTP
+      Cf-Request-Id:
+      - 083a4de5870000acdc31198000000001
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Feb 2021 00:05:22 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-07-lb-gprd
+      Gitlab-Sv:
+      - api-13-sv-gprd
+      Link:
+      - <https://gitlab.com/api/v4/projects/16606088/merge_requests/2/resource_state_events?eventable_iid=2&id=16606088&page=1&per_page=20>;
+        rel="first", <https://gitlab.com/api/v4/projects/16606088/merge_requests/2/resource_state_events?eventable_iid=2&id=16606088&page=1&per_page=20>;
+        rel="last"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Feature-Category:
+      - code_review
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "20"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - 01EYCB9KF9Y5GV5N0RFMKZ8AQ0
+      X-Runtime:
+      - "0.051033"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/16606088/merge_requests/2/pipelines?page=1
+    method: GET
+  response:
+    body: '[]'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 620a4c1e19ebacdc-OTP
+      Cf-Request-Id:
+      - 083a4de6cb0000acdc1d138000000001
+      Content-Length:
+      - "2"
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Feb 2021 00:05:22 GMT
+      Etag:
+      - W/"4f53cda18c2baa0c0354bb5f9a3ecbe5"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-03-lb-gprd
+      Gitlab-Sv:
+      - api-06-sv-gprd
+      Link:
+      - <https://gitlab.com/api/v4/projects/16606088/merge_requests/2/pipelines?id=16606088&merge_request_iid=2&page=1&per_page=>;
+        rel="first", <https://gitlab.com/api/v4/projects/16606088/merge_requests/2/pipelines?id=16606088&merge_request_iid=2&page=1&per_page=>;
+        rel="last"
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Feature-Category:
+      - code_review
+      X-Next-Page:
+      - ""
+      X-Page:
+      - "1"
+      X-Per-Page:
+      - "20"
+      X-Prev-Page:
+      - ""
+      X-Request-Id:
+      - 01EYCB9KSD795P224W7N6ZZCT6
+      X-Runtime:
+      - "0.063704"
+      X-Total:
+      - "0"
+      X-Total-Pages:
+      - "1"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/repos/testdata/sources/GitlabSource_LoadChangeset_not-found.yaml
+++ b/internal/repos/testdata/sources/GitlabSource_LoadChangeset_not-found.yaml
@@ -1,0 +1,45 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/16606088/merge_requests/100000
+    method: GET
+  response:
+    body: '{"message":"404 Not found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 620a4bc8bbfafd09-OTP
+      Cf-Request-Id:
+      - 083a4db16e0000fd09f2bca000000001
+      Content-Length:
+      - "27"
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Feb 2021 00:05:08 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-06-lb-gprd
+      Gitlab-Sv:
+      - api-06-sv-gprd
+      Server:
+      - cloudflare
+      Vary:
+      - Origin
+      X-Request-Id:
+      - 01EYCB96EP4X79DX44JMWDQAGN
+      X-Runtime:
+      - "0.051018"
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/internal/repos/testdata/sources/GitlabSource_LoadChangeset_project-not-found.yaml
+++ b/internal/repos/testdata/sources/GitlabSource_LoadChangeset_project-not-found.yaml
@@ -1,0 +1,51 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/999999999999/merge_requests/100000
+    method: GET
+  response:
+    body: '{"message":"404 Project Not Found"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 620a4c6b2c41acbe-OTP
+      Cf-Request-Id:
+      - 083a4e16fc0000acbe2b0c6000000001
+      Content-Length:
+      - "35"
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Feb 2021 00:05:34 GMT
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-10-lb-gprd
+      Gitlab-Sv:
+      - api-07-sv-gprd
+      Server:
+      - cloudflare
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Feature-Category:
+      - code_review
+      X-Request-Id:
+      - 01EYCB9ZV25SYMGN24FFV0ES6P
+      X-Runtime:
+      - "0.027809"
+    status: 404 Not Found
+    code: 404
+    duration: ""


### PR DESCRIPTION
I discovered this while investigating how we could use a single bot account with multiple tokens over all changesets.
Before, these errors were not handled properly and a token not having the right scope would mark a changeset as deleted in a syncer run, which is bad and currently may cause issues if an external service gets updated with an invalid token, for example. That would mean it would mark all changesets as deleted as the syncer proceeds.
This fixes it by relying on the fact that every pull/merge request in a repo can be seen, if the repo can be seen. (This is at least valid for the three code hosts currently supported). So if the error is a project/repo not found error, it should be safe to assume that there is no access, instead of the changeset being deleted.
This was already working for GitHub, but not for GitLab and Bitbucket Server.
Sadly, GitLabs error reporting is a bit vague, but it works good enough, I think.