### PR TITLE
Add list of extension repos to docs directly

### DIFF
--- a/doc/dev/background-information/index.md
+++ b/doc/dev/background-information/index.md
@@ -16,6 +16,7 @@
 - [Developing code intelligence](codeintel/index.md)
 - [Developing code monitoring](codemonitoring/index.md)
 - [Developing observability](observability/index.md)
+- [Developing Sourcegraph extensions](sourcegraph_extensions.md)
 - [Dependencies and generated code](dependencies_and_codegen.md)
 
 ## Tools

--- a/doc/dev/background-information/sourcegraph_extensions.md
+++ b/doc/dev/background-information/sourcegraph_extensions.md
@@ -1,0 +1,53 @@
+# Developing Sourcegraph extensions
+
+## List of Sourcegraph-maintained extension repositories
+
+Here are all repositories beyond sourcegraph/sourcegraph that relate to extensions. 
+
+### Code host integrations
+- [phabricator-extension](https://github.com/sourcegraph/phabricator-extension)
+- [bitbucket-server-plugin](https://github.com/sourcegraph/bitbucket-server-plugin)
+
+### Editor extensions
+- [sourcegraph-vscode](https://github.com/sourcegraph/sourcegraph-vscode)
+- [sourcegraph-sublime](https://github.com/sourcegraph/sourcegraph-sublime)
+- [sourcegraph-atom](https://github.com/sourcegraph/sourcegraph-atom)
+- [sourcegraph-jetbrains](https://github.com/sourcegraph/sourcegraph-jetbrains)
+
+### Sourcegraph Extensions
+- [extension-api-classes](https://github.com/sourcegraph/extension-api-classes)
+- [codeintellify](https://github.com/sourcegraph/codeintellify)
+- [create-extension](https://github.com/sourcegraph/create-extension)
+- [extension-api-stubs](https://github.com/sourcegraph/extension-api-stubs)
+- [codecov/sourcegraph-codecov](https://github.com/codecov/sourcegraph-codecov)
+- [sourcegraph-extension-samples](https://github.com/sourcegraph/sourcegraph-extension-samples)
+- [sourcegraph-git-extras](https://github.com/sourcegraph/sourcegraph-git-extras)
+- [sourcegraph-code-ownership](https://github.com/sourcegraph/sourcegraph-code-ownership)
+- [sourcegraph-jira](https://github.com/sourcegraph/sourcegraph-jira)
+- [sourcegraph-search-export](https://github.com/sourcegraph/sourcegraph-search-export)
+- [sourcegraph-code-discussions](https://github.com/sourcegraph/sourcegraph-code-discussions)
+- [sourcegraph-debug-extension](https://github.com/sourcegraph/sourcegraph-debug-extension)
+- [contributors-extension](https://github.com/sourcegraph/contributors-extension)
+- [skeleton-language-extension](https://github.com/sourcegraph/skeleton-language-extension)
+- [sourcegraph-sentry](https://github.com/sourcegraph/sourcegraph-sentry)
+- [sourcegraph-eslint](https://github.com/sourcegraph/sourcegraph-eslint)
+- [codenav-bash](https://github.com/sourcegraph/codenav-bash)
+- [sourcegraph-github-extras](https://github.com/sourcegraph/sourcegraph-github-extras)
+- [sourcegraph-lightstep](https://github.com/sourcegraph/sourcegraph-lightstep)
+- [open-in-editor-extension](https://github.com/sourcegraph/open-in-editor-extension)
+- [sourcegraph-open-in-intellij](https://github.com/sourcegraph/sourcegraph-open-in-intellij)
+- [sourcegraph-open-in-atom](https://github.com/sourcegraph/sourcegraph-open-in-atom)
+- [sourcegraph-open-in-sublime](https://github.com/sourcegraph/sourcegraph-open-in-sublime)
+- [sourcegraph-open-in-vscode](https://github.com/sourcegraph/sourcegraph-open-in-vscode) (vscode-extras)
+- [sourcegraph-datadog-metrics](https://github.com/sourcegraph/sourcegraph-datadog-metrics)
+- [sourcegraph-hubspot](https://github.com/sourcegraph/sourcegraph-hubspot)
+- [sourcegraph-sonarqube](https://github.com/sourcegraph/sourcegraph-sonarqube)
+- [sourcegraph-snyk](https://github.com/sourcegraph/sourcegraph-snky)
+- [sourcegraph-link-preview-expander](https://github.com/sourcegraph/sourcegraph-link-preview-expander)
+- [sourcegraph-contact-author](https://github.com/sourcegraph/sourcegraph-contact-author)
+- [sourcegraph-who-knows-about-this](https://github.com/sourcegraph/sourcegraph-who-knows-about-this)
+- [python-imports-search](https://github.com/sourcegraph/python-imports-search)
+- [java-imports-search](https://github.com/sourcegraph/java-imports-search)
+- [go-imports-search](https://github.com/sourcegraph/go-imports-search)
+- [js-dependency-search](https://github.com/sourcegraph/js-dependency-search)
+- [sourcegraph-find-replace](https://github.com/sourcegraph/sourcegraph-find-replace)


### PR DESCRIPTION
The extensibility team should consider adding more to the "Developing Extensions" page that didn't exist prior (maybe even nest this, I have no strong opinion) but I wanted to document this somewhere and this seemed like the most logical place. For the reason why we don't want to document this on the extensions authoring docs yet, please see [this PR comment](https://github.com/sourcegraph/sourcegraph/pull/18042#issuecomment-776327112).

This decision is modeled off of the code intel page, which links to their extension repos from the first paragraph of their ["developing code intelligence" page](https://docs.sourcegraph.com/dev/background-information/codeintel). 