### PR TITLE
gitserver: set transfer-encoding to chunked for exec

### DIFF
--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -378,6 +378,8 @@ func newFlushingResponseWriter(w http.ResponseWriter) *flushingResponseWriter {
 		return nil
 	}
 
+	w.Header().Set("Transfer-Encoding", "chunked")
+
 	f := &flushingResponseWriter{w: w, flusher: flusher}
 	go f.periodicFlush()
 	return f


### PR DESCRIPTION
We have had a "flushingResponseWriter" since the dawn of time. However,
I believe it has never been effective since we never set the
transfer-encoding to chunked. So the server may be flushing data
constantly, but our clients would not be informed that data would often
be flushed.

This was originally added to make things like diff/commit search faster
if I remember. This now correctly does that. For example on
sourcegraph.com if you do a streaming search you will now see results
much faster.

Fixes https://github.com/sourcegraph/sourcegraph/issues/18142