### PR TITLE
search: Add definition for CommitSearchResult

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -27,8 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-// CommitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
-type CommitSearchResultResolver struct {
+type CommitSearchResult struct {
 	commit         *GitCommitResolver
 	refs           []*GitRefResolver
 	sourceRefs     []*GitRefResolver
@@ -40,6 +39,9 @@ type CommitSearchResultResolver struct {
 	detail         string
 	matches        []*searchResultMatchResolver
 }
+
+// CommitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
+type CommitSearchResultResolver CommitSearchResult
 
 func (r *CommitSearchResultResolver) Select(path filter.SelectPath) SearchResultResolver {
 	switch path.Type {


### PR DESCRIPTION
Splits CommitSearchResultResolver and CommitSearchResult so that the
graphql-specific methods are defined independently of the result type.
This paves the way for moving result types out of `graphqlbackend`.

Progresses #18348 

This is what #18497 was supposed to be, but I misunderstood what automerge does, so I reverted that PR. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
