### PR TITLE
db: remove GlobalSurveyResponses store

### DIFF
--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -101,7 +101,7 @@ func (r *schemaResolver) SubmitSurvey(ctx context.Context, args *struct {
 		}
 	}
 
-	_, err := database.GlobalSurveyResponses.Create(ctx, uid, email, int(input.Score), input.Reason, input.Better)
+	_, err := database.SurveyResponses(r.db).Create(ctx, uid, email, int(input.Score), input.Reason, input.Better)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/survey_responses.go
+++ b/cmd/frontend/graphqlbackend/survey_responses.go
@@ -28,7 +28,7 @@ func (r *surveyResponseConnectionResolver) Nodes(ctx context.Context) ([]*survey
 		return nil, err
 	}
 
-	responses, err := database.GlobalSurveyResponses.GetAll(ctx)
+	responses, err := database.SurveyResponses(r.db).GetAll(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (r *surveyResponseConnectionResolver) TotalCount(ctx context.Context) (int3
 		return 0, err
 	}
 
-	count, err := database.GlobalSurveyResponses.Count(ctx)
+	count, err := database.SurveyResponses(r.db).Count(ctx)
 	return int32(count), err
 }
 
@@ -56,7 +56,7 @@ func (r *surveyResponseConnectionResolver) AverageScore(ctx context.Context) (fl
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return 0, err
 	}
-	return database.GlobalSurveyResponses.Last30DaysAverageScore(ctx)
+	return database.SurveyResponses(r.db).Last30DaysAverageScore(ctx)
 }
 
 func (r *surveyResponseConnectionResolver) NetPromoterScore(ctx context.Context) (int32, error) {
@@ -64,7 +64,7 @@ func (r *surveyResponseConnectionResolver) NetPromoterScore(ctx context.Context)
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return 0, err
 	}
-	nps, err := database.GlobalSurveyResponses.Last30DaysNetPromoterScore(ctx)
+	nps, err := database.SurveyResponses(r.db).Last30DaysNetPromoterScore(ctx)
 	return int32(nps), err
 }
 
@@ -73,6 +73,6 @@ func (r *surveyResponseConnectionResolver) Last30DaysCount(ctx context.Context) 
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 		return 0, err
 	}
-	count, err := database.GlobalSurveyResponses.Last30DaysCount(ctx)
+	count, err := database.SurveyResponses(r.db).Last30DaysCount(ctx)
 	return int32(count), err
 }

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -260,7 +260,7 @@ func (r *UserResolver) SurveyResponses(ctx context.Context) ([]*surveyResponseRe
 		return nil, err
 	}
 
-	responses, err := database.GlobalSurveyResponses.GetByUserID(ctx, r.user.ID)
+	responses, err := database.SurveyResponses(r.db).GetByUserID(ctx, r.user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -18,7 +18,6 @@ var (
 	GlobalUserCredentials             = &UserCredentialsStore{}
 	GlobalUserEmails                  = &UserEmailsStore{}
 	GlobalEventLogs                   = &EventLogStore{}
-	GlobalSurveyResponses             = &SurveyResponseStore{}
 	GlobalExternalAccounts            = &UserExternalAccountsStore{}
 	GlobalOrgInvitations              = &OrgInvitationStore{}
 	GlobalAuthz            AuthzStore = &authzStore{}


### PR DESCRIPTION
This PR removes the GlobalSurveyReponses store and replaces
all calls to that store by the SurveyReponses store constructor.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
