### PR TITLE
Add first draft of beta and prototype descriptions

### DIFF
--- a/doc/admin/beta_and_prototype_features.md
+++ b/doc/admin/beta_and_prototype_features.md
@@ -1,6 +1,6 @@
 # Beta and prototype features
 
-Sourcegraph often beta-tests major features before we make them generally available. 
+Sourcegraph often beta tests major features before we make them generally available. 
 
 Exposing beta and prototype features gives you an opportunity to try our newest features sooner.
 

--- a/doc/admin/beta_and_prototype_features.md
+++ b/doc/admin/beta_and_prototype_features.md
@@ -8,7 +8,7 @@ In return, your feedback helps us make sure that our new features are reliable a
 
 ## **Both** beta and prototype features
 
-For both features labeled `Beta` and those labelled `Prototype`, Sourcegraph wants to be transparent that:  
+For both features labeled `Beta` and those labeled `Prototype`, Sourcegraph wants to be transparent that:  
 
 - The feature is undergoing active development and your [feedback](mailto:feedback@sourcegraph.com) is especially appreciated
 - The feature may have bugs

--- a/doc/admin/beta_and_prototype_features.md
+++ b/doc/admin/beta_and_prototype_features.md
@@ -2,7 +2,7 @@
 
 Sourcegraph often beta-tests major features before we make them generally available. 
 
-Exposing beta and prototype features gives you an opportunity to try our newest features soonest, and for no additional cost. 
+Exposing beta and prototype features gives you an opportunity to try our newest features sooner.
 
 In return, your feedback helps us make sure that our new features are reliable and useful, and we appreciate any and all feedback you want to provide. You can [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose), email it directly to [feedback@sourcegraph.com](mailto:feedback@sourcegraph.com), or use the in-app feedback modal. 
 

--- a/doc/admin/beta_and_prototype_features.md
+++ b/doc/admin/beta_and_prototype_features.md
@@ -1,0 +1,33 @@
+# Beta and prototype features
+
+Sourcegraph often beta-tests major features before we make them generally available. 
+
+Exposing beta and prototype features gives you an opportunity to try our newest features soonest, and for no additional cost. 
+
+In return, your feedback helps us make sure that our new features are reliable and useful, and we appreciate any and all feedback you want to provide. You can [file an issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose), email it directly to [feedback@sourcegraph.com](mailto:feedback@sourcegraph.com), or use the in-app feedback modal. 
+
+## **Both** beta and prototype features
+
+For both features labeled `Beta` and those labelled `Prototype`, Sourcegraph wants to be transparent that:  
+
+- The feature is undergoing active development and your [feedback](mailto:feedback@sourcegraph.com) is especially appreciated
+- The feature may have bugs
+- The feature may be changed, deprecated, or removed
+- The feature may have an additional cost to use once it becomes generally available 
+- Any documentation for the feature will explicitly note the feature is in beta or prototype mode
+
+## Prototype features
+
+If a feature is labeled `Prototype`, this specifically means: 
+
+- The feature may be primarily supported by the product engineering team rather than our customer support team
+- The feature may have limited support and no documentation in the Sourcegraph docs
+- The feature will have to be deliberately enabled
+
+## Beta features
+
+If a feature is labeled `Beta`, this specifically means: 
+
+- The feature will have documentation on docs.sourcegraph.com
+- The feature will be primarily supported by the customer support team
+- The feature may require intentional setup, or it may be widely available to all users by default 

--- a/doc/admin/index.md
+++ b/doc/admin/index.md
@@ -38,6 +38,7 @@ Site administrators are the admins responsible for deploying, managing, and conf
 - [Pings](pings.md)
 - [Usage statistics](usage_statistics.md)
 - [User feedback surveys](user_surveys.md)
+- [Beta and prototype features](beta_and_prototype_features.md)
 
 ## Integrations
 


### PR DESCRIPTION
The goal of this page is to provide a place we can link to in-product or in emails and documentation to explicitly convey the expectations around our not-generally-available features. 

In addition to wording tweaks (welcome!), particularly want feedback on: 

- Do we want to use the word "prototype" or "experimental" for the "earlier than beta" stage (or change both to "alpha")? I think that there is a useful distinction in prototype vs beta (see the descriptions here) so my opinion is that we should keep something. Code insights uses prototype; [other places](https://docs.sourcegraph.com/admin/validation) use "experimental." 

- We don't have an official definition of either of these prior to this PR. Please do make comments/discuss in order to align this page with your expectations, current process, or what you think is best! 