### PR TITLE
Fine-tune animation and focus states

### DIFF
--- a/client/web/src/nav/Feedback/FeedbackIcons.tsx
+++ b/client/web/src/nav/Feedback/FeedbackIcons.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export const VerySad = (
-    <svg width="28" height="28" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M20 10C20 15.5228 15.5228 20 10 20C4.47778 20 0 15.5228 0 10C0 4.47778 4.47778 0 10 0C15.5228 0 20 4.47778 20 10Z"
             fill="#FFCC4D"
@@ -14,7 +14,7 @@ export const VerySad = (
 )
 
 export const Sad = (
-    <svg width="28" height="28" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M20 10C20 15.5228 15.5228 20 10 20C4.47778 20 0 15.5228 0 10C0 4.47778 4.47778 0 10 0C15.5228 0 20 4.47778 20 10Z"
             fill="#FFCC4D"
@@ -35,7 +35,7 @@ export const Sad = (
 )
 
 export const Happy = (
-    <svg width="28" height="28" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M10 20C15.5228 20 20 15.5228 20 10C20 4.47715 15.5228 0 10 0C4.47715 0 0 4.47715 0 10C0 15.5228 4.47715 20 10 20Z"
             fill="#FFCC4D"
@@ -56,7 +56,7 @@ export const Happy = (
 )
 
 export const VeryHappy = (
-    <svg width="28" height="28" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="24" height="24" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path
             d="M20 10C20 15.5228 15.5228 20 10 20C4.47778 20 0 15.5228 0 10C0 4.47778 4.47778 0 10 0C15.5228 0 20 4.47778 20 10Z"
             fill="#FFCC4D"

--- a/client/web/src/nav/IconRadioButtons.scss
+++ b/client/web/src/nav/IconRadioButtons.scss
@@ -9,7 +9,18 @@
         align-items: center;
         height: 2.25rem;
         width: 2.25rem;
+        margin-bottom: 0;
+        border-radius: 50%;
+        box-shadow: inset 0 0 0 3px rgba(#329af0, 0);
+
+        transition: box-shadow 50ms ease-in;
+
+        &:focus-within {
+            box-shadow: inset 0 0 0 3px rgba(#329af0, .5);
+            transition-delay: 0;
+        }
     }
+
     &__border {
         z-index: 1;
         position: absolute;
@@ -19,24 +30,31 @@
         cursor: pointer;
         margin: 0;
         border-radius: 50%;
-        transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 50ms ease;
-        border: 1px solid var(--color-bg-5);
+        transform-origin: center center;
+        transition: transform 0.15s ease, box-shadow 0.2s ease;
+        border: 1px solid var(--border-color-2);
+
         &:hover {
             transform: scale(1.08);
+            border-color: var(--border-color);
         }
         &:active {
+            cursor: pointer;
             transform: scale(0.99);
         }
         &--active {
             border: none;
-            animation: pop 150ms ease-in-out;
+            //animation: pop 150ms ease-in-out;
+            //animation-iteration-count: 1;
         }
     }
     &__emoji {
+        transform-origin: center center;
+
         &--active {
             border: none;
-            animation: pop 150ms ease-in-out;
-            transform: scale(1.2855555);
+            animation: pop 150ms;
+            transform: scale(1.285555);
         }
         &--inactive {
             filter: grayscale(1);
@@ -52,12 +70,12 @@
 
 @keyframes pop {
     from {
-        transform: scale(0.97);
+        transform: scale(0.95);
     }
     20% {
-        transform: scale(1.05);
+        transform: scale(1.6);
     }
     to {
-        transform: scale(1.2855555);
+        transform: scale(1.285555);
     }
 }

--- a/client/web/src/nav/IconRadioButtons.scss
+++ b/client/web/src/nav/IconRadioButtons.scss
@@ -44,8 +44,6 @@
         }
         &--active {
             border: none;
-            //animation: pop 150ms ease-in-out;
-            //animation-iteration-count: 1;
         }
     }
     &__emoji {

--- a/client/web/src/nav/IconRadioButtons.scss
+++ b/client/web/src/nav/IconRadioButtons.scss
@@ -11,11 +11,10 @@
         width: 2.25rem;
         margin-bottom: 0;
         border-radius: 50%;
-
         transition: box-shadow 50ms ease-in;
 
         &:focus-within {
-            box-shadow: inset 0 0 0 3px rgba($primary, .75);
+            box-shadow: inset 0 0 0 3px rgba($primary, 0.75);
             transition-delay: 0;
         }
     }

--- a/client/web/src/nav/IconRadioButtons.scss
+++ b/client/web/src/nav/IconRadioButtons.scss
@@ -11,12 +11,11 @@
         width: 2.25rem;
         margin-bottom: 0;
         border-radius: 50%;
-        box-shadow: inset 0 0 0 3px rgba(#329af0, 0);
 
         transition: box-shadow 50ms ease-in;
 
         &:focus-within {
-            box-shadow: inset 0 0 0 3px rgba(#329af0, .5);
+            box-shadow: inset 0 0 0 3px rgba($primary, .75);
             transition-delay: 0;
         }
     }

--- a/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
@@ -231,9 +231,9 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -270,9 +270,9 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -317,9 +317,9 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -364,9 +364,9 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -946,9 +946,9 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -985,9 +985,9 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -1032,9 +1032,9 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -1079,9 +1079,9 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -1671,9 +1671,9 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -1710,9 +1710,9 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -1757,9 +1757,9 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -1804,9 +1804,9 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -2367,9 +2367,9 @@ exports[`NavLinks authed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -2406,9 +2406,9 @@ exports[`NavLinks authed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -2453,9 +2453,9 @@ exports[`NavLinks authed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -2500,9 +2500,9 @@ exports[`NavLinks authed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3073,9 +3073,9 @@ exports[`NavLinks unauthed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3112,9 +3112,9 @@ exports[`NavLinks unauthed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3159,9 +3159,9 @@ exports[`NavLinks unauthed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3206,9 +3206,9 @@ exports[`NavLinks unauthed Sourcegraph.com /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3530,9 +3530,9 @@ exports[`NavLinks unauthed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3569,9 +3569,9 @@ exports[`NavLinks unauthed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3616,9 +3616,9 @@ exports[`NavLinks unauthed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3663,9 +3663,9 @@ exports[`NavLinks unauthed Sourcegraph.com /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -3997,9 +3997,9 @@ exports[`NavLinks unauthed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -4036,9 +4036,9 @@ exports[`NavLinks unauthed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -4083,9 +4083,9 @@ exports[`NavLinks unauthed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -4130,9 +4130,9 @@ exports[`NavLinks unauthed self-hosted /foo 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -4442,9 +4442,9 @@ exports[`NavLinks unauthed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -4481,9 +4481,9 @@ exports[`NavLinks unauthed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -4528,9 +4528,9 @@ exports[`NavLinks unauthed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
@@ -4575,9 +4575,9 @@ exports[`NavLinks unauthed self-hosted /search 1`] = `
               >
                 <svg
                   fill="none"
-                  height="28"
+                  height="24"
                   viewBox="0 0 20 20"
-                  width="28"
+                  width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path


### PR DESCRIPTION
I've made a few changes to the animation handling for the emojis in the feedback widget, and also introduced an updated focus state to better convey that the emojis are focused via keyboard navigation. Previously, it was obvious which emoji was switched _to_, but not that the emojis were focused at all.