### PR TITLE
Add support for SSH credentials in reconciler and gitserver

### DIFF
--- a/cmd/gitserver/server/patch.go
+++ b/cmd/gitserver/server/patch.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,8 +16,6 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -267,7 +262,7 @@ func (s *Server) createCommitFromPatch(ctx context.Context, req protocol.CreateC
 			// it in the background.
 			// This is used to pass the private key to be used when pushing to the remote,
 			// without the need to store it on the disk.
-			agent, err := NewSSHAgent([]byte(req.Push.PrivateKey), []byte(req.Push.Passphrase))
+			agent, err := newSSHAgent([]byte(req.Push.PrivateKey), []byte(req.Push.Passphrase))
 			if err != nil {
 				resp.SetError(repo, "", "", errors.Wrap(err, "gitserver: error creating ssh-agent"))
 				return http.StatusInternalServerError, resp
@@ -317,107 +312,4 @@ func cleanUpTmpRepo(path string) {
 // Copied from git package to avoid cycle import when testing git package.
 func ensureRefPrefix(ref string) string {
 	return "refs/heads/" + strings.TrimPrefix(ref, "refs/heads/")
-}
-
-type SSHAgent struct {
-	l       net.Listener
-	sock    string
-	keyring agent.Agent
-}
-
-func NewSSHAgent(raw, passphrase []byte) (*SSHAgent, error) {
-	// This does error if the passphrase is invalid, so we get immediate
-	// feedback here if we screw up.
-	key, err := ssh.ParseRawPrivateKeyWithPassphrase(raw, passphrase)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing private key")
-	}
-
-	// The keyring type implements the agent.Agent interface we need to provide
-	// when serving an SSH agent. It also provides thread-safe storage for the
-	// keys we provide to it. No need to reinvent the wheel!
-	keyring := agent.NewKeyring()
-	err = keyring.Add(agent.AddedKey{
-		PrivateKey: key,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	socketName, err := generateSocketFilename()
-	if err != nil {
-		return nil, err
-	}
-
-	// Start listening.
-	l, err := net.Listen("unix", socketName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "listening on socket %q", socketName)
-	}
-
-	// Set up the type we're going to return.
-	a := &SSHAgent{
-		l:       l,
-		sock:    socketName,
-		keyring: keyring,
-	}
-	return a, nil
-}
-
-func (a *SSHAgent) Listen() {
-	for {
-		// This will return when we call l.Close(), which Agent.Close() does.
-		conn, err := a.l.Accept()
-		if err == io.EOF {
-			return
-		} else if err != nil {
-			log15.Error("error accepting socket connection", "err", err)
-			return
-		}
-
-		// We don't control how SSH handles the agent, so we should handle
-		// this "correctly" and spawn another goroutine, even though in
-		// practice there should only ever be one connection at a time to
-		// the agent.
-		go func(conn net.Conn) {
-			defer conn.Close()
-
-			if err := agent.ServeAgent(a.keyring, conn); err != nil && err != io.EOF {
-				log15.Error("error serving SSH agent", "err", err)
-			}
-		}(conn)
-	}
-}
-
-func (a *SSHAgent) Close() error {
-	// net.Listen() helpfully recreated the socket file for us, so we need to
-	// remove it again.
-	os.Remove(a.sock)
-
-	// Close down the listener, which terminates the loop in Listen().
-	return a.l.Close()
-}
-
-func (a *SSHAgent) Socket() string {
-	return a.sock
-}
-
-func generateSocketFilename() (string, error) {
-	// We need to set up a Unix socket. We need a temporary file.
-	f, err := ioutil.TempFile(os.TempDir(), "ssh-agent-*.sock")
-	if err != nil {
-		return "", errors.Wrap(err, "creating temporary socket")
-	}
-	name := f.Name()
-
-	// Unfortunately, the Unix socket can't exist when we call Listen, so
-	// there's a potential race condition here. I don't think it's too bad in
-	// practice.
-	if err := f.Close(); err != nil {
-		return "", errors.Wrap(err, "closing temporary socket")
-	}
-	if err := os.Remove(name); err != nil {
-		return "", errors.Wrap(err, "removing temporary socket")
-	}
-	return name, nil
 }

--- a/cmd/gitserver/server/ssh_agent.go
+++ b/cmd/gitserver/server/ssh_agent.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path"
+	"time"
+
+	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// sshAgent speaks the ssh-agent protocol and can be used by gitserver
+// to provide a private key to ssh when talking to the code host.
+type sshAgent struct {
+	l       net.Listener
+	sock    string
+	keyring agent.Agent
+	done    chan struct{}
+}
+
+// newSSHAgent takes a private key and it's passphrase and returns an `sshAgent`.
+func newSSHAgent(raw, passphrase []byte) (*sshAgent, error) {
+	// This does error if the passphrase is invalid, so we get immediate
+	// feedback here if we screw up.
+	key, err := ssh.ParseRawPrivateKeyWithPassphrase(raw, passphrase)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing private key")
+	}
+
+	// The keyring type implements the agent.Agent interface we need to provide
+	// when serving an SSH agent. It also provides thread-safe storage for the
+	// keys we provide to it. No need to reinvent the wheel!
+	keyring := agent.NewKeyring()
+	err = keyring.Add(agent.AddedKey{
+		PrivateKey: key,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Start listening.
+	socketName := generateSocketFilename()
+	l, err := net.ListenUnix("unix", &net.UnixAddr{Net: "unix", Name: socketName})
+	if err != nil {
+		return nil, errors.Wrapf(err, "listening on socket %q", socketName)
+	}
+	l.SetUnlinkOnClose(true)
+
+	// Set up the type we're going to return.
+	a := &sshAgent{
+		l:       l,
+		sock:    socketName,
+		keyring: keyring,
+		done:    make(chan struct{}),
+	}
+	return a, nil
+}
+
+// Listen starts accepting connections of the ssh agent.
+func (a *sshAgent) Listen() {
+	for {
+		// This will return when we call l.Close(), which Agent.Close() does.
+		conn, err := a.l.Accept()
+		if err == io.EOF {
+			return
+		} else if err != nil {
+			select {
+			case <-a.done:
+			default:
+				log15.Error("error accepting socket connection", "err", err)
+			}
+			return
+		}
+
+		// We don't control how SSH handles the agent, so we should handle
+		// this "correctly" and spawn another goroutine, even though in
+		// practice there should only ever be one connection at a time to
+		// the agent.
+		go func(conn net.Conn) {
+			defer conn.Close()
+
+			if err := agent.ServeAgent(a.keyring, conn); err != nil && err != io.EOF {
+				log15.Error("error serving SSH agent", "err", err)
+			}
+		}(conn)
+	}
+}
+
+// Close closes the server.
+func (a *sshAgent) Close() error {
+	close(a.done)
+
+	// Close down the listener, which terminates the loop in Listen().
+	return a.l.Close()
+}
+
+// Socket returns the path to the unix socket the ssh-agent server is
+// listening on.
+func (a *sshAgent) Socket() string {
+	return a.sock
+}
+
+var sshAgentSockID = atomic.NewInt64(0)
+
+func generateSocketFilename() string {
+	// We need to set up a Unix socket. We need a unique, temporary file.
+	return path.Join(os.TempDir(), fmt.Sprintf("ssh-agent-%d-%d.sock", time.Now().Unix(), sshAgentSockID.Inc()))
+}

--- a/cmd/gitserver/server/ssh_agent.go
+++ b/cmd/gitserver/server/ssh_agent.go
@@ -67,15 +67,14 @@ func (a *sshAgent) Listen() {
 	for {
 		// This will return when we call l.Close(), which Agent.Close() does.
 		conn, err := a.l.Accept()
-		if err == io.EOF {
-			return
-		} else if err != nil {
+		if err != nil {
 			select {
 			case <-a.done:
+				return
 			default:
 				log15.Error("error accepting socket connection", "err", err)
+				return
 			}
-			return
 		}
 
 		// We don't control how SSH handles the agent, so we should handle

--- a/cmd/gitserver/server/ssh_agent.go
+++ b/cmd/gitserver/server/ssh_agent.go
@@ -6,11 +6,11 @@ import (
 	"net"
 	"os"
 	"path"
+	"sync/atomic"
 	"time"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
-	"go.uber.org/atomic"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
@@ -105,9 +105,9 @@ func (a *sshAgent) Socket() string {
 	return a.sock
 }
 
-var sshAgentSockID = atomic.NewInt64(0)
+var sshAgentSockID int64 = 0
 
 func generateSocketFilename() string {
 	// We need to set up a Unix socket. We need a unique, temporary file.
-	return path.Join(os.TempDir(), fmt.Sprintf("ssh-agent-%d-%d.sock", time.Now().Unix(), sshAgentSockID.Inc()))
+	return path.Join(os.TempDir(), fmt.Sprintf("ssh-agent-%d-%d.sock", time.Now().Unix(), atomic.AddInt64(&sshAgentSockID, 1)))
 }

--- a/cmd/gitserver/server/ssh_agent_test.go
+++ b/cmd/gitserver/server/ssh_agent_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+)
+
+func TestSSHAgent(t *testing.T) {
+	// Generate a keypair to use for the client-server connection.
+	keypair, err := encryption.GenerateRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Spawn the agent using the keypair from above.
+	a, err := newSSHAgent([]byte(keypair.PrivateKey), []byte(keypair.Passphrase))
+	if err != nil {
+		t.Fatal(err)
+	}
+	go a.Listen()
+	defer a.Close()
+
+	// Spawn an ssh server which will accept the public key from the keypair.
+	authorizedKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(keypair.PublicKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverConfig := &ssh.ServerConfig{
+		PublicKeyCallback: func(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
+			// If the public keys match, grant access.
+			if string(pubKey.Marshal()) == string(authorizedKey.Marshal()) {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("unknown public key for %q", c.User())
+		},
+	}
+	serverKey, err := encryption.GenerateRSAKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	decryptedServerKey, err := ssh.ParsePrivateKeyWithPassphrase([]byte(serverKey.PrivateKey), []byte(serverKey.Passphrase))
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverConfig.AddHostKey(decryptedServerKey)
+	// Listen on a random available port.
+	serverListener, err := net.Listen("tcp", "127.0.0.1:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer serverListener.Close()
+	errs := make(chan error)
+	defer close(errs)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		netConn, err := serverListener.Accept()
+		if err != nil {
+			select {
+			case <-done:
+			default:
+				errs <- err
+			}
+			return
+		}
+		defer netConn.Close()
+		conn, chans, reqs, err := ssh.NewServerConn(netConn, serverConfig)
+		if err != nil {
+			errs <- err
+			return
+		}
+		defer conn.Close()
+		go ssh.DiscardRequests(reqs)
+		for newChannel := range chans {
+			// Accept and goodbye.
+			channel, _, err := newChannel.Accept()
+			if err != nil {
+				errs <- err
+				return
+			}
+			channel.Close()
+		}
+	}()
+
+	// Now try to connect to that server using the private key from the keypair.
+	agentConn, err := net.Dial("unix", a.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer agentConn.Close()
+	agentClient := agent.NewClient(agentConn)
+	clientConfig := &ssh.ClientConfig{
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth: []ssh.AuthMethod{ssh.PublicKeysCallback(func() (signers []ssh.Signer, err error) {
+			// Talk to the ssh-agent to get the signers.
+			return agentClient.Signers()
+		})},
+	}
+	client, err := ssh.Dial("tcp", serverListener.Addr().String(), clientConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	select {
+	// Check if the server errored.
+	case err := <-errs:
+		if err != nil {
+			t.Fatal(err)
+		}
+	default:
+		return
+	}
+}

--- a/enterprise/internal/campaigns/background/ssh_migrator.go
+++ b/enterprise/internal/campaigns/background/ssh_migrator.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 
-	cauth "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/auth"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -82,7 +82,7 @@ func (m *sshMigrator) Up(ctx context.Context) error {
 		switch a := cred.Credential.(type) {
 		case *auth.OAuthBearerToken:
 			newCred := &auth.OAuthBearerTokenWithSSH{OAuthBearerToken: *a}
-			keypair, err := cauth.GenerateRSAKey()
+			keypair, err := encryption.GenerateRSAKey()
 			if err != nil {
 				return err
 			}
@@ -95,7 +95,7 @@ func (m *sshMigrator) Up(ctx context.Context) error {
 			}
 		case *auth.BasicAuth:
 			newCred := &auth.BasicAuthWithSSH{BasicAuth: *a}
-			keypair, err := cauth.GenerateRSAKey()
+			keypair, err := encryption.GenerateRSAKey()
 			if err != nil {
 				return err
 			}

--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -559,6 +559,10 @@ func buildPushConfig(extSvcType, cloneURL string, a auth.Authenticator) (*protoc
 		if a == nil {
 			// This is OK: we'll just send no key and gitserver will use
 			// the keys installed locally.
+			// This path is only triggered when `loadAuthenticator` returns
+			// nil, which is only the case for site-admins currently.
+			// We want to revisit this once we start disabling usage of global
+			// credentials altogether in RFC312.
 			return &protocol.PushConfig{RemoteURL: cloneURL}, nil
 		}
 		sshA, ok := a.(auth.AuthenticatorWithSSH)
@@ -595,6 +599,10 @@ func buildPushConfig(extSvcType, cloneURL string, a auth.Authenticator) (*protoc
 	case nil:
 		// This is OK: we'll just send an empty token and gitserver will use
 		// the credential stored in the clone URL of the repository.
+		// This path is only triggered when `loadAuthenticator` returns
+		// nil, which is only the case for site-admins currently.
+		// We want to revisit this once we start disabling usage of global
+		// credentials altogether in RFC312.
 
 	default:
 		return nil, ErrNoPushCredentials{credentialsType: fmt.Sprintf("%T", a)}

--- a/enterprise/internal/campaigns/reconciler/executor.go
+++ b/enterprise/internal/campaigns/reconciler/executor.go
@@ -538,15 +538,15 @@ func buildCommitOpts(repo *types.Repo, extSvc *types.ExternalService, spec *camp
 	return opts, nil
 }
 
-// ErrNoSSHPush is returned by buildPushConfig if the clone URL of the
-// repository uses the ssh:// scheme, which is currently not supported by campaigns.
-type ErrNoSSHPush struct{}
+// ErrNoSSHCredential is returned by buildPushConfig if the clone URL of the
+// repository uses the ssh:// scheme, but the authenticator doesn't support SSH pushes.
+type ErrNoSSHCredential struct{}
 
-func (e ErrNoSSHPush) Error() string {
-	return "campaigns currently do not support pushing commits via SSH, only HTTP(s) is supported. See https://docs.sourcegraph.com/admin/repo/auth for information on which settings can cause SSH to be used."
+func (e ErrNoSSHCredential) Error() string {
+	return "The used credential doesn't support SSH pushes, but the repo requires pushing over SSH."
 }
 
-func (e ErrNoSSHPush) NonRetryable() bool { return true }
+func (e ErrNoSSHCredential) NonRetryable() bool { return true }
 
 func buildPushConfig(extSvcType, cloneURL string, a auth.Authenticator) (*protocol.PushConfig, error) {
 	u, err := url.Parse(cloneURL)
@@ -554,8 +554,23 @@ func buildPushConfig(extSvcType, cloneURL string, a auth.Authenticator) (*protoc
 		return nil, errors.Wrap(err, "parsing repository clone URL")
 	}
 
+	// If the repo is cloned using SSH, we need to pass along a private key and passphrase.
 	if u.Scheme == "ssh" {
-		return nil, ErrNoSSHPush{}
+		if a == nil {
+			// This is OK: we'll just send no key and gitserver will use
+			// the keys installed locally.
+			return &protocol.PushConfig{RemoteURL: cloneURL}, nil
+		}
+		sshA, ok := a.(auth.AuthenticatorWithSSH)
+		if !ok {
+			return nil, ErrNoSSHCredential{}
+		}
+		privateKey, passphrase := sshA.SSHPrivateKey()
+		return &protocol.PushConfig{
+			RemoteURL:  cloneURL,
+			PrivateKey: privateKey,
+			Passphrase: passphrase,
+		}, nil
 	}
 
 	switch av := a.(type) {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -12,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
-	cauth "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/auth"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/search"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/service"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
@@ -22,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -856,7 +856,7 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 		return nil, ErrDuplicateCredential{}
 	}
 
-	keypair, err := cauth.GenerateRSAKey()
+	keypair, err := encryption.GenerateRSAKey()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/encryption/rsa.go
+++ b/internal/encryption/rsa.go
@@ -1,4 +1,4 @@
-package auth
+package encryption
 
 import (
 	"crypto/rand"

--- a/internal/encryption/rsa_test.go
+++ b/internal/encryption/rsa_test.go
@@ -1,4 +1,4 @@
-package auth
+package encryption
 
 import (
 	"crypto/x509"

--- a/internal/gitserver/protocol/gitserver.go
+++ b/internal/gitserver/protocol/gitserver.go
@@ -204,6 +204,15 @@ type PushConfig struct {
 	// The URL needs to include HTTP basic auth credentials if no
 	// unauthenticated requests are allowed by the remote host.
 	RemoteURL string
+
+	// PrivateKey is used when the remote URL uses scheme `ssh`. If set,
+	// this value is used as the content of the private key. Needs to be
+	// set in conjunction with a passphrase.
+	PrivateKey string
+
+	// Passphrase is the passphrase to decrypt the private key. It is required
+	// when passing PrivateKey.
+	Passphrase string
 }
 
 // CreateCommitFromPatchResponse is the response type returned after creating


### PR DESCRIPTION
This is part 2 of campaigns SSH support, adding support in gitserver for private keys and not bailing out in the reconciler when an ssh credential is encountered.

Huge thanks to @LawnGnome for coming up with the idea to use an ssh-agent running in go, and the PoC code for it!

Closes https://github.com/sourcegraph/sourcegraph/issues/16895