### PR TITLE
streaming search: show message at bottom of results when limit is hit

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
@@ -252,3 +252,25 @@ add('error with some results', () => {
 
     return <WebStory>{() => <StreamingSearchResults {...defaultProps} streamSearch={() => of(result)} />}</WebStory>
 })
+
+add('limit hit with some results', () => {
+    const result: AggregateStreamingSearchResults = {
+        state: 'complete',
+        results: MULTIPLE_SEARCH_RESULT.results,
+        filters: MULTIPLE_SEARCH_RESULT.dynamicFilters,
+        progress: {
+            durationMs: 500,
+            matchCount: MULTIPLE_SEARCH_RESULT.matchCount,
+            skipped: [
+                {
+                    reason: 'document-match-limit',
+                    message: 'result limit hit',
+                    severity: 'info',
+                    title: 'result limit hit',
+                },
+            ],
+        },
+    }
+
+    return <WebStory>{() => <StreamingSearchResults {...defaultProps} streamSearch={() => of(result)} />}</WebStory>
+})

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -318,27 +318,41 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     renderItem={renderResult}
                 />
 
-                {(!results || results?.state === 'loading') && (
-                    <div className="text-center my-4" data-testid="loading-container">
-                        <LoadingSpinner className="icon-inline" />
-                    </div>
-                )}
+                {itemsToShow >= (results?.results.length || 0) && (
+                    <>
+                        {(!results || results?.state === 'loading') && (
+                            <div className="text-center my-4" data-testid="loading-container">
+                                <LoadingSpinner className="icon-inline" />
+                            </div>
+                        )}
 
-                {results?.state === 'error' && (
-                    <ErrorAlert
-                        className="m-2"
-                        data-testid="search-results-list-error"
-                        error={results.error}
-                        history={history}
-                    />
-                )}
+                        {results?.state === 'error' && (
+                            <ErrorAlert
+                                className="m-3"
+                                data-testid="search-results-list-error"
+                                error={results.error}
+                                history={history}
+                            />
+                        )}
 
-                {results?.state === 'complete' && !results?.alert && results?.results.length === 0 && (
-                    <div className="alert alert-info d-flex m-2">
-                        <h3 className="m-0">
-                            <SearchIcon className="icon-inline" /> No results
-                        </h3>
-                    </div>
+                        {results?.state === 'complete' && !results?.alert && results?.results.length === 0 && (
+                            <div className="alert alert-info d-flex m-3">
+                                <h3 className="m-0">
+                                    <SearchIcon className="icon-inline" /> No results
+                                </h3>
+                            </div>
+                        )}
+
+                        {results?.state === 'complete' &&
+                            results.progress.skipped.some(skipped => skipped.reason.includes('-limit')) && (
+                                <div className="alert alert-info d-flex m-3">
+                                    <h3 className="m-0 font-weight-normal">
+                                        <strong>Result limit hit.</strong> Modify your search with <code>count:</code>{' '}
+                                        to return additional items.
+                                    </h3>
+                                </div>
+                            )}
+                    </>
                 )}
             </div>
         </div>

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -200,6 +200,13 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         () => setItemsToShow(items => Math.min(results?.results.length || 0, items + incrementalItemsToShow)),
         [results?.results.length]
     )
+
+    // Reset scroll visibility state and expanded state when new search is started
+    useEffect(() => {
+        setItemsToShow(initialItemsToShow)
+        setAllExpanded(false)
+    }, [location.search])
+
     const logSearchResultClicked = useCallback(() => telemetryService.log('SearchResultClicked'), [telemetryService])
 
     const itemKey = useCallback((item: GQL.GenericSearchResultInterface | GQL.IFileMatch): string => {


### PR DESCRIPTION
Fixes #17773

Also fixes the following issues:
- Only shows alerts at the bottom of the page if the last search result is being shown (prevents the alerts from flashing while scrolling rapidly because of virtual list loading)
- Virtual list state and expanded result state are now reset when a new search happens

Also, `StreamingSearchResults.tsx` is getting very big. I'll break it up in my next PR.

![image](https://user-images.githubusercontent.com/206864/108774102-1827f680-7514-11eb-9fc6-32ac1d896300.png)
