### PR TITLE
search: refactor hasTypeRepo to not use query.Fields()

### DIFF
--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -115,7 +115,7 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 
 	var defaultRepos []*types.RepoName
 
-	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 && !hasTypeRepo(op.Query) && searchcontexts.IsGlobalSearchContext(searchContext) {
+	if envvar.SourcegraphDotComMode() && len(includePatterns) == 0 && !query.HasTypeRepo(op.Query) && searchcontexts.IsGlobalSearchContext(searchContext) {
 		start := time.Now()
 		defaultRepos, err = defaultRepositories(ctx, r.DefaultReposFunc, r.Zoekt, excludePatterns)
 		if err != nil {
@@ -574,19 +574,6 @@ func findPatternRevs(includePatterns []string) (includePatternRevs []patternRevs
 		}
 	}
 	return
-}
-
-func hasTypeRepo(q query.Q) bool {
-	fields := q.Fields()
-	if len(fields["type"]) == 0 {
-		return false
-	}
-	for _, t := range fields["type"] {
-		if t.Value() == "repo" {
-			return true
-		}
-	}
-	return false
 }
 
 type defaultReposFunc func(ctx context.Context) ([]*types.RepoName, error)

--- a/cmd/frontend/internal/search/repos/repos_test.go
+++ b/cmd/frontend/internal/search/repos/repos_test.go
@@ -368,58 +368,6 @@ func TestDefaultRepositories(t *testing.T) {
 	}
 }
 
-func TestHasTypeRepo(t *testing.T) {
-	tests := []struct {
-		query           string
-		wantHasTypeRepo bool
-	}{
-		{
-			query:           "sourcegraph type:repo",
-			wantHasTypeRepo: true,
-		},
-		{
-			query:           "sourcegraph type:symbol type:repo",
-			wantHasTypeRepo: true,
-		},
-		{
-			query:           "(sourcegraph type:repo) or (goreman type:repo)",
-			wantHasTypeRepo: true,
-		},
-		{
-			query:           "sourcegraph repohasfile:Dockerfile type:repo",
-			wantHasTypeRepo: true,
-		},
-		{
-			query:           "repo:sourcegraph type:repo",
-			wantHasTypeRepo: true,
-		},
-		{
-			query:           "repo:sourcegraph",
-			wantHasTypeRepo: false,
-		},
-		{
-			query:           "repository",
-			wantHasTypeRepo: false,
-		},
-		{
-			query:           "",
-			wantHasTypeRepo: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.query, func(t *testing.T) {
-			q, err := query.ProcessAndOr(tt.query, query.ParserOptions{SearchType: query.SearchTypeLiteral})
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got := hasTypeRepo(q); got != tt.wantHasTypeRepo {
-				t.Fatalf("got %t, expected %t", got, tt.wantHasTypeRepo)
-			}
-		})
-	}
-}
-
 func TestUseDefaultReposIfMissingOrGlobalSearchContext(t *testing.T) {
 	orig := envvar.SourcegraphDotComMode()
 	envvar.MockSourcegraphDotComMode(true)

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -479,3 +479,13 @@ func ContainsRefGlobs(q Q) bool {
 	}
 	return containsRefGlobs
 }
+
+func HasTypeRepo(q Q) bool {
+	found := false
+	VisitField(q, "type", func(value string, _ bool, _ Annotation) {
+		if value == "repo" {
+			found = true
+		}
+	})
+	return found
+}

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -339,3 +339,55 @@ func TestContainsRefGlobs(t *testing.T) {
 		})
 	}
 }
+
+func TestHasTypeRepo(t *testing.T) {
+	tests := []struct {
+		query           string
+		wantHasTypeRepo bool
+	}{
+		{
+			query:           "sourcegraph type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "sourcegraph type:symbol type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "(sourcegraph type:repo) or (goreman type:repo)",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "sourcegraph repohasfile:Dockerfile type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "repo:sourcegraph type:repo",
+			wantHasTypeRepo: true,
+		},
+		{
+			query:           "repo:sourcegraph",
+			wantHasTypeRepo: false,
+		},
+		{
+			query:           "repository",
+			wantHasTypeRepo: false,
+		},
+		{
+			query:           "",
+			wantHasTypeRepo: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.query, func(t *testing.T) {
+			q, err := ParseLiteral(tt.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := HasTypeRepo(q); got != tt.wantHasTypeRepo {
+				t.Fatalf("got %t, expected %t", got, tt.wantHasTypeRepo)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #18470.

Just breaks the dependency on `q.Fields()` for this part of the code and moves it to `validate.go`.