### PR TITLE
gitserver: disable reclone for Perforce

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -141,7 +141,7 @@ func (s *Server) cleanupRepos() {
 		}
 
 		// We believe converting a Perforce depot to a Git repository is generally a
-		// very expansive operation, therefore we do not try to reclone/redo the
+		// very expensive operation, therefore we do not try to reclone/redo the
 		// conversion only because it is old or slow to do "git gc".
 		if repoType == "perforce" && reason != maybeCorrupt {
 			reason = ""

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -112,6 +112,11 @@ func (s *Server) cleanupRepos() {
 	}
 
 	maybeReclone := func(dir GitDir) (done bool, err error) {
+		repoType, err := getRepositoryType(dir)
+		if err != nil {
+			return false, err
+		}
+
 		recloneTime, err := getRecloneTime(dir)
 		if err != nil {
 			return false, err
@@ -120,8 +125,9 @@ func (s *Server) cleanupRepos() {
 		// Add a jitter to spread out recloning of repos cloned at the same
 		// time.
 		var reason string
+		const maybeCorrupt = "maybeCorrupt"
 		if maybeCorrupt, _ := gitConfigGet(dir, "sourcegraph.maybeCorruptRepo"); maybeCorrupt != "" {
-			reason = "maybeCorrupt"
+			reason = maybeCorrupt
 			// unset flag to stop constantly recloning if it fails.
 			_ = gitConfigUnset(dir, "sourcegraph.maybeCorruptRepo")
 		}
@@ -133,6 +139,14 @@ func (s *Server) cleanupRepos() {
 				reason = fmt.Sprintf("git gc %s", string(bytes.TrimSpace(gclog)))
 			}
 		}
+
+		// We believe converting a Perforce depot to a Git repository is generally a
+		// very expansive operation, therefore we do not try to reclone/redo the
+		// conversion only because it is old or slow to do "git gc".
+		if repoType == "perforce" && reason != maybeCorrupt {
+			reason = ""
+		}
+
 		if reason == "" {
 			return false, nil
 		}
@@ -586,6 +600,16 @@ func (s *Server) SetupAndClearTmp() (string, error) {
 	}
 
 	return dir, nil
+}
+
+// setRepositoryType sets the type of the repository.
+func setRepositoryType(dir GitDir, typ string) error {
+	return gitConfigSet(dir, "sourcegraph.type", typ)
+}
+
+// getRepositoryType returns the type of the repository.
+func getRepositoryType(dir GitDir) (string, error) {
+	return gitConfigGet(dir, "sourcegraph.type")
 }
 
 // setRecloneTime sets the time a repository is cloned.

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -609,7 +609,11 @@ func setRepositoryType(dir GitDir, typ string) error {
 
 // getRepositoryType returns the type of the repository.
 func getRepositoryType(dir GitDir) (string, error) {
-	return gitConfigGet(dir, "sourcegraph.type")
+	val, err := gitConfigGet(dir, "sourcegraph.type")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(val), nil
 }
 
 // setRecloneTime sets the time a repository is cloned.

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -182,8 +182,16 @@ func TestCleanupExpired(t *testing.T) {
 	repoGCOld := path.Join(root, "repo-gc-old", ".git")
 	repoBoom := path.Join(root, "repo-boom", ".git")
 	repoCorrupt := path.Join(root, "repo-corrupt", ".git")
+	repoPerforce := path.Join(root, "repo-perforce", ".git")
+	repoPerforceGCOld := path.Join(root, "repo-perforce-gc-old", ".git")
 	remote := path.Join(root, "remote", ".git")
-	for _, path := range []string{repoNew, repoOld, repoGCNew, repoGCOld, repoBoom, repoCorrupt, remote} {
+	for _, path := range []string{
+		repoNew, repoOld,
+		repoGCNew, repoGCOld,
+		repoBoom, repoCorrupt,
+		repoPerforce, repoPerforceGCOld,
+		remote,
+	} {
 		cmd := exec.Command("git", "--bare", "init", path)
 		if err := cmd.Run(); err != nil {
 			t.Fatal(err)
@@ -218,10 +226,12 @@ func TestCleanupExpired(t *testing.T) {
 	writeFile(t, filepath.Join(repoGCOld, "gc.log"), []byte("warning: There are too many unreachable loose objects; run 'git prune' to remove them."))
 
 	for path, delta := range map[string]time.Duration{
-		repoOld:     2 * repoTTL,
-		repoGCOld:   2 * repoTTLGC,
-		repoBoom:    2 * repoTTL,
-		repoCorrupt: repoTTLGC / 2, // should only trigger corrupt, not old
+		repoOld:           2 * repoTTL,
+		repoGCOld:         2 * repoTTLGC,
+		repoBoom:          2 * repoTTL,
+		repoCorrupt:       repoTTLGC / 2, // should only trigger corrupt, not old
+		repoPerforce:      2 * repoTTL,
+		repoPerforceGCOld: 2 * repoTTLGC,
 	} {
 		ts := time.Now().Add(-delta)
 		if err := setRecloneTime(GitDir(path), ts); err != nil {
@@ -234,6 +244,12 @@ func TestCleanupExpired(t *testing.T) {
 	if err := gitConfigSet(GitDir(repoCorrupt), "sourcegraph.maybeCorruptRepo", "1"); err != nil {
 		t.Fatal(err)
 	}
+	if err := setRepositoryType(GitDir(repoPerforce), "perforce"); err != nil {
+		t.Fatal(err)
+	}
+	if err := setRepositoryType(GitDir(repoPerforceGCOld), "perforce"); err != nil {
+		t.Fatal(err)
+	}
 
 	now := time.Now()
 	repoNewTime := modTime(repoNew)
@@ -241,6 +257,8 @@ func TestCleanupExpired(t *testing.T) {
 	repoGCNewTime := modTime(repoGCNew)
 	repoGCOldTime := modTime(repoGCOld)
 	repoCorruptTime := modTime(repoBoom)
+	repoPerforceTime := modTime(repoPerforce)
+	repoPerforceGCOldTime := modTime(repoPerforceGCOld)
 	repoBoomTime := modTime(repoBoom)
 	repoBoomRecloneTime := recloneTime(repoBoom)
 
@@ -260,6 +278,12 @@ func TestCleanupExpired(t *testing.T) {
 	}
 	if repoGCNewTime.Before(modTime(repoGCNew)) {
 		t.Error("expected repoGCNew to not be modified")
+	}
+	if repoPerforceTime.Before(modTime(repoPerforce)) {
+		t.Error("expected repoPerforce to not be modified")
+	}
+	if repoPerforceGCOldTime.Before(modTime(repoPerforceGCOld)) {
+		t.Error("expected repoPerforceGCOld to not be modified")
 	}
 
 	// repos that should be recloned

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1073,12 +1073,12 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 			testRepoCorrupter(ctx, tmp)
 		}
 
+		removeBadRefs(ctx, tmp)
+		ensureHead(tmp)
+
 		if err := setRepositoryType(tmp, syncer.Type()); err != nil {
 			return errors.Wrap(err, `git config set "sourcegraph.type"`)
 		}
-
-		removeBadRefs(ctx, tmp)
-		ensureHead(tmp)
 
 		// Update the last-changed stamp.
 		if err := setLastChanged(tmp); err != nil {
@@ -1544,12 +1544,12 @@ func (s *Server) doRepoUpdate2(repo api.RepoName) error {
 		return errors.Wrap(err, "failed to update")
 	}
 
+	removeBadRefs(ctx, dir)
+	ensureHead(dir)
+
 	if err := setRepositoryType(dir, syncer.Type()); err != nil {
 		return errors.Wrap(err, `git config set "sourcegraph.type"`)
 	}
-
-	removeBadRefs(ctx, dir)
-	ensureHead(dir)
 
 	// Update the last-changed stamp.
 	if err := setLastChanged(dir); err != nil {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1073,7 +1073,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 			testRepoCorrupter(ctx, tmp)
 		}
 
-		if err := setRepositoryType(dir, syncer.Type()); err != nil {
+		if err := setRepositoryType(tmp, syncer.Type()); err != nil {
 			return errors.Wrap(err, `git config set "sourcegraph.type"`)
 		}
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1073,6 +1073,10 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 			testRepoCorrupter(ctx, tmp)
 		}
 
+		if err := setRepositoryType(dir, syncer.Type()); err != nil {
+			return errors.Wrap(err, `git config set "sourcegraph.type"`)
+		}
+
 		removeBadRefs(ctx, tmp)
 		ensureHead(tmp)
 
@@ -1538,6 +1542,10 @@ func (s *Server) doRepoUpdate2(repo api.RepoName) error {
 	if output, err := runWith(ctx, cmd, configRemoteOpts, nil); err != nil {
 		log15.Error("Failed to update", "repo", repo, "error", err, "output", string(output))
 		return errors.Wrap(err, "failed to update")
+	}
+
+	if err := setRepositoryType(dir, syncer.Type()); err != nil {
+		return errors.Wrap(err, `git config set "sourcegraph.type"`)
 	}
 
 	removeBadRefs(ctx, dir)

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -664,7 +664,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		dst := s.dir(api.RepoName("example.com/foo/bar"))
+		dst := s.dir("example.com/foo/bar")
 		for i := 0; i < 1000; i++ {
 			_, cloning := s.locker.Status(dst)
 			if !cloning {

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -21,6 +21,8 @@ import (
 // VCSSyncer describes whether and how to sync content from a VCS remote to
 // local disk.
 type VCSSyncer interface {
+	// Type returns the type of the syncer.
+	Type() string
 	// IsCloneable checks to see if the VCS remote URL is cloneable. Any non-nil
 	// error indicates there is a problem.
 	IsCloneable(ctx context.Context, remoteURL *url.URL) error
@@ -34,6 +36,10 @@ type VCSSyncer interface {
 
 // GitRepoSyncer is a syncer for Git repositories.
 type GitRepoSyncer struct{}
+
+func (s *GitRepoSyncer) Type() string {
+	return "git"
+}
 
 // IsCloneable checks to see if the Git remote URL is cloneable.
 func (s *GitRepoSyncer) IsCloneable(ctx context.Context, remoteURL *url.URL) error {
@@ -105,6 +111,10 @@ func (s *GitRepoSyncer) RemoteShowCommand(ctx context.Context, remoteURL *url.UR
 type PerforceDepotSyncer struct {
 	// MaxChanges indicates to only import at most n changes when possible.
 	MaxChanges int
+}
+
+func (s *PerforceDepotSyncer) Type() string {
+	return "perforce"
 }
 
 // decomposePerforceRemoteURL decomposes information back from a clone URL for a


### PR DESCRIPTION
When clone and fetch repositories, we set a custom Git option `sourcegraph.type` to be the origin type. For Git repositories converted from Perforce depots, it would be `perforce`. We then use this value to determine if we should skip reclone because the process of reclone/redo the conversion is considered very expensive in general. 

Fixes https://github.com/sourcegraph/sourcegraph/issues/17687