### PR TITLE
db: remove GlobalNamespaces store

### DIFF
--- a/cmd/frontend/graphqlbackend/namespaces.go
+++ b/cmd/frontend/graphqlbackend/namespaces.go
@@ -59,7 +59,7 @@ func UnmarshalNamespaceID(id graphql.ID, userID *int32, orgID *int32) (err error
 }
 
 func (r *schemaResolver) NamespaceByName(ctx context.Context, args *struct{ Name string }) (*NamespaceResolver, error) {
-	namespace, err := database.GlobalNamespaces.GetByName(ctx, args.Name)
+	namespace, err := database.Namespaces(r.db).GetByName(ctx, args.Name)
 	if err == database.ErrNamespaceNotFound {
 		return nil, nil
 	}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -464,7 +464,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		CommitAfter:        commitAfter,
 		Query:              r.Query,
 	}
-	repositoryResolver := &searchrepos.Resolver{Zoekt: r.zoekt, DefaultReposFunc: database.GlobalDefaultRepos.List, NamespaceStore: database.GlobalNamespaces}
+	repositoryResolver := &searchrepos.Resolver{Zoekt: r.zoekt, DefaultReposFunc: database.GlobalDefaultRepos.List, NamespaceStore: database.Namespaces(r.db)}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	tr.LazyPrintf("resolveRepositories - done")
 	if effectiveRepoFieldValues == nil {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -120,7 +120,7 @@ func alertForStalePermissions(db dbutil.DB) *searchAlert {
 // query does not contain any repos to search.
 func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Options) bool {
 	options.UserSettings = r.UserSettings
-	repositoryResolver := &searchrepos.Resolver{Zoekt: r.zoekt, DefaultReposFunc: database.GlobalDefaultRepos.List, NamespaceStore: database.GlobalNamespaces}
+	repositoryResolver := &searchrepos.Resolver{Zoekt: r.zoekt, DefaultReposFunc: database.GlobalDefaultRepos.List, NamespaceStore: database.Namespaces(r.db)}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0
 }

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/session"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
@@ -21,7 +22,7 @@ import (
 //
 // 🚨 SECURITY: The caller MUST wrap the returned handler in middleware that checks authentication
 // and sets the actor in the request context.
-func NewHandler() http.Handler {
+func NewHandler(db dbutil.DB) http.Handler {
 	session.SetSessionStore(session.NewRedisStore(func() bool {
 		return globals.ExternalURL().Scheme == "https"
 	}))
@@ -61,7 +62,7 @@ func NewHandler() http.Handler {
 	r.Get(router.ResetPasswordInit).Handler(trace.Route(http.HandlerFunc(userpasswd.HandleResetPasswordInit)))
 	r.Get(router.ResetPasswordCode).Handler(trace.Route(http.HandlerFunc(userpasswd.HandleResetPasswordCode)))
 
-	r.Get(router.CheckUsernameTaken).Handler(trace.Route(http.HandlerFunc(userpasswd.HandleCheckUsernameTaken)))
+	r.Get(router.CheckUsernameTaken).Handler(trace.Route(http.HandlerFunc(userpasswd.HandleCheckUsernameTaken(db))))
 
 	r.Get(router.RegistryExtensionBundle).Handler(trace.Route(gziphandler.GzipHandler(http.HandlerFunc(registry.HandleRegistryExtensionBundle))))
 

--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -56,7 +56,7 @@ func newExternalHTTPHandler(db dbutil.DB, schema *graphql.Schema, gitHubWebhook 
 	executorProxyHandler := newExecutorProxyHandler()
 
 	// App handler (HTML pages), the call order of middleware is LIFO.
-	appHandler := app.NewHandler()
+	appHandler := app.NewHandler(db)
 	if hooks.PostAuthMiddleware != nil {
 		// 🚨 SECURITY: These all run after the auth handler so the client is authenticated.
 		appHandler = hooks.PostAuthMiddleware(appHandler)

--- a/enterprise/internal/campaigns/reconciler/executor_test.go
+++ b/enterprise/internal/campaigns/reconciler/executor_test.go
@@ -900,7 +900,7 @@ func TestDecorateChangesetBody(t *testing.T) {
 
 	body := "body"
 	rcs := &repos.Changeset{Body: body, Changeset: cs}
-	if err := decorateChangesetBody(context.Background(), fs, database.GlobalNamespaces, rcs); err != nil {
+	if err := decorateChangesetBody(context.Background(), fs, database.Namespaces(new(dbtesting.MockDB)), rcs); err != nil {
 		t.Errorf("unexpected non-nil error: %v", err)
 	}
 	if want := body + "\n\n[_Created by Sourcegraph campaign `my-user/reconciler-test-campaign`._](https://sourcegraph.test/users/my-user/campaigns/reconciler-test-campaign)"; rcs.Body != want {

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -8,7 +8,6 @@ var (
 	GlobalRepos                       = &RepoStore{}
 	GlobalPhabricator                 = &PhabricatorStore{}
 	GlobalQueryRunnerState            = &QueryRunnerStateStore{}
-	GlobalNamespaces                  = &NamespaceStore{}
 	GlobalOrgs                        = &OrgStore{}
 	GlobalOrgMembers                  = &OrgMemberStore{}
 	GlobalSavedSearches               = &SavedSearchStore{}


### PR DESCRIPTION
This PR removes the GlobalNamespaces store and replaces
all calls to that store by the Namespaces store constructor.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
