### PR TITLE
search: update zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -212,7 +212,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210216134814-a58c3d2968a6
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210223153151-e34da978df5b
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1297,6 +1297,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20210216134814-a58c3d2968a6 h1:D5iMROXehGV4wSLnCniL8Fy5vE18CRYELn1mhbwA5Rs=
 github.com/sourcegraph/zoekt v0.0.0-20210216134814-a58c3d2968a6/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
+github.com/sourcegraph/zoekt v0.0.0-20210223153151-e34da978df5b h1:1JsdFaIroRrex+Xp3h6GUFTxl2DTc2c/KRA0V1jc0Nw=
+github.com/sourcegraph/zoekt v0.0.0-20210223153151-e34da978df5b/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/internal/search/backend/fake.go
+++ b/internal/search/backend/fake.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/zoekt"
 	zoektquery "github.com/google/zoekt/query"
-	zoektstream "github.com/google/zoekt/stream"
 )
 
 // FakeSearcher is a zoekt.Searcher that returns a predefined search Result.
@@ -26,7 +25,7 @@ func (ss *FakeSearcher) Search(ctx context.Context, q zoektquery.Q, opts *zoekt.
 	return ss.Result, nil
 }
 
-func (ss *FakeSearcher) StreamSearch(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions, z zoektstream.Streamer) error {
+func (ss *FakeSearcher) StreamSearch(ctx context.Context, q zoektquery.Q, opts *zoekt.SearchOptions, z zoekt.Sender) error {
 	return (&StreamSearchAdapter{ss}).StreamSearch(ctx, q, opts, z)
 }
 

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
-	zoektstream "github.com/google/zoekt/stream"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -28,7 +27,7 @@ type HorizontalSearcher struct {
 }
 
 // StreamSearch does a search which merges the stream from every endpoint in Map.
-func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoektstream.Streamer) error {
+func (s *HorizontalSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoekt.Sender) error {
 	clients, err := s.searchers()
 	if err != nil {
 		return err
@@ -71,7 +70,7 @@ func (s *HorizontalSearcher) Search(ctx context.Context, q query.Q, opts *zoekt.
 
 // AggregateStreamSearch aggregates the stream events into a single batch
 // result.
-func AggregateStreamSearch(ctx context.Context, streamSearch func(context.Context, query.Q, *zoekt.SearchOptions, zoektstream.Streamer) error, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
+func AggregateStreamSearch(ctx context.Context, streamSearch func(context.Context, query.Q, *zoekt.SearchOptions, zoekt.Sender) error, q query.Q, opts *zoekt.SearchOptions) (*zoekt.SearchResult, error) {
 	start := time.Now()
 
 	var mu sync.Mutex

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	zoektstream "github.com/google/zoekt/stream"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/zoekt"
@@ -340,7 +338,7 @@ func (s *mockSearcher) Search(context.Context, query.Q, *zoekt.SearchOptions) (*
 	return res, s.searchError
 }
 
-func (s *mockSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoektstream.Streamer) error {
+func (s *mockSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, streamer zoekt.Sender) error {
 	return (&StreamSearchAdapter{s}).StreamSearch(ctx, q, opts, streamer)
 }
 

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
-	zoektstream "github.com/google/zoekt/stream"
 	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/rpc"
 	"github.com/opentracing/opentracing-go"
@@ -41,7 +40,7 @@ func NewMeteredSearcher(hostname string, z StreamSearcher) StreamSearcher {
 	}
 }
 
-func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoektstream.Streamer) error {
+func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoekt.Sender) error {
 	start := time.Now()
 
 	// isLeaf is true if this is a zoekt.Searcher which does a network

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
-	zoektstream "github.com/google/zoekt/stream"
 )
 
 // ZoektStreamFunc is a convenience function to create a stream receiver from a
@@ -24,7 +23,7 @@ type StreamSearcher interface {
 	zoekt.Searcher
 
 	// StreamSearch returns a channel which needs to be read until closed.
-	StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoektstream.Streamer) error
+	StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoekt.Sender) error
 }
 
 // StreamSearchEvent has fields optionally set representing events that happen
@@ -43,7 +42,7 @@ type StreamSearchAdapter struct {
 	zoekt.Searcher
 }
 
-func (s *StreamSearchAdapter) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoektstream.Streamer) error {
+func (s *StreamSearchAdapter) StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoekt.Sender) error {
 	sr, err := s.Search(ctx, q, opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
This updates go.mod AND changes `zoekt/stream.Streamer` to `zoekt.Sender`
because we moved the interface in commit 6e49f33 from package `stream`
to `zoekt`.

Includes the following commits:

e34da97 fix: replace Searcher with Streamer
6e49f33 streaming: add zoekt.Streamer
cec0396 Merge remote-tracking branch 'gerrit/master'
031d445 shards: wait for watcher to stop when closing
217568b shards: clear out shards map when closing
cd15fd3 zoekt-archive-index: disable log in tests unless verbose



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
