### PR TITLE
campaigns: request the user:email scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Go `1.15` introduced changes to SSL/TLS connection validation which requires certificates to include a `SAN`. This field was not included in older certificates and clients relied on the `CN` field. You might see an error like `x509: certificate relies on legacy Common Name field`. We recommend that customers using Sourcegraph with an external database and connecting to it using SSL/TLS check whether the certificate is up to date.
   - RDS Customers please reference [AWS' documentation on updating the SSL/TLS certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html).
 - Search results on `.rs` files now recommend `lang:rust` instead of `lang:renderscript` as a filter. [#18316](https://github.com/sourcegraph/sourcegraph/pull/18316)
+- Campaigns users creating Personal Access Tokens on GitHub are now asked to request the `user:email` scope in addition to the [previous scopes](https://docs.sourcegraph.com/@3.24/admin/external_service/github#github-api-token-and-access). This will be used in a future Sourcegraph release to display more fine-grained information on the progress of pull requests. [#17555](https://github.com/sourcegraph/sourcegraph/issues/17555)
 
 ### Fixed
 

--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
@@ -41,7 +41,8 @@ const helpTexts: Record<ExternalServiceKind, JSX.Element> = {
             >
                 Create a new access token
             </a>{' '}
-            with <code>repo</code>, <code>read:org</code>, and <code>read:discussion</code> scopes.
+            with <code>repo</code>, <code>read:org</code>, <code>user:email</code>, and <code>read:discussion</code>{' '}
+            scopes.
         </>
     ),
     [ExternalServiceKind.GITLAB]: (

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -38,7 +38,7 @@ No token scopes are required if you only want to sync public repositories and do
 
 - `repo` to sync private repositories from GitHub to Sourcegraph.
 - `read:org` to use the `"allowOrgs"` setting [with a GitHub authentication provider](../auth/index.md#github).
-- `repo`, `read:org`, and `read:discussion` to use [campaigns](../../campaigns/index.md) with GitHub repositories. See "[Code host interactions in campaigns](../../campaigns/explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns)" for details.
+- `repo`, `read:org`, `user:email`, and `read:discussion` to use [campaigns](../../campaigns/index.md) with GitHub repositories. See "[Code host interactions in campaigns](../../campaigns/explanations/permissions_in_campaigns.md#code-host-interactions-in-campaigns)" for details.
 
 >NOTE: If you plan to use repository permissions with background syncing, an access token that has admin access to all private repositories is required. It is because only admin can list all collaborators of a repository.
 

--- a/doc/campaigns/how-tos/configuring_user_credentials.md
+++ b/doc/campaigns/how-tos/configuring_user_credentials.md
@@ -25,7 +25,7 @@ You should now see a list of the code hosts that are configured on Sourcegraph. 
 
 To add a token for a code host, click on the **Add token** button next to its name. This will display an input modal like the following:
 
-<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-token-input.png" alt="An input dialog, titled &quot;Github campaigns token for https://github.com&quot;, with an input box to type or paste a token and a list of scopes that must be enabled on the token, which are repo, read:org, and read:discussion">
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-token-input-3.25.png" alt="An input dialog, titled &quot;Github campaigns token for https://github.com&quot;, with an input box to type or paste a token and a list of scopes that must be enabled on the token, which are repo, read:org, user:email, and read:discussion">
 
 To create a personal access token for a specific code host provider, please refer to the relevant section for "[GitHub](#github)", "[GitLab](#gitlab)", or "[Bitbucket Server](#bitbucket-server)". Once you have a token, you should paste it into the Sourcegraph input shown above, and click **Add token**.
 
@@ -39,7 +39,7 @@ Once this is done, Sourcegraph should indicate that you have a token with a gree
 
 In addition to the below, you should refer to [GitHub's documentation on creating a personal access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token).
 
-Sourcegraph requires the `repo`, `read:org`, and `read:discussion` scopes to be enabled on the user token. This is done by selecting the relevant checkboxes when creating the token:
+Sourcegraph requires the `repo`, `read:org`, `user:email`, and `read:discussion` scopes to be enabled on the user token. This is done by selecting the relevant checkboxes when creating the token:
 
 <img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/github-token.png" alt="The GitHub token creation page, with the repo scope selected">
 


### PR DESCRIPTION
Note that I've broken with our usual convention in the changelog by referring directly to "pull requests" instead of "changesets", since this is GitHub specific.

Addresses, but does not close, #17555.