### PR TITLE
search: correct font-size variance in infobar

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -89,7 +89,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
         const toURL = `/code-monitoring/new?${searchParameters.toString()}`
         return (
             <li className="nav-item">
-                <Link to={toURL} className="btn btn-link nav-link text-decoration-none">
+                <Link to={toURL} className="btn btn-sm btn-link nav-link text-decoration-none">
                     Create code monitor
                 </Link>
             </li>
@@ -108,7 +108,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         menu={ContributableMenu.SearchResultsToolbar}
                         wrapInList={false}
                         showLoadingSpinnerDuringExecution={true}
-                        actionItemClass="btn btn-link nav-link text-decoration-none"
+                        actionItemClass="btn btn-sm btn-link nav-link text-decoration-none"
                     />
                     {CreateCodeMonitorButton}
                     {props.showSavedQueryButton !== false && props.authenticatedUser && (
@@ -116,7 +116,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                             <button
                                 type="button"
                                 onClick={props.onSaveQueryClick}
-                                className="btn btn-link nav-link text-decoration-none test-save-search-link"
+                                className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
                             >
                                 Save search
                             </button>
@@ -127,7 +127,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                             <button
                                 type="button"
                                 onClick={props.onExpandAllResultsToggle}
-                                className="btn btn-link nav-link text-decoration-none"
+                                className="btn btn-sm btn-link nav-link text-decoration-none"
                                 data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
                             >
                                 {props.allExpanded ? (

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
         className="nav-item"
       >
         <button
-          className="btn btn-link nav-link text-decoration-none test-save-search-link"
+          className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
           onClick={[Function]}
           type="button"
         >
@@ -27,7 +27,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
         className="nav-item"
       >
         <button
-          className="btn btn-link nav-link text-decoration-none"
+          className="btn btn-sm btn-link nav-link text-decoration-none"
           data-tooltip="Hide more matches on all results"
           onClick={[Function]}
           type="button"
@@ -66,7 +66,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         className="nav-item"
       >
         <a
-          className="btn btn-link nav-link text-decoration-none"
+          className="btn btn-sm btn-link nav-link text-decoration-none"
           href="/code-monitoring/new?trigger-query=foo+type%3Adiff+patterntype%3Aliteral"
         >
           Create code monitor
@@ -76,7 +76,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         className="nav-item"
       >
         <button
-          className="btn btn-link nav-link text-decoration-none test-save-search-link"
+          className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
           onClick={[Function]}
           type="button"
         >
@@ -87,7 +87,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         className="nav-item"
       >
         <button
-          className="btn btn-link nav-link text-decoration-none"
+          className="btn btn-sm btn-link nav-link text-decoration-none"
           data-tooltip="Hide more matches on all results"
           onClick={[Function]}
           type="button"
@@ -126,7 +126,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         className="nav-item"
       >
         <button
-          className="btn btn-link nav-link text-decoration-none test-save-search-link"
+          className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
           onClick={[Function]}
           type="button"
         >
@@ -137,7 +137,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         className="nav-item"
       >
         <button
-          className="btn btn-link nav-link text-decoration-none"
+          className="btn btn-sm btn-link nav-link text-decoration-none"
           data-tooltip="Hide more matches on all results"
           onClick={[Function]}
           type="button"

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -31,7 +31,7 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
                 <ButtonDropdown isOpen={isOpen} toggle={toggleOpen}>
                     <DropdownToggle
                         className={classNames(
-                            'streaming-progress__skipped mb-0 ml-2 d-flex align-items-center text-decoration-none',
+                            'streaming-progress__skipped mb-0 ml-2 d-flex align-items-center text-decoration-none btn-sm',
                             {
                                 'streaming-progress__skipped--warning': skippedWithWarningOrError,
                             }


### PR DESCRIPTION
Fixes #17696

All infobar items are now small-sized (font size 12px)

![image](https://user-images.githubusercontent.com/206864/108778526-59230980-751a-11eb-9507-e477248ba30b.png)
