### PR TITLE
Show reference actions in new UX

### DIFF
--- a/client/branded/src/components/Tabs.tsx
+++ b/client/branded/src/components/Tabs.tsx
@@ -39,6 +39,7 @@ interface TabBarProps<ID extends string, T extends Tab<ID>> {
     tabComponent: React.ComponentType<{ tab: T; className: string; role: string }>
 
     tabClassName?: string
+    tabBarClassName?: string
 }
 
 /**
@@ -50,7 +51,14 @@ interface TabBarProps<ID extends string, T extends Tab<ID>> {
 class TabBar<ID extends string, T extends Tab<ID>> extends React.PureComponent<TabBarProps<ID, T>> {
     public render(): JSX.Element | null {
         return (
-            <div className={`tab-bar ${this.props.tabs.length === 0 ? 'tab-bar--empty' : ''}`} role="tablist">
+            <div
+                className={classNames(
+                    'tab-bar',
+                    this.props.tabs.length === 0 && 'tab-bar--empty',
+                    this.props.tabBarClassName
+                )}
+                role="tablist"
+            >
                 {this.props.tabs
                     .filter(({ hidden }) => !hidden)
                     .map(tab => (
@@ -109,6 +117,7 @@ interface TabsProps<ID extends string, T extends Tab<ID>> {
 
     id?: string
     className?: string
+    tabBarClassName?: string
     tabClassName?: string
 
     /** Optional handler when a tab is selected */
@@ -149,6 +158,7 @@ class Tabs<ID extends string, T extends Tab<ID>> extends React.PureComponent<
                     tabs={this.props.tabs}
                     activeTab={this.props.activeTab}
                     endFragment={this.props.tabBarEndFragment}
+                    tabBarClassName={this.props.tabBarClassName}
                     tabClassName={this.props.tabClassName}
                     tabComponent={this.props.tabComponent}
                 />

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -67,10 +67,10 @@
 
     &__actions {
         padding-right: 2rem;
-        opacity: 0.6;
 
         // Ensures the action border always completes the full line it breaks onto
         &::after {
+            opacity: 0.6;
             position: absolute;
             content: '';
             width: 100%;

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -45,9 +45,6 @@
         flex: 1;
         min-height: 0; /* needed for Firefox for content scrolling to work properly; See sourcegraph/sourcegraph#12340 and https://codepen.io/slimsag/pen/mjPXyN */
         &-content {
-            margin-top: 4px;
-            border-top: 1px solid var(--border-color);
-
             flex: 1;
             &--scroll {
                 overflow: auto;

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -50,4 +50,11 @@
             }
         }
     }
+
+    &__tabs &__tabs__action {
+        max-width: none;
+        border-bottom: 3px solid var(--border-color);
+        opacity: 0.6;
+        padding: 0.25rem 0.75rem;
+    }
 }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -44,6 +44,7 @@
     &__tab-bar {
         flex-wrap: wrap;
         position: relative;
+        overflow-x: hidden; /* We can rely on the tab bar breaking onto new lines */
     }
 
     &__tabs {
@@ -66,16 +67,15 @@
 
     &__actions {
         padding-right: 2rem;
-        border-bottom: 3px solid var(--border-color);
         opacity: 0.6;
 
-        // Complete border if content is pushed onto new line
+        // Ensures the action border always completes the full line it breaks onto
         &::after {
             position: absolute;
             content: '';
             width: 100%;
             top: calc(100% - 3px);
-            border-bottom: inherit;
+            border-bottom: 3px solid var(--border-color);
         }
     }
 

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -84,6 +84,6 @@
     }
 
     &__action {
-        padding: 0.25rem 0.75rem;
+        padding: 0.25rem 0.75rem calc(0.25rem + 3px);
     }
 }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -84,6 +84,7 @@
     }
 
     &__action {
+        // stylelint-disable-next-line declaration-property-unit-whitelist
         padding: 0.25rem 0.75rem calc(0.25rem + 3px);
     }
 }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -62,13 +62,24 @@
         }
 
         &__actions {
-            margin-right: 2rem;
+            position: relative;
+            padding-right: 2rem;
+            border-bottom: 3px solid var(--border-color);
+            opacity: 0.6;
+
+            // Complete border if content is pushed onto new line
+            &:after {
+                position: absolute;
+                content: '';
+                top: 100%;
+                left: 100%;
+                width: 100%;
+                border-bottom: inherit;
+            }
         }
 
         &__action {
-            opacity: 0.6;
             padding: 0.25rem 0.75rem;
-            border-bottom: 3px solid var(--border-color);
         }
     }
 }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -15,6 +15,7 @@
 
     display: flex;
     flex-direction: column;
