### PR TITLE
Rate limit fails on nested named fragments

### DIFF
--- a/cmd/frontend/graphqlbackend/rate_limit_test.go
+++ b/cmd/frontend/graphqlbackend/rate_limit_test.go
@@ -176,6 +176,25 @@ query{
 			},
 		},
 		{
+			name: "Nested named fragments",
+			query: `
+query{
+    __typename
+	...FooFields
+}
+fragment FooFields on Foo {
+	...BarFields
+}
+fragment BarFields on Bar {
+	one
+}
+`,
+			want: QueryCost{
+				FieldCount: 2,
+				MaxDepth:   2,
+			},
+		},
+		{
 			name: "Search query",
 			query: `
 query Search($query: String!, $version: SearchVersion!, $patternType: SearchPatternType!, $versionContext: String) {


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
