### PR TITLE
search: Add perf optimization for select:repo

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1220,6 +1220,14 @@ func getPatternInfo(q query.Q, opts *getPatternInfoOptions) (*search.TextPattern
 
 	languages, _ := q.StringValues(query.FieldLang)
 
+	var sp filter.SelectPath
+	if sf, _ := q.StringValue(query.FieldSelect); sf != "" {
+		sp, err = filter.SelectPathFromString(sf)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	patternInfo := &search.TextPatternInfo{
 		IsRegExp:                     isRegExp,
 		IsStructuralPat:              isStructuralPat,
@@ -1234,6 +1242,7 @@ func getPatternInfo(q query.Q, opts *getPatternInfoOptions) (*search.TextPattern
 		PathPatternsAreCaseSensitive: q.IsCaseSensitive(),
 		CombyRule:                    strings.Join(combyRule, ""),
 		Index:                        indexValue(q),
+		Select:                       sp,
 	}
 	if len(excludePatterns) > 0 {
 		patternInfo.ExcludePattern = searchrepos.UnionRegExps(excludePatterns)

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
@@ -262,18 +263,19 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 	// We use reposResolved to synchronize repo resolution and event processing.
 	reposResolved := make(chan struct{})
 	var getRepoInputRev zoektutil.RepoRevFunc
+	var repoRevMap map[string]*search.RepositoryRevisions
 
 	g, ctx := errgroup.WithContext(ctx)
 
 	// Resolve repositories.
 	g.Go(func() error {
 		defer close(reposResolved)
-		if args.Mode == search.ZoektGlobalSearch {
+		if args.Mode == search.ZoektGlobalSearch || args.PatternInfo.Select.Type == filter.Repository {
 			repos, err := getRepos(ctx, args.RepoPromise)
 			if err != nil {
 				return err
 			}
-			repoRevMap := make(map[string]*search.RepositoryRevisions, len(repos))
+			repoRevMap = make(map[string]*search.RepositoryRevisions, len(repos))
 			for _, r := range repos {
 				repoRevMap[string(r.Repo.Name)] = r
 			}
@@ -310,6 +312,38 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 			ctx, cancel = contextWithoutDeadline(ctx)
 			defer cancel()
 		}
+
+		// PERF: if we are going to be selecting to repo results only anyways, we can just ask
+		// zoekt for only results of type repo.
+		if args.PatternInfo.Select.Type == filter.Repository {
+			repoList, err := args.Zoekt.Client.List(ctx, finalQuery)
+			if err != nil {
+				return err
+			}
+
+			<-reposResolved
+			// getRepoInputRev is nil only if we encountered an error during repo resolution.
+			if getRepoInputRev == nil {
+				return nil
+			}
+
+			resolvers := make([]SearchResultResolver, 0, len(repoList.Repos))
+			for _, repo := range repoList.Repos {
+				rev, ok := repoRevMap[repo.Repository.Name]
+				if !ok {
+					continue
+				}
+
+				resolvers = append(resolvers, NewRepositoryResolver(db, &types.Repo{Name: rev.Repo.Name, ID: rev.Repo.ID}))
+			}
+
+			c.Send(SearchEvent{
+				Results: resolvers,
+				Stats:   streaming.Stats{}, // TODO
+			})
+			return nil
+		}
+
 		return args.Zoekt.Client.StreamSearch(ctx, finalQuery, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 
 			mu.Lock()

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -121,6 +121,11 @@ type PatternInfo struct {
 	// a flag to activate the old structural search path, which queries zoekt for the
 	// file list in the frontend and passes it to searcher.
 	CombyRule string
+
+	// Select is the value of the the select field in the query. It is not necessary to
+	// use it since selection is done after the query completes, but exposing it can enable
+	// optimizations.
+	Select string
 }
 
 func (p *PatternInfo) String() string {
@@ -152,6 +157,9 @@ func (p *PatternInfo) String() string {
 	}
 	for _, lang := range p.Languages {
 		args = append(args, fmt.Sprintf("lang:%s", lang))
+	}
+	if p.Select != "" {
+		args = append(args, fmt.Sprintf("select:%s", p.Select))
 	}
 
 	path := "glob"

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -154,6 +154,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	span.SetTag("patternMatchesPath", p.PatternMatchesPath)
 	span.SetTag("deadline", p.Deadline)
 	span.SetTag("indexerEndpoints", p.IndexerEndpoints)
+	span.SetTag("select", p.Select)
 	defer func(start time.Time) {
 		code := "200"
 		// We often have canceled and timed out requests. We do not want to

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 )
 
@@ -271,6 +272,14 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 		fileMatchLimit = maxFileMatchLimit
 	}
 
+	var sp filter.SelectPath
+	if p.Select != "" {
+		sp, err = filter.SelectPathFromString(p.Select)
+		if err != nil {
+			return nil, false, false, err
+		}
+	}
+
 	patternInfo :=
 		&search.TextPatternInfo{
 			Pattern:                      p.Pattern,
@@ -287,6 +296,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			PatternMatchesContent:        p.PatternMatchesContent,
 			PatternMatchesPath:           p.PatternMatchesPath,
 			Languages:                    p.Languages,
+			Select:                       sp,
 		}
 
 	if p.Branch == "" {

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 )
 
@@ -272,14 +271,6 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 		fileMatchLimit = maxFileMatchLimit
 	}
 
-	var sp filter.SelectPath
-	if p.Select != "" {
-		sp, err = filter.SelectPathFromString(p.Select)
-		if err != nil {
-			return nil, false, false, err
-		}
-	}
-
 	patternInfo :=
 		&search.TextPatternInfo{
 			Pattern:                      p.Pattern,
@@ -296,7 +287,6 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 			PatternMatchesContent:        p.PatternMatchesContent,
 			PatternMatchesPath:           p.PatternMatchesPath,
 			Languages:                    p.Languages,
-			Select:                       sp,
 		}
 
 	if p.Branch == "" {

--- a/internal/search/filter/select.go
+++ b/internal/search/filter/select.go
@@ -17,6 +17,10 @@ type SelectPath struct {
 	Type SelectType
 }
 
+func (sp SelectPath) String() string {
+	return string(sp.Type)
+}
+
 var validSelectors = map[SelectType]struct{}{
 	Commit:     {},
 	Content:    {},

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -67,6 +67,7 @@ func Search(ctx context.Context, searcherURLs *endpoint.Map, repo api.RepoName, 
 
 		"PathPatternsAreRegExps": []string{"true"},
 		"IndexerEndpoints":       indexerEndpoints,
+		"Select":                 []string{string(p.Select.Type)},
 	}
 	if deadline, ok := ctx.Deadline(); ok {
 		t, err := deadline.MarshalText()

--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -154,6 +155,7 @@ type TextPatternInfo struct {
 	IsCaseSensitive bool
 	FileMatchLimit  int32
 	Index           query.YesNoOnly
+	Select          filter.SelectPath
 
 	// We do not support IsMultiline
 	// IsMultiline     bool


### PR DESCRIPTION
Adds an optimization where, if we are selecting repo anyways, we can ask
zoekt for only repo results.

Revised from #18449 
Fixes #18449 

Sample query that hits this new path: `patterntype:literal searchZoekt select:repo`

Some notes/thoughts:
- We have to use `Zoekt.Client.List()` rather than `Zoekt.Client.StreamSearch()` because adding a type to the query is unsupported with the standard search path.
- It's not clear to me what `ZoektGlobalSearch` actually means (we could probably use some documentation on that type), so I don't actually know if it's reasonable to hit that code path in this case (we're getting `GlobalSearchType.None`).
- I could use some guidance constructing the stats portion of the result. It's not clear to me which of those fields are relevant in this case.
- It's possible this isn't worth the added complexity. I'm still leaning towards adding it because it will also significantly help with the "show more" issue. (It's difficult to know whether there are more results if a limit is hit). 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
