### PR TITLE
oobmigration: Refactor runner

### DIFF
--- a/internal/oobmigration/runner_test.go
+++ b/internal/oobmigration/runner_test.go
@@ -126,12 +126,12 @@ func TestRunnerRemovesCompleted(t *testing.T) {
 	}
 
 	// finished after 2 updates
-	if callCount := len(migrator2.DownFunc.History()); callCount != 2 {
-		t.Errorf("unexpected number of calls to Down. want=%d have=%d", 2, callCount)
+	if callCount := len(migrator2.DownFunc.History()); callCount != 1 {
+		t.Errorf("unexpected number of calls to Down. want=%d have=%d", 1, callCount)
 	}
 
 	// finished after 2 updates
-	if callCount := len(migrator3.UpFunc.History()); callCount != 2 {
-		t.Errorf("unexpected number of calls to Up. want=%d have=%d", 2, callCount)
+	if callCount := len(migrator3.UpFunc.History()); callCount != 1 {
+		t.Errorf("unexpected number of calls to Up. want=%d have=%d", 1, callCount)
 	}
 }

--- a/internal/oobmigration/store.go
+++ b/internal/oobmigration/store.go
@@ -29,6 +29,20 @@ type Migration struct {
 	Errors         []MigrationError
 }
 
+// Complete returns true if the migration has 0 un-migrated record in whichever
+// direction is indicated by the ApplyReverse flag.
+func (m Migration) Complete() bool {
+	if m.Progress == 1 && !m.ApplyReverse {
+		return true
+	}
+
+	if m.Progress == 0 && m.ApplyReverse {
+		return true
+	}
+
+	return false
+}
+
 // MigrationError pairs an error message and the time the error occurred.
 type MigrationError struct {
 	Message string


### PR DESCRIPTION
Clean up runner implementation in preparation for https://github.com/sourcegraph/sourcegraph/issues/18407. This changes the behavior slightly to favor calling `Progress` early so that they can be pruned from the migration list when complete. This stops us from periodically calling `Up` or `Down` on a long-finished migration, which we assume is more expensive than a progress check.