### PR TITLE
Improve performance of VirtualList

### DIFF
--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -161,7 +161,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
         }
     }
 
-    private itemKey = (item: OrderedURI): string => `${item.uri}:${item.repo}`
+    private itemKey = (item: OrderedURI): string => item.uri
 
     private renderFileMatch = (
         { uri }: OrderedURI,

--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -61,6 +61,11 @@ interface State {
     itemsToShow: number
 }
 
+interface OrderedURI {
+    uri: string
+    repo: string
+}
+
 /**
  * Displays a flat list of file excerpts. For a tree view, use FileLocationsTree.
  */
@@ -134,23 +139,13 @@ export class FileLocations extends React.PureComponent<Props, State> {
 
         return (
             <div className={`file-locations ${this.props.className || ''}`}>
-                <VirtualList
+                <VirtualList<OrderedURI, { locationsByURI: Map<string, Location[]> }>
                     itemsToShow={this.state.itemsToShow}
                     onShowMoreItems={this.onShowMoreItems}
-                    items={orderedURIs.map(({ uri, repo }, index) => (
-                        <FileMatch
-                            key={index}
-                            location={this.props.location}
-                            expanded={true}
-                            result={referencesToFileLineMatch(uri, locationsByURI.get(uri)!)}
-                            icon={this.props.icon}
-                            onSelect={this.onSelect}
-                            showAllMatches={true}
-                            isLightTheme={this.props.isLightTheme}
-                            fetchHighlightedFileLineRanges={this.props.fetchHighlightedFileLineRanges}
-                            settingsCascade={this.props.settingsCascade}
-                        />
-                    ))}
+                    items={orderedURIs}
+                    renderItem={this.renderFileMatch}
+                    itemProps={{ locationsByURI }}
+                    itemKey={this.itemKey}
                 />
             </div>
         )
@@ -165,6 +160,25 @@ export class FileLocations extends React.PureComponent<Props, State> {
             this.props.onSelect()
         }
     }
+
+    private itemKey = (item: OrderedURI): string => `${item.uri}:${item.repo}`
+
+    private renderFileMatch = (
+        { uri }: OrderedURI,
+        { locationsByURI }: { locationsByURI: Map<string, Location[]> }
+    ): JSX.Element => (
+        <FileMatch
+            location={this.props.location}
+            expanded={true}
+            result={referencesToFileLineMatch(uri, locationsByURI.get(uri)!)}
+            icon={this.props.icon}
+            onSelect={this.onSelect}
+            showAllMatches={true}
+            isLightTheme={this.props.isLightTheme}
+            fetchHighlightedFileLineRanges={this.props.fetchHighlightedFileLineRanges}
+            settingsCascade={this.props.settingsCascade}
+        />
+    )
 }
 
 function referencesToFileLineMatch(uri: string, references: Badged<Location>[]): FileLineMatch {

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -43,9 +43,6 @@ interface Props extends SettingsCascadeProps {
      */
     result: FileLineMatch
 
-    /* Called when the first result has fully loaded. */
-    onFirstResultLoad?: () => void
-
     /**
      * Formatted repository name to be displayed in repository link. If not
      * provided, the default format will be displayed.

--- a/client/shared/src/components/VirtualList.tsx
+++ b/client/shared/src/components/VirtualList.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react'
 import VisibilitySensor from 'react-visibility-sensor'
 
-interface Props<T, U> {
+interface Props<TItem, TExtraItemProps> {
     itemsToShow: number
-    items: T[]
+    items: TItem[]
 
-    // Additional props passed to the render function.
-    itemProps: U
-    // Function to render an item once it becomes visible.
-    renderItem: (item: T, additionalProps: U) => JSX.Element
-    // Determines the list key of an item. Needed for stable react array rendering.
-    itemKey: (item: T) => string
+    /* Additional props passed to the render function. */
+    itemProps: TExtraItemProps
+    /* Function to render an item once it becomes visible. */
+    renderItem: (item: TItem, additionalProps: TExtraItemProps) => JSX.Element
+    /* Determines the list key of an item. Needed for stable react array rendering. */
+    itemKey: (item: TItem) => string
 
     /**
      * Called when the user scrolled close to the bottom of the list.
@@ -36,7 +36,10 @@ interface Props<T, U> {
 
 interface State {}
 
-export class VirtualList<TItem, TExtraItemProps = undefined> extends React.PureComponent<Props<TItem, TExtraItemProps>, State> {
+export class VirtualList<TItem, TExtraItemProps = undefined> extends React.PureComponent<
+    Props<TItem, TExtraItemProps>,
+    State
+> {
     public onChangeVisibility = (isVisible: boolean, index: number): void => {
         if (isVisible && index >= this.props.itemsToShow - 2) {
             this.props.onShowMoreItems()

--- a/client/shared/src/components/VirtualList.tsx
+++ b/client/shared/src/components/VirtualList.tsx
@@ -36,7 +36,7 @@ interface Props<T, U> {
 
 interface State {}
 
-export class VirtualList<T, U = undefined> extends React.PureComponent<Props<T, U>, State> {
+export class VirtualList<TItem, TExtraItemProps = undefined> extends React.PureComponent<Props<TItem, TExtraItemProps>, State> {
     public onChangeVisibility = (isVisible: boolean, index: number): void => {
         if (isVisible && index >= this.props.itemsToShow - 2) {
             this.props.onShowMoreItems()

--- a/client/shared/src/components/VirtualList.tsx
+++ b/client/shared/src/components/VirtualList.tsx
@@ -1,9 +1,16 @@
 import * as React from 'react'
 import VisibilitySensor from 'react-visibility-sensor'
 
-interface Props {
+interface Props<T, U> {
     itemsToShow: number
-    items: JSX.Element[]
+    items: T[]
+
+    // Additional props passed to the render function.
+    itemProps: U
+    // Function to render an item once it becomes visible.
+    renderItem: (item: T, additionalProps: U) => JSX.Element
+    // Determines the list key of an item. Needed for stable react array rendering.
+    itemKey: (item: T) => string
 
     /**
      * Called when the user scrolled close to the bottom of the list.
@@ -29,7 +36,7 @@ interface Props {
 
 interface State {}
 
-export class VirtualList extends React.PureComponent<Props, State> {
+export class VirtualList<T, U = undefined> extends React.PureComponent<Props<T, U>, State> {
     public onChangeVisibility = (isVisible: boolean, index: number): void => {
         if (isVisible && index >= this.props.itemsToShow - 2) {
             this.props.onShowMoreItems()
@@ -47,11 +54,11 @@ export class VirtualList extends React.PureComponent<Props, State> {
                     <VisibilitySensor
                         // eslint-disable-next-line react/jsx-no-bind
                         onChange={isVisible => this.onChangeVisibility(isVisible, index)}
-                        key={item.key || '0'}
+                        key={this.props.itemKey(item)}
                         containment={this.props.containment}
                         partialVisibility={true}
                     >
-                        {item}
+                        {this.props.renderItem(item, this.props.itemProps)}
                     </VisibilitySensor>
                 ))}
             </div>

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -422,13 +422,14 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                                     )}
 
                                     {/* Results */}
-                                    <VirtualList
+                                    <VirtualList<GQL.SearchResult>
                                         itemsToShow={this.state.resultsShown}
                                         onShowMoreItems={this.onBottomHit(results.results.length)}
                                         onVisibilityChange={this.nextItemVisibilityChange}
-                                        items={results.results
-                                            .map((result, index) => this.renderResult(result, index === 0))
-                                            .filter(isDefined)}
+                                        items={results.results}
+                                        itemKey={this.itemKey}
+                                        itemProps={undefined}
+                                        renderItem={this.renderResult}
                                         containment={this.scrollableElementRef || undefined}
                                         onRef={this.nextVirtualListContainerElement}
                                     />
@@ -501,18 +502,13 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
         )
     }
 
