### PR TITLE
search: Fix select for streaming

### DIFF
--- a/cmd/frontend/graphqlbackend/result_deduper.go
+++ b/cmd/frontend/graphqlbackend/result_deduper.go
@@ -69,7 +69,7 @@ func (d *searchResultDeduper) Seen(r SearchResultResolver) (ok bool) {
 		}
 	}
 
-	return
+	return ok
 }
 
 // Results returns a slice of SearchResultResolvers, deduplicated from

--- a/cmd/frontend/graphqlbackend/result_deduper.go
+++ b/cmd/frontend/graphqlbackend/result_deduper.go
@@ -53,6 +53,25 @@ func (d *searchResultDeduper) Add(r SearchResultResolver) {
 	}
 }
 
+// Seen returns whether the given url exists for a file type in the deduper without
+// modifying the contents of the deduper
+func (d *searchResultDeduper) Seen(r SearchResultResolver) (ok bool) {
+	switch v := r.(type) {
+	case *FileMatchResolver:
+		_, ok = d.seenFileMatches[v.uri]
+	case *RepositoryResolver:
+		_, ok = d.seenRepoMatches[v.URL()]
+	case *CommitSearchResultResolver:
+		if v.DiffPreview() != nil {
+			_, ok = d.seenDiffMatches[v.URL()]
+		} else {
+			_, ok = d.seenCommitMatches[v.URL()]
+		}
+	}
+
+	return
+}
+
 // Results returns a slice of SearchResultResolvers, deduplicated from
 // the SearchResultResolvers that were added with Add
 func (d *searchResultDeduper) Results() []SearchResultResolver {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -123,6 +124,12 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (_ SearchImplem
 	defaultLimit := defaultMaxSearchResults
 	if args.Stream != nil {
 		defaultLimit = defaultMaxSearchResultsStreaming
+	}
+
+	if sp, _ := q.StringValue(query.FieldSelect); sp != "" {
+		// Invariant: error already checked
+		selectPath, _ := filter.SelectPathFromString(sp)
+		args.Stream = WithSelect(args.Stream, selectPath)
 	}
 
 	return &searchResolver{

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -126,7 +126,7 @@ func NewSearchImplementer(ctx context.Context, args *SearchArgs) (_ SearchImplem
 		defaultLimit = defaultMaxSearchResultsStreaming
 	}
 
-	if sp, _ := q.StringValue(query.FieldSelect); sp != "" {
+	if sp, _ := q.StringValue(query.FieldSelect); sp != "" && args.Stream != nil {
 		// Invariant: error already checked
 		selectPath, _ := filter.SelectPathFromString(sp)
 		args.Stream = WithSelect(args.Stream, selectPath)

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -77,7 +77,7 @@ func WithSelect(parent Streamer, s filter.SelectPath) Streamer {
 	return StreamFunc(func(e SearchEvent) {
 		mux.Lock()
 
-		selected := make([]SearchResultResolver, 0, len(e.Results))
+		selected := e.Results[:0]
 		for _, result := range e.Results {
 			var current SearchResultResolver
 			switch v := result.(type) {
@@ -109,7 +109,9 @@ func WithSelect(parent Streamer, s filter.SelectPath) Streamer {
 		e.Results = selected
 
 		mux.Unlock()
-		parent.Send(e)
+		if parent != nil {
+			parent.Send(e)
+		}
 	})
 }
 

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -68,6 +68,8 @@ func WithLimit(ctx context.Context, parent Streamer, limit int) (context.Context
 	return ctx, stream, cancel
 }
 
+// WithSelect returns a child Stream of parent that runs the select operation
+// on each event, deduplicating where possible.
 func WithSelect(parent Streamer, s filter.SelectPath) Streamer {
 	var mux sync.Mutex
 	dedup := NewDeduper()
@@ -93,8 +95,10 @@ func WithSelect(parent Streamer, s filter.SelectPath) Streamer {
 				continue
 			}
 
-			seen := dedup.Seen(current)
+			// If the selected file is a file match, send it unconditionally
+			// to ensure we get all line matches for a file.
 			_, isFileMatch := current.(*FileMatchResolver)
+			seen := dedup.Seen(current)
 			if seen && !isFileMatch {
 				continue
 			}


### PR DESCRIPTION
This is a re-open of #18309, which caused build failures when merged. This time, I remembered to run with `master-dry-run`. 

The only change from the previous PR was the last commit, which wraps `args.Stream` only if `args.Stream` is already non-nil. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
