### PR TITLE
search: export types on exported fields in FileMatch

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -59,9 +59,9 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	defer git.ResetMocks()
 
 	fileMatch := func(path string, lineNumbers ...int32) *FileMatchResolver {
-		var lines []*lineMatch
+		var lines []*LineMatch
 		for _, n := range lineNumbers {
-			lines = append(lines, &lineMatch{LineNumber: n})
+			lines = append(lines, &LineMatch{LineNumber: n})
 		}
 		return mkFileMatchResolver(db, FileMatch{
 			Path:        path,

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1039,7 +1039,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 					&FileMatchResolver{
 						db: db,
 						FileMatch: FileMatch{
-							Symbols: []*searchSymbolResult{
+							Symbols: []*SearchSymbolResult{
 								// 1
 								{},
 								// 2
@@ -1059,7 +1059,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 					&FileMatchResolver{
 						db: db,
 						FileMatch: FileMatch{
-							Symbols: []*searchSymbolResult{
+							Symbols: []*SearchSymbolResult{
 								// 1
 								{},
 								// 2
@@ -1475,7 +1475,7 @@ func repoResult(db dbutil.DB, url string) *RepositoryResolver {
 	})
 }
 
-func fileResult(db dbutil.DB, uri string, lineMatches []*LineMatch, symbolMatches []*searchSymbolResult) *FileMatchResolver {
+func fileResult(db dbutil.DB, uri string, lineMatches []*LineMatch, symbolMatches []*SearchSymbolResult) *FileMatchResolver {
 	return &FileMatchResolver{
 		db: db,
 		FileMatch: FileMatch{
@@ -1614,7 +1614,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", nil, []*searchSymbolResult{
+					fileResult(db, "a", nil, []*SearchSymbolResult{
 						{symbol: protocol.Symbol{Name: "a"}},
 						{symbol: protocol.Symbol{Name: "b"}},
 					}),
@@ -1622,7 +1622,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", nil, []*searchSymbolResult{
+					fileResult(db, "a", nil, []*SearchSymbolResult{
 						{symbol: protocol.Symbol{Name: "c"}},
 						{symbol: protocol.Symbol{Name: "d"}},
 					}),

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1475,7 +1475,7 @@ func repoResult(db dbutil.DB, url string) *RepositoryResolver {
 	})
 }
 
-func fileResult(db dbutil.DB, uri string, lineMatches []*lineMatch, symbolMatches []*searchSymbolResult) *FileMatchResolver {
+func fileResult(db dbutil.DB, uri string, lineMatches []*LineMatch, symbolMatches []*searchSymbolResult) *FileMatchResolver {
 	return &FileMatchResolver{
 		db: db,
 		FileMatch: FileMatch{
@@ -1576,7 +1576,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*lineMatch{
+					fileResult(db, "b", []*LineMatch{
 						{Preview: "a"},
 						{Preview: "b"},
 					}, nil),
@@ -1584,7 +1584,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*lineMatch{
+					fileResult(db, "b", []*LineMatch{
 						{Preview: "c"},
 						{Preview: "d"},
 					}, nil),
@@ -1595,7 +1595,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", []*lineMatch{
+					fileResult(db, "a", []*LineMatch{
 						{Preview: "a"},
 						{Preview: "b"},
 					}, nil),
@@ -1603,7 +1603,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*lineMatch{
+					fileResult(db, "b", []*LineMatch{
 						{Preview: "c"},
 						{Preview: "d"},
 					}, nil),

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -27,14 +27,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-// searchSymbolResult is a result from symbol search.
-type searchSymbolResult struct {
+// SearchSymbolResult is a result from symbol search.
+type SearchSymbolResult struct {
 	symbol  protocol.Symbol
 	baseURI *gituri.URI
 	lang    string
 }
 
-func (s *searchSymbolResult) uri() *gituri.URI {
+func (s *SearchSymbolResult) uri() *gituri.URI {
 	return s.baseURI.WithFilePath(s.symbol.Path)
 }
 
@@ -200,7 +200,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 	fileMatches := make([]*FileMatchResolver, 0)
 
 	for _, symbol := range symbols {
-		symbolRes := &searchSymbolResult{
+		symbolRes := &SearchSymbolResult{
 			symbol:  symbol,
 			baseURI: baseURI,
 			lang:    strings.ToLower(symbol.Language),
@@ -213,7 +213,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 				db: db,
 				FileMatch: FileMatch{
 					Path:     symbolRes.symbol.Path,
-					Symbols:  []*searchSymbolResult{symbolRes},
+					Symbols:  []*SearchSymbolResult{symbolRes},
 					uri:      uri,
 					Repo:     repoRevs.Repo,
 					CommitID: api.CommitID(commitID),

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -26,7 +26,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 
 	repoResolver := NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"})
-	sr := &searchSymbolResult{symbol, baseURI, "go"}
+	sr := &SearchSymbolResult{symbol, baseURI, "go"}
 
 	tests := []struct {
 		rev  string
@@ -66,7 +66,7 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("one file match, one symbol", func(t *testing.T) {
-		res := mkSymbolFileMatchResolvers(db, []*searchSymbolResult{{
+		res := mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{{
 			symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
@@ -95,11 +95,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, one symbol per file", func(t *testing.T) {
-		res := mkSymbolFileMatchResolvers(db, []*searchSymbolResult{{
+		res := mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{{
 			symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
-		}}, []*searchSymbolResult{{
+		}}, []*SearchSymbolResult{{
 			symbol: protocol.Symbol{
 				Name: "symbol-name-2",
 			},
@@ -136,10 +136,10 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, multiple symbols per file", func(t *testing.T) {
-		res := mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
+		res := mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
 			{symbol: protocol.Symbol{Name: "symbol-name-1"}},
 			{symbol: protocol.Symbol{Name: "symbol-name-2"}},
-		}, []*searchSymbolResult{
+		}, []*SearchSymbolResult{
 			{symbol: protocol.Symbol{Name: "symbol-name-3"}},
 			{symbol: protocol.Symbol{Name: "symbol-name-4"}},
 		})
@@ -163,14 +163,14 @@ func TestLimitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 1 => one file match with one symbol",
 				limit: 1,
-				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
 					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
 				}),
 			},
 			{
 				name:  "limit 2 => one file match with all symbols",
 				limit: 2,
-				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
 					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
 					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}),
@@ -178,20 +178,20 @@ func TestLimitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 3 => two file matches with three symbols",
 				limit: 3,
-				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
 					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
 					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
-				}, []*searchSymbolResult{
+				}, []*SearchSymbolResult{
 					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
 				}),
 			},
 			{
 				name:  "limit 4 => two file matches with all symbols",
 				limit: 4,
-				want: mkSymbolFileMatchResolvers(db, []*searchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
 					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
 					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
-				}, []*searchSymbolResult{
+				}, []*SearchSymbolResult{
 					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
 					{symbol: protocol.Symbol{Name: "symbol-name-4"}},
 				}),
@@ -226,7 +226,7 @@ func TestSymbolRange(t *testing.T) {
 	})
 }
 
-func mkSymbolFileMatchResolvers(db dbutil.DB, symbols ...[]*searchSymbolResult) []*FileMatchResolver {
+func mkSymbolFileMatchResolvers(db dbutil.DB, symbols ...[]*SearchSymbolResult) []*FileMatchResolver {
 	var resolvers []*FileMatchResolver
 	for _, s := range symbols {
 		resolvers = append(resolvers, mkFileMatchResolver(db, FileMatch{

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -556,9 +556,9 @@ func mkFileMatch(db dbutil.DB, repo *types.RepoName, path string, lineNumbers ..
 			Name: "repo",
 		}
 	}
-	var lines []*lineMatch
+	var lines []*LineMatch
 	for _, n := range lineNumbers {
-		lines = append(lines, &lineMatch{LineNumber: n})
+		lines = append(lines, &LineMatch{LineNumber: n})
 	}
 	return mkFileMatchResolver(db, FileMatch{
 		uri:         fileMatchURI(repo.Name, "", path),

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -152,7 +152,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 
 				res = append(res, toSymbolResolver(
 					db,
-					&searchSymbolResult{
+					&SearchSymbolResult{
 						symbol: protocol.Symbol{
 							Name:       m.SymbolInfo.Sym,
 							Kind:       m.SymbolInfo.Kind,
@@ -209,7 +209,7 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	}
 	resolvers := make([]symbolResolver, 0, len(symbols))
 	for _, symbol := range symbols {
-		sr := searchSymbolResult{
+		sr := SearchSymbolResult{
 			symbol:  symbol,
 			baseURI: baseURI,
 			lang:    strings.ToLower(symbol.Language),
@@ -220,10 +220,10 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	return resolvers, err
 }
 
-func toSymbolResolver(db dbutil.DB, sr *searchSymbolResult) symbolResolver {
+func toSymbolResolver(db dbutil.DB, sr *SearchSymbolResult) symbolResolver {
 	return symbolResolver{
 		db:                 db,
-		searchSymbolResult: sr,
+		SearchSymbolResult: sr,
 	}
 }
 
@@ -241,7 +241,7 @@ func (r *symbolConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 
 type symbolResolver struct {
 	db dbutil.DB
-	*searchSymbolResult
+	*SearchSymbolResult
 }
 
 func (r symbolResolver) Name() string { return r.symbol.Name }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -37,7 +37,7 @@ var textSearchLimiter = mutablelimiter.New(32)
 
 type FileMatch struct {
 	Path        string
-	LineMatches []*lineMatch
+	LineMatches []*LineMatch
 	LimitHit    bool
 
 	Symbols  []*searchSymbolResult `json:"-"`
@@ -188,8 +188,8 @@ func (fm *FileMatchResolver) Select(t filter.SelectPath) SearchResultResolver {
 	return nil
 }
 
-// lineMatch is the struct used by vscode to receive search results for a line
-type lineMatch struct {
+// LineMatch is the struct used by vscode to receive search results for a line
+type LineMatch struct {
 	Preview          string
 	OffsetAndLengths [][2]int32
 	LineNumber       int32
@@ -197,27 +197,27 @@ type lineMatch struct {
 }
 
 type lineMatchResolver struct {
-	*lineMatch
+	*LineMatch
 }
 
 func (lm lineMatchResolver) Preview() string {
-	return lm.lineMatch.Preview
+	return lm.LineMatch.Preview
 }
 
 func (lm lineMatchResolver) LineNumber() int32 {
-	return lm.lineMatch.LineNumber
+	return lm.LineMatch.LineNumber
 }
 
 func (lm lineMatchResolver) OffsetAndLengths() [][]int32 {
-	r := make([][]int32, len(lm.lineMatch.OffsetAndLengths))
-	for i := range lm.lineMatch.OffsetAndLengths {
-		r[i] = lm.lineMatch.OffsetAndLengths[i][:]
+	r := make([][]int32, len(lm.LineMatch.OffsetAndLengths))
+	for i := range lm.LineMatch.OffsetAndLengths {
+		r[i] = lm.LineMatch.OffsetAndLengths[i][:]
 	}
 	return r
 }
 
 func (lm lineMatchResolver) LimitHit() bool {
-	return lm.lineMatch.LimitHit
+	return lm.LineMatch.LimitHit
 }
 
 var mockSearchFilesInRepo func(ctx context.Context, repo *types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
@@ -263,13 +263,13 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 	repoResolver := NewRepositoryResolver(db, repo.ToRepo())
 	resolvers := make([]*FileMatchResolver, 0, len(matches))
 	for _, fm := range matches {
-		lineMatches := make([]*lineMatch, 0, len(fm.LineMatches))
+		lineMatches := make([]*LineMatch, 0, len(fm.LineMatches))
 		for _, lm := range fm.LineMatches {
 			ranges := make([][2]int32, 0, len(lm.OffsetAndLengths))
 			for _, ol := range lm.OffsetAndLengths {
 				ranges = append(ranges, [2]int32{int32(ol[0]), int32(ol[1])})
 			}
-			lineMatches = append(lineMatches, &lineMatch{
+			lineMatches = append(lineMatches, &LineMatch{
 				Preview:          lm.Preview,
 				OffsetAndLengths: ranges,
 				LineNumber:       int32(lm.LineNumber),

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -40,7 +40,7 @@ type FileMatch struct {
 	LineMatches []*LineMatch
 	LimitHit    bool
 
-	Symbols  []*searchSymbolResult `json:"-"`
+	Symbols  []*SearchSymbolResult `json:"-"`
 	uri      string                `json:"-"`
 	Repo     *types.RepoName       `json:"-"`
 	CommitID api.CommitID          `json:"-"`

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -378,7 +378,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 				for _, inputRev := range inputRevs {
 					inputRev := inputRev // copy so we can take the pointer
 
-					var symbols []*searchSymbolResult
+					var symbols []*SearchSymbolResult
 					if typ == symbolRequest {
 						symbols = zoektFileMatchToSymbolResults(repoResolver, inputRev, &file)
 					}
@@ -493,14 +493,14 @@ func escape(s string) string {
 	return string(escaped)
 }
 
-func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*searchSymbolResult {
+func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*SearchSymbolResult {
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.
 	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: repo.Name(), RawQuery: url.QueryEscape(inputRev)}}
 	lang := strings.ToLower(file.Language)
 
-	symbols := make([]*searchSymbolResult, 0, len(file.LineMatches))
+	symbols := make([]*SearchSymbolResult, 0, len(file.LineMatches))
 	for _, l := range file.LineMatches {
 		if l.FileName {
 			continue
@@ -511,7 +511,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 				continue
 			}
 
-			symbols = append(symbols, &searchSymbolResult{
+			symbols = append(symbols, &SearchSymbolResult{
 				symbol: protocol.Symbol{
 					Name:       m.SymbolInfo.Sym,
 					Kind:       m.SymbolInfo.Kind,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -370,7 +370,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 					repoResolvers[repo.Name] = repoResolver
 				}
 
-				var lines []*lineMatch
+				var lines []*LineMatch
 				if typ != symbolRequest {
 					lines = zoektFileMatchToLineMatches(maxLineFragmentMatches, &file)
 				}
@@ -434,8 +434,8 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 	return nil
 }
 
-func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) []*lineMatch {
-	lines := make([]*lineMatch, 0, len(file.LineMatches))
+func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) []*LineMatch {
+	lines := make([]*LineMatch, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {
 		if l.FileName {
@@ -451,7 +451,7 @@ func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMat
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 			offsets[k] = [2]int32{int32(offset), int32(length)}
 		}
-		lines = append(lines, &lineMatch{
+		lines = append(lines, &LineMatch{
 			Preview:          string(l.Line),
 			LineNumber:       int32(l.LineNumber - 1),
 			OffsetAndLengths: offsets,


### PR DESCRIPTION
Weird to have fields exported but not the types for them. For example this leads to packages which rely on reflection to fail. In particular I am playing around with `testing/quick` and it can't generate FileMatch's due to this.