### PR TITLE
Revert "Remove commit from searchSymbolResult"

### DIFF
--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -26,7 +26,8 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 
 	repoResolver := NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"})
-	sr := &SearchSymbolResult{symbol, baseURI, "go"}
+	commitResolver := toGitCommitResolver(repoResolver, db, "", nil)
+	sr := &SearchSymbolResult{symbol, baseURI, "go", commitResolver}
 
 	tests := []struct {
 		rev  string

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -163,6 +163,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 						},
 						baseURI: baseURI,
 						lang:    strings.ToLower(file.Language),
+						commit:  commit,
 					},
 				))
 			}
@@ -213,6 +214,7 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 			symbol:  symbol,
 			baseURI: baseURI,
 			lang:    strings.ToLower(symbol.Language),
+			commit:  commit,
 		}
 		resolver := toSymbolResolver(db, &sr)
 		resolvers = append(resolvers, resolver)
@@ -268,8 +270,9 @@ func (r symbolResolver) Location() *locationResolver {
 	sr := symbolRange(r.symbol)
 	return &locationResolver{
 		resource: &GitTreeEntryResolver{
-			db:   r.db,
-			stat: CreateFileInfo(uri.Fragment, false), // assume the path refers to a file (not dir)
+			db:     r.db,
+			commit: r.commit,
+			stat:   CreateFileInfo(uri.Fragment, false), // assume the path refers to a file (not dir)
 		},
 		lspRange: &sr,
 	}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1040,7 +1040,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 
 	repo := NewRepositoryResolver(db, &types.Repo{Name: "foo"})
 
-	results := zoektFileMatchToSymbolResults(repo, "master", file)
+	results := zoektFileMatchToSymbolResults(repo, new(dbtesting.MockDB), "master", file)
 	var symbols []protocol.Symbol
 	for _, res := range results {
 		// Check the fields which are not specific to the symbol
@@ -1050,6 +1050,16 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		if got, want := res.baseURI.URL.String(), "git://foo?master"; got != want {
 			t.Fatalf("baseURI: got %q want %q", got, want)
 		}
+		if got, want := res.commit.Repository().Name(), "foo"; got != want {
+			t.Fatalf("reporesolver: got %q want %q", got, want)
+		}
+		if got, want := string(res.commit.OID()), "deadbeef"; got != want {
+			t.Fatalf("oid: got %q want %q", got, want)
+		}
+		if got, want := *res.commit.InputRev(), "master"; got != want {
+			t.Fatalf("inputRev: got %q want %q", got, want)
+		}
+
 		symbols = append(symbols, res.symbol)
 	}
 


### PR DESCRIPTION
This reverts commit 0e8bb27a97eeaecaabec0228220b959b44d3f73a.

Removing commit caused a panic when trying to get the URL from the location. Reverting for now because it might take a bit of rethinking to fix this properly. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
