### PR TITLE
Use separate usernames in campaigns-notify action, because maybe it's the slash

### DIFF
--- a/.github/workflows/campaigns-notify.yml
+++ b/.github/workflows/campaigns-notify.yml
@@ -13,4 +13,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           body: |
-            Hey, @sourcegraph/campaigns - we have been mentioned. Let's take a look.
+            Hey, @sourcegraph/campaigns (@eseliger @mrnugget @LawnGnome @malomarrec @chrispine) - we have been mentioned. Let's take a look.


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
