### PR TITLE
Editor extensions: support unknown code hosts

### DIFF
--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/cloneurls"
-	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 func editorRev(ctx context.Context, repoName api.RepoName, rev string, beExplicit bool) (string, error) {
@@ -282,6 +281,3 @@ func serveEditor(w http.ResponseWriter, r *http.Request) error {
 	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
 	return nil
 }
-
-// gitProtocolRegExp is a regular expression that matches any URL that looks like it has a git protocol
-var gitProtocolRegExp = lazyregexp.New("^(git|(git+)?(https?|ssh))://")

--- a/cmd/frontend/internal/app/editor.go
+++ b/cmd/frontend/internal/app/editor.go
@@ -123,10 +123,6 @@ func (r *editorRequest) searchRedirect(ctx context.Context) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		// Probably a generic git host, or a host without a `CloneURLToRepoName` implementation.
-		if repoName == "" {
-			repoName = guessRepoNameFromRemoteURL(s.remoteURL, s.hostnameToPattern)
-		}
 		if repoName == "" {
 			// Any error here is a problem with the user's configured git remote
 			// URL. We want them to actually read this error message.
@@ -178,10 +174,6 @@ func (r *editorRequest) openFileRedirect(ctx context.Context) (string, error) {
 	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, of.remoteURL)
 	if err != nil {
 		return "", err
-	}
-	// Probably a generic git host, or a host without a `CloneURLToRepoName` implementation.
-	if repoName == "" {
-		repoName = guessRepoNameFromRemoteURL(of.remoteURL, of.hostnameToPattern)
 	}
 	if repoName == "" {
 		// Any error here is a problem with the user's configured git remote
@@ -293,37 +285,3 @@ func serveEditor(w http.ResponseWriter, r *http.Request) error {
 
 // gitProtocolRegExp is a regular expression that matches any URL that looks like it has a git protocol
 var gitProtocolRegExp = lazyregexp.New("^(git|(git+)?(https?|ssh))://")
-
-// guessRepoNameFromRemoteURL return a guess at the repo name for the given remote URL.
-//
-// It first normalizes the remote URL (ensuring a scheme exists, stripping any "git@" username in
-// the host, stripping any trailing ".git" from the path, etc.). It then returns the repo name as
-// templatized by the pattern specified, which references the hostname and path of the normalized
-// URL. Patterns are keyed by hostname in the hostnameToPattern parameter. The default pattern is
-// "{hostname}/{path}".
-//
-// For example, given "https://github.com/foo/bar.git" and an empty hostnameToPattern, it returns
-// "github.com/foo/bar". Given the same remote URL and hostnametoPattern
-// `map[string]string{"github.com": "{path}"}`, it returns "foo/bar".
-func guessRepoNameFromRemoteURL(urlStr string, hostnameToPattern map[string]string) api.RepoName {
-	if !gitProtocolRegExp.MatchString(urlStr) {
-		urlStr = "ssh://" + strings.Replace(strings.TrimPrefix(urlStr, "git@"), ":", "/", 1)
-	}
-	urlStr = strings.TrimSuffix(urlStr, ".git")
-	u, _ := url.Parse(urlStr)
-	if u == nil {
-		return ""
-	}
-
-	pattern := "{hostname}/{path}"
-	if hostnameToPattern != nil {
-		if p, ok := hostnameToPattern[u.Hostname()]; ok {
-			pattern = p
-		}
-	}
-
-	return api.RepoName(strings.NewReplacer(
-		"{hostname}", u.Hostname(),
-		"{path}", strings.TrimPrefix(u.Path, "/"),
-	).Replace(pattern))
-}

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -77,7 +77,15 @@ func TestEditorRedirect(t *testing.T) {
 				ID:          3,
 				Kind:        extsvc.KindOther,
 				DisplayName: "OtherDefault",
-				Config:      `{"url": "https://default.generic"}`,
+				Config:      `{"url": "https://default.com"}`,
+			},
+			// This service won't be used, but is included to prevent regression where ReposourceCloneURLToRepoName returned an error when
+			// Phabricator was iterated over before the actual code host (e.g. The clone URL is handled by reposource.GitLab).
+			{
+				ID:          4,
+				Kind:        extsvc.KindPhabricator,
+				DisplayName: "PHABRICATOR #1",
+				Config:      `{"repos": [{"path": "default.com/foo/bar", "callsign": "BAR"}], "token": "abc", "url": "https://phabricator.example.com"}`,
 			},
 		}, nil
 	}
@@ -119,6 +127,22 @@ func TestEditorRedirect(t *testing.T) {
 			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?utm_source=Atom-v1.2.1#L1:1", // L1:1 is expected (but could be nicer by omitting it)
 		},
 		{
+			name: "open file in repository (Phabricator mirrored)",
+			q: url.Values{
+				"editor":     []string{"Atom"},
+				"version":    []string{"v1.2.1"},
+				"remote_url": []string{"https://default.com/foo/bar"},
+				"branch":     []string{"dev"},
+				"revision":   []string{"0ad12f"},
+				"file":       []string{"mux.go"},
+				"start_row":  []string{"123"},
+				"start_col":  []string{"1"},
+				"end_row":    []string{"123"},
+				"end_col":    []string{"10"},
+			},
+			wantRedirectURL: "/default.com/foo/bar@0ad12f/-/blob/mux.go?utm_source=Atom-v1.2.1#L124:2-124:11",
+		},
+		{
 			name: "open file in repository with generic code host (with repositoryPathPattern)",
 			q: url.Values{
 				"editor":     []string{"Atom"},
@@ -139,7 +163,7 @@ func TestEditorRedirect(t *testing.T) {
 			q: url.Values{
 				"editor":     []string{"Atom"},
 				"version":    []string{"v1.2.1"},
-				"remote_url": []string{"https://default.generic/a/b"},
+				"remote_url": []string{"https://default.com/a/b"},
 				"branch":     []string{"dev"},
 				"revision":   []string{"0ad12f"},
 				"file":       []string{"mux.go"},
@@ -148,7 +172,7 @@ func TestEditorRedirect(t *testing.T) {
 				"end_row":    []string{"123"},
 				"end_col":    []string{"10"},
 			},
-			wantRedirectURL: "/default.generic/a/b@0ad12f/-/blob/mux.go?utm_source=Atom-v1.2.1#L124:2-124:11",
+			wantRedirectURL: "/default.com/a/b@0ad12f/-/blob/mux.go?utm_source=Atom-v1.2.1#L124:2-124:11",
 		},
 		{
 			name: "search",

--- a/cmd/frontend/internal/app/editor_test.go
+++ b/cmd/frontend/internal/app/editor_test.go
@@ -107,6 +107,22 @@ func TestEditorRedirect(t *testing.T) {
 			wantRedirectURL: "/github.com/a/b@0ad12f/-/blob/mux.go?utm_source=Atom-v1.2.1#L1:1", // L1:1 is expected (but could be nicer by omitting it)
 		},
 		{
+			name: "open file in repository with unknown code host",
+			q: url.Values{
+				"editor":     []string{"Atom"},
+				"version":    []string{"v1.2.1"},
+				"remote_url": []string{"git@somecodehost.com:a/b"},
+				"branch":     []string{"dev"},
+				"revision":   []string{"0ad12f"},
+				"file":       []string{"mux.go"},
+				"start_row":  []string{"123"},
+				"start_col":  []string{"1"},
+				"end_row":    []string{"123"},
+				"end_col":    []string{"10"},
+			},
+			wantRedirectURL: "/somecodehost.com/a/b@0ad12f/-/blob/mux.go?utm_source=Atom-v1.2.1#L124:2-124:11",
+		},
+		{
 			name: "search",
 			q: url.Values{
 				"editor":  []string{"Atom"},
@@ -154,6 +170,16 @@ func TestEditorRedirect(t *testing.T) {
 				"search_revision":   []string{"0ad12f"},
 			},
 			wantRedirectURL: "/search?patternType=literal&q=repo%3Agithub%5C.com%2Fa%2Fb%24%400ad12f+foobar&utm_source=Atom-v1.2.1",
+		},
+		{
+			name: "search in repository with unknown code host",
+			q: url.Values{
+				"editor":            []string{"Atom"},
+				"version":           []string{"v1.2.1"},
+				"search":            []string{"foobar"},
+				"search_remote_url": []string{"git@somecodehost.com:a/b"},
+			},
+			wantRedirectURL: "/search?patternType=literal&q=repo%3Asomecodehost%5C.com%2Fa%2Fb%24+foobar&utm_source=Atom-v1.2.1",
 		},
 		{
 			name: "search in repository file",

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -32,6 +32,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 			extsvc.KindBitbucketServer,
 			extsvc.KindAWSCodeCommit,
 			extsvc.KindGitolite,
+			extsvc.KindOther,
 		},
 		LimitOffset: &database.LimitOffset{
 			Limit: 500, // The number is randomly chosen
@@ -71,6 +72,9 @@ func ReposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 			case *schema.GitoliteConnection:
 				rs = reposource.Gitolite{GitoliteConnection: c}
 				// Gitolite type does not have URL
+			case *schema.OtherExternalServiceConnection:
+				rs = reposource.Other{OtherExternalServiceConnection: c}
+				host = c.Url
 			default:
 				return "", errors.Errorf("unexpected connection type: %T", cfg)
 			}

--- a/internal/cloneurls/clone_urls.go
+++ b/internal/cloneurls/clone_urls.go
@@ -32,6 +32,7 @@ func ReposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 			extsvc.KindBitbucketServer,
 			extsvc.KindAWSCodeCommit,
 			extsvc.KindGitolite,
+			extsvc.KindPhabricator,
 			extsvc.KindOther,
 		},
 		LimitOffset: &database.LimitOffset{
@@ -72,6 +73,12 @@ func ReposourceCloneURLToRepoName(ctx context.Context, cloneURL string) (repoNam
 			case *schema.GitoliteConnection:
 				rs = reposource.Gitolite{GitoliteConnection: c}
 				// Gitolite type does not have URL
+			case *schema.PhabricatorConnection:
+				// If this repository is mirrored by Phabricator, its clone URL should be
+				// handled by a supported code host or an OtherExternalServiceConnection.
+				// If this repository is hosted by Phabricator, it should be handled by
+				// an OtherExternalServiceConnection.
+				continue
 			case *schema.OtherExternalServiceConnection:
 				rs = reposource.Other{OtherExternalServiceConnection: c}
 				host = c.Url

--- a/internal/conf/reposource/other.go
+++ b/internal/conf/reposource/other.go
@@ -41,7 +41,7 @@ func cloneURLToRepoName(cloneURL, baseURL, repositoryPathPattern string) (string
 		return "", err
 	}
 	if !match {
-		return "", urlMismatchErr{cloneURL: cloneURL, hostURL: baseURL}
+		return "", nil
 	}
 
 	basePrefix := parsedBaseURL.Path
@@ -52,7 +52,6 @@ func cloneURLToRepoName(cloneURL, baseURL, repositoryPathPattern string) (string
 		return "", urlMismatchErr{cloneURL: cloneURL, hostURL: baseURL}
 	}
 	relativeRepoPath := strings.TrimPrefix(parsedCloneURL.Path, basePrefix)
-
 	base := url.URL{
 		Host: parsedBaseURL.Host,
 		Path: parsedBaseURL.Path,

--- a/internal/conf/reposource/other_test.go
+++ b/internal/conf/reposource/other_test.go
@@ -21,7 +21,7 @@ func TestOtherCloneURLToRepoName(t *testing.T) {
 			urls: []urlToRepoNameErr{
 				{"https://github.com/gorilla/mux", "github.com/gorilla/mux", nil},
 				{"https://github.com/gorilla/mux.git", "github.com/gorilla/mux", nil},
-				{"https://asdf.com/gorilla/mux.git", "", urlMismatchErr{"https://asdf.com/gorilla/mux.git", "https://github.com"}},
+				{"https://asdf.com/gorilla/mux.git", "", nil},
 			},
 		},
 		{
@@ -59,7 +59,7 @@ func TestOtherCloneURLToRepoName(t *testing.T) {
 			},
 			urls: []urlToRepoNameErr{
 				{"ssh://thaddeus@gerrit.com:12345/repos/repo1", "repo1", nil},
-				{"ssh://thaddeus@asdf.com/repos/repo1", "", urlMismatchErr{"ssh://thaddeus@asdf.com/repos/repo1", "ssh://thaddeus@gerrit.com:12345/repos"}},
+				{"ssh://thaddeus@asdf.com/repos/repo1", "", nil},
 				{"ssh://thaddeus@gerrit.com:12345/asdf/repo1", "", urlMismatchErr{"ssh://thaddeus@gerrit.com:12345/asdf/repo1", "ssh://thaddeus@gerrit.com:12345/repos"}},
 			},
 		},


### PR DESCRIPTION
Closes #18117

We refactored the editor endpoint to use `ReposourceCloneURLToRepoName` (#16846), but it only maps clone URLs for [5 different code hosts](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/cloneurls/clone_urls.go#L28-34), so the editor extensions broke for users with unsupported or generic git hosts. 

This PR adds a check for `Other` external services in `ReposourceCloneURLToRepoName`. 

#### Manual testing with a Gerrit repository

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/37420160/108416562-dee24480-71fc-11eb-9aec-c001c8b93882.gif" />
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/37420160/108416583-e6a1e900-71fc-11eb-9a24-e2d66b2642da.gif" />
</details>

#### Notes

I didn't implement `reposource.Reposource` for Phabricator because most customers mirror repositories from other code hosts on Phabricator. In that case, the clone URL will be handled either by a supported code host's `CloneURLToRepoName` or a user-configured `Other` code host. If the customer hosts their repositories on Phabricator, they have to add an `Other` code host to handle each repository (according to sqs in this Slack thread: [point 1](https://sourcegraph.slack.com/archives/C01JKF7KUBD/p1611784795045100?thread_ts=1611783692.045000&cid=C01JKF7KUBD), [point 2](https://sourcegraph.slack.com/archives/C01JKF7KUBD/p1611785233046400?thread_ts=1611783692.045000&cid=C01JKF7KUBD)).