### PR TITLE
search: Untangle commit results

### DIFF
--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -176,8 +176,8 @@ func (r *GitCommitResolver) URL() string {
 	return r.repoResolver.URL() + "/-/commit/" + r.inputRevOrImmutableRev()
 }
 
-func (r *GitCommitResolver) CanonicalURL() (string, error) {
-	return r.repoResolver.URL() + "/-/commit/" + string(r.oid), nil
+func (r *GitCommitResolver) CanonicalURL() string {
+	return r.repoResolver.URL() + "/-/commit/" + string(r.oid)
 }
 
 func (r *GitCommitResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -129,7 +128,7 @@ func (r *GitCommitResolver) Message(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return commit.Message, err
+	return string(commit.Message), err
 }
 
 func (r *GitCommitResolver) Subject(ctx context.Context) (string, error) {
@@ -137,7 +136,7 @@ func (r *GitCommitResolver) Subject(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return GitCommitSubject(commit.Message), err
+	return commit.Message.Subject(), nil
 }
 
 func (r *GitCommitResolver) Body(ctx context.Context) (*string, error) {
@@ -146,7 +145,7 @@ func (r *GitCommitResolver) Body(ctx context.Context) (*string, error) {
 		return nil, err
 	}
 
-	body := GitCommitBody(commit.Message)
+	body := commit.Message.Body()
 	if body == "" {
 		return nil, nil
 	}
@@ -335,22 +334,4 @@ func (r *GitCommitResolver) repoRevURL() (string, error) {
 
 func (r *GitCommitResolver) canonicalRepoRevURL() (string, error) {
 	return r.repoResolver.URL() + "@" + string(r.oid), nil
-}
-
-// GitCommitSubject returns the first line of the Git commit message.
-func GitCommitSubject(message string) string {
-	i := strings.Index(message, "\n")
-	if i == -1 {
-		return message
-	}
-	return message[:i]
-}
-
-// GitCommitBody returns the contents of the Git commit message after the subject.
-func GitCommitBody(message string) string {
-	i := strings.Index(message, "\n")
-	if i == -1 {
-		return ""
-	}
-	return strings.TrimSpace(message[i:])
 }

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -174,7 +174,7 @@ func (r *GitCommitResolver) Parents(ctx context.Context) ([]*GitCommitResolver, 
 }
 
 func (r *GitCommitResolver) URL() (string, error) {
-	return r.repoResolver.URL() + "/-/commit/" + string(r.inputRevOrImmutableRev()), nil
+	return r.repoResolver.URL() + "/-/commit/" + r.inputRevOrImmutableRev(), nil
 }
 
 func (r *GitCommitResolver) CanonicalURL() (string, error) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -173,8 +173,8 @@ func (r *GitCommitResolver) Parents(ctx context.Context) ([]*GitCommitResolver, 
 	return resolvers, nil
 }
 
-func (r *GitCommitResolver) URL() (string, error) {
-	return r.repoResolver.URL() + "/-/commit/" + r.inputRevOrImmutableRev(), nil
+func (r *GitCommitResolver) URL() string {
+	return r.repoResolver.URL() + "/-/commit/" + r.inputRevOrImmutableRev()
 }
 
 func (r *GitCommitResolver) CanonicalURL() (string, error) {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -45,8 +45,10 @@ type GitCommitResolver struct {
 
 	gitRepo api.RepoName
 
-	commitOnce sync.Once
+	// commit should not be accessed directly since it might not be initialized.
+	// Use the resolver methods instead.
 	commit     *git.Commit
+	commitOnce sync.Once
 	commitErr  error
 }
 

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -87,7 +87,7 @@ func TestGitCommitResolver(t *testing.T) {
 			name: "canonical-url",
 			want: "/bob-repo/-/commit/c1",
 			have: func(r *GitCommitResolver) (interface{}, error) {
-				return r.CanonicalURL()
+				return r.CanonicalURL(), nil
 			},
 		}} {
 			t.Run(tc.name, func(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -81,7 +81,7 @@ func TestGitCommitResolver(t *testing.T) {
 			name: "url",
 			want: "/bob-repo/-/commit/c1",
 			have: func(r *GitCommitResolver) (interface{}, error) {
-				return r.URL()
+				return r.URL(), nil
 			},
 		}, {
 			name: "canonical-url",

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -60,7 +60,7 @@ func TestGitCommitResolver(t *testing.T) {
 			},
 		}, {
 			name: "message",
-			want: commit.Message,
+			want: string(commit.Message),
 			have: func(r *GitCommitResolver) (interface{}, error) {
 				return r.Message(ctx)
 			},
@@ -107,21 +107,4 @@ func TestGitCommitResolver(t *testing.T) {
 			})
 		}
 	})
-}
-
-func TestGitCommitBody(t *testing.T) {
-	tests := map[string]string{
-		"hello":               "",
-		"hello\n":             "",
-		"hello\n\n":           "",
-		"hello\nworld":        "world",
-		"hello\n\nworld":      "world",
-		"hello\n\nworld\nfoo": "world\nfoo",
-	}
-	for input, want := range tests {
-		got := GitCommitBody(input)
-		if got != want {
-			t.Errorf("got %q, want %q", got, want)
-		}
-	}
 }

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -36,7 +36,6 @@ type CommitSearchResult struct {
 	sourceRefs     []string
 	messagePreview *highlightedString
 	diffPreview    *highlightedString
-	url            string
 	matches        []*searchResultMatchResolver
 }
 
@@ -114,13 +113,13 @@ func (r *CommitSearchResultResolver) Label() Markdown {
 }
 
 func (r *CommitSearchResultResolver) URL() string {
-	return r.url
+	return r.Commit().URL()
 }
 
 func (r *CommitSearchResultResolver) Detail() Markdown {
 	commitHash := r.commit.ID.Short()
 	timeagoConfig := timeago.NoMax(timeago.English)
-	detail := fmt.Sprintf("[`%v` %v](%v)", commitHash, timeagoConfig.Format(r.commit.Author.Date), r.url)
+	detail := fmt.Sprintf("[`%v` %v](%v)", commitHash, timeagoConfig.Format(r.commit.Author.Date), r.Commit().URL())
 	return Markdown(detail)
 }
 
@@ -427,7 +426,6 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 
 		url := commitResolver.URL()
 
-		results[i].url = url
 		match := &searchResultMatchResolver{body: matchBody, highlights: matchHighlights, url: url}
 		matches := []*searchResultMatchResolver{match}
 		results[i].matches = matches

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -419,16 +419,9 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 			matchBody, matchHighlights = cleanDiffPreview(fromVCSHighlights(rawResult.DiffHighlights), rawResult.Diff.Raw)
 		}
 
-		var err error
-		results[i].label, err = createLabel(rawResult, commitResolver)
-		if err != nil {
-			return nil, err
-		}
+		results[i].label = createLabel(rawResult, commitResolver)
 
-		url, err := commitResolver.URL()
-		if err != nil {
-			return nil, err
-		}
+		url := commitResolver.URL()
 
 		results[i].url = url
 		match := &searchResultMatchResolver{body: matchBody, highlights: matchHighlights, url: url}
@@ -487,17 +480,14 @@ func cleanDiffPreview(highlights []*highlightedRange, rawDiffResult string) (str
 	return body, highlights
 }
 
-func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *GitCommitResolver) (string, error) {
+func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *GitCommitResolver) string {
 	message := commitSubject(rawResult.Commit.Message)
 	author := rawResult.Commit.Author.Name
 	repoName := displayRepoName(commitResolver.Repository().Name())
 	repoURL := commitResolver.Repository().URL()
-	url, err := commitResolver.URL()
-	if err != nil {
-		return "", err
-	}
+	url := commitResolver.URL()
 
-	return fmt.Sprintf("[%s](%s) › [%s](%s): [%s](%s)", repoName, repoURL, author, url, message, url), nil
+	return fmt.Sprintf("[%s](%s) › [%s](%s): [%s](%s)", repoName, repoURL, author, url, message, url)
 }
 
 func commitSubject(message string) string {

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -404,7 +404,7 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 					matchHighlights = results[i].messagePreview.highlights
 				}
 			} else {
-				results[i].messagePreview = &highlightedString{value: string(commit.Message)}
+				results[i].messagePreview = &highlightedString{value: commit.Message}
 			}
 			matchBody = "```COMMIT_EDITMSG\n" + rawResult.Commit.Message + "\n```"
 		}

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -38,7 +38,6 @@ type CommitSearchResult struct {
 	diffPreview    *highlightedString
 	label          string
 	url            string
-	detail         string
 	matches        []*searchResultMatchResolver
 }
 
@@ -113,7 +112,10 @@ func (r *CommitSearchResultResolver) URL() string {
 }
 
 func (r *CommitSearchResultResolver) Detail() Markdown {
-	return Markdown(r.detail)
+	commitHash := r.commit.ID.Short()
+	timeagoConfig := timeago.NoMax(timeago.English)
+	detail := fmt.Sprintf("[`%v` %v](%v)", commitHash, timeagoConfig.Format(r.commit.Author.Date), r.url)
+	return Markdown(detail)
 }
 
 func (r *CommitSearchResultResolver) Matches() []*searchResultMatchResolver {
@@ -422,15 +424,12 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 		if err != nil {
 			return nil, err
 		}
-		commitHash := rawResult.Commit.ID.Short()
-		timeagoConfig := timeago.NoMax(timeago.English)
 
 		url, err := commitResolver.URL()
 		if err != nil {
 			return nil, err
 		}
 
-		results[i].detail = fmt.Sprintf("[`%v` %v](%v)", commitHash, timeagoConfig.Format(rawResult.Commit.Author.Date), url)
 		results[i].url = url
 		match := &searchResultMatchResolver{body: matchBody, highlights: matchHighlights, url: url}
 		matches := []*searchResultMatchResolver{match}

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -36,7 +36,6 @@ type CommitSearchResult struct {
 	sourceRefs     []string
 	messagePreview *highlightedString
 	diffPreview    *highlightedString
-	icon           string
 	label          string
 	url            string
 	detail         string
@@ -100,8 +99,9 @@ func (r *CommitSearchResultResolver) SourceRefs() []*GitRefResolver {
 
 func (r *CommitSearchResultResolver) MessagePreview() *highlightedString { return r.messagePreview }
 func (r *CommitSearchResultResolver) DiffPreview() *highlightedString    { return r.diffPreview }
+
 func (r *CommitSearchResultResolver) Icon() string {
-	return r.icon
+	return "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4="
 }
 
 func (r *CommitSearchResultResolver) Label() Markdown {
@@ -417,7 +417,6 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 			matchBody, matchHighlights = cleanDiffPreview(fromVCSHighlights(rawResult.DiffHighlights), rawResult.Diff.Raw)
 		}
 
-		commitIcon := "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4="
 		var err error
 		results[i].label, err = createLabel(rawResult, commitResolver)
 		if err != nil {
@@ -436,7 +435,6 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 
 		results[i].detail = fmt.Sprintf("[`%v` %v](%v)", commitHash, timeagoConfig.Format(rawResult.Commit.Author.Date), url)
 		results[i].url = url
-		results[i].icon = commitIcon
 		match := &searchResultMatchResolver{body: matchBody, highlights: matchHighlights, url: url}
 		matches := []*searchResultMatchResolver{match}
 		results[i].matches = matches

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -406,9 +406,9 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 					matchHighlights = results[i].messagePreview.highlights
 				}
 			} else {
-				results[i].messagePreview = &highlightedString{value: commit.Message}
+				results[i].messagePreview = &highlightedString{value: string(commit.Message)}
 			}
-			matchBody = "```COMMIT_EDITMSG\n" + rawResult.Commit.Message + "\n```"
+			matchBody = "```COMMIT_EDITMSG\n" + string(rawResult.Commit.Message) + "\n```"
 		}
 
 		if rawResult.Diff != nil && op.Diff {
@@ -481,21 +481,13 @@ func cleanDiffPreview(highlights []*highlightedRange, rawDiffResult string) (str
 }
 
 func createLabel(rawResult *git.LogCommitSearchResult, commitResolver *GitCommitResolver) string {
-	message := commitSubject(rawResult.Commit.Message)
+	message := rawResult.Commit.Message.Subject()
 	author := rawResult.Commit.Author.Name
 	repoName := displayRepoName(commitResolver.Repository().Name())
 	repoURL := commitResolver.Repository().URL()
 	url := commitResolver.URL()
 
 	return fmt.Sprintf("[%s](%s) › [%s](%s): [%s](%s)", repoName, repoURL, author, url, message, url)
-}
-
-func commitSubject(message string) string {
-	idx := strings.Index(message, "\n")
-	if idx != -1 {
-		return message[:idx]
-	}
-	return message
 }
 
 func displayRepoName(repoPath string) string {

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -422,10 +422,7 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 		if err != nil {
 			return nil, err
 		}
-		commitHash := string(rawResult.Commit.ID)
-		if len(rawResult.Commit.ID) > 7 {
-			commitHash = string(rawResult.Commit.ID)[:7]
-		}
+		commitHash := rawResult.Commit.ID.Short()
 		timeagoConfig := timeago.NoMax(timeago.English)
 
 		url, err := commitResolver.URL()

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -399,9 +399,8 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 		var matchHighlights []*highlightedRange
 		// TODO(sqs): properly combine message: and term values for type:commit searches
 		if !op.Diff {
-			var patString string
 			if len(op.ExtraMessageValues) > 0 {
-				patString = orderedFuzzyRegexp(op.ExtraMessageValues)
+				patString := orderedFuzzyRegexp(op.ExtraMessageValues)
 				if !op.Query.IsCaseSensitive() {
 					patString = "(?i:" + patString + ")"
 				}

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -74,7 +74,6 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
 			repoName:    types.RepoName{ID: 1, Name: "repo"},
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-			url:         "/repo/-/commit/c1",
 			matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
 		},
 	}}
@@ -91,6 +90,11 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	wantLabel := Markdown("[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)")
 	if gotLabel := want[0].Label(); gotLabel != wantLabel {
 		t.Errorf("label\ngot  %v\nwant %v", gotLabel, wantLabel)
+	}
+
+	wantURL := "/repo/-/commit/c1"
+	if gotURL := want[0].URL(); gotURL != wantURL {
+		t.Errorf("url\ngot  %v\nwant %v", gotURL, wantURL)
 	}
 
 	if limitHit {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -75,7 +75,6 @@ func TestSearchCommitsInRepo(t *testing.T) {
 				commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
 				repoName:    types.RepoName{ID: 1, Name: "repo"},
 				diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-				icon:        "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
 				label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
 				url:         "/repo/-/commit/c1",
 				detail:      "[`c1` one day ago](/repo/-/commit/c1)",

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -74,11 +74,8 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
 			repoName:    types.RepoName{ID: 1, Name: "repo"},
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-			label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
 			url:         "/repo/-/commit/c1",
-			// TODO add test for detail
-			// detail:      "[`c1` one day ago](/repo/-/commit/c1)",
-			matches: []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
+			matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
 		},
 	}}
 
@@ -89,6 +86,11 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	wantDetail := Markdown("[`c1` one day ago](/repo/-/commit/c1)")
 	if gotDetail := want[0].Detail(); gotDetail != wantDetail {
 		t.Errorf("detail\ngot  %v\nwant %v", gotDetail, wantDetail)
+	}
+
+	wantLabel := Markdown("[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)")
+	if gotLabel := want[0].Label(); gotLabel != wantLabel {
+		t.Errorf("label\ngot  %v\nwant %v", gotLabel, wantLabel)
 	}
 
 	if limitHit {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -68,22 +68,19 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wantCommit := toGitCommitResolver(
-		NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"}),
-		db,
-		"c1",
-		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
-	)
-
 	if want := []*CommitSearchResultResolver{
 		{
-			commit:      wantCommit,
-			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-			icon:        "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
-			label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
-			url:         "/repo/-/commit/c1",
-			detail:      "[`c1` one day ago](/repo/-/commit/c1)",
-			matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
+			db: db,
+			CommitSearchResult: CommitSearchResult{
+				commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
+				repoName:    types.RepoName{ID: 1, Name: "repo"},
+				diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
+				icon:        "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE3LDEyQzE3LDE0LjQyIDE1LjI4LDE2LjQ0IDEzLDE2LjlWMjFIMTFWMTYuOUM4LjcyLDE2LjQ0IDcsMTQuNDIgNywxMkM3LDkuNTggOC43Miw3LjU2IDExLDcuMVYzSDEzVjcuMUMxNS4yOCw3LjU2IDE3LDkuNTggMTcsMTJNMTIsOUEzLDMgMCAwLDAgOSwxMkEzLDMgMCAwLDAgMTIsMTVBMywzIDAgMCwwIDE1LDEyQTMsMyAwIDAsMCAxMiw5WiIgLz48L3N2Zz4=",
+				label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
+				url:         "/repo/-/commit/c1",
+				detail:      "[`c1` one day ago](/repo/-/commit/c1)",
+				matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
+			},
 		},
 	}; !reflect.DeepEqual(results, want) {
 		t.Errorf("results\ngot  %v\nwant %v", results, want)
@@ -100,7 +97,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 }
 
 func (r *CommitSearchResultResolver) String() string {
-	return fmt.Sprintf("{commit: %+v diffPreview: %+v messagePreview: %+v}", r.commit, r.diffPreview, r.messagePreview)
+	return fmt.Sprintf("{commit: %+v diffPreview: %+v messagePreview: %+v}", r.Commit(), r.diffPreview, r.messagePreview)
 }
 
 func TestExpandUsernamesToEmails(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -68,22 +68,29 @@ func TestSearchCommitsInRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want := []*CommitSearchResultResolver{
-		{
-			db: db,
-			CommitSearchResult: CommitSearchResult{
-				commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
-				repoName:    types.RepoName{ID: 1, Name: "repo"},
-				diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-				label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
-				url:         "/repo/-/commit/c1",
-				detail:      "[`c1` one day ago](/repo/-/commit/c1)",
-				matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
-			},
+	want := []*CommitSearchResultResolver{{
+		db: db,
+		CommitSearchResult: CommitSearchResult{
+			commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
+			repoName:    types.RepoName{ID: 1, Name: "repo"},
+			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
+			label:       "[repo](/repo) › [](/repo/-/commit/c1): [](/repo/-/commit/c1)",
+			url:         "/repo/-/commit/c1",
+			// TODO add test for detail
+			// detail:      "[`c1` one day ago](/repo/-/commit/c1)",
+			matches: []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
 		},
-	}; !reflect.DeepEqual(results, want) {
+	}}
+
+	if !reflect.DeepEqual(results, want) {
 		t.Errorf("results\ngot  %v\nwant %v", results, want)
 	}
+
+	wantDetail := Markdown("[`c1` one day ago](/repo/-/commit/c1)")
+	if gotDetail := want[0].Detail(); gotDetail != wantDetail {
+		t.Errorf("detail\ngot  %v\nwant %v", gotDetail, wantDetail)
+	}
+
 	if limitHit {
 		t.Error("limitHit")
 	}

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -74,7 +74,8 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
 			repoName:    types.RepoName{ID: 1, Name: "repo"},
 			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-			matches:     []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}},
+			body:        "```diff\nx```",
+			highlights:  []*highlightedRange{},
 		},
 	}}
 
@@ -95,6 +96,11 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	wantURL := "/repo/-/commit/c1"
 	if gotURL := want[0].URL(); gotURL != wantURL {
 		t.Errorf("url\ngot  %v\nwant %v", gotURL, wantURL)
+	}
+
+	wantMatches := []*searchResultMatchResolver{{url: "/repo/-/commit/c1", body: "```diff\nx```", highlights: []*highlightedRange{}}}
+	if gotMatches := want[0].Matches(); !reflect.DeepEqual(gotMatches, wantMatches) {
+		t.Errorf("matches\ngot  %v\nwant %v", gotMatches, wantMatches)
 	}
 
 	if limitHit {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -301,7 +301,7 @@ loop:
 			continue
 		case *CommitSearchResultResolver:
 			// Diff searches are cheap, because we implicitly have author date info.
-			addPoint(m.commit.commit.Author.Date)
+			addPoint(m.Commit().commit.Author.Date)
 		case *FileMatchResolver:
 			// File match searches are more expensive, because we must blame the
 			// (first) line in order to know its placement in our sparkline.
@@ -1906,7 +1906,10 @@ func compareSearchResults(left, right SearchResultResolver, exactFilePatterns ma
 			// Commits are relatively sorted by date, and after repo
 			// or path names. We use ~ as the key for repo and
 			// paths,lexicographically last in ASCII.
-			return "~", "~", &r.commit.commit.Author.Date
+			if r.Commit().commit != nil {
+				return "~", "~", &r.Commit().commit.Author.Date
+			}
+			return "~", "~", &time.Time{}
 		}
 		// Unreachable.
 		panic("unreachable: compareSearchResults expects RepositoryResolver, FileMatchResolver, or CommitSearchResultResolver")

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1450,16 +1450,16 @@ func TestSearchContext(t *testing.T) {
 }
 
 func commitResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{
+	return &CommitSearchResultResolver{CommitSearchResult: CommitSearchResult{
 		url: url,
-	}
+	}}
 }
 
 func diffResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{
+	return &CommitSearchResultResolver{CommitSearchResult: CommitSearchResult{
 		url:         url,
 		diffPreview: &highlightedString{},
-	}
+	}}
 }
 
 func repoResult(db dbutil.DB, url string) *RepositoryResolver {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1449,17 +1449,27 @@ func TestSearchContext(t *testing.T) {
 	}
 }
 
