### PR TITLE
cloud: Don't show uncloned repo count on Cloud

### DIFF
--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 )
@@ -21,7 +22,7 @@ func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageRe
 
 	// 🚨 SECURITY: Users will fetch status messages for any external services they
 	// own. In addition, site admins will also fetch site level external services.
-	messages, err := repos.FetchStatusMessages(ctx, r.db, currentUser)
+	messages, err := repos.FetchStatusMessages(ctx, r.db, currentUser, envvar.SourcegraphDotComMode())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repos/status_messages.go
+++ b/internal/repos/status_messages.go
@@ -17,7 +17,7 @@ var MockStatusMessages func(context.Context, *types.User) ([]StatusMessage, erro
 // external service sync errors we'll fetch any external services owned by the
 // user. In addition, if the user is a site admin we'll also fetch site level
 // external services.
-func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]StatusMessage, error) {
+func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User, cloud bool) ([]StatusMessage, error) {
 	if MockStatusMessages != nil {
 		return MockStatusMessages(ctx, u)
 	}
@@ -32,17 +32,22 @@ func FetchStatusMessages(ctx context.Context, db dbutil.DB, u *types.User) ([]St
 	if !u.SiteAdmin {
 		opts.UserID = u.ID
 	}
-	notCloned, err := database.Repos(db).Count(ctx, opts)
-	if err != nil {
-		return nil, errors.Wrap(err, "counting uncloned repos")
-	}
 
-	if notCloned != 0 {
-		messages = append(messages, StatusMessage{
-			Cloning: &CloningProgress{
-				Message: fmt.Sprintf("%d repositories enqueued for cloning...", notCloned),
-			},
-		})
+	if !cloud {
+		// The number of uncloned repos on cloud is misleading due to the fact that we do
+		// on demand sycing and also remove stale repos.
+		notCloned, err := database.Repos(db).Count(ctx, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "counting uncloned repos")
+		}
+
+		if notCloned != 0 {
+			messages = append(messages, StatusMessage{
+				Cloning: &CloningProgress{
+					Message: fmt.Sprintf("%d repositories enqueued for cloning...", notCloned),
+				},
+			})
+		}
 	}
 
 	syncErrors, err := database.ExternalServices(db).GetAffiliatedSyncErrors(ctx, u)

--- a/internal/repos/status_messages_test.go
+++ b/internal/repos/status_messages_test.go
@@ -78,6 +78,7 @@ func TestStatusMessages(t *testing.T) {
 		user            *types.User
 		// maps repoName to external service id
 		repoOwner map[api.RepoName]int64
+		cloud     bool
 		err       string
 	}{
 		{
@@ -99,6 +100,15 @@ func TestStatusMessages(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			// We don't show uncloned count in Cloud as it is misleading
+			name:            "nothing cloned cloud",
+			stored:          []*types.Repo{{Name: "foobar"}},
+			user:            admin,
+			gitserverCloned: []string{},
+			res:             nil,
+			cloud:           true,
 		},
 		{
 			name:            "subset cloned",
@@ -282,7 +292,7 @@ func TestStatusMessages(t *testing.T) {
 				tc.err = "<nil>"
 			}
 
-			res, err := FetchStatusMessages(ctx, db, tc.user)
+			res, err := FetchStatusMessages(ctx, db, tc.user, tc.cloud)
 			if have, want := fmt.Sprint(err), tc.err; have != want {
 				t.Errorf("have err: %q, want: %q", have, want)
 			}


### PR DESCRIPTION
It is misleading since we perform on demand syncing and it is normal to
have a large number of uncloned repos there.
