### PR TITLE
search: document GlobalSearchMode

### DIFF
--- a/internal/search/types.go
+++ b/internal/search/types.go
@@ -83,11 +83,27 @@ type SymbolsParameters struct {
 	First int
 }
 
+// GlobalSearchMode designates code paths which optimize performance for global
+// searches, i.e., literal or regexp, indexed searches without repo: filter.
 type GlobalSearchMode int
 
 const (
+	// ZoektGlobalSearch designates a performance optimised code path for indexed
+	// searches. For a global search we don't need to resolve repos before searching
+	// shards on Zoekt, instead we can resolve repos and call Zoekt concurrently.
+	//
+	// Note: Even for a global search we have to resolve repos to filter search results
+	// returned by Zoekt.
 	ZoektGlobalSearch GlobalSearchMode = iota + 1
+
+	// SearcherOnly designated a code path on which we skip indexed search, even if
+	// the user specified index:yes. SearcherOnly is used in conjunction with
+	// ZoektGlobalSearch and designates the non-indexed part of the performance
+	// optimised code path.
 	SearcherOnly
+
+	// Disables file/path search. Used only in conjunction with ZoektGlobalSearch on
+	// Sourcegraph.com.
 	NoFilePath
 )
 


### PR DESCRIPTION
This adds docstrings for `GlobalSearchMode`.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
