### PR TITLE
Fix a chrome update that deprecated space for tab when using search shortcuts

### DIFF
--- a/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
+++ b/client/browser/src/browser-extension/after-install-page/AfterInstallPageContent.tsx
@@ -78,7 +78,7 @@ export const AfterInstallPageContent: React.FunctionComponent<ThemeProps> = prop
                                 <h3>Search shortcut in the URL location bar</h3>
                                 <p>
                                     Type <code>src</code>
-                                    <kbd>space</kbd> in the address bar of your browser to search for queries on
+                                    <kbd>tab</kbd> in the address bar of your browser to search for queries on
                                     Sourcegraph.
                                 </p>
                                 <Video {...props} name="BrowserShortcut" width={1196} height={720} />

--- a/doc/integration/browser_extension.md
+++ b/doc/integration/browser_extension.md
@@ -60,7 +60,7 @@ When you hover your mouse over code in files, diffs, pull requests, etc., the So
 
 The Sourcegraph extension adds a search engine shortcut to your web browser that performs a search on your Sourcegraph instance. After you've installed it (see above), use the search shortcut it provides to perform a search:
 
-1. Place cursor in the URL location bar, then type <kbd>src</kbd> <kbd>Space</kbd>.
+1. Place cursor in the URL location bar, then type <kbd>src</kbd> <kbd>Tab</kbd>.
 1. Start typing your search query.
 1. Select an instant search suggestion or press <kbd>Enter</kbd> to see all results.
 

--- a/doc/integration/browser_search_engine.md
+++ b/doc/integration/browser_search_engine.md
@@ -19,13 +19,13 @@ The easiest way is to install the [Sourcegraph browser extension](browser_extens
 1. Go to [`chrome://settings`](chrome://settings.md). Under **Search engine**, click **Manage search engines**. Next to **Other search engines**, click **ADD**.
 ![](img/AddButton.png)
 1. In the **Add search engine** form, paste the URL you copied (in step 1) in the **URL with %s in place of query** field. Insert the string `%s` into the URL's `?q=` query parameter (and remove any parts of the query that you don't want to keep).
-1. Fill in the keyword field with the keyboard shortcut you want for searching on Sourcegraph. In this example, it's set to <kbd>Tab</kbd>.
+1. Fill in the keyword field with the keyboard shortcut you want for searching on Sourcegraph. In this example, it's set to <kbd>s</kbd>.
 
 ![](img/Replace.png)
 
 5.Click **ADD**.
 
-To use the shortcut, focus in the browser address bar, type in the keyword you chose (such as <kbd>src</kbd>), and press <kbd>Space</kbd>. Now type your Sourcegraph code search query and hit enter. You'll be taken to the search results page on your Sourcegraph instance.
+To use the shortcut, focus in the browser address bar, type in the keyword you chose (such as <kbd>src</kbd>), and press <kbd>Tab</kbd>. Now type your Sourcegraph code search query and hit enter. You'll be taken to the search results page on your Sourcegraph instance.
 
 ![](img/KeyboardShortcut.png)
 
@@ -49,7 +49,7 @@ To configure a shortcut (keyword) for quicker access:
 1. In the URL bar, enter about:preferences#search
 1. Scroll down to **One-Click Search Engines**, double-click the **Keyword** cell for **Sourcegraph** and type in a shortcut (such as <kbd>src</kbd>).
 
-To use the search engine, type <kbd>src</kbd> <kbd>Space</kbd> in the URL bar, then type your Sourcegraph search query. Pressing <kbd>Enter</kbd> will then go right to Sourcegraph!
+To use the search engine, type <kbd>src</kbd> <kbd>Tab</kbd> in the URL bar, then type your Sourcegraph search query. Pressing <kbd>Enter</kbd> will then go right to Sourcegraph!
 
 See "[Add or remove a search engine in Firefox](https://support.mozilla.org/en-US/kb/add-or-remove-search-engine-firefox)" for more information.
 


### PR DESCRIPTION
The best support I could find on this was [this reddit thread](https://www.reddit.com/r/chrome/comments/lilkij/custom_automatic_searches_not_working/). Noticed this was broken immediately after updating. Src + space still works if you enable some custom overrides (for now) but the thread makes it sound like Tab is the supported method (and it currently works). 