### PR TITLE
Remove Firefox update_url for hosted add-on

### DIFF
--- a/client/browser/src/browser-extension/manifest.spec.json
+++ b/client/browser/src/browser-extension/manifest.spec.json
@@ -35,8 +35,7 @@
   },
   "applications": {
     "gecko": {
-      "id": "sourcegraph-for-firefox@sourcegraph.com",
-      "update_url": "https://storage.googleapis.com/sourcegraph-for-firefox/updates.json"
+      "id": "sourcegraph-for-firefox@sourcegraph.com"
     }
   },
   "dev": {

--- a/client/browser/src/types/webextension-polyfill/index.d.ts
+++ b/client/browser/src/types/webextension-polyfill/index.d.ts
@@ -930,7 +930,6 @@ declare namespace browser.runtime {
         id?: string
         strict_min_version?: string
         strict_max_version?: string
-        update_url?: string
     }
 
     type IconPath = { [urlName: string]: string } | string
@@ -1158,7 +1157,6 @@ declare namespace browser.runtime {
                 event_types: ('start' | 'word' | 'sentence' | 'marker' | 'end' | 'error')[]
             }[]
         }
-        update_url?: string
         version_name?: string
     }
 

--- a/client/browser/src/types/webextension-polyfill/index.d.ts
+++ b/client/browser/src/types/webextension-polyfill/index.d.ts
@@ -930,6 +930,7 @@ declare namespace browser.runtime {
         id?: string
         strict_min_version?: string
         strict_max_version?: string
+        update_url?: string
     }
 
     type IconPath = { [urlName: string]: string } | string
@@ -1157,6 +1158,7 @@ declare namespace browser.runtime {
                 event_types: ('start' | 'word' | 'sentence' | 'marker' | 'end' | 'error')[]
             }[]
         }
+        update_url?: string
         version_name?: string
     }
 


### PR DESCRIPTION
For self-hosted addons, the `update_url` field in the manifest is used by Firefox to fetch updates to an add-on.

For Mozilla-hosted addons (in the add-on store), this field isn't used, and if the field is present, then validation fails and the add-on can't be published.

Since we've started to migrate the Sourcegraph add-on from self-hosted to Mozilla-hosted, we need to remove the `update_url` field in order to pass validation.