### PR TITLE
db: remove GlobalPhabricator store

### DIFF
--- a/cmd/frontend/graphqlbackend/externallink/repository_test.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -34,7 +35,7 @@ func TestRepository(t *testing.T) {
 		database.Mocks.Phabricator.GetByName = func(repo api.RepoName) (*types.PhabricatorRepo, error) {
 			return nil, errors.New("x")
 		}
-		links, err := Repository(context.Background(), &types.Repo{Name: api.RepoName(repoName)})
+		links, err := Repository(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: api.RepoName(repoName)})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -60,7 +61,7 @@ func TestRepository(t *testing.T) {
 			}
 			return &types.PhabricatorRepo{URL: "http://phabricator.example.com/", Callsign: "MYREPO"}, nil
 		}
-		links, err := Repository(context.Background(), &types.Repo{Name: "myrepo"})
+		links, err := Repository(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: "myrepo"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +84,7 @@ func TestRepository(t *testing.T) {
 		database.Mocks.Phabricator.GetByName = func(repo api.RepoName) (*types.PhabricatorRepo, error) {
 			return nil, errors.New("x")
 		}
-		links, err := Repository(context.Background(), &types.Repo{Name: "myrepo"})
+		links, err := Repository(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: "myrepo"})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -133,7 +134,7 @@ func TestFileOrDir(t *testing.T) {
 				database.Mocks.Phabricator.GetByName = func(repo api.RepoName) (*types.PhabricatorRepo, error) {
 					return nil, errors.New("x")
 				}
-				links, err := FileOrDir(context.Background(), &types.Repo{Name: api.RepoName(repoName)}, rev, path, isDir)
+				links, err := FileOrDir(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: api.RepoName(repoName)}, rev, path, isDir)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -164,7 +165,7 @@ func TestFileOrDir(t *testing.T) {
 			return []byte("mybranch"), nil, 0, nil
 		}
 		defer git.ResetMocks()
-		links, err := FileOrDir(context.Background(), &types.Repo{Name: "myrepo"}, rev, path, true)
+		links, err := FileOrDir(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: "myrepo"}, rev, path, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -187,7 +188,7 @@ func TestFileOrDir(t *testing.T) {
 		database.Mocks.Phabricator.GetByName = func(repo api.RepoName) (*types.PhabricatorRepo, error) {
 			return nil, errors.New("x")
 		}
-		links, err := FileOrDir(context.Background(), &types.Repo{Name: "myrepo"}, rev, path, true)
+		links, err := FileOrDir(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: "myrepo"}, rev, path, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -218,7 +219,7 @@ func TestCommit(t *testing.T) {
 		database.Mocks.Phabricator.GetByName = func(repo api.RepoName) (*types.PhabricatorRepo, error) {
 			return nil, errors.New("x")
 		}
-		links, err := Commit(context.Background(), &types.Repo{Name: api.RepoName(repoName)}, commit)
+		links, err := Commit(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: api.RepoName(repoName)}, commit)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -244,7 +245,7 @@ func TestCommit(t *testing.T) {
 			}
 			return &types.PhabricatorRepo{URL: "http://phabricator.example.com/", Callsign: "MYREPO"}, nil
 		}
-		links, err := Commit(context.Background(), &types.Repo{Name: "myrepo"}, commit)
+		links, err := Commit(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: "myrepo"}, commit)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -267,7 +268,7 @@ func TestCommit(t *testing.T) {
 		database.Mocks.Phabricator.GetByName = func(repo api.RepoName) (*types.PhabricatorRepo, error) {
 			return nil, errors.New("x")
 		}
-		links, err := Commit(context.Background(), &types.Repo{Name: "myrepo"}, commit)
+		links, err := Commit(context.Background(), new(dbtesting.MockDB), &types.Repo{Name: "myrepo"}, commit)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -185,7 +185,7 @@ func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.R
 		return nil, err
 	}
 
