### PR TITLE
search frontend: escape spaces in repo/file and avoid quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - A repository's `remote.origin.url` is not stored on gitserver disk anymore. Note: if you use the experimental feature `customGitFetch` your setting may need to be updated to specify the remote URL. [#18535](https://github.com/sourcegraph/sourcegraph/pull/18535)
+- Repositories and files containing spaces will now render with escaped spaces in the query bar rather than being quoted. [#18642](https://github.com/sourcegraph/sourcegraph/pull/18642)
 
 ### Fixed
 

--- a/client/web/src/integration/repository.test.ts
+++ b/client/web/src/integration/repository.test.ts
@@ -479,7 +479,7 @@ describe('Repository', () => {
             )?.replace(/\u00A0/g, ' ')
             assert.strictEqual(
                 searchQuery,
-                'repo:^github\\.com/ggilmore/q-test$ file:"^Geoffrey\'s random queries\\\\.32r242442bf/% token\\\\.4288249258\\\\.sql"'
+                "repo:^github\\.com/ggilmore/q-test$ file:^Geoffrey's\\ random\\ queries\\.32r242442bf/%\\ token\\.4288249258\\.sql"
             )
 
             await driver.page.waitForSelector('.test-go-to-code-host')

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -24,7 +24,6 @@ import {
     PatternTypeProps,
     CaseSensitivityProps,
     CopyQueryButtonProps,
-    quoteIfNeeded,
     SearchContextProps,
 } from '../search'
 import { RouteDescriptor } from '../util/contributions'
@@ -59,6 +58,7 @@ import { IS_CHROME } from '../marketing/util'
 import { useLocalStorage } from '../util/useLocalStorage'
 import { Settings } from '../schema/settings.schema'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
+import { escapeSpaces } from '../../../shared/src/search/query/filters'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -266,7 +266,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
     useEffect(() => {
         let query = searchQueryForRepoRevision(repoName, globbing, revision)
         if (filePath) {
-            query = `${query.trimEnd()} file:${quoteIfNeeded(globbing ? filePath : '^' + escapeRegExp(filePath))}`
+            query = `${query.trimEnd()} file:${escapeSpaces(globbing ? filePath : '^' + escapeRegExp(filePath))}`
         }
         onNavbarQueryChange({
             query,

--- a/client/web/src/search/index.test.tsx
+++ b/client/web/src/search/index.test.tsx
@@ -1,5 +1,10 @@
-import { parseSearchURL, resolveVersionContext } from '.'
+import { parseSearchURL, repoFilterForRepoRevision, resolveVersionContext } from '.'
 import { SearchPatternType } from '../graphql-operations'
+
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value),
+    test: () => true,
+})
 
 describe('search/index', () => {
     test('parseSearchURL', () => {
@@ -135,5 +140,13 @@ describe('search/index', () => {
             ])
         ).toBe(undefined)
         expect(resolveVersionContext('3.15', undefined)).toBe(undefined)
+    })
+})
+
+describe('repoFilterForRepoRevision escapes values with spaces', () => {
+    test('escapes spaces in value', () => {
+        expect(repoFilterForRepoRevision('7 is my final answer', false)).toMatchInlineSnapshot(
+            '"^7\\\\ is\\\\ my\\\\ final\\\\ answer$"'
+        )
     })
 })

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -1,6 +1,6 @@
 import { escapeRegExp } from 'lodash'
 import { replaceRange } from '../../../shared/src/util/strings'
-import { discreteValueAliases } from '../../../shared/src/search/query/filters'
+import { discreteValueAliases, escapeSpaces } from '../../../shared/src/search/query/filters'
 import { VersionContext } from '../schema/site.schema'
 import { SearchPatternType } from '../../../shared/src/graphql-operations'
 import { Observable } from 'rxjs'
@@ -119,9 +119,9 @@ export function parseSearchURL(
 
 export function repoFilterForRepoRevision(repoName: string, globbing: boolean, revision?: string): string {
     if (globbing) {
-        return `${quoteIfNeeded(`${repoName}${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
+        return `${escapeSpaces(`${repoName}${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
     }
-    return `${quoteIfNeeded(`^${escapeRegExp(repoName)}$${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
+    return `${escapeSpaces(`^${escapeRegExp(repoName)}$${revision ? `@${abbreviateOID(revision)}` : ''}`)}`
 }
 
 export function searchQueryForRepoRevision(repoName: string, globbing: boolean, revision?: string): string {


### PR DESCRIPTION
Stacked on #18638. Fixes https://github.com/sourcegraph/sourcegraph/issues/18636

Navigating to files and repos will now escape spaces of values if needed, instead of quoting. Quoting is less desirable because:

1. it adds complexity by imposing more potential escaping requirements for `"`, `'`, and `\`
2. we lose syntax highlighting and hovers for quoted values, and implementing highlighting and hovers is more complicated precisely because of (1)
3. it is more consistent with how commands like `ls` render escaped file names/spaces rather than with quotes

https://user-images.githubusercontent.com/888624/109096557-fe84db80-76da-11eb-882d-151951f82b7e.mp4

I'm surprised this change didn't break any tests. I added one to lock in the repo behavior--the file one is difficult to test.

**Edit**: Oh cool, it did break a test for `file:^Geoffrey's\ random\ queries\.32r242442bf/%\ token\.4288249258\.sql` so we are covered for the file case. Not sure why `repository.test.ts` doesn't run locally under `yarn test`--how does running puppeteer tests work locally?