### PR TITLE
search: Fix select:repo when only searching file names

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -842,17 +842,9 @@ func (r *searchResolver) evaluate(ctx context.Context, q query.Q) (*SearchResult
 	}
 	if pattern == nil {
 		r.setQuery(scopeParameters)
-		result, err := r.evaluateLeaf(ctx)
-		result.SearchResults = r.selectResults(result.SearchResults)
-		return result, err
+		return r.evaluateLeaf(ctx)
 	}
-	result, err := r.evaluatePatternExpression(ctx, scopeParameters, pattern)
-	if err != nil {
-		return nil, err
-	}
-	result.SearchResults = r.selectResults(result.SearchResults)
-	r.sortResults(ctx, result.SearchResults)
-	return result, nil
+	return r.evaluatePatternExpression(ctx, scopeParameters, pattern)
 }
 
 // invalidateRepoCache returns whether resolved repos should be invalidated when
@@ -903,6 +895,7 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 			return nil, err
 		}
 		if newResult != nil {
+			newResult.SearchResults = r.selectResults(newResult.SearchResults)
 			srr = union(srr, newResult)
 			if len(srr.SearchResults) > wantCount {
 				srr.SearchResults = srr.SearchResults[:wantCount]

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -842,7 +842,9 @@ func (r *searchResolver) evaluate(ctx context.Context, q query.Q) (*SearchResult
 	}
 	if pattern == nil {
 		r.setQuery(scopeParameters)
-		return r.evaluateLeaf(ctx)
+		result, err := r.evaluateLeaf(ctx)
+		result.SearchResults = r.selectResults(result.SearchResults)
+		return result, err
 	}
 	result, err := r.evaluatePatternExpression(ctx, scopeParameters, pattern)
 	if err != nil {

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -921,6 +921,11 @@ func TestSearch(t *testing.T) {
 				counts{Repo: 1},
 			},
 			{
+				`select repo, only file`,
+				`file:go-diff.go select:repo`,
+				counts{Repo: 1},
+			},
+			{
 				`select file`,
 				`repo:go-diff patterntype:literal HunkNoChunksize select:file`,
 				counts{File: 1},


### PR DESCRIPTION
When pattern was unset, we were skipping the select logic, so for a query like `file:go-diff.go`, we select wasn't being applied. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
