### PR TITLE
dev: allow codeinsights-db more time to startup

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -13,7 +13,7 @@ echo "--- comby install"
 # For code insights test
 ./dev/codeinsights-db.sh &
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
-export DB_STARTUP_TIMEOUT=30s # codeinsights-db needs more time to start in some instances.
+export DB_STARTUP_TIMEOUT=120s # codeinsights-db needs more time to start in some instances.
 
 # Separate out time for go mod from go test
 echo "--- go mod download"

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -64,7 +64,7 @@ export CODEINTEL_PG_ALLOW_SINGLE_DB=true
 # Code Insights uses a separate database, because it's easier to run TimescaleDB in
 # Docker than install as a Postgres extension in dev environments.
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
-export DB_STARTUP_TIMEOUT=30s # codeinsights-db needs more time to start in some instances.
+export DB_STARTUP_TIMEOUT=120s # codeinsights-db needs more time to start in some instances.
 
 # Default to "info" level debugging, and "condensed" log format (nice for human readers)
 export SRC_LOG_LEVEL=${SRC_LOG_LEVEL:-info}


### PR DESCRIPTION
I notice in some cases codeinsights-db needs some more time to start because
my CPU is consumed by e.g. webpack or similar and building the Docker image
takes a bit longer.

I think we can actually make relying on the codeinsights-db on startup optional
(it should be, with errors just communicated at query-time, I think) - I will
send a PR to do this but for now this is better.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>