### PR TITLE
insights: turn on in dev environments by default

### DIFF
--- a/dev/global-settings.json
+++ b/dev/global-settings.json
@@ -3,8 +3,25 @@
   "experimentalFeatures": {
     "showRepogroupHomepage": true,
     "showMultilineSearchConsole": true,
-    "codeMonitoring": true
+    "codeMonitoring": true,
+    "codeInsights": true
   },
+  "insights": [
+    {
+      "title": "fmt usage",
+      "description": "fmt.Errorf/fmt.Printf usage",
+      "series": [
+        {
+          "label": "fmt.Errorf",
+          "search": "errorf"
+        },
+        {
+          "label": "printf",
+          "search": "fmt.Printf"
+        }
+      ]
+    }
+  ],
   "search.repositoryGroups": {
     "test": ["github.com/gorilla/mux", "github.com/gorilla/pat"]
   }

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -75,8 +75,6 @@ func (r *workHandler) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 		matchCount = results.Data.Search.Results.MatchCount
 	}
 
-	log15.Info("insights query runner", "found matches", matchCount, "query", job.SearchQuery)
-
 	// 🚨 SECURITY: The request is performed without authentication, we get back results from every
 	// repository on Sourcegraph - so we must be careful to only record insightful information that
 	// is OK to expose to every user on Sourcegraph (e.g. total result counts are fine, exposing


### PR DESCRIPTION
This enables the feature flag + basic configuration out of the box on all dev environments.