### PR TITLE
Update the pinned Go image version in internal/cmd

### DIFF
--- a/internal/cmd/resources-report/Dockerfile
+++ b/internal/cmd/resources-report/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine@sha256:25a2602c4abab48d55dcf91525f4d78ad04a74994af69a7700cffa0d4aff9589 AS builder
+FROM golang:1.15-alpine@sha256:12aa158054046aea052f7d05f282e0a5c9d47193f1851353fd3aaaf6f836cf7d AS builder
 
 WORKDIR /go/src/resources-report
 

--- a/internal/cmd/tracking-issue/Dockerfile
+++ b/internal/cmd/tracking-issue/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine@sha256:25a2602c4abab48d55dcf91525f4d78ad04a74994af69a7700cffa0d4aff9589 AS builder
+FROM golang:1.15-alpine@sha256:12aa158054046aea052f7d05f282e0a5c9d47193f1851353fd3aaaf6f836cf7d AS builder
 
 WORKDIR /go/src/tracking-issue
 COPY . .


### PR DESCRIPTION
We updated the images in https://github.com/sourcegraph/sourcegraph/pull/18024 to use Go 1.15 but it seems like the chosen SHA was pulling the wrong architecture `linux/s390x` which causes builds to fail.

Failed run: https://github.com/sourcegraph/sourcegraph/runs/1953384446


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->