### PR TITLE
RFC 311: Add oobmigration store

### DIFF
--- a/internal/oobmigration/CODENOTIFY
+++ b/internal/oobmigration/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation.
+
+**/* @efritz

--- a/internal/oobmigration/store.go
+++ b/internal/oobmigration/store.go
@@ -1,0 +1,243 @@
+package oobmigration
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+// Migration stores metadata and tracks progress of an out-of-band migration routine.
+type Migration struct {
+	ID             int
+	Team           string
+	Component      string
+	Description    string
+	Introduced     string
+	Deprecated     string
+	Progress       float64
+	Created        time.Time
+	LastUpdated    *time.Time
+	NonDestructive bool
+	ApplyReverse   bool
+	Errors         []MigrationError
+}
+
+// MigrationError pairs an error message and the time the error occurred.
+type MigrationError struct {
+	Message string
+	Created time.Time
+}
+
+func scanMigrations(rows *sql.Rows, queryErr error) (_ []Migration, err error) {
+	defer func() { err = basestore.CloseRows(rows, err) }()
+
+	var values []Migration
+	for rows.Next() {
+		var message string
+		var created *time.Time
+		value := Migration{Errors: []MigrationError{}}
+
+		if err := rows.Scan(
+			&value.ID,
+			&value.Team,
+			&value.Component,
+			&value.Description,
+			&value.Introduced,
+			&dbutil.NullString{S: &value.Deprecated},
+			&value.Progress,
+			&value.Created,
+			&value.LastUpdated,
+			&value.NonDestructive,
+			&value.ApplyReverse,
+			&dbutil.NullString{S: &message},
+			&created,
+		); err != nil {
+			return nil, err
+		}
+
+		if message != "" {
+			value.Errors = append(value.Errors, MigrationError{
+				Message: message,
+				Created: *created,
+			})
+		}
+
+		if n := len(values); n > 0 && values[n-1].ID == value.ID {
+			values[n-1].Errors = append(values[n-1].Errors, value.Errors...)
+		} else {
+			values = append(values, value)
+		}
+	}
+
+	return values, nil
+}
+
+// Store is the interface over the out-of-band migrations tables.
+type Store struct {
+	*basestore.Store
+}
+
+func NewStoreWithDB(db dbutil.DB) *Store {
+	return &Store{
+		Store: basestore.NewWithDB(db, sql.TxOptions{}),
+	}
+}
+
+func (s *Store) With(other basestore.ShareableStore) *Store {
+	return &Store{
+		Store: s.Store.With(other),
+	}
+}
+
+func (s *Store) Transact(ctx context.Context) (*Store, error) {
+	txBase, err := s.Store.Transact(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Store{
+		Store: txBase,
+	}, nil
+}
+
+// GetByID retrieves a migration by its identifier. If the migration does not exist, a false
+// valued flag is returned.
+func (s *Store) GetByID(ctx context.Context, id int) (_ Migration, _ bool, err error) {
+	migrations, err := scanMigrations(s.Store.Query(ctx, sqlf.Sprintf(getByIDQuery, id)))
+	if err != nil {
+		return Migration{}, false, err
+	}
+
+	if len(migrations) == 0 {
+		return Migration{}, false, nil
+	}
+
+	return migrations[0], true, nil
+}
+
+const getByIDQuery = `
+-- source: internal/oobmigration/store.go:GetByID
+SELECT
+	m.id,
+	m.team,
+	m.component,
+	m.description,
+	m.introduced,
+	m.deprecated,
+	m.progress,
+	m.created,
+	m.last_updated,
+	m.non_destructive,
+	m.apply_reverse,
+	e.message,
+	e.created
+FROM out_of_band_migrations m
+LEFT JOIN out_of_band_migrations_errors e ON e.migration_id = m.id
+WHERE m.id = %s
+ORDER BY e.created desc
+`
+
+// List returns the complete list of out-of-band migrations.
+func (s *Store) List(ctx context.Context) (_ []Migration, err error) {
+	return scanMigrations(s.Store.Query(ctx, sqlf.Sprintf(listQuery)))
+}
+
+const listQuery = `
+-- source: internal/oobmigration/store.go:List
+SELECT
+	m.id,
+	m.team,
+	m.component,
+	m.description,
+	m.introduced,
+	m.deprecated,
+	m.progress,
+	m.created,
+	m.last_updated,
+	m.non_destructive,
+	m.apply_reverse,
+	e.message,
+	e.created
+FROM out_of_band_migrations m
+LEFT JOIN out_of_band_migrations_errors e ON e.migration_id = m.id
+ORDER BY m.id desc, e.created desc
+`
+
+// UpdateDirection updates the direction for the given migration.
+func (s *Store) UpdateDirection(ctx context.Context, id int, applyReverse bool) error {
+	return s.Store.Exec(ctx, sqlf.Sprintf(updateDirectionQuery, applyReverse, id))
+}
+
+const updateDirectionQuery = `
+-- source: internal/oobmigration/store.go:UpdateDirection
+UPDATE out_of_band_migrations SET apply_reverse = %s WHERE id = %s
+`
+
+// UpdateProgress updates the progress for the given migration.
+func (s *Store) UpdateProgress(ctx context.Context, id int, progress float64) error {
+	return s.updateProgress(ctx, id, progress, time.Now())
+}
+
+func (s *Store) updateProgress(ctx context.Context, id int, progress float64, now time.Time) error {
+	return s.Store.Exec(ctx, sqlf.Sprintf(updateProgressQuery, progress, now, id, progress))
+}
+
+const updateProgressQuery = `
+-- source: internal/oobmigration/store.go:UpdateProgress
+UPDATE out_of_band_migrations SET progress = %s, last_updated = %s WHERE id = %s AND progress != %s
+`
+
+// MaxMigrationErrors is the maximum number of errors we'll track for a single migration before
+// pruning older entries.
+const MaxMigrationErrors = 100
+
+// AddError associates the given error message with the given migration. While there are more
+// than MaxMigrationErrors errors for this, the oldest error entries will be pruned to keep the
+// error list relevant and short.
+func (s *Store) AddError(ctx context.Context, id int, message string) (err error) {
+	return s.addError(ctx, id, message, time.Now())
+}
+
+func (s *Store) addError(ctx context.Context, id int, message string, now time.Time) (err error) {
+	tx, err := s.Store.Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(addErrorQuery, id, message, now)); err != nil {
+		return err
+	}
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(addErrorUpdateTimeQuery, now, id)); err != nil {
+		return err
+	}
+
+	if err := tx.Exec(ctx, sqlf.Sprintf(addErrorPruneQuery, id, MaxMigrationErrors)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const addErrorQuery = `
+-- source: internal/oobmigration/store.go:AddError
+INSERT INTO out_of_band_migrations_errors (migration_id, message, created) VALUES (%s, %s, %s)
+`
+
+const addErrorUpdateTimeQuery = `
+-- source: internal/oobmigration/store.go:AddError
+UPDATE out_of_band_migrations SET last_updated = %s where id = %s
+`
+
+const addErrorPruneQuery = `
+-- source: internal/oobmigration/store.go:AddError
+DELETE FROM out_of_band_migrations_errors WHERE id IN (
+	SELECT id FROM out_of_band_migrations_errors WHERE migration_id = %s ORDER BY created DESC OFFSET %s
+)
+`

--- a/internal/oobmigration/store_test.go
+++ b/internal/oobmigration/store_test.go
@@ -1,0 +1,307 @@
+package oobmigration
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+func init() {
+	dbtesting.DBNameSuffix = "oobmigration"
+}
+
+func TestList(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore(t)
+
+	migrations, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error getting migrations: %s", err)
+	}
+
+	expectedMigrations := make([]Migration, len(testMigrations))
+	copy(expectedMigrations, testMigrations)
+	sort.Slice(expectedMigrations, func(i, j int) bool {
+		return expectedMigrations[i].ID > expectedMigrations[j].ID
+	})
+
+	if diff := cmp.Diff(expectedMigrations, migrations); diff != "" {
+		t.Errorf("unexpected migrations (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateDirection(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore(t)
+
+	if err := store.UpdateDirection(context.Background(), 3, true); err != nil {
+		t.Fatalf("unexpected error updating direction: %s", err)
+	}
+
+	migration, exists, err := store.GetByID(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("unexpected error getting migrations: %s", err)
+	}
+	if !exists {
+		t.Fatalf("expected record to exist")
+	}
+
+	expectedMigration := testMigrations[2] // ID = 3
+	expectedMigration.ApplyReverse = true
+
+	if diff := cmp.Diff(expectedMigration, migration); diff != "" {
+		t.Errorf("unexpected migration (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateProgress(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	now := testTime.Add(time.Hour * 7)
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore(t)
+
+	if err := store.updateProgress(context.Background(), 3, 0.7, now); err != nil {
+		t.Fatalf("unexpected error updating migration: %s", err)
+	}
+
+	migration, exists, err := store.GetByID(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("unexpected error getting migrations: %s", err)
+	}
+	if !exists {
+		t.Fatalf("expected record to exist")
+	}
+
+	expectedMigration := testMigrations[2] // ID = 3
+	expectedMigration.Progress = 0.7
+	expectedMigration.LastUpdated = timePtr(now)
+
+	if diff := cmp.Diff(expectedMigration, migration); diff != "" {
+		t.Errorf("unexpected migration (-want +got):\n%s", diff)
+	}
+}
+
+func TestAddError(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	now := testTime.Add(time.Hour * 8)
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore(t)
+
+	if err := store.addError(context.Background(), 2, "oops", now); err != nil {
+		t.Fatalf("unexpected error updating migration: %s", err)
+	}
+
+	migration, exists, err := store.GetByID(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("unexpected error getting migrations: %s", err)
+	}
+	if !exists {
+		t.Fatalf("expected record to exist")
+	}
+
+	expectedMigration := testMigrations[1] // ID = 2
+	expectedMigration.LastUpdated = timePtr(now)
+	expectedMigration.Errors = []MigrationError{
+		{Message: "oops", Created: now},
+		{Message: "uh-oh 1", Created: testTime.Add(time.Hour*5 + time.Second*2)},
+		{Message: "uh-oh 2", Created: testTime.Add(time.Hour*5 + time.Second*1)},
+	}
+
+	if diff := cmp.Diff(expectedMigration, migration); diff != "" {
+		t.Errorf("unexpected migration (-want +got):\n%s", diff)
+	}
+}
+
+func TestAddErrorBounded(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	now := testTime.Add(time.Hour * 9)
+	dbtesting.SetupGlobalTestDB(t)
+	store := testStore(t)
+
+	var expectedErrors []MigrationError
+	for i := 0; i < MaxMigrationErrors*1.5; i++ {
+		now = now.Add(time.Second)
+
+		if err := store.addError(context.Background(), 2, fmt.Sprintf("oops %d", i), now); err != nil {
+			t.Fatalf("unexpected error updating migration: %s", err)
+		}
+
+		expectedErrors = append(expectedErrors, MigrationError{
+			Message: fmt.Sprintf("oops %d", i),
+			Created: now,
+		})
+	}
+
+	migration, exists, err := store.GetByID(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("unexpected error getting migration: %s", err)
+	}
+	if !exists {
+		t.Fatalf("expected record to exist")
+	}
+
+	n := len(expectedErrors) - 1
+	for i := 0; i < len(expectedErrors)/2; i++ {
+		expectedErrors[i], expectedErrors[n-i] = expectedErrors[n-i], expectedErrors[i]
+	}
+
+	expectedMigration := testMigrations[1] // ID = 2
+	expectedMigration.LastUpdated = timePtr(now)
+	expectedMigration.Errors = expectedErrors[:MaxMigrationErrors]
+
+	if diff := cmp.Diff(expectedMigration, migration); diff != "" {
+		t.Errorf("unexpected migrations (-want +got):\n%s", diff)
+	}
+}
+
+//
+//
+
+var testTime = time.Unix(1613414740, 0)
+
+var testMigrations = []Migration{
+	{
+		ID:             1,
+		Team:           "search",
+		Component:      "zoekt-index",
+		Description:    "rot13 all the indexes for security",
+		Introduced:     "3.25.0",
+		Deprecated:     "",
+		Progress:       0,
+		Created:        testTime,
+		LastUpdated:    nil,
+		NonDestructive: false,
+		ApplyReverse:   false,
+		Errors:         []MigrationError{},
+	},
+	{
+		ID:             2,
+		Team:           "codeintel",
+		Component:      "lsif_data_documents",
+		Description:    "denormalize counts",
+		Introduced:     "3.26.0",
+		Deprecated:     "3.28.0",
+		Progress:       0.5,
+		Created:        testTime.Add(time.Hour * 1),
+		LastUpdated:    timePtr(testTime.Add(time.Hour * 2)),
+		NonDestructive: true,
+		ApplyReverse:   false,
+		Errors: []MigrationError{
+			{Message: "uh-oh 1", Created: testTime.Add(time.Hour*5 + time.Second*2)},
+			{Message: "uh-oh 2", Created: testTime.Add(time.Hour*5 + time.Second*1)},
+		},
+	},
+	{
+		ID:             3,
+		Team:           "platform",
+		Component:      "lsif_data_documents",
+		Description:    "gzip payloads",
+		Introduced:     "3.24.0",
+		Deprecated:     "",
+		Progress:       0.4,
+		Created:        testTime.Add(time.Hour * 3),
+		LastUpdated:    timePtr(testTime.Add(time.Hour * 4)),
+		NonDestructive: false,
+		ApplyReverse:   true,
+		Errors: []MigrationError{
+			{Message: "uh-oh 3", Created: testTime.Add(time.Hour*5 + time.Second*4)},
+			{Message: "uh-oh 4", Created: testTime.Add(time.Hour*5 + time.Second*3)},
+		},
+	},
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func testStore(t *testing.T) *Store {
+	store := NewStoreWithDB(dbconn.Global)
+
+	for i := range testMigrations {
+		if err := insertMigration(store, testMigrations[i]); err != nil {
+			t.Fatalf("unexpected error inserting migration: %s", err)
+		}
+	}
+
+	return store
+}
+
+func insertMigration(store *Store, migration Migration) error {
+	var dep *string
+	if migration.Deprecated != "" {
+		dep = &migration.Deprecated
+	}
+
+	query := sqlf.Sprintf(`
+		INSERT INTO out_of_band_migrations (
+			id,
+			team,
+			component,
+			description,
+			introduced,
+			deprecated,
+			progress,
+			created,
+			last_updated,
+			non_destructive,
+			apply_reverse
+		) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+	`,
+		migration.ID,
+		migration.Team,
+		migration.Component,
+		migration.Description,
+		migration.Introduced,
+		dbutil.NullString{S: dep},
+		migration.Progress,
+		migration.Created,
+		migration.LastUpdated,
+		migration.NonDestructive,
+		migration.ApplyReverse,
+	)
+
+	if err := store.Store.Exec(context.Background(), query); err != nil {
+		return err
+	}
+
+	for _, err := range migration.Errors {
+		query := sqlf.Sprintf(`
+			INSERT INTO out_of_band_migrations_errors (
+				migration_id,
+				message,
+				created
+			) VALUES (%s, %s, %s)
+		`,
+			migration.ID,
+			err.Message,
+			err.Created,
+		)
+
+		if err := store.Store.Exec(context.Background(), query); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This helps #18353. This adds a store that interfaces with the new out-of-band migrations table introduced in https://github.com/sourcegraph/sourcegraph/pull/18392.