### PR TITLE
Fix Gerrit change ref string prefix

### DIFF
--- a/client/browser/src/shared/code-hosts/gerrit/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/gerrit/codeHost.ts
@@ -22,8 +22,9 @@ interface GerritChangeAndPatchset {
 }
 
 function buildGerritChangeString(changeId: string, patchsetId: string): string {
-    // The "change directory prefix" is a prefix composed of the first two characters of the change ID, zero-padded.
-    const changeDirectoryPrefix = changeId.slice(0, 2).padStart(2, '0')
+    // The "change directory prefix" is a prefix composed of the *LAST* two
+    // characters of the change ID, zero-padded.
+    const changeDirectoryPrefix = changeId.slice(-2).padStart(2, '0')
     return `refs/changes/${changeDirectoryPrefix}/${changeId}/${patchsetId}`
 }
 


### PR DESCRIPTION
Fix the format for the ref string for Gerrit changes, which causes a bug when the change ID is longer than two characters.

> A change ref has the format refs/changes/X/Y/Z where X is the last two digits of the change number, Y is the entire change number, and Z is the patch set. For example, if the change number is 263270, the ref would be refs/changes/70/263270/2 for the second patch set.

Source: [Gerrit documentation](https://gerrit-review.googlesource.com/Documentation/intro-user.html)
