### PR TITLE
search: Split out CommitSearchResult

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -27,8 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-// CommitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
-type CommitSearchResultResolver struct {
+type CommitSearchResult struct {
 	commit         *GitCommitResolver
 	refs           []*GitRefResolver
 	sourceRefs     []*GitRefResolver
@@ -39,6 +38,11 @@ type CommitSearchResultResolver struct {
 	url            string
 	detail         string
 	matches        []*searchResultMatchResolver
+}
+
+// CommitSearchResult is a resolver for the GraphQL type `CommitSearchResult`
+type CommitSearchResultResolver struct {
+	CommitSearchResult
 }
 
 func (r *CommitSearchResultResolver) Select(path filter.SelectPath) SearchResultResolver {
@@ -333,7 +337,7 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 	for i, rawResult := range rawResults {
 		commit := rawResult.Commit
 		commitResolver := toGitCommitResolver(repoResolver, db, commit.ID, &commit)
-		results[i] = &CommitSearchResultResolver{commit: commitResolver}
+		results[i] = &CommitSearchResultResolver{CommitSearchResult{commit: commitResolver}}
 
 		addRefs := func(dst *[]*GitRefResolver, src []string) {
 			for _, ref := range src {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -76,7 +76,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	)
 
 	if want := []*CommitSearchResultResolver{
-		{
+		{CommitSearchResult{
 			commit:      wantCommit,
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
 			icon:        "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
@@ -84,7 +84,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			url:         "/repo/-/commit/c1",
 			detail:      "[`c1` one day ago](/repo/-/commit/c1)",
 			matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
-		},
+		}},
 	}; !reflect.DeepEqual(results, want) {
 		t.Errorf("results\ngot  %v\nwant %v", results, want)
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1450,16 +1450,16 @@ func TestSearchContext(t *testing.T) {
 }
 
 func commitResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{
+	return &CommitSearchResultResolver{CommitSearchResult{
 		url: url,
-	}
+	}}
 }
 
 func diffResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{
+	return &CommitSearchResultResolver{CommitSearchResult{
 		url:         url,
 		diffPreview: &highlightedString{},
-	}
+	}}
 }
 
 func repoResult(db dbutil.DB, url string) *RepositoryResolver {
@@ -1534,11 +1534,11 @@ func TestUnionMerge(t *testing.T) {
 			want: SearchResultsResolver{
 				db: db,
 				SearchResults: []SearchResultResolver{
-					&CommitSearchResultResolver{url: "a"},
-					&CommitSearchResultResolver{
+					&CommitSearchResultResolver{CommitSearchResult{url: "a"}},
+					&CommitSearchResultResolver{CommitSearchResult{
 						diffPreview: &highlightedString{},
 						url:         "a",
-					},
+					}},
 					&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "a"}},
 					NewRepositoryResolver(db, &types.Repo{Name: api.RepoName("a")}),
 				},
@@ -1555,11 +1555,11 @@ func TestUnionMerge(t *testing.T) {
 				},
 			},
 			want: SearchResultsResolver{db: db, SearchResults: []SearchResultResolver{
-				&CommitSearchResultResolver{url: "a"},
-				&CommitSearchResultResolver{
+				&CommitSearchResultResolver{CommitSearchResult{url: "a"}},
+				&CommitSearchResultResolver{CommitSearchResult{
 					diffPreview: &highlightedString{},
 					url:         "a",
-				},
+				}},
 				&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "a"}},
 				NewRepositoryResolver(db, &types.Repo{Name: api.RepoName("a")}),
 			},
@@ -1582,16 +1582,16 @@ func TestUnionMerge(t *testing.T) {
 				},
 			},
 			want: SearchResultsResolver{db: db, SearchResults: []SearchResultResolver{
-				&CommitSearchResultResolver{url: "a"},
-				&CommitSearchResultResolver{url: "b"},
-				&CommitSearchResultResolver{
+				&CommitSearchResultResolver{CommitSearchResult{url: "a"}},
+				&CommitSearchResultResolver{CommitSearchResult{url: "b"}},
+				&CommitSearchResultResolver{CommitSearchResult{
 					diffPreview: &highlightedString{},
 					url:         "a",
-				},
-				&CommitSearchResultResolver{
+				}},
+				&CommitSearchResultResolver{CommitSearchResult{
 					diffPreview: &highlightedString{},
 					url:         "b",
-				},
+				}},
 				&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "a"}},
 				&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "b"}},
 				NewRepositoryResolver(db, &types.Repo{Name: api.RepoName("a")}),


### PR DESCRIPTION
Splits CommitSearchResult from CommitSearchResultResolver so that
graphql-specific functionality can be isolated from the result type, and
the result type can be moved to `internal/search`.

This is just a first step, and it's not yet ready to move out of this
package. Next is to remove the dependency on the GitCommitResolver, which
makes requests to hydrate its fields.

Note that the nesting of the types is slightly awkward right now, but in many 
cases, we can replace `CommitSearchResultResolver` with `CommitSearchResult`,
so the nesting won't be required.

Progresses #18348 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
