### PR TITLE
streaming: count highlights for diff/commit search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -139,6 +139,10 @@ func (r *CommitSearchResultResolver) ResultCount() int32 {
 	return 1
 }
 
+func (r *CommitSearchResultResolver) HighlightsCount() int {
+	return len(r.highlights)
+}
+
 func commitParametersToDiffParameters(ctx context.Context, op *search.CommitParameters) (*search.DiffParameters, error) {
 	args := []string{
 		"--no-prefix",

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -42,8 +42,8 @@ type CommitSearchResult struct {
 // ResultCount for CommitSearchResult returns the number of highlights if there
 // are highlights and 1 otherwise. We implemented this method because we want to
 // return a more meaningful result count for streaming while maintaining backward
-// compatibility for the batch API. The batch API calls the ResultCount on the
-// resolver, while streaming calls ResultCount in CommitSearchResult.
+// compatibility for our GraphQL API. The GraphQL API calls ResultCount on the
+// resolver, while streaming calls ResultCount on CommitSearchResult.
 func (r *CommitSearchResult) ResultCount() int {
 	if n := len(r.highlights); n > 0 {
 		return n

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -29,6 +29,10 @@ func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
 	p.Dirty = true
 	p.Stats.Update(&event.Stats)
 	for _, result := range event.Results {
+		if crs, ok := result.ToCommitSearchResult(); ok {
+			p.MatchCount += crs.HighlightsCount()
+			continue
+		}
 		p.MatchCount += int(result.ResultCount())
 	}
 

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -30,7 +30,7 @@ func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
 	p.Stats.Update(&event.Stats)
 	for _, result := range event.Results {
 		if crs, ok := result.ToCommitSearchResult(); ok {
-			p.MatchCount += crs.HighlightsCount()
+			p.MatchCount += crs.CommitSearchResult.ResultCount()
 			continue
 		}
 		p.MatchCount += int(result.ResultCount())


### PR DESCRIPTION
Closes #18301

For backward compatibility, we leave the method `ResultCount` on the resolver as is, 
but instead implement a new method `ResultCount` on `CommitSearchResult`.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
