### PR TITLE
search: Use symbolResolver rather than searchSymbolResult in suggestions

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -84,7 +84,7 @@ func TestResolverTo(t *testing.T) {
 		&RepositoryResolver{db: db},
 		&CommitSearchResultResolver{},
 		&gitRevSpec{},
-		&searchSuggestionResolver{db: db},
+		&searchSuggestionResolver{},
 		&settingsSubject{},
 		&statusMessageResolver{db: db},
 		&versionContextResolver{},

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -531,7 +531,6 @@ func (e *badRequestError) Cause() error {
 
 // searchSuggestionResolver is a resolver for the GraphQL union type `SearchSuggestion`
 type searchSuggestionResolver struct {
-	db dbutil.DB
 	// result is either a RepositoryResolver or a GitTreeEntryResolver
 	result interface{}
 	// score defines how well this item matches the query for sorting purposes
@@ -563,11 +562,8 @@ func (r *searchSuggestionResolver) ToGitTree() (*GitTreeEntryResolver, bool) {
 }
 
 func (r *searchSuggestionResolver) ToSymbol() (*symbolResolver, bool) {
-	s, ok := r.result.(*searchSymbolResult)
-	if !ok {
-		return nil, false
-	}
-	return toSymbolResolver(r.db, s.symbol, s.baseURI, s.lang, s.commit), true
+	s, ok := r.result.(*symbolResolver)
+	return s, ok
 }
 
 func (r *searchSuggestionResolver) ToLanguage() (*languageResolver, bool) {
@@ -583,16 +579,16 @@ func (r *searchSuggestionResolver) ToLanguage() (*languageResolver, bool) {
 func newSearchSuggestionResolver(result interface{}, score int) *searchSuggestionResolver {
 	switch r := result.(type) {
 	case *RepositoryResolver:
-		return &searchSuggestionResolver{db: r.db, result: r, score: score, length: len(r.Name()), label: r.Name()}
+		return &searchSuggestionResolver{result: r, score: score, length: len(r.Name()), label: r.Name()}
 
 	case *GitTreeEntryResolver:
-		return &searchSuggestionResolver{db: r.db, result: r, score: score, length: len(r.Path()), label: r.Path()}
+		return &searchSuggestionResolver{result: r, score: score, length: len(r.Path()), label: r.Path()}
 
-	case *searchSymbolResult:
-		return &searchSuggestionResolver{db: r.db, result: r, score: score, length: len(r.symbol.Name + " " + r.symbol.Parent), label: r.symbol.Name + " " + r.symbol.Parent}
+	case *symbolResolver:
+		return &searchSuggestionResolver{result: r, score: score, length: len(r.symbol.Name + " " + r.symbol.Parent), label: r.symbol.Name + " " + r.symbol.Parent}
 
 	case *languageResolver:
-		return &searchSuggestionResolver{db: r.db, result: r, score: score, length: len(r.Name()), label: r.Name()}
+		return &searchSuggestionResolver{result: r, score: score, length: len(r.Name()), label: r.Name()}
 
 	default:
 		panic("never here")

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-lsp"
 
+	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -350,6 +351,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		file     string
 		symbol   string
 		lang     string
+		uri      *gituri.URI
 	}
 	seen := make(map[key]struct{}, len(allSuggestions))
 	uniqueSuggestions := allSuggestions[:0]
@@ -370,8 +372,8 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			// (that do specify a commit ID), because their key k (i.e., k in seen[k]) will not
 			// equal.
 			k.file = s.Path()
-		case *searchSymbolResult:
-			k.repoName = api.RepoName(s.commit.Repository().Name())
+		case *symbolResolver:
+			k.uri = s.uri
 			k.symbol = s.symbol.Name + s.symbol.Parent
 		case *languageResolver:
 			k.lang = s.name

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -14,12 +14,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-lsp"
 
-	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -254,7 +254,8 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 				if len(sr.symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.uri().String()), strings.ToLower(sr.symbol.Name)) {
 					score++
 				}
-				results = append(results, newSearchSuggestionResolver(sr, score))
+				symbolResolver := toSymbolResolver(r.db, sr.symbol, sr.baseURI, sr.lang, sr.commit)
+				results = append(results, newSearchSuggestionResolver(symbolResolver, score))
 			}
 		}
 


### PR DESCRIPTION
We were previously using searchSymbolResults when creating suggestion
resolvers, which required that we also saved a reference to a database
so we could convert it to a symbolResolver. However, there's no reason
we can't just create the suggestion resolver from a symbolResolver
instead, allowing us to skip saving a database on the suggestion
resolver type.

Additionally, this will make it easier to remove the database from `searchSymbolResult`

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
