### PR TITLE
Fix check in campaigns-notify GitHub action

### DIFF
--- a/.github/workflows/campaigns-notify.yml
+++ b/.github/workflows/campaigns-notify.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-create-comment@v1
-        if: contains(github.event.comment.body, 'campaigns') && !contains(github.event.pull_request.labels.*.name, 'team/campaigns')
+        if: contains(github.event.issue.body, 'campaigns') && !contains(github.event.issue.labels.*.name, 'team/campaigns')
         with:
           github_token: ${{ secrets.github_token }}
           body: |


### PR DESCRIPTION
Previously it checked for... the stuff I copy and pasted. This is the correct thing (I hope)