### PR TITLE
 docs: add note to single-server upgrade guide to upgrade past 3.17.0 to 3.17.2

### DIFF
--- a/doc/admin/updates/server.md
+++ b/doc/admin/updates/server.md
@@ -33,7 +33,11 @@ If you had LSIF data uploaded prior to upgrading to 3.21.0, there is a backgroun
 
 In Sourcegraph version 3.20, we would automatically generate a secret key file (`/var/lib/sourcegraph/token`) inside the container for encrypting secrets stored in the database. However, it is not yet ready for general use and format of the secret key file might change. Therefore, it is best to delete the secret key file (`/var/lib/sourcegraph/token`) and turn off the database secrets encryption.
 
-### Standard upgrade procedure
+## 3.16 -> 3.17
+
+- There was [a bug](https://github.com/sourcegraph/sourcegraph/issues/11618) in the `sourcegraph/server:3.17.0` release that caused the version displayed on the `site-admin/update` page to be `0.0.0+dev` instead of `3.17.0`. This issue [was fixed](https://github.com/sourcegraph/sourcegraph/pull/11633) in the `3.17.2` release. We recommend that you avoid this issue by upgrading past `3.17.0` to `3.17.2` using the [Standard upgrade procedure](#Standard-upgrade-procedure) listed below.
+
+## Standard upgrade procedure
 
 To update, just use the newer `sourcegraph/server:N.N.N` Docker image (where `N.N.N` is the version number) in place of the older one, using the same Docker volumes. Your server's data will be migrated automatically if needed.
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/customer/issues/183

I have tested this procedure on  **single server**, **docker-compose**, and **Kubernetes** deployments. I was not able to replicate the issue on the **Kubernetes** deployment, and the issue turned out to be moot in the **docker-compose** deployment since we never cut an official `3.17.0` release for it. 