### PR TITLE
graphql: Attribute request to IP address if unknown

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -74,6 +74,13 @@ func (h honeycombTracer) TraceQuery(ctx context.Context, queryString string, ope
 		if anonymous {
 			uid = sgtrace.AnonymousUID(ctx)
 		}
+		if uid == "unknown" {
+			// The user is anonymous with no cookie, use IP
+			ip := sgtrace.IPAddress(ctx)
+			if ip != "" {
+				uid = ip
+			}
+		}
 
 		ev := honey.Event("graphql-cost")
 		ev.SampleRate = uint(traceGraphQLQueriesSample)

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -33,6 +33,9 @@ func serveGraphQL(schema *graphql.Schema, isInternal bool) func(w http.ResponseW
 		if cookie, err := r.Cookie("sourcegraphAnonymousUid"); err == nil && cookie.Value != "" {
 			r = r.WithContext(trace.WithAnonymousUID(r.Context(), cookie.Value))
 		}
+		if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
+			r = r.WithContext(trace.WithIPAddress(r.Context(), ip))
+		}
 
 		if r.Header.Get("Content-Encoding") == "gzip" {
 			gzipReader, err := gzip.NewReader(r.Body)

--- a/internal/trace/httptrace.go
+++ b/internal/trace/httptrace.go
@@ -35,6 +35,7 @@ const (
 	sourceKey
 	isInternalKey
 	anonymousUIDKey
+	ipAddressKey
 )
 
 // trackOrigin specifies a URL value. When an incoming request has the request header "Origin" set
@@ -95,6 +96,17 @@ func IsInternalRequest(ctx context.Context) bool {
 // external API handler.
 func WithIsInternal(ctx context.Context, isInternal bool) context.Context {
 	return context.WithValue(ctx, isInternalKey, isInternal)
+}
+
+// IPAddress attempts to fetch an IP address stored in the context.
+func IPAddress(ctx context.Context) string {
+	v, _ := ctx.Value(ipAddressKey).(string)
+	return v
+}
+
+// WithIPAddress sets the IP address associated with request.
+func WithIPAddress(ctx context.Context, ip string) context.Context {
+	return context.WithValue(ctx, ipAddressKey, ip)
 }
 
 // AnonymousUID sets the anonymous UID associated with the request.


### PR DESCRIPTION
Use ip address as uid if the user is anonymous and we don't have an
anonymous id in their cookie.
