### PR TITLE
Avoid logging "Could not serialize" in Puppeteer tests

### DIFF
--- a/client/shared/src/testing/console.ts
+++ b/client/shared/src/testing/console.ts
@@ -27,13 +27,6 @@ export async function formatPuppeteerConsoleMessage(
     message: ConsoleMessage,
     simple?: boolean
 ): Promise<string> {
-    // Firefox tests with `puppeteer-firefox`: It does not support
-    // `argumentHandle.evaluateHandle` so messages will be broken, until we
-    // migrate away from `puppeteer-firefox` which is deprecated.
-    if (simple) {
-        return `Browser console (${message.type()}): ${message.text()}`
-    }
-
     const color = colors[message.type()] ?? identity
     const icon = icons[message.type()] ?? ''
     const formattedLocation =
@@ -54,35 +47,48 @@ export async function formatPuppeteerConsoleMessage(
                       formattedLocation
                     : '\t' + formattedLocation)
     )
+
+    const argumentObjects = simple
+        ? // Firefox tests with `puppeteer-firefox`: It does not support
+          // `argumentHandle.evaluateHandle` so messages will be broken, until we
+          // migrate away from `puppeteer-firefox` which is deprecated.
+          []
+        : await Promise.allSettled(
+              message.args().map(async argumentHandle => {
+                  const json = (await (
+                      await argumentHandle.evaluateHandle(value =>
+                          JSON.stringify(value, (key, value: unknown) => {
+                              // Check if value is error, because Errors are not serializable but commonly logged
+                              if (value instanceof Error) {
+                                  return value.stack
+                              }
+                              return value
+                          })
+                      )
+                  ).jsonValue()) as string
+                  const parsed: unknown = JSON.parse(json)
+                  return parsed
+              })
+          )
+
     return [
         chalk.bold('🖥  Browser console:'),
         color(
             ...[
                 message.type() !== 'log' ? chalk.bold(icon, message.type()) : '',
                 message.args().length === 0 ? message.text() : '',
-                ...(
-                    await Promise.all(
-                        message.args().map(async argumentHandle => {
-                            try {
-                                const json = (await (
-                                    await argumentHandle.evaluateHandle(value =>
-                                        JSON.stringify(value, (key, value: unknown) => {
-                                            // Check if value is error, because Errors are not serializable but commonly logged
-                                            if (value instanceof Error) {
-                                                return value.stack
-                                            }
-                                            return value
-                                        })
-                                    )
-                                ).jsonValue()) as string
-                                const parsed: unknown = JSON.parse(json)
-                                return parsed
-                            } catch (error) {
-                                return chalk.italic(`[Could not serialize: ${asError(error).message}]`)
-                            }
-                        })
-                    )
-                ).map(value => (typeof value === 'string' ? value : util.inspect(value))),
+                ...(message.args().length > 0 && argumentObjects.every(result => result.status === 'rejected')
+                    ? // If all arguments failed, fall back to the text.
+                      [message.text()]
+                    : argumentObjects.map(result => {
+                          if (result.status === 'rejected') {
+                              return chalk.italic(`[Could not serialize: ${asError(result.reason).message}]`)
+                          }
+                          if (typeof result.value === 'string') {
+                              return result.value
+                          }
+                          return util.inspect(result.value)
+                      })),
                 locationLine,
             ].filter(Boolean)
         ),

--- a/client/shared/src/testing/console.ts
+++ b/client/shared/src/testing/console.ts
@@ -76,9 +76,8 @@ export async function formatPuppeteerConsoleMessage(
         color(
             ...[
                 message.type() !== 'log' ? chalk.bold(icon, message.type()) : '',
-                message.args().length === 0 ? message.text() : '',
-                ...(message.args().length > 0 && argumentObjects.every(result => result.status === 'rejected')
-                    ? // If all arguments failed, fall back to the text.
+                ...(argumentObjects.every(result => result.status === 'rejected')
+                    ? // If all arguments failed or there are no arguments, fall back to the text.
                       [message.text()]
                     : argumentObjects.map(result => {
                           if (result.status === 'rejected') {


### PR DESCRIPTION
Reduces logspam by falling back to the text if we couldn't do rich serialization of _any_ arguments, instead of logging an error.