### PR TITLE
search: Fix bug where select:repo doesn't work on repo results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -50,6 +50,7 @@ func searchRepositories(ctx context.Context, args *search.TextParameters, limit 
 		query.FieldRepoHasFile:        {},
 		query.FieldRepoHasCommitAfter: {},
 		query.FieldPatternType:        {},
+		query.FieldSelect:             {},
 	}
 	// Don't return repo results if the search contains fields that aren't on the allowlist.
 	// Matching repositories based whether they contain files at a certain path (etc.) is not yet implemented.

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -916,6 +916,11 @@ func TestSearch(t *testing.T) {
 				counts{Repo: 1},
 			},
 			{
+				`select repo, only repo`,
+				`repo:go-diff select:repo`,
+				counts{Repo: 1},
+			},
+			{
 				`select file`,
 				`repo:go-diff patterntype:literal HunkNoChunksize select:file`,
 				counts{File: 1},


### PR DESCRIPTION
The select field was not on the allowlist for repo results. 

Fixes #18292 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
