### PR TITLE
Don't log errors while proxying web requests to frontend

### DIFF
--- a/client/web/gulpfile.js
+++ b/client/web/gulpfile.js
@@ -79,7 +79,11 @@ async function webpackDevelopmentServer() {
       '/': {
         target: 'http://localhost:3081',
         // Avoid crashing on "read ECONNRESET".
-        onError: error => console.error(error),
+        onError: () => undefined,
+        // Don't log proxy errors, these usually just contain
+        // ECONNRESET errors caused by the browser cancelling
+        // requests. This should not be needed to actually debug something.
+        logLevel: 'silent',
         onProxyReqWs: (_proxyRequest, _request, socket) =>
           socket.on('error', error => console.error('WebSocket proxy error:', error)),
       },


### PR DESCRIPTION
These usually just contain ECONNRESET errors caused by the browser cancelling requests. This should not be needed to actually debug something, and in the very rare case, it can be easily turned on again. Also, having onError log made the error message appear twice.
