### PR TITLE
search: Make GlobalSearchMode stringer more resilient

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -84,15 +84,23 @@ type SymbolsParameters struct {
 
 type GlobalSearchMode int
 
-// Keep the order in sync with func (m GlobalSearchMode) String() string.
 const (
 	ZoektGlobalSearch GlobalSearchMode = iota + 1
 	SearcherOnly
 	NoFilePath
 )
 
+var globalSearchModeStrings = map[GlobalSearchMode]string{
+	ZoektGlobalSearch: "ZoektGlobalSearch",
+	SearcherOnly:      "SearcherOnly",
+	NoFilePath:        "NoFilePath",
+}
+
 func (m GlobalSearchMode) String() string {
-	return []string{"None", "ZoektGlobalSearch", "SearcherOnly", "NoFilePath"}[m]
+	if s, ok := globalSearchModeStrings[m]; ok {
+		return s
+	}
+	return "None"
 }
 
 // TextParameters are the parameters passed to a search backend. It contains the Pattern


### PR DESCRIPTION
The `String()` method previously allocated a slice every call, and would
panic if there was an invalid GlobalSearchMode. Additionally, it
required keeping the order of the slice in sync with the order of the
defined GlobalSearchModes.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
