### PR TITLE
Revert "Send a smaller footprint version of graphql queries"

### DIFF
--- a/client/shared/src/graphql/graphql.ts
+++ b/client/shared/src/graphql/graphql.ts
@@ -67,15 +67,11 @@ export function requestGraphQLCommon<T, V = object>({
     variables?: V
 }): Observable<GraphQLResult<T>> {
     const nameMatch = request.match(/^\s*(?:query|mutation)\s+(\w+)/)
-    // We trim the request body, because with all the white-spaces and newlines
-    // it's hard to copy into other commands. It can still be pasted in the
-    // API explorer to get a pretty printed version of it.
-    const trimmedRequest = request.replace(/\\n/g, ' ').replace(/\s+/g, ' ').trim()
     const apiURL = `/.api/graphql${nameMatch ? '?' + nameMatch[1] : ''}`
     return fromFetch(baseUrl ? new URL(apiURL, baseUrl).href : apiURL, {
         ...options,
         method: 'POST',
-        body: JSON.stringify({ query: trimmedRequest, variables }),
+        body: JSON.stringify({ query: request, variables }),
         selector: response => checkOk(response).json(),
     })
 }


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#18435

This is likely breaking search functionality, see https://sourcegraph.slack.com/archives/CMBA8F926/p1613681610068100.