### PR TITLE
search: use interface assertion on select

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1935,22 +1935,17 @@ func (r *searchResolver) selectResults(results []SearchResultResolver) []SearchR
 
 	dedup := NewDeduper()
 	for _, result := range results {
-		var current SearchResultResolver
-		switch v := result.(type) {
-		case *FileMatchResolver:
-			current = v.Select(sm)
-		case *RepositoryResolver:
-			current = v.Select(sm)
-		case *CommitSearchResultResolver:
-			current = v.Select(sm)
-		default:
-			current = result
+		if v, ok := result.(interface {
+			Select(filter.SelectPath) SearchResultResolver
+		}); ok {
+			result = v.Select(sm)
 		}
 
-		if current == nil {
+		if result == nil {
 			continue
 		}
-		dedup.Add(current)
+
+		dedup.Add(result)
 	}
 	return dedup.Results()
 }


### PR DESCRIPTION
This is a minor change. I noticed when reading the code that we did
explicit type assertions for each result type. However, the function we
called in each case matched the same interface. Instead we can just
assert on the interface.

If we want to enforce that each result type matches the interface we can
either add it to the SearchResultResolver interface or we can add type
assertions for each result type.
