### PR TITLE
eventLogger: add event for external auth signup

### DIFF
--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -121,7 +121,6 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
 
     const onClickExternalAuthSignup = useCallback(
         (serviceType: string): React.MouseEventHandler => event => {
-            event.preventDefault()
             eventLogger.log('externalAuthSignupClicked', { type: serviceType })
         },
         []

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -122,7 +122,6 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
     const onClickExternalAuthSignup = useCallback(
         (serviceType: string): React.MouseEventHandler => event => {
             event.preventDefault()
-            console.log('TEST')
             eventLogger.log('externalAuthSignupClicked', { type: serviceType })
         },
         []

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -119,6 +119,14 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
 
     const externalAuthProviders = context.authProviders.filter(provider => !provider.isBuiltin)
 
+    const onClickExternalAuthSignup = useCallback(
+        (serviceType: string): React.MouseEventHandler => event => {
+            event.preventDefault()
+            console.log('TEST')
+            eventLogger.log('externalAuthSignupClicked', { type: serviceType })
+        },
+        []
+    )
     return (
         <>
             {error && <ErrorAlert className="mt-4 mb-0" error={error} history={history} />}
@@ -261,7 +269,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
                             // Use index as key because display name may not be unique. This is OK
                             // here because this list will not be updated during this component's lifetime.
                             /* eslint-disable react/no-array-index-key */
-                            <div className="mb-2" key={index}>
+                            <div className="mb-2" key={index} onClick={onClickExternalAuthSignup(provider.serviceType)}>
                                 <a href={provider.authenticationURL} className="btn btn-secondary btn-block">
                                     {provider.serviceType === 'github' ? (
                                         <GithubIcon className="icon-inline" />

--- a/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
+++ b/client/web/src/auth/__snapshots__/SignUpPage.test.tsx.snap
@@ -182,6 +182,7 @@ exports[`SignUpPage renders sign up page (cloud) 1`] = `
         </div>
         <div
           className="mb-2"
+          onClick={[Function]}
         >
           <a
             className="btn btn-secondary btn-block"


### PR DESCRIPTION
Adds an event when a user clicks a button to sign up via an external provider (we have GitHub, and soon GitLab, on Cloud). We want to use this to know approximately how many users are signing up via external providers.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
