### PR TITLE
db: remove GlobalAccessTokenStore

### DIFF
--- a/cmd/frontend/graphqlbackend/access_token.go
+++ b/cmd/frontend/graphqlbackend/access_token.go
@@ -30,7 +30,7 @@ func accessTokenByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*accessT
 	if err != nil {
 		return nil, err
 	}
-	accessToken, err := database.GlobalAccessTokens.GetByID(ctx, accessTokenID)
+	accessToken, err := database.AccessTokens(db).GetByID(ctx, accessTokenID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -74,7 +74,7 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 		return nil, fmt.Errorf("all access tokens must have scope %q", authz.ScopeUserAll)
 	}
 
-	id, token, err := database.GlobalAccessTokens.Create(ctx, userID, args.Scopes, args.Note, actor.FromContext(ctx).UID)
+	id, token, err := database.AccessTokens(r.db).Create(ctx, userID, args.Scopes, args.Note, actor.FromContext(ctx).UID)
 
 	if conf.CanSendEmail() {
 		if err := backend.UserEmails.SendUserEmailOnFieldUpdate(ctx, userID, "created an access token"); err != nil {
@@ -113,7 +113,7 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 		if err != nil {
 			return nil, err
 		}
-		token, err := database.GlobalAccessTokens.GetByID(ctx, accessTokenID)
+		token, err := database.AccessTokens(r.db).GetByID(ctx, accessTokenID)
 		if err != nil {
 			return nil, err
 		}
@@ -123,12 +123,12 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 		if err := backend.CheckSiteAdminOrSameUser(ctx, token.SubjectUserID); err != nil {
 			return nil, err
 		}
-		if err := database.GlobalAccessTokens.DeleteByID(ctx, token.ID, token.SubjectUserID); err != nil {
+		if err := database.AccessTokens(r.db).DeleteByID(ctx, token.ID, token.SubjectUserID); err != nil {
 			return nil, err
 		}
 
 	case args.ByToken != nil:
-		token, err := database.GlobalAccessTokens.GetByToken(ctx, *args.ByToken)
+		token, err := database.AccessTokens(r.db).GetByToken(ctx, *args.ByToken)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +136,7 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 
 		// 🚨 SECURITY: This is easier than the ByID case because anyone holding the access token's
 		// secret value is assumed to be allowed to delete it.
-		if err := database.GlobalAccessTokens.DeleteByToken(ctx, *args.ByToken); err != nil {
+		if err := database.AccessTokens(r.db).DeleteByToken(ctx, *args.ByToken); err != nil {
 			return nil, err
 		}
 
@@ -200,7 +200,7 @@ func (r *accessTokenConnectionResolver) compute(ctx context.Context) ([]*databas
 			opt2.Limit++ // so we can detect if there is a next page
 		}
 
-		r.accessTokens, r.err = database.GlobalAccessTokens.List(ctx, opt2)
+		r.accessTokens, r.err = database.AccessTokens(r.db).List(ctx, opt2)
 	})
 	return r.accessTokens, r.err
 }
@@ -222,7 +222,7 @@ func (r *accessTokenConnectionResolver) Nodes(ctx context.Context) ([]*accessTok
 }
 
 func (r *accessTokenConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	count, err := database.GlobalAccessTokens.Count(ctx, r.opt)
+	count, err := database.AccessTokens(r.db).Count(ctx, r.opt)
 	return int32(count), err
 }
 

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -49,7 +49,7 @@ func newExternalHTTPHandler(db dbutil.DB, schema *graphql.Schema, gitHubWebhook 
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication (except those with the
 	// X-Requested-With header). Doing so would open it up to CSRF attacks.
 	apiHandler = session.CookieMiddlewareWithCSRFSafety(apiHandler, corsAllowHeader, isTrustedOrigin) // API accepts cookies with special header
-	apiHandler = internalhttpapi.AccessTokenAuthMiddleware(apiHandler)                                // API accepts access tokens
+	apiHandler = internalhttpapi.AccessTokenAuthMiddleware(db, apiHandler)                            // API accepts access tokens
 	apiHandler = gziphandler.GzipHandler(apiHandler)
 
 	// 🚨 SECURITY: This handler implements its own token auth inside enterprise
@@ -64,9 +64,9 @@ func newExternalHTTPHandler(db dbutil.DB, schema *graphql.Schema, gitHubWebhook 
 	appHandler = handlerutil.CSRFMiddleware(appHandler, func() bool {
 		return globals.ExternalURL().Scheme == "https"
 	}) // after appAuthMiddleware because SAML IdP posts data to us w/o a CSRF token
-	appHandler = authMiddlewares.App(appHandler)                       // 🚨 SECURITY: auth middleware
-	appHandler = session.CookieMiddleware(appHandler)                  // app accepts cookies
-	appHandler = internalhttpapi.AccessTokenAuthMiddleware(appHandler) // app accepts access tokens
+	appHandler = authMiddlewares.App(appHandler)                           // 🚨 SECURITY: auth middleware
+	appHandler = session.CookieMiddleware(appHandler)                      // app accepts cookies
+	appHandler = internalhttpapi.AccessTokenAuthMiddleware(db, appHandler) // app accepts access tokens
 
 	// Mount handlers and assets.
 	sm := http.NewServeMux()

--- a/cmd/frontend/internal/httpapi/auth_test.go
+++ b/cmd/frontend/internal/httpapi/auth_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestAccessTokenAuthMiddleware(t *testing.T) {
-	handler := AccessTokenAuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := AccessTokenAuthMiddleware(new(dbtesting.MockDB), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		actor := actor.FromContext(r.Context())
 		if actor.IsAuthenticated() {
 			fmt.Fprintf(w, "user %v", actor.UID)

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -3,7 +3,6 @@ package database
 // Global reference to database stores using the global dbconn.Global connection handle.
 // Deprecated: Use store constructors instead.
 var (
-	GlobalAccessTokens                = &AccessTokenStore{}
 	GlobalExternalServices            = &ExternalServiceStore{}
 	GlobalDefaultRepos                = &DefaultRepoStore{}
 	GlobalRepos                       = &RepoStore{}


### PR DESCRIPTION
This PR removes the GlobalAccessTokenStore and replaces
all calls to that store by the AccessTokenStore constructor.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
