### PR TITLE
db: remove GlobalOrgInvitations store

### DIFF
--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -137,7 +137,7 @@ func (o *OrgResolver) ConfigurationCascade() *settingsCascade { return o.Setting
 
 func (o *OrgResolver) ViewerPendingInvitation(ctx context.Context) (*organizationInvitationResolver, error) {
 	if actor := actor.FromContext(ctx); actor.IsAuthenticated() {
-		orgInvitation, err := database.GlobalOrgInvitations.GetPending(ctx, o.org.ID, actor.UID)
+		orgInvitation, err := database.OrgInvitations(o.db).GetPending(ctx, o.org.ID, actor.UID)
 		if errcode.IsNotFound(err) {
 			return nil, nil
 		}

--- a/cmd/frontend/graphqlbackend/org_invitation.go
+++ b/cmd/frontend/graphqlbackend/org_invitation.go
@@ -25,7 +25,7 @@ func orgInvitationByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*organ
 }
 
 func orgInvitationByIDInt64(ctx context.Context, db dbutil.DB, id int64) (*organizationInvitationResolver, error) {
-	orgInvitation, err := database.GlobalOrgInvitations.GetByID(ctx, id)
+	orgInvitation, err := database.OrgInvitations(db).GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -54,7 +54,7 @@ type inviteUserToOrganizationResult struct {
 func (r *inviteUserToOrganizationResult) SentInvitationEmail() bool { return r.sentInvitationEmail }
 func (r *inviteUserToOrganizationResult) InvitationURL() string     { return r.invitationURL }
 
-func (*schemaResolver) InviteUserToOrganization(ctx context.Context, args *struct {
+func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *struct {
 	Organization graphql.ID
 	Username     string
 }) (*inviteUserToOrganizationResult, error) {
@@ -81,7 +81,7 @@ func (*schemaResolver) InviteUserToOrganization(ctx context.Context, args *struc
 	if err != nil {
 		return nil, err
 	}
-	if _, err := database.GlobalOrgInvitations.Create(ctx, orgID, sender.ID, recipient.ID); err != nil {
+	if _, err := database.OrgInvitations(r.db).Create(ctx, orgID, sender.ID, recipient.ID); err != nil {
 		return nil, err
 	}
 	result := &inviteUserToOrganizationResult{
@@ -130,7 +130,7 @@ func (r *schemaResolver) RespondToOrganizationInvitation(ctx context.Context, ar
 
 	// 🚨 SECURITY: This fails if the org invitation's recipient is not the one given (or if the
 	// invitation is otherwise invalid), so we do not need to separately perform that check.
-	orgID, err := database.GlobalOrgInvitations.Respond(ctx, id, currentUser.user.ID, accept)
+	orgID, err := database.OrgInvitations(r.db).Respond(ctx, id, currentUser.user.ID, accept)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (r *schemaResolver) RevokeOrganizationInvitation(ctx context.Context, args 
 		return nil, err
 	}
 
-	if err := database.GlobalOrgInvitations.Revoke(ctx, orgInvitation.v.ID); err != nil {
+	if err := database.OrgInvitations(r.db).Revoke(ctx, orgInvitation.v.ID); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -20,6 +20,5 @@ var (
 	GlobalEventLogs                   = &EventLogStore{}
 	GlobalSurveyResponses             = &SurveyResponseStore{}
 	GlobalExternalAccounts            = &UserExternalAccountsStore{}
-	GlobalOrgInvitations              = &OrgInvitationStore{}
 	GlobalAuthz            AuthzStore = &authzStore{}
 )


### PR DESCRIPTION
This PR removes the GlobalOrgInvitations store and replaces
all calls to that store by the OrgInvitationsStore constructor.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
