### PR TITLE
Adding a link to the safari extension

### DIFF
--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -11,6 +11,12 @@ Enterprise, GitLab, Phabricator, and Bitbucket Server.
 </p>
 
 <p>
+  <a target="_blank" href="https://apps.apple.com/us/app/sourcegraph-for-safari/id1543262193" style="display:flex;align-items:center">
+  <img src="img/safari.svg" width="24" height="24" style="margin-right:5px" /> <strong>Install Sourcegraph for Safari</strong>
+  </a>
+</p>
+
+<p>
   <a target="_blank" href="https://storage.googleapis.com/sourcegraph-for-firefox/latest.xpi" style="display:flex;align-items:center">
   <img src="img/firefox.svg" width="24" height="24" style="margin-right:5px" /> <strong>Install Sourcegraph for Firefox</strong>
   </a>


### PR DESCRIPTION
Adding a link to the Safari extension. This "list" probably needs some intentional design soonish (noting for myself), but we might need to unify that pattern across our docs and wanted to make a quick change and document this now that we have a Safari extension. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
