### PR TITLE
search contexts: Use local storage to store last selected search context

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -435,10 +435,10 @@ describe('Search', () => {
             expect(await getSelectedSearchContextSpec()).toStrictEqual('context:@user')
         })
 
-        test('Missing context param should default to global context', async () => {
+        test('Missing context param should default to users context', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
             await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
-            expect(await getSelectedSearchContextSpec()).toStrictEqual('context:global')
+            expect(await getSelectedSearchContextSpec()).toStrictEqual('context:@test')
         })
 
         test('Unavailable search context should get appended to navbar query and disable the search context dropdown', async () => {


### PR DESCRIPTION
Use local storage to track last selected search context and set users search context as default. Set the last used search context (from local storage) as the selected search context if exists, otherwise use the users search context as selected.