### PR TITLE
Don't use global dbconn in campaigns tests

### DIFF
--- a/enterprise/internal/campaigns/reconciler/reconciler_test.go
+++ b/enterprise/internal/campaigns/reconciler/reconciler_test.go
@@ -10,7 +10,6 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -23,13 +22,13 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	store := store.New(dbconn.Global)
+	store := store.New(db)
 
-	admin := ct.CreateTestUser(t, true)
+	admin := ct.CreateTestUser(t, db, true)
 
-	rs, extSvc := ct.CreateTestRepos(t, ctx, dbconn.Global, 1)
+	rs, extSvc := ct.CreateTestRepos(t, ctx, db, 1)
 
 	state := ct.MockChangesetSyncState(&protocol.RepoInfo{
 		Name: rs[0].Name,
@@ -159,6 +158,6 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 		})
 
 		// Clean up database.
-		ct.TruncateTables(t, dbconn.Global, "changeset_events", "changesets", "campaigns", "campaign_specs", "changeset_specs")
+		ct.TruncateTables(t, db, "changeset_events", "changesets", "campaigns", "campaign_specs", "changeset_specs")
 	}
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
@@ -26,11 +25,11 @@ func TestCampaignConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
 
@@ -77,7 +76,7 @@ func TestCampaignConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,17 +177,17 @@ func TestCampaignsListing(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
-	orgID := ct.InsertTestOrg(t, "org")
+	orgID := ct.InsertTestOrg(t, db, "org")
 
-	store := store.New(dbconn.Global)
+	store := store.New(db)
 
 	r := &Resolver{store: store}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
@@ -28,9 +27,9 @@ func TestCampaignSpecResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
 
@@ -41,9 +40,9 @@ func TestCampaignSpecResolver(t *testing.T) {
 	repoID := graphqlbackend.MarshalRepositoryID(repo.ID)
 
 	orgname := "test-org"
-	userID := ct.CreateTestUser(t, false).ID
-	adminID := ct.CreateTestUser(t, true).ID
-	orgID := ct.InsertTestOrg(t, orgname)
+	userID := ct.CreateTestUser(t, db, false).ID
+	adminID := ct.CreateTestUser(t, db, true).ID
+	orgID := ct.InsertTestOrg(t, db, orgname)
 
 	spec, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawCampaignSpec)
 	if err != nil {
@@ -79,7 +78,7 @@ func TestCampaignSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_test.go
@@ -15,7 +15,6 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
@@ -26,15 +25,15 @@ func TestCampaignResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 	orgName := "test-campaign-resolver-org"
-	orgID := ct.InsertTestOrg(t, orgName)
+	orgID := ct.InsertTestOrg(t, db, orgName)
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	cstore := store.NewWithClock(dbconn.Global, clock)
+	cstore := store.NewWithClock(db, clock)
 
 	campaignSpec := &campaigns.CampaignSpec{
 		RawSpec:        ct.TestRawCampaignSpec,
@@ -58,7 +57,7 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
@@ -16,7 +16,6 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -27,11 +26,11 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, false).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	campaignSpec := &campaigns.CampaignSpec{
 		UserID:          userID,
@@ -72,7 +71,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
@@ -14,7 +14,6 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -25,11 +24,11 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, false).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	// Create a campaign spec for the target campaign.
 	oldCampaignSpec := &campaigns.CampaignSpec{
@@ -98,7 +97,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 		OwnedByCampaign:  campaign.ID,
 	})
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event_connection_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -28,13 +27,13 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	cstore := store.NewWithClock(dbconn.Global, clock)
+	cstore := store.NewWithClock(db, clock)
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
 
@@ -96,7 +95,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 
 	addChangeset(t, ctx, cstore, changeset, campaign.ID)
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -14,7 +14,6 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -25,11 +24,11 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, false).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	campaignSpec := &campaigns.CampaignSpec{
 		UserID:          userID,
@@ -70,7 +69,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		changesetSpecs = append(changesetSpecs, s)
 	}
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -26,11 +25,11 @@ func TestChangesetSpecResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, false).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 	esStore := database.ExternalServicesWith(cstore)
 
 	// Creating user with matching email to the changeset spec author.
@@ -63,7 +62,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
@@ -15,7 +15,6 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -31,15 +30,15 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 
 	pruneUserCredentials(t, db)
 
-	userID := ct.CreateTestUser(t, false).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
-	ghRepos, _ := ct.CreateTestRepos(t, ctx, dbconn.Global, 1)
+	ghRepos, _ := ct.CreateTestRepos(t, ctx, db, 1)
 	ghRepo := ghRepos[0]
