### PR TITLE
cli: update minimum version and reference docs

### DIFF
--- a/doc/cli/references/campaigns/apply.md
+++ b/doc/cli/references/campaigns/apply.md
@@ -13,7 +13,7 @@
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-f` | The campaign spec file to read. |  |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
-| `-j` | The maximum number of parallel jobs. (Default: GOMAXPROCS.) | `0` |
+| `-j` | The maximum number of parallel jobs. Default is GOMAXPROCS. | `8` |
 | `-keep-logs` | Retain logs after executing steps. | `false` |
 | `-n` | Alias for -namespace. |  |
 | `-namespace` | The user or organization namespace to place the campaign within. Default is the currently authenticated user. |  |
@@ -46,7 +46,7 @@ Usage of 'src campaigns apply':
   -get-curl
     	Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
   -j int
-    	The maximum number of parallel jobs. (Default: GOMAXPROCS.)
+    	The maximum number of parallel jobs. Default is GOMAXPROCS. (default 8)
   -keep-logs
     	Retain logs after executing steps.
   -n string

--- a/doc/cli/references/campaigns/preview.md
+++ b/doc/cli/references/campaigns/preview.md
@@ -13,7 +13,7 @@
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-f` | The campaign spec file to read. |  |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
-| `-j` | The maximum number of parallel jobs. (Default: GOMAXPROCS.) | `0` |
+| `-j` | The maximum number of parallel jobs. Default is GOMAXPROCS. | `8` |
 | `-keep-logs` | Retain logs after executing steps. | `false` |
 | `-n` | Alias for -namespace. |  |
 | `-namespace` | The user or organization namespace to place the campaign within. Default is the currently authenticated user. |  |
@@ -46,7 +46,7 @@ Usage of 'src campaigns preview':
   -get-curl
     	Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
   -j int
-    	The maximum number of parallel jobs. (Default: GOMAXPROCS.)
+    	The maximum number of parallel jobs. Default is GOMAXPROCS. (default 8)
   -keep-logs
     	Retain logs after executing steps.
   -n string

--- a/internal/src-cli/consts.go
+++ b/internal/src-cli/consts.go
@@ -6,4 +6,4 @@ package srccli
 // as the suggested download with this instance.
 //
 // At the time of a Sourcegraph release, this is always the latest src-cli version.
-const MinimumVersion = "3.24.3"
+const MinimumVersion = "3.25.0"


### PR DESCRIPTION
I don't _love_ that the generated defaults for `-j` now include the `GOMAXPROCS` of the generating user, but I also don't see an obvious way to avoid that, so here we are.