### PR TITLE
monitoring: Add panels to track table bloat

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2109,6 +2109,90 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
+## postgres: codeintel_commit_graph_db_bloat
+
+<p class="subtitle">code intelligence commit graph tables</p>
+
+**Descriptions**
+
+- <span class="badge badge-critical">critical</span> postgres: 50+ code intelligence commit graph tables for 5m0s
+
+**Possible solutions**
+
+- Run ANALYZE on the table to correct its statistics
+- Run VACUUM on the table manually to remove dead tuples
+- Run VACUUM FULL on the table manually to remove all dead tuples (requires an exclusive table lock)
+- Reconfigure the Postgres autovacuum daemon with additional resources
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "critical_postgres_codeintel_commit_graph_db_bloat"
+]
+```
+
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-codeintel-commit-graph-db-bloat).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+## postgres: codeintel_package_versions_db_bloat
+
+<p class="subtitle">code intelligence package version tables</p>
+
+**Descriptions**
+
+- <span class="badge badge-critical">critical</span> postgres: 50+ code intelligence package version tables for 5m0s
+
+**Possible solutions**
+
+- Run ANALYZE on the table to correct its statistics
+- Run VACUUM on the table manually to remove dead tuples
+- Run VACUUM FULL on the table manually to remove all dead tuples (requires an exclusive table lock)
+- Reconfigure the Postgres autovacuum daemon with additional resources
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "critical_postgres_codeintel_package_versions_db_bloat"
+]
+```
+
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-codeintel-package-versions-db-bloat).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+## postgres: codeintel_lsif_db_bloat
+
+<p class="subtitle">code intelligence LSIF data tables (codeintel-db)</p>
+
+**Descriptions**
+
+- <span class="badge badge-critical">critical</span> postgres: 50+ code intelligence LSIF data tables (codeintel-db) for 5m0s
+
+**Possible solutions**
+
+- Run ANALYZE on the table to correct its statistics
+- Run VACUUM on the table manually to remove dead tuples
+- Run VACUUM FULL on the table manually to remove all dead tuples (requires an exclusive table lock)
+- Reconfigure the Postgres autovacuum daemon with additional resources
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "critical_postgres_codeintel_lsif_db_bloat"
+]
+```
+
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-codeintel-lsif-db-bloat).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 ## postgres: provisioning_container_cpu_usage_long_term
 
 <p class="subtitle">container cpu usage total (90th percentile over 1d) across all cores by instance</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -1223,6 +1223,44 @@ A 0 value indicates that no migration is in progress.
 
 <br />
 
+### Postgres: Table bloat (dead tuples / live tuples)
+
+#### postgres: codeintel_commit_graph_db_bloat
+
+This panel indicates code intelligence commit graph tables.
+
+This value indicates the factor by which a table`s overhead outweighs its minimum overhead.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-codeintel-commit-graph-db-bloat).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+#### postgres: codeintel_package_versions_db_bloat
+
+This panel indicates code intelligence package version tables.
+
+This value indicates the factor by which a table`s overhead outweighs its minimum overhead.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-codeintel-package-versions-db-bloat).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
+#### postgres: codeintel_lsif_db_bloat
+
+This panel indicates code intelligence LSIF data tables (codeintel-db).
+
+This value indicates the factor by which a table`s overhead outweighs its minimum overhead.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-codeintel-lsif-db-bloat).
+
+<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
+
+<br />
+
 ### Postgres: Provisioning indicators (not available on server)
 
 #### postgres: provisioning_container_cpu_usage_long_term


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/18284. This adds panels to the Postgres dashboard to alert when groups of code intelligence tables which are known to get easily bloated in some deployments get disproportionately large.

This also adds a utility function to easily track the same thing for other groups of tables.

<img width="1362" alt="Screen Shot 2021-02-16 at 2 53 04 PM" src="https://user-images.githubusercontent.com/103087/108120313-b6284680-7066-11eb-9c8b-1ec41ed0669e.png">
