### PR TITLE
search: avoid zip work for no zoekt results in structural search

### DIFF
--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -299,6 +299,10 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 		return nil, false, false, err
 	}
 
+	if len(zoektMatches) == 0 {
+		return nil, false, false, nil
+	}
+
 	zipFile, err := ioutil.TempFile("", "*.zip")
 	if err != nil {
 		return nil, false, false, err


### PR DESCRIPTION
Structural search sometimes 504'ed if we searched a lot of repos on Sourcegraph.com (repogroup with > 100 repos, for example). For smaller amounts of repos, like 10, things were also slower than before.

It turns the majority of the slow down was caused by the fact that we unconditionally created zip files for comby to search, even if we didn't find files to zip. Doing this 100 times or more adds up, up to timing out. Locally this just takes longer for me, but on Sourcegraph.com it 504s. Anecdotally, global structural search wasn't as "broken" by this on Sourcegraph.com because (I think) it doesn't force us to search the entirety of the repos, it just continues until finding results/timeout, unlike repogroups, where we do consider the whole batch.

This change is a stopgap--I'm still going through our code here to look for opportunities to speed things up, but this takes care of the major regression I ran into as of ~Saturday. Feel like test is low-value here, so I'm skipping it (integration-wise, there's no way to test the behavior; unit test seems low-value).