### PR TITLE
codeintel: Fix bulk moniker query ordering to match index

### DIFF
--- a/enterprise/internal/codeintel/stores/lsifstore/monikers.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/monikers.go
@@ -135,7 +135,7 @@ outer:
 
 const bulkMonikerResultsQuery = `
 -- source: enterprise/internal/codeintel/stores/lsifstore/monikers.go:BulkMonikerResults
-SELECT dump_id, scheme, identifier, data FROM %s WHERE dump_id IN (%s) AND (scheme, identifier) IN (%s) ORDER BY (scheme, identifier, dump_id)
+SELECT dump_id, scheme, identifier, data FROM %s WHERE dump_id IN (%s) AND (scheme, identifier) IN (%s) ORDER BY (dump_id, scheme, identifier)
 `
 
 func monikersToString(vs []MonikerData) string {


### PR DESCRIPTION
Not sure why I had it the other way around :shrug:.