### PR TITLE
web: move percy-specific CSS to percy config file

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -3,3 +3,8 @@ snapshot:
   widths:
     - 960 # Half-width browser window (e.g. docked to the side next to an editor)
     - 1920 # Full-width browser window
+  percy-css: |
+    .percy-hide,
+    .monaco-editor .cursor {
+      visibility: hidden !important;
+    }

--- a/client/web/src/SourcegraphWebApp.scss
+++ b/client/web/src/SourcegraphWebApp.scss
@@ -72,14 +72,6 @@ body,
     min-width: 0;
 }
 
-// Hide the given element from Percy.
-.percy-hide,
-.monaco-editor .cursor {
-    @media only percy {
-        visibility: hidden !important;
-    }
-}
-
 // Pages
 @import './Layout';
 @import './api/ApiConsole';


### PR DESCRIPTION
Percy is [failing the build intermittently](https://percy.io/Sourcegraph/Sourcegraph/builds/8974887/changed/508960393?browser=chrome&browser_ids=16&subcategories=unreviewed%2Cchanges_requested&viewLayout=side-by-side&viewMode=new&width=1920&widths=960%2C1920) due to rendering the Monaco cursor. We were previously successfully hiding the Monaco cursor using `@media only percy` CSS but that isn't working anymore. I have opened a support request with the Percy/Browserstack team but I'm trying this in the meantime to see if it resolves our issue.

Percy documentation: https://docs.percy.io/docs/percy-specific-css