### PR TITLE
HubSpot: add IsServerAdmin and AnonymousUid properties for server installers

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -397,13 +397,23 @@ func servePingFromSelfHosted(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 	email := r.URL.Query().Get("email")
-	cookie, err := r.Cookie("sourcegraphSourceUrl")
+
+	sourceURLCookie, err := r.Cookie("sourcegraphSourceUrl")
 	var sourceURL string
-	if err == nil && cookie != nil {
-		sourceURL = cookie.Value
+	if err == nil && sourceURLCookie != nil {
+		sourceURL = sourceURLCookie.Value
 	}
+
+	anonymousUIDCookie, err := r.Cookie("sourcegraphAnonymousUid")
+	var anonymousUserId string
+	if err == nil && anonymousUIDCookie != nil {
+		anonymousUserId = anonymousUIDCookie.Value
+	}
+
 	hubspotutil.SyncUser(email, hubspotutil.SelfHostedSiteInitEventID, &hubspot.ContactProperties{
-		FirstSourceURL: sourceURL,
+		IsServerAdmin:   true,
+		AnonymousUserID: anonymousUserId,
+		FirstSourceURL:  sourceURL,
 	})
 	return nil
 }


### PR DESCRIPTION
I just discovered that the `IsServerAdmin` property was not getting populated for HubSpot contacts created via the server install. We rely on this for some of our HubSpot workflows to correctly categorize users' First Touchpoint property.  

Also discovered that anonymous user ID was not getting populated (see https://github.com/sourcegraph/sourcegraph/issues/18088 for spec), so also adding that here.

We have updated the workflow to change the `IsServerAdmin` property based on the HubSpot EventID (`SelfHostedSiteInitEventID`) we send, so we don't need to patch a release for these fixes. However, if we do a patch, it would be good to include this change.

I am not able to test this locally so will have to test once merged (@arussellsaw, this is how you verified these changes in the past, right?).

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