-	glRepos, _ := ct.CreateGitlabTestRepos(t, ctx, dbconn.Global, 1)
+	glRepos, _ := ct.CreateGitlabTestRepos(t, ctx, db, 1)
 	glRepo := glRepos[0]
-	bbsRepos, _ := ct.CreateBbsTestRepos(t, ctx, dbconn.Global, 1)
+	bbsRepos, _ := ct.CreateBbsTestRepos(t, ctx, db, 1)
 	bbsRepo := bbsRepos[0]
 
 	cred, err := cstore.UserCredentials().Create(ctx, database.UserCredentialScope{
@@ -52,7 +51,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, &Resolver{store: cstore}, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -36,9 +35,9 @@ func TestPermissionLevels(t *testing.T) {
 
 	db := dbtesting.GetDB(t)
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 	sr := New(cstore)
-	s, err := graphqlbackend.NewSchema(dbconn.Global, sr, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,8 +51,8 @@ func TestPermissionLevels(t *testing.T) {
 	ctx := context.Background()
 
 	// Global test data that we reuse in every test
-	adminID := ct.CreateTestUser(t, true).ID
-	userID := ct.CreateTestUser(t, false).ID
+	adminID := ct.CreateTestUser(t, db, true).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
@@ -760,11 +759,11 @@ func TestRepositoryPermissions(t *testing.T) {
 		t.Skip()
 	}
 
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 	sr := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, sr, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +774,7 @@ func TestRepositoryPermissions(t *testing.T) {
 	mockBackendCommits(t, testRev)
 
 	// Global test data that we reuse in every test
-	userID := ct.CreateTestUser(t, false).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
@@ -873,7 +872,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// Now we set permissions and filter out the repository of one changeset
 		filteredRepo := changesets[0].RepoID
 		accessibleRepo := changesets[1].RepoID
-		ct.MockRepoPermissions(t, userID, accessibleRepo)
+		ct.MockRepoPermissions(t, db, userID, accessibleRepo)
 
 		// Send query again and check that for each filtered repository we get a
 		// HiddenChangeset
@@ -972,7 +971,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		// Now we set permissions and filter out the repository of one changeset
 		filteredRepo := changesetSpecs[0].RepoID
 		accessibleRepo := changesetSpecs[1].RepoID
-		ct.MockRepoPermissions(t, userID, accessibleRepo)
+		ct.MockRepoPermissions(t, db, userID, accessibleRepo)
 
 		// Send query again and check that for each filtered repository we get a
 		// HiddenChangesetSpec.

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -32,9 +31,10 @@ import (
 )
 
 func TestNullIDResilience(t *testing.T) {
-	sr := &Resolver{store: store.New(dbconn.Global)}
+	db := dbtesting.GetDB(t)
+	sr := New(store.New(db))
 
-	s, err := graphqlbackend.NewSchema(dbconn.Global, sr, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,12 +90,12 @@ func TestCreateCampaignSpec(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	user := ct.CreateTestUser(t, true)
+	user := ct.CreateTestUser(t, db, true)
 	userID := user.ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
 
@@ -120,7 +120,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,11 +264,11 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
 
@@ -278,7 +278,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -337,13 +337,13 @@ func TestApplyCampaign(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
-	cstore := store.NewWithClock(dbconn.Global, clock)
+	cstore := store.NewWithClock(db, clock)
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
 
@@ -389,7 +389,7 @@ func TestApplyCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -494,11 +494,11 @@ func TestCreateCampaign(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	campaignSpec := &campaigns.CampaignSpec{
 		RawSpec: ct.TestRawCampaignSpec,
@@ -514,7 +514,7 @@ func TestCreateCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -556,15 +556,15 @@ func TestMoveCampaign(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	user := ct.CreateTestUser(t, true)
+	user := ct.CreateTestUser(t, db, true)
 	userID := user.ID
 
 	orgName := "move-campaign-test"
-	orgID := ct.InsertTestOrg(t, orgName)
+	orgID := ct.InsertTestOrg(t, db, orgName)
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	campaignSpec := &campaigns.CampaignSpec{
 		RawSpec:         ct.TestRawCampaignSpec,
@@ -588,7 +588,7 @@ func TestMoveCampaign(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -800,12 +800,12 @@ func TestCreateCampaignsCredential(t *testing.T) {
 
 	pruneUserCredentials(t, db)
 
-	userID := ct.CreateTestUser(t, false).ID
+	userID := ct.CreateTestUser(t, db, false).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -854,9 +854,9 @@ func TestDeleteCampaignsCredential(t *testing.T) {
 
 	pruneUserCredentials(t, db)
 
-	userID := ct.CreateTestUser(t, true).ID
+	userID := ct.CreateTestUser(t, db, true).ID
 
-	cstore := store.New(dbconn.Global)
+	cstore := store.New(db)
 
 	cred, err := cstore.UserCredentials().Create(ctx, database.UserCredentialScope{
 		Domain:              database.UserCredentialDomainCampaigns,
@@ -869,7 +869,7 @@ func TestDeleteCampaignsCredential(t *testing.T) {
 	}
 
 	r := &Resolver{store: cstore}
-	s, err := graphqlbackend.NewSchema(dbconn.Global, r, nil, nil, nil, nil, nil)
+	s, err := graphqlbackend.NewSchema(db, r, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -33,16 +32,16 @@ func TestServicePermissionLevels(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	s := store.New(dbconn.Global)
+	s := store.New(db)
 	svc := New(s)
 
-	admin := ct.CreateTestUser(t, true)
-	user := ct.CreateTestUser(t, false)
-	otherUser := ct.CreateTestUser(t, false)
+	admin := ct.CreateTestUser(t, db, true)
+	user := ct.CreateTestUser(t, db, false)
+	otherUser := ct.CreateTestUser(t, db, false)
 
-	rs, _ := ct.CreateTestRepos(t, ctx, dbconn.Global, 1)
+	rs, _ := ct.CreateTestRepos(t, ctx, db, 1)
 
 	createTestData := func(t *testing.T, s *store.Store, svc *Service, author int32) (*campaigns.Campaign, *campaigns.Changeset, *campaigns.CampaignSpec) {
 		spec := testCampaignSpec(author)
@@ -172,14 +171,14 @@ func TestService(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	db := dbtesting.GetDB(t)
 
-	admin := ct.CreateTestUser(t, true)
-	user := ct.CreateTestUser(t, false)
+	admin := ct.CreateTestUser(t, db, true)
+	user := ct.CreateTestUser(t, db, false)
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
 
-	s := store.NewWithClock(dbconn.Global, clock)
-	rs, _ := ct.CreateTestRepos(t, ctx, dbconn.Global, 4)
+	s := store.NewWithClock(db, clock)
+	rs, _ := ct.CreateTestRepos(t, ctx, db, 4)
 
 	fakeSource := &ct.FakeChangesetSource{}
 	sourcer := repos.NewFakeSourcer(nil, fakeSource)
@@ -316,7 +315,7 @@ func TestService(t *testing.T) {
 		}
 
 		// rs[0] is filtered out
-		ct.MockRepoPermissions(t, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
+		ct.MockRepoPermissions(t, db, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
 
 		// should result in a not found error
 		if err := svc.EnqueueChangesetSync(ctx, changeset.ID); !errcode.IsNotFound(err) {
@@ -360,7 +359,7 @@ func TestService(t *testing.T) {
 		})
 
 		// rs[0] is filtered out
-		ct.MockRepoPermissions(t, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
+		ct.MockRepoPermissions(t, db, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
 
 		// should result in a not found error
 		if _, _, err := svc.ReenqueueChangeset(ctx, changeset.ID); !errcode.IsNotFound(err) {
@@ -450,7 +449,7 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("missing repository permissions", func(t *testing.T) {
-			ct.MockRepoPermissions(t, user.ID)
+			ct.MockRepoPermissions(t, db, user.ID)
 
 			opts := CreateCampaignSpecOpts{
 				NamespaceUserID:      user.ID,
@@ -501,7 +500,7 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("missing access to namespace org", func(t *testing.T) {
-			orgID := ct.InsertTestOrg(t, "test-org")
+			orgID := ct.InsertTestOrg(t, db, "test-org")
 
 			opts := CreateCampaignSpecOpts{
 				NamespaceOrgID:       orgID,
@@ -597,7 +596,7 @@ func TestService(t *testing.T) {
 		})
 
 		t.Run("missing repository permissions", func(t *testing.T) {
-			ct.MockRepoPermissions(t, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
+			ct.MockRepoPermissions(t, db, user.ID, rs[1].ID, rs[2].ID, rs[3].ID)
 
 			_, err := svc.CreateChangesetSpec(ctx, rawSpec, admin.ID)
 			if !errcode.IsNotFound(err) {
@@ -658,7 +657,7 @@ func TestService(t *testing.T) {
 		t.Run("new user namespace", func(t *testing.T) {
 			campaign := createCampaign(t, "old-name", admin.ID, admin.ID, 0)
 
-			user2 := ct.CreateTestUser(t, false)
+			user2 := ct.CreateTestUser(t, db, false)
 
 			opts := MoveCampaignOpts{CampaignID: campaign.ID, NewNamespaceUserID: user2.ID}
 			moved, err := svc.MoveCampaign(ctx, opts)
@@ -678,7 +677,7 @@ func TestService(t *testing.T) {
 		t.Run("new user namespace but current user is not admin", func(t *testing.T) {
 			campaign := createCampaign(t, "old-name", user.ID, user.ID, 0)
 
-			user2 := ct.CreateTestUser(t, false)
+			user2 := ct.CreateTestUser(t, db, false)
 
 			opts := MoveCampaignOpts{CampaignID: campaign.ID, NewNamespaceUserID: user2.ID}
 
@@ -692,7 +691,7 @@ func TestService(t *testing.T) {
 		t.Run("new org namespace", func(t *testing.T) {
 			campaign := createCampaign(t, "old-name", admin.ID, admin.ID, 0)
 
-			orgID := ct.InsertTestOrg(t, "org")
+			orgID := ct.InsertTestOrg(t, db, "org")
 
 			opts := MoveCampaignOpts{CampaignID: campaign.ID, NewNamespaceOrgID: orgID}
 			moved, err := svc.MoveCampaign(ctx, opts)
@@ -712,7 +711,7 @@ func TestService(t *testing.T) {
 		t.Run("new org namespace but current user is missing access", func(t *testing.T) {
 			campaign := createCampaign(t, "old-name", user.ID, user.ID, 0)
 
-			orgID := ct.InsertTestOrg(t, "org-no-access")
+			orgID := ct.InsertTestOrg(t, db, "org-no-access")
 
 			opts := MoveCampaignOpts{CampaignID: campaign.ID, NewNamespaceOrgID: orgID}
 
@@ -803,7 +802,7 @@ func TestService(t *testing.T) {
 		testSvc := New(s)
 		testSvc.sourcer = sourcer
 
-		rs, _ := ct.CreateBbsTestRepos(t, ctx, dbconn.Global, 1)
+		rs, _ := ct.CreateBbsTestRepos(t, ctx, db, 1)
 		repo := rs[0]
 
 		url := repo.ExternalRepo.ServiceID

--- a/enterprise/internal/campaigns/store/campaigns_test.go
+++ b/enterprise/internal/campaigns/store/campaigns_test.go
@@ -466,7 +466,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 	})
 
 	t.Run("GetCampaignDiffStat", func(t *testing.T) {
-		userID := ct.CreateTestUser(t, false).ID
+		userID := ct.CreateTestUser(t, s.DB(), false).ID
 		userCtx := actor.WithActor(ctx, actor.FromUser(userID))
 		repoStore := database.ReposWith(s)
 		esStore := database.ExternalServicesWith(s)
@@ -504,7 +504,7 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 		}
 
 		// Now revoke repo access, and check that we don't see it in the diff stat anymore.
-		ct.MockRepoPermissions(t, 0, repo.ID)
+		ct.MockRepoPermissions(t, s.DB(), 0, repo.ID)
 		{
 			want := &diff.Stat{
 				Added:   0,
@@ -543,8 +543,8 @@ func testStoreCampaigns(t *testing.T, ctx context.Context, s *Store, clock ct.Cl
 }
 
 func testUserDeleteCascades(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
-	orgID := ct.InsertTestOrg(t, "user-delete-cascades")
-	user := ct.CreateTestUser(t, false)
+	orgID := ct.InsertTestOrg(t, s.DB(), "user-delete-cascades")
+	user := ct.CreateTestUser(t, s.DB(), false)
 
 	t.Run("User delete", func(t *testing.T) {
 		// Set up two campaigns and specs: one in the user's namespace (which

--- a/enterprise/internal/campaigns/store/changeset_specs_test.go
+++ b/enterprise/internal/campaigns/store/changeset_specs_test.go
@@ -486,7 +486,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 
 	t.Run("GetRewirerMappings", func(t *testing.T) {
 		// Create some test data
-		user := ct.CreateTestUser(t, true)
+		user := ct.CreateTestUser(t, s.DB(), true)
 		campaignSpec := ct.CreateCampaignSpec(t, ctx, s, "get-rewirer-mappings", user.ID)
 		var mappings RewirerMappings = make(RewirerMappings, 3)
 		changesetSpecIDs := make([]int64, 0, cap(mappings))
@@ -690,7 +690,7 @@ func testStoreChangesetSpecsCurrentState(t *testing.T, ctx context.Context, s *S
 	}
 
 	// Create a user.
-	user := ct.CreateTestUser(t, false)
+	user := ct.CreateTestUser(t, s.DB(), false)
 
 	// Next, we need old and new campaign specs.
 	oldCampaignSpec := ct.CreateCampaignSpec(t, ctx, s, "old", user.ID)
@@ -784,7 +784,7 @@ func testStoreChangesetSpecsCurrentStateAndTextSearch(t *testing.T, ctx context.
 	}
 
 	// Create a user.
-	user := ct.CreateTestUser(t, false)
+	user := ct.CreateTestUser(t, s.DB(), false)
 
 	// Next, we need old and new campaign specs.
 	oldCampaignSpec := ct.CreateCampaignSpec(t, ctx, s, "old", user.ID)
@@ -949,7 +949,7 @@ func testStoreChangesetSpecsTextSearch(t *testing.T, ctx context.Context, s *Sto
 	}
 
 	// Create a user.
-	user := ct.CreateTestUser(t, false)
+	user := ct.CreateTestUser(t, s.DB(), false)
 
 	// Next, we need a campaign spec.
 	oldCampaignSpec := ct.CreateCampaignSpec(t, ctx, s, "text", user.ID)

--- a/enterprise/internal/campaigns/store/integration_test.go
+++ b/enterprise/internal/campaigns/store/integration_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
@@ -14,20 +13,20 @@ func TestIntegration(t *testing.T) {
 
 	t.Parallel()
 
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
 	t.Run("Store", func(t *testing.T) {
-		t.Run("Campaigns", storeTest(dbconn.Global, testStoreCampaigns))
-		t.Run("Changesets", storeTest(dbconn.Global, testStoreChangesets))
-		t.Run("ChangesetEvents", storeTest(dbconn.Global, testStoreChangesetEvents))
-		t.Run("ListChangesetSyncData", storeTest(dbconn.Global, testStoreListChangesetSyncData))
-		t.Run("ListChangesetsTextSearch", storeTest(dbconn.Global, testStoreListChangesetsTextSearch))
-		t.Run("CampaignSpecs", storeTest(dbconn.Global, testStoreCampaignSpecs))
-		t.Run("ChangesetSpecs", storeTest(dbconn.Global, testStoreChangesetSpecs))
-		t.Run("ChangesetSpecsCurrentState", storeTest(dbconn.Global, testStoreChangesetSpecsCurrentState))
-		t.Run("ChangesetSpecsCurrentStateAndTextSearch", storeTest(dbconn.Global, testStoreChangesetSpecsCurrentStateAndTextSearch))
-		t.Run("ChangesetSpecsTextSearch", storeTest(dbconn.Global, testStoreChangesetSpecsTextSearch))
-		t.Run("CodeHosts", storeTest(dbconn.Global, testStoreCodeHost))
-		t.Run("UserDeleteCascades", storeTest(dbconn.Global, testUserDeleteCascades))
+		t.Run("Campaigns", storeTest(db, testStoreCampaigns))
+		t.Run("Changesets", storeTest(db, testStoreChangesets))
+		t.Run("ChangesetEvents", storeTest(db, testStoreChangesetEvents))
+		t.Run("ListChangesetSyncData", storeTest(db, testStoreListChangesetSyncData))
+		t.Run("ListChangesetsTextSearch", storeTest(db, testStoreListChangesetsTextSearch))
+		t.Run("CampaignSpecs", storeTest(db, testStoreCampaignSpecs))
+		t.Run("ChangesetSpecs", storeTest(db, testStoreChangesetSpecs))
+		t.Run("ChangesetSpecsCurrentState", storeTest(db, testStoreChangesetSpecsCurrentState))
+		t.Run("ChangesetSpecsCurrentStateAndTextSearch", storeTest(db, testStoreChangesetSpecsCurrentStateAndTextSearch))
+		t.Run("ChangesetSpecsTextSearch", storeTest(db, testStoreChangesetSpecsTextSearch))
+		t.Run("CodeHosts", storeTest(db, testStoreCodeHost))
+		t.Run("UserDeleteCascades", storeTest(db, testUserDeleteCascades))
 	})
 }

--- a/enterprise/internal/campaigns/testing/mock_repo_perms.go
+++ b/enterprise/internal/campaigns/testing/mock_repo_perms.go
@@ -10,15 +10,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
 // MockRepoPermissions mocks repository permissions to include
 // repositories by IDs for the given user.
-func MockRepoPermissions(t *testing.T, userID int32, repoIDs ...api.RepoID) {
+func MockRepoPermissions(t *testing.T, db dbutil.DB, userID int32, repoIDs ...api.RepoID) {
 	t.Helper()
 
-	permsStore := database.Perms(dbconn.Global, time.Now)
+	permsStore := database.Perms(db, time.Now)
 
 	userIDs := roaring.New()
 	userIDs.Add(uint32(userID))

--- a/enterprise/internal/campaigns/testing/org.go
+++ b/enterprise/internal/campaigns/testing/org.go
@@ -1,17 +1,19 @@
 package testing
 
 import (
+	"context"
 	"testing"
 
 	"github.com/keegancsmith/sqlf"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
-func InsertTestOrg(t *testing.T, name string) (orgID int32) {
+func InsertTestOrg(t *testing.T, db dbutil.DB, name string) (orgID int32) {
 	t.Helper()
 
 	q := sqlf.Sprintf("INSERT INTO orgs (name) VALUES (%s) RETURNING id", name)
-	err := dbconn.Global.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&orgID)
+	err := db.QueryRowContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&orgID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/testing/user.go
+++ b/enterprise/internal/campaigns/testing/user.go
@@ -1,24 +1,25 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-var CreateTestUser = func() func(*testing.T, bool) *types.User {
+var CreateTestUser = func() func(*testing.T, dbutil.DB, bool) *types.User {
 	var mu sync.Mutex
 	count := 0
 
 	// This function replicates the minium amount of work required by
 	// database.Users.Create to create a new user, but it doesn't require passing in
 	// a full database.NewUser every time.
-	return func(t *testing.T, siteAdmin bool) *types.User {
+	return func(t *testing.T, db dbutil.DB, siteAdmin bool) *types.User {
 		t.Helper()
 
 		mu.Lock()
@@ -32,7 +33,7 @@ var CreateTestUser = func() func(*testing.T, bool) *types.User {
 		}
 
 		q := sqlf.Sprintf("INSERT INTO users (username, site_admin) VALUES (%s, %t) RETURNING id, site_admin", user.Username, siteAdmin)
-		err := dbconn.Global.QueryRow(q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&user.ID, &user.SiteAdmin)
+		err := db.QueryRowContext(context.Background(), q.Query(sqlf.PostgresBindVar), q.Args()...).Scan(&user.ID, &user.SiteAdmin)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -41,7 +42,7 @@ var CreateTestUser = func() func(*testing.T, bool) *types.User {
 			t.Fatalf("user.SiteAdmin=%t, but expected is %t", user.SiteAdmin, siteAdmin)
 		}
 
-		_, err = dbconn.Global.Exec("INSERT INTO names(name, user_id) VALUES($1, $2)", user.Username, user.ID)
+		_, err = db.ExecContext(context.Background(), "INSERT INTO names(name, user_id) VALUES($1, $2)", user.Username, user.ID)
 		if err != nil {
 			t.Fatalf("failed to create name: %s", err)
 		}

--- a/enterprise/internal/campaigns/webhooks/webhooks_integration_test.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks_integration_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
@@ -15,11 +14,11 @@ func TestWebhooksIntegration(t *testing.T) {
 
 	t.Parallel()
 
-	dbtesting.SetupGlobalTestDB(t)
+	db := dbtesting.GetDB(t)
 
-	user := ct.CreateTestUser(t, false)
+	user := ct.CreateTestUser(t, db, false)
 
-	t.Run("GitHubWebhook", testGitHubWebhook(dbconn.Global, user.ID))
-	t.Run("BitbucketWebhook", testBitbucketWebhook(dbconn.Global, user.ID))
-	t.Run("GitLabWebhook", testGitLabWebhook(dbconn.Global, user.ID))
+	t.Run("GitHubWebhook", testGitHubWebhook(db, user.ID))
+	t.Run("BitbucketWebhook", testBitbucketWebhook(db, user.ID))
+	t.Run("GitLabWebhook", testGitLabWebhook(db, user.ID))
 }


### PR DESCRIPTION
The very last instances of global db state in the campaigns code 👋 