### PR TITLE
Refactor out uses of innerRepo

### DIFF
--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -12,7 +12,7 @@ func (r *GitTreeEntryResolver) Blame(ctx context.Context,
 		StartLine int32
 		EndLine   int32
 	}) ([]*hunkResolver, error) {
-	hunks, err := git.BlameFile(ctx, r.commit.repoResolver.innerRepo.Name, r.Path(), &git.BlameOptions{
+	hunks, err := git.BlameFile(ctx, r.commit.repoResolver.name, r.Path(), &git.BlameOptions{
 		NewestCommit: api.CommitID(r.commit.OID()),
 		StartLine:    int(args.StartLine),
 		EndLine:      int(args.EndLine),

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -54,7 +54,7 @@ func toGitCommitResolver(repo *RepositoryResolver, id api.CommitID, commit *git.
 	return &GitCommitResolver{
 		repoResolver:    repo,
 		includeUserInfo: true,
-		gitRepo:         repo.innerRepo.Name,
+		gitRepo:         repo.name,
 		oid:             GitObjectID(id),
 		commit:          commit,
 	}

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -48,7 +48,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*git.Commi
 		if r.after != nil {
 			after = *r.after
 		}
-		return git.Commits(ctx, r.repo.innerRepo.Name, git.CommitsOptions{
+		return git.Commits(ctx, r.repo.name, git.CommitsOptions{
 			Range:        r.revisionRange,
 			N:            uint(n),
 			MessageQuery: query,

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -76,7 +76,7 @@ type gitObjectResolver struct {
 
 func (o *gitObjectResolver) resolve(ctx context.Context) (GitObjectID, gitObjectType, error) {
 	o.once.Do(func() {
-		oid, objectType, err := git.GetObject(ctx, o.repo.innerRepo.Name, o.revspec)
+		oid, objectType, err := git.GetObject(ctx, o.repo.name, o.revspec)
 		if err != nil {
 			o.err = err
 			return

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -16,7 +16,7 @@ type gitRevSpecExpr struct {
 func (r *gitRevSpecExpr) Expr() string { return r.expr }
 
 func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
-	oid, err := git.ResolveRevision(ctx, r.repo.innerRepo.Name, r.expr, git.ResolveRevisionOptions{})
+	oid, err := git.ResolveRevision(ctx, r.repo.name, r.expr, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -40,7 +40,7 @@ func (r *GitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConn
 func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi os.FileInfo) bool) ([]*GitTreeEntryResolver, error) {
 	entries, err := git.ReadDir(
 		ctx,
-		r.commit.repoResolver.innerRepo.Name,
+		r.commit.repoResolver.name,
 		api.CommitID(r.commit.OID()),
 		r.Path(),
 		r.isRecursive || args.Recursive,

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -75,7 +75,7 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 
 		r.content, r.contentErr = git.ReadFile(
 			ctx,
-			r.commit.repoResolver.innerRepo.Name,
+			r.commit.repoResolver.name,
 			api.CommitID(r.commit.OID()),
 			r.Path(),
 			0,
@@ -107,7 +107,7 @@ func (r *GitTreeEntryResolver) Highlight(ctx context.Context, args *HighlightArg
 		return nil, err
 	}
 	return highlightContent(ctx, args, content, r.Path(), highlight.Metadata{
-		RepoName: string(r.commit.repoResolver.Name()),
+		RepoName: r.commit.repoResolver.Name(),
 		Revision: string(r.commit.oid),
 	})
 }
@@ -209,7 +209,7 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	}
 	entries, err := git.ReadDir(
 		ctx,
-		r.commit.repoResolver.innerRepo.Name,
+		r.commit.repoResolver.name,
 		api.CommitID(r.commit.OID()),
 		path.Dir(r.Path()),
 		false,

--- a/cmd/frontend/graphqlbackend/git_tree_entry_test.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry_test.go
@@ -16,9 +16,7 @@ import (
 func TestGitTreeEntry_RawZipArchiveURL(t *testing.T) {
 	got := (&GitTreeEntryResolver{
 		commit: &GitCommitResolver{
-			repoResolver: &RepositoryResolver{
-				innerRepo: &types.Repo{Name: "my/repo"},
-			},
+			repoResolver: NewRepositoryResolver(&types.Repo{Name: "my/repo"}),
 		},
 		stat: CreateFileInfo("a/b", true),
 	}).RawZipArchiveURL()
@@ -51,9 +49,7 @@ func TestGitTreeEntry_Content(t *testing.T) {
 
 	gitTree := &GitTreeEntryResolver{
 		commit: &GitCommitResolver{
-			repoResolver: &RepositoryResolver{
-				innerRepo: &types.Repo{Name: "my/repo"},
-			},
+			repoResolver: NewRepositoryResolver(&types.Repo{Name: "my/repo"}),
 		},
 		stat: CreateFileInfo(wantPath, true),
 	}

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -802,7 +802,7 @@ func (r *schemaResolver) RepositoryRedirect(ctx context.Context, args *struct {
 		}
 		return nil, err
 	}
-	return &repositoryRedirect{repo: &RepositoryResolver{innerRepo: repo}}, nil
+	return &repositoryRedirect{repo: NewRepositoryResolver(repo)}, nil
 }
 
 func (r *schemaResolver) PhabricatorRepo(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -199,7 +199,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 			break
 		}
 
-		resolvers = append(resolvers, &RepositoryResolver{innerRepo: repo})
+		resolvers = append(resolvers, NewRepositoryResolver(repo))
 	}
 	return resolvers, nil
 }
@@ -297,7 +297,7 @@ func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct 
 
 	// Trigger update when enabling.
 	if args.Enabled {
-		if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.innerRepo.Name); err != nil {
+		if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.name); err != nil {
 			return nil, err
 		}
 	}
@@ -320,7 +320,7 @@ func toRepositoryResolvers(repos []*types.RepoName) []*RepositoryResolver {
 
 	resolvers := make([]*RepositoryResolver, len(repos))
 	for i := range repos {
-		resolvers[i] = &RepositoryResolver{innerRepo: repos[i].ToRepo()}
+		resolvers[i] = NewRepositoryResolver(repos[i].ToRepo())
 	}
 
 	return resolvers

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -33,6 +33,14 @@ type RepositoryResolver struct {
 	hydration sync.Once
 	err       error
 
+	// Invariant: name and id are always set and safe to use.
+	// They are used to hydrate the inner repo, and should always
+	// be the same as the name and id of the inner repo, but referring
+	// to the inner repo directly is unsafe because it may cause a race
+	// during hydration.
+	name api.RepoName
+	id   api.RepoID
+
 	// innerRepo may only contain ID and Name information.
 	// To access any other repo information, use repo() instead.
 	innerRepo *types.Repo
@@ -47,7 +55,11 @@ type RepositoryResolver struct {
 }
 
 func NewRepositoryResolver(repo *types.Repo) *RepositoryResolver {
-	return &RepositoryResolver{innerRepo: repo}
+	return &RepositoryResolver{
+		innerRepo: repo,
+		name:      repo.Name,
+		id:        repo.ID,
+	}
 }
 
 var RepositoryByID = repositoryByID
@@ -61,7 +73,7 @@ func repositoryByID(ctx context.Context, id graphql.ID) (*RepositoryResolver, er
 	if err != nil {
 		return nil, err
 	}
-	return &RepositoryResolver{innerRepo: repo}, nil
+	return NewRepositoryResolver(repo), nil
 }
 
 func RepositoryByIDInt32(ctx context.Context, repoID api.RepoID) (*RepositoryResolver, error) {
@@ -69,7 +81,7 @@ func RepositoryByIDInt32(ctx context.Context, repoID api.RepoID) (*RepositoryRes
 	if err != nil {
 		return nil, err
 	}
-	return &RepositoryResolver{innerRepo: repo}, nil
+	return NewRepositoryResolver(repo), nil
 }
 
 func (r *RepositoryResolver) ID() graphql.ID {
@@ -77,7 +89,7 @@ func (r *RepositoryResolver) ID() graphql.ID {
 }
 
 func (r *RepositoryResolver) IDInt32() api.RepoID {
-	return r.innerRepo.ID
+	return r.id
 }
 
 func MarshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }
@@ -101,8 +113,8 @@ func (r *RepositoryResolver) repo(ctx context.Context) (*types.Repo, error) {
 	return r.innerRepo, err
 }
 
-func (r *RepositoryResolver) Name() string {
-	return string(r.innerRepo.Name)
+func (r *RepositoryResolver) Name() api.RepoName {
+	return r.name
 }
 
 func (r *RepositoryResolver) ExternalRepo(ctx context.Context) (*api.ExternalRepoSpec, error) {
@@ -183,12 +195,12 @@ func (r *RepositoryResolver) CommitFromID(ctx context.Context, args *RepositoryC
 
 func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver, error) {
 	do := func() (*GitRefResolver, error) {
-		refBytes, _, exitCode, err := git.ExecSafe(ctx, r.innerRepo.Name, []string{"symbolic-ref", "HEAD"})
+		refBytes, _, exitCode, err := git.ExecSafe(ctx, r.Name(), []string{"symbolic-ref", "HEAD"})
 		refName := string(bytes.TrimSpace(refBytes))
 
 		if err == nil && exitCode == 0 {
 			// Check that our repo is not empty
-			_, err = git.ResolveRevision(ctx, r.innerRepo.Name, "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
+			_, err = git.ResolveRevision(ctx, r.Name(), "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
 		}
 
 		// If we fail to get the default branch due to cloning or being empty, we return nothing.
@@ -248,7 +260,7 @@ func (r *RepositoryResolver) UpdatedAt() *DateTime {
 }
 
 func (r *RepositoryResolver) URL() string {
-	url := "/" + escapePathForURL(r.Name())
+	url := "/" + escapePathForURL(string(r.Name()))
 	if r.rev != "" {
 		url += "@" + escapePathForURL(r.rev)
 	}
@@ -274,9 +286,9 @@ func (r *RepositoryResolver) Rev() string {
 func (r *RepositoryResolver) Label() (Markdown, error) {
 	var label string
 	if r.rev != "" {
-		label = r.Name() + "@" + r.rev
+		label = string(r.Name()) + "@" + r.rev
 	} else {
-		label = r.Name()
+		label = string(r.Name())
 	}
 	text := "[" + label + "](/" + label + ")"
 	return Markdown(text), nil
@@ -413,7 +425,7 @@ func (*schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struct 
 		if err != nil {
 			return nil, err
 		}
-		r := &RepositoryResolver{innerRepo: repo}
+		r := NewRepositoryResolver(repo)
 		return r.Commit(ctx, &RepositoryCommitArgs{Rev: targetRef})
 	}
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -57,7 +57,7 @@ type RepositoryResolver struct {
 func NewRepositoryResolver(repo *types.Repo) *RepositoryResolver {
 	// Protect against a nil repo
 	var name api.RepoName
-	var id  api.RepoID
+	var id api.RepoID
 	if repo != nil {
 		name = repo.Name
 		id = repo.ID

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -113,8 +113,8 @@ func (r *RepositoryResolver) repo(ctx context.Context) (*types.Repo, error) {
 	return r.innerRepo, err
 }
 
-func (r *RepositoryResolver) Name() api.RepoName {
-	return r.name
+func (r *RepositoryResolver) Name() string {
+	return string(r.name)
 }
 
 func (r *RepositoryResolver) ExternalRepo(ctx context.Context) (*api.ExternalRepoSpec, error) {
@@ -195,12 +195,12 @@ func (r *RepositoryResolver) CommitFromID(ctx context.Context, args *RepositoryC
 
 func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver, error) {
 	do := func() (*GitRefResolver, error) {
-		refBytes, _, exitCode, err := git.ExecSafe(ctx, r.Name(), []string{"symbolic-ref", "HEAD"})
+		refBytes, _, exitCode, err := git.ExecSafe(ctx, r.name, []string{"symbolic-ref", "HEAD"})
 		refName := string(bytes.TrimSpace(refBytes))
 
 		if err == nil && exitCode == 0 {
 			// Check that our repo is not empty
-			_, err = git.ResolveRevision(ctx, r.Name(), "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
+			_, err = git.ResolveRevision(ctx, r.name, "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
 		}
 
 		// If we fail to get the default branch due to cloning or being empty, we return nothing.
@@ -260,7 +260,7 @@ func (r *RepositoryResolver) UpdatedAt() *DateTime {
 }
 
 func (r *RepositoryResolver) URL() string {
-	url := "/" + escapePathForURL(string(r.Name()))
+	url := "/" + escapePathForURL(r.Name())
 	if r.rev != "" {
 		url += "@" + escapePathForURL(r.rev)
 	}
@@ -286,9 +286,9 @@ func (r *RepositoryResolver) Rev() string {
 func (r *RepositoryResolver) Label() (Markdown, error) {
 	var label string
 	if r.rev != "" {
-		label = string(r.Name()) + "@" + r.rev
+		label = r.Name() + "@" + r.rev
 	} else {
-		label = string(r.Name())
+		label = r.Name()
 	}
 	text := "[" + label + "](/" + label + ")"
 	return Markdown(text), nil

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -55,10 +55,18 @@ type RepositoryResolver struct {
 }
 
 func NewRepositoryResolver(repo *types.Repo) *RepositoryResolver {
+	// Protect against a nil repo
+	var name api.RepoName
+	var id  api.RepoID
+	if repo != nil {
+		name = repo.Name
+		id = repo.ID
+	}
+
 	return &RepositoryResolver{
 		innerRepo: repo,
-		name:      repo.Name,
-		id:        repo.ID,
+		name:      name,
+		id:        id,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -88,14 +88,14 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 		return toGitCommitResolver(r, commitID, nil), nil
 	}
 
-	head, err := getCommit(ctx, r.Name(), headRevspec)
+	head, err := getCommit(ctx, r.name, headRevspec)
 	if err != nil {
 		return nil, err
 	}
 
 	// Find the common merge-base for the diff. That's the revision the diff applies to,
 	// not the baseRevspec.
-	mergeBaseCommit, err := git.MergeBase(ctx, r.Name(), api.CommitID(baseRevspec), api.CommitID(headRevspec))
+	mergeBaseCommit, err := git.MergeBase(ctx, r.name, api.CommitID(baseRevspec), api.CommitID(headRevspec))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 	// We use the merge-base as the base commit here, as the diff will only be guaranteed to be
 	// applicable to the file from that revision.
 	commitString := strings.TrimSpace(string(mergeBaseCommit))
-	base, err := getCommit(ctx, r.Name(), commitString)
+	base, err := getCommit(ctx, r.name, commitString)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 
 			var iter *git.DiffFileIterator
 			iter, err = git.Diff(ctx, git.DiffOptions{
-				Repo: cmp.repo.Name(),
+				Repo: cmp.repo.name,
 				Base: base,
 				Head: string(cmp.head.OID()),
 			})

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -88,14 +88,14 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 		return toGitCommitResolver(r, commitID, nil), nil
 	}
 
-	head, err := getCommit(ctx, r.innerRepo.Name, headRevspec)
+	head, err := getCommit(ctx, r.Name(), headRevspec)
 	if err != nil {
 		return nil, err
 	}
 
 	// Find the common merge-base for the diff. That's the revision the diff applies to,
 	// not the baseRevspec.
-	mergeBaseCommit, err := git.MergeBase(ctx, r.innerRepo.Name, api.CommitID(baseRevspec), api.CommitID(headRevspec))
+	mergeBaseCommit, err := git.MergeBase(ctx, r.Name(), api.CommitID(baseRevspec), api.CommitID(headRevspec))
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +103,7 @@ func NewRepositoryComparison(ctx context.Context, r *RepositoryResolver, args *R
 	// We use the merge-base as the base commit here, as the diff will only be guaranteed to be
 	// applicable to the file from that revision.
 	commitString := strings.TrimSpace(string(mergeBaseCommit))
-	base, err := getCommit(ctx, r.innerRepo.Name, commitString)
+	base, err := getCommit(ctx, r.Name(), commitString)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 
 			var iter *git.DiffFileIterator
 			iter, err = git.Diff(ctx, git.DiffOptions{
-				Repo: cmp.repo.innerRepo.Name,
+				Repo: cmp.repo.Name(),
 				Base: base,
 				Head: string(cmp.head.OID()),
 			})

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -49,7 +49,7 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.After != nil {
 			opt.After = *r.args.After
 		}
-		r.results, r.err = git.ShortLog(ctx, r.repo.innerRepo.Name, opt)
+		r.results, r.err = git.ShortLog(ctx, r.repo.name, opt)
 	})
 	return r.results, r.err
 }

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -35,7 +35,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var branches []*git.Branch
 	if args.Type == nil || *args.Type == gitRefTypeBranch {
 		var err error
-		branches, err = git.ListBranches(ctx, r.Name(), git.BranchesOptions{
+		branches, err = git.ListBranches(ctx, r.name, git.BranchesOptions{
 			// We intentionally do not ask for commits here since it requires
 			// a separate git call per branch. We only need the git commits to
 			// sort by author/commit date and there are few enough branches to
@@ -63,7 +63,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 		if args.OrderBy != nil && *args.OrderBy == gitRefOrderAuthoredOrCommittedAt {
 			// Sort branches by most recently committed.
 
-			ok, err := hydrateBranchCommits(ctx, r.Name(), args.Interactive, branches)
+			ok, err := hydrateBranchCommits(ctx, r.name, args.Interactive, branches)
 			if err != nil {
 				return nil, err
 			}
@@ -102,7 +102,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var tags []*git.Tag
 	if args.Type == nil || *args.Type == gitRefTypeTag {
 		var err error
-		tags, err = git.ListTags(ctx, r.Name())
+		tags, err = git.ListTags(ctx, r.name)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -35,7 +35,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var branches []*git.Branch
 	if args.Type == nil || *args.Type == gitRefTypeBranch {
 		var err error
-		branches, err = git.ListBranches(ctx, r.innerRepo.Name, git.BranchesOptions{
+		branches, err = git.ListBranches(ctx, r.Name(), git.BranchesOptions{
 			// We intentionally do not ask for commits here since it requires
 			// a separate git call per branch. We only need the git commits to
 			// sort by author/commit date and there are few enough branches to
@@ -63,7 +63,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 		if args.OrderBy != nil && *args.OrderBy == gitRefOrderAuthoredOrCommittedAt {
 			// Sort branches by most recently committed.
 
-			ok, err := hydrateBranchCommits(ctx, r.innerRepo.Name, args.Interactive, branches)
+			ok, err := hydrateBranchCommits(ctx, r.Name(), args.Interactive, branches)
 			if err != nil {
 				return nil, err
 			}
@@ -102,7 +102,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var tags []*git.Tag
 	if args.Type == nil || *args.Type == gitRefTypeTag {
 		var err error
-		tags, err = git.ListTags(ctx, r.innerRepo.Name)
+		tags, err = git.ListTags(ctx, r.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -39,8 +39,8 @@ type repositoryMirrorInfoResolver struct {
 
 func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfo, error) {
 	r.repoInfoOnce.Do(func() {
-		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.Name())
-		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.Name()], err
+		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.name)
+		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.name], err
 	})
 	return r.repoInfoResponse, r.repoInfoErr
 }
@@ -48,7 +48,7 @@ func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*
 func (r *repositoryMirrorInfoResolver) repoUpdateSchedulerInfo(ctx context.Context) (*repoupdaterprotocol.RepoUpdateSchedulerInfoResult, error) {
 	r.repoUpdateSchedulerInfoOnce.Do(func() {
 		args := repoupdaterprotocol.RepoUpdateSchedulerInfoArgs{
-			RepoName: r.repository.innerRepo.Name,
+			RepoName: r.repository.name,
 			ID:       r.repository.IDInt32(),
 		}
 		r.repoUpdateSchedulerInfoResult, r.repoUpdateSchedulerInfoErr = repoupdater.DefaultClient.RepoUpdateSchedulerInfo(ctx, args)
@@ -92,7 +92,7 @@ func (r *repositoryMirrorInfoResolver) RemoteURL(ctx context.Context) (string, e
 	{
 		// Look up the remote URL in repo-updater.
 		result, err := repoupdater.DefaultClient.RepoLookup(ctx, repoupdaterprotocol.RepoLookupArgs{
-			Repo: r.repository.innerRepo.Name,
+			Repo: r.repository.name,
 		})
 		if err != nil {
 			return "", err
@@ -261,7 +261,7 @@ func (r *schemaResolver) UpdateMirrorRepository(ctx context.Context, args *struc
 		return nil, err
 	}
 
-	if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.innerRepo.Name); err != nil {
+	if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.name); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -39,8 +39,8 @@ type repositoryMirrorInfoResolver struct {
 
 func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfo, error) {
 	r.repoInfoOnce.Do(func() {
-		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.innerRepo.Name)
-		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.innerRepo.Name], err
+		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.Name())
+		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.Name()], err
 	})
 	return r.repoInfoResponse, r.repoInfoErr
 }

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -86,7 +86,7 @@ func TestRepositoryHydration(t *testing.T) {
 		}
 		defer func() { database.Mocks = database.MockStores{} }()
 
-		repoResolver := &RepositoryResolver{innerRepo: minimalRepo}
+		repoResolver := NewRepositoryResolver(minimalRepo)
 		assertRepoResolverHydrated(ctx, t, repoResolver, hydratedRepo)
 	})
 
@@ -100,7 +100,7 @@ func TestRepositoryHydration(t *testing.T) {
 		}
 		defer func() { database.Mocks = database.MockStores{} }()
 
-		repoResolver := &RepositoryResolver{innerRepo: minimalRepo}
+		repoResolver := NewRepositoryResolver(minimalRepo)
 		_, err := repoResolver.Description(ctx)
 		if err == nil {
 			t.Fatal("err is unexpected nil")

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -37,13 +37,13 @@ type repoLister interface {
 
 func (r *repositoryTextSearchIndexResolver) resolve(ctx context.Context) (*zoekt.RepoListEntry, error) {
 	r.once.Do(func() {
-		repoList, err := r.client.List(ctx, zoektquery.NewRepoSet(string(r.repo.innerRepo.Name)))
+		repoList, err := r.client.List(ctx, zoektquery.NewRepoSet(r.repo.Name()))
 		if err != nil {
 			r.err = err
 			return
 		}
 		if len(repoList.Repos) > 1 {
-			r.err = fmt.Errorf("more than 1 indexed repo found for %q", r.repo.innerRepo.Name)
+			r.err = fmt.Errorf("more than 1 indexed repo found for %q", r.repo.Name())
 			return
 		}
 		if len(repoList.Repos) == 1 {
@@ -122,7 +122,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 	refByName := func(name string) *repositoryTextSearchIndexedRef {
 		possibleRefNames := []string{"refs/heads/" + name, "refs/tags/" + name}
 		for _, ref := range possibleRefNames {
-			if _, err := git.ResolveRevision(ctx, r.repo.innerRepo.Name, ref, git.ResolveRevisionOptions{NoEnsureRevision: true}); err == nil {
+			if _, err := git.ResolveRevision(ctx, r.repo.name, ref, git.ResolveRevisionOptions{NoEnsureRevision: true}); err == nil {
 				name = ref
 				break
 			}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -575,7 +575,7 @@ func (r *searchSuggestionResolver) ToLanguage() (*languageResolver, bool) {
 func newSearchSuggestionResolver(result interface{}, score int) *searchSuggestionResolver {
 	switch r := result.(type) {
 	case *RepositoryResolver:
-		return &searchSuggestionResolver{result: r, score: score, length: len(r.innerRepo.Name), label: r.Name()}
+		return &searchSuggestionResolver{result: r, score: score, length: len(r.Name()), label: string(r.Name())}
 
 	case *GitTreeEntryResolver:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.Path()), label: r.Path()}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -575,7 +575,7 @@ func (r *searchSuggestionResolver) ToLanguage() (*languageResolver, bool) {
 func newSearchSuggestionResolver(result interface{}, score int) *searchSuggestionResolver {
 	switch r := result.(type) {
 	case *RepositoryResolver:
-		return &searchSuggestionResolver{result: r, score: score, length: len(r.Name()), label: string(r.Name())}
+		return &searchSuggestionResolver{result: r, score: score, length: len(r.Name()), label: r.Name()}
 
 	case *GitTreeEntryResolver:
 		return &searchSuggestionResolver{result: r, score: score, length: len(r.Path()), label: r.Path()}

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -452,7 +452,7 @@ func cleanDiffPreview(highlights []*highlightedRange, rawDiffResult string) (str
 func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *GitCommitResolver) (string, error) {
 	message := commitSubject(rawResult.Commit.Message)
 	author := rawResult.Commit.Author.Name
-	repoName := displayRepoName(string(commitResolver.Repository().Name()))
+	repoName := displayRepoName(commitResolver.Repository().Name())
 	repoURL := commitResolver.Repository().URL()
 	url, err := commitResolver.URL()
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -287,7 +287,7 @@ func doSearchCommitsInRepoStream(ctx context.Context, op search.CommitParameters
 		}
 	}()
 
-	repoResolver := &RepositoryResolver{innerRepo: op.RepoRevs.Repo.ToRepo()}
+	repoResolver := NewRepositoryResolver(op.RepoRevs.Repo.ToRepo())
 	for event := range events {
 		// if the result is incomplete, git log timed out and the client
 		// should be notified of that.
@@ -452,7 +452,7 @@ func cleanDiffPreview(highlights []*highlightedRange, rawDiffResult string) (str
 func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *GitCommitResolver) (string, error) {
 	message := commitSubject(rawResult.Commit.Message)
 	author := rawResult.Commit.Author.Name
-	repoName := displayRepoName(commitResolver.Repository().Name())
+	repoName := displayRepoName(string(commitResolver.Repository().Name()))
 	repoURL := commitResolver.Repository().URL()
 	url, err := commitResolver.URL()
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -65,7 +65,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	}
 
 	wantCommit := toGitCommitResolver(
-		&RepositoryResolver{innerRepo: &types.Repo{ID: 1, Name: "repo"}},
+		NewRepositoryResolver(&types.Repo{ID: 1, Name: "repo"}),
 		"c1",
 		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
 	)

--- a/cmd/frontend/graphqlbackend/search_filters.go
+++ b/cmd/frontend/graphqlbackend/search_filters.go
@@ -98,7 +98,7 @@ func (s *SearchFilters) Update(event SearchEvent) {
 	}
 
 	addRepoFilter := func(repo *RepositoryResolver, rev string, lineMatchCount int32) {
-		uri := string(repo.Name())
+		uri := repo.Name()
 		var filter string
 		if s.Globbing {
 			filter = fmt.Sprintf(`repo:%s`, uri)

--- a/cmd/frontend/graphqlbackend/search_filters.go
+++ b/cmd/frontend/graphqlbackend/search_filters.go
@@ -98,7 +98,7 @@ func (s *SearchFilters) Update(event SearchEvent) {
 	}
 
 	addRepoFilter := func(repo *RepositoryResolver, rev string, lineMatchCount int32) {
-		uri := repo.Name()
+		uri := string(repo.Name())
 		var filter string
 		if s.Globbing {
 			filter = fmt.Sprintf(`repo:%s`, uri)

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -314,7 +314,7 @@ type executor func(batch []*search.RepositoryRevisions) ([]SearchResultResolver,
 func repoOfResult(result SearchResultResolver) string {
 	switch r := result.(type) {
 	case *RepositoryResolver:
-		return string(r.Name())
+		return r.Name()
 	case *FileMatchResolver:
 		return string(r.Repo.Name)
 	case *CommitSearchResultResolver:

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -116,6 +116,9 @@ func repoRevsToSearchResultResolver(ctx context.Context, repos []*search.Reposit
 			revs = r.RevSpecs()
 		}
 		for _, rev := range revs {
+			rr := NewRepositoryResolver(r.Repo.ToRepo())
+			rr.icon = repoIcon
+			rr.rev = rev
 			results = append(results, &RepositoryResolver{innerRepo: r.Repo.ToRepo(), icon: repoIcon, rev: rev})
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -119,7 +119,7 @@ func repoRevsToSearchResultResolver(ctx context.Context, repos []*search.Reposit
 			rr := NewRepositoryResolver(r.Repo.ToRepo())
 			rr.icon = repoIcon
 			rr.rev = rev
-			results = append(results, &RepositoryResolver{innerRepo: r.Repo.ToRepo(), icon: repoIcon, rev: rev})
+			results = append(results, rr)
 		}
 	}
 	return results

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -304,7 +304,7 @@ func BenchmarkSearchRepositories(b *testing.B) {
 func mkFileMatchResolver(fm FileMatch) *FileMatchResolver {
 	var repo *RepositoryResolver
 	if fm.Repo != nil {
-		repo = &RepositoryResolver{innerRepo: fm.Repo.ToRepo()}
+		repo = NewRepositoryResolver(fm.Repo.ToRepo())
 	}
 	return &FileMatchResolver{
 		FileMatch:    fm,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1893,7 +1893,7 @@ func compareSearchResults(left, right SearchResultResolver, exactFilePatterns ma
 	sortKeys := func(result SearchResultResolver) (string, string, *time.Time) {
 		switch r := result.(type) {
 		case *RepositoryResolver:
-			return string(r.Name()), "", nil
+			return r.Name(), "", nil
 		case *FileMatchResolver:
 			return string(r.Repo.Name), r.JPath, nil
 		case *CommitSearchResultResolver:

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -54,10 +54,10 @@ func (c *SearchResultsResolver) Repositories() []*RepositoryResolver {
 	repos := c.Repos
 	resolvers := make([]*RepositoryResolver, 0, len(repos))
 	for _, r := range repos {
-		resolvers = append(resolvers, &RepositoryResolver{innerRepo: r.ToRepo()})
+		resolvers = append(resolvers, NewRepositoryResolver(r.ToRepo()))
 	}
 	sort.Slice(resolvers, func(a, b int) bool {
-		return resolvers[a].innerRepo.ID < resolvers[b].innerRepo.ID
+		return resolvers[a].ID() < resolvers[b].ID()
 	})
 	return resolvers
 }
@@ -71,11 +71,11 @@ func (c *SearchResultsResolver) repositoryResolvers(mask search.RepoStatus) []*R
 	c.Status.Filter(mask, func(id api.RepoID) {
 		r := c.Repos[id]
 		if r != nil {
-			resolvers = append(resolvers, &RepositoryResolver{innerRepo: c.Repos[id].ToRepo()})
+			resolvers = append(resolvers, NewRepositoryResolver(c.Repos[id].ToRepo()))
 		}
 	})
 	sort.Slice(resolvers, func(a, b int) bool {
-		return resolvers[a].innerRepo.ID < resolvers[b].innerRepo.ID
+		return resolvers[a].ID() < resolvers[b].ID()
 	})
 	return resolvers
 }

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatisticsResolver, error) {
@@ -47,7 +46,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 	}
 
 	var (
-		repos    = map[api.RepoID]*types.Repo{}
+		repos    = map[api.RepoID]*RepositoryResolver{}
 		filesMap = map[repoCommit]*fileStatsWork{}
 
 		run = parallel.NewRun(16)
@@ -57,9 +56,9 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 	)
 
 	// Track the mapping of repo ID -> repo object as we iterate.
-	sawRepo := func(repo *types.Repo) {
-		if _, ok := repos[repo.ID]; !ok {
-			repos[repo.ID] = repo
+	sawRepo := func(repo *RepositoryResolver) {
+		if _, ok := repos[repo.IDInt32()]; !ok {
+			repos[repo.IDInt32()] = repo
 		}
 	}
 
@@ -75,7 +74,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 
 	for _, res := range results {
 		if fileMatch, ok := res.ToFileMatch(); ok {
-			sawRepo(fileMatch.Repository().innerRepo)
+			sawRepo(fileMatch.Repository())
 			key := repoCommit{repo: fileMatch.Repository().IDInt32(), commitID: fileMatch.CommitID}
 
 			if _, ok := filesMap[key]; !ok {
@@ -96,7 +95,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 				})
 			}
 		} else if repo, ok := res.ToRepository(); ok && !hasNonRepoMatches {
-			sawRepo(repo.innerRepo)
+			sawRepo(repo)
 			run.Acquire()
 			goroutine.Go(func() {
 				defer run.Release()
@@ -140,7 +139,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 		goroutine.Go(func() {
 			defer run.Release()
 
-			invCtx, err := backend.InventoryContext(repos[key.repo].Name, key.commitID, true)
+			invCtx, err := backend.InventoryContext(repos[key.repo].Name(), key.commitID, true)
 			if err != nil {
 				run.Error(err)
 				return

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -139,7 +139,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 		goroutine.Go(func() {
 			defer run.Release()
 
-			invCtx, err := backend.InventoryContext(repos[key.repo].Name(), key.commitID, true)
+			invCtx, err := backend.InventoryContext(repos[key.repo].name, key.commitID, true)
 			if err != nil {
 				run.Error(err)
 				return

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -98,9 +98,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 		},
 		"1 entire repo": {
 			results: []SearchResultResolver{
-				&RepositoryResolver{
-					innerRepo: &types.Repo{Name: "r", CreatedAt: time.Now()},
-				},
+				NewRepositoryResolver(&types.Repo{Name: "r", CreatedAt: time.Now()}),
 			},
 			getFiles: []os.FileInfo{
 				fileInfo{path: "two.go"},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -57,7 +57,7 @@ func TestSearchResults(t *testing.T) {
 			// just remove that assumption in the following line of code.
 			switch m := result.(type) {
 			case *RepositoryResolver:
-				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.innerRepo.Name)
+				resultDescriptions[i] = fmt.Sprintf("repo:%s", m.Name())
 			case *FileMatchResolver:
 				resultDescriptions[i] = fmt.Sprintf("%s:%d", m.JPath, m.JLineMatches[0].JLineNumber)
 			default:
@@ -557,9 +557,7 @@ func TestSearchResolver_getPatternInfo(t *testing.T) {
 
 func TestSearchResolver_DynamicFilters(t *testing.T) {
 	repo := &types.RepoName{Name: "testRepo"}
-	repoMatch := &RepositoryResolver{
-		innerRepo: repo.ToRepo(),
-	}
+	repoMatch := NewRepositoryResolver(repo.ToRepo())
 	fileMatch := func(path string) *FileMatchResolver {
 		return mkFileMatch(repo, path)
 	}
@@ -1427,11 +1425,9 @@ func diffResult(url string) *CommitSearchResultResolver {
 }
 
 func repoResult(url string) *RepositoryResolver {
-	return &RepositoryResolver{
-		innerRepo: &types.Repo{
-			Name: api.RepoName(url),
-		},
-	}
+	return NewRepositoryResolver(&types.Repo{
+		Name: api.RepoName(url),
+	})
 }
 
 func fileResult(uri string, lineMatches []*lineMatch, symbolMatches []*searchSymbolResult) *FileMatchResolver {
@@ -1500,7 +1496,7 @@ func TestUnionMerge(t *testing.T) {
 						url:         "a",
 					},
 					&FileMatchResolver{FileMatch: FileMatch{uri: "a"}},
-					&RepositoryResolver{innerRepo: &types.Repo{Name: api.RepoName("a")}},
+					NewRepositoryResolver(&types.Repo{Name: api.RepoName("a")}),
 				},
 			}},
 		{
@@ -1520,7 +1516,7 @@ func TestUnionMerge(t *testing.T) {
 					url:         "a",
 				},
 				&FileMatchResolver{FileMatch: FileMatch{uri: "a"}},
-				&RepositoryResolver{innerRepo: &types.Repo{Name: api.RepoName("a")}},
+				NewRepositoryResolver(&types.Repo{Name: api.RepoName("a")}),
 			},
 			}},
 		{
@@ -1553,8 +1549,8 @@ func TestUnionMerge(t *testing.T) {
 				},
 				&FileMatchResolver{FileMatch: FileMatch{uri: "a"}},
 				&FileMatchResolver{FileMatch: FileMatch{uri: "b"}},
-				&RepositoryResolver{innerRepo: &types.Repo{Name: api.RepoName("a")}},
-				&RepositoryResolver{innerRepo: &types.Repo{Name: api.RepoName("b")}},
+				NewRepositoryResolver(&types.Repo{Name: api.RepoName("a")}),
+				NewRepositoryResolver(&types.Repo{Name: api.RepoName("b")}),
 			}},
 		},
 		{

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -155,7 +155,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, args *search.TextParameters, 
 		}
 		repoRev := repos.repoRevs[file.Repository]
 		if repoResolvers[repoRev.Repo.Name] == nil {
-			repoResolvers[repoRev.Repo.Name] = &RepositoryResolver{innerRepo: repoRev.Repo.ToRepo()}
+			repoResolvers[repoRev.Repo.Name] = NewRepositoryResolver(repoRev.Repo.ToRepo())
 		}
 		matches[i] = &FileMatchResolver{
 			FileMatch: FileMatch{

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -354,9 +354,9 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		var k key
 		switch s := s.result.(type) {
 		case *RepositoryResolver:
-			k.repoName = s.innerRepo.Name
+			k.repoName = s.name
 		case *GitTreeEntryResolver:
-			k.repoName = s.commit.repoResolver.innerRepo.Name
+			k.repoName = s.commit.repoResolver.name
 			// We explicitly do not use GitCommitResolver.OID() to get the OID here
 			// because it could significantly slow down search suggestions from zoekt as
 			// it doesn't specify the commit the default branch is on. This result would in

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -102,7 +102,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			resolvers := make([]*searchSuggestionResolver, 0, len(resolved.RepoRevs))
 			for _, rev := range resolved.RepoRevs {
 				resolvers = append(resolvers, newSearchSuggestionResolver(
-					&RepositoryResolver{innerRepo: rev.Repo.ToRepo()},
+					NewRepositoryResolver(rev.Repo.ToRepo()),
 					math.MaxInt32,
 				))
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -24,7 +24,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
 
 	commit := toGitCommitResolver(
-		&RepositoryResolver{innerRepo: &types.Repo{ID: 1, Name: "repo"}},
+		NewRepositoryResolver(&types.Repo{ID: 1, Name: "repo"}),
 		"c1",
 		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
 	)

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -109,7 +109,7 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, branch s
 
 	ands := []zoektquery.Q{
 		&zoektquery.RepoBranches{Set: map[string][]string{
-			string(commit.repoResolver.Name()): {branch},
+			commit.repoResolver.Name(): {branch},
 		}},
 		&zoektquery.Symbol{Expr: query},
 	}
@@ -136,7 +136,7 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, branch s
 		return nil, err
 	}
 
-	baseURI, err := gituri.Parse("git://" + string(commit.repoResolver.Name()) + "?" + string(commit.oid))
+	baseURI, err := gituri.Parse("git://" + commit.repoResolver.Name() + "?" + string(commit.oid))
 	for _, file := range resp.Files {
 		for _, l := range file.LineMatches {
 			if l.FileName {
@@ -170,7 +170,7 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, branch s
 func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
 	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
 	// and remove indexedSymbolsBranch.
-	if branch := indexedSymbolsBranch(ctx, string(commit.repoResolver.Name()), string(commit.oid)); branch != "" {
+	if branch := indexedSymbolsBranch(ctx, commit.repoResolver.Name(), string(commit.oid)); branch != "" {
 		return searchZoektSymbols(ctx, commit, branch, query, first, includePatterns)
 	}
 
@@ -189,13 +189,13 @@ func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *strin
 	searchArgs := search.SymbolsParameters{
 		CommitID:        api.CommitID(commit.oid),
 		First:           limitOrDefault(first) + 1, // add 1 so we can determine PageInfo.hasNextPage
-		Repo:            commit.repoResolver.Name(),
+		Repo:            commit.repoResolver.name,
 		IncludePatterns: includePatternsSlice,
 	}
 	if query != nil {
 		searchArgs.Query = *query
 	}
-	baseURI, err := gituri.Parse("git://" + string(commit.repoResolver.Name()) + "?" + string(commit.oid))
+	baseURI, err := gituri.Parse("git://" + commit.repoResolver.Name() + "?" + string(commit.oid))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -109,7 +109,7 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, branch s
 
 	ands := []zoektquery.Q{
 		&zoektquery.RepoBranches{Set: map[string][]string{
-			string(commit.repoResolver.innerRepo.Name): {branch},
+			string(commit.repoResolver.Name()): {branch},
 		}},
 		&zoektquery.Symbol{Expr: query},
 	}
@@ -136,7 +136,7 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, branch s
 		return nil, err
 	}
 
-	baseURI, err := gituri.Parse("git://" + string(commit.repoResolver.innerRepo.Name) + "?" + string(commit.oid))
+	baseURI, err := gituri.Parse("git://" + string(commit.repoResolver.Name()) + "?" + string(commit.oid))
 	for _, file := range resp.Files {
 		for _, l := range file.LineMatches {
 			if l.FileName {
@@ -170,7 +170,7 @@ func searchZoektSymbols(ctx context.Context, commit *GitCommitResolver, branch s
 func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
 	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
 	// and remove indexedSymbolsBranch.
-	if branch := indexedSymbolsBranch(ctx, string(commit.repoResolver.innerRepo.Name), string(commit.oid)); branch != "" {
+	if branch := indexedSymbolsBranch(ctx, string(commit.repoResolver.Name()), string(commit.oid)); branch != "" {
 		return searchZoektSymbols(ctx, commit, branch, query, first, includePatterns)
 	}
 
@@ -189,13 +189,13 @@ func computeSymbols(ctx context.Context, commit *GitCommitResolver, query *strin
 	searchArgs := search.SymbolsParameters{
 		CommitID:        api.CommitID(commit.oid),
 		First:           limitOrDefault(first) + 1, // add 1 so we can determine PageInfo.hasNextPage
-		Repo:            commit.repoResolver.innerRepo.Name,
+		Repo:            commit.repoResolver.Name(),
 		IncludePatterns: includePatternsSlice,
 	}
 	if query != nil {
 		searchArgs.Query = *query
 	}
-	baseURI, err := gituri.Parse("git://" + string(commit.repoResolver.innerRepo.Name) + "?" + string(commit.oid))
+	baseURI, err := gituri.Parse("git://" + string(commit.repoResolver.Name()) + "?" + string(commit.oid))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -237,7 +237,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo *ty
 	}
 
 	workspace := fileMatchURI(repo.Name, rev, "")
-	repoResolver := &RepositoryResolver{innerRepo: repo.ToRepo()}
+	repoResolver := NewRepositoryResolver(repo.ToRepo())
 	resolvers := make([]*FileMatchResolver, 0, len(matches))
 	for _, fm := range matches {
 		lineMatches := make([]*lineMatch, 0, len(fm.LineMatches))

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -363,7 +363,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 			}
 			repoResolver := repoResolvers[repo.Name]
 			if repoResolver == nil {
-				repoResolver = &RepositoryResolver{innerRepo: repo.ToRepo()}
+				repoResolver = NewRepositoryResolver(repo.ToRepo())
 				repoResolvers[repo.Name] = repoResolver
 			}
 
@@ -487,7 +487,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.
-	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: repo.Name(), RawQuery: url.QueryEscape(inputRev)}}
+	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: string(repo.Name()), RawQuery: url.QueryEscape(inputRev)}}
 	commit := &GitCommitResolver{
 		repoResolver: repo,
 		oid:          GitObjectID(file.Version),

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -487,7 +487,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.
-	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: string(repo.Name()), RawQuery: url.QueryEscape(inputRev)}}
+	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: repo.Name(), RawQuery: url.QueryEscape(inputRev)}}
 	commit := &GitCommitResolver{
 		repoResolver: repo,
 		oid:          GitObjectID(file.Version),

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1043,7 +1043,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		if got, want := res.baseURI.URL.String(), "git://foo?master"; got != want {
 			t.Fatalf("baseURI: got %q want %q", got, want)
 		}
-		if got, want := string(res.commit.Repository().Name()), "foo"; got != want {
+		if got, want := res.commit.Repository().Name(), "foo"; got != want {
 			t.Fatalf("reporesolver: got %q want %q", got, want)
 		}
 		if got, want := string(res.commit.OID()), "deadbeef"; got != want {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1031,7 +1031,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		}},
 	}
 
-	repo := &RepositoryResolver{innerRepo: &types.Repo{Name: "foo"}}
+	repo := NewRepositoryResolver(&types.Repo{Name: "foo"})
 
 	results := zoektFileMatchToSymbolResults(repo, "master", file)
 	var symbols []protocol.Symbol

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -349,7 +349,7 @@ func fromRepository(repo *graphqlbackend.RepositoryResolver) eventRepoMatch {
 
 	return eventRepoMatch{
 		Type:       repoMatch,
-		Repository: string(repo.Name()),
+		Repository: repo.Name(),
 		Branches:   branches,
 	}
 }

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -349,7 +349,7 @@ func fromRepository(repo *graphqlbackend.RepositoryResolver) eventRepoMatch {
 
 	return eventRepoMatch{
 		Type:       repoMatch,
-		Repository: repo.Name(),
+		Repository: string(repo.Name()),
 		Branches:   branches,
 	}
 }

--- a/internal/campaigns/changeset.go
+++ b/internal/campaigns/changeset.go
@@ -730,7 +730,7 @@ func (cs Changesets) RepoIDs() []api.RepoID {
 	for _, c := range cs {
 		repoIDMap[c.RepoID] = struct{}{}
 	}
-	repoIDs := make([]api.RepoID, len(repoIDMap))
+	repoIDs := make([]api.RepoID, 0, len(repoIDMap))
 	for id := range repoIDMap {
 		repoIDs = append(repoIDs, id)
 	}


### PR DESCRIPTION
This turned into a _much_ larger change than I was hoping for, especially since there is a chance this will become obsolete if I ever get through the `graphqlbackend` refactor, but I think it's necessary in order to get rid of all race conditions with hydration. 

Essentially, the issue was that there were _many_ parts of the codebase that were accessing `innerRepo` directly, which is problematic if we want the methods of `RepositoryResolver` to be safe to use from multiple goroutines. 

Summary of the changes:
- When creating a `RepositoryResolver`, always save the name and ID outside of the hydrated repo. This way, they can always be safely accessed even if a concurrent hydration is occuring
- Always create a `RepositoryResolver` with `NewRepositoryResolver` so that the name and ID are saved
- Convert all accesses of `RepositoryResolver.innerRepo.Name` to `RepositoryResolver.name`

Fixes #18342 

I added Campaigns as a reviewer because the last commit here touches campaigns-specific code (there was a slice that was being initialized incorrectly)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
