### PR TITLE
perforce: git-p4 requires Python2 to be installed

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -27,7 +27,8 @@ RUN apk add --no-cache \
     # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
     'git>=2.18' \
     openssh-client \
-    git-p4
+    git-p4 \
+    python2
 
 # hadolint ignore=DL3022
 COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -40,6 +40,7 @@ RUN apk update && apk add --no-cache \
     # Gitserver requires Git protocol v2 https://github.com/sourcegraph/sourcegraph/issues/13168
     'git>=2.18' \
     git-p4 \
+    python2 \
     'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=14.5.0-r0'
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/18137 was not working for the gitserver image in k8s or docker-compose, turns out Python2 has to be installed.

Fixes https://github.com/sourcegraph/sourcegraph/issues/17596