+    position: relative;
 
     background-color: var(--color-bg-1);
     border-top: 1px solid var(--border-color);
@@ -44,17 +45,30 @@
         flex: 1;
         min-height: 0; /* needed for Firefox for content scrolling to work properly; See sourcegraph/sourcegraph#12340 and https://codepen.io/slimsag/pen/mjPXyN */
         &-content {
+            margin-top: 4px;
+            border-top: 1px solid var(--border-color);
+
             flex: 1;
             &--scroll {
                 overflow: auto;
             }
         }
-    }
 
-    &__tabs &__tabs__action {
-        max-width: none;
-        border-bottom: 3px solid var(--border-color);
-        opacity: 0.6;
-        padding: 0.25rem 0.75rem;
+        &__dismiss {
+            position: absolute;
+            right: 0.5rem;
+            top: 4px;
+            border: none;
+        }
+
+        &__actions {
+            margin-right: 2rem;
+        }
+
+        &__action {
+            opacity: 0.6;
+            padding: 0.25rem 0.75rem;
+            border-bottom: 3px solid var(--border-color);
+        }
     }
 }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -41,6 +41,11 @@
         }
     }
 
+    &__tab-bar {
+        flex-wrap: wrap;
+        position: relative;
+    }
+
     &__tabs {
         flex: 1;
         min-height: 0; /* needed for Firefox for content scrolling to work properly; See sourcegraph/sourcegraph#12340 and https://codepen.io/slimsag/pen/mjPXyN */
@@ -59,7 +64,6 @@
         }
 
         &__actions {
-            position: relative;
             padding-right: 2rem;
             border-bottom: 3px solid var(--border-color);
             opacity: 0.6;
@@ -68,9 +72,8 @@
             &:after {
                 position: absolute;
                 content: '';
-                top: 100%;
-                left: 100%;
                 width: 100%;
+                top: calc(100% - 3px);
                 border-bottom: inherit;
             }
         }

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -77,6 +77,10 @@
             top: calc(100% - 3px);
             border-bottom: 3px solid var(--border-color);
         }
+
+        li:first-child .panel__action {
+            padding-left: 0.5rem;
+        }
     }
 
     &__action {

--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -55,31 +55,31 @@
                 overflow: auto;
             }
         }
+    }
 
