### PR TITLE
codeintel: Lower lsifstore Ranges memory usage

### DIFF
--- a/enterprise/internal/codeintel/stores/lsifstore/observability.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/observability.go
@@ -25,7 +25,8 @@ type operations struct {
 	writeReferences    *observation.Operation
 	writeResultChunks  *observation.Operation
 
-	locations *observation.Operation
+	locations           *observation.Operation
+	locationsWithinFile *observation.Operation
 }
 
 func newOperations(observationContext *observation.Context) *operations {
@@ -71,6 +72,7 @@ func newOperations(observationContext *observation.Context) *operations {
 		writeReferences:    op("WriteReferences"),
 		writeResultChunks:  op("WriteResultChunks"),
 
-		locations: subOp("locations"),
+		locations:           subOp("locations"),
+		locationsWithinFile: subOp("locationsWithinFile"),
 	}
 }

--- a/enterprise/internal/codeintel/stores/lsifstore/ranges.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/ranges.go
@@ -24,64 +24,32 @@ func (s *Store) Ranges(ctx context.Context, bundleID int, path string, startLine
 	if err != nil || !exists {
 		return nil, err
 	}
-	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
 
-	ranges := map[ID]RangeData{}
-	for id, r := range documentData.Document.Ranges {
-		if RangeIntersectsSpan(r, startLine, endLine) {
-			ranges[id] = r
-		}
-	}
+	traceLog(log.Int("numRanges", len(documentData.Document.Ranges)))
+	ranges := FindRangesInWindow(documentData.Document.Ranges, startLine, endLine)
 	traceLog(log.Int("numIntersectingRanges", len(ranges)))
 
-	resultIDMap := make(map[ID]struct{}, 2*len(ranges))
-	for _, r := range ranges {
-		if r.DefinitionResultID != "" {
-			resultIDMap[r.DefinitionResultID] = struct{}{}
-		}
-		if r.ReferenceResultID != "" {
-			resultIDMap[r.ReferenceResultID] = struct{}{}
-		}
+	definitionResultIDs := extractResultIDs(ranges, func(r RangeData) ID { return r.DefinitionResultID })
+	definitionLocations, err := s.locations(ctx, bundleID, definitionResultIDs)
+	if err != nil {
+		return nil, err
 	}
 
-	resultIDs := make([]ID, 0, len(resultIDMap))
-	for id := range resultIDMap {
-		resultIDs = append(resultIDs, id)
-	}
-
-	locations, err := s.locations(ctx, bundleID, resultIDs)
+	referenceResultIDs := extractResultIDs(ranges, func(r RangeData) ID { return r.ReferenceResultID })
+	referenceLocations, err := s.locationsWithinFile(ctx, bundleID, referenceResultIDs, path, documentData.Document)
 	if err != nil {
 		return nil, err
 	}
 
 	codeintelRanges := make([]CodeIntelligenceRange, 0, len(ranges))
 	for _, r := range ranges {
-		var hoverText string
-		if r.HoverResultID != "" {
-			if text, exists := documentData.Document.HoverResults[r.HoverResultID]; exists {
-				hoverText = text
-			}
-		}
-
-		// Return only references that are in the same file. Otherwise this set
-		// gets very big and such results are of limited use to consumers such as
-		// the code intel extensions, which only use references for highlighting
-		// uses of an identifier within the same file.
-		fileLocalReferences := make([]Location, 0, len(locations[r.ReferenceResultID]))
-		for _, r := range locations[r.ReferenceResultID] {
-			if r.Path == path {
-				fileLocalReferences = append(fileLocalReferences, r)
-			}
-		}
-
 		codeintelRanges = append(codeintelRanges, CodeIntelligenceRange{
 			Range:       newRange(r.StartLine, r.StartCharacter, r.EndLine, r.EndCharacter),
-			Definitions: locations[r.DefinitionResultID],
-			References:  fileLocalReferences,
-			HoverText:   hoverText,
+			Definitions: definitionLocations[r.DefinitionResultID],
+			References:  referenceLocations[r.ReferenceResultID],
+			HoverText:   documentData.Document.HoverResults[r.HoverResultID],
 		})
 	}
-
 	sort.Slice(codeintelRanges, func(i, j int) bool {
 		return compareBundleRanges(codeintelRanges[i].Range, codeintelRanges[j].Range)
 	})
@@ -93,3 +61,45 @@ const rangesDocumentQuery = `
 -- source: enterprise/internal/codeintel/stores/lsifstore/ranges.go:Ranges
 SELECT dump_id, path, data FROM lsif_data_documents WHERE dump_id = %s AND path = %s LIMIT 1
 `
+
+// locationsWithinFile queries the file-local locations associated with the given definition or reference
+// identifiers. Like locations, this method returns a map from result set identifiers to another map from
+// document paths to locations within that document.
+func (s *Store) locationsWithinFile(ctx context.Context, bundleID int, ids []ID, path string, documentData DocumentData) (_ map[ID][]Location, err error) {
+	ctx, traceLog, endObservation := s.operations.locationsWithinFile.WithAndLogger(ctx, &err, observation.Args{LogFields: []log.Field{
+		log.Int("bundleID", bundleID),
+		log.Int("numIDs", len(ids)),
+		log.String("ids", idsToString(ids)),
+		log.String("path", path),
+	}})
+	defer endObservation(1, observation.Args{})
+
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	// Get the list of indexes we need to read in order to find each result set identifier
+	indexes, err := s.translateIDsToResultChunkIndexes(ctx, bundleID, ids)
+	if err != nil {
+		return nil, err
+	}
+	traceLog(
+		log.Int("numIndexes", len(indexes)),
+		log.String("indexes", intsToString(indexes)),
+	)
+
+	// Read the result sets and gather the set of range identifiers we need to resolve with
+	// the given document data.
+	_, rangeIDsByResultID, err := s.readLocationsFromResultChunks(ctx, bundleID, ids, indexes, path)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hydrate the locations result set by replacing range ids with their actual data from their
+	// containing document. This refines the map constructed in the previous step.
+	locationsByResultID := make(map[ID][]Location, len(ids))
+	totalCount := s.readRangesFromDocument(bundleID, rangeIDsByResultID, locationsByResultID, path, documentData, traceLog)
+	traceLog(log.Int("numLocations", totalCount))
+
+	return locationsByResultID, nil
+}

--- a/enterprise/internal/codeintel/stores/lsifstore/util.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/util.go
@@ -20,6 +20,23 @@ func FindRanges(ranges map[ID]RangeData, line, character int) []RangeData {
 	return filtered
 }
 
+// FindRangesInWIndow filters the given ranges and returns those that intersect with the
+// given window of lines. Ranges are returned in reading order (top-down/left-right).
+func FindRangesInWindow(ranges map[ID]RangeData, startLine, endLine int) []RangeData {
+	var filtered []RangeData
+	for _, r := range ranges {
+		if RangeIntersectsSpan(r, startLine, endLine) {
+			filtered = append(filtered, r)
+		}
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		return CompareRanges(filtered[i], filtered[j]) < 0
+	})
+
+	return filtered
+}
+
 // CompareRanges compares two ranges.
 // Returns -1 if the range A starts before range B, or starts at the same place but ends earlier.
 // Returns 0 if they're exactly equal. Returns 1 otherwise.


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/18247. The current Ranges implementation gathers all the ranges that intersect the given window of lines, extracts each definition and result id, queries all related locations, then inverts the location results to be keyed on range.

The implementation _post-filters_ the reference locations that do not occur within the source document. This PR ensures that we don't build a map containing reference locations in external documents. This also reduces the number of total database queries we need to make.