### PR TITLE
gitserver: Avoid redundant URL parsing

### DIFF
--- a/cmd/gitserver/server/customfetch.go
+++ b/cmd/gitserver/server/customfetch.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -29,26 +28,13 @@ func buildCustomFetchMappings(c []*schema.CustomGitFetchMapping) map[string][]st
 	return cgm
 }
 
-func extractDomainPath(cloneURL string) (string, error) {
-	gitURL, err := url.Parse(cloneURL)
-	if err != nil {
-		return "", err
-	}
-
-	return path.Join(gitURL.Host, gitURL.Path), nil
-}
-
-func customFetchCmd(ctx context.Context, urlVal string) *exec.Cmd {
+func customFetchCmd(ctx context.Context, remoteURL *url.URL) *exec.Cmd {
 	cgm := customGitFetch().(map[string][]string)
 	if len(cgm) == 0 {
 		return nil
 	}
 
-	dp, err := extractDomainPath(urlVal)
-	if err != nil {
-		log15.Error("failed to extract domain and path", "url", urlVal, "err", err)
-		return nil
-	}
+	dp := path.Join(remoteURL.Host, remoteURL.Path)
 	cmdParts := cgm[dp]
 	if len(cmdParts) == 0 {
 		return nil

--- a/cmd/gitserver/server/customfetch_test.go
+++ b/cmd/gitserver/server/customfetch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -13,7 +14,8 @@ func TestEmptyCustomGitFetch(t *testing.T) {
 		return buildCustomFetchMappings(nil)
 	}
 
-	customCmd := customFetchCmd(context.Background(), "git@github.com:sourcegraph/sourcegraph.git")
+	remoteURL, _ := vcs.ParseURL("git@github.com:sourcegraph/sourcegraph.git")
+	customCmd := customFetchCmd(context.Background(), remoteURL)
 	if customCmd != nil {
 		t.Errorf("expected nil custom cmd for empty configuration, got %+v", customCmd)
 	}
@@ -60,7 +62,8 @@ func TestCustomGitFetch(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		customCmd := customFetchCmd(context.Background(), test.url)
+		remoteURL, _ := vcs.ParseURL(test.url)
+		customCmd := customFetchCmd(context.Background(), remoteURL)
 		var args []string
 		if customCmd != nil {
 			args = customCmd.Args

--- a/cmd/gitserver/server/refspecoverrides.go
+++ b/cmd/gitserver/server/refspecoverrides.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -25,13 +26,13 @@ func useRefspecOverrides() bool {
 //
 // To not clone everything we instead init a bare repo and only add the
 // refspecs we care about. Then we finally do a fetch.
-func refspecOverridesCloneCmd(ctx context.Context, url, tmpPath string) (*exec.Cmd, error) {
+func refspecOverridesCloneCmd(ctx context.Context, remoteURL *url.URL, tmpPath string) (*exec.Cmd, error) {
 	if err := os.MkdirAll(tmpPath, os.ModePerm); err != nil {
 		return nil, errors.Wrapf(err, "clone failed to create tmp dir")
 	}
 	cmds := [][]string{
 		{"init", "--bare", "."},
-		{"config", "--add", "remote.origin.url", url},
+		{"config", "--add", "remote.origin.url", remoteURL.String()},
 		{"config", "--add", "remote.origin.mirror", "true"},
 	}
 	for _, refspec := range refspecOverrides {
@@ -51,6 +52,6 @@ func refspecOverridesCloneCmd(ctx context.Context, url, tmpPath string) (*exec.C
 
 // HACK(keegancsmith) workaround to experiment with cloning less in a large
 // monorepo. https://github.com/sourcegraph/customer/issues/19
-func refspecOverridesFetchCmd(ctx context.Context, url string) *exec.Cmd {
-	return exec.CommandContext(ctx, "git", append([]string{"fetch", "--prune", url}, refspecOverrides...)...)
+func refspecOverridesFetchCmd(ctx context.Context, remoteURL *url.URL) *exec.Cmd {
+	return exec.CommandContext(ctx, "git", append([]string{"fetch", "--prune", remoteURL.String()}, refspecOverrides...)...)
 }

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -28,7 +28,7 @@ func (s *Server) repoInfo(ctx context.Context, repo api.RepoName) (*protocol.Rep
 		if err != nil {
 			return nil, err
 		}
-		resp.URL = remoteURL
+		resp.URL = remoteURL.String()
 	}
 	{
 		resp.CloneProgress, resp.CloneInProgress = s.locker.Status(dir)

--- a/cmd/gitserver/server/repo_info_test.go
+++ b/cmd/gitserver/server/repo_info_test.go
@@ -96,7 +96,7 @@ func TestServer_handleRepoInfo(t *testing.T) {
 					Cloned:      true,
 					LastFetched: &lastFetched,
 					LastChanged: &lastChanged,
-					URL:         "u",
+					URL:         "file://u",
 				},
 			},
 		}

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -271,10 +272,11 @@ var repoLastChanged = func(dir GitDir) (time.Time, error) {
 //
 // The ref prefix `ref/<ref type>/` is stripped away from the returned
 // refs.
-var repoRemoteRefs = func(ctx context.Context, url, prefix string) (map[string]string, error) {
+var repoRemoteRefs = func(ctx context.Context, remoteURL *url.URL, prefix string) (map[string]string, error) {
 	// The expected output of this git command is a list of:
 	// <commit hash> <ref name>
-	cmd := exec.Command("git", "ls-remote", url, prefix+"*")
+	cmd := exec.Command("git", "ls-remote", remoteURL.String(), prefix+"*")
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -23,28 +23,28 @@ import (
 type VCSSyncer interface {
 	// IsCloneable checks to see if the VCS remote URL is cloneable. Any non-nil
 	// error indicates there is a problem.
-	IsCloneable(ctx context.Context, url string) error
+	IsCloneable(ctx context.Context, remoteURL *url.URL) error
 	// CloneCommand returns the command to be executed for cloning from remote.
-	CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error)
+	CloneCommand(ctx context.Context, remoteURL *url.URL, tmpPath string) (cmd *exec.Cmd, err error)
 	// FetchCommand returns the command to be executed for fetching updates from remote.
-	FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error)
+	FetchCommand(ctx context.Context, remoteURL *url.URL) (cmd *exec.Cmd, configRemoteOpts bool, err error)
 	// RemoteShowCommand returns the command to be executed for showing remote.
-	RemoteShowCommand(ctx context.Context, url string) (cmd *exec.Cmd, err error)
+	RemoteShowCommand(ctx context.Context, remoteURL *url.URL) (cmd *exec.Cmd, err error)
 }
 
 // GitRepoSyncer is a syncer for Git repositories.
 type GitRepoSyncer struct{}
 
 // IsCloneable checks to see if the Git remote URL is cloneable.
-func (s *GitRepoSyncer) IsCloneable(ctx context.Context, url string) error {
-	if strings.ToLower(string(protocol.NormalizeRepo(api.RepoName(url)))) == "github.com/sourcegraphtest/alwayscloningtest" {
+func (s *GitRepoSyncer) IsCloneable(ctx context.Context, remoteURL *url.URL) error {
+	if strings.ToLower(string(protocol.NormalizeRepo(api.RepoName(remoteURL.String())))) == "github.com/sourcegraphtest/alwayscloningtest" {
 		return nil
 	}
 	if testGitRepoExists != nil {
-		return testGitRepoExists(ctx, url)
+		return testGitRepoExists(ctx, remoteURL)
 	}
 
-	args := []string{"ls-remote", url, "HEAD"}
+	args := []string{"ls-remote", remoteURL.String(), "HEAD"}
 	ctx, cancel := context.WithTimeout(ctx, shortGitCommandTimeout(args))
 	defer cancel()
 
@@ -63,23 +63,23 @@ func (s *GitRepoSyncer) IsCloneable(ctx context.Context, url string) error {
 }
 
 // CloneCommand returns the command to be executed for cloning a Git repository.
-func (s *GitRepoSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (cmd *exec.Cmd, err error) {
+func (s *GitRepoSyncer) CloneCommand(ctx context.Context, remoteURL *url.URL, tmpPath string) (cmd *exec.Cmd, err error) {
 	if useRefspecOverrides() {
-		return refspecOverridesCloneCmd(ctx, url, tmpPath)
+		return refspecOverridesCloneCmd(ctx, remoteURL, tmpPath)
 	}
-	return exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", url, tmpPath), nil
+	return exec.CommandContext(ctx, "git", "clone", "--mirror", "--progress", remoteURL.String(), tmpPath), nil
 }
 
 // FetchCommand returns the command to be executed for fetching updates of a Git repository.
-func (s *GitRepoSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
+func (s *GitRepoSyncer) FetchCommand(ctx context.Context, remoteURL *url.URL) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
 	configRemoteOpts = true
-	if customCmd := customFetchCmd(ctx, url); customCmd != nil {
+	if customCmd := customFetchCmd(ctx, remoteURL); customCmd != nil {
 		cmd = customCmd
 		configRemoteOpts = false
 	} else if useRefspecOverrides() {
-		cmd = refspecOverridesFetchCmd(ctx, url)
+		cmd = refspecOverridesFetchCmd(ctx, remoteURL)
 	} else {
-		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", url,
+		cmd = exec.CommandContext(ctx, "git", "fetch", "--prune", remoteURL.String(),
 			// Normal git refs
 			"+refs/heads/*:refs/heads/*", "+refs/tags/*:refs/tags/*",
 			// GitHub pull requests
@@ -97,8 +97,8 @@ func (s *GitRepoSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec
 }
 
 // RemoteShowCommand returns the command to be executed for showing remote of a Git repository.
-func (s *GitRepoSyncer) RemoteShowCommand(ctx context.Context, url string) (cmd *exec.Cmd, err error) {
-	return exec.CommandContext(ctx, "git", "remote", "show", url), nil
+func (s *GitRepoSyncer) RemoteShowCommand(ctx context.Context, remoteURL *url.URL) (cmd *exec.Cmd, err error) {
+	return exec.CommandContext(ctx, "git", "remote", "show", remoteURL.String()), nil
 }
 
 // PerforceDepotSyncer is a syncer for Perforce depots.
@@ -107,20 +107,14 @@ type PerforceDepotSyncer struct {
 	MaxChanges int
 }
 
-// decomposePerforceCloneURL decomposes information back from a clone URL for a
+// decomposePerforceRemoteURL decomposes information back from a clone URL for a
 // Perforce depot.
-func decomposePerforceCloneURL(cloneURL string) (username, password, host, depot string, err error) {
-	url, err := url.Parse(cloneURL)
-	if err != nil {
-		return "", "", "", "", err
-	}
-
-	if url.Scheme != "perforce" {
+func decomposePerforceRemoteURL(remoteURL *url.URL) (username, password, host, depot string, err error) {
+	if remoteURL.Scheme != "perforce" {
 		return "", "", "", "", errors.New(`scheme is not "perforce"`)
 	}
-
-	password, _ = url.User.Password()
-	return url.User.Username(), password, url.Host, url.Path, nil
+	password, _ = remoteURL.User.Password()
+	return remoteURL.User.Username(), password, remoteURL.Host, remoteURL.Path, nil
 }
 
 // p4ping sends one message to the Perforce Server to check connectivity.
@@ -211,8 +205,8 @@ func p4pingWithLogin(ctx context.Context, host, username, password string) error
 }
 
 // IsCloneable checks to see if the Perforce remote URL is cloneable.
-func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error {
-	username, password, host, _, err := decomposePerforceCloneURL(url)
+func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, remoteURL *url.URL) error {
+	username, password, host, _, err := decomposePerforceRemoteURL(remoteURL)
 	if err != nil {
 		return errors.Wrap(err, "decompose")
 	}
@@ -222,8 +216,8 @@ func (s *PerforceDepotSyncer) IsCloneable(ctx context.Context, url string) error
 }
 
 // CloneCommand returns the command to be executed for cloning a Perforce depot as a Git repository.
-func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, url, tmpPath string) (*exec.Cmd, error) {
-	username, password, host, depot, err := decomposePerforceCloneURL(url)
+func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, remoteURL *url.URL, tmpPath string) (*exec.Cmd, error) {
+	username, password, host, depot, err := decomposePerforceRemoteURL(remoteURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "decompose")
 	}
@@ -250,8 +244,8 @@ func (s *PerforceDepotSyncer) CloneCommand(ctx context.Context, url, tmpPath str
 }
 
 // FetchCommand returns the command to be executed for fetching updates of a Perforce depot as a Git repository.
-func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, url string) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
-	username, password, host, _, err := decomposePerforceCloneURL(url)
+func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, remoteURL *url.URL) (cmd *exec.Cmd, configRemoteOpts bool, err error) {
+	username, password, host, _, err := decomposePerforceRemoteURL(remoteURL)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "decompose")
 	}
@@ -277,7 +271,7 @@ func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, url string) (cmd
 }
 
 // RemoteShowCommand returns the command to be executed for showing Git remote of a Perforce depot.
-func (s *PerforceDepotSyncer) RemoteShowCommand(ctx context.Context, url string) (cmd *exec.Cmd, err error) {
+func (s *PerforceDepotSyncer) RemoteShowCommand(ctx context.Context, remoteURL *url.URL) (cmd *exec.Cmd, err error) {
 	// Remote info is encoded as in the current repository
 	return exec.CommandContext(ctx, "git", "remote", "show", "./"), nil
 }

--- a/cmd/gitserver/server/vcs_syncer_test.go
+++ b/cmd/gitserver/server/vcs_syncer_test.go
@@ -2,11 +2,14 @@ package server
 
 import (
 	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 
-func TestDecomposePerforceCloneURL(t *testing.T) {
+func TestDecomposePerforceRemoteURL(t *testing.T) {
 	t.Run("not a perforce scheme", func(t *testing.T) {
-		_, _, _, _, err := decomposePerforceCloneURL("https://www.google.com")
+		remoteURL, _ := vcs.ParseURL("https://www.google.com")
+		_, _, _, _, err := decomposePerforceRemoteURL(remoteURL)
 		if err == nil {
 			t.Fatal("Want non-nil error but got nil")
 		}
@@ -61,7 +64,8 @@ func TestDecomposePerforceCloneURL(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.cloneURL, func(t *testing.T) {
-			username, password, host, depot, err := decomposePerforceCloneURL(test.cloneURL)
+			remoteURL, _ := vcs.ParseURL(test.cloneURL)
+			username, password, host, depot, err := decomposePerforceRemoteURL(remoteURL)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/vcs/url.go
+++ b/internal/vcs/url.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2014 Will Maier <wcmaier@m.aier.us>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package vcs
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// ParseURL parses rawurl into a URL structure. Parse first attempts to
+// find a standard URL with a valid VCS URL scheme. If
+// that cannot be found, it then attempts to find a SCP-like URL.
+// And if that cannot be found, it assumes rawurl is a local path.
+// If none of these rules apply, Parse returns an error.
+//
+// Code copied and modified from github.com/whilp/git-urls to support perforce scheme.
+func ParseURL(rawurl string) (u *url.URL, err error) {
+	parsers := []func(string) (*url.URL, error){
+		parseScheme,
+		parseScp,
+		parseLocal,
+	}
+
+	// Apply each parser in turn; if the parser succeeds, accept its
+	// result and return.
+	for _, p := range parsers {
+		u, err = p(rawurl)
+		if err == nil {
+			return u, err
+		}
+	}
+
+	// It's unlikely that none of the parsers will succeed, since
+	// ParseLocal is very forgiving.
+	return new(url.URL), fmt.Errorf("failed to parse %q", rawurl)
+}
+
+var schemes = map[string]struct{}{
+	"ssh":      struct{}{},
+	"git":      struct{}{},
+	"git+ssh":  struct{}{},
+	"http":     struct{}{},
+	"https":    struct{}{},
+	"ftp":      struct{}{},
+	"ftps":     struct{}{},
+	"rsync":    struct{}{},
+	"perforce": struct{}{},
+}
+
+func parseScheme(rawurl string) (*url.URL, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, valid := schemes[u.Scheme]; !valid {
+		return nil, fmt.Errorf("scheme %q is not a valid transport", u.Scheme)
+	}
+
+	return u, nil
+}
+
+// scpSyntax was modified from https://golang.org/src/cmd/go/vcs.go.
+var scpSyntax = regexp.MustCompile(`^([a-zA-Z0-9-._~]+@)?([a-zA-Z0-9._-]+):([a-zA-Z0-9./._-]+)(?:\?||$)(.*)$`)
+
+// parseScp parses rawurl into a URL object. The rawurl must be
+// an SCP-like URL, otherwise ParseScp returns an error.
+func parseScp(rawurl string) (*url.URL, error) {
+	match := scpSyntax.FindAllStringSubmatch(rawurl, -1)
+	if len(match) == 0 {
+		return nil, fmt.Errorf("no scp URL found in %q", rawurl)
+	}
+	m := match[0]
+	user := strings.TrimRight(m[1], "@")
+	var userinfo *url.Userinfo
+	if user != "" {
+		userinfo = url.User(user)
+	}
+	rawquery := ""
+	if len(m) > 3 {
+		rawquery = m[4]
+	}
+	return &url.URL{
+		Scheme:   "ssh",
+		User:     userinfo,
+		Host:     m[2],
+		Path:     m[3],
+		RawQuery: rawquery,
+	}, nil
+}
+
+// parseLocal parses rawurl into a URL object with a "file"
+// scheme. This will effectively never return an error.
+func parseLocal(rawurl string) (*url.URL, error) {
+	return &url.URL{
+		Scheme: "file",
+		Host:   "",
+		Path:   rawurl,
+	}, nil
+}

--- a/internal/vcs/url.go
+++ b/internal/vcs/url.go
@@ -52,16 +52,16 @@ func ParseURL(rawurl string) (u *url.URL, err error) {
 }
 
 var schemes = map[string]struct{}{
-	"ssh":      struct{}{},
-	"git":      struct{}{},
-	"git+ssh":  struct{}{},
-	"http":     struct{}{},
-	"https":    struct{}{},
-	"ftp":      struct{}{},
-	"ftps":     struct{}{},
-	"rsync":    struct{}{},
-	"file":     struct{}{},
-	"perforce": struct{}{},
+	"ssh":      {},
+	"git":      {},
+	"git+ssh":  {},
+	"http":     {},
+	"https":    {},
+	"ftp":      {},
+	"ftps":     {},
+	"rsync":    {},
+	"file":     {},
+	"perforce": {},
 }
 
 func parseScheme(rawurl string) (*url.URL, error) {

--- a/internal/vcs/url.go
+++ b/internal/vcs/url.go
@@ -60,6 +60,7 @@ var schemes = map[string]struct{}{
 	"ftp":      struct{}{},
 	"ftps":     struct{}{},
 	"rsync":    struct{}{},
+	"file":     struct{}{},
 	"perforce": struct{}{},
 }
 

--- a/internal/vcs/url_test.go
+++ b/internal/vcs/url_test.go
@@ -1,0 +1,221 @@
+package vcs
+
+import (
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseURL(t *testing.T) {
+	type parseURLTest struct {
+		in      string
+		wantURL *url.URL
+		wantStr string // expected result of reserializing the URL; empty means same as "in".
+	}
+
+	newParseURLTest := func(in, scheme, user, host, path, str, rawquery string) *parseURLTest {
+		var userinfo *url.Userinfo
+
+		if user != "" {
+			if strings.Contains(user, ":") {
+				username := strings.Split(user, ":")[0]
+				password := strings.Split(user, ":")[1]
+				userinfo = url.UserPassword(username, password)
+			} else {
+				userinfo = url.User(user)
+			}
+		}
+		if str == "" {
+			str = in
+		}
+
+		return &parseURLTest{
+			in: in,
+			wantURL: &url.URL{
+				Scheme:   scheme,
+				Host:     host,
+				Path:     path,
+				User:     userinfo,
+				RawQuery: rawquery,
+			},
+			wantStr: str,
+		}
+	}
+
+	// https://www.kernel.org/pub/software/scm/git/docs/git-clone.html
+	tests := []*parseURLTest{
+		newParseURLTest(
+			"user@host.xz:path/to/repo.git/",
+			"ssh", "user", "host.xz", "path/to/repo.git/",
+			"ssh://user@host.xz/path/to/repo.git/", "",
+		),
+		newParseURLTest(
+			"host.xz:path/to/repo.git/",
+			"ssh", "", "host.xz", "path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/", "",
+		),
+		newParseURLTest(
+			"host.xz:/path/to/repo.git/",
+			"ssh", "", "host.xz", "/path/to/repo.git/",
+			"ssh://host.xz/path/to/repo.git/", "",
+		),
+		newParseURLTest(
+			"host.xz:path/to/repo-with_specials.git/",
+			"ssh", "", "host.xz", "path/to/repo-with_specials.git/",
+			"ssh://host.xz/path/to/repo-with_specials.git/", "",
+		),
+		newParseURLTest(
+			"git://host.xz/path/to/repo.git/",
+			"git", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"git://host.xz:1234/path/to/repo.git/",
+			"git", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"http://host.xz/path/to/repo.git/",
+			"http", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"http://host.xz:1234/path/to/repo.git/",
+			"http", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"https://host.xz/path/to/repo.git/",
+			"https", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"https://host.xz:1234/path/to/repo.git/",
+			"https", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"ftp://host.xz/path/to/repo.git/",
+			"ftp", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"ftp://host.xz:1234/path/to/repo.git/",
+			"ftp", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"ftps://host.xz/path/to/repo.git/",
+			"ftps", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"ftps://host.xz:1234/path/to/repo.git/",
+			"ftps", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"rsync://host.xz/path/to/repo.git/",
+			"rsync", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"ssh://user@host.xz:1234/path/to/repo.git/",
+			"ssh", "user", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"ssh://host.xz:1234/path/to/repo.git/",
+			"ssh", "", "host.xz:1234", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"ssh://host.xz/path/to/repo.git/",
+			"ssh", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"git+ssh://host.xz/path/to/repo.git/",
+			"git+ssh", "", "host.xz", "/path/to/repo.git/",
+			"", "",
+		),
+		// Tests with query strings
+		newParseURLTest(
+			"https://host.xz/organization/repo.git?ref=",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=",
+		),
+		newParseURLTest(
+			"https://host.xz/organization/repo.git?ref=test",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=test",
+		),
+		newParseURLTest(
+			"https://host.xz/organization/repo.git?ref=feature/test",
+			"https", "", "host.xz", "/organization/repo.git",
+			"", "ref=feature/test",
+		),
+		newParseURLTest(
+			"git@host.xz:organization/repo.git?ref=test",
+			"ssh", "git", "host.xz", "organization/repo.git",
+			"ssh://git@host.xz/organization/repo.git?ref=test", "ref=test",
+		),
+		newParseURLTest(
+			"git@host.xz:organization/repo.git?ref=feature/test",
+			"ssh", "git", "host.xz", "organization/repo.git",
+			"ssh://git@host.xz/organization/repo.git?ref=feature/test", "ref=feature/test",
+		),
+		// Tests with user+password and some with query strings
+		newParseURLTest(
+			"https://user:password@host.xz/organization/repo.git/",
+			"https", "user:password", "host.xz", "/organization/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"https://user:password@host.xz/organization/repo.git?ref=test",
+			"https", "user:password", "host.xz", "/organization/repo.git",
+			"", "ref=test",
+		),
+		newParseURLTest(
+			"https://user:password@host.xz/organization/repo.git?ref=feature/test",
+			"https", "user:password", "host.xz", "/organization/repo.git",
+			"", "ref=feature/test",
+		),
+		newParseURLTest(
+			"user-1234@host.xz:path/to/repo.git/",
+			"ssh", "user-1234", "host.xz", "path/to/repo.git/",
+			"ssh://user-1234@host.xz/path/to/repo.git/", "",
+		),
+		newParseURLTest(
+			"/path/to/repo.git/",
+			"file", "", "", "/path/to/repo.git/",
+			"file:///path/to/repo.git/", "",
+		),
+		newParseURLTest(
+			"file:///path/to/repo.git/",
+			"file", "", "", "/path/to/repo.git/",
+			"", "",
+		),
+		newParseURLTest(
+			"perforce://admin:pa$$word@ssl:192.168.1.100:1666//Sourcegraph/",
+			"perforce", "admin:pa$$word", "ssl:192.168.1.100:1666", "//Sourcegraph/",
+			"perforce://admin:pa$$word@ssl:192.168.1.100:1666//Sourcegraph/", "",
+		),
+	}
+
+	for _, tt := range tests {
+		got, err := ParseURL(tt.in)
+		if err != nil {
+			t.Errorf("ParseURL(%q) = unexpected err %q, want %q", tt.in, err, tt.wantURL)
+			continue
+		}
+		if !reflect.DeepEqual(got, tt.wantURL) {
+			t.Errorf("ParseURL(%q)\ngot  %q\nwant %q", tt.in, got, tt.wantURL)
+		}
+		str := got.String()
+		if str != tt.wantStr {
+			t.Errorf("Parse(%q).String() = %q, want %q", tt.in, str, tt.wantStr)
+		}
+	}
+}


### PR DESCRIPTION
This commit changes a few interfaces and signatures in gitserver to deal with a
`remoteURL *url.URL` instead of a bare string, which we were ultimately
parsing multiple times.

It also introduces a `ParseURL` function in the `vcs` package which
works with all git URL types as well as our custom `perforce://` URL
scheme.

This paves the way to avoid yet another URL parsing instance in an
upcoming `ParseGitCredentials` function call that will be used to
authenticate git commands using the git credential helper protocol.

Part of #18054



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
