### PR TITLE
Include code insights from the backend in the webapp

### DIFF
--- a/client/shared/src/api/client/services/viewService.ts
+++ b/client/shared/src/api/client/services/viewService.ts
@@ -1,5 +1,5 @@
 import { Observable, BehaviorSubject, of, combineLatest, concat, Subscription } from 'rxjs'
-import { View as ExtensionView, DirectoryViewContext } from 'sourcegraph'
+import type { View as ExtensionView, DirectoryViewContext } from 'sourcegraph'
 import { switchMap, map, distinctUntilChanged, startWith, delay, catchError } from 'rxjs/operators'
 import { Evaluated, Contributions, ContributableViewContainer } from '../../protocol'
 import { isEqual } from 'lodash'

--- a/client/web/src/insights/InsightsPage.tsx
+++ b/client/web/src/insights/InsightsPage.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
 import { useObservable } from '../../../shared/src/util/useObservable'
-import { getViewsForContainer } from '../../../shared/src/api/client/services/viewService'
 import { ContributableViewContainer } from '../../../shared/src/api/protocol'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { ViewGrid, ViewGridProps } from '../repo/tree/ViewGrid'
@@ -14,6 +13,7 @@ import { BreadcrumbsProps, BreadcrumbSetters } from '../components/Breadcrumbs'
 import { StatusBadge } from '../components/StatusBadge'
 import { Page } from '../components/Page'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
+import { getCombinedViews } from './backend'
 
 interface InsightsPageProps
     extends ExtensionsControllerProps,
@@ -21,6 +21,7 @@ interface InsightsPageProps
         BreadcrumbsProps,
         BreadcrumbSetters,
         TelemetryProps {}
