### PR TITLE
search: lower structural search result count for streaming

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -125,6 +125,10 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	if args.Stream != nil {
 		defaultLimit = defaultMaxSearchResultsStreaming
 	}
+	if searchType == query.SearchTypeStructural {
+		// Set a lower max result count until structural search supports true streaming.
+		defaultLimit = defaultMaxSearchResults
+	}
 
 	if sp, _ := q.StringValue(query.FieldSelect); sp != "" && args.Stream != nil {
 		// Invariant: error already checked


### PR DESCRIPTION
#17994 changed the max result count from 30 to 500 for all searches. Structural search doesn't speed up commensurately until we can also stream Zoekt results to `comby`, so for quicker time-to-first-result I'd like to lower this back to 30 for structural search.