### PR TITLE
codeintel: Deterministically order range lists during processing

### DIFF
--- a/enterprise/internal/codeintel/lsif/correlation/group.go
+++ b/enterprise/internal/codeintel/lsif/correlation/group.go
@@ -195,7 +195,7 @@ func serializeResultChunks(ctx context.Context, state *State, numResultChunks in
 			}
 
 			documentPaths := map[lsifstore.ID]string{}
-			rangeIDsByResultID := map[lsifstore.ID][]lsifstore.DocumentIDRangeID{}
+			rangeIDsByResultID := make(map[lsifstore.ID][]lsifstore.DocumentIDRangeID, len(resultIDs))
 
 			for _, resultID := range resultIDs {
 				documentRanges, ok := state.DefinitionData[resultID]


### PR DESCRIPTION
Each place in LSIF processing where we submit a list of items that can be paged, we should ensure there is a deterministic order. I ran into some issues having ranges later in a document come earlier than ranges earlier in a document in some test result sets (in unit tests), which was undesirable. I think we can do better by making the order deterministic when serializing to the database so we can intelligently page things within lsifstore.