### PR TITLE
codeintel: Paginate definitions lsifstore results

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -41,8 +41,8 @@ type DBStore interface {
 type LSIFStore interface {
 	Exists(ctx context.Context, bundleID int, path string) (bool, error)
 	Ranges(ctx context.Context, bundleID int, path string, startLine, endLine int) ([]lsifstore.CodeIntelligenceRange, error)
-	Definitions(ctx context.Context, bundleID int, path string, line, character int) ([]lsifstore.Location, error)
-	PagedReferences(ctx context.Context, bundleID int, path string, line, character, limit, offset int) ([]lsifstore.Location, int, error)
+	Definitions(ctx context.Context, bundleID int, path string, line, character, limit, offset int) ([]lsifstore.Location, int, error)
+	References(ctx context.Context, bundleID int, path string, line, character, limit, offset int) ([]lsifstore.Location, int, error)
 	Hover(ctx context.Context, bundleID int, path string, line, character int) (string, lsifstore.Range, bool, error)
 	Diagnostics(ctx context.Context, bundleID int, prefix string, limit, offset int) ([]lsifstore.Diagnostic, int, error)
 	MonikersByPosition(ctx context.Context, bundleID int, path string, line, character int) ([][]lsifstore.MonikerData, error)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions_test.go
@@ -24,8 +24,8 @@ func TestDefinitions(t *testing.T) {
 		{DumpID: 51, Path: "b.go", Range: testRange4},
 		{DumpID: 51, Path: "c.go", Range: testRange5},
 	}
-	mockLSIFStore.DefinitionsFunc.PushReturn(nil, nil)
-	mockLSIFStore.DefinitionsFunc.PushReturn(locations, nil)
+	mockLSIFStore.DefinitionsFunc.PushReturn(nil, 0, nil)
+	mockLSIFStore.DefinitionsFunc.PushReturn(locations, len(locations), nil)
 
 	uploads := []dbstore.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references.go
@@ -296,7 +296,7 @@ func (r *queryResolver) pageLocalReferences(ctx context.Context, adjustedUploads
 			continue
 		}
 
-		locations, totalCount, err := r.lsifStore.PagedReferences(
+		locations, totalCount, err := r.lsifStore.References(
 			ctx,
 			adjustedUploads[i].Upload.ID,
 			adjustedUploads[i].AdjustedPathInBundle,
@@ -306,7 +306,7 @@ func (r *queryResolver) pageLocalReferences(ctx context.Context, adjustedUploads
 			cursor.LocalOffset,
 		)
 		if err != nil {
-			return nil, false, errors.Wrap(err, "lsifstore.PagedReferences")
+			return nil, false, errors.Wrap(err, "lsifstore.References")
 		}
 
 		cursor.LocalOffset += len(locations)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_references_test.go
@@ -28,9 +28,9 @@ func TestReferences(t *testing.T) {
 		{DumpID: 51, Path: "b.go", Range: testRange4},
 		{DumpID: 51, Path: "c.go", Range: testRange5},
 	}
-	mockLSIFStore.PagedReferencesFunc.PushReturn(locations[:1], 1, nil)
-	mockLSIFStore.PagedReferencesFunc.PushReturn(locations[1:4], 3, nil)
-	mockLSIFStore.PagedReferencesFunc.PushReturn(locations[4:], 1, nil)
+	mockLSIFStore.ReferencesFunc.PushReturn(locations[:1], 1, nil)
+	mockLSIFStore.ReferencesFunc.PushReturn(locations[1:4], 3, nil)
+	mockLSIFStore.ReferencesFunc.PushReturn(locations[4:], 1, nil)
 
 	uploads := []dbstore.Dump{
 		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
@@ -132,9 +132,9 @@ func TestReferencesRemote(t *testing.T) {
 		{DumpID: 51, Path: "b.go", Range: testRange4},
 		{DumpID: 51, Path: "c.go", Range: testRange5},
 	}
-	mockLSIFStore.PagedReferencesFunc.PushReturn(locations[:1], 1, nil)
-	mockLSIFStore.PagedReferencesFunc.PushReturn(locations[1:4], 3, nil)
-	mockLSIFStore.PagedReferencesFunc.PushReturn(locations[4:5], 1, nil)
+	mockLSIFStore.ReferencesFunc.PushReturn(locations[:1], 1, nil)
+	mockLSIFStore.ReferencesFunc.PushReturn(locations[1:4], 3, nil)
+	mockLSIFStore.ReferencesFunc.PushReturn(locations[4:5], 1, nil)
 
 	monikerLocations := []lsifstore.Location{
 		{DumpID: 53, Path: "a.go", Range: testRange1},

--- a/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/bundle_test.go
@@ -168,7 +168,7 @@ func TestDatabaseDefinitions(t *testing.T) {
 	// `\ts, err := indexer.Index()` -> `\t Index() (*Stats, error)`
 	//                      ^^^^^           ^^^^^
 
-	if actual, err := store.Definitions(context.Background(), testBundleID, "cmd/lsif-go/main.go", 110, 22); err != nil {
+	if actual, _, err := store.Definitions(context.Background(), testBundleID, "cmd/lsif-go/main.go", 110, 22, 5, 0); err != nil {
 		t.Fatalf("unexpected error %s", err)
 	} else {
 		expected := []Location{
@@ -181,7 +181,7 @@ func TestDatabaseDefinitions(t *testing.T) {
 	}
 }
 
-func TestDatabasePagedReferences(t *testing.T) {
+func TestDatabaseReferences(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -217,7 +217,7 @@ func TestDatabasePagedReferences(t *testing.T) {
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("i=%d", i), func(t *testing.T) {
-			if actual, totalCount, err := store.PagedReferences(context.Background(), testBundleID, "protocol/writer.go", 85, 20, testCase.limit, testCase.offset); err != nil {
+			if actual, totalCount, err := store.References(context.Background(), testBundleID, "protocol/writer.go", 85, 20, testCase.limit, testCase.offset); err != nil {
 				t.Fatalf("unexpected error %s", err)
 			} else {
 				if totalCount != 3 {

--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -17,7 +17,6 @@ type operations struct {
 	monikerResults     *observation.Operation
 	monikersByPosition *observation.Operation
 	packageInformation *observation.Operation
-	pagedReferences    *observation.Operation
 	ranges             *observation.Operation
 	references         *observation.Operation
 	writeDefinitions   *observation.Operation
@@ -64,7 +63,6 @@ func newOperations(observationContext *observation.Context) *operations {
 		monikerResults:     op("MonikerResults"),
 		monikersByPosition: op("MonikersByPosition"),
 		packageInformation: op("PackageInformation"),
-		pagedReferences:    op("PagedReferences"),
 		ranges:             op("Ranges"),
 		references:         op("References"),
 		writeDefinitions:   op("WriteDefinitions"),


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/18245. This renames `PagedReferences` to `References`, and changes the behavior of definitions to be symmetric to references w.r.t. limit and offset.