### PR TITLE
insights: turn on for Sourcegraph.com

### DIFF
--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/resolvers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
@@ -17,6 +18,13 @@ import (
 
 // IsEnabled tells if code insights are enabled or not.
 func IsEnabled() bool {
+	if envvar.SourcegraphDotComMode() {
+		// Explicitly enabled for Sourcegraph.com currently, but not customer/user deployments.
+		if v, _ := strconv.ParseBool(os.Getenv("DISABLE_CODE_INSIGHTS")); v {
+			// Unless it's disabled / we need an escape hatch.
+			return false
+		}
+	}
 	if !conf.IsDev(conf.DeployType()) {
 		// Code Insights is not yet deployed to non-dev/testing instances. We don't yet have
 		// TimescaleDB in those deployments. https://github.com/sourcegraph/sourcegraph/issues/17218


### PR DESCRIPTION
This PR turns on insights code Sourcegraph.com only (not customer deployments,
not our dogfood deployment, etc.)

Rollout should go smoothly, but in case it doesn't there is an escape hatch
`DISABLE_CODE_INSIGHTS=true` we can set to disable it. Only reason not to turn
on for all customers currently is because the PR for TimescaleDB in Docker Compose
hasn't yet been sent - that will come in the next day or so.