### PR TITLE
gitserver: set Content-Type and Cache-Control on exec

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -693,6 +693,9 @@ func (s *Server) exec(w http.ResponseWriter, r *http.Request, req *protocol.Exec
 		ensureRevisionStatus = "noop"
 	}
 
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+
 	w.Header().Set("Trailer", "X-Exec-Error")
 	w.Header().Add("Trailer", "X-Exec-Exit-Status")
 	w.Header().Add("Trailer", "X-Exec-Stderr")


### PR DESCRIPTION
We hadn't done this before. Our client doesn't care about this, so it
shouldnt' affect anything. The only possibility it may affect is direct
callers to `git archive`. However, this content type is more correct
since it actually indicates the data can be binary. So this would likely
lead to better behaviour in other cases.