### PR TITLE
graphqlbackend: Add a soft rate limiter

### DIFF
--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -3,12 +3,18 @@ package graphqlbackend
 import (
 	"fmt"
 	"strconv"
+	"sync/atomic"
 
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/graphql-go/graphql/language/kinds"
 	"github.com/graphql-go/graphql/language/parser"
 	"github.com/graphql-go/graphql/language/visitor"
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"github.com/throttled/throttled/v2"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // Included in tracing so that we can differentiate different costs as we tweak
@@ -351,4 +357,145 @@ func shouldCheckParam(p visitor.VisitFuncParams) bool {
 		return false
 	}
 	return true
+}
+
+// RateLimitWatcher stores the currently configured rate limiter and whether or
+// not rate limiting is enabled.
+type RateLimitWatcher struct {
+	store throttled.GCRAStore
+	rl    atomic.Value // *RateLimiter
+}
+
+// NewRateLimiter creates a new limiter with the provided store and starts
+// watching for config changes.
+func NewRateLimiter(store throttled.GCRAStore) *RateLimitWatcher {
+	w := &RateLimitWatcher{
+		store: store,
+	}
+
+	conf.Watch(func() {
+		log15.Debug("Rate limit config updated, applying changes")
+		w.updateFromConfig(conf.Get().ApiRatelimit)
+	})
+
+	return w
+}
+
+// Get returns the current rate limiter. If rate limiting is currently disabled
+// (nil, false) us returned.
+func (w *RateLimitWatcher) Get() (*RateLimiter, bool) {
+	if l, ok := w.rl.Load().(*RateLimiter); ok && l.enabled {
+		return l, true
+	}
+	return nil, false
+}
+
+func (w *RateLimitWatcher) updateFromConfig(rlc *schema.ApiRatelimit) {
+	// We can burst up to a max of 20% of limit
+	maxBurstPercentage := 0.2
+
+	if rlc == nil || !rlc.Enabled {
+		w.rl.Store(&RateLimiter{enabled: false})
+		return
+	}
+
+	ipQuota := throttled.RateQuota{
+		MaxRate:  throttled.PerHour(rlc.PerIP),
+		MaxBurst: int(float64(rlc.PerIP) * maxBurstPercentage),
+	}
+	ipLimiter, err := throttled.NewGCRARateLimiter(w.store, ipQuota)
+	if err != nil {
+		log15.Warn("error creating ip rate limiter", "error", err)
+		return
+	}
+
+	userQuota := throttled.RateQuota{
+		MaxRate:  throttled.PerHour(rlc.PerUser),
+		MaxBurst: int(float64(rlc.PerUser) * maxBurstPercentage),
+	}
+	userLimiter, err := throttled.NewGCRARateLimiter(w.store, userQuota)
+	if err != nil {
+		log15.Warn("error creating user rate limiter", "error", err)
+		return
+	}
+
+	overrides := make(map[string]limiter)
+	for _, o := range rlc.Overrides {
+		switch l := o.Limit.(type) {
+		case string:
+			if l == "blocked" {
+				overrides[o.Key] = &fixedLimiter{
+					limited: true,
+					result: throttled.RateLimitResult{
+						Limit:      0,
+						Remaining:  0,
+						ResetAfter: 0,
+						RetryAfter: 0,
+					},
+				}
+			} else if l == "unlimited" {
+				overrides[o.Key] = &fixedLimiter{
+					limited: false,
+					result: throttled.RateLimitResult{
+						Limit:      100000,
+						Remaining:  100000,
+						ResetAfter: 0,
+						RetryAfter: 0,
+					},
+				}
+			} else {
+				log15.Warn("unknown limit value", "value", l)
+				return
+			}
+		case int:
+			rl, err := throttled.NewGCRARateLimiter(w.store, throttled.RateQuota{
+				MaxRate:  throttled.PerHour(l),
+				MaxBurst: int(float64(l) * maxBurstPercentage),
+			})
+			if err != nil {
+				log15.Warn("error creating override rate limiter", "key", o.Key, "error", err)
+				return
+			}
+			overrides[o.Key] = rl
+		}
+	}
+
+	// Store the new limiter
+	w.rl.Store(&RateLimiter{
+		enabled:     true,
+		ipLimiter:   ipLimiter,
+		userLimiter: userLimiter,
+		overrides:   overrides,
+	})
+}
+
+type RateLimiter struct {
+	enabled     bool
+	ipLimiter   *throttled.GCRARateLimiter
+	userLimiter *throttled.GCRARateLimiter
+	overrides   map[string]limiter
+}
+
+func (rl *RateLimiter) RateLimit(uid string, isIP bool, cost int) (bool, throttled.RateLimitResult, error) {
+	if r, ok := rl.overrides[uid]; ok {
+		return r.RateLimit(uid, cost)
+	}
+	if isIP {
+		return rl.ipLimiter.RateLimit(uid, cost)
+	}
+	return rl.userLimiter.RateLimit(uid, cost)
+}
+
+type limiter interface {
+	RateLimit(string, int) (bool, throttled.RateLimitResult, error)
+}
+
+// fixedLimiter is a rate limiter that always returns the same result
+type fixedLimiter struct {
+	limited bool
+	result  throttled.RateLimitResult
+}
+
+func (f *fixedLimiter) RateLimit(string, int) (bool, throttled.RateLimitResult, error) {
+	return f.limited, f.result, nil
 }

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -382,7 +382,7 @@ func NewRateLimiteWatcher(store throttled.GCRAStore) *RateLimitWatcher {
 }
 
 // Get returns the current rate limiter. If rate limiting is currently disabled
