### PR TITLE
insights: store: add fast data existence check

### DIFF
--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -126,10 +126,10 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 		preds = append(preds, sqlf.Sprintf("series_id = %s", *opts.SeriesID))
 	}
 	if opts.From != nil {
-		preds = append(preds, sqlf.Sprintf("time > %s", *opts.From))
+		preds = append(preds, sqlf.Sprintf("time >= %s", *opts.From))
 	}
 	if opts.To != nil {
-		preds = append(preds, sqlf.Sprintf("time < %s", *opts.To))
+		preds = append(preds, sqlf.Sprintf("time <= %s", *opts.To))
 	}
 
 	if len(preds) == 0 {
@@ -144,6 +144,27 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 		sqlf.Join(preds, "\n AND "),
 	)
 }
+
+// DistinctSeriesWithData returns the distinct Series IDs that have at least one data point recorded
+// in the given time range.
+func (s *Store) DistinctSeriesWithData(ctx context.Context, from, to time.Time) ([]string, error) {
+	query := sqlf.Sprintf(distinctSeriesWithDataFmtstr, from, to)
+	var seriesIDs []string
+	err := s.query(ctx, query, func(sc scanner) error {
+		var seriesID string
+		err := sc.Scan(&seriesID)
+		if err != nil {
+			return err
+		}
+		seriesIDs = append(seriesIDs, seriesID)
+		return nil
+	})
+	return seriesIDs, err
+}
+
+const distinctSeriesWithDataFmtstr = `
+SELECT DISTINCT series_id FROM series_points WHERE time >= %s AND time <= %s;
+`
 
 // RecordSeriesPointArgs describes arguments for the RecordSeriesPoint method.
 type RecordSeriesPointArgs struct {

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -86,9 +86,9 @@ SELECT time,
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Want("SeriesPoints(3).len", int(551)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(3)[0].String()", `SeriesPoint{Time: "2020-05-31 20:00:00 +0000 UTC", Value: -11.269436460802638, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
-		autogold.Want("SeriesPoints(3)[len()-1].String()", `SeriesPoint{Time: "2020-03-01 04:00:00 +0000 UTC", Value: 35.85710033014749, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
+		autogold.Want("SeriesPoints(3).len", int(553)).Equal(t, len(points))
+		autogold.Want("SeriesPoints(3)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
+		autogold.Want("SeriesPoints(3)[len()-1].String()", `SeriesPoint{Time: "2020-03-01 00:00:00 +0000 UTC", Value: 34.08303991578748, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
 	})
 
 	t.Run("latest 3 points", func(t *testing.T) {


### PR DESCRIPTION
For backfilling of historical data, we need a way to check if data in a given
timeframe does not exist for a series. It doesn't make sense to query the actual
data in that case, and so we add this method to get just the unique series IDs
that do have at least one data point in a specific timeframe.

Also fix an issue where the timeframe was not inclusive as it should've been.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>