### PR TITLE
dev: only trigger generate for schema/*.json

### DIFF
--- a/dev/watchmanwrapper/watch.json
+++ b/dev/watchmanwrapper/watch.json
@@ -9,10 +9,9 @@
       [
         "anyof",
         ["suffix", "go"],
-        ["dirname", "cmd/symbols"],
-        ["dirname", "schema"],
+        ["name", "cmd/frontend/graphqlbackend/schema.graphql", "wholename"],
         ["dirname", "monitoring"],
-        ["name", "cmd/frontend/graphqlbackend/schema.graphql", "wholename"]
+        ["match", "schema/*.json", "wholename"]
       ]
     ],
     "fields": ["name"]


### PR DESCRIPTION
The watch rules trigger handle-change.sh. handle-change.sh had a section
for "schema/*.json" which would cause us to run go generate in
schema. However, the watchman rule was for any file in schema. This
change makes the watchman rule the same.

handle-change.sh has a fallback rule of build everything. There was a
webstep that wrote to "schema/out". This would then trigger the fallback
option of rebuilding everything. The symbols build uses cgo which does
not seem to be a idempotent build. This lead to the symbols build often
being rebuilt on startup.

Co-authored-by: Erik Seliger <erikseliger@me.com>
