### PR TITLE
Revert "search: Split out CommitSearchResult"

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -27,7 +27,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-type CommitSearchResult struct {
+// CommitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
+type CommitSearchResultResolver struct {
 	commit         *GitCommitResolver
 	refs           []*GitRefResolver
 	sourceRefs     []*GitRefResolver
@@ -38,11 +39,6 @@ type CommitSearchResult struct {
 	url            string
 	detail         string
 	matches        []*searchResultMatchResolver
-}
-
-// CommitSearchResult is a resolver for the GraphQL type `CommitSearchResult`
-type CommitSearchResultResolver struct {
-	CommitSearchResult
 }
 
 func (r *CommitSearchResultResolver) Select(path filter.SelectPath) SearchResultResolver {
@@ -337,7 +333,7 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 	for i, rawResult := range rawResults {
 		commit := rawResult.Commit
 		commitResolver := toGitCommitResolver(repoResolver, db, commit.ID, &commit)
-		results[i] = &CommitSearchResultResolver{CommitSearchResult{commit: commitResolver}}
+		results[i] = &CommitSearchResultResolver{commit: commitResolver}
 
 		addRefs := func(dst *[]*GitRefResolver, src []string) {
 			for _, ref := range src {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -76,7 +76,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	)
 
 	if want := []*CommitSearchResultResolver{
-		{CommitSearchResult{
+		{
 			commit:      wantCommit,
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
 			icon:        "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
@@ -84,7 +84,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			url:         "/repo/-/commit/c1",
 			detail:      "[`c1` one day ago](/repo/-/commit/c1)",
 			matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
-		}},
+		},
 	}; !reflect.DeepEqual(results, want) {
 		t.Errorf("results\ngot  %v\nwant %v", results, want)
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1450,16 +1450,16 @@ func TestSearchContext(t *testing.T) {
 }
 
 func commitResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{CommitSearchResult{
+	return &CommitSearchResultResolver{
 		url: url,
-	}}
+	}
 }
 
 func diffResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{CommitSearchResult{
+	return &CommitSearchResultResolver{
 		url:         url,
 		diffPreview: &highlightedString{},
-	}}
+	}
 }
 
 func repoResult(db dbutil.DB, url string) *RepositoryResolver {
@@ -1534,11 +1534,11 @@ func TestUnionMerge(t *testing.T) {
 			want: SearchResultsResolver{
 				db: db,
 				SearchResults: []SearchResultResolver{
-					&CommitSearchResultResolver{CommitSearchResult{url: "a"}},
-					&CommitSearchResultResolver{CommitSearchResult{
+					&CommitSearchResultResolver{url: "a"},
+					&CommitSearchResultResolver{
 						diffPreview: &highlightedString{},
 						url:         "a",
-					}},
+					},
 					&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "a"}},
 					NewRepositoryResolver(db, &types.Repo{Name: api.RepoName("a")}),
 				},
@@ -1555,11 +1555,11 @@ func TestUnionMerge(t *testing.T) {
 				},
 			},
 			want: SearchResultsResolver{db: db, SearchResults: []SearchResultResolver{
-				&CommitSearchResultResolver{CommitSearchResult{url: "a"}},
-				&CommitSearchResultResolver{CommitSearchResult{
+				&CommitSearchResultResolver{url: "a"},
+				&CommitSearchResultResolver{
 					diffPreview: &highlightedString{},
 					url:         "a",
-				}},
+				},
 				&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "a"}},
 				NewRepositoryResolver(db, &types.Repo{Name: api.RepoName("a")}),
 			},
@@ -1582,16 +1582,16 @@ func TestUnionMerge(t *testing.T) {
 				},
 			},
 			want: SearchResultsResolver{db: db, SearchResults: []SearchResultResolver{
-				&CommitSearchResultResolver{CommitSearchResult{url: "a"}},
-				&CommitSearchResultResolver{CommitSearchResult{url: "b"}},
-				&CommitSearchResultResolver{CommitSearchResult{
+				&CommitSearchResultResolver{url: "a"},
+				&CommitSearchResultResolver{url: "b"},
+				&CommitSearchResultResolver{
 					diffPreview: &highlightedString{},
 					url:         "a",
-				}},
-				&CommitSearchResultResolver{CommitSearchResult{
+				},
+				&CommitSearchResultResolver{
 					diffPreview: &highlightedString{},
 					url:         "b",
-				}},
+				},
 				&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "a"}},
 				&FileMatchResolver{db: db, FileMatch: FileMatch{db: db, uri: "b"}},
 				NewRepositoryResolver(db, &types.Repo{Name: api.RepoName("a")}),


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#18497 because I misunderstood automerge