### PR TITLE
insights: default to 90d display; improve handling of forked/archived repos

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2503,7 +2503,7 @@ type InsightsSeries {
     """
     Data points over a time range (inclusive)
 
-    If no 'from' time range is specified, the last 30d of data is assumed.
+    If no 'from' time range is specified, the last 90 days of data is assumed.
 
     If no 'to' time range is specified, the current point in time is assumed.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2496,7 +2496,7 @@ type InsightsSeries {
     """
     Data points over a time range (inclusive)
 
-    If no 'from' time range is specified, the last 30d of data is assumed.
+    If no 'from' time range is specified, the last 90 days of data is assumed.
 
     If no 'to' time range is specified, the current point in time is assumed.
     """

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -30,8 +30,8 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 	opts.SeriesID = &seriesID
 
 	if args.From == nil {
-		// Default to last 30d of data.
-		args.From = &graphqlbackend.DateTime{Time: time.Now().Add(-30 * 24 * time.Hour)}
+		// Default to last 3mo of data.
+		args.From = &graphqlbackend.DateTime{Time: time.Now().Add(-3 * 30 * 24 * time.Hour)}
 	}
 	if args.From != nil {
 		opts.From = &args.From.Time


### PR DESCRIPTION
* Default to showing the last 90d of data, this is a better display of data points now that we aggregated to 12h.
* Improve handling of forked/archived repo searches.