### PR TITLE
Use real MutationObserver for non-gerrit codehosts

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/inject.ts
+++ b/client/browser/src/shared/code-hosts/shared/inject.ts
@@ -1,10 +1,9 @@
 import { Observable, Subscription } from 'rxjs'
 import { startWith } from 'rxjs/operators'
-import { MutationRecordLike } from '../../util/dom'
+import { MutationRecordLike, observeMutations as defaultObserveMutations } from '../../util/dom'
 
 import { determineCodeHost, injectCodeIntelligenceToCodeHost, ObserveMutations } from './codeHost'
 import { SourcegraphIntegrationURLs } from '../../platform/context'
-import { observeMutations as defaultObserveMutations } from '../gerrit/codeHost'
 
 /**
  * Checks if the current page is a known code host. If it is,


### PR DESCRIPTION
In code host integrations, using the polling Gerrit `MutationObserver` "shim" on other code hosts makes extensions less responsive since users could have to wait up to 1 second for code views to be "hoverified" and decorated. Use a real `MutationObserver` when the code host object doesn't provide its own implementation.