+
 export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props => {
     props.useBreadcrumb(
         useMemo(
@@ -35,11 +36,7 @@ export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props =>
     const views = useObservable(
         useMemo(
             () =>
-                getViewsForContainer(
-                    ContributableViewContainer.InsightsPage,
-                    {},
-                    props.extensionsController.services.view
-                ),
+                getCombinedViews(ContributableViewContainer.InsightsPage, {}, props.extensionsController.services.view),
             [props.extensionsController.services.view]
         )
     )

--- a/client/web/src/insights/backend.ts
+++ b/client/web/src/insights/backend.ts
@@ -1,0 +1,95 @@
+import { combineLatest, Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
+import { requestGraphQL } from '../backend/graphql'
+import { InsightsResult, InsightFields } from '../graphql-operations'
+import { LineChartContent } from 'sourcegraph'
+import {
+    getViewsForContainer,
+    ViewContexts,
+    ViewProviderResult,
+    ViewService,
+} from '../../../shared/src/api/client/services/viewService'
+import { ContributableViewContainer } from '../../../shared/src/api/protocol'
+import { dataOrThrowErrors, gql } from '../../../shared/src/graphql/graphql'
+
+const insightFieldsFragment = gql`
+    fragment InsightFields on Insight {
+        title
+        description
+        series {
+            label
+            points {
+                dateTime
+                value
+            }
+        }
+    }
+`
+function fetchBackendInsights(): Observable<InsightFields[]> {
+    return requestGraphQL<InsightsResult>(gql`
+        query Insights {
+            insights {
+                nodes {
+                    ...InsightFields
+                }
+            }
+        }
+        ${insightFieldsFragment}
+    `).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.insights?.nodes ?? [])
+    )
+}
+
+export function getCombinedViews<W extends ContributableViewContainer>(
+    where: W,
+    parameters: ViewContexts[W],
+    viewService: Pick<ViewService, 'getWhere'>
+): Observable<ViewProviderResult[]> {
+    return combineLatest([
+        getViewsForContainer(where, parameters, viewService),
+        fetchBackendInsights().pipe(
+            map(backendInsights =>
+                backendInsights.map((insight, index) => ({
+                    id: `insight.backend${index}`,
+                    view: {
+                        title: insight.title,
+                        subtitle: insight.description,
+                        content: [backendInsightToViewContent(insight)],
+                    },
+                }))
+            )
+        ),
+    ]).pipe(map(([extensionViews, backendInsights]) => [...backendInsights, ...extensionViews]))
+}
+
+function backendInsightToViewContent(
+    insight: InsightFields
+): LineChartContent<{ dateTime: number; [seriesKey: string]: number }, 'dateTime'> {
+    const dataByXValue = new Map<string, { dateTime: number; [seriesKey: string]: number }>()
+    for (const [seriesIndex, series] of insight.series.entries()) {
+        for (const point of series.points) {
+            let dataObject = dataByXValue.get(point.dateTime)
+            if (!dataObject) {
+                dataObject = {
+                    dateTime: Date.parse(point.dateTime),
+                }
+                dataByXValue.set(point.dateTime, dataObject)
+            }
+            dataObject[`series${seriesIndex}`] = point.value
+        }
+    }
+    return {
+        chart: 'line',
+        data: [...dataByXValue.values()],
+        series: insight.series.map((series, index) => ({
+            name: series.label,
+            dataKey: `series${index}`,
+        })),
+        xAxis: {
+            dataKey: 'dateTime',
+            scale: 'time',
+            type: 'number',
+        },
+    }
+}

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -37,7 +37,6 @@ import { subYears, formatISO } from 'date-fns'
 import { pluralize } from '../../../../shared/src/util/strings'
 import { useObservable } from '../../../../shared/src/util/useObservable'
 import { encodeURIPathComponent, toPrettyBlobURL, toURIWithPath } from '../../../../shared/src/util/url'
-import { getViewsForContainer } from '../../../../shared/src/api/client/services/viewService'
 import { Settings } from '../../schema/settings.schema'
 import { ViewGrid } from './ViewGrid'
 import { VersionContextProps } from '../../../../shared/src/search/util'
@@ -49,6 +48,7 @@ import { GitCommitFields, Scalars, TreePageRepositoryFields } from '../../graphq
 import { getFileDecorations } from '../../backend/features'
 import { FileDecorationsByPath } from '../../../../shared/src/api/extension/flatExtensionApi'
 import SettingsIcon from 'mdi-react/SettingsIcon'
+import { getCombinedViews } from '../../insights/backend'
 
 const fetchTreeCommits = memoizeObservable(
     (args: {
@@ -235,7 +235,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
         useMemo(
             () =>
                 codeInsightsEnabled && workspaceUri
-                    ? getViewsForContainer(
+                    ? getCombinedViews(
                           ContributableViewContainer.Directory,
                           {
                               viewer: {

--- a/client/web/src/search/input/SearchPage.tsx
+++ b/client/web/src/search/input/SearchPage.tsx
@@ -24,7 +24,6 @@ import { VersionContextProps } from '../../../../shared/src/search/util'
 import { VersionContext } from '../../schema/site.schema'
 import { ViewGrid } from '../../repo/tree/ViewGrid'
 import { useObservable } from '../../../../shared/src/util/useObservable'
-import { getViewsForContainer } from '../../../../shared/src/api/client/services/viewService'
 import { isErrorLike } from '../../../../shared/src/util/errors'
 import { ContributableViewContainer } from '../../../../shared/src/api/protocol'
 import { EMPTY } from 'rxjs'
@@ -38,6 +37,7 @@ import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryServic
 import { HomePanels } from '../panels/HomePanels'
 import { SearchPageFooter } from './SearchPageFooter'
 import { SyntaxHighlightedSearchQuery } from '../../components/SyntaxHighlightedSearchQuery'
+import { getCombinedViews } from '../../insights/backend'
 
 export interface SearchPageProps
     extends SettingsCascadeProps<Settings>,
@@ -95,7 +95,7 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
         useMemo(
             () =>
                 codeInsightsEnabled
-                    ? getViewsForContainer(
+                    ? getCombinedViews(
                           ContributableViewContainer.Homepage,
                           {},
                           props.extensionsController.services.view

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2481,6 +2481,10 @@ type InsightsSeries {
 
     """
     Data points over a time range (inclusive)
+
+    If no 'from' time range is specified, the last 30d of data is assumed.
+
+    If no 'to' time range is specified, the current point in time is assumed.
     """
     points(from: DateTime, to: DateTime): [InsightDataPoint!]!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2474,6 +2474,10 @@ type InsightsSeries {
 
     """
     Data points over a time range (inclusive)
+
+    If no 'from' time range is specified, the last 30d of data is assumed.
+
+    If no 'to' time range is specified, the current point in time is assumed.
     """
     points(from: DateTime, to: DateTime): [InsightDataPoint!]!
 }

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
@@ -20,6 +21,10 @@ func (r *insightSeriesResolver) Label() string { return r.series.Label }
 func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend.InsightsPointsArgs) ([]graphqlbackend.InsightsDataPointResolver, error) {
 	var opts store.SeriesPointsOpts
 	opts.SeriesID = nil // TODO(slimsag): future: set opts.SeriesID to effective hash of r.series
+	if args.From == nil {
+		// Default to last 30d of data.
+		args.From = &graphqlbackend.DateTime{Time: time.Now().Add(-30 * 24 * time.Hour)}
+	}
 	if args.From != nil {
 		opts.From = &args.From.Time
 	}


### PR DESCRIPTION
This merges both insights from the backend and views from extensions and displays them both.

Didn't really test this cause I wasn't sure how to add data to the DB for testing.

- [x] TODO: constrain the timeframe.