### PR TITLE
graphql: Instrument field count and depth

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -93,7 +93,7 @@ func (h honeycombTracer) TraceQuery(ctx context.Context, queryString string, ope
 		ev.AddField("requestName", sgtrace.GraphQLRequestName(ctx))
 		ev.AddField("requestSource", sgtrace.RequestSource(ctx))
 
-		cost, err := estimateQueryCost(queryString)
+		cost, err := estimateQueryCost(queryString, variables)
 		if err != nil {
 			log15.Warn("estimating GraphQL cost", "error", err)
 			ev.AddField("hasCostError", true)

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -100,7 +100,8 @@ func (h honeycombTracer) TraceQuery(ctx context.Context, queryString string, ope
 			ev.AddField("costError", err.Error())
 		} else {
 			ev.AddField("hasCostError", false)
-			ev.AddField("cost", cost)
+			ev.AddField("cost", cost.FieldCount)
+			ev.AddField("depth", cost.MaxDepth)
 			ev.AddField("costVersion", costEstimateVersion)
 		}
 

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -24,6 +24,10 @@ type queryCost struct {
 // executed. It is a worst cast estimate of the number of fields expected to be
 // returned by the query and handles nested queries a well as fragments.
 func estimateQueryCost(query string, variables map[string]interface{}) (totalCost *queryCost, err error) {
+	// NOTE: When we encounter errors in our visit funcs we return
+	// visitor.ActionBreak to stop walking the tree and set the top level err
+	// variable so that it is returned
+
 	// TODO: Remove this. It's here as a safeguard until we've run over a large
 	// number of real world queries.
 	defer func() {
@@ -93,7 +97,11 @@ func estimateQueryCost(query string, variables map[string]interface{}) (totalCos
 }
 
 func calcOperationCost(def ast.Node, fragmentCosts map[string]int, variables map[string]interface{}) (*queryCost, error) {
+	// NOTE: When we encounter errors in our visit funcs we return
+	// visitor.ActionBreak to stop walking the tree and set the top level err
+	// variable so that it is returned
 	var err error
+
 	if fragmentCosts == nil {
 		fragmentCosts = make(map[string]int)
 	}

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -135,8 +135,8 @@ func calcOperationCost(def ast.Node, fragmentCosts map[string]int, variables map
 				}
 				pushLimit()
 			case *ast.Field:
-				// Ignore the "nodes" field as it does not appear in the result
 				if node.Name.Value == "nodes" {
+					// Ignore the "nodes" field as it does not appear in the result
 					return visitor.ActionNoChange, nil
 				}
 				if inlineFragmentDepth > 0 {

--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -1,127 +1,18 @@
 package graphqlbackend
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
 
 func TestEstimateQueryCost(t *testing.T) {
 	for _, tc := range []struct {
-		name  string
-		query string
-		want  int
+		name      string
+		query     string
+		variables map[string]interface{}
+		want      queryCost
 	}{
-		{
-			name: "Canonical example",
-			query: `query {
-  viewer {
-    login
-    repositories(first: 100) {
-      edges {
-        node {
-          id
-          issues(first: 50) {
-            edges {
-              node {
-                id
-                labels(first: 60) {
-                  edges {
-                    node {
-                      id
-                      name
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}`,
-			want: 51,
-		},
-		{
-			name: "simple query",
-			query: `
-query {
-  viewer {
-    repositories(first: 50) {
-      edges {
-        repository:node {
-          name
-          issues(first: 10) {
-            totalCount
-            edges {
-              node {
-                title
-                bodyHTML
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-`,
-			want: 1,
-		},
-		{
-			name: "complex query",
-			query: `query {
-  viewer {
-    repositories(first: 50) {
-      edges {
-        repository:node {
-          name
-
-          pullRequests(first: 20) {
-            edges {
-              pullRequest:node {
-                title
-
-                comments(first: 10) {
-                  edges {
-                    comment:node {
-                      bodyHTML
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          issues(first: 20) {
-            totalCount
-            edges {
-              issue:node {
-                title
-                bodyHTML
-
-                comments(first: 10) {
-                  edges {
-                    comment:node {
-                      bodyHTML
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-
-    followers(first: 10) {
-      edges {
-        follower:node {
-          login
-        }
-      }
-    }
-  }
-}`,
-			want: 21,
-		},
 		{
 			name: "Multiple top level queries",
 			query: `query {
@@ -131,16 +22,129 @@ query{
   thing
 }
 `,
-			want: 1,
+			want: queryCost{
+				FieldCount: 2,
+				MaxDepth:   1,
+			},
+		},
+		{
+			name: "Simple query, no variables",
+			query: `
+query SiteProductVersion {
+                site {
+                    productVersion
+                    buildVersion
+                    hasCodeIntelligence
+                }
+            }
+`,
+			want: queryCost{
+				FieldCount: 4,
+				MaxDepth:   2,
+			},
+		},
+		{
+			name: "nodes field should not be counted",
+			query: `
+query{
+  externalServices(first: 10){
+    nodes{
+      displayName
+      webhookURL
+    }
+  }
+}
+`,
+			want: queryCost{
+				FieldCount: 21,
+				MaxDepth:   3,
+			},
+		},
+		{
+			name: "Query with variables",
+			query: `
+query Extensions($first: Int!, $prioritizeExtensionIDs: [String!]!) {
+                    extensionRegistry {
+                        extensions(first: $first, prioritizeExtensionIDs: $prioritizeExtensionIDs) {
+                            nodes {
+                                id
+                                extensionID
+                                url
+                                manifest {
+                                    raw
+                                }
+                                viewerCanAdminister
+                            }
+                        }
+                    }
+                }
+`,
+			variables: map[string]interface{}{
+				"first": 10,
+			},
+			want: queryCost{
+				FieldCount: 62,
+				MaxDepth:   5,
+			},
+		},
+		{
+			name: "Query with default variables",
+			query: `
+query fetchExternalServices($first: Int = 10){
+  externalServices(first: $first){
+    nodes{
+      displayName
+      webhookURL
+    }
+  }
+}
+`,
+			variables: map[string]interface{}{
+				"first": 5,
+			},
+			want: queryCost{
+				FieldCount: 11,
+				MaxDepth:   3,
+			},
+		},
+		{
+			name: "Query with fragments",
+			query: `
+query StatusMessages {
+	 statusMessages {
+		 ...StatusMessageFields
+	 }
+ }
+ fragment StatusMessageFields on StatusMessage {
+	 __typename
+	 ... on CloningProgress {
+		 message
+	 }
+	 ... on SyncError {
+		 message
+	 }
+	 ... on ExternalServiceSyncError {
+		 message
+		 externalService {
+			 id
+			 displayName
+		 }
+	 }
+ }
+`,
+			want: queryCost{
+				FieldCount: 0,
+				MaxDepth:   0,
+			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			have, err := estimateQueryCost(tc.query)
+			have, err := estimateQueryCost(tc.query, tc.variables)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if have != tc.want {
-				t.Fatalf("have %d, want %d", have, tc.want)
+			if diff := cmp.Diff(tc.want, *have); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -133,8 +133,8 @@ query StatusMessages {
  }
 `,
 			want: queryCost{
-				FieldCount: 0,
-				MaxDepth:   0,
+				FieldCount: 5,
+				MaxDepth:   2,
 			},
 		},
 	} {


### PR DESCRIPTION
This is v2 of our cost estimator, it's still a WIP and the idea is to deploy this in production
so that we can get a sample of real world costs using this algorithm in Honeycomb.

This version tries to count the worst case number of fields returned by a query and treats all
fields as having a cost of 1. 

Additionally, it finds `first` and `last` parameters and uses them to multiply cost. For example, in the
following query we always assume that 10 `externalServices` nodes will be returned and we therefore expect
10 occurences of `displayName` and `webhookURL` in the result:

```graphql
query{
  externalServices(first: 10){
    nodes{
      displayName
      webhookURL
    }
  }
  somethingElse
}
```

When the estimator encounters inline fragments it evaluates the cost of each and pick the most
expensive as we want the worst case.
