### PR TITLE
search: filters call ".rs" files rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Sourcegraph is now built with Go 1.15
   - Go `1.15` introduced changes to SSL/TLS connection validation which requires certificates to include a `SAN`. This field was not included in older certificates and clients relied on the `CN` field. You might see an error like `x509: certificate relies on legacy Common Name field`. We recommend that customers using Sourcegraph with an external database and connecting to it using SSL/TLS check whether the certificate is up to date.
   - RDS Customers please reference [AWS' documentation on updating the SSL/TLS certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html).
+- Search results on `.rs` files now recommend `lang:rust` instead of `lang:renderscript` as a filter. [#18316](https://github.com/sourcegraph/sourcegraph/pull/18316)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -684,6 +684,21 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		},
 
 		{
+			descr: "prefer rust to renderscript",
+			searchResults: []SearchResultResolver{
+				fileMatch("/channel.rs"),
+			},
+			expectedDynamicFilterStrsRegexp: map[string]int{
+				`repo:^testRepo$`: 1,
+				`lang:rust`:       1,
+			},
+			expectedDynamicFilterStrsGlobbing: map[string]int{
+				`repo:testRepo`: 1,
+				`lang:rust`:     1,
+			},
+		},
+
+		{
 			descr: "javascript filters",
 			searchResults: []SearchResultResolver{
 				fileMatch("/jsrender.min.js.map"),

--- a/cmd/frontend/internal/inventory/inventory.go
+++ b/cmd/frontend/internal/inventory/inventory.go
@@ -154,7 +154,6 @@ func preferLanguage(lang, ext string) {
 			for ; i > 0; i-- {
 				langs[i-1], langs[i] = langs[i], langs[i-1]
 			}
-			data.LanguagesByExtension[ext] = langs
 			return
 		}
 	}

--- a/cmd/frontend/internal/inventory/inventory.go
+++ b/cmd/frontend/internal/inventory/inventory.go
@@ -6,8 +6,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log"
 	"os"
-	"path/filepath"
 
 	"github.com/go-enry/go-enry/v2"
 	"github.com/go-enry/go-enry/v2/data"
@@ -125,14 +125,10 @@ func countLines(r io.Reader, buf []byte) (lineCount int, byteCount int, err erro
 	return lineCount, byteCount, nil
 }
 
-// GetLanguageByFilename returns the guessed language for the named file (and safe == true if this
-// is very likely to be correct).
+// GetLanguageByFilename returns the guessed language for the named file (and
+// safe == true if this is very likely to be correct).
 func GetLanguageByFilename(name string) (language string, safe bool) {
-	language, safe = enry.GetLanguageByExtension(name)
-	if language == "GCC Machine Description" && filepath.Ext(name) == ".md" {
-		language = "Markdown" // override detection for .md
-	}
-	return language, safe
+	return enry.GetLanguageByExtension(name)
 }
 
 func init() {
@@ -142,4 +138,25 @@ func init() {
 	data.LanguagesByExtension[".tsx"] = []string{"TypeScript"}
 	data.ExtensionsByLanguage["JavaScript"] = append(data.ExtensionsByLanguage["JavaScript"], ".jsx")
 	data.LanguagesByExtension[".jsx"] = []string{"JavaScript"}
+
+	// Prefer more popular languages which share extensions
+	preferLanguage("Markdown", ".md") // instead of GCC Machine Description
+	preferLanguage("Rust", ".rs")     // instead of RenderScript
+}
+
+// preferLanguage updates LanguagesByExtension to have lang listed first for
+// ext.
+func preferLanguage(lang, ext string) {
+	langs := data.LanguagesByExtension[ext]
+	for i := range langs {
+		if langs[i] == lang {
+			// swap to front
+			for ; i > 0; i-- {
+				langs[i-1], langs[i] = langs[i], langs[i-1]
+			}
+			data.LanguagesByExtension[ext] = langs
+			return
+		}
+	}
+	log.Fatalf("%q not in %q: %q", lang, ext, langs)
 }


### PR DESCRIPTION
Previously we called these files "RenderScript" files.

Fixes https://github.com/sourcegraph/sourcegraph/issues/18104