### PR TITLE
search: Untangle symbol results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1041,9 +1041,9 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 						FileMatch: FileMatch{
 							symbols: []*searchSymbolResult{
 								// 1
-								{db: db},
+								{},
 								// 2
-								{db: db},
+								{},
 							},
 						},
 					},
@@ -1061,9 +1061,9 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 						FileMatch: FileMatch{
 							symbols: []*searchSymbolResult{
 								// 1
-								{db: db},
+								{},
 								// 2
-								{db: db},
+								{},
 							},
 						},
 					},
@@ -1613,16 +1613,16 @@ func TestUnionMerge(t *testing.T) {
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
 					fileResult(db, "a", nil, []*searchSymbolResult{
-						{db: db, symbol: protocol.Symbol{Name: "a"}},
-						{db: db, symbol: protocol.Symbol{Name: "b"}},
+						{symbol: protocol.Symbol{Name: "a"}},
+						{symbol: protocol.Symbol{Name: "b"}},
 					}),
 				},
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
 					fileResult(db, "a", nil, []*searchSymbolResult{
-						{db: db, symbol: protocol.Symbol{Name: "c"}},
-						{db: db, symbol: protocol.Symbol{Name: "d"}},
+						{symbol: protocol.Symbol{Name: "c"}},
+						{symbol: protocol.Symbol{Name: "d"}},
 					}),
 				},
 			},

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -255,7 +255,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 				if len(sr.symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.uri().String()), strings.ToLower(sr.symbol.Name)) {
 					score++
 				}
-				symbolResolver := toSymbolResolver(r.db, sr.symbol, sr.baseURI, sr.lang, sr.commit)
+				symbolResolver := toSymbolResolver(r.db, sr)
 				results = append(results, newSearchSuggestionResolver(symbolResolver, score))
 			}
 		}
@@ -373,7 +373,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			// equal.
 			k.file = s.Path()
 		case *symbolResolver:
-			k.uri = s.uri
+			k.uri = s.uri()
 			k.symbol = s.symbol.Name + s.symbol.Parent
 		case *languageResolver:
 			k.lang = s.name

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -213,7 +213,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 			lang:    strings.ToLower(symbol.Language),
 			commit:  commitResolver,
 		}
-		uri := makeFileMatchURIFromSymbol(symbolRes, inputRev)
+		uri := makeFileMatchURI(repoResolver.URL(), inputRev, symbolRes.uri().Fragment)
 		if fileMatch, ok := fileMatchesByURI[uri]; ok {
 			fileMatch.symbols = append(fileMatch.symbols, symbolRes)
 		} else {
@@ -235,14 +235,14 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 	return fileMatches, err
 }
 
-// makeFileMatchURIFromSymbol makes a git://repo?rev#path URI from a symbol
+// makeFileMatchURI makes a git://repo?rev#path URI from a symbol
 // search result to use in a fileMatchResolver
