### PR TITLE
search: move ContainsRefGlobs check to validate.go

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -71,25 +71,6 @@ type indexedSearchRequest struct {
 	db dbutil.DB
 }
 
-// TODO (stefan) move this out of zoekt.go to the new parser once it is guaranteed that the old parser is turned off for all customers
-func containsRefGlobs(q query.Q) bool {
-	containsRefGlobs := false
-	if repoFilterValues, _ := q.RegexpPatterns(query.FieldRepo); len(repoFilterValues) > 0 {
-		for _, v := range repoFilterValues {
-			repoRev := strings.SplitN(v, "@", 2)
-			if len(repoRev) == 1 { // no revision
-				continue
-			}
-			if query.ContainsNoGlobSyntax(repoRev[1]) {
-				continue
-			}
-			containsRefGlobs = true
-			break
-		}
-	}
-	return containsRefGlobs
-}
-
 func newIndexedSearchRequest(ctx context.Context, db dbutil.DB, args *search.TextParameters, typ indexedRequestType, stream Streamer) (_ *indexedSearchRequest, err error) {
 	tr, ctx := trace.New(ctx, "newIndexedSearchRequest", string(typ))
 	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
@@ -116,7 +97,7 @@ func newIndexedSearchRequest(ctx context.Context, db dbutil.DB, args *search.Tex
 	}
 
 	// Fallback to Unindexed if the query contains ref-globs
-	if containsRefGlobs(args.Query) {
+	if query.ContainsRefGlobs(args.Query) {
 		if args.PatternInfo.Index == query.Only {
 			return nil, fmt.Errorf("invalid index:%q (revsions with glob pattern cannot be resolved for indexed searches)", args.PatternInfo.Index)
 		}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1101,65 +1101,6 @@ func repoRevsSliceToMap(rs []*search.RepositoryRevisions) map[string]*search.Rep
 	return m
 }
 
-func TestContainsRefGlobs(t *testing.T) {
-	tests := []struct {
-		query    string
-		want     bool
-		globbing bool
-	}{
-		{
-			query: "repo:foo",
-			want:  false,
-		},
-		{
-			query: "repo:foo@bar",
-			want:  false,
-		},
-		{
-			query: "repo:foo@*ref/tags",
-			want:  true,
-		},
-		{
-			query: "repo:foo@*!refs/tags",
-			want:  true,
-		},
-		{
-			query: "repo:foo@bar:*refs/heads",
-			want:  true,
-		},
-		{
-			query: "repo:foo@refs/tags/v3.14.3",
-			want:  false,
-		},
-		{
-			query: "repo:foo@*refs/tags/v3.14.?",
-			want:  true,
-		},
-		{
-			query:    "repo:*foo*@v3.14.3",
-			globbing: true,
-			want:     false,
-		},
-		{
-			query: "repo:foo@v3.14.3 repo:foo@*refs/tags/v3.14.* bar",
-			want:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.query, func(t *testing.T) {
-			qInfo, err := query.ProcessAndOr(tt.query, query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: tt.globbing})
-			if err != nil {
-				t.Error(err)
-			}
-			got := containsRefGlobs(qInfo)
-			if got != tt.want {
-				t.Errorf("got %t, expected %t", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestContextWithoutDeadline(t *testing.T) {
 	ctxWithDeadline, cancelWithDeadline := context.WithTimeout(context.Background(), time.Minute)
 	defer cancelWithDeadline()

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -461,3 +461,21 @@ func ParseYesNoOnly(s string) YesNoOnly {
 		return Invalid
 	}
 }
+
+func ContainsRefGlobs(q Q) bool {
+	containsRefGlobs := false
+	if repoFilterValues, _ := q.RegexpPatterns(FieldRepo); len(repoFilterValues) > 0 {
+		for _, v := range repoFilterValues {
+			repoRev := strings.SplitN(v, "@", 2)
+			if len(repoRev) == 1 { // no revision
+				continue
+			}
+			if ContainsNoGlobSyntax(repoRev[1]) {
+				continue
+			}
+			containsRefGlobs = true
+			break
+		}
+	}
+	return containsRefGlobs
+}

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -280,3 +280,62 @@ func TestForAll(t *testing.T) {
 		t.Errorf("Expected all nodes to be parameters.")
 	}
 }
+
+func TestContainsRefGlobs(t *testing.T) {
+	tests := []struct {
+		query    string
+		want     bool
+		globbing bool
+	}{
+		{
+			query: "repo:foo",
+			want:  false,
+		},
+		{
+			query: "repo:foo@bar",
+			want:  false,
+		},
+		{
+			query: "repo:foo@*ref/tags",
+			want:  true,
+		},
+		{
+			query: "repo:foo@*!refs/tags",
+			want:  true,
+		},
+		{
+			query: "repo:foo@bar:*refs/heads",
+			want:  true,
+		},
+		{
+			query: "repo:foo@refs/tags/v3.14.3",
+			want:  false,
+		},
+		{
+			query: "repo:foo@*refs/tags/v3.14.?",
+			want:  true,
+		},
+		{
+			query:    "repo:*foo*@v3.14.3",
+			globbing: true,
+			want:     false,
+		},
+		{
+			query: "repo:foo@v3.14.3 repo:foo@*refs/tags/v3.14.* bar",
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			qInfo, err := ProcessAndOr(tt.query, ParserOptions{SearchType: SearchTypeLiteral, Globbing: tt.globbing})
+			if err != nil {
+				t.Error(err)
+			}
+			got := ContainsRefGlobs(qInfo)
+			if got != tt.want {
+				t.Errorf("got %t, expected %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #18468.

Addresses:

> // TODO (stefan) move this out of zoekt.go to the new parser once it is guaranteed that the old parser is turned off for all customers

Since this is true now :-)