### PR TITLE
Fix enterprise insights resolver not set for dotcom

### DIFF
--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -24,6 +24,7 @@ func IsEnabled() bool {
 			// Unless it's disabled / we need an escape hatch.
 			return false
 		}
+		return true
 	}
 	if !conf.IsDev(conf.DeployType()) {
 		// Code Insights is not yet deployed to non-dev/testing instances. We don't yet have


### PR DESCRIPTION
I haven't tested this but am like 90% sure 😬 should we try? 