### PR TITLE
graphql: Remove specialised function

### DIFF
--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -171,7 +171,7 @@ query{
 }
 `,
 			want: queryCost{
-				FieldCount: 3,
+				FieldCount: 2,
 				MaxDepth:   2,
 			},
 		},
@@ -317,7 +317,7 @@ query Search($query: String!, $version: SearchVersion!, $patternType: SearchPatt
 }
 `,
 			want: queryCost{
-				FieldCount: 53,
+				FieldCount: 50,
 				MaxDepth:   9,
 			},
 		},


### PR DESCRIPTION
calcNodeCost can also be used to calculate fragment costs.

Also, don't count "__typename" fields.
