### PR TITLE
search: Exercise symbol resolver methods in integration tests

### DIFF
--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -114,6 +114,13 @@ query Search($query: String!) {
 					file {
 						name
 					}
+					symbols {
+						name
+						containerName
+						kind
+						language
+						url
+					}
 					repository {
 						name
 					}


### PR DESCRIPTION
The integration tests didn't catch a very basic panic condition because
the graphql query didn't actually exercise any of the symbol result
methods. This adds those fields to the query (but does not validate the
output) so that we can at least catch very high level issues with symbol
search.

I validated that this would have caught the issue that caused #18628 

Additionally, we should probably follow up with a few other types whose 
resolver methods aren't being exercised.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
