### PR TITLE
dev: rely on go compiler to decide if binary changed

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -100,13 +100,13 @@ esac
 
 # Cross-platform md5sum. Fallback to BSD md5 if md5sum doesn't exist.
 do_md5() {
-  pushd "${GOBIN}" > /dev/null || exit 1
+  pushd "${GOBIN}" >/dev/null || exit 1
   if command -v md5sum >/dev/null 2>&1; then
-    md5sum "$@" 2> /dev/null
+    md5sum "$@" 2>/dev/null
   else
-    md5 -r "$@" 2> /dev/null
+    md5 -r "$@" 2>/dev/null
   fi
-  popd > /dev/null || exit 1
+  popd >/dev/null || exit 1
 }
 
 # Shared logic for the go install part
@@ -131,12 +131,12 @@ do_install() {
   # Store hashes of binaries so we know what changes. We let go install
   # directly write to the binaries since go will skip compiling a binary if it
   # believes it hasn't changed.
-  do_md5 "${cmdlist[@]}" > "${tmpdir}/digest.txt"
+  do_md5 "${cmdlist[@]}" >"${tmpdir}/digest.txt"
 
   if (go install -v -gcflags="$GCFLAGS" -tags "$TAGS" -race="$race" "${cmds[@]}"); then
     if $verbose; then
       # Add the digests after compilation
-      do_md5 "${cmdlist[@]}" >> "${tmpdir}/digest.txt"
+      do_md5 "${cmdlist[@]}" >>"${tmpdir}/digest.txt"
       # Now any digest that is unique ($1 == 1) will mean the binary for it
       # changed or came into existance.
       sort "${tmpdir}/digest.txt" | uniq -c | awk '$1 == 1 { print $3 }' | sort | uniq

--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -65,7 +65,6 @@ fi
 # we can update only those packages that change. Clean up the temp at exit.
 tmpdir="$(mktemp -d -t src-binaries.XXXXXXXX)"
 trap 'rm -rf "$tmpdir"' EXIT
-export GOBIN="$tmpdir"
 
 TAGS='dev'
 if [ -n "$DELVE" ]; then
@@ -99,13 +98,24 @@ case $GORACED in
     ;;
 esac
 
+# Cross-platform md5sum. Fallback to BSD md5 if md5sum doesn't exist.
+do_md5() {
+  pushd "${GOBIN}" > /dev/null || exit 1
+  if command -v md5sum >/dev/null 2>&1; then
+    md5sum "$@" 2> /dev/null
+  else
+    md5 -r "$@" 2> /dev/null
+  fi
+  popd > /dev/null || exit 1
+}
+
 # Shared logic for the go install part
 do_install() {
   race=$1
   shift
-  cmdlist="$*"
+  cmdlist=("$@")
   cmds=()
-  for cmd in $cmdlist; do
+  for cmd in "${cmdlist[@]}"; do
     replaced=false
     for enterpriseCmd in $ENTERPRISE_COMMANDS; do
       if [ "$cmd" == "$enterpriseCmd" ]; then
@@ -117,20 +127,22 @@ do_install() {
       cmds+=("github.com/sourcegraph/sourcegraph/cmd/$cmd")
     fi
   done
-  if (go install -v -gcflags="$GCFLAGS" -tags "$TAGS" -race="$race" "${cmds[@]}"); then
-    for cmd in $cmdlist; do
-      # Check whether the binary of each command has changed
-      if ! cmp -s "${GOBIN}/${cmd}" "${PWD}/.bin/${cmd}"; then
-        # Binary updated. Move it to correct location.
-        mv "${GOBIN}/${cmd}" "${PWD}/.bin/${cmd}"
 
-        if $verbose; then
-          echo "$cmd"
-        fi
-      fi
-    done
+  # Store hashes of binaries so we know what changes. We let go install
+  # directly write to the binaries since go will skip compiling a binary if it
+  # believes it hasn't changed.
+  do_md5 "${cmdlist[@]}" > "${tmpdir}/digest.txt"
+
+  if (go install -v -gcflags="$GCFLAGS" -tags "$TAGS" -race="$race" "${cmds[@]}"); then
+    if $verbose; then
+      # Add the digests after compilation
+      do_md5 "${cmdlist[@]}" >> "${tmpdir}/digest.txt"
+      # Now any digest that is unique ($1 == 1) will mean the binary for it
+      # changed or came into existance.
+      sort "${tmpdir}/digest.txt" | uniq -c | awk '$1 == 1 { print $3 }' | sort | uniq
+    fi
   else
-    failed="$failed $cmdlist"
+    failed="$failed ${cmdlist[*]}"
   fi
 }
 


### PR DESCRIPTION
In our dev environment when a file changes we recompile and restart all
binaries that may depend on it. Previously we would compile to a
temporary location and then only restart services if the binary
changed. This had two downsides:

- Go would do a lot of work since it still has to link the binaries to
  create the final executable.
- The symbols service would always change due to cgo.

Now that we pass the final destination to go install, it inspects the
binary and uses metadata in it to skip building/linking unless something
has really changed.

To achieve this we rely on md5 summing the binaries before and after
compilation. We can't rely on timestamps because go will always update
them. This took a while to implement because bash is sadomasochism.

Co-authored-by: @eseliger 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
