### PR TITLE
search: Remove JSON struct tags from matching fields

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -36,9 +36,9 @@ const maxUnindexedRepoRevSearchesPerQuery = 200
 var textSearchLimiter = mutablelimiter.New(32)
 
 type FileMatch struct {
-	Path        string       `json:"Path"`
-	LineMatches []*lineMatch `json:"LineMatches"`
-	LimitHit    bool         `json:"LimitHit"`
+	Path        string
+	LineMatches []*lineMatch
+	LimitHit    bool
 	symbols     []*searchSymbolResult
 	uri         string
 	Repo        *types.RepoName


### PR DESCRIPTION
Now that the struct fields don't start with J, the struct tags are
redundant.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
