### PR TITLE
search: import zoekt.Streamer

### DIFF
--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -29,11 +29,11 @@ import (
 
 var zoektOnce sync.Once
 var endpointMap atomicEndpoints
-var zoektClient backend.StreamSearcher
+var zoektClient zoekt.Streamer
 
-func getZoektClient(indexerEndpoints []string) backend.StreamSearcher {
+func getZoektClient(indexerEndpoints []string) zoekt.Streamer {
 	zoektOnce.Do(func() {
-		dial := func(endpoint string) backend.StreamSearcher {
+		dial := func(endpoint string) zoekt.Streamer {
 			return backend.NewMeteredSearcher(endpoint, &backend.StreamSearchAdapter{zoektrpc.Client(endpoint)})
 		}
 		zoektClient = backend.NewMeteredSearcher(

--- a/internal/search/backend/horizontal.go
+++ b/internal/search/backend/horizontal.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// HorizontalSearcher is a StreamSearcher which aggregates searches over
+// HorizontalSearcher is a Streamer which aggregates searches over
 // Map. It manages the connections to Map as the endpoints come and go.
 type HorizontalSearcher struct {
 	// Map is a subset of EndpointMap only using the Endpoints function. We
@@ -20,10 +20,10 @@ type HorizontalSearcher struct {
 	Map interface {
 		Endpoints() (map[string]struct{}, error)
 	}
-	Dial func(endpoint string) StreamSearcher
+	Dial func(endpoint string) zoekt.Streamer
 
 	mu      sync.RWMutex
-	clients map[string]StreamSearcher // addr -> client
+	clients map[string]zoekt.Streamer // addr -> client
 }
 
 // StreamSearch does a search which merges the stream from every endpoint in Map.
@@ -111,7 +111,7 @@ func (s *HorizontalSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoLi
 	}
 	results := make(chan result, len(clients))
 	for _, c := range clients {
-		go func(c StreamSearcher) {
+		go func(c zoekt.Streamer) {
 			rl, err := c.List(ctx, q)
 			results <- result{rl: rl, err: err}
 		}(c)
@@ -158,7 +158,7 @@ func (s *HorizontalSearcher) String() string {
 }
 
 // searchers returns the list of clients to aggregate over.
-func (s *HorizontalSearcher) searchers() (map[string]StreamSearcher, error) {
+func (s *HorizontalSearcher) searchers() (map[string]zoekt.Streamer, error) {
 	eps, err := s.Map.Endpoints()
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func (s *HorizontalSearcher) searchers() (map[string]StreamSearcher, error) {
 // syncSearchers syncs the set of clients with the set of endpoints. It is the
 // slow-path of "searchers" since it obtains an write lock on the state before
 // proceeding.
-func (s *HorizontalSearcher) syncSearchers() (map[string]StreamSearcher, error) {
+func (s *HorizontalSearcher) syncSearchers() (map[string]zoekt.Streamer, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -203,7 +203,7 @@ func (s *HorizontalSearcher) syncSearchers() (map[string]StreamSearcher, error) 
 	}
 
 	// Use new map to avoid read conflicts
-	clients := make(map[string]StreamSearcher, len(eps))
+	clients := make(map[string]zoekt.Streamer, len(eps))
 	for addr := range eps {
 		// Try re-use
 		client, ok := s.clients[addr]
@@ -217,7 +217,7 @@ func (s *HorizontalSearcher) syncSearchers() (map[string]StreamSearcher, error) 
 	return s.clients, nil
 }
 
-func equalKeys(a map[string]StreamSearcher, b map[string]struct{}) bool {
+func equalKeys(a map[string]zoekt.Streamer, b map[string]struct{}) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/internal/search/backend/horizontal_test.go
+++ b/internal/search/backend/horizontal_test.go
@@ -20,7 +20,7 @@ func TestHorizontalSearcher(t *testing.T) {
 
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
-		Dial: func(endpoint string) StreamSearcher {
+		Dial: func(endpoint string) zoekt.Streamer {
 			var rle zoekt.RepoListEntry
 			rle.Repository.Name = endpoint
 			client := &mockSearcher{
@@ -109,7 +109,7 @@ func TestDoStreamSearch(t *testing.T) {
 
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
-		Dial: func(endpoint string) StreamSearcher {
+		Dial: func(endpoint string) zoekt.Streamer {
 			client := &mockSearcher{
 				searchResult: nil,
 				searchError:  fmt.Errorf("test error"),
@@ -149,7 +149,7 @@ func TestSyncSearchers(t *testing.T) {
 	dialNumCounter := 0
 	searcher := &HorizontalSearcher{
 		Map: &endpoints,
-		Dial: func(endpoint string) StreamSearcher {
+		Dial: func(endpoint string) zoekt.Streamer {
 			dialNumCounter++
 			return &mock{
 				dialNum: dialNumCounter,

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -28,15 +28,15 @@ func init() {
 }
 
 type meteredSearcher struct {
-	StreamSearcher
+	zoekt.Streamer
 
 	hostname string
 }
 
-func NewMeteredSearcher(hostname string, z StreamSearcher) StreamSearcher {
+func NewMeteredSearcher(hostname string, z zoekt.Streamer) zoekt.Streamer {
 	return &meteredSearcher{
-		StreamSearcher: z,
-		hostname:       hostname,
+		Streamer: z,
+		hostname: hostname,
 	}
 }
 
@@ -113,7 +113,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 		first sync.Once
 	)
 
-	err := m.StreamSearcher.StreamSearch(ctx, q, opts, ZoektStreamFunc(func(zsr *zoekt.SearchResult) {
+	err := m.Streamer.StreamSearch(ctx, q, opts, ZoektStreamFunc(func(zsr *zoekt.SearchResult) {
 		first.Do(func() {
 			if isLeaf {
 				tr.LogFields(
@@ -175,7 +175,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList,
 
 	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q), tags...)
 
-	zsl, err := m.StreamSearcher.List(ctx, q)
+	zsl, err := m.Streamer.List(ctx, q)
 
 	code := "200"
 	if err != nil {
@@ -194,7 +194,7 @@ func (m *meteredSearcher) List(ctx context.Context, q query.Q) (*zoekt.RepoList,
 }
 
 func (m *meteredSearcher) String() string {
-	return "MeteredSearcher{" + m.StreamSearcher.String() + "}"
+	return "MeteredSearcher{" + m.Streamer.String() + "}"
 }
 
 func queryString(q query.Q) string {

--- a/internal/search/backend/text.go
+++ b/internal/search/backend/text.go
@@ -18,7 +18,7 @@ import (
 // Note: Zoekt starts up background goroutines, so call Close when done using
 // the Client.
 type Zoekt struct {
-	Client StreamSearcher
+	Client zoekt.Streamer
 
 	// DisableCache when true prevents caching of Client.List. Useful in
 	// tests.

--- a/internal/search/backend/zoekt.go
+++ b/internal/search/backend/zoekt.go
@@ -15,17 +15,6 @@ func (f ZoektStreamFunc) Send(event *zoekt.SearchResult) {
 	f(event)
 }
 
-// StreamSearcher is an optional interface which sends results over a channel
-// as they are found.
-//
-// This is a Sourcegraph extension.
-type StreamSearcher interface {
-	zoekt.Searcher
-
-	// StreamSearch returns a channel which needs to be read until closed.
-	StreamSearch(ctx context.Context, q query.Q, opts *zoekt.SearchOptions, c zoekt.Sender) error
-}
-
 // StreamSearchEvent has fields optionally set representing events that happen
 // during a search.
 //

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/rpc"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -42,11 +43,11 @@ func SearcherURLs() *endpoint.Map {
 
 func Indexed() *backend.Zoekt {
 	indexedSearchOnce.Do(func() {
-		dial := func(endpoint string) backend.StreamSearcher {
+		dial := func(endpoint string) zoekt.Streamer {
 			return backend.NewMeteredSearcher(endpoint, &backend.StreamSearchAdapter{rpc.Client(endpoint)})
 		}
 
-		var client backend.StreamSearcher
+		var client zoekt.Streamer
 		if indexers := Indexers(); indexers.Enabled() {
 			client = backend.NewMeteredSearcher(
 				"", // no hostname means its the aggregator


### PR DESCRIPTION
This is a mechanical refactor.

We replace `backend.StreamSearcher` with `zoekt.Streamer`.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
