### PR TITLE
search frontend: hovers for selector values

### DIFF
--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -33,6 +33,7 @@ export type MetaToken =
     | MetaRepoRevisionSeparator
     | MetaRevision
     | MetaContextPrefix
+    | MetaSelector
 
 /**
  * Defines common properties for meta tokens.
@@ -139,6 +140,19 @@ export interface MetaRepoRevisionSeparator extends BaseMetaToken {
  */
 export interface MetaContextPrefix extends BaseMetaToken {
     type: 'metaContextPrefix'
+}
+
+export interface MetaSelector extends BaseMetaToken {
+    type: 'metaSelector'
+    kind: MetaSelectorKind
+}
+
+export enum MetaSelectorKind {
+    Repo = 'repo',
+    File = 'file',
+    Content = 'content',
+    Symbol = 'symbol',
+    Commit = 'commit',
 }
 
 /**
@@ -687,6 +701,14 @@ const decorateContext = (token: Literal): DecoratedToken[] => {
     ]
 }
 
+const decorateSelector = (token: Literal): DecoratedToken[] => {
+    const kind = token.value as MetaSelectorKind
+    if (!kind) {
+        return [token]
+    }
+    return [{ type: 'metaSelector', range: token.range, value: token.value, kind }]
+}
+
 export const decorate = (token: Token): DecoratedToken[] => {
     const decorated: DecoratedToken[] = []
     switch (token.type) {
@@ -740,6 +762,8 @@ export const decorate = (token: Token): DecoratedToken[] => {
                 )
             } else if (token.field.value === 'context' && token.value?.type === 'literal') {
                 decorated.push(...decorateContext(token.value))
+            } else if (token.field.value === 'select' && token.value?.type === 'literal') {
+                decorated.push(...decorateSelector(token.value))
             } else if (token.value) {
                 decorated.push(token.value)
             }

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -591,3 +591,23 @@ describe('getHoverResult()', () => {
         `)
     })
 })
+
+test('returns hover contents for select', () => {
+    const scannedQuery = toSuccess(scanSearchQuery('select:repo repo:foo', false, SearchPatternType.literal))
+
+    expect(getHoverResult(scannedQuery, { column: 8 }, true)).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "Select and display distinct repository paths from search results."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 8,
+            "endColumn": 12
+          }
+        }
+    `)
+})

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -11,6 +11,8 @@ import {
     MetaSourcegraphRevision,
     MetaStructural,
     MetaStructuralKind,
+    MetaSelector,
+    MetaSelectorKind,
 } from './decoratedToken'
 import { resolveFilter } from './filters'
 
@@ -136,6 +138,21 @@ const toRevisionHover = (token: MetaRevision): string => {
     }
 }
 
+const toSelectorHover = (token: MetaSelector): string => {
+    switch (token.kind) {
+        case MetaSelectorKind.Repo:
+            return 'Select and display distinct repository paths from search results.'
+        case MetaSelectorKind.File:
+            return 'Select and display distinct file paths from search results.'
+        case MetaSelectorKind.Content:
+            return 'Select and display only results matching content inside files.'
+        case MetaSelectorKind.Commit:
+            return 'Select and display only commit data of the result. Must be used in conjunction with commit search, i.e., `type:commit`.'
+        case MetaSelectorKind.Symbol:
+            return 'Select and display only symbol data of the result. Must be used in conjunction with a symbol search, i.e., `type:symbol`.'
+    }
+}
+
 const toHover = (token: DecoratedToken): string => {
     switch (token.type) {
         case 'pattern': {
@@ -148,6 +165,8 @@ const toHover = (token: DecoratedToken): string => {
             return toRevisionHover(token)
         case 'metaRepoRevisionSeparator':
             return '**Search at revision**. Separates a repository pattern and the revisions to search, like commits or branches. The part before the `@` specifies the repositories to search, the part after the `@` specifies which revisions to search.'
+        case 'metaSelector':
+            return toSelectorHover(token)
         case 'metaStructural':
             return toStructuralHover(token)
     }
@@ -204,6 +223,7 @@ export const getHoverResult = (
             case 'pattern':
             case 'metaRevision':
             case 'metaRepoRevisionSeparator':
+            case 'metaSelector':
                 values.push(toHover(token))
                 range = toMonacoRange(token.range)
                 break


### PR DESCRIPTION
Shows hover detail for selector values

<img width="625" alt="Screen Shot 2021-02-16 at 9 43 35 PM" src="https://user-images.githubusercontent.com/888624/108157471-11c2f600-70a0-11eb-9035-c96013078058.png">

The messaging is to make it explicit to the user that `select` does not influence the kind of search being performed currently, it only selects values "after" running the query (even though we can technically, underneath the hood, optimize for queries like `select:repo`). Feel free to give input on wording here.

Additionally, `select:symbol` and `select:commit` are really only "identity" mappers for `type:symbol` and `type:commit` searches, so they are not currently very useful on their own. They will become more useful once we support `select.symbol.kind` and `select:commit.kind` to expose other data. We could make the call to omit `select:symbol` and `select:commit` if we think this is low-value to expose right now. Personally, I believe we should just keep it--we'll not be advertising `select` usage in the upcoming release/changelog but will ship these features on-by-default.(we are only 2 weeks in from an estimated 5 week time to polish this).