### PR TITLE
search: Remove database from FileMatch

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -43,7 +43,6 @@ func TestSearchRepositories(t *testing.T) {
 		case "foo/one":
 			return []*FileMatchResolver{
 				mkFileMatchResolver(db, FileMatch{
-					db:   db,
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
@@ -51,7 +50,6 @@ func TestSearchRepositories(t *testing.T) {
 		case "bar/one":
 			return []*FileMatchResolver{
 				mkFileMatchResolver(db, FileMatch{
-					db:   db,
 					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &types.RepoName{ID: 789},
 				}),

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -64,7 +64,6 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 			lines = append(lines, &lineMatch{LineNumber: n})
 		}
 		return mkFileMatchResolver(db, FileMatch{
-			db:          db,
 			Path:        path,
 			LineMatches: lines,
 			Repo:        &types.RepoName{Name: "r"},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1039,7 +1039,6 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 					&FileMatchResolver{
 						db: db,
 						FileMatch: FileMatch{
-							db: db,
 							symbols: []*searchSymbolResult{
 								// 1
 								{db: db},
@@ -1060,7 +1059,6 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 					&FileMatchResolver{
 						db: db,
 						FileMatch: FileMatch{
-							db: db,
 							symbols: []*searchSymbolResult{
 								// 1
 								{db: db},
@@ -1153,7 +1151,6 @@ func TestCompareSearchResults(t *testing.T) {
 
 	makeResult := func(repo, file string) *FileMatchResolver {
 		return mkFileMatchResolver(db, FileMatch{
-			db:   db,
 			Repo: &types.RepoName{Name: api.RepoName(repo)},
 			Path: file,
 		})
@@ -1482,7 +1479,6 @@ func fileResult(db dbutil.DB, uri string, lineMatches []*lineMatch, symbolMatche
 	return &FileMatchResolver{
 		db: db,
 		FileMatch: FileMatch{
-			db:          db,
 			uri:         uri,
 			LineMatches: lineMatches,
 			symbols:     symbolMatches,

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -161,7 +161,6 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, db dbutil.DB, args *search.Te
 		matches[i] = &FileMatchResolver{
 			db: db,
 			FileMatch: FileMatch{
-				db:       db,
 				Path:     file.FileName,
 				LimitHit: fileLimitHit,
 				uri:      fileMatchURI(repoRev.Repo.Name, "", file.FileName),

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -222,7 +222,6 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 			fileMatch := &FileMatchResolver{
 				db: db,
 				FileMatch: FileMatch{
-					db:       db,
 					Path:     symbolRes.symbol.Path,
 					symbols:  []*searchSymbolResult{symbolRes},
 					uri:      uri,

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -241,7 +241,6 @@ func mkSymbolFileMatchResolvers(db dbutil.DB, symbols ...[]*searchSymbolResult) 
 	var resolvers []*FileMatchResolver
 	for _, s := range symbols {
 		resolvers = append(resolvers, mkFileMatchResolver(db, FileMatch{
-			db:      db,
 			symbols: s,
 		}))
 	}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -561,7 +561,6 @@ func mkFileMatch(db dbutil.DB, repo *types.RepoName, path string, lineNumbers ..
 		lines = append(lines, &lineMatch{LineNumber: n})
 	}
 	return mkFileMatchResolver(db, FileMatch{
-		db:          db,
 		uri:         fileMatchURI(repo.Name, "", path),
 		Path:        path,
 		LineMatches: lines,

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -36,7 +36,6 @@ const maxUnindexedRepoRevSearchesPerQuery = 200
 var textSearchLimiter = mutablelimiter.New(32)
 
 type FileMatch struct {
-	db          dbutil.DB
 	Path        string       `json:"Path"`
 	LineMatches []*lineMatch `json:"LineMatches"`
 	LimitHit    bool         `json:"LimitHit"`
@@ -280,7 +279,6 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 		resolvers = append(resolvers, &FileMatchResolver{
 			db: db,
 			FileMatch: FileMatch{
-				db:          db,
 				Path:        fm.Path,
 				LineMatches: lineMatches,
 				LimitHit:    fm.LimitHit,

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -39,12 +39,10 @@ func TestSearchFilesInRepos(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				db:  db,
 				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/two":
 			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				db:  db,
 				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/empty":
@@ -134,17 +132,14 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				db:  db,
 				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/two":
 			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				db:  db,
 				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/three":
 			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				db:  db,
 				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		default:
@@ -211,7 +206,6 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		switch repoName {
 		case "foo":
 			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				db:  db,
 				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		default:

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -385,7 +385,6 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 					fm := &FileMatchResolver{
 						db: db,
 						FileMatch: FileMatch{
-							db:          db,
 							Path:        file.FileName,
 							LineMatches: lines,
 							LimitHit:    fileLimitHit,


### PR DESCRIPTION
The database lives on the FileMatchResolver now, and is not used
anywhere else, so can be safely removed.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
