### PR TITLE
Document workspaces.onlyFetchWorkspace in campaign spec YAML reference

### DIFF
--- a/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
+++ b/doc/campaigns/how-tos/creating_changesets_per_project_in_monorepos.md
@@ -123,6 +123,10 @@ The `workspace` property leverages Sourcegraph search to find the location of th
 
 That has the advantage that it's _dynamic_: whenever `src campaign [apply|preview]` is re-executed, Sourcegraph search is used again to find workspaces, automatically picking up new ones and removing workspaces that no longer exist.
 
+## Only downloading workspace data in large repositories
+
+If the repository containing the workspaces is really large and it's not feasible to download to make it available for the `steps` execution, the [`workspaces.onlyFetchWorkspaces`][onlyFetchWorkspaces] field can be set to `true` to only download the workspaces, without the rest of the repository.
+
 ## Learn more
 
 To learn more about `workspaces`, take a look at its entry in the "[Campaign Spec YAML reference][workspaces]".
@@ -132,6 +136,7 @@ To learn more about `workspaces`, take a look at its entry in the "[Campaign Spe
 [cli]: ../cli/index.md
 [steps]: ../references/campaign_spec_yaml_reference.md#steps
 [workspaces]: ../references/campaign_spec_yaml_reference.md#workspaces
+[onlyfetchworkspace]: ../references/campaign_spec_yaml_reference.md#workspaces-onlyfetchworkspace
 [on]: ../references/campaign_spec_yaml_reference.md#on
 [branch]: ../references/campaign_spec_yaml_reference.md#changesettemplate-branch
 [templating]: ../references/campaign_spec_templating.md

--- a/doc/campaigns/references/campaign_spec_yaml_reference.md
+++ b/doc/campaigns/references/campaign_spec_yaml_reference.md
@@ -710,6 +710,7 @@ workspaces:
     in: github.com/sourcegraph/go-*
   - rootAtLocationOf: package.json
     in: github.com/sourcegraph/*-js
+    onlyFetchWorkspace: true
   - rootAtLocationOf: Cargo.toml
     in: github.com/rusty-org/*
 
@@ -796,4 +797,57 @@ Match all repository names that begin with `gitlab.com/my-javascript-org/` and e
 workspaces:
   - rootAtLocationOf: package.json
     in: gitlab.com/my-javascript-org/*-plugin
+```
+
+## [`workspaces.onlyFetchWorkspace`](#workspaces-onlyfetchworkspace)
+
+When set to `true`, only the folder containing the workspace is downloaded to execute the `steps`.
+
+This field is not required and when not set the default is `false`.
+
+Additional files — `.gitignore` and `.gitattributes` as of now — are downloaded from the location of the workspace up to the root of the repository.
+
+For example, with the following file layout in a repository
+
+```
+.
+├── a
+│   ├── b
+│   │   ├── [... other files in b ...]
+│   │   ├── package.json
+│   │   └── .gitignore
+│   │
+│   ├── [... other files in a ...]
+│   ├── .gitattributes
+│   └── .gitignore
+│
+├── [... other files in root ... ]
+└── .gitignore
+```
+
+and this workspace configuration
+
+```yaml
+workspaces:
+  - rootAtLocationOf: package.json
+    in: github.com/our-our/our-large-monorepo
+    fetchOnlyWorkspace: true
+```
+
+then
+
+- the `steps` will be executed in `b`
+- the complete contents of `b` will be downloaded and are available to the steps
+- the `.gitattributes` and `.gitignore` files in `a` will be downloaded and put in `a`, **but only those**
+- the `.gitignore` files in the root will be downloaded and put in the root folder, **but only that file**
+
+### Examples
+
+Only download the workspaces of specific JavaScript projects in a large monorepo:
+
+```yaml
+workspaces:
+  - rootAtLocationOf: package.json
+    in: github.com/our-our/our-large-monorepo
+    fetchOnlyWorkspace: true
 ```


### PR DESCRIPTION
This closes https://github.com/sourcegraph/sourcegraph/issues/17920 by adding the last bit of documentation.