### PR TITLE
internal/vcs/git: add ability to get first ever commit in a repository

### DIFF
--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -283,7 +283,7 @@ func FirstEverCommit(ctx context.Context, repo api.RepoName) (*Commit, error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Git: FirstEverCommit")
 	defer span.Finish()
 
-	args := []string{"rev-list", "--max-parents=0", "HEAD"}
+	args := []string{"rev-list", "--max-count=1", "--max-parents=0", "HEAD"}
 	cmd := gitserver.DefaultClient.Command("git", args...)
 	cmd.Repo = repo
 	out, err := cmd.CombinedOutput(ctx)

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -278,6 +278,22 @@ func CommitCount(ctx context.Context, repo api.RepoName, opt CommitsOptions) (ui
 	return uint(n), err
 }
 
+// FirstEverCommit returns the first commit ever made to the repository.
+func FirstEverCommit(ctx context.Context, repo api.RepoName) (*Commit, error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "Git: FirstEverCommit")
+	defer span.Finish()
+
+	args := []string{"rev-list", "--max-parents=0", "HEAD"}
+	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd.Repo = repo
+	out, err := cmd.CombinedOutput(ctx)
+	if err != nil {
+		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", args, out))
+	}
+	id := api.CommitID(bytes.TrimSpace(out))
+	return GetCommit(ctx, repo, id, ResolveRevisionOptions{NoEnsureRevision: true})
+}
+
 const (
 	partsPerCommit = 10 // number of \x00-separated fields per commit
 

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -158,6 +158,49 @@ func TestRepository_HasCommitAfter(t *testing.T) {
 	}
 }
 
+func TestRepository_FirstEverCommit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	testCases := []struct {
+		commitDates []string
+		want        string
+	}{
+		{
+			commitDates: []string{
+				"2006-01-02T15:04:05Z",
+				"2007-01-02T15:04:05Z",
+				"2008-01-02T15:04:05Z",
+			},
+			want: "2006-01-02T15:04:05Z",
+		},
+		{
+			commitDates: []string{
+				"2007-01-02T15:04:05Z", // Don't think this is possible, but if it is we still want the first commit (not strictly "oldest")
+				"2006-01-02T15:04:05Z",
+				"2007-01-02T15:04:06Z",
+			},
+			want: "2007-01-02T15:04:05Z",
+		},
+	}
+	for _, tc := range testCases {
+		gitCommands := make([]string, len(tc.commitDates))
+		for i, date := range tc.commitDates {
+			gitCommands[i] = fmt.Sprintf("GIT_COMMITTER_NAME=a GIT_COMMITTER_EMAIL=a@a.com GIT_COMMITTER_DATE=%s git commit --allow-empty -m foo --author='a <a@a.com>'", date)
+		}
+
+		repo := MakeGitRepository(t, gitCommands...)
+		gotCommit, err := FirstEverCommit(ctx, repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := gotCommit.Committer.Date.Format(time.RFC3339)
+		if got != tc.want {
+			t.Errorf("got %q, want %q", got, tc.want)
+		}
+	}
+}
+
 func TestRepository_Commits(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
For backfilling Code Insights data, we need to run `type:diff before: after:` searches
for historical timeframes. In this context, we can skip large amounts of timeframes for
a repository if we know when the first commit to the repository was made.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>