-func commitResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{CommitSearchResult: CommitSearchResult{
-		url: url,
-	}}
+func commitResult(urlKey string) *CommitSearchResultResolver {
+	return &CommitSearchResultResolver{
+		gitCommitResolver: &GitCommitResolver{
+			repoResolver: &RepositoryResolver{
+				name: api.RepoName(urlKey),
+			},
+		},
+	}
 }
 
-func diffResult(url string) *CommitSearchResultResolver {
-	return &CommitSearchResultResolver{CommitSearchResult: CommitSearchResult{
-		url:         url,
-		diffPreview: &highlightedString{},
-	}}
+func diffResult(urlKey string) *CommitSearchResultResolver {
+	return &CommitSearchResultResolver{
+		CommitSearchResult: CommitSearchResult{
+			diffPreview: &highlightedString{},
+		},
+		gitCommitResolver: &GitCommitResolver{
+			repoResolver: &RepositoryResolver{
+				name: api.RepoName(urlKey),
+			},
+		},
+	}
 }
 
 func repoResult(db dbutil.DB, url string) *RepositoryResolver {
@@ -1488,9 +1498,9 @@ func resultToString(r SearchResultResolver) string {
 		return fmt.Sprintf("Repository:%s", v.URL())
 	case *CommitSearchResultResolver:
 		if v.diffPreview != nil {
-			return fmt.Sprintf("Diff:%s", v.url)
+			return fmt.Sprintf("Diff:%s", v.Commit().URL())
 		}
-		return fmt.Sprintf("Commit:%s", v.url)
+		return fmt.Sprintf("Commit:%s", v.Commit().URL())
 	}
 	return "unknown"
 }
@@ -1531,7 +1541,7 @@ func TestUnionMerge(t *testing.T) {
 				},
 			},
 			right: SearchResultsResolver{db: db},
