### PR TITLE
search: remove event loop in zoektSearch

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -355,7 +355,9 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 					fileLimitHit = true
 					limitHit = true
 				}
+				mu.Lock()
 				repo, inputRevs, ok := getRepoInputRev(&file)
+				mu.Unlock()
 				if !ok {
 					continue
 				}


### PR DESCRIPTION
This moves the event loop inside the `ZoektStreamFunc`. We use a channel
to synchronize repository resolution and event processing.

Co-authored-by: Keegan Carruthers-Smith <keegan.csmith@gmail.com>

master-dry-run: https://buildkite.com/sourcegraph/sourcegraph/builds/87660

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