-        &__dismiss {
+    &__dismiss {
+        position: absolute;
+        right: 0.5rem;
+        top: 4px;
+        border: none;
+    }
+
+    &__actions {
+        padding-right: 2rem;
+        border-bottom: 3px solid var(--border-color);
+        opacity: 0.6;
+
+        // Complete border if content is pushed onto new line
+        &::after {
             position: absolute;
-            right: 0.5rem;
-            top: 4px;
-            border: none;
+            content: '';
+            width: 100%;
+            top: calc(100% - 3px);
+            border-bottom: inherit;
         }
+    }
 
-        &__actions {
-            padding-right: 2rem;
-            border-bottom: 3px solid var(--border-color);
-            opacity: 0.6;
-
-            // Complete border if content is pushed onto new line
-            &:after {
-                position: absolute;
-                content: '';
-                width: 100%;
-                top: calc(100% - 3px);
-                border-bottom: inherit;
-            }
-        }
-
-        &__action {
-            padding: 0.25rem 0.75rem;
-        }
+    &__action {
+        padding: 0.25rem 0.75rem;
     }
 }

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -3,7 +3,6 @@ import CloseIcon from 'mdi-react/CloseIcon'
 import * as React from 'react'
 import { Observable, Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
-import classNames from 'classnames'
 import {
     PanelViewWithComponent,
     PanelViewProviderRegistrationOptions,
@@ -61,11 +60,6 @@ interface PanelItem extends Tab<string> {
      * location provider (even if the result set is empty).
      */
     hasLocations?: boolean
-}
-
-interface PanelActionsProps extends Props {
-    activePanel?: PanelItem
-    className?: string
 }
 
 /**
@@ -149,7 +143,7 @@ class Panel extends React.PureComponent<Props, State> {
                             </>
                         }
                         className="panel__tabs"
-                        tabBarClassName="flex-wrap"
+                        tabBarClassName="panel__tab-bar"
                         tabClassName="tab-bar__tab--h5like"
                         location={this.props.location}
                     >

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -3,6 +3,7 @@ import CloseIcon from 'mdi-react/CloseIcon'
 import * as React from 'react'
 import { Observable, Subscription } from 'rxjs'
 import { map } from 'rxjs/operators'
+import classNames from 'classnames'
 import {
     PanelViewWithComponent,
     PanelViewProviderRegistrationOptions,
@@ -62,6 +63,33 @@ interface PanelItem extends Tab<string> {
     hasLocations?: boolean
 }
 
+interface PanelActionsProps extends Props {
+    activePanel?: PanelItem
+    className?: string
+}
+
+const PanelActions: React.FunctionComponent<PanelActionsProps> = ({ activePanel, className, ...props }) => (
+    <ActionsNavItems
+        {...props}
+        // TODO remove references to Bootstrap from shared, get class name from prop
+        // This is okay for now because the Panel is currently only used in the webapp
+        listClass={classNames('nav', className)}
+        actionItemClass="nav-link panel__tabs__action"
+        actionItemIconClass="icon-inline"
+        menu={ContributableMenu.PanelToolbar}
+        scope={
+            activePanel !== undefined
+                ? {
+                      type: 'panelView',
+                      id: activePanel.id,
+                      hasLocations: Boolean(activePanel.hasLocations),
+                  }
+                : undefined
+        }
+        wrapInList={true}
+    />
+)
+
 /**
  * The panel, which is a tabbed component with contextual information. Components rendering the panel should
  * generally use ResizablePanel, not Panel.
@@ -113,10 +141,15 @@ class Panel extends React.PureComponent<Props, State> {
                         tabBarEndFragment={
                             <>
                                 <Spacer />
+                                <PanelActions
+                                    {...this.props}
+                                    activePanel={activePanelView}
+                                    className="d-none d-md-flex"
+                                />
                                 <button
                                     type="button"
                                     onClick={this.onDismiss}
-                                    className="btn btn-icon tab-bar__end-fragment-other-element"
+                                    className="btn btn-icon tab-bar__end-fragment-other-element pr-2 pl-1"
                                     data-tooltip="Close"
                                 >
                                     <CloseIcon className="icon-inline" />
@@ -124,25 +157,7 @@ class Panel extends React.PureComponent<Props, State> {
                             </>
                         }
                         toolbarFragment={
-                            <ActionsNavItems
-                                {...this.props}
-                                // TODO remove references to Bootstrap from shared, get class name from prop
-                                // This is okay for now because the Panel is currently only used in the webapp
-                                listClass="nav w-100 justify-content-end"
-                                actionItemClass="nav-link"
-                                actionItemIconClass="icon-inline"
-                                menu={ContributableMenu.PanelToolbar}
-                                scope={
-                                    activePanelViewID !== undefined
-                                        ? {
-                                              type: 'panelView',
-                                              id: activePanelViewID,
-                                              hasLocations: Boolean(activePanelView?.hasLocations),
-                                          }
-                                        : undefined
-                                }
-                                wrapInList={true}
-                            />
+                            <PanelActions {...this.props} activePanel={activePanelView} className="d-md-none" />
                         }
                         className="panel__tabs"
                         tabClassName="tab-bar__tab--h5like"

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -117,8 +117,8 @@ class Panel extends React.PureComponent<Props, State> {
                                     {...this.props}
                                     // TODO remove references to Bootstrap from shared, get class name from prop
                                     // This is okay for now because the Panel is currently only used in the webapp
-                                    listClass="nav panel__tabs__actions"
-                                    actionItemClass="nav-link mw-100 panel__tabs__action"
+                                    listClass="nav panel__actions"
+                                    actionItemClass="nav-link mw-100 panel__action"
                                     actionItemIconClass="icon-inline"
                                     menu={ContributableMenu.PanelToolbar}
                                     scope={
@@ -135,7 +135,7 @@ class Panel extends React.PureComponent<Props, State> {
                                 <button
                                     type="button"
                                     onClick={this.onDismiss}
-                                    className="btn btn-icon tab-bar__end-fragment-other-element panel__tabs__dismiss"
+                                    className="btn btn-icon tab-bar__end-fragment-other-element panel__dismiss"
                                     data-tooltip="Close"
                                 >
                                     <CloseIcon className="icon-inline" />

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -68,28 +68,6 @@ interface PanelActionsProps extends Props {
     className?: string
 }
 
-const PanelActions: React.FunctionComponent<PanelActionsProps> = ({ activePanel, className, ...props }) => (
-    <ActionsNavItems
-        {...props}
-        // TODO remove references to Bootstrap from shared, get class name from prop
-        // This is okay for now because the Panel is currently only used in the webapp
-        listClass={classNames('nav', className)}
-        actionItemClass="nav-link panel__tabs__action"
-        actionItemIconClass="icon-inline"
-        menu={ContributableMenu.PanelToolbar}
-        scope={
-            activePanel !== undefined
-                ? {
-                      type: 'panelView',
-                      id: activePanel.id,
-                      hasLocations: Boolean(activePanel.hasLocations),
-                  }
-                : undefined
-        }
-        wrapInList={true}
-    />
-)
-
 /**
  * The panel, which is a tabbed component with contextual information. Components rendering the panel should
  * generally use ResizablePanel, not Panel.
@@ -141,25 +119,37 @@ class Panel extends React.PureComponent<Props, State> {
                         tabBarEndFragment={
                             <>
                                 <Spacer />
-                                <PanelActions
+                                <ActionsNavItems
                                     {...this.props}
-                                    activePanel={activePanelView}
-                                    className="d-none d-md-flex"
+                                    // TODO remove references to Bootstrap from shared, get class name from prop
+                                    // This is okay for now because the Panel is currently only used in the webapp
+                                    listClass="nav panel__tabs__actions"
+                                    actionItemClass="nav-link mw-100 panel__tabs__action"
+                                    actionItemIconClass="icon-inline"
+                                    menu={ContributableMenu.PanelToolbar}
+                                    scope={
+                                        activePanelView !== undefined
+                                            ? {
+                                                  type: 'panelView',
+                                                  id: activePanelView.id,
+                                                  hasLocations: Boolean(activePanelView.hasLocations),
+                                              }
+                                            : undefined
+                                    }
+                                    wrapInList={true}
                                 />
                                 <button
                                     type="button"
                                     onClick={this.onDismiss}
-                                    className="btn btn-icon tab-bar__end-fragment-other-element pr-2 pl-1"
+                                    className="btn btn-icon tab-bar__end-fragment-other-element panel__tabs__dismiss"
                                     data-tooltip="Close"
                                 >
                                     <CloseIcon className="icon-inline" />
                                 </button>
                             </>
                         }
-                        toolbarFragment={
-                            <PanelActions {...this.props} activePanel={activePanelView} className="d-md-none" />
-                        }
                         className="panel__tabs"
+                        tabBarClassName="flex-wrap"
                         tabClassName="tab-bar__tab--h5like"
                         location={this.props.location}
                     >


### PR DESCRIPTION
<!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
## Overview
This PR moves the reference action items to the top bar, and removes their min width.

Note: There is some tricky styles to implement here. The design indicates that we want these action items (e.g. `Group by file`) to break onto a new line responsively. I didn't want to implement this using just a media query, because the length and amount of these items are unknown (populated by extensions). Now we just use `flex-wrap` to ensure content is pushed onto a new line, and we use a psuedo element to modify the `border-bottom` of the reference items to always fill the full width of the tab bar.

<!-- Insert before and after screenshot(s) that makes it easy to identify the changes made -->
## Screenshots desktop
| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/9516420/108703574-b57a2f00-7502-11eb-974a-30f9dee439a2.png) | ![image](https://user-images.githubusercontent.com/9516420/108703607-c034c400-7502-11eb-9a28-6f27e490c927.png)

## Screenshots mobile
| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/9516420/108703685-dc386580-7502-11eb-8baa-f4a4ca8227e1.png) | ![image](https://user-images.githubusercontent.com/9516420/108703712-e5293700-7502-11eb-95cf-abdabff6b38b.png)


<!-- Update the implementation steps that should be completed to implement the feature/bug fix/tech debt cleanup -->
## Progress
- [X] Documentation text/screenshots updated (if relevant)
- [x] Approved by a frontend engineer (if touching frontend code)
- [ ] Approved by a designer (if it touches the UI)

<!-- Add a reference to the issue that this PR addresses if relevant -->
Closes https://github.com/sourcegraph/sourcegraph/issues/9740
