### PR TITLE
search frontend: escape spaces in repo/file values on autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Pings now contain aggregate Sourcegraph extension activation statistics: the number of users and number of activations per (public) extension per week, and the number of total extension users per week and average extensions activated per user. [#16421](https://github.com/sourcegraph/sourcegraph/pull/16421)
 - Pings now contain aggregate code insights usage data: total insight views, interactions, edits, creations, removals, and counts of unique users that view and create insights. [#16421](https://github.com/sourcegraph/sourcegraph/pull/17805)
 - When previewing a campaign spec, changesets can be filtered by current state or the action(s) to be performed. [#16960](https://github.com/sourcegraph/sourcegraph/issues/16960)
+- Auto complete suggestions for repositories and files containing spaces will now be automatically escaped when accepting the suggestion. [#18635](https://github.com/sourcegraph/sourcegraph/issues/18635)
 
 ### Changed
 

--- a/client/shared/src/search/query/completion.test.ts
+++ b/client/shared/src/search/query/completion.test.ts
@@ -456,4 +456,22 @@ describe('getCompletionItems()', () => {
             )?.suggestions.map(({ insertText }) => insertText)
         ).toStrictEqual(['^some/path/main\\.go$ '])
     })
+
+    test('escapes spaces in repo value', async () => {
+        expect(
+            (
+                await getCompletionItems(
+                    toSuccess(scanSearchQuery('repo:')),
+                    { column: 5 },
+                    of([
+                        {
+                            __typename: 'Repository',
+                            name: 'repo/with a space',
+                        },
+                    ] as SearchSuggestion[]),
+                    false
+                )
+            )?.suggestions.map(({ insertText }) => insertText)
+        ).toStrictEqual(['^repo/with\\ a\\ space$ '])
+    })
 })

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -7,7 +7,7 @@ import { Observable } from 'rxjs'
 import { IRepository, IFile, ISymbol, ILanguage, IRepoGroup, ISearchContext } from '../../graphql/schema'
 import { SearchSuggestion } from '../suggestions'
 import { isDefined } from '../../util/types'
-import { FilterType, isNegatableFilter, resolveFilter, FILTERS } from './filters'
+import { FilterType, isNegatableFilter, resolveFilter, FILTERS, escapeSpaces } from './filters'
 import { first } from 'rxjs/operators'
 import { SymbolKind } from '../../graphql-operations'
 
@@ -67,6 +67,7 @@ const repositoryToCompletion = (
     options: { isFilterValue: boolean; globbing: boolean }
 ): PartialCompletionItem => {
     let insertText = options.globbing ? name : `^${escapeRegExp(name)}$`
+    insertText = escapeSpaces(insertText)
     insertText = (options.isFilterValue ? insertText : `${FilterType.repo}:${insertText}`) + ' '
     return {
         label: name,
@@ -82,6 +83,7 @@ const fileToCompletion = (
     options: { isFilterValue: boolean; globbing: boolean }
 ): PartialCompletionItem => {
     let insertText = options.globbing ? path : `^${escapeRegExp(path)}$`
+    insertText = escapeSpaces(insertText)
     insertText = (options.isFilterValue ? insertText : `${FilterType.file}:${insertText}`) + ' '
     return {
         label: name,

--- a/client/shared/src/search/query/filters.test.ts
+++ b/client/shared/src/search/query/filters.test.ts
@@ -1,5 +1,10 @@
-import { validateFilter } from './filters'
+import { escapeSpaces, validateFilter } from './filters'
 import { Literal, Quoted } from './token'
+
+expect.addSnapshotSerializer({
+    serialize: value => value as string,
+    test: () => true,
+})
 
 describe('validateFilter()', () => {
     interface TestCase {
@@ -65,4 +70,18 @@ describe('validateFilter()', () => {
             expect(validateFilter(filterType, token)).toStrictEqual(expected)
         })
     }
+})
+
+describe('escapeSpaces', () => {
+    test('escapes spaces in value', () => {
+        expect(escapeSpaces('contains a space')).toMatchInlineSnapshot('contains\\ a\\ space')
+    })
+
+    test('skips escaped values', () => {
+        expect(escapeSpaces('\\\\already\\ escaped')).toMatchInlineSnapshot('\\\\already\\ escaped')
+    })
+
+    test('terminates with \\', () => {
+        expect(escapeSpaces('last\\')).toMatchInlineSnapshot('last\\')
+    })
 })

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -373,3 +373,38 @@ export const validateFilter = (
     }
     return { valid: true }
 }
+
+/**
+ * Prepends a \ to spaces, taking care to skip over existing escape sequences. We apply this to
+ * regexp field values like repo: and file:.
+ *
+ * @param value the value to escape
+ */
+export const escapeSpaces = (value: string): string => {
+    const escaped: string[] = []
+    let current = 0
+    while (value[current]) {
+        switch (value[current]) {
+            case '\\': {
+                if (value[current + 1]) {
+                    escaped.push('\\', value[current + 1])
+                    current = current + 2 // Continue past escaped value.
+                    continue
+                }
+                escaped.push('\\')
+                current = current + 1
+                continue
+            }
+            case ' ': {
+                escaped.push('\\', ' ')
+                current = current + 1
+                continue
+            }
+            default:
+                escaped.push(value[current])
+                current = current + 1
+                continue
+        }
+    }
+    return escaped.join('')
+}


### PR DESCRIPTION
Repos and files with spaces will have spaces escaped when accepting an autocomplete. Addresses important issue in https://github.com/sourcegraph/customer/issues/152#issuecomment-785294806.

I went a bit back and forth on escaping spaces, versus wrapping the value in parentheses, e.g., `repo:(^repo with spaces$)`, or quoting, which would also work. I favor the `\ ` escape because (a) it's consistent with operating systems like `ls` displaying files with spaces on Mac OS X and other bash terminals and (b) it's less visually jarring--the highlighting helps make it clear that there's an escape value in there.

https://user-images.githubusercontent.com/888624/109078303-595a0b00-76ba-11eb-88be-306ec61f53af.mp4

At the end of the video, you'll see that clicking on a result quotes repo and file values, and does not escape the spaces like I do in the autocomplete. I dislike the quoting because (a) it's visually jarring (b) it introduces more complex escaping requirements--if you want to escape, e.g., a regex character when it's quoted, the `\` needs to be escaped itself (c) we don't currently do special highlighting for quoted regex values, mostly because of (b): we need to do even more special casing on escaped values to do that accurately (there is no regex library that will just parse a quoted regex). All this considered, I want to change that we quote repo and file when we navigate, to using `\` as the escape sequence, to be consistent with the autocomplete suggestion. Filed https://github.com/sourcegraph/sourcegraph/issues/18636 for this and WIP in #18642.

---

There are two bugs that I believe exist and are orthogonal to the autocompletion code that should be addressed alongside this change, but I do not consider them blocking for merging this PR (because they would exist anyway in the current state):

1. We seem to have an issue creating a link when there is _only_ a repository match for a repo containing spaces (repository name match)--it's not clickable and won't navigate to the repo. This issue disappears when there are other results, like matching files or content. Filed https://github.com/sourcegraph/sourcegraph/issues/18634 for this.

1. The filter suggestions don't autocomplete correctly. I don't think we do any special processing here, so the escape function should be called on that as well. I will try find where that code lives. Filed https://github.com/sourcegraph/sourcegraph/issues/18633 for this WIP in https://github.com/sourcegraph/sourcegraph/pull/18638.

https://user-images.githubusercontent.com/888624/109078307-5bbc6500-76ba-11eb-991a-a7eb136061cc.mp4

