### PR TITLE
search: use full query in proposed queries, or punt if they're complex

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -310,6 +310,18 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 			},
 		},
 		{
+			name:          "this query is not basic, so return a default alert without suggestions",
+			cancelContext: false,
+			repoRevs:      1,
+			query:         "a or (b and c)",
+			wantAlert: &searchAlert{
+				prometheusType:  "over_repo_limit",
+				title:           "Too many matching repositories",
+				proposedQueries: nil,
+				description:     "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results.",
+			},
+		},
+		{
 			name:          "should return smart alert",
 			cancelContext: false,
 			repoRevs:      1,
@@ -337,7 +349,8 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 			}
 			sr := searchResolver{
 				SearchInputs: &SearchInputs{
-					Query: q,
+					OriginalQuery: test.query,
+					Query:         q,
 					UserSettings: &schema.Settings{
 						SearchGlobbing: &test.globbing,
 					}},

--- a/internal/search/query/printer_test.go
+++ b/internal/search/query/printer_test.go
@@ -25,4 +25,5 @@ func TestStringHuman(t *testing.T) {
 	autogold.Want("10", "repo:foo file:bar").Equal(t, test("repo:foo file:bar"))
 	autogold.Want("11", "((repo:foo or repo:bar) or ((repo:baz or repo:qux) and (a or b)))").Equal(t, test("(repo:foo or repo:bar) or (repo:baz or repo:qux) (a or b)"))
 	autogold.Want("12", "((repo:foo or repo:bar file:a) or ((repo:baz or repo:qux file:b) and a and b))").Equal(t, test("(repo:foo or repo:bar file:a) or (repo:baz or repo:qux and file:b) a and b"))
+	autogold.Want("13", "repo:foo ((not b) and (not c) and a)").Equal(t, test("repo:foo a -content:b -content:c"))
 }

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -12,6 +12,16 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 )
 
+// IsBasic returns whether a query is a basic query. A basic query is one which
+// does not have a DNF-expansion. I.e., there is only one disjunct. A basic
+// query implies that it has no subexpressions that we need to evaluate. IsBasic
+// is used in our codebase where legacy code has not been updated to handle
+// queries with multiple expressions (like alerts), and assume only one
+// evaluatable query.
+func IsBasic(nodes []Node) bool {
+	return len(Dnf(nodes)) == 1
+}
+
 // exists traverses every node in nodes and returns early as soon as fn is satisfied.
 func exists(nodes []Node, fn func(node Node) bool) bool {
 	found := false


### PR DESCRIPTION
Fixes #18181.

When a query is expanded by DNF, and multiple subexpressions are evaluated, we can't use the value of `r.Query` to generate a string suggestion, because `r.Query` is mutated to various subexpression during evaluation. So we need to use the original string to preserve all the subexpressions.

This PR fixes the case for a timeout alert suggestions. In the case of repo alert suggestions, we just can't make the same assumptions that the current code does, so we punt and don't propose any queries if they are not basic.

This is generally annoying code to deal with that would work much better in the frontend. Besides that, I should clean up our internal query representation so we don't have to deal with the problem of `r.Query` varying. Filed https://github.com/sourcegraph/sourcegraph/issues/18258 for this.