### PR TITLE
call Zoekt's /stream endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -212,7 +212,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210223153151-e34da978df5b
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210224103651-ed2848a6422c
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1299,6 +1299,8 @@ github.com/sourcegraph/zoekt v0.0.0-20210216134814-a58c3d2968a6 h1:D5iMROXehGV4w
 github.com/sourcegraph/zoekt v0.0.0-20210216134814-a58c3d2968a6/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
 github.com/sourcegraph/zoekt v0.0.0-20210223153151-e34da978df5b h1:1JsdFaIroRrex+Xp3h6GUFTxl2DTc2c/KRA0V1jc0Nw=
 github.com/sourcegraph/zoekt v0.0.0-20210223153151-e34da978df5b/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
+github.com/sourcegraph/zoekt v0.0.0-20210224103651-ed2848a6422c h1:iCwC2/0fZ2UJM/HhdT82dBwCaSgBllcp8PCoDC565qk=
+github.com/sourcegraph/zoekt v0.0.0-20210224103651-ed2848a6422c/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -27,12 +27,6 @@ func (f ZoektStreamFunc) Send(event *zoekt.SearchResult) {
 	f(event)
 }
 
-// streamSearcher is an interface which calls c.Send(result *zoekt.SearchResults)
-// as results are found.
-type streamSearcher interface {
-	StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoekt.Sender) error
-}
-
 // StreamSearchEvent has fields optionally set representing events that happen
 // during a search.
 //
@@ -75,5 +69,5 @@ func NewZoektStream(address string) zoekt.Streamer {
 
 type zoektStream struct {
 	zoekt.Searcher
-	streamSearcher
+	*zoektstream.Client
 }

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -3,12 +3,16 @@ package backend
 import (
 	"context"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/rpc"
 	zoektstream "github.com/google/zoekt/stream"
 
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
@@ -55,17 +59,83 @@ func (s *StreamSearchAdapter) String() string {
 	return "streamSearchAdapter{" + s.Searcher.String() + "}"
 }
 
+// Temporarily store if we are on sourcegraph.com mode. We don't want to
+// introduce a dependency on frontend/envvar so just duplicating how we do
+// this.
+var sourcegraphDotComMode, _ = strconv.ParseBool(os.Getenv("SOURCEGRAPHDOTCOM_MODE"))
+
 // ZoektDial connects to a Searcher HTTP RPC server at address (host:port).
 func ZoektDial(endpoint string) zoekt.Streamer {
-	client := &zoektStream{
-		rpc.Client(endpoint),
-		zoektstream.NewClient("http://"+endpoint, zoektHTTPClient),
+	client := rpc.Client(endpoint)
+
+	batchClient := &StreamSearchAdapter{client}
+	streamClient := &zoektStream{
+		Searcher: client,
+		Client:   zoektstream.NewClient("http://"+endpoint, zoektHTTPClient),
 	}
 
-	return NewMeteredSearcher(endpoint, client)
+	if !sourcegraphDotComMode {
+		return NewMeteredSearcher(endpoint, batchClient)
+	}
+
+	// Temporary Sourcegraph.com only mode. For Stefan and Keegan use our new
+	// streaming mode.
+	ds := &dynamicStreamer{
+		Streamers: []zoekt.Streamer{batchClient, streamClient},
+		Pick: func(ctx context.Context) zoekt.Streamer {
+			uid := actor.FromContext(ctx).UID
+			if uid == 7 || uid == 23082 {
+				return streamClient
+			}
+			return batchClient
+		},
+	}
+
+	return NewMeteredSearcher(endpoint, ds)
 }
 
 type zoektStream struct {
 	zoekt.Searcher
 	*zoektstream.Client
+}
+
+// dynamicStreamer picks a Streamer to use at search time based on the
+// context.
+type dynamicStreamer struct {
+	// Streamers is the list of Streamers Pick can return. This is stored here
+	// so we can propagate Close.
+	Streamers []zoekt.Streamer
+
+	// Pick returns a Streamer to run a search against.
+	Pick func(context.Context) zoekt.Streamer
+}
+
+func (ds *dynamicStreamer) Search(ctx context.Context, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
+	s := ds.Pick(ctx)
+	return s.Search(ctx, q, opts)
+}
+
+func (ds *dynamicStreamer) List(ctx context.Context, q query.Q) (*zoekt.RepoList, error) {
+	s := ds.Pick(ctx)
+	return s.List(ctx, q)
+}
+
+func (ds *dynamicStreamer) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, sender zoekt.Sender) (err error) {
+	s := ds.Pick(ctx)
+	return s.StreamSearch(ctx, q, opts, sender)
+}
+
+func (ds *dynamicStreamer) Close() {
+	for _, s := range ds.Streamers {
+		s.Close()
+	}
+}
+
+func (ds *dynamicStreamer) String() string {
+	var streamers []string
+	for _, s := range ds.Streamers {
+		streamers = append(streamers, s.String())
+	}
+
+	return "DynamicSearcher{" + strings.Join(streamers, " ") + "}"
 }

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
@@ -56,15 +55,14 @@ func (s *StreamSearchAdapter) String() string {
 	return "streamSearchAdapter{" + s.Searcher.String() + "}"
 }
 
-func NewZoektStream(address string) zoekt.Streamer {
-	addressWithScheme := address
-	if !strings.HasPrefix(addressWithScheme, "http://") {
-		addressWithScheme = "http://" + addressWithScheme
+// ZoektDial connects to a Searcher HTTP RPC server at address (host:port).
+func ZoektDial(endpoint string) zoekt.Streamer {
+	client := &zoektStream{
+		rpc.Client(endpoint),
+		zoektstream.NewClient("http://"+endpoint, zoektHTTPClient),
 	}
-	return &zoektStream{
-		rpc.Client(address),
-		zoektstream.NewClient(addressWithScheme, zoektHTTPClient),
-	}
+
+	return NewMeteredSearcher(endpoint, client)
 }
 
 type zoektStream struct {

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -44,7 +44,7 @@ func SearcherURLs() *endpoint.Map {
 func Indexed() *backend.Zoekt {
 	indexedSearchOnce.Do(func() {
 		dial := func(endpoint string) zoekt.Streamer {
-			return backend.NewMeteredSearcher(endpoint, &backend.StreamSearchAdapter{rpc.Client(endpoint)})
+			return backend.NewMeteredSearcher(endpoint, backend.NewZoektStream(endpoint))
 		}
 
 		var client zoekt.Streamer

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -43,20 +43,16 @@ func SearcherURLs() *endpoint.Map {
 
 func Indexed() *backend.Zoekt {
 	indexedSearchOnce.Do(func() {
-		dial := func(endpoint string) zoekt.Streamer {
-			return backend.NewMeteredSearcher(endpoint, backend.NewZoektStream(endpoint))
-		}
-
 		var client zoekt.Streamer
 		if indexers := Indexers(); indexers.Enabled() {
 			client = backend.NewMeteredSearcher(
 				"", // no hostname means its the aggregator
 				&backend.HorizontalSearcher{
 					Map:  indexers.Map,
-					Dial: dial,
+					Dial: backend.ZoektDial,
 				})
 		} else if addr := zoektAddr(os.Environ()); addr != "" {
-			client = dial(addr)
+			client = backend.ZoektDial(addr)
 		}
 
 		indexedSearch = &backend.Zoekt{Client: client}


### PR DESCRIPTION
This updates our search backend to call Zoekt's new /stream endpoint.
For testing, we select a `zoekt.Streamer` (batch vs stream) based on
`context`. The /stream endpoint will only be called on Cloud and only
for @stefanhengl and @keegancsmith.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