-func makeFileMatchURIFromSymbol(symbolResult *searchSymbolResult, inputRev string) string {
-	uri := "git:/" + symbolResult.commit.Repository().URL()
+func makeFileMatchURI(repoURL, inputRev, symbolFragment string) string {
+	uri := "git:/" + repoURL
 	if inputRev != "" {
 		uri += "?" + inputRev
 	}
-	uri += "#" + symbolResult.uri().Fragment
+	uri += "#" + symbolFragment
 	return uri
 }
 

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -29,7 +29,6 @@ import (
 
 // searchSymbolResult is a result from symbol search.
 type searchSymbolResult struct {
-	db      dbutil.DB
 	symbol  protocol.Symbol
 	baseURI *gituri.URI
 	lang    string
@@ -209,7 +208,6 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 
 	for _, symbol := range symbols {
 		symbolRes := &searchSymbolResult{
-			db:      db,
 			symbol:  symbol,
 			baseURI: baseURI,
 			lang:    strings.ToLower(symbol.Language),

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -238,7 +238,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 // makeFileMatchURIFromSymbol makes a git://repo?rev#path URI from a symbol
 // search result to use in a fileMatchResolver
 func makeFileMatchURIFromSymbol(symbolResult *searchSymbolResult, inputRev string) string {
-	uri := "git:/" + string(symbolResult.commit.Repository().URL())
+	uri := "git:/" + symbolResult.commit.Repository().URL()
 	if inputRev != "" {
 		uri += "?" + inputRev
 	}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -28,8 +28,9 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
 
+	repoResolver := NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"})
 	commit := toGitCommitResolver(
-		NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"}),
+		repoResolver,
 		db,
 		"c1",
 		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
@@ -45,7 +46,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := makeFileMatchURIFromSymbol(sr, test.rev)
+		got := makeFileMatchURI(repoResolver.URL(), test.rev, sr.uri().Fragment)
 		if got != test.want {
 			t.Errorf("rev(%v) got %v want %v", test.rev, got, test.want)
 		}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -34,7 +34,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 		"c1",
 		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
 	)
-	sr := &searchSymbolResult{db, symbol, baseURI, "go", commit}
+	sr := &searchSymbolResult{symbol, baseURI, "go", commit}
 
 	tests := []struct {
 		rev  string
@@ -75,7 +75,6 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("one file match, one symbol", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*searchSymbolResult{{
-			db: db,
 			symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
@@ -105,12 +104,10 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("two file matches, one symbol per file", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*searchSymbolResult{{
-			db: db,
 			symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
 		}}, []*searchSymbolResult{{
-			db: db,
 			symbol: protocol.Symbol{
 				Name: "symbol-name-2",
 			},
@@ -148,11 +145,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("two file matches, multiple symbols per file", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
-			{db: db, symbol: protocol.Symbol{Name: "symbol-name-1"}},
-			{db: db, symbol: protocol.Symbol{Name: "symbol-name-2"}},
+			{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+			{symbol: protocol.Symbol{Name: "symbol-name-2"}},
 		}, []*searchSymbolResult{
-			{db: db, symbol: protocol.Symbol{Name: "symbol-name-3"}},
-			{db: db, symbol: protocol.Symbol{Name: "symbol-name-4"}},
+			{symbol: protocol.Symbol{Name: "symbol-name-3"}},
+			{symbol: protocol.Symbol{Name: "symbol-name-4"}},
 		})
 
 		t.Run("symbol count is 4", func(t *testing.T) {
@@ -175,36 +172,36 @@ func TestLimitingSymbolResults(t *testing.T) {
 				name:  "limit 1 => one file match with one symbol",
 				limit: 1,
 				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
 				}),
 			},
 			{
 				name:  "limit 2 => one file match with all symbols",
 				limit: 2,
 				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}),
 			},
 			{
 				name:  "limit 3 => two file matches with three symbols",
 				limit: 3,
 				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}, []*searchSymbolResult{
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-3"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
 				}),
 			},
 			{
 				name:  "limit 4 => two file matches with all symbols",
 				limit: 4,
 				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}, []*searchSymbolResult{
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-3"}},
-					{db: db, symbol: protocol.Symbol{Name: "symbol-name-4"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
+					{symbol: protocol.Symbol{Name: "symbol-name-4"}},
 				}),
 			},
 		}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
@@ -13,7 +12,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
-	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func TestMakeFileMatchURIFromSymbol(t *testing.T) {
@@ -26,16 +24,9 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 		Pattern: "",
 	}
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
-	gitSignatureWithDate := git.Signature{Date: time.Now().UTC().AddDate(0, 0, -1)}
 
 	repoResolver := NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"})
-	commit := toGitCommitResolver(
-		repoResolver,
-		db,
-		"c1",
-		&git.Commit{ID: "c1", Author: gitSignatureWithDate},
-	)
-	sr := &searchSymbolResult{symbol, baseURI, "go", commit}
+	sr := &searchSymbolResult{symbol, baseURI, "go"}
 
 	tests := []struct {
 		rev  string

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -163,7 +163,6 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 						},
 						baseURI: baseURI,
 						lang:    strings.ToLower(file.Language),
-						commit:  commit,
 					},
 				))
 			}
@@ -214,7 +213,6 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 			symbol:  symbol,
 			baseURI: baseURI,
 			lang:    strings.ToLower(symbol.Language),
-			commit:  commit,
 		}
 		resolver := toSymbolResolver(db, &sr)
 		resolvers = append(resolvers, resolver)
@@ -270,9 +268,8 @@ func (r symbolResolver) Location() *locationResolver {
 	sr := symbolRange(r.symbol)
 	return &locationResolver{
 		resource: &GitTreeEntryResolver{
-			db:     r.db,
-			commit: r.commit,
-			stat:   CreateFileInfo(uri.Fragment, false), // assume the path refers to a file (not dir)
+			db:   r.db,
+			stat: CreateFileInfo(uri.Fragment, false), // assume the path refers to a file (not dir)
 		},
 		lspRange: &sr,
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -45,7 +45,7 @@ func (r *GitCommitResolver) Symbols(ctx context.Context, args *symbolsArgs) (*sy
 
 type symbolConnectionResolver struct {
 	first   *int32
-	symbols []*symbolResolver
+	symbols []symbolResolver
 }
 
 func limitOrDefault(first *int32) int {
@@ -85,7 +85,7 @@ func indexedSymbolsBranch(ctx context.Context, repository, commit string) string
 	return ""
 }
 
-func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver, branch string, queryString *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
+func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver, branch string, queryString *string, first *int32, includePatterns *[]string) (res []symbolResolver, err error) {
 	raw := *queryString
 	if raw == "" {
 		raw = ".*"
@@ -152,17 +152,19 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 
 				res = append(res, toSymbolResolver(
 					db,
-					protocol.Symbol{
-						Name:       m.SymbolInfo.Sym,
-						Kind:       m.SymbolInfo.Kind,
-						Parent:     m.SymbolInfo.Parent,
-						ParentKind: m.SymbolInfo.ParentKind,
-						Path:       file.FileName,
-						Line:       l.LineNumber,
+					&searchSymbolResult{
+						symbol: protocol.Symbol{
+							Name:       m.SymbolInfo.Sym,
+							Kind:       m.SymbolInfo.Kind,
+							Parent:     m.SymbolInfo.Parent,
+							ParentKind: m.SymbolInfo.ParentKind,
+							Path:       file.FileName,
+							Line:       l.LineNumber,
+						},
+						baseURI: baseURI,
+						lang:    strings.ToLower(file.Language),
+						commit:  commit,
 					},
-					baseURI,
-					strings.ToLower(file.Language),
-					commit,
 				))
 			}
 		}
@@ -170,7 +172,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 	return
 }
 
-func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []*symbolResolver, err error) {
+func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver, query *string, first *int32, includePatterns *[]string) (res []symbolResolver, err error) {
 	// TODO(keegancsmith) we should be able to use indexedSearchRequest here
 	// and remove indexedSymbolsBranch.
 	if branch := indexedSymbolsBranch(ctx, commit.repoResolver.Name(), string(commit.oid)); branch != "" {
@@ -206,36 +208,28 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	if baseURI == nil {
 		return
 	}
-	resolvers := make([]*symbolResolver, 0, len(symbols))
+	resolvers := make([]symbolResolver, 0, len(symbols))
 	for _, symbol := range symbols {
-		resolver := toSymbolResolver(db, symbol, baseURI, strings.ToLower(symbol.Language), commit)
-		if resolver == nil {
-			continue
+		sr := searchSymbolResult{
+			symbol:  symbol,
+			baseURI: baseURI,
+			lang:    strings.ToLower(symbol.Language),
+			commit:  commit,
 		}
+		resolver := toSymbolResolver(db, &sr)
 		resolvers = append(resolvers, resolver)
 	}
 	return resolvers, err
 }
 
-func toSymbolResolver(db dbutil.DB, symbol protocol.Symbol, baseURI *gituri.URI, lang string, commitResolver *GitCommitResolver) *symbolResolver {
-	resolver := &symbolResolver{
-		symbol:   symbol,
-		language: lang,
-		uri:      baseURI.WithFilePath(symbol.Path),
+func toSymbolResolver(db dbutil.DB, sr *searchSymbolResult) symbolResolver {
+	return symbolResolver{
+		db:                 db,
+		searchSymbolResult: sr,
 	}
-	symbolRange := symbolRange(symbol)
-	resolver.location = &locationResolver{
-		resource: &GitTreeEntryResolver{
-			db:     db,
-			commit: commitResolver,
-			stat:   CreateFileInfo(resolver.uri.Fragment, false), // assume the path refers to a file (not dir)
-		},
-		lspRange: &symbolRange,
-	}
-	return resolver
 }
 
-func (r *symbolConnectionResolver) Nodes(ctx context.Context) ([]*symbolResolver, error) {
+func (r *symbolConnectionResolver) Nodes(ctx context.Context) ([]symbolResolver, error) {
 	symbols := r.symbols
 	if len(r.symbols) > limitOrDefault(r.first) {
 		symbols = symbols[:limitOrDefault(r.first)]
@@ -248,22 +242,20 @@ func (r *symbolConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 }
 
 type symbolResolver struct {
-	symbol   protocol.Symbol
-	language string
-	location *locationResolver
-	uri      *gituri.URI
+	db dbutil.DB
+	*searchSymbolResult
 }
 
-func (r *symbolResolver) Name() string { return r.symbol.Name }
+func (r symbolResolver) Name() string { return r.symbol.Name }
 
-func (r *symbolResolver) ContainerName() *string {
+func (r symbolResolver) ContainerName() *string {
 	if r.symbol.Parent == "" {
 		return nil
 	}
 	return &r.symbol.Parent
 }
 
-func (r *symbolResolver) Kind() string /* enum SymbolKind */ {
+func (r symbolResolver) Kind() string /* enum SymbolKind */ {
 	kind := ctagsKindToLSPSymbolKind(r.symbol.Kind)
 	if kind == 0 {
 		return "UNKNOWN"
@@ -271,12 +263,23 @@ func (r *symbolResolver) Kind() string /* enum SymbolKind */ {
 	return strings.ToUpper(kind.String())
 }
 
-func (r *symbolResolver) Language() string { return r.language }
+func (r symbolResolver) Language() string { return r.symbol.Language }
 
-func (r *symbolResolver) Location() *locationResolver { return r.location }
+func (r symbolResolver) Location() *locationResolver {
+	uri := r.baseURI.WithFilePath(r.symbol.Path)
+	sr := symbolRange(r.symbol)
+	return &locationResolver{
+		resource: &GitTreeEntryResolver{
+			db:     r.db,
+			commit: r.commit,
+			stat:   CreateFileInfo(uri.Fragment, false), // assume the path refers to a file (not dir)
+		},
+		lspRange: &sr,
+	}
+}
 
-func (r *symbolResolver) URL(ctx context.Context) (string, error) { return r.location.URL(ctx) }
+func (r symbolResolver) URL(ctx context.Context) (string, error) { return r.Location().URL(ctx) }
 
-func (r *symbolResolver) CanonicalURL() (string, error) { return r.location.CanonicalURL() }
+func (r symbolResolver) CanonicalURL() (string, error) { return r.Location().CanonicalURL() }
 
-func (r *symbolResolver) FileLocal() bool { return r.symbol.FileLimited }
+func (r symbolResolver) FileLocal() bool { return r.symbol.FileLimited }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -117,10 +117,10 @@ func (fm *FileMatchResolver) Resource() string {
 	return fm.uri
 }
 
-func (fm *FileMatchResolver) Symbols() []*symbolResolver {
-	symbols := make([]*symbolResolver, len(fm.symbols))
+func (fm *FileMatchResolver) Symbols() []symbolResolver {
+	symbols := make([]symbolResolver, len(fm.symbols))
 	for i, s := range fm.symbols {
-		symbols[i] = toSymbolResolver(fm.db, s.symbol, s.baseURI, s.lang, s.commit)
+		symbols[i] = toSymbolResolver(fm.db, s)
 	}
 	return symbols
 }

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -380,7 +380,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 
 					var symbols []*searchSymbolResult
 					if typ == symbolRequest {
-						symbols = zoektFileMatchToSymbolResults(repoResolver, db, inputRev, &file)
+						symbols = zoektFileMatchToSymbolResults(repoResolver, inputRev, &file)
 					}
 					fm := &FileMatchResolver{
 						db: db,
@@ -493,17 +493,11 @@ func escape(s string) string {
 	return string(escaped)
 }
 
-func zoektFileMatchToSymbolResults(repo *RepositoryResolver, db dbutil.DB, inputRev string, file *zoekt.FileMatch) []*searchSymbolResult {
+func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*searchSymbolResult {
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.
 	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: repo.Name(), RawQuery: url.QueryEscape(inputRev)}}
-	commit := &GitCommitResolver{
-		db:           db,
-		repoResolver: repo,
-		oid:          GitObjectID(file.Version),
-		inputRev:     &inputRev,
-	}
 	lang := strings.ToLower(file.Language)
 
 	symbols := make([]*searchSymbolResult, 0, len(file.LineMatches))
@@ -533,7 +527,6 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, db dbutil.DB, input
 				},
 				lang:    lang,
 				baseURI: baseURI,
-				commit:  commit,
 			})
 		}
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -518,7 +518,6 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, db dbutil.DB, input
 			}
 
 			symbols = append(symbols, &searchSymbolResult{
-				db: db,
 				symbol: protocol.Symbol{
 					Name:       m.SymbolInfo.Sym,
 					Kind:       m.SymbolInfo.Kind,

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1040,7 +1040,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 
 	repo := NewRepositoryResolver(db, &types.Repo{Name: "foo"})
 
-	results := zoektFileMatchToSymbolResults(repo, new(dbtesting.MockDB), "master", file)
+	results := zoektFileMatchToSymbolResults(repo, "master", file)
 	var symbols []protocol.Symbol
 	for _, res := range results {
 		// Check the fields which are not specific to the symbol
@@ -1050,16 +1050,6 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		if got, want := res.baseURI.URL.String(), "git://foo?master"; got != want {
 			t.Fatalf("baseURI: got %q want %q", got, want)
 		}
-		if got, want := res.commit.Repository().Name(), "foo"; got != want {
-			t.Fatalf("reporesolver: got %q want %q", got, want)
-		}
-		if got, want := string(res.commit.OID()), "deadbeef"; got != want {
-			t.Fatalf("oid: got %q want %q", got, want)
-		}
-		if got, want := *res.commit.InputRev(), "master"; got != want {
-			t.Fatalf("inputRev: got %q want %q", got, want)
-		}
-
 		symbols = append(symbols, res.symbol)
 	}
 


### PR DESCRIPTION
The goal of this PR is to untangle `searchSymbolResult` from all resolver types. It also includes a few small cleanup items that help achieve that along the way. 

Each commit is self-contained, self-describing, and passes all tests, so please review by commit. 

Overview of the changes:
- Moves some fields of `symbolResolver` into methods so that `symbolResolver` can be a thin wrapper over `searchSymbolResult`
- Removes `db` from `searchSymbolResult`
- Removes `commit` from `searchSymbolResult`

Depends on #18593 
Progresses #18348 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