-// (nil, false) us returned.
+// (nil, false) is returned.
 func (w *RateLimitWatcher) Get() (*RateLimiter, bool) {
 	if l, ok := w.rl.Load().(*RateLimiter); ok && l.enabled {
 		return l, true

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -366,9 +366,9 @@ type RateLimitWatcher struct {
 	rl    atomic.Value // *RateLimiter
 }
 
-// NewRateLimiter creates a new limiter with the provided store and starts
+// NewRateLimiteWatcher creates a new limiter with the provided store and starts
 // watching for config changes.
-func NewRateLimiter(store throttled.GCRAStore) *RateLimitWatcher {
+func NewRateLimiteWatcher(store throttled.GCRAStore) *RateLimitWatcher {
 	w := &RateLimitWatcher{
 		store: store,
 	}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/tmpfriend"
+	"github.com/throttled/throttled/v2/store/redigostore"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
@@ -38,6 +39,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/logging"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 	"github.com/sourcegraph/sourcegraph/internal/profiler"
+	"github.com/sourcegraph/sourcegraph/internal/redispool"
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
@@ -225,12 +227,18 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 		return err
 	}
 
-	server, err := makeExternalAPI(db, schema, enterprise)
+	ratelimitStore, err := redigostore.New(redispool.Cache, "gql:rl:", 0)
+	if err != nil {
+		return err
+	}
+	rateLimitWatcher := graphqlbackend.NewRateLimiter(ratelimitStore)
+
+	server, err := makeExternalAPI(db, schema, enterprise, rateLimitWatcher)
 	if err != nil {
 		return err
 	}
 
-	internalAPI, err := makeInternalAPI(schema, db, enterprise)
+	internalAPI, err := makeInternalAPI(schema, db, enterprise, rateLimitWatcher)
 	if err != nil {
 		return err
 	}
@@ -254,9 +262,9 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 	return nil
 }
 
-func makeExternalAPI(db dbutil.DB, schema *graphql.Schema, enterprise enterprise.Services) (goroutine.BackgroundRoutine, error) {
+func makeExternalAPI(db dbutil.DB, schema *graphql.Schema, enterprise enterprise.Services, rateLimiter *graphqlbackend.RateLimitWatcher) (goroutine.BackgroundRoutine, error) {
 	// Create the external HTTP handler.
-	externalHandler, err := newExternalHTTPHandler(db, schema, enterprise.GitHubWebhook, enterprise.GitLabWebhook, enterprise.BitbucketServerWebhook, enterprise.NewCodeIntelUploadHandler, enterprise.NewExecutorProxyHandler)
+	externalHandler, err := newExternalHTTPHandler(db, schema, enterprise.GitHubWebhook, enterprise.GitLabWebhook, enterprise.BitbucketServerWebhook, enterprise.NewCodeIntelUploadHandler, enterprise.NewExecutorProxyHandler, rateLimiter)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +284,7 @@ func makeExternalAPI(db dbutil.DB, schema *graphql.Schema, enterprise enterprise
 	return server, nil
 }
 
-func makeInternalAPI(schema *graphql.Schema, db dbutil.DB, enterprise enterprise.Services) (goroutine.BackgroundRoutine, error) {
+func makeInternalAPI(schema *graphql.Schema, db dbutil.DB, enterprise enterprise.Services, rateLimiter *graphqlbackend.RateLimitWatcher) (goroutine.BackgroundRoutine, error) {
 	if httpAddrInternal == "" {
 		return nil, nil
 	}
@@ -287,7 +295,7 @@ func makeInternalAPI(schema *graphql.Schema, db dbutil.DB, enterprise enterprise
 	}
 
 	// The internal HTTP handler does not include the auth handlers.
-	internalHandler := newInternalHTTPHandler(schema, db, enterprise.NewCodeIntelUploadHandler)
+	internalHandler := newInternalHTTPHandler(schema, db, enterprise.NewCodeIntelUploadHandler, rateLimiter)
 
 	server := httpserver.New(listener, &http.Server{
 		Handler:     internalHandler,

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -231,7 +231,7 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 	if err != nil {
 		return err
 	}
-	rateLimitWatcher := graphqlbackend.NewRateLimiter(ratelimitStore)
+	rateLimitWatcher := graphqlbackend.NewRateLimiteWatcher(ratelimitStore)
 
 	server, err := makeExternalAPI(db, schema, enterprise, rateLimitWatcher)
 	if err != nil {

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -20,7 +20,7 @@ func newTest() *httptestutil.Client {
 	enterpriseServices := enterprise.DefaultServices()
 	db := new(dbtesting.MockDB)
 	rateLimitStore, _ := memstore.New(1024)
-	rateLimiter := graphqlbackend.NewRateLimiter(rateLimitStore)
+	rateLimiter := graphqlbackend.NewRateLimiteWatcher(rateLimitStore)
 
 	return httptestutil.NewTest(NewHandler(db,
 		router.New(mux.NewRouter()),

--- a/cmd/frontend/internal/httpapi/api_test.go
+++ b/cmd/frontend/internal/httpapi/api_test.go
@@ -2,8 +2,10 @@ package httpapi
 
 import (
 	"github.com/gorilla/mux"
+	"github.com/throttled/throttled/v2/store/memstore"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
@@ -17,6 +19,8 @@ func init() {
 func newTest() *httptestutil.Client {
 	enterpriseServices := enterprise.DefaultServices()
 	db := new(dbtesting.MockDB)
+	rateLimitStore, _ := memstore.New(1024)
+	rateLimiter := graphqlbackend.NewRateLimiter(rateLimitStore)
 
 	return httptestutil.NewTest(NewHandler(db,
 		router.New(mux.NewRouter()),
@@ -25,5 +29,6 @@ func newTest() *httptestutil.Client {
 		enterpriseServices.GitLabWebhook,
 		enterpriseServices.BitbucketServerWebhook,
 		enterpriseServices.NewCodeIntelUploadHandler,
+		rateLimiter,
 	))
 }

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -13,6 +13,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/inconshreveable/log15"
+	"github.com/throttled/throttled/v2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -20,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
 
-func serveGraphQL(schema *graphql.Schema, isInternal bool) func(w http.ResponseWriter, r *http.Request) (err error) {
+func serveGraphQL(schema *graphql.Schema, rlw *graphqlbackend.RateLimitWatcher, isInternal bool) func(w http.ResponseWriter, r *http.Request) (err error) {
 	return func(w http.ResponseWriter, r *http.Request) (err error) {
 		if r.Method != "POST" {
 			// The URL router should not have routed to this handler if method is not POST, but just in
@@ -51,14 +52,21 @@ func serveGraphQL(schema *graphql.Schema, isInternal bool) func(w http.ResponseW
 			defer gzipReader.Close()
 		}
 
-		var params struct {
-			Query         string                 `json:"query"`
-			OperationName string                 `json:"operationName"`
-			Variables     map[string]interface{} `json:"variables"`
-		}
+		var params graphQLQueryParams
 		if err := json.NewDecoder(r.Body).Decode(&params); err != nil {
 			return err
 		}
+
+		traceData := traceData{
+			queryParams:   params,
+			isInternal:    isInternal,
+			requestName:   requestName,
+			requestSource: string(requestSource),
+		}
+
+		uid, isIP, anonymous := getUID(r)
+		traceData.uid = uid
+		traceData.anonymous = anonymous
 
 		validationErrs := schema.ValidateWithVariables(params.Query, params.Variables)
 
@@ -71,11 +79,25 @@ func serveGraphQL(schema *graphql.Schema, isInternal bool) func(w http.ResponseW
 				// We send errors to Honeycomb, no need to spam logs
 				log15.Debug("estimating GraphQL cost", "error", costErr)
 			}
+			traceData.costError = costErr
+			traceData.cost = cost
 		}
 
-		start := time.Now()
+		if rl, enabled := rlw.Get(); enabled {
+			limited, result, err := rl.RateLimit(uid, isIP, cost.FieldCount)
+			if err != nil {
+				log15.Error("checking GraphQL rate limit", "error", err)
+				traceData.limitError = err
+			} else {
+				traceData.limited = limited
+				traceData.limitResult = result
+			}
+		}
+
+		traceData.execStart = time.Now()
 		response := schema.Exec(r.Context(), params.Query, params.OperationName, params.Variables)
-		traceGraphQL(r, params.Query, params.OperationName, params.Variables, response.Errors, cost, costErr, isInternal, requestName, string(requestSource), start)
+		traceData.queryErrors = response.Errors
+		traceGraphQL(traceData)
 		responseJSON, err := json.Marshal(response)
 		if err != nil {
 			return err
@@ -88,50 +110,71 @@ func serveGraphQL(schema *graphql.Schema, isInternal bool) func(w http.ResponseW
 	}
 }
 
-func traceGraphQL(r *http.Request,
-	queryString string,
-	operationName string,
-	variables map[string]interface{},
-	queryErrors []*gqlerrors.QueryError,
-	cost *graphqlbackend.QueryCost,
-	costErr error,
-	isInternal bool,
-	requestName string,
-	requestSource string,
-	requestStart time.Time) {
+type graphQLQueryParams struct {
+	Query         string                 `json:"query"`
+	OperationName string                 `json:"operationName"`
+	Variables     map[string]interface{} `json:"variables"`
+}
 
+type traceData struct {
+	queryParams   graphQLQueryParams
+	execStart     time.Time
+	uid           string
+	anonymous     bool
+	isInternal    bool
+	requestName   string
+	requestSource string
+	queryErrors   []*gqlerrors.QueryError
+
+	cost      *graphqlbackend.QueryCost
+	costError error
+
+	limited     bool
+	limitError  error
+	limitResult throttled.RateLimitResult
+}
+
+func traceGraphQL(data traceData) {
 	if !honey.Enabled() || traceGraphQLQueriesSample <= 0 {
 		return
 	}
 
-	duration := time.Since(requestStart)
-	uid, anonymous := getUID(r)
+	duration := time.Since(data.execStart)
 
 	ev := honey.Event("graphql-cost")
 	ev.SampleRate = uint(traceGraphQLQueriesSample)
-	ev.AddField("query", queryString)
-	ev.AddField("variables", variables)
-	ev.AddField("anonymous", anonymous)
-	ev.AddField("uid", uid)
-	ev.AddField("operationName", operationName)
-	ev.AddField("isInternal", isInternal)
+
+	ev.AddField("query", data.queryParams.Query)
+	ev.AddField("variables", data.queryParams.Variables)
+	ev.AddField("operationName", data.queryParams.OperationName)
+
+	ev.AddField("anonymous", data.anonymous)
+	ev.AddField("uid", data.uid)
+	ev.AddField("isInternal", data.isInternal)
 	// Honeycomb has built in support for latency if you use milliseconds. We
 	// multiply seconds by 1000 here instead of using d.Milliseconds() so that we
 	// don't truncate durations of less than 1 millisecond.
 	ev.AddField("durationMilliseconds", duration.Seconds()*1000)
-	ev.AddField("hasQueryErrors", len(queryErrors) > 0)
-	ev.AddField("requestName", requestName)
-	ev.AddField("requestSource", requestSource)
+	ev.AddField("hasQueryErrors", len(data.queryErrors) > 0)
+	ev.AddField("requestName", data.requestName)
+	ev.AddField("requestSource", data.requestSource)
 
-	if costErr != nil {
-		log15.Warn("estimating GraphQL cost", "error", costErr)
+	if data.costError != nil {
 		ev.AddField("hasCostError", true)
-		ev.AddField("costError", costErr.Error())
-	} else if cost != nil {
+		ev.AddField("costError", data.costError.Error())
+	} else if data.cost != nil {
 		ev.AddField("hasCostError", false)
-		ev.AddField("cost", cost.FieldCount)
-		ev.AddField("depth", cost.MaxDepth)
-		ev.AddField("costVersion", cost.Version)
+		ev.AddField("cost", data.cost.FieldCount)
+		ev.AddField("depth", data.cost.MaxDepth)
+		ev.AddField("costVersion", data.cost.Version)
+	}
+
+	ev.AddField("rateLimited", data.limited)
+	if data.limitError != nil {
+		ev.AddField("rateLimitError", data.limitError.Error())
+	} else {
+		ev.AddField("rateLimit", data.limitResult.Limit)
+		ev.AddField("rateLimitRemaining", data.limitResult.Remaining)
 	}
 
 	_ = ev.Send()
@@ -142,20 +185,20 @@ var traceGraphQLQueriesSample = func() int {
 	return rate
 }()
 
-func getUID(r *http.Request) (uid string, anonymous bool) {
+func getUID(r *http.Request) (uid string, ip bool, anonymous bool) {
 	a := actor.FromContext(r.Context())
 	anonymous = !a.IsAuthenticated()
 	if !anonymous {
-		return a.UIDString(), anonymous
+		return a.UIDString(), false, anonymous
 	}
 	if cookie, err := r.Cookie("sourcegraphAnonymousUid"); err == nil && cookie.Value != "" {
-		return cookie.Value, anonymous
+		return cookie.Value, false, anonymous
 	}
 	// The user is anonymous with no cookie, use IP
 	if ip := r.Header.Get("X-Forwarded-For"); ip != "" {
-		return ip, anonymous
+		return ip, true, anonymous
 	}
-	return "unknown", anonymous
+	return "unknown", false, anonymous
 }
 
 // guessSource guesses the source the request came from (browser, other HTTP client, etc.)

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -14,9 +14,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
-
 	apirouter "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/httpapi/router"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )

--- a/go.mod
+++ b/go.mod
@@ -170,6 +170,7 @@ require (
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stripe/stripe-go v70.15.0+incompatible
 	github.com/temoto/robotstxt v1.1.1
+	github.com/throttled/throttled/v2 v2.7.1
 	github.com/tidwall/gjson v1.6.1
 	github.com/tinylib/msgp v1.1.2 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80

--- a/go.sum
+++ b/go.sum
@@ -465,6 +465,7 @@ github.com/go-openapi/validate v0.19.8/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85n
 github.com/go-openapi/validate v0.19.10/go.mod h1:RKEZTUWDkxKQxN2jDT7ZnZi2bhZlbNMAuKvKB+IaGx8=
 github.com/go-openapi/validate v0.19.11 h1:8lCr0b9lNWKjVjW/hSZZvltUy+bULl7vbnCTsOzlhPo=
 github.com/go-openapi/validate v0.19.11/go.mod h1:Rzou8hA/CBw8donlS6WNEUQupNvUZ0waH08tGe6kAQ4=
+github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-redsync/redsync v1.4.2 h1:KADEZ2rlaHMZWnlkthQCxfGP+8ZWwJLiSjOYN3mntKA=
 github.com/go-redsync/redsync v1.4.2/go.mod h1:my8/M5YL986u2jBMtZTLkBIgBsKNNSixJWzWwISH6Uw=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
@@ -738,6 +739,7 @@ github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -1352,6 +1354,10 @@ github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKN
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
+github.com/throttled/throttled v1.0.0 h1:GQ7a1ilkYMXnZ6V0EG7RiU3qHk1k/kpXO/aIQQXPfEQ=
+github.com/throttled/throttled v2.2.5+incompatible h1:65UB52X0qNTYiT0Sohp8qLYVFwZQPDw85uSa65OljjQ=
+github.com/throttled/throttled/v2 v2.7.1 h1:FnBysDX4Sok55bvfDMI0l2Y71V1vM2wi7O79OW7fNtw=
+github.com/throttled/throttled/v2 v2.7.1/go.mod h1:fuOeyK9fmnA+LQnsBbfT/mmPHjmkdogRBQxaD8YsgZ8=
 github.com/tidwall/gjson v1.6.1 h1:LRbvNuNuvAiISWg6gxLEFuCe72UKy5hDqhxW/8183ws=
 github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
@@ -1643,6 +1649,7 @@ golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191128015809-6d18c012aee9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -916,13 +916,13 @@
           "description": "Limit granted per user per hour",
           "type": "integer",
           "minimum": 1,
-          "default": 5000
+          "default": 1000000
         },
         "perIP": {
           "description": "Limit granted per IP per hour, only applied to anonymous users",
           "type": "integer",
           "minimum": 1,
-          "default": 5000
+          "default": 1000000
         },
         "overrides": {
           "description": "An array of rate limit overrides",

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -921,13 +921,13 @@ const SiteSchemaJSON = `{
           "description": "Limit granted per user per hour",
           "type": "integer",
           "minimum": 1,
-          "default": 5000
+          "default": 1000000
         },
         "perIP": {
           "description": "Limit granted per IP per hour, only applied to anonymous users",
           "type": "integer",
           "minimum": 1,
-          "default": 5000
+          "default": 1000000
         },
         "overrides": {
           "description": "An array of rate limit overrides",


### PR DESCRIPTION
This adds a rate limiter that can be configured at runtime from site
config. It is a soft limiter in that it does not actually stop requests
that exceed the rate limit but instead just instruments to Honeycomb.

It's backed by our Redis cache instance.

Closes: https://github.com/sourcegraph/sourcegraph/issues/18100