### PR TITLE
search: restore structural search back-compat

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -534,6 +534,17 @@ func callSearcherOverRepos(
 				// Make a new repoRev for just the operation of searching this revspec.
 				repoRev := &search.RepositoryRevisions{Repo: repoAllRevs.Repo, Revs: []search.RevisionSpecifier{{RevSpec: rev}}}
 
+				args := *args
+				if args.PatternInfo.IsStructuralPat && searcherReposFilteredFiles != nil {
+					// Modify the search query to only run for the filtered files
+					if v, ok := searcherReposFilteredFiles[string(repoRev.Repo.Name)]; ok {
+						patternCopy := *args.PatternInfo
+						args.PatternInfo = &patternCopy
+						includePatternsCopy := []string{}
+						args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
+					}
+				}
+
 				g.Go(func() error {
 					ctx, done := limitCtx, limitDone
 					defer done()

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -526,11 +526,15 @@ func TestSearch(t *testing.T) {
 			wantAlert  *gqltestutil.SearchAlert
 		}{
 			{
-				name:  "Global search, structural, index only, nonzero result",
+				name:  "Structural, index only, nonzero result",
 				query: `repo:^github\.com/sgtest/go-diff$ make(:[1]) index:only patterntype:structural count:3`,
 			},
 			{
-				name:  "Global search, structural, unindexed, nonzero result",
+				name:  "Structural, index only, backcompat, nonzero result",
+				query: `repo:^github\.com/sgtest/go-diff$ make(:[1]) lang:go rule:'where "backcompat" == "backcompat"' patterntype:structural`,
+			},
+			{
+				name:  "Structural, unindexed, nonzero result",
 				query: `repo:^github\.com/sgtest/go-diff$@adde71 make(:[1]) index:no patterntype:structural count:3`,
 			},
 			{


### PR DESCRIPTION
Fixes #18266.

This PR adds back the code that disappeared in https://github.com/sourcegraph/sourcegraph/pull/17952, which sets `includePatterns` for structural search (currently `searcherReposFilteredFiles` is just dead). We need it for backwards compatibility. We can delete this and the backcompat function soon: After branch cut/release or once I'm done benchmarking old versus new for complex queries / many repos on Sourcegraph.com.