### PR TITLE
Show status messages for authed admins and users with a tag

### DIFF
--- a/client/web/src/nav/NavLinks.tsx
+++ b/client/web/src/nav/NavLinks.tsx
@@ -132,7 +132,10 @@ export class NavLinks extends React.PureComponent<Props> {
                         )}
                     </>
                 )}
-                {!this.props.isSourcegraphDotCom && this.props.authenticatedUser?.siteAdmin && (
+
+                {/* show status messages if authenticated user is admin or opted-in with a user tag  */}
+                {(this.props.authenticatedUser?.siteAdmin ||
+                    this.props.authenticatedUser?.tags.includes('AllowUserExternalServicePublic')) && (
                     <li className="nav-item">
                         <StatusMessagesNavItem
                             isSiteAdmin={this.props.authenticatedUser.siteAdmin}

--- a/client/web/src/nav/NavLinks.tsx
+++ b/client/web/src/nav/NavLinks.tsx
@@ -135,7 +135,7 @@ export class NavLinks extends React.PureComponent<Props> {
 
                 {/* show status messages if authenticated user is admin or opted-in with a user tag  */}
                 {(this.props.authenticatedUser?.siteAdmin ||
-                    this.props.authenticatedUser?.tags.includes('AllowUserExternalServicePublic')) && (
+                    this.props.authenticatedUser?.tags?.includes('AllowUserExternalServicePublic')) && (
                     <li className="nav-item">
                         <StatusMessagesNavItem
                             isSiteAdmin={this.props.authenticatedUser.siteAdmin}


### PR DESCRIPTION
### Description

Closes #18199

Show status messages everywhere, when a _**signed-in**_ user has an `admin` role or has `AllowUserExternalServicePublic` tag set.