### PR TITLE
search: Move commit from searchSymbolResult to symbolResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -238,7 +238,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			if !ok {
 				continue
 			}
-			for _, sr := range fileMatch.FileMatch.Symbols {
+			for _, sr := range fileMatch.Symbols() {
 				score := 20
 				if sr.symbol.Parent == "" {
 					score++
@@ -255,8 +255,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 				if len(sr.symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.uri().String()), strings.ToLower(sr.symbol.Name)) {
 					score++
 				}
-				symbolResolver := toSymbolResolver(r.db, fileMatch.Commit(), sr)
-				results = append(results, newSearchSuggestionResolver(symbolResolver, score))
+				results = append(results, newSearchSuggestionResolver(sr, score))
 			}
 		}
 

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -255,7 +255,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 				if len(sr.symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.uri().String()), strings.ToLower(sr.symbol.Name)) {
 					score++
 				}
-				symbolResolver := toSymbolResolver(r.db, sr)
+				symbolResolver := toSymbolResolver(r.db, fileMatch.Commit(), sr)
 				results = append(results, newSearchSuggestionResolver(symbolResolver, score))
 			}
 		}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -31,7 +31,6 @@ type SearchSymbolResult struct {
 	symbol  protocol.Symbol
 	baseURI *gituri.URI
 	lang    string
-	commit  *GitCommitResolver // TODO: change to utility type we create to remove git resolvers from search.
 }
 
 func (s *SearchSymbolResult) uri() *gituri.URI {
@@ -185,13 +184,6 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 	}
 
 	repoResolver := NewRepositoryResolver(db, repoRevs.Repo.ToRepo())
-	commitResolver := &GitCommitResolver{
-		db:           db,
-		repoResolver: repoResolver,
-		oid:          GitObjectID(commitID),
-		inputRev:     &inputRev,
-		// NOTE: Not all fields are set, for performance.
-	}
 
 	symbols, err := backend.Symbols.ListTags(ctx, search.SymbolsParameters{
 		Repo:            repoRevs.Repo.Name,
@@ -212,7 +204,6 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 			symbol:  symbol,
 			baseURI: baseURI,
 			lang:    strings.ToLower(symbol.Language),
-			commit:  commitResolver,
 		}
 		uri := makeFileMatchURI(repoResolver.URL(), inputRev, symbolRes.uri().Fragment)
 		if fileMatch, ok := fileMatchesByURI[uri]; ok {

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -14,7 +14,6 @@ import (
 	"github.com/sourcegraph/go-lsp"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
@@ -226,7 +225,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 					Symbols:  []*SearchSymbolResult{symbolRes},
 					uri:      uri,
 					Repo:     repoRevs.Repo,
-					CommitID: api.CommitID(symbolRes.commit.OID()),
+					CommitID: commitID,
 				},
 				RepoResolver: repoResolver,
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -26,8 +26,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 
 	repoResolver := NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"})
-	commitResolver := toGitCommitResolver(repoResolver, db, "", nil)
-	sr := &SearchSymbolResult{symbol, baseURI, "go", commitResolver}
+	sr := &SearchSymbolResult{symbol, baseURI, "go"}
 
 	tests := []struct {
 		rev  string

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -164,7 +164,6 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 						},
 						baseURI: baseURI,
 						lang:    strings.ToLower(file.Language),
-						commit:  commit,
 					},
 				))
 			}
@@ -215,7 +214,6 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 			symbol:  symbol,
 			baseURI: baseURI,
 			lang:    strings.ToLower(symbol.Language),