-    private renderResult(
-        result: GQL.GenericSearchResultInterface | GQL.IFileMatch,
-        isFirst: boolean
-    ): JSX.Element | undefined {
+    private renderResult = (result: GQL.GenericSearchResultInterface | GQL.IFileMatch): JSX.Element => {
         switch (result.__typename) {
             case 'FileMatch':
                 return (
                     <FileMatch
-                        key={'file:' + result.file.url}
                         location={this.props.location}
                         eventLogger={eventLogger}
-                        onFirstResultLoad={isFirst ? this.props.onFirstResultLoad : undefined}
                         icon={result.lineMatches && result.lineMatches.length > 0 ? SourceRepositoryIcon : FileIcon}
                         result={result}
                         onSelect={this.logEvent}
@@ -526,14 +522,14 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     />
                 )
         }
-        return (
-            <SearchResult
-                key={result.url}
-                result={result}
-                isLightTheme={this.props.isLightTheme}
-                history={this.props.history}
-            />
-        )
+        return <SearchResult result={result} isLightTheme={this.props.isLightTheme} history={this.props.history} />
+    }
+
+    private itemKey = (item: GQL.GenericSearchResultInterface | GQL.IFileMatch): string => {
+        if (item.__typename === 'FileMatch') {
+            return `file:${item.file.url}`
+        }
+        return item.url
     }
 
     /** onBottomHit increments the amount of results to be shown when we have scrolled to the bottom of the list. */

--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -241,10 +241,11 @@ describe('StreamingSearchResults', () => {
             </BrowserRouter>
         )
 
-        const renderedResultsList = element.find(VirtualList).prop('items')
+        const listComponent = element.find<VirtualList<SearchResult>>(VirtualList)
+        const renderedResultsList = listComponent.prop('items')
         expect(renderedResultsList.length).toBe(2)
-        expect(renderedResultsList[0].type).toBe(FileMatch)
-        expect(renderedResultsList[1].type).toBe(SearchResult)
+        expect(listComponent.prop('renderItem')(renderedResultsList[0], undefined).type).toBe(FileMatch)
+        expect(listComponent.prop('renderItem')(renderedResultsList[1], undefined).type).toBe(SearchResult)
 
         element.unmount()
     })


### PR DESCRIPTION
while we didn't _display_ all elements at once with the VirtualList, it still required to render the react components in memory, before we pass them in. For searches with a lot of results, this caused thousands of renders to happen on each rerender (ie when streaming search receives a new event). This is fixed by providing an explicit render function, that renders the items lazily, instead of being passed-in the eager rendered components.