### PR TITLE
search frontend: highlight and partition path separators

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1125,4 +1125,115 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('returns path separator tokens for regexp values', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com/sourcegraph@HEAD f:a/b/')), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "metaRegexpAssertion"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaPathSeparator"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 25,
+                "scopes": "metaRepoRevisionSeparator"
+              },
+              {
+                "startIndex": 26,
+                "scopes": "metaRevisionLabel"
+              },
+              {
+                "startIndex": 30,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 31,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 33,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 34,
+                "scopes": "metaPathSeparator"
+              },
+              {
+                "startIndex": 35,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 36,
+                "scopes": "metaPathSeparator"
+              }
+            ]
+        `)
+    })
+
+    test('returns regexp highlighting if path separators cannot be parsed', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('r:^github.com(/)sourcegraph')), true)).toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 2,
+                "scopes": "metaRegexpAssertion"
+              },
+              {
+                "startIndex": 3,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 9,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 10,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaRegexpDelimited"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 15,
+                "scopes": "metaRegexpDelimited"
+              },
+              {
+                "startIndex": 16,
+                "scopes": "identifier"
+              }
+            ]
+        `)
+    })
 })

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -474,19 +474,14 @@ const mapPathMeta = (token: Literal): DecoratedToken[] => {
  * Tries to parse a pattern into decorated regexp tokens.
  * It always succeeds, even if regexp fails to parse.
  */
-const mapRegexpMetaSucceed = (token: Pattern): DecoratedToken[] => {
-    const parsedRegexp = mapRegexpMeta(token)
-    return parsedRegexp ? parsedRegexp : [token]
-}
+const mapRegexpMetaSucceed = (token: Pattern): DecoratedToken[] => mapRegexpMeta(token) || [token]
 
-const toPattern = (token: Literal): Pattern => {
-    return {
-        type: 'pattern',
-        kind: PatternKind.Regexp,
-        value: token.value,
-        range: token.range,
-    }
-}
+const toPattern = (token: Literal): Pattern => ({
+    type: 'pattern',
+    kind: PatternKind.Regexp,
+    value: token.value,
+    range: token.range,
+})
 
 /**
  * Tries to convert all literal tokens in a list of tokens to regular expression tokens.

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -34,6 +34,7 @@ export type MetaToken =
     | MetaRevision
     | MetaContextPrefix
     | MetaSelector
+    | MetaPath
 
 /**
  * Defines common properties for meta tokens.
@@ -155,6 +156,21 @@ export enum MetaSelectorKind {
     Commit = 'commit',
 }
 
+export enum MetaPathKind {
+    Separator = 'Separator',
+}
+
+/**
+ * Tokens that are meaningful in path patterns, like
+ * path separators / or wildcards *.
+ */
+export interface MetaPath {
+    type: 'metaPath'
+    range: CharacterRange
+    kind: MetaPathKind
+    value: string
+}
+
 /**
  * Coalesces consecutive pattern tokens. Used, for example, when parsing
  * literal characters like 'f', 'o', 'o' in regular expressions, which are
@@ -186,7 +202,7 @@ const coalescePatterns = (tokens: DecoratedToken[]): DecoratedToken[] => {
     return newTokens
 }
 
-const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
+const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] | undefined => {
     const tokens: DecoratedToken[] = []
     try {
         const ast = new RegExpParser().parsePattern(pattern.value)
@@ -386,7 +402,7 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
             },
         })
     } catch {
-        tokens.push(pattern)
+        return undefined
     }
     // The AST is not necessarily traversed in increasing range. We need
     // to sort by increasing range because the ordering is significant to Monaco.
@@ -397,6 +413,112 @@ const mapRegexpMeta = (pattern: Pattern): DecoratedToken[] => {
         return 0
     })
     return coalescePatterns(tokens)
+}
+
+/**
+ * Returns true for filter values that have path-like values, i.e., values that typically
+ * contain path separators like `/`.
+ */
+export const hasPathLikeValue = (field: string): boolean => {
+    const fieldName = field.startsWith('-') ? field.slice(1) : field
+    switch (fieldName.toLocaleLowerCase()) {
+        case 'repo':
+        case 'r':
+        case 'file':
+        case 'f':
+        case 'repohasfile':
+            return true
+        default:
+            return false
+    }
+}
+
+// Tokenize a literal value like "^foo/bar/baz$" by a path separator '/'.
+const mapPathMeta = (token: Literal): DecoratedToken[] => {
+    const tokens: DecoratedToken[] = []
+    const offset = token.range.start
+    let start = 0
+    let current = 0
+    while (token.value[current]) {
+        if (token.value[current] === '\\') {
+            current = current + 2 // Continue past escaped value.
+            continue
+        } else if (token.value[current] === '/') {
+            tokens.push({
+                type: 'literal',
+                range: { start: offset + start, end: offset + current - 1 },
+                value: token.value.slice(start, current),
+            })
+            tokens.push({
+                type: 'metaPath',
+                range: { start: offset + current, end: offset + current + 1 },
+                kind: MetaPathKind.Separator,
+                value: '/',
+            })
+            current = current + 1
+            start = current
+            continue
+        }
+        current = current + 1
+    }
+    // Push last token.
+    tokens.push({
+        type: 'literal',
+        range: { start: offset + start, end: offset + current },
+        value: token.value.slice(start, current),
+    })
+    return tokens
+}
+
+/**
+ * Tries to parse a pattern into decorated regexp tokens.
+ * It always succeeds, even if regexp fails to parse.
+ */
+const mapRegexpMetaSucceed = (token: Pattern): DecoratedToken[] => {
+    const parsedRegexp = mapRegexpMeta(token)
+    return parsedRegexp ? parsedRegexp : [token]
+}
+
+const toPattern = (token: Literal): Pattern => {
+    return {
+        type: 'pattern',
+        kind: PatternKind.Regexp,
+        value: token.value,
+        range: token.range,
+    }
+}
+
+/**
+ * Tries to convert all literal tokens in a list of tokens to regular expression tokens.
+ * If any tokens fail to parse, the result is undefined.
+ */
+const tryMapLiteralsToRegexp = (tokens: DecoratedToken[]): DecoratedToken[] | undefined => {
+    const decorated: DecoratedToken[] = []
+    for (const token of tokens) {
+        if (token.type === 'literal') {
+            const parsedRegexp = mapRegexpMeta(toPattern(token))
+            if (!parsedRegexp) {
+                return undefined
+            }
+            decorated.push(...parsedRegexp)
+            continue
+        }
+        decorated.push(token)
+    }
+    return decorated
+}
+
+/**
+ * A helper function for converting path-like regexp values like ^github.com/foo$ to
+ * tokens that highlight regexp metasyntax and path separator syntax. It always succeeds,
+ * even if regexp fails to parse.
+ */
+const mapPathMetaForRegexp = (token: Literal): DecoratedToken[] => {
+    const patterns = tryMapLiteralsToRegexp(mapPathMeta(token))
+    if (!patterns) {
+        return mapRegexpMetaSucceed(toPattern(token))
+    }
+    return patterns
 }
 
 const mapRevisionMeta = (token: Literal): DecoratedToken[] => {
@@ -524,7 +646,7 @@ const mapStructuralMeta = (pattern: Pattern): DecoratedToken[] => {
                         range: { start: variableRange.end, end: variableRange.end + 1 },
                         value: '~',
                     },
-                    ...mapRegexpMeta({
+                    ...mapRegexpMetaSucceed({
                         type: 'pattern',
                         kind: PatternKind.Regexp,
                         range: patternRange,
@@ -663,13 +785,11 @@ const decorateRepoRevision = (token: Literal): DecoratedToken[] => {
     const offset = token.range.start
 
     return [
-        ...decorate({
-            type: 'pattern',
-            kind: PatternKind.Regexp,
+        ...mapPathMetaForRegexp({
+            type: 'literal',
             value: repo,
             range: { start: offset, end: offset + repo.length },
         }),
-
         {
             type: 'metaRepoRevisionSeparator',
             value: '@',
@@ -715,7 +835,7 @@ export const decorate = (token: Token): DecoratedToken[] => {
         case 'pattern':
             switch (token.kind) {
                 case PatternKind.Regexp:
-                    decorated.push(...mapRegexpMeta(token))
+                    decorated.push(...mapRegexpMetaSucceed(token))
                     break
                 case PatternKind.Structural:
                     decorated.push(...mapStructuralMeta(token))
@@ -752,14 +872,11 @@ export const decorate = (token: Token): DecoratedToken[] => {
                 )
             } else if (token.value && token.value.type === 'literal' && hasRegexpValue(token.field.value)) {
                 // Highlight fields with regexp values.
-                decorated.push(
-                    ...decorate({
-                        type: 'pattern',
-                        kind: PatternKind.Regexp,
-                        value: token.value.value,
-                        range: token.value.range,
-                    })
-                )
+                if (hasPathLikeValue(token.field.value) && token.value?.type === 'literal') {
+                    decorated.push(...mapPathMetaForRegexp(token.value))
+                } else {
+                    decorated.push(...mapRegexpMetaSucceed(toPattern(token.value)))
+                }
             } else if (token.field.value === 'context' && token.value?.type === 'literal') {
                 decorated.push(...decorateContext(token.value))
             } else if (token.field.value === 'select' && token.value?.type === 'literal') {
@@ -789,6 +906,7 @@ const decoratedToMonaco = (token: DecoratedToken): Monaco.languages.IToken => {
                 startIndex: token.range.start,
                 scopes: token.type,
             }
+        case 'metaPath':
         case 'metaRevision':
         case 'metaRegexp':
         case 'metaStructural':

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -67,6 +67,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         { token: 'metaRevisionLabel', foreground: '#f2f4f8' },
         { token: 'metaRevisionReferencePath', foreground: '#f2f4f8' },
         { token: 'metaRevisionWildcard', foreground: '#3bc9db' },
+        // Path-like highlighting
+        { token: 'metaPathSeparator', foreground: '#868e96' },
     ],
 })
 
@@ -125,6 +127,8 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         { token: 'metaRevisionLabel', foreground: '#2b3750' },
         { token: 'metaRevisionReferencePath', foreground: '#2b3750' },
         { token: 'metaRevisionWildcard', foreground: '#1098ad' },
+        // Path-like highlighting
+        { token: 'metaPathSeparator', foreground: '#868e96' },
     ],
 })
 


### PR DESCRIPTION
This adds highlighting to path separators `/` for repo and file regex values. I hacked on it in December and had time to clean it up now. The idea is that this functionality will also be future-compatible for glob highlighting.

![Screen Shot 2021-02-18 at 6 57 36 PM](https://user-images.githubusercontent.com/888624/108446414-4dce9600-721b-11eb-86a7-85c8380e2dd9.png)

![Screen Shot 2021-02-18 at 6 57 02 PM](https://user-images.githubusercontent.com/888624/108446421-5030f000-721b-11eb-8749-bdf34c27c8c3.png)

It has a nice aesthetic effect of separating the values between `/`, such that hovering on the parts between `/` only show matches for that string (and not the whole thing like `a/b/c`):


https://user-images.githubusercontent.com/888624/108446482-6dfe5500-721b-11eb-990e-26519c2a2510.mp4


Implementation details:

The way it works is to try and first parse a value on `/` (Taking care of escaping). Once we have a list of values of fragments between `/`s, we try to parse those to regular expressions and return regular expression highlights. Doing it the other way around is possible (first regex, then scan `/`) but complicates things, because currently all path-like values are regexp, but not all regexp are path-like. I kind of just chose this route naturally.

The one tricky thing to get right is if we have a regular expression like `foo(/)bar`. Now, parsing on `/` gives you fragments `foo(` and `)bar`, and these fragments are not valid regex independently. But we still want to get regexp highlights for `foo(/)bar`. So this implementation will attempt parsing on `/` first and then highlight regexps, but if it fails, it will parse the entire string as regexp and leave out the `/` processing.

---

I will break up the this file in a subsequent PR, it's too large.