### PR TITLE
search: move ResultCount and appendMatches to FileMatch from resolver

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -61,6 +61,14 @@ func (fm *FileMatch) ResultCount() int {
 	return rc
 }
 
+// appendMatches appends the line matches from src as well as updating match
+// counts and limit.
+func (fm *FileMatch) appendMatches(src *FileMatch) {
+	fm.JLineMatches = append(fm.JLineMatches, src.JLineMatches...)
+	fm.symbols = append(fm.symbols, src.symbols...)
+	fm.JLimitHit = fm.JLimitHit || src.JLimitHit
+}
+
 // FileMatchResolver is a resolver for the GraphQL type `FileMatch`
 type FileMatchResolver struct {
 	FileMatch
@@ -145,9 +153,7 @@ func (fm *FileMatchResolver) path() string {
 // appendMatches appends the line matches from src as well as updating match
 // counts and limit.
 func (fm *FileMatchResolver) appendMatches(src *FileMatchResolver) {
-	fm.JLineMatches = append(fm.JLineMatches, src.JLineMatches...)
-	fm.symbols = append(fm.symbols, src.symbols...)
-	fm.JLimitHit = fm.JLimitHit || src.JLimitHit
+	fm.FileMatch.appendMatches(&src.FileMatch)
 }
 
 func (fm *FileMatchResolver) ResultCount() int32 {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -50,6 +50,17 @@ type FileMatch struct {
 	InputRev *string
 }
 
+func (fm *FileMatch) ResultCount() int {
+	rc := len(fm.symbols)
+	for _, m := range fm.JLineMatches {
+		rc += len(m.OffsetAndLengths)
+	}
+	if rc == 0 {
+		return 1 // 1 to count "empty" results like type:path results
+	}
+	return rc
+}
+
 // FileMatchResolver is a resolver for the GraphQL type `FileMatch`
 type FileMatchResolver struct {
 	FileMatch
@@ -140,14 +151,7 @@ func (fm *FileMatchResolver) appendMatches(src *FileMatchResolver) {
 }
 
 func (fm *FileMatchResolver) ResultCount() int32 {
-	rc := len(fm.symbols)
-	for _, m := range fm.JLineMatches {
-		rc += len(m.OffsetAndLengths)
-	}
-	if rc == 0 {
-		return 1 // 1 to count "empty" results like type:path results
-	}
-	return int32(rc)
+	return int32(fm.FileMatch.ResultCount())
 }
 
 func (fm *FileMatchResolver) Select(t filter.SelectPath) SearchResultResolver {


### PR DESCRIPTION
These functions will continue to be used by our search layer once search has been extracted out of graphqlbackend. This also makes it easier for another change I am doing.