-			want:  autogold.Want("LeftOnly", "Commit:a, Diff:a, File{url:a,symbols:[],lineMatches:[]}, Repo:/a"),
+			want:  autogold.Want("LeftOnly", "Commit:/a/-/commit/, Diff:/a/-/commit/, File{url:a,symbols:[],lineMatches:[]}, Repo:/a"),
 		},
 		{
 			left: SearchResultsResolver{db: db},
@@ -1544,7 +1554,7 @@ func TestUnionMerge(t *testing.T) {
 					fileResult(db, "a", nil, nil),
 				},
 			},
-			want: autogold.Want("RightOnly", "Commit:a, Diff:a, File{url:a,symbols:[],lineMatches:[]}, Repo:/a"),
+			want: autogold.Want("RightOnly", "Commit:/a/-/commit/, Diff:/a/-/commit/, File{url:a,symbols:[],lineMatches:[]}, Repo:/a"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
@@ -1563,7 +1573,7 @@ func TestUnionMerge(t *testing.T) {
 					fileResult(db, "b", nil, nil),
 				},
 			},
-			want: autogold.Want("MergeAllDifferent", "Commit:a, Commit:b, Diff:a, Diff:b, File{url:a,symbols:[],lineMatches:[]}, File{url:b,symbols:[],lineMatches:[]}, Repo:/a, Repo:/b"),
+			want: autogold.Want("MergeAllDifferent", "Commit:/a/-/commit/, Commit:/b/-/commit/, Diff:/a/-/commit/, Diff:/b/-/commit/, File{url:a,symbols:[],lineMatches:[]}, File{url:b,symbols:[],lineMatches:[]}, Repo:/a, Repo:/b"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
@@ -1646,27 +1656,27 @@ func TestSearchResultDeduper(t *testing.T) {
 		},
 		{
 			[]SearchResultResolver{commitResult("a")},
-			autogold.Want("SingleCommit", "Commit:a"),
+			autogold.Want("SingleCommit", "Commit:/a/-/commit/"),
 		},
 		{
 			[]SearchResultResolver{commitResult("a"), commitResult("a")},
-			autogold.Want("DuplicateCommits", "Commit:a"),
+			autogold.Want("DuplicateCommits", "Commit:/a/-/commit/"),
 		},
 		{
 			[]SearchResultResolver{commitResult("a"), diffResult("a")},
-			autogold.Want("SharedURLCommitDiff", "Commit:a, Diff:a"),
+			autogold.Want("SharedURLCommitDiff", "Commit:/a/-/commit/, Diff:/a/-/commit/"),
 		},
 		{
 			[]SearchResultResolver{commitResult("a"), diffResult("b")},
-			autogold.Want("DifferentURLCommitDiff", "Commit:a, Diff:b"),
+			autogold.Want("DifferentURLCommitDiff", "Commit:/a/-/commit/, Diff:/b/-/commit/"),
 		},
 		{
 			[]SearchResultResolver{commitResult("a"), diffResult("a"), repoResult(db, "a"), fileResult(db, "a", nil, nil)},
-			autogold.Want("EachTypeSameURL", "Commit:a, Diff:a, File{url:a,symbols:[],lineMatches:[]}, Repo:/a"),
+			autogold.Want("EachTypeSameURL", "Commit:/a/-/commit/, Diff:/a/-/commit/, File{url:a,symbols:[],lineMatches:[]}, Repo:/a"),
 		},
 		{
 			[]SearchResultResolver{commitResult("a"), commitResult("b"), commitResult("a"), commitResult("b")},
-			autogold.Want("FourCommitsTwoURLs", "Commit:a, Commit:b"),
+			autogold.Want("FourCommitsTwoURLs", "Commit:/a/-/commit/, Commit:/b/-/commit/"),
 		},
 	}
 

