### PR TITLE
eslint: remove use of null coalesce

### DIFF
--- a/client/packages/@sourcegraph/eslint-plugin-sourcegraph/lib/rules/check-help-links.js
+++ b/client/packages/@sourcegraph/eslint-plugin-sourcegraph/lib/rules/check-help-links.js
@@ -73,7 +73,7 @@ module.exports = {
 
         // Go find the link target in the attribute array.
         const target = node.attributes.reduce(
-          (target, attr) => target ?? (attr.name && attr.name.name === attrName ? attr.value.value : undefined),
+          (target, attr) => target || (attr.name && attr.name.name === attrName ? attr.value.value : undefined),
           undefined
         )
 


### PR DESCRIPTION
However VSCode was running eslint locally for me, it was choking on the null coalescing operator in the rule definition. Since the value being compared should only be false-y if it's undefined, we can use good old `||` here instead and fix the error.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
