### PR TITLE
Add CODECOV_TOKEN to Vagrant runners

### DIFF
--- a/dev/ci/test/Vagrantfile
+++ b/dev/ci/test/Vagrantfile
@@ -71,6 +71,7 @@ export PGUSER=#{ENV['PGUSER']}
 export PGDATABASE=#{ENV['PGDATABASE']}
 export PGSSLMODE=#{ENV['PGSSLMODE']}
 export PERCY_TOKEN=#{ENV['PERCY_TOKEN']}
+export CODECOV_TOKEN=#{ENV['CODECOV_TOKEN']}
 export CI=#{ENV['CI']}
 
 # Env vars shared by e2e and QA tests - see:


### PR DESCRIPTION
Fixes and issue with codecov on Vagrant runners because of a missing
token.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->