--- a/enterprise/internal/campaigns/resolvers/changeset_spec.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec.go
@@ -200,10 +200,10 @@ func (r *gitCommitDescriptionResolver) Author() *graphqlbackend.PersonResolver {
 }
 func (r *gitCommitDescriptionResolver) Message() string { return r.message }
 func (r *gitCommitDescriptionResolver) Subject() string {
-	return graphqlbackend.GitCommitSubject(r.message)
+	return git.Message(r.message).Subject()
 }
 func (r *gitCommitDescriptionResolver) Body() *string {
-	body := graphqlbackend.GitCommitBody(r.message)
+	body := git.Message(r.message).Body()
 	if body == "" {
 		return nil
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -17,6 +17,14 @@ type RepoName string
 // CommitID is the 40-character SHA-1 hash for a Git commit.
 type CommitID string
 
+// Short returns the SHA-1 commit hash truncated to 7 characters
+func (c CommitID) Short() string {
+	if len(c) >= 7 {
+		return string(c)[:7]
+	}
+	return string(c)
+}
+
 // Repo represents a source code repository.
 type Repo struct {
 	// ID is the unique numeric ID for this repository on Sourcegraph.

--- a/internal/vcs/git/blame.go
+++ b/internal/vcs/git/blame.go
@@ -110,7 +110,7 @@ func blameFileCmd(ctx context.Context, command cmdFunc, path string, opt *BlameO
 			summary := strings.Join(strings.Split(remainingLines[9], " ")[1:], " ")
 			commit := Commit{
 				ID:      api.CommitID(commitID),
-				Message: summary,
+				Message: Message(summary),
 				Author: Signature{
 					Name:  author,
 					Email: email,
@@ -143,7 +143,7 @@ func blameFileCmd(ctx context.Context, command cmdFunc, path string, opt *BlameO
 			// git-blame parser above.
 			hunk.CommitID = commit.ID
 			hunk.Author = commit.Author
-			hunk.Message = commit.Message
+			hunk.Message = string(commit.Message)
 		}
 
 		// Consume remaining lines in hunk

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -25,9 +25,31 @@ type Commit struct {
 	ID        api.CommitID `json:"ID,omitempty"`
 	Author    Signature    `json:"Author"`
 	Committer *Signature   `json:"Committer,omitempty"`
-	Message   string       `json:"Message,omitempty"`
+	Message   Message      `json:"Message,omitempty"`
 	// Parents are the commit IDs of this commit's parent commits.
 	Parents []api.CommitID `json:"Parents,omitempty"`
+}
+
+type Message string
+
+// Subject returns the first line of the commit message
+func (m Message) Subject() string {
+	message := string(m)
+	i := strings.Index(message, "\n")
+	if i == -1 {
+		return strings.TrimSpace(message)
+	}
+	return strings.TrimSpace(message[:i])
+}
+
+// Body returns the contents of the Git commit message after the subject.
+func (m Message) Body() string {
+	message := string(m)
+	i := strings.Index(message, "\n")
+	if i == -1 {
+		return ""
+	}
+	return strings.TrimSpace(message[i:])
 }
 
 type Signature struct {
@@ -344,7 +366,7 @@ func parseCommitFromLog(data []byte) (commit *Commit, refs []string, rest []byte
 		ID:        commitID,
 		Author:    Signature{Name: string(parts[2]), Email: string(parts[3]), Date: time.Unix(authorTime, 0).UTC()},
 		Committer: &Signature{Name: string(parts[5]), Email: string(parts[6]), Date: time.Unix(committerTime, 0).UTC()},
-		Message:   string(bytes.TrimSuffix(parts[8], []byte{'\n'})),
+		Message:   Message(strings.TrimSuffix(string(parts[8]), "\n")),
 		Parents:   parents,
 	}
 

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -598,3 +598,23 @@ func TestLogOnelineBatchScanner_small(t *testing.T) {
 		t.Fatal("unexpected error:", err)
 	}
 }
+
+func TestMessage(t *testing.T) {
+	t.Run("Body", func(t *testing.T) {
+		tests := map[Message]string{
+			"hello":                 "",
+			"hello\n":               "",
+			"hello\n\n":             "",
+			"hello\nworld":          "world",
+			"hello\n\nworld":        "world",
+			"hello\n\nworld\nfoo":   "world\nfoo",
+			"hello\n\nworld\nfoo\n": "world\nfoo",
+		}
+		for input, want := range tests {
+			got := input.Body()
+			if got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		}
+	})
+}


### PR DESCRIPTION
The goal of this PR is to tease apart `CommitSearchResult` and its associated resolvers. As I was doing that, I also included many small simplifications. 

Progresses #18348 
Depends on #18189 (you can skip the first commit)

The sum of the changes is fairly large, so please review by commit. Each commit is self contained and contains an explanation of what it's doing and why. I believe tests pass on each commit individually. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
