### PR TITLE
Fix repo-updater panicing on start due to duplicate metric

### DIFF
--- a/enterprise/internal/insights/background/background.go
+++ b/enterprise/internal/insights/background/background.go
@@ -88,7 +88,7 @@ func newWorkerMetrics(observationContext *observation.Context, workerName string
 	observationContext.Registerer.MustRegister(workerResetFailures)
 
 	workerErrors := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "src_insights_" + workerName + "_errors_total",
+		Name: "src_insights_" + workerName + "_reset_errors_total",
 		Help: "The number of errors that occurred during a worker job.",
 	})
 	observationContext.Registerer.MustRegister(workerErrors)


### PR DESCRIPTION
Without this, repo-updater won't start up:

```
panic: a previously registered descriptor with the same fully-qualified name as Desc{fqName: "src_insights_query_runner_worker_errors_total", help: "Total number of errors when performing insights_query_runner_worker operations", constLabels: {}, variableLabels: [op]} has different label names or a different help string
goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc00013a640, 0xc0012f0b70, 0x1, 0x1)
	/Users/roknovosel/.asdf/installs/golang/1.15/packages/pkg/mod/github.com/prometheus/client_golang@v1.9.0/prometheus/registry.go:403 +0xad
github.com/sourcegraph/sourcegraph/internal/metrics.NewOperationMetrics(0x32a0d20, 0xc00013a640, 0xc00129f0e0, 0x1c, 0xc000a0f680, 0x2, 0x2, 0x1)
	/Users/roknovosel/sourcegraph/internal/metrics/operation.go:114 +0x8a3
github.com/sourcegraph/sourcegraph/internal/workerutil.newOperations(0xc001622810, 0xc00129f0e0, 0x1c, 0x456f5a0, 0x0, 0x0, 0x456f5a0, 0x0, 0x0, 0x10553cf)
	/Users/roknovosel/sourcegraph/internal/workerutil/observability.go:59 +0x125
github.com/sourcegraph/sourcegraph/internal/workerutil.NewMetrics(0xc001622810, 0xc00129f0e0, 0x1c, 0x0, 0x13, 0xc00129f0e0, 0x1c)
	/Users/roknovosel/sourcegraph/internal/workerutil/observability.go:53 +0x4ad
github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background.newWorkerMetrics(0xc001622810, 0x2e3c981, 0x13, 0xcfc0150, 0xc00012e1c0, 0x32c9f20, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/roknovosel/sourcegraph/enterprise/internal/insights/background/background.go:96 +0x5b3
github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background.StartBackgroundJobs(0x32bb360, 0xc001573500, 0xc001211790)
	/Users/roknovosel/sourcegraph/enterprise/internal/insights/background/background.go:53 +0x335
main.enterpriseInit(0xc001211790, 0xc00152e000, 0xc001509740, 0xc00151e090, 0x0, 0xc001509120, 0xc001509140)
	/Users/roknovosel/sourcegraph/enterprise/cmd/repo-updater/main.go:52 +0xf1
github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared.Main(0x2f93cf0)
	/Users/roknovosel/sourcegraph/cmd/repo-updater/shared/main.go:138 +0x1a0b
main.main()
	/Users/roknovosel/sourcegraph/enterprise/cmd/repo-updater/main.go:38 +0x7b
Terminating repo-updater
```

This here fixes the problem by doing what I supposed was meant to happen: different metrics are defined for the resetter, not just the worker.

Since the other two metrics had the `reset` prefix in there, this adds
it to the clashing metric name.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
