### PR TITLE
streaming search: handle server side errors correctly

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -394,6 +394,26 @@ describe('Search', () => {
                 'sourcegraph/sourcegraph@test/branch › stream.ts',
             ])
         })
+
+        test('Streaming search with error', async () => {
+            const searchStreamEvents: SearchEvent[] = [
+                {
+                    type: 'error',
+                    data: { message: 'Search is invalid' },
+                },
+            ]
+
+            testContext.overrideGraphQL({ ...commonSearchGraphQLResults, ...viewerSettingsWithStreamingSearch })
+            testContext.overrideSearchStreamEvents(searchStreamEvents)
+
+            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
+            await driver.page.waitForSelector('[data-testid="search-results-list-error"]', { visible: true })
+
+            const results = await driver.page.evaluate(
+                () => document.querySelector('[data-testid="search-results-list-error"]')?.textContent
+            )
+            expect(results).toContain('Search is invalid')
+        })
     })
 
     describe('Search contexts', () => {

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -184,7 +184,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	resultsResolver, err := results()
 	if err != nil {
-		_ = eventWriter.Event("error", err.Error())
+		_ = eventWriter.Event("error", eventError{Message: err.Error()})
 		return
 	}
 
@@ -468,4 +468,10 @@ type eventAlert struct {
 type proposedQuery struct {
 	Description string `json:"description,omitempty"`
 	Query       string `json:"query"`
+}
+
+// eventError emulates a JavaScript error with a message property
+// as is returned when the search encounters an error.
+type eventError struct {
+	Message string `json:"message"`
 }


### PR DESCRIPTION
Fixes #18576. Server-side errors from streaming search are now being passed correctly as ErrorLike objects and parsed correctly on the client-side. Also added an integration test for streaming search with server-side errors.

![image](https://user-images.githubusercontent.com/206864/108900524-8fba5c00-75ce-11eb-92b7-c1c228bc9046.png)