-	return externallink.Commit(ctx, repo, api.CommitID(r.oid))
+	return externallink.Commit(ctx, r.db, repo, api.CommitID(r.oid))
 }
 
 func (r *GitCommitResolver) Tree(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -170,7 +170,7 @@ func (r *GitTreeEntryResolver) ExternalURLs(ctx context.Context) ([]*externallin
 	if err != nil {
 		return nil, err
 	}
-	return externallink.FileOrDir(ctx, repo, r.commit.inputRevOrImmutableRev(), r.Path(), r.stat.Mode().IsDir())
+	return externallink.FileOrDir(ctx, r.db, repo, r.commit.inputRevOrImmutableRev(), r.Path(), r.stat.Mode().IsDir())
 }
 
 func (r *GitTreeEntryResolver) RawZipArchiveURL() string {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -832,7 +832,7 @@ func (r *schemaResolver) PhabricatorRepo(ctx context.Context, args *struct {
 		args.URI = args.Name
 	}
 
-	repo, err := database.GlobalPhabricator.GetByName(ctx, api.RepoName(*args.URI))
+	repo, err := database.Phabricator(r.db).GetByName(ctx, api.RepoName(*args.URI))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -281,7 +281,7 @@ func (r *RepositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.
 	if err != nil {
 		return nil, err
 	}
-	return externallink.Repository(ctx, repo)
+	return externallink.Repository(ctx, r.db, repo)
 }
 
 func (r *RepositoryResolver) Icon() string {
@@ -390,7 +390,7 @@ func (r *RepositoryResolver) PermissionsInfo(ctx context.Context) (PermissionsIn
 	return EnterpriseResolvers.authzResolver.RepositoryPermissionsInfo(ctx, r.ID())
 }
 
-func (*schemaResolver) AddPhabricatorRepo(ctx context.Context, args *struct {
+func (r *schemaResolver) AddPhabricatorRepo(ctx context.Context, args *struct {
 	Callsign string
 	Name     *string
 	// TODO(chris): Remove URI in favor of Name.
@@ -401,7 +401,7 @@ func (*schemaResolver) AddPhabricatorRepo(ctx context.Context, args *struct {
 		args.URI = args.Name
 	}
 
-	_, err := database.GlobalPhabricator.CreateIfNotExists(ctx, args.Callsign, api.RepoName(*args.URI), args.URL)
+	_, err := database.Phabricator(r.db).CreateIfNotExists(ctx, args.Callsign, api.RepoName(*args.URI), args.URL)
 	if err != nil {
 		log15.Error("adding phabricator repo", "callsign", args.Callsign, "name", args.URI, "url", args.URL)
 	}
@@ -444,7 +444,7 @@ func (r *schemaResolver) ResolvePhabricatorDiff(ctx context.Context, args *struc
 	}
 
 	origin := ""
-	if phabRepo, err := database.GlobalPhabricator.GetByName(ctx, api.RepoName(args.RepoName)); err == nil {
+	if phabRepo, err := database.Phabricator(r.db).GetByName(ctx, api.RepoName(args.RepoName)); err == nil {
 		origin = phabRepo.URL
 	}
 

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -112,7 +112,7 @@ func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, new
 
 	m.Get(apirouter.ExternalServiceConfigs).Handler(trace.Route(handler(serveExternalServiceConfigs)))
 	m.Get(apirouter.ExternalServicesList).Handler(trace.Route(handler(serveExternalServicesList)))
-	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.Route(handler(servePhabricatorRepoCreate)))
+	m.Get(apirouter.PhabricatorRepoCreate).Handler(trace.Route(handler(servePhabricatorRepoCreate(db))))
 	reposList := &reposListServer{
 		SourcegraphDotComMode: envvar.SourcegraphDotComMode(),
 		Repos:                 backend.Repos,

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -6,7 +6,6 @@ var (
 	GlobalExternalServices            = &ExternalServiceStore{}
 	GlobalDefaultRepos                = &DefaultRepoStore{}
 	GlobalRepos                       = &RepoStore{}
-	GlobalPhabricator                 = &PhabricatorStore{}
 	GlobalOrgs                        = &OrgStore{}
 	GlobalOrgMembers                  = &OrgMemberStore{}
 	GlobalSettings                    = &SettingStore{}


### PR DESCRIPTION
This PR removes the GlobalPhabricator store and replaces
all calls to that store by the Phabricator store constructor.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
