### PR TITLE
Add a notice to closed campaigns that changesets may be outdated

### DIFF
--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -28,6 +28,7 @@ import { UnpublishedNotice } from './UnpublishedNotice'
 import { SupersedingCampaignSpecAlert } from './SupersedingCampaignSpecAlert'
 import { CampaignsIcon } from '../icons'
 import { PageHeader } from '../../../components/PageHeader'
+import { ClosedNotice } from './ClosedNotice'
 
 export interface CampaignDetailsPageProps
     extends ThemeProps,
@@ -135,6 +136,7 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
                 className="test-campaign-details-page mb-3"
             />
             <SupersedingCampaignSpecAlert spec={campaign.currentSpec.supersedingCampaignSpec} />
+            <ClosedNotice closedAt={campaign.closedAt} className="mb-3" />
             <UnpublishedNotice
                 unpublished={campaign.changesetsStats.unpublished}
                 total={campaign.changesetsStats.total}

--- a/client/web/src/enterprise/campaigns/detail/ClosedNotice.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/ClosedNotice.story.tsx
@@ -1,0 +1,10 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { ClosedNotice } from './ClosedNotice'
+
+const { add } = storiesOf('web/campaigns/details/ClosedNotice', module).addDecorator(story => (
+    <div className="p-3 container web-content">{story()}</div>
+))
+
+add('Campaign closed', () => <EnterpriseWebStory>{() => <ClosedNotice closedAt="2021-02-02" />}</EnterpriseWebStory>)

--- a/client/web/src/enterprise/campaigns/detail/ClosedNotice.tsx
+++ b/client/web/src/enterprise/campaigns/detail/ClosedNotice.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import classNames from 'classnames'
+import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
+import { CampaignFields } from '../../../graphql-operations'
+
+interface ClosedNoticeProps {
+    closedAt: CampaignFields['closedAt']
+    className?: string
+}
+
+export const ClosedNotice: React.FunctionComponent<ClosedNoticeProps> = ({ closedAt, className }) => {
+    if (!closedAt) {
+        return <></>
+    }
+    return (
+        <div className={classNames('alert alert-info', className)}>
+            <InformationOutlineIcon className="icon-inline" /> Information on this page may be out of date because
+            changesets which only exist in closed campaigns are not synced with the code host.
+        </div>
+    )
+}

--- a/client/web/src/enterprise/campaigns/detail/ClosedNotice.tsx
+++ b/client/web/src/enterprise/campaigns/detail/ClosedNotice.tsx
@@ -15,7 +15,7 @@ export const ClosedNotice: React.FunctionComponent<ClosedNoticeProps> = ({ close
     return (
         <div className={classNames('alert alert-info', className)}>
             <InformationOutlineIcon className="icon-inline" /> Information on this page may be out of date because
-            changesets which only exist in closed campaigns are not synced with the code host.
+            changesets that only exist in closed campaigns are not synced with the code host.
         </div>
     )
 }


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/16924 by
adding a notice on the CampaignsDetails page.

@eseliger I'm a bit lost when it comes to updating the required tests. Working on it.


### Screenshots

![image](https://user-images.githubusercontent.com/1185253/108209764-f81ac080-712a-11eb-8ef5-a283ddeefffb.png)
![image](https://user-images.githubusercontent.com/1185253/108209787-fc46de00-712a-11eb-99cb-2fa433a28721.png)
