### PR TITLE
gitserver: Remove stale code and comments.

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -36,10 +36,9 @@ import (
 )
 
 var (
-	reposDir          = env.Get("SRC_REPOS_DIR", "/data/repos", "Root dir containing repos.")
-	runRepoCleanup, _ = strconv.ParseBool(env.Get("SRC_RUN_REPO_CLEANUP", "", "Periodically remove inactive repositories."))
-	wantPctFree       = env.Get("SRC_REPOS_DESIRED_PERCENT_FREE", "10", "Target percentage of free space on disk.")
-	janitorInterval   = env.Get("SRC_REPOS_JANITOR_INTERVAL", "1m", "Interval between cleanup runs")
+	reposDir        = env.Get("SRC_REPOS_DIR", "/data/repos", "Root dir containing repos.")
+	wantPctFree     = env.Get("SRC_REPOS_DESIRED_PERCENT_FREE", "10", "Target percentage of free space on disk.")
+	janitorInterval = env.Get("SRC_REPOS_JANITOR_INTERVAL", "1m", "Interval between cleanup runs")
 )
 
 func main() {
@@ -72,9 +71,8 @@ func main() {
 	}
 
 	gitserver := server.Server{
-		ReposDir:                reposDir,
-		DeleteStaleRepositories: runRepoCleanup,
-		DesiredPercentFree:      wantPctFree2,
+		ReposDir:           reposDir,
+		DesiredPercentFree: wantPctFree2,
 		GetRemoteURLFunc: func(ctx context.Context, repo api.RepoName) (string, error) {
 			r, err := repoStore.GetByName(ctx, repo)
 			if err != nil {

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -72,7 +73,7 @@ const reposStatsName = "repos-stats.json"
 //
 // 1. Remove corrupt repos.
 // 2. Remove stale lock files.
-// 3. Remove inactive repos on sourcegraph.com
+// 3. Remove repos based on disk pressure.
 // 4. Reclone repos after a while. (simulate git gc)
 func (s *Server) cleanupRepos() {
 	janitorRunning.Set(1)

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )
@@ -102,7 +103,7 @@ func TestCleanupInactive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s := &Server{ReposDir: root, DeleteStaleRepositories: true}
+	s := &Server{ReposDir: root}
 	s.Handler() // Handler as a side-effect sets up Server
 	s.cleanupRepos()
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -109,10 +109,6 @@ type Server struct {
 	// ReposDir is the path to the base directory for gitserver storage.
 	ReposDir string
 
-	// DeleteStaleRepositories when true will delete old repositories when the
-	// Janitor job runs.
-	DeleteStaleRepositories bool
-
 	// DesiredPercentFree is the desired percentage of disk space to keep free.
 	DesiredPercentFree int
 


### PR DESCRIPTION
We no longer cleanup stale repos based on a flag, instead we clean them
up based on disk pressure.