### PR TITLE
db: remove GlobalEventLogs store

### DIFF
--- a/cmd/frontend/graphqlbackend/event_logs.go
+++ b/cmd/frontend/graphqlbackend/event_logs.go
@@ -30,7 +30,7 @@ type userEventLogsConnectionResolver struct {
 }
 
 func (r *userEventLogsConnectionResolver) Nodes(ctx context.Context) ([]*userEventLogResolver, error) {
-	events, err := database.GlobalEventLogs.ListAll(ctx, r.opt)
+	events, err := database.EventLogs(r.db).ListAll(ctx, r.opt)
 	if err != nil {
 		return nil, err
 	}
@@ -48,9 +48,9 @@ func (r *userEventLogsConnectionResolver) TotalCount(ctx context.Context) (int32
 	var err error
 
 	if r.opt.EventName != nil {
-		count, err = database.GlobalEventLogs.CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
+		count, err = database.EventLogs(r.db).CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
 	} else {
-		count, err = database.GlobalEventLogs.CountByUserID(ctx, r.opt.UserID)
+		count, err = database.EventLogs(r.db).CountByUserID(ctx, r.opt.UserID)
 	}
 
 	return int32(count), err
@@ -61,9 +61,9 @@ func (r *userEventLogsConnectionResolver) PageInfo(ctx context.Context) (*graphq
 	var err error
 
 	if r.opt.EventName != nil {
-		count, err = database.GlobalEventLogs.CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
+		count, err = database.EventLogs(r.db).CountByUserIDAndEventName(ctx, r.opt.UserID, *r.opt.EventName)
 	} else {
-		count, err = database.GlobalEventLogs.CountByUserID(ctx, r.opt.UserID)
+		count, err = database.EventLogs(r.db).CountByUserID(ctx, r.opt.UserID)
 	}
 
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -416,7 +416,7 @@ func (r *searchResolver) logSearchLatency(ctx context.Context, durationMs int32)
 			value := fmt.Sprintf(`{"durationMs": %d}`, durationMs)
 			eventName := fmt.Sprintf("search.latencies.%s", types[0])
 			go func() {
-				err := usagestats.LogBackendEvent(actor.UID, eventName, json.RawMessage(value))
+				err := usagestats.LogBackendEvent(r.db, actor.UID, eventName, json.RawMessage(value))
 				if err != nil {
 					log15.Warn("Could not log search latency", "err", err)
 				}

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -75,7 +75,7 @@ func (*schemaResolver) LogUserEvent(ctx context.Context, args *struct {
 	return nil, usagestatsdeprecated.LogActivity(actor.IsAuthenticated(), actor.UID, args.UserCookieID, args.Event)
 }
 
-func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
+func (r *schemaResolver) LogEvent(ctx context.Context, args *struct {
 	Event        string
 	UserCookieID string
 	URL          string
@@ -101,7 +101,7 @@ func (*schemaResolver) LogEvent(ctx context.Context, args *struct {
 	}
 
 	actor := actor.FromContext(ctx)
-	return nil, usagestats.LogEvent(ctx, usagestats.Event{
+	return nil, usagestats.LogEvent(ctx, r.db, usagestats.Event{
 		EventName:    args.Event,
 		URL:          args.URL,
 		UserID:       actor.UID,

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -63,11 +63,11 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, in
 		var err error
 		switch *r.activePeriod {
 		case "TODAY":
-			r.opt.UserIDs, err = usagestats.ListRegisteredUsersToday(ctx)
+			r.opt.UserIDs, err = usagestats.ListRegisteredUsersToday(ctx, r.db)
 		case "THIS_WEEK":
-			r.opt.UserIDs, err = usagestats.ListRegisteredUsersThisWeek(ctx)
+			r.opt.UserIDs, err = usagestats.ListRegisteredUsersThisWeek(ctx, r.db)
 		case "THIS_MONTH":
-			r.opt.UserIDs, err = usagestats.ListRegisteredUsersThisMonth(ctx)
+			r.opt.UserIDs, err = usagestats.ListRegisteredUsersThisMonth(ctx, r.db)
 		default:
 			err = fmt.Errorf("unknown user active period %s", *r.activePeriod)
 		}

--- a/cmd/frontend/internal/app/app.go
+++ b/cmd/frontend/internal/app/app.go
@@ -67,10 +67,10 @@ func NewHandler(db dbutil.DB) http.Handler {
 	r.Get(router.RegistryExtensionBundle).Handler(trace.Route(gziphandler.GzipHandler(http.HandlerFunc(registry.HandleRegistryExtensionBundle))))
 
 	// Usage statistics ZIP download
-	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler)))
+	r.Get(router.UsageStatsDownload).Handler(trace.Route(http.HandlerFunc(usageStatsArchiveHandler(db))))
 
 	// Ping retrieval
-	r.Get(router.LatestPing).Handler(trace.Route(http.HandlerFunc(latestPingHandler)))
+	r.Get(router.LatestPing).Handler(trace.Route(http.HandlerFunc(latestPingHandler(db))))
 
 	r.Get(router.GDDORefs).Handler(trace.Route(errorutil.Handler(serveGDDORefs)))
 	r.Get(router.Editor).Handler(trace.Route(errorutil.Handler(serveEditor)))

--- a/cmd/frontend/internal/app/ping.go
+++ b/cmd/frontend/internal/app/ping.go
@@ -21,7 +21,7 @@ func latestPingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	ping, err := database.GlobalEventLogs.LatestPing(r.Context())
+	ping, err := database.EventLogs(db).LatestPing(r.Context())
 	switch err {
 	case sql.ErrNoRows:
 		_, _ = io.WriteString(w, "{}")

--- a/cmd/frontend/internal/app/ping.go
+++ b/cmd/frontend/internal/app/ping.go
@@ -9,26 +9,29 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // latestPingHandler fetches the most recent ping data from the event log
 // (if any is present) and returns it as JSON.
-func latestPingHandler(w http.ResponseWriter, r *http.Request) {
-	// 🚨SECURITY: Only site admins may access ping data.
-	if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
-		return
-	}
+func latestPingHandler(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// 🚨SECURITY: Only site admins may access ping data.
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
 
-	w.Header().Set("Content-Type", "application/json")
-	ping, err := database.EventLogs(db).LatestPing(r.Context())
-	switch err {
-	case sql.ErrNoRows:
-		_, _ = io.WriteString(w, "{}")
-	case nil:
-		_, _ = io.WriteString(w, ping.Argument)
-	default:
-		log15.Error("pings.latest", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		ping, err := database.EventLogs(db).LatestPing(r.Context())
+		switch err {
+		case sql.ErrNoRows:
+			_, _ = io.WriteString(w, "{}")
+		case nil:
+			_, _ = io.WriteString(w, ping.Argument)
+		default:
+			log15.Error("pings.latest", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 	}
 }

--- a/cmd/frontend/internal/app/ping_test.go
+++ b/cmd/frontend/internal/app/ping_test.go
@@ -22,12 +22,12 @@ func TestLatestPingHandler(t *testing.T) {
 		t.Skip()
 	}
 
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
 	t.Run("non-admins can't access the ping data", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/site-admin/pings/latest", nil)
 		rec := httptest.NewRecorder()
-		latestPingHandler(rec, req)
+		latestPingHandler(new(dbtesting.MockDB))(rec, req)
 
 		if have, want := rec.Code, http.StatusUnauthorized; have != want {
 			t.Errorf("status code: have %d, want %d", have, want)
@@ -61,7 +61,7 @@ func TestLatestPingHandler(t *testing.T) {
 
 			req, _ := http.NewRequest("GET", "/site-admin/pings/latest", nil)
 			rec := httptest.NewRecorder()
-			latestPingHandler(rec, req.WithContext(backend.WithAuthzBypass(context.Background())))
+			latestPingHandler(db)(rec, req.WithContext(backend.WithAuthzBypass(context.Background())))
 
 			resp := rec.Result()
 			body, err := ioutil.ReadAll(resp.Body)

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
@@ -76,9 +77,9 @@ func recordOperation(method string) func(*error) {
 	}
 }
 
-func getAndMarshalSiteActivityJSON(ctx context.Context, criticalOnly bool) (_ json.RawMessage, err error) {
+func getAndMarshalSiteActivityJSON(ctx context.Context, db dbutil.DB, criticalOnly bool) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalSiteActivityJSON")(&err)
-	siteActivity, err := usagestats.GetSiteUsageStats(ctx, criticalOnly)
+	siteActivity, err := usagestats.GetSiteUsageStats(ctx, db, criticalOnly)
 
 	if err != nil {
 		return nil, err
@@ -294,7 +295,7 @@ func parseRedisInfo(buf []byte) (map[string]string, error) {
 	return m, nil
 }
 
-func updateBody(ctx context.Context) (io.Reader, error) {
+func updateBody(ctx context.Context, db dbutil.DB) (io.Reader, error) {
 	logFunc := log15.Debug
 	if envvar.SourcegraphDotComMode() {
 		logFunc = log15.Warn
@@ -420,7 +421,7 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r.Activity, err = getAndMarshalSiteActivityJSON(ctx, false)
+			r.Activity, err = getAndMarshalSiteActivityJSON(ctx, db, false)
 			if err != nil {
 				logFunc("telemetry: updatecheck.getAndMarshalSiteActivityJSON failed", "error", err)
 			}
@@ -451,7 +452,7 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 			logFunc("telemetry: updatecheck.getAndMarshalRepositoriesJSON failed", "error", err)
 		}
 
-		r.Activity, err = getAndMarshalSiteActivityJSON(ctx, true)
+		r.Activity, err = getAndMarshalSiteActivityJSON(ctx, db, true)
 		if err != nil {
 			logFunc("telemetry: updatecheck.getAndMarshalSiteActivityJSON failed", "error", err)
 		}
@@ -462,7 +463,7 @@ func updateBody(ctx context.Context) (io.Reader, error) {
 		return nil, err
 	}
 
-	err = database.GlobalEventLogs.Insert(ctx, &database.Event{
+	err = database.EventLogs(db).Insert(ctx, &database.Event{
 		UserID:          0,
 		Name:            "ping",
 		URL:             "",
@@ -491,12 +492,12 @@ func externalServiceKinds(ctx context.Context) (kinds []string, err error) {
 }
 
 // check performs an update check and updates the global state.
-func check() {
+func check(db dbutil.DB) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()
 
 	doCheck := func() (updateVersion string, err error) {
-		body, err := updateBody(ctx)
+		body, err := updateBody(ctx, db)
 		if err != nil {
 			return "", err
 		}
@@ -562,7 +563,7 @@ func check() {
 var started bool
 
 // Start starts checking for software updates periodically.
-func Start() {
+func Start(db dbutil.DB) {
 	if started {
 		panic("already started")
 	}
@@ -574,7 +575,7 @@ func Start() {
 
 	const delay = 30 * time.Minute
 	for {
-		check()
+		check(db)
 
 		// Randomize sleep to prevent thundering herds.
 		randomDelay := time.Duration(rand.Intn(600)) * time.Second

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -190,10 +190,10 @@ func getAndMarshalSearchOnboardingJSON(ctx context.Context) (_ json.RawMessage, 
 	return json.Marshal(searchOnboarding)
 }
 
-func getAndMarshalAggregatedCodeIntelUsageJSON(ctx context.Context) (_ json.RawMessage, err error) {
+func getAndMarshalAggregatedCodeIntelUsageJSON(ctx context.Context, db dbutil.DB) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalAggregatedCodeIntelUsageJSON")(&err)
 
-	codeIntelUsage, err := usagestats.GetAggregatedCodeIntelStats(ctx)
+	codeIntelUsage, err := usagestats.GetAggregatedCodeIntelStats(ctx, db)
 	if err != nil {
 		return nil, err
 	}
@@ -201,10 +201,10 @@ func getAndMarshalAggregatedCodeIntelUsageJSON(ctx context.Context) (_ json.RawM
 	return json.Marshal(codeIntelUsage)
 }
 
-func getAndMarshalAggregatedSearchUsageJSON(ctx context.Context) (_ json.RawMessage, err error) {
+func getAndMarshalAggregatedSearchUsageJSON(ctx context.Context, db dbutil.DB) (_ json.RawMessage, err error) {
 	defer recordOperation("getAndMarshalAggregatedSearchUsageJSON")(&err)
 
-	searchUsage, err := usagestats.GetAggregatedSearchStats(ctx)
+	searchUsage, err := usagestats.GetAggregatedSearchStats(ctx, db)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func updateBody(ctx context.Context, db dbutil.DB) (io.Reader, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r.NewCodeIntelUsage, err = getAndMarshalAggregatedCodeIntelUsageJSON(ctx)
+			r.NewCodeIntelUsage, err = getAndMarshalAggregatedCodeIntelUsageJSON(ctx, db)
 			if err != nil {
 				logFunc("telemetry: updatecheck.getAndMarshalAggregatedCodeIntelUsageJSON failed", "error", err)
 			}
@@ -439,7 +439,7 @@ func updateBody(ctx context.Context, db dbutil.DB) (io.Reader, error) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r.SearchUsage, err = getAndMarshalAggregatedSearchUsageJSON(ctx)
+			r.SearchUsage, err = getAndMarshalAggregatedSearchUsageJSON(ctx, db)
 			if err != nil {
 				logFunc("telemetry: updatecheck.getAndMarshalAggregatedSearchUsageJSON failed", "error", err)
 			}

--- a/cmd/frontend/internal/app/usage_stats.go
+++ b/cmd/frontend/internal/app/usage_stats.go
@@ -6,25 +6,28 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
-func usageStatsArchiveHandler(w http.ResponseWriter, r *http.Request) {
-	// 🚨SECURITY: Only site admins may get this archive.
-	if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
-		w.WriteHeader(http.StatusUnauthorized)
-		return
+func usageStatsArchiveHandler(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// 🚨SECURITY: Only site admins may get this archive.
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/zip")
+		w.Header().Set("Content-Disposition", "attachment; filename=\"SourcegraphUsersUsageArchive.zip\"")
+
+		archive, err := usagestats.GetArchive(r.Context(), db)
+		if err != nil {
+			log15.Error("usagestats.WriteArchive", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		_, _ = w.Write(archive)
 	}
-
-	w.Header().Set("Content-Type", "application/zip")
-	w.Header().Set("Content-Disposition", "attachment; filename=\"SourcegraphUsersUsageArchive.zip\"")
-
-	archive, err := usagestats.GetArchive(r.Context())
-	if err != nil {
-		log15.Error("usagestats.WriteArchive", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	_, _ = w.Write(archive)
 }

--- a/cmd/frontend/internal/app/usage_stats_test.go
+++ b/cmd/frontend/internal/app/usage_stats_test.go
@@ -21,12 +21,12 @@ func TestUsageStatsArchiveHandler(t *testing.T) {
 		t.Skip()
 	}
 
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
 	t.Run("non-admins can't download archive", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "", nil)
 		rec := httptest.NewRecorder()
-		usageStatsArchiveHandler(rec, req)
+		usageStatsArchiveHandler(db)(rec, req)
 
 		if have, want := rec.Code, http.StatusUnauthorized; have != want {
 			t.Errorf("status code: have %d, want %d", have, want)
@@ -36,7 +36,7 @@ func TestUsageStatsArchiveHandler(t *testing.T) {
 	t.Run("admins can download archive", func(t *testing.T) {
 		req, _ := http.NewRequest("GET", "", nil)
 		rec := httptest.NewRecorder()
-		usageStatsArchiveHandler(rec, req.WithContext(backend.WithAuthzBypass(context.Background())))
+		usageStatsArchiveHandler(db)(rec, req.WithContext(backend.WithAuthzBypass(context.Background())))
 
 		contentType := rec.Header().Get("Content-Type")
 		if have, want := contentType, "application/zip"; have != want {

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -212,7 +212,7 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 	goroutine.Go(func() { bg.CheckRedisCacheEvictionPolicy() })
 	goroutine.Go(func() { bg.DeleteOldCacheDataInRedis() })
 	goroutine.Go(func() { bg.DeleteOldEventLogsInPostgres(context.Background()) })
-	go updatecheck.Start()
+	go updatecheck.Start(db)
 
 	// Parse GraphQL schema and set up resolvers that depend on dbconn.Global
 	// being initialized

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -141,7 +141,7 @@ func NewInternalHandler(m *mux.Router, db dbutil.DB, schema *graphql.Schema, new
 	}
 	m.Get(apirouter.GitInfoRefs).Handler(trace.Route(http.HandlerFunc(gitService.serveInfoRefs)))
 	m.Get(apirouter.GitUploadPack).Handler(trace.Route(http.HandlerFunc(gitService.serveGitUploadPack)))
-	m.Get(apirouter.Telemetry).Handler(trace.Route(telemetryHandler))
+	m.Get(apirouter.Telemetry).Handler(trace.Route(telemetryHandler(db)))
 	m.Get(apirouter.GraphQL).Handler(trace.Route(handler(serveGraphQL(schema, true))))
 	m.Get(apirouter.Configuration).Handler(trace.Route(handler(serveConfiguration)))
 	m.Get(apirouter.SearchConfiguration).Handler(trace.Route(handler(serveSearchConfiguration)))

--- a/cmd/frontend/internal/httpapi/telemetry.go
+++ b/cmd/frontend/internal/httpapi/telemetry.go
@@ -7,20 +7,19 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/usagestatsdeprecated"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/eventlogger"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
 
-var telemetryHandler http.Handler
-
-func init() {
-	telemetryHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func telemetryHandler(db dbutil.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var tr eventlogger.TelemetryRequest
 		err := json.NewDecoder(r.Body).Decode(&tr)
 		if err != nil {
 			log15.Error("telemetryHandler: Decode", "error", err)
 		}
-		err = usagestats.LogBackendEvent(tr.UserID, tr.EventName, tr.Argument)
+		err = usagestats.LogBackendEvent(db, tr.UserID, tr.EventName, tr.Argument)
 		if err != nil {
 			log15.Error("telemetryHandler: usagestats.LogBackendEvent", "error", err)
 		}

--- a/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 var (
@@ -166,7 +167,7 @@ var logStageEvent = func(userID int32, event string, isAuthenticated bool) error
 }
 
 // LogEvent logs users events.
-func LogEvent(ctx context.Context, name, url string, userID int32, userCookieID, source string, argument json.RawMessage) error {
+func LogEvent(ctx context.Context, db dbutil.DB, name, url string, userID int32, userCookieID, source string, argument json.RawMessage) error {
 	info := &database.Event{
 		Name:            name,
 		URL:             url,

--- a/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/action_handlers.go
@@ -175,5 +175,5 @@ func LogEvent(ctx context.Context, name, url string, userID int32, userCookieID,
 		Source:          source,
 		Argument:        argument,
 	}
-	return database.GlobalEventLogs.Insert(ctx, info)
+	return database.EventLogs(db).Insert(ctx, info)
 }

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -383,7 +384,7 @@ func (r *Resolver) CreateCampaignSpec(ctx context.Context, args *graphqlbackend.
 		return nil, err
 	}
 
-	if err := logCampaignSpecCreated(ctx, &opts); err != nil {
+	if err := logCampaignSpecCreated(ctx, r.store.DB(), &opts); err != nil {
 		return nil, err
 	}
 
@@ -395,7 +396,7 @@ func (r *Resolver) CreateCampaignSpec(ctx context.Context, args *graphqlbackend.
 	return specResolver, nil
 }
 
-func logCampaignSpecCreated(ctx context.Context, opts *service.CreateCampaignSpecOpts) error {
+func logCampaignSpecCreated(ctx context.Context, db dbutil.DB, opts *service.CreateCampaignSpecOpts) error {
 	// Log an analytics event when a CampaignSpec has been created.
 	// See internal/usagestats/campaigns.go.
 	actor := actor.FromContext(ctx)
@@ -410,7 +411,7 @@ func logCampaignSpecCreated(ctx context.Context, opts *service.CreateCampaignSpe
 		return err
 	}
 
-	return usagestats.LogBackendEvent(actor.UID, "CampaignSpecCreated", json.RawMessage(jsonArg))
+	return usagestats.LogBackendEvent(db, actor.UID, "CampaignSpecCreated", json.RawMessage(jsonArg))
 }
 
 func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend.CreateChangesetSpecArgs) (graphqlbackend.ChangesetSpecResolver, error) {

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -12,7 +12,6 @@ var (
 	GlobalUsers                       = &UserStore{}
 	GlobalUserCredentials             = &UserCredentialsStore{}
 	GlobalUserEmails                  = &UserEmailsStore{}
-	GlobalEventLogs                   = &EventLogStore{}
 	GlobalExternalAccounts            = &UserExternalAccountsStore{}
 	GlobalAuthz            AuthzStore = &authzStore{}
 )

--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func GetSiteUsageStats(ctx context.Context, monthsOnly bool) (*types.SiteUsageStatistics, error) {
-	summary, err := database.GlobalEventLogs.SiteUsage(ctx)
+func GetSiteUsageStats(ctx context.Context, db dbutil.DB, monthsOnly bool) (*types.SiteUsageStatistics, error) {
+	summary, err := database.EventLogs(db).SiteUsage(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +59,8 @@ func groupSiteUsageStats(summary types.SiteUsageSummary, monthsOnly bool) *types
 }
 
 // GetAggregatedCodeIntelStats returns aggregated statistics for code intelligence usage.
-func GetAggregatedCodeIntelStats(ctx context.Context) (*types.NewCodeIntelUsageStatistics, error) {
-	codeIntelEvents, err := database.GlobalEventLogs.AggregatedCodeIntelEvents(ctx)
+func GetAggregatedCodeIntelStats(ctx context.Context, db dbutil.DB) (*types.NewCodeIntelUsageStatistics, error) {
+	codeIntelEvents, err := database.EventLogs(db).AggregatedCodeIntelEvents(ctx)
 	if err != nil {
 		return nil, err
 	} else if len(codeIntelEvents) == 0 {
@@ -71,12 +72,12 @@ func GetAggregatedCodeIntelStats(ctx context.Context) (*types.NewCodeIntelUsageS
 		fetch  func(ctx context.Context) (int, error)
 		target **int32
 	}{
-		{database.GlobalEventLogs.CodeIntelligenceWAUs, &stats.WAUs},
-		{database.GlobalEventLogs.CodeIntelligencePreciseWAUs, &stats.PreciseWAUs},
-		{database.GlobalEventLogs.CodeIntelligenceSearchBasedWAUs, &stats.SearchBasedWAUs},
-		{database.GlobalEventLogs.CodeIntelligenceCrossRepositoryWAUs, &stats.CrossRepositoryWAUs},
-		{database.GlobalEventLogs.CodeIntelligencePreciseCrossRepositoryWAUs, &stats.PreciseCrossRepositoryWAUs},
-		{database.GlobalEventLogs.CodeIntelligenceSearchBasedCrossRepositoryWAUs, &stats.SearchBasedCrossRepositoryWAUs},
+		{database.EventLogs(db).CodeIntelligenceWAUs, &stats.WAUs},
+		{database.EventLogs(db).CodeIntelligencePreciseWAUs, &stats.PreciseWAUs},
+		{database.EventLogs(db).CodeIntelligenceSearchBasedWAUs, &stats.SearchBasedWAUs},
+		{database.EventLogs(db).CodeIntelligenceCrossRepositoryWAUs, &stats.CrossRepositoryWAUs},
+		{database.EventLogs(db).CodeIntelligencePreciseCrossRepositoryWAUs, &stats.PreciseCrossRepositoryWAUs},
+		{database.EventLogs(db).CodeIntelligenceSearchBasedCrossRepositoryWAUs, &stats.SearchBasedCrossRepositoryWAUs},
 	}
 
 	for _, pair := range pairs {
@@ -143,8 +144,8 @@ func groupAggregatedCodeIntelStats(rawEvents []types.CodeIntelAggregatedEvent) *
 }
 
 // GetAggregatedSearchStats returns aggregates statistics for search usage.
-func GetAggregatedSearchStats(ctx context.Context) (*types.SearchUsageStatistics, error) {
-	events, err := database.GlobalEventLogs.AggregatedSearchEvents(ctx)
+func GetAggregatedSearchStats(ctx context.Context, db dbutil.DB) (*types.SearchUsageStatistics, error) {
+	events, err := database.EventLogs(db).AggregatedSearchEvents(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usagestats/retention_test.go
+++ b/internal/usagestats/retention_test.go
@@ -24,7 +24,7 @@ func TestRetentionUsageStatistics(t *testing.T) {
 	userCreationDate := time.Date(2020, 10, 26, 0, 0, 0, 0, time.UTC)
 
 	mockTimeNow(eventDate)
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
 	events := []database.Event{{
 		Name:      "ViewHome",
@@ -41,7 +41,7 @@ func TestRetentionUsageStatistics(t *testing.T) {
 	}}
 
 	for _, event := range events {
-		err := database.GlobalEventLogs.Insert(ctx, &event)
+		err := database.EventLogs(db).Insert(ctx, &event)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This PR removes the GlobalEventLogs store and replaces
all calls to that store by the EventLogs store constructor.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