-			commit:  commit,
 		}
 		resolver := toSymbolResolver(db, commit, &sr)
 		resolvers = append(resolvers, resolver)

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -152,6 +152,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 
 				res = append(res, toSymbolResolver(
 					db,
+					commit,
 					&SearchSymbolResult{
 						symbol: protocol.Symbol{
 							Name:       m.SymbolInfo.Sym,
@@ -216,15 +217,16 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 			lang:    strings.ToLower(symbol.Language),
 			commit:  commit,
 		}
-		resolver := toSymbolResolver(db, &sr)
+		resolver := toSymbolResolver(db, commit, &sr)
 		resolvers = append(resolvers, resolver)
 	}
 	return resolvers, err
 }
 
-func toSymbolResolver(db dbutil.DB, sr *SearchSymbolResult) symbolResolver {
+func toSymbolResolver(db dbutil.DB, commit *GitCommitResolver, sr *SearchSymbolResult) symbolResolver {
 	return symbolResolver{
 		db:                 db,
+		commit:             commit,
 		SearchSymbolResult: sr,
 	}
 }
@@ -242,7 +244,8 @@ func (r *symbolConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 }
 
 type symbolResolver struct {
-	db dbutil.DB
+	db     dbutil.DB
+	commit *GitCommitResolver
 	*SearchSymbolResult
 }
 

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -267,13 +267,10 @@ func (r symbolResolver) Language() string { return r.symbol.Language }
 
 func (r symbolResolver) Location() *locationResolver {
 	uri := r.baseURI.WithFilePath(r.symbol.Path)
+	stat := CreateFileInfo(uri.Fragment, false)
 	sr := symbolRange(r.symbol)
 	return &locationResolver{
-		resource: &GitTreeEntryResolver{
-			db:     r.db,
-			commit: r.commit,
-			stat:   CreateFileInfo(uri.Fragment, false), // assume the path refers to a file (not dir)
-		},
+		resource: NewGitTreeEntryResolver(r.commit, r.db, stat),
 		lspRange: &sr,
 	}
 }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -123,9 +123,10 @@ func (fm *FileMatchResolver) Resource() string {
 }
 
 func (fm *FileMatchResolver) Symbols() []symbolResolver {
+	commit := fm.Commit()
 	symbols := make([]symbolResolver, len(fm.FileMatch.Symbols))
 	for i, s := range fm.FileMatch.Symbols {
-		symbols[i] = toSymbolResolver(fm.db, s)
+		symbols[i] = toSymbolResolver(fm.db, commit, s)
 	}
 	return symbols
 }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -90,14 +90,18 @@ func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
 	// (which would make it slow). This GitCommitResolver will return empty
 	// values for all other fields.
 	return &GitTreeEntryResolver{
-		db: fm.db,
-		commit: &GitCommitResolver{
-			db:           fm.db,
-			repoResolver: fm.RepoResolver,
-			oid:          GitObjectID(fm.CommitID),
-			inputRev:     fm.InputRev,
-		},
-		stat: CreateFileInfo(fm.Path, false),
+		db:     fm.db,
+		commit: fm.Commit(),
+		stat:   CreateFileInfo(fm.Path, false),
+	}
+}
+
+func (fm *FileMatchResolver) Commit() *GitCommitResolver {
+	return &GitCommitResolver{
+		db:           fm.db,
+		repoResolver: fm.RepoResolver,
+		oid:          GitObjectID(fm.CommitID),
+		inputRev:     fm.InputRev,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -396,7 +396,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 
 					var symbols []*SearchSymbolResult
 					if typ == symbolRequest {
-						symbols = zoektFileMatchToSymbolResults(repoResolver, db, inputRev, &file)
+						symbols = zoektFileMatchToSymbolResults(repoResolver, inputRev, &file)
 					}
 					fm := &FileMatchResolver{
 						db: db,
@@ -540,7 +540,7 @@ func escape(s string) string {
 	return string(escaped)
 }
 
-func zoektFileMatchToSymbolResults(repo *RepositoryResolver, db dbutil.DB, inputRev string, file *zoekt.FileMatch) []*SearchSymbolResult {
+func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*SearchSymbolResult {
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -545,12 +545,6 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, db dbutil.DB, input
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.
 	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: repo.Name(), RawQuery: url.QueryEscape(inputRev)}}
-	commit := &GitCommitResolver{
-		db:           db,
-		repoResolver: repo,
-		oid:          GitObjectID(file.Version),
-		inputRev:     &inputRev,
-	}
 	lang := strings.ToLower(file.Language)
 
 	symbols := make([]*SearchSymbolResult, 0, len(file.LineMatches))
@@ -580,7 +574,6 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, db dbutil.DB, input
 				},
 				lang:    lang,
 				baseURI: baseURI,
-				commit:  commit,
 			})
 		}
 	}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1040,7 +1040,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 
 	repo := NewRepositoryResolver(db, &types.Repo{Name: "foo"})
 
-	results := zoektFileMatchToSymbolResults(repo, new(dbtesting.MockDB), "master", file)
+	results := zoektFileMatchToSymbolResults(repo, "master", file)
 	var symbols []protocol.Symbol
 	for _, res := range results {
 		// Check the fields which are not specific to the symbol

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1050,15 +1050,6 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		if got, want := res.baseURI.URL.String(), "git://foo?master"; got != want {
 			t.Fatalf("baseURI: got %q want %q", got, want)
 		}
-		if got, want := res.commit.Repository().Name(), "foo"; got != want {
-			t.Fatalf("reporesolver: got %q want %q", got, want)
-		}
-		if got, want := string(res.commit.OID()), "deadbeef"; got != want {
-			t.Fatalf("oid: got %q want %q", got, want)
-		}
-		if got, want := *res.commit.InputRev(), "master"; got != want {
-			t.Fatalf("inputRev: got %q want %q", got, want)
-		}
 
 		symbols = append(symbols, res.symbol)
 	}


### PR DESCRIPTION
As learned from the issues earlier today with panics (#18628), commit cannot be entirely removed from the symbol result type. However, it can be safely moved from the searchSymbolResult to the symbolResolver. So, we're going to try this again.

Progresses #18348 

This is the last resolver that exists in the type tree of `FileMatch`. Once this is moved, `FileMatch` can safely be moved out of `graphqlbackend`. Additionally, many of the functions that return `FileMatchResolver`s can be modified to return `FileMatch`, and also moved out of `graphqlbackend` if we so choose 🎉 

Each commit in this PR is self-contained, self-describing, and as small as possible, so please review by commit.

This will likely conflict some with #18631, so I will plan to merge that one first. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
