### PR TITLE
db: remove GlobalOrgMembers store

### DIFF
--- a/cmd/frontend/graphqlbackend/org_members.go
+++ b/cmd/frontend/graphqlbackend/org_members.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (r *UserResolver) OrganizationMemberships(ctx context.Context) (*organizationMembershipConnectionResolver, error) {
-	memberships, err := database.GlobalOrgMembers.GetByUserID(ctx, r.user.ID)
+	memberships, err := database.OrgMembers(r.db).GetByUserID(ctx, r.user.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -45,7 +45,7 @@ func (r *schemaResolver) savedSearchByID(ctx context.Context, id graphql.ID) (*s
 			return nil, err
 		}
 	} else if ss.Config.OrgID != nil {
-		if err := backend.CheckOrgAccess(ctx, *ss.Config.OrgID); err != nil {
+		if err := backend.CheckOrgAccess(ctx, r.db, *ss.Config.OrgID); err != nil {
 			return nil, err
 		}
 	} else {
@@ -173,7 +173,7 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 		orgID = &o
-		if err := backend.CheckOrgAccess(ctx, o); err != nil {
+		if err := backend.CheckOrgAccess(ctx, r.db, o); err != nil {
 			return nil, err
 		}
 	} else {
@@ -225,7 +225,7 @@ func (r *schemaResolver) UpdateSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 		orgID = &o
-		if err := backend.CheckOrgAccess(ctx, o); err != nil {
+		if err := backend.CheckOrgAccess(ctx, r.db, o); err != nil {
 			return nil, err
 		}
 	} else {
@@ -274,7 +274,7 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 	} else if ss.Config.OrgID != nil {
-		if err := backend.CheckOrgAccess(ctx, *ss.Config.OrgID); err != nil {
+		if err := backend.CheckOrgAccess(ctx, r.db, *ss.Config.OrgID); err != nil {
 			return nil, err
 		}
 	} else {

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -45,7 +46,7 @@ func settingsSubjectForNode(ctx context.Context, n Node) (*settingsSubject, erro
 
 	case *OrgResolver:
 		// 🚨 SECURITY: Check that the current user is a member of the org.
-		if err := backend.CheckOrgAccess(ctx, s.org.ID); err != nil {
+		if err := backend.CheckOrgAccess(ctx, s.db, s.org.ID); err != nil {
 			return nil, err
 		}
 		return &settingsSubject{org: s}, nil

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -126,7 +126,7 @@ func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, new
 	m.Get(apirouter.SavedQueriesGetInfo).Handler(trace.Route(handler(serveSavedQueriesGetInfo(db))))
 	m.Get(apirouter.SavedQueriesSetInfo).Handler(trace.Route(handler(serveSavedQueriesSetInfo(db))))
 	m.Get(apirouter.SavedQueriesDeleteInfo).Handler(trace.Route(handler(serveSavedQueriesDeleteInfo(db))))
-	m.Get(apirouter.OrgsListUsers).Handler(trace.Route(handler(serveOrgsListUsers)))
+	m.Get(apirouter.OrgsListUsers).Handler(trace.Route(handler(serveOrgsListUsers(db))))
 	m.Get(apirouter.OrgsGetByName).Handler(trace.Route(handler(serveOrgsGetByName)))
 	m.Get(apirouter.UsersGetByUsername).Handler(trace.Route(handler(serveUsersGetByUsername)))
 	m.Get(apirouter.UserEmailsGetEmail).Handler(trace.Route(handler(serveUserEmailsGetEmail)))

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -394,24 +394,26 @@ func serveSettingsGetForSubject(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func serveOrgsListUsers(w http.ResponseWriter, r *http.Request) error {
-	var orgID int32
-	err := json.NewDecoder(r.Body).Decode(&orgID)
-	if err != nil {
-		return errors.Wrap(err, "Decode")
+func serveOrgsListUsers(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) error {
+	return func(w http.ResponseWriter, r *http.Request) error {
+		var orgID int32
+		err := json.NewDecoder(r.Body).Decode(&orgID)
+		if err != nil {
+			return errors.Wrap(err, "Decode")
+		}
+		orgMembers, err := database.OrgMembers(db).GetByOrgID(r.Context(), orgID)
+		if err != nil {
+			return errors.Wrap(err, "OrgMembers.GetByOrgID")
+		}
+		users := make([]int32, 0, len(orgMembers))
+		for _, member := range orgMembers {
+			users = append(users, member.UserID)
+		}
+		if err := json.NewEncoder(w).Encode(users); err != nil {
+			return errors.Wrap(err, "Encode")
+		}
+		return nil
 	}
-	orgMembers, err := database.GlobalOrgMembers.GetByOrgID(r.Context(), orgID)
-	if err != nil {
-		return errors.Wrap(err, "OrgMembers.GetByOrgID")
-	}
-	users := make([]int32, 0, len(orgMembers))
-	for _, member := range orgMembers {
-		users = append(users, member.UserID)
-	}
-	if err := json.NewEncoder(w).Encode(users); err != nil {
-		return errors.Wrap(err, "Encode")
-	}
-	return nil
 }
 
 func serveOrgsGetByName(w http.ResponseWriter, r *http.Request) error {

--- a/enterprise/cmd/frontend/internal/registry/extension_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_graphql.go
@@ -87,7 +87,7 @@ func (r *extensionDBResolver) IsWorkInProgress() bool {
 }
 
 func (r *extensionDBResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
-	err := toRegistryPublisherID(r.v).viewerCanAdminister(ctx)
+	err := toRegistryPublisherID(r.v).viewerCanAdminister(ctx, r.db)
 	if err == backend.ErrMustBeSiteAdmin || err == backend.ErrNotAnOrgMember || err == backend.ErrNotAuthenticated {
 		return false, nil
 	}

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -136,14 +136,14 @@ func unmarshalRegistryPublisherID(id graphql.ID) (*registryPublisherID, error) {
 // registry extension with the given publisher.
 //
 // 🚨 SECURITY
-func (p *registryPublisherID) viewerCanAdminister(ctx context.Context) error {
+func (p *registryPublisherID) viewerCanAdminister(ctx context.Context, db dbutil.DB) error {
 	switch {
 	case p.userID != 0:
 		// 🚨 SECURITY: Check that the current user is either the publisher or a site admin.
 		return backend.CheckSiteAdminOrSameUser(ctx, p.userID)
 	case p.orgID != 0:
 		// 🚨 SECURITY: Check that the current user is a member of the publisher org.
-		return backend.CheckOrgAccess(ctx, p.orgID)
+		return backend.CheckOrgAccess(ctx, db, p.orgID)
 	default:
 		return errRegistryUnknownPublisher
 	}

--- a/enterprise/cmd/frontend/internal/registry/registry_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/registry_graphql.go
@@ -46,7 +46,7 @@ func extensionRegistryCreateExtension(ctx context.Context, db dbutil.DB, args *g
 		return nil, err
 	}
 	// 🚨 SECURITY: Check that the current user can create an extension for this publisher.
-	if err := publisher.viewerCanAdminister(ctx); err != nil {
+	if err := publisher.viewerCanAdminister(ctx, db); err != nil {
 		return nil, err
 	}
 
@@ -58,7 +58,7 @@ func extensionRegistryCreateExtension(ctx context.Context, db dbutil.DB, args *g
 	return &frontendregistry.ExtensionRegistryMutationResult{DB: db, ID: id}, nil
 }
 
-func viewerCanAdministerExtension(ctx context.Context, id frontendregistry.RegistryExtensionID) error {
+func viewerCanAdministerExtension(ctx context.Context, db dbutil.DB, id frontendregistry.RegistryExtensionID) error {
 	if id.LocalID == 0 {
 		return errors.New("unable to administer extension on remote registry")
 	}
@@ -66,7 +66,7 @@ func viewerCanAdministerExtension(ctx context.Context, id frontendregistry.Regis
 	if err != nil {
 		return err
 	}
-	return toRegistryPublisherID(extension).viewerCanAdminister(ctx)
+	return toRegistryPublisherID(extension).viewerCanAdminister(ctx, db)
 }
 
 func extensionRegistryUpdateExtension(ctx context.Context, db dbutil.DB, args *graphqlbackend.ExtensionRegistryUpdateExtensionArgs) (graphqlbackend.ExtensionRegistryMutationResult, error) {
@@ -76,7 +76,7 @@ func extensionRegistryUpdateExtension(ctx context.Context, db dbutil.DB, args *g
 	}
 
 	// 🚨 SECURITY: Check that the current user is authorized to update the extension.
-	if err := viewerCanAdministerExtension(ctx, id); err != nil {
+	if err := viewerCanAdministerExtension(ctx, db, id); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +93,7 @@ func extensionRegistryDeleteExtension(ctx context.Context, db dbutil.DB, args *g
 	}
 
 	// 🚨 SECURITY: Check that the current user is authorized to delete the extension.
-	if err := viewerCanAdministerExtension(ctx, id); err != nil {
+	if err := viewerCanAdministerExtension(ctx, db, id); err != nil {
 		return nil, err
 	}
 
@@ -145,7 +145,7 @@ func extensionRegistryPublishExtension(ctx context.Context, db dbutil.DB, args *
 		}
 		publisherID := registryPublisherID{userID: publisher.UserID, orgID: publisher.OrgID}
 		// 🚨 SECURITY: Check that the current user can create an extension for this publisher.
-		if err := publisherID.viewerCanAdminister(ctx); err != nil {
+		if err := publisherID.viewerCanAdminister(ctx, db); err != nil {
 			return nil, err
 		}
 
@@ -164,7 +164,7 @@ func extensionRegistryPublishExtension(ctx context.Context, db dbutil.DB, args *
 	}
 
 	// 🚨 SECURITY: Check that the current user is authorized to publish the extension.
-	if err := viewerCanAdministerExtension(ctx, id); err != nil {
+	if err := viewerCanAdministerExtension(ctx, db, id); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -170,7 +170,7 @@ func TestService(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
 	admin := ct.CreateTestUser(t, true)
 	user := ct.CreateTestUser(t, false)
@@ -520,7 +520,7 @@ func TestService(t *testing.T) {
 			}
 
 			// Create org membership and try again
-			if _, err := database.GlobalOrgMembers.Create(ctx, org.ID, user.ID); err != nil {
+			if _, err := database.OrgMembers(db).Create(ctx, org.ID, user.ID); err != nil {
 				t.Fatal(err)
 			}
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -405,7 +405,7 @@ func (r *Resolver) isAllowedToCreate(ctx context.Context, owner graphql.ID) erro
 	case "User":
 		return backend.CheckSiteAdminOrSameUser(ctx, ownerInt32)
 	case "Org":
-		return backend.CheckOrgAccess(ctx, ownerInt32)
+		return backend.CheckOrgAccess(ctx, r.store.Handle().DB(), ownerInt32)
 	default:
 		return fmt.Errorf("provided ID is not a namespace")
 	}

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -8,7 +8,6 @@ var (
 	GlobalRepos                       = &RepoStore{}
 	GlobalPhabricator                 = &PhabricatorStore{}
 	GlobalOrgs                        = &OrgStore{}
-	GlobalOrgMembers                  = &OrgMemberStore{}
 	GlobalSettings                    = &SettingStore{}
 	GlobalUsers                       = &UserStore{}
 	GlobalUserCredentials             = &UserCredentialsStore{}


### PR DESCRIPTION
This PR removes the GlobalOrgMembers store and replaces
all calls to that store by the OrgMembers store constructor.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
