### PR TITLE
search contexts: results missing when running searches

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1575,7 +1575,7 @@ func (r *searchResolver) isGlobalSearch() bool {
 		return false
 	}
 	querySearchContextSpec, _ := r.Query.StringValue(query.FieldContext)
-	if envvar.SourcegraphDotComMode() && searchcontexts.IsGlobalSearchContextSpec(querySearchContextSpec) {
+	if envvar.SourcegraphDotComMode() && !searchcontexts.IsGlobalSearchContextSpec(querySearchContextSpec) {
 		return false
 	}
 	return len(r.Query.Values(query.FieldRepo)) == 0 && len(r.Query.Values(query.FieldRepoGroup)) == 0 && len(r.Query.Values(query.FieldRepoHasFile)) == 0

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1745,3 +1745,51 @@ func TestSearchResultDeduper(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGlobalSearch(t *testing.T) {
+	orig := envvar.SourcegraphDotComMode()
+	envvar.MockSourcegraphDotComMode(true)
+	defer envvar.MockSourcegraphDotComMode(orig)
+
+	versionContext := "versionCtx"
+	tts := []struct {
+		name           string
+		searchQuery    string
+		versionContext *string
+		patternType    query.SearchType
+		wantIsGlobal   bool
+	}{
+		{name: "user search context", searchQuery: "foo context:@userA", wantIsGlobal: false},
+		{name: "structural search", searchQuery: "foo", patternType: query.SearchTypeStructural, wantIsGlobal: false},
+		{name: "version context", searchQuery: "foo", versionContext: &versionContext, wantIsGlobal: false},
+		{name: "repo", searchQuery: "foo repo:sourcegraph/sourcegraph", versionContext: &versionContext, wantIsGlobal: false},
+		{name: "repogroup", searchQuery: "foo repogroup:grp", versionContext: &versionContext, wantIsGlobal: false},
+		{name: "repohasfile", searchQuery: "foo repohasfile:bar", versionContext: &versionContext, wantIsGlobal: false},
+		{name: "global search context", searchQuery: "foo context:global", wantIsGlobal: true},
+		{name: "global search", searchQuery: "foo", wantIsGlobal: true},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			qinfo, err := query.ParseLiteral(tt.searchQuery)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resolver := searchResolver{
+				SearchInputs: &SearchInputs{
+					Query:          qinfo,
+					UserSettings:   &schema.Settings{},
+					PatternType:    tt.patternType,
+					VersionContext: tt.versionContext,
+				},
+			}
+
+			gotIsGlobal := resolver.isGlobalSearch()
+			if gotIsGlobal != tt.wantIsGlobal {
+				t.Fatalf("got %+v, want %+v", gotIsGlobal, tt.wantIsGlobal)
+			}
+		})
+	}
+
+}

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -419,40 +419,6 @@ func resolveVersionContext(versionContext string) (*schema.VersionContext, error
 	return nil, errors.New("version context not found")
 }
 
-const globalSearchContextName = "global"
-
-type getNamespaceByNameFunc func(ctx context.Context, name string) (*database.Namespace, error)
-
-func resolveSearchContextSpec(ctx context.Context, searchContextSpec string, getNamespaceByName getNamespaceByNameFunc) (*types.SearchContext, error) {
-	if !envvar.SourcegraphDotComMode() {
-		return nil, nil
-	}
-
-	if isGlobalSearchContextSpec(searchContextSpec) {
-		return &types.SearchContext{Name: globalSearchContextName}, nil
-	} else if strings.HasPrefix(searchContextSpec, "@") {
-		name := searchContextSpec[1:]
-		namespace, err := getNamespaceByName(ctx, name)
-		if err != nil {
-			return nil, err
-		}
-		if namespace.User == 0 {
-			return nil, errors.Errorf("search context '%s' not found", searchContextSpec)
-		}
-		return &types.SearchContext{Name: name, UserID: namespace.User}, nil
-	}
-	return nil, errors.Errorf("search context '%s' does not have the correct format (global or @username)", searchContextSpec)
-}
-
-func isGlobalSearchContextSpec(searchContextSpec string) bool {
-	// Empty search context spec resolves to global search context
-	return searchContextSpec == "" || searchContextSpec == globalSearchContextName
-}
-
-func isGlobalSearchContext(searchContext *types.SearchContext) bool {
-	return searchContext != nil && searchContext.Name == globalSearchContextName
-}
-
 // Cf. golang/go/src/regexp/syntax/parse.go.
 const regexpFlags = regexpsyntax.ClassNL | regexpsyntax.PerlX | regexpsyntax.UnicodeGroups
 

--- a/cmd/frontend/internal/search/repos/repos_test.go
+++ b/cmd/frontend/internal/search/repos/repos_test.go
@@ -420,66 +420,6 @@ func TestHasTypeRepo(t *testing.T) {
 	}
 }
 
-func TestResolvingValidSearchContextSpecs(t *testing.T) {
-	orig := envvar.SourcegraphDotComMode()
-	envvar.MockSourcegraphDotComMode(true)
-	defer envvar.MockSourcegraphDotComMode(orig)
-
-	tests := []struct {
-		name                  string
-		searchContextSpec     string
-		wantSearchContextName string
-	}{
-		{name: "resolve user search context", searchContextSpec: "@user", wantSearchContextName: "user"},
-		{name: "resolve global search context", searchContextSpec: "global", wantSearchContextName: "global"},
-		{name: "resolve empty search context as global", searchContextSpec: "", wantSearchContextName: "global"},
-	}
-
-	getNamespaceByName := func(ctx context.Context, name string) (*database.Namespace, error) {
-		return &database.Namespace{Name: name, User: 1}, nil
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			searchContext, err := resolveSearchContextSpec(context.Background(), tt.searchContextSpec, getNamespaceByName)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if searchContext.Name != tt.wantSearchContextName {
-				t.Fatalf("got %q, expected %q", searchContext.Name, tt.wantSearchContextName)
-			}
-		})
-	}
-}
-
-func TestResolvingInvalidSearchContextSpecs(t *testing.T) {
-	orig := envvar.SourcegraphDotComMode()
-	envvar.MockSourcegraphDotComMode(true)
-	defer envvar.MockSourcegraphDotComMode(orig)
-
-	tests := []struct {
-		name              string
-		searchContextSpec string
-		wantErr           string
-	}{
-		{name: "invalid format", searchContextSpec: "+user", wantErr: "search context '+user' does not have the correct format (global or @username)"},
-		{name: "user not found", searchContextSpec: "@user", wantErr: "search context '@user' not found"},
-		{name: "empty user not found", searchContextSpec: "@", wantErr: "search context '@' not found"},
-	}
-
-	getNamespaceByName := func(ctx context.Context, name string) (*database.Namespace, error) { return &database.Namespace{}, nil }
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := resolveSearchContextSpec(context.Background(), tt.searchContextSpec, getNamespaceByName)
-			if err == nil {
-				t.Error("Expected error, but there was none")
-			}
-			if err.Error() != tt.wantErr {
-				t.Fatalf("err: got %q, expected %q", err.Error(), tt.wantErr)
-			}
-		})
-	}
-}
-
 func TestUseDefaultReposIfMissingOrGlobalSearchContext(t *testing.T) {
 	orig := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)


### PR DESCRIPTION
Fixed global search context check in isGlobalSearch function. Also removed dead search contexts code, which was a result of a bad merge. Added tests for `isGlobalSearch` function to prevent this in the future.

Fixes #18365