### PR TITLE
search: add + suffix to result count if limit hit

### DIFF
--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -57,4 +57,20 @@ describe('StreamingProgressCount', () => {
 
         expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()
     })
+
+    it('should render correctly for limithit', () => {
+        const progress: Progress = {
+            durationMs: 1250,
+            matchCount: 123,
+            repositoriesCount: 500,
+            skipped: [{
+                reason: 'document-match-limit',
+                title: 'match limit',
+                message: 'match limit',
+                severity: 'warn',
+            }],
+        }
+
+        expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()
+    })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -63,12 +63,14 @@ describe('StreamingProgressCount', () => {
             durationMs: 1250,
             matchCount: 123,
             repositoriesCount: 500,
-            skipped: [{
-                reason: 'document-match-limit',
-                title: 'match limit',
-                message: 'match limit',
-                severity: 'warn',
-            }],
+            skipped: [
+                {
+                    reason: 'document-match-limit',
+                    title: 'match limit',
+                    message: 'match limit',
+                    severity: 'warn',
+                },
+            ],
         }
 
         expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import CalculatorIcon from 'mdi-react/CalculatorIcon'
 import * as React from 'react'
 import { pluralize } from '../../../../../../shared/src/util/strings'
+import { Progress } from '../../../stream'
 import { StreamingProgressProps } from './StreamingProgress'
 
 const abbreviateNumber = (number: number): string => {
@@ -17,6 +18,8 @@ const abbreviateNumber = (number: number): string => {
     return (number / 1e9).toFixed(1) + 'b'
 }
 
+const limitHit = (progress: Progress): boolean => progress.skipped.some(skipped => skipped.reason.indexOf('-limit') > 0)
+
 export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgressProps, 'progress' | 'state'>> = ({
     progress,
     state,
@@ -27,7 +30,8 @@ export const StreamingProgressCount: React.FunctionComponent<Pick<StreamingProgr
         })}
     >
         <CalculatorIcon className="mr-2 icon-inline" />
-        {abbreviateNumber(progress.matchCount)} {pluralize('result', progress.matchCount)} in{' '}
+        {abbreviateNumber(progress.matchCount)}
+        {limitHit(progress) ? '+' : ''} {pluralize('result', progress.matchCount)} in{' '}
         {(progress.durationMs / 1000).toFixed(2)}s
         {progress.repositoriesCount !== undefined && (
             <>

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -163,3 +163,45 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
   </div>
 </StreamingProgressCount>
 `;
+
+exports[`StreamingProgressCount should render correctly for limithit 1`] = `
+<StreamingProgressCount
+  progress={
+    Object {
+      "durationMs": 1250,
+      "matchCount": 123,
+      "repositoriesCount": 500,
+      "skipped": Array [
+        Object {
+          "message": "match limit",
+          "reason": "document-match-limit",
+          "severity": "warn",
+          "title": "match limit",
+        },
+      ],
+    }
+  }
+  state="complete"
+>
+  <div
+    className="streaming-progress__count d-flex align-items-center"
+  >
+    <Memo(CalculatorIcon)
+      className="mr-2 icon-inline"
+    />
+    123
+    +
+     
+    results
+     in
+     
+    1.25
+    s
+     
+    from 
+    500
+     
+    repositories
+  </div>
+</StreamingProgressCount>
+`;


### PR DESCRIPTION
It wasn't clear enough when viewing result counts that we had hit a limit.

Part of https://github.com/sourcegraph/sourcegraph/issues/18076