### PR TITLE
streaming search: performance fixes for filter bars

### DIFF
--- a/client/web/src/search/results/SearchResultsFilterBars.tsx
+++ b/client/web/src/search/results/SearchResultsFilterBars.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames'
+import { debounce } from 'lodash'
 import MenuLeftIcon from 'mdi-react/MenuLeftIcon'
 import MenuRightIcon from 'mdi-react/MenuRightIcon'
 import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
@@ -71,10 +72,10 @@ const FilterCarousel: React.FunctionComponent<{ children: JSX.Element | JSX.Elem
     }, [canScrollForward])
 
     useLayoutEffect(() => {
-        const updateCanScroll = (): void => {
+        const updateCanScroll = debounce((): void => {
             setCanScrollBack(computeCanScrollBack)
             setCanScrollForward(computeCanScrollForward)
-        }
+        }, 50)
 
         updateCanScroll()
         const current = filtersReference.current

--- a/client/web/src/search/results/streaming/StreamingSearchResultsFilterBars.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsFilterBars.tsx
@@ -40,6 +40,9 @@ export const StreamingSearchResultsFilterBars: React.FunctionComponent<Props> = 
     const filters = props.results?.filters
     const quickLinks = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final.quicklinks) || []
 
+    const genericFilters = useMemo(() => getFilters(filters, settingsCascade), [filters, settingsCascade])
+    const repoFilters = useMemo(() => getRepoFilters(filters), [filters])
+
     const onDynamicFilterClicked = useCallback(
         (value: string) => {
             props.telemetryService.log('DynamicFilterClicked', {
@@ -60,9 +63,9 @@ export const StreamingSearchResultsFilterBars: React.FunctionComponent<Props> = 
             navbarSearchQuery={props.navbarSearchQueryState.query}
             searchSucceeded={!!results}
             resultsLimitHit={!!results && results.progress.skipped.some(skipped => skipped.reason.includes('-limit'))}
-            genericFilters={getFilters(filters, settingsCascade)}
+            genericFilters={genericFilters}
             extensionFilters={contributions?.searchFilters}
-            repoFilters={getRepoFilters(filters)}
+            repoFilters={repoFilters}
             quickLinks={quickLinks}
             onFilterClick={onDynamicFilterClicked}
             onShowMoreResultsClick={showMoreResults}


### PR DESCRIPTION
- Debounce `useLayoutEffect` used to calculate when to show the scroll buttons for `SearchResultsFilterBars` (I think this is the big one. Basically every time this is called, layout has to be recalculated as we need to measure the size of the window to figure out if we need to show the arrows or not)
- `useMemo` to calculate filters in `StreamingSearchResultsFilterBars`