### PR TITLE
search: remove all references to QueryInfo

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -185,7 +185,7 @@ func queryForStableResults(args *SearchArgs, q query.Q) (*SearchArgs, query.Q, e
 	return args, q, nil
 }
 
-func processPaginationRequest(args *SearchArgs, queryInfo query.QueryInfo) (*searchPaginationInfo, error) {
+func processPaginationRequest(args *SearchArgs, q query.Q) (*searchPaginationInfo, error) {
 	var pagination *searchPaginationInfo
 	if args.First != nil {
 		cursor, err := unmarshalSearchCursor(args.After)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1241,7 +1241,7 @@ func getPatternInfo(q query.Q, opts *getPatternInfoOptions) (*search.TextPattern
 
 // indexValue converts the query index field to one of yes (default), only, or no
 // enum values.
-func indexValue(q query.QueryInfo) query.YesNoOnly {
+func indexValue(q query.Q) query.YesNoOnly {
 	indexParam := query.Yes
 	if index := q.Values(query.FieldIndex); len(index) > 0 {
 		indexParam = query.ParseYesNoOnly(index[0].ToString())

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -69,7 +69,7 @@ type indexedSearchRequest struct {
 }
 
 // TODO (stefan) move this out of zoekt.go to the new parser once it is guaranteed that the old parser is turned off for all customers
-func containsRefGlobs(q query.QueryInfo) bool {
+func containsRefGlobs(q query.Q) bool {
 	containsRefGlobs := false
 	if repoFilterValues, _ := q.RegexpPatterns(query.FieldRepo); len(repoFilterValues) > 0 {
 		for _, v := range repoFilterValues {

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -290,7 +290,7 @@ type Options struct {
 	CommitAfter        string
 	OnlyPrivate        bool
 	OnlyPublic         bool
-	Query              query.QueryInfo
+	Query              query.Q
 }
 
 func (op *Options) String() string {
@@ -430,7 +430,7 @@ type ExcludedRepos struct {
 
 // computeExcludedRepositories returns a list of excluded repositories (Forks or
 // archives) based on the search Query.
-func computeExcludedRepositories(ctx context.Context, q query.QueryInfo, op database.ReposListOptions) (excluded ExcludedRepos) {
+func computeExcludedRepositories(ctx context.Context, q query.Q, op database.ReposListOptions) (excluded ExcludedRepos) {
 	if q == nil {
 		return ExcludedRepos{}
 	}
@@ -576,7 +576,7 @@ func findPatternRevs(includePatterns []string) (includePatternRevs []patternRevs
 	return
 }
 
-func hasTypeRepo(q query.QueryInfo) bool {
+func hasTypeRepo(q query.Q) bool {
 	fields := q.Fields()
 	if len(fields["type"]) == 0 {
 		return false

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -23,7 +23,7 @@ func (TextParameters) typeParametersValue()    {}
 type CommitParameters struct {
 	RepoRevs           *RepositoryRevisions
 	PatternInfo        *CommitPatternInfo
-	Query              query.QueryInfo
+	Query              query.Q
 	Diff               bool
 	ExtraMessageValues []string
 }
@@ -131,7 +131,7 @@ type TextParameters struct {
 type TextParametersForCommitParameters struct {
 	PatternInfo *CommitPatternInfo
 	Repos       []*RepositoryRevisions
-	Query       query.QueryInfo
+	Query       query.Q
 }
 
 // TextPatternInfo is the struct used by vscode pass on search queries. Keep it in


### PR DESCRIPTION
Semantics preserving. Found some lingering references to the `QueryInfo` interface we shouldn't use any more.