### PR TITLE
Add exit_code autoretry support for buildkite steps

### DIFF
--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -46,12 +46,14 @@ func addLint(pipeline *bk.Pipeline) {
 func addWebApp(pipeline *bk.Pipeline) {
 	// Webapp build
 	pipeline.AddStep(":webpack::globe_with_meridians: Build",
+		bk.FailedAgentAutomaticRetry(2),
 		bk.Cmd("dev/ci/yarn-build.sh client/web"),
 		bk.Env("NODE_ENV", "production"),
 		bk.Env("ENTERPRISE", "0"))
 
 	// Webapp enterprise build
 	pipeline.AddStep(":webpack::globe_with_meridians::moneybag: Enterprise build",
+		bk.FailedAgentAutomaticRetry(2),
 		bk.Cmd("dev/ci/yarn-build.sh client/web"),
 		bk.Env("NODE_ENV", "production"),
 		bk.Env("ENTERPRISE", "1"))
@@ -94,7 +96,7 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			chromaticCommand += " --auto-accept-changes"
 		}
 		pipeline.AddStep(":chromatic: Upload storybook to Chromatic",
-			bk.AutomaticRetry(5),
+			bk.AutomaticRetry(5, "*"),
 			bk.Cmd("yarn --mutex network --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("yarn gulp generate"),
 			bk.Env("MINIFY", "1"),

--- a/internal/buildkite/buildkite.go
+++ b/internal/buildkite/buildkite.go
@@ -41,11 +41,12 @@ type Step struct {
 }
 
 type RetryOptions struct {
-	Automatic *AutomaticRetryOptions `json:"automatic,omitempty"`
+	Automatic []*AutomaticRetryOptions `json:"automatic,omitempty"`
 }
 
 type AutomaticRetryOptions struct {
-	Limit int `json:"limit,omitempty"`
+	Limit      int    `json:"limit,omitempty"`
+	ExitStatus string `json:"exit_status,omitempty"`
 }
 
 var Plugins = make(map[string]interface{})
@@ -147,11 +148,31 @@ func SoftFail(softFail bool) StepOpt {
 	}
 }
 
-func AutomaticRetry(limit int) StepOpt {
+func AutomaticRetry(limit int, exitStatus string) StepOpt {
 	return func(step *Step) {
 		step.Retry = &RetryOptions{
-			Automatic: &AutomaticRetryOptions{
-				Limit: limit,
+			Automatic: []*AutomaticRetryOptions{
+				{
+					Limit:      limit,
+					ExitStatus: exitStatus,
+				},
+			},
+		}
+	}
+}
+
+func FailedAgentAutomaticRetry(limit int) StepOpt {
+	return func(step *Step) {
+		step.Retry = &RetryOptions{
+			Automatic: []*AutomaticRetryOptions{
+				{
+					Limit:      2,
+					ExitStatus: "-1",
+				},
+				{
+					Limit:      2,
+					ExitStatus: "255",
+				},
 			},
 		}
 	}


### PR DESCRIPTION
This would help expensive builds automatically retry when agents are lost or otherwise terminated as they are ephemeral Kuberentes pods.