### PR TITLE
insights: query data aggregated over 12h

### DIFF
--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -110,13 +110,14 @@ func (s *Store) SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]Seri
 
 var seriesPointsQueryFmtstr = `
 -- source: enterprise/internal/insights/store/store.go:SeriesPoints
-SELECT time,
-	value,
+SELECT time_bucket(INTERVAL '12 hours', time) AS time_bucket,
+	SUM(value),
 	m.metadata
 FROM series_points p
 LEFT JOIN metadata m ON p.metadata_id = m.id
 WHERE %s
-ORDER BY time DESC
+GROUP BY metadata, time_bucket
+ORDER BY time_bucket DESC
 `
 
 func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -72,8 +72,8 @@ SELECT time,
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Want("SeriesPoints(2).len", int(913)).Equal(t, len(points))
-		autogold.Want("SeriesPoints(2)[len()-1].String()", `SeriesPoint{Time: "2020-01-01 00:00:00 +0000 UTC", Value: -20.00716650672132, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
+		autogold.Want("SeriesPoints(2).len", int(305)).Equal(t, len(points))
+		autogold.Want("SeriesPoints(2)[len()-1].String()", `SeriesPoint{Time: "2020-01-01 00:00:00 +0000 UTC", Value: -21.511725698767634, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
 		autogold.Want("SeriesPoints(2)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
 	})
 
@@ -86,9 +86,9 @@ SELECT time,
 		if err != nil {
 			t.Fatal(err)
 		}
-		autogold.Want("SeriesPoints(3).len", int(553)).Equal(t, len(points))
+		autogold.Want("SeriesPoints(3).len", int(185)).Equal(t, len(points))
 		autogold.Want("SeriesPoints(3)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
-		autogold.Want("SeriesPoints(3)[len()-1].String()", `SeriesPoint{Time: "2020-03-01 00:00:00 +0000 UTC", Value: 34.08303991578748, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
+		autogold.Want("SeriesPoints(3)[len()-1].String()", `SeriesPoint{Time: "2020-03-01 00:00:00 +0000 UTC", Value: 36.838050688297415, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[len(points)-1].String())
 	})
 
 	t.Run("latest 3 points", func(t *testing.T) {
@@ -101,8 +101,8 @@ SELECT time,
 		}
 		autogold.Want("SeriesPoints(4).len", int(3)).Equal(t, len(points))
 		autogold.Want("SeriesPoints(4)[0].String()", `SeriesPoint{Time: "2020-06-01 00:00:00 +0000 UTC", Value: -37.8750440811433, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[0].String())
-		autogold.Want("SeriesPoints(4)[1].String()", `SeriesPoint{Time: "2020-05-31 20:00:00 +0000 UTC", Value: -11.269436460802638, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[1].String())
-		autogold.Want("SeriesPoints(4)[2].String()", `SeriesPoint{Time: "2020-05-31 16:00:00 +0000 UTC", Value: 17.838503552871998, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[2].String())
+		autogold.Want("SeriesPoints(4)[1].String()", `SeriesPoint{Time: "2020-05-31 12:00:00 +0000 UTC", Value: -24.52205825517467, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[1].String())
+		autogold.Want("SeriesPoints(4)[2].String()", `SeriesPoint{Time: "2020-05-31 00:00:00 +0000 UTC", Value: -62.971218255773636, Metadata: {"hello": "world", "languages": ["Go", "Python", "Java"]}}`).Equal(t, points[2].String())
 	})
 
 }


### PR DESCRIPTION
Today, we query every data point that TimescaleDB has for a series. We record
data points at a rate of 1 per 12h - however, there can still sometimes be
duplicate data points which appear at a faster rate:

1. Each time Sourcegraph is started (repo-updater) we enqueue data points, so
   the interval between data points is not strictly deterministic.
2. More important, if we record 1 data point per repository (# of search results
   per repository), we have many data points recorded roughly at the same time
   and need to aggregate them if we intend to display an insight for "total results
   across all repositories" - this will be true once we start doing data
   backfilling and once I implement recording of data points per repository
   (very soon.)

Thus, this change makes us aggregate so we only ever get back 1 data point every 12h.

In the future, it may make sense for the web UI to ask for different granularity
values - e.g. give me 1 point for every month in the last year. We can support this
efficiently using pre-defined [TimescaleDB continuous aggregates](https://docs.timescale.com/latest/using-timescaledb/continuous-aggregates)
but for now 12h is the minimal and default aggregation, which should be OK without
a special index.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
