### PR TITLE
insights: ensure search queries run with a large count:

### DIFF
--- a/enterprise/internal/insights/background/insight_enqueuer_test.go
+++ b/enterprise/internal/insights/background/insight_enqueuer_test.go
@@ -92,7 +92,7 @@ func Test_discoverAndEnqueueInsights(t *testing.T) {
 	autogold.Want("0", `[
   {
     "SeriesID": "s:087855E6A24440837303FD8A252E9893E8ABDFECA55B61AC83DA1B521906626E",
-    "SearchQuery": "errorf",
+    "SearchQuery": "errorf count:9999999",
     "ID": 0,
     "State": "queued",
     "FailureMessage": null,
@@ -105,7 +105,7 @@ func Test_discoverAndEnqueueInsights(t *testing.T) {
   },
   {
     "SeriesID": "s:7FBD292BF97936C4B6397688CFFB05DEA95E650C3D5B653AAEA8F77BBD25CE93",
-    "SearchQuery": "fmt.Printf",
+    "SearchQuery": "fmt.Printf count:9999999",
     "ID": 0,
     "State": "queued",
     "FailureMessage": null,
@@ -118,7 +118,7 @@ func Test_discoverAndEnqueueInsights(t *testing.T) {
   },
   {
     "SeriesID": "s:FB8CFBB7C7C28834957FBE1B830EDD79C5E710FD55B0ACF246C0D7267C5462B4",
-    "SearchQuery": "gitserver.Exec",
+    "SearchQuery": "gitserver.Exec count:9999999",
     "ID": 0,
     "State": "queued",
     "FailureMessage": null,
@@ -131,7 +131,7 @@ func Test_discoverAndEnqueueInsights(t *testing.T) {
   },
   {
     "SeriesID": "s:2B55C7CE2EB30BFFAF1F0276E525B36BB71908E3893A27F416F62A3E23542566",
-    "SearchQuery": "gitserver.Close",
+    "SearchQuery": "gitserver.Close count:9999999",
     "ID": 0,
     "State": "queued",
     "FailureMessage": null,


### PR DESCRIPTION
This ensures insights without a `count:` field in them have `count:9999999` (10m)
implicitly added. All search queries have a timeout of 60s, so this is unlikely to
cause any major issues. Additionally, is is a source of large issues for code insights
because we implicitly measure "number of fluctuating results" leading to super wonky
things _like this_:

![image](https://user-images.githubusercontent.com/3173176/108571739-15d45b00-72ce-11eb-849b-029032d1ba01.png)

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>
