### PR TITLE
Record the matching route pattern when submitting from the feedback widget

### DIFF
--- a/client/web/src/hooks/index.ts
+++ b/client/web/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useMutation } from './useMutation'
+export { useRoutesMatch } from './useRoutesMatch'

--- a/client/web/src/hooks/useRoutesMatch.ts
+++ b/client/web/src/hooks/useRoutesMatch.ts
@@ -2,6 +2,13 @@ import { useEffect, useState } from 'react'
 import { matchPath, useLocation } from 'react-router'
 import { LayoutRouteProps } from '../routes'
 
+/**
+ * Match the current pathname against a list of route patterns
+ *
+ * @param routes List of routes to match against
+ *
+ * @returns A matching route pattern
+ */
 export const useRoutesMatch = (routes: readonly LayoutRouteProps<{}>[]): string | undefined => {
     const location = useLocation()
     const [match, setMatch] = useState<string | undefined>('')

--- a/client/web/src/hooks/useRoutesMatch.ts
+++ b/client/web/src/hooks/useRoutesMatch.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+import { matchPath, useLocation } from 'react-router'
+import { LayoutRouteProps } from '../routes'
+
+export const useRoutesMatch = (routes: readonly LayoutRouteProps<{}>[]): string | undefined => {
+    const location = useLocation()
+    const [match, setMatch] = useState<string | undefined>('')
+
+    useEffect(() => {
+        const newMatch = routes.find(({ path, exact }) => matchPath(location.pathname, { path, exact }))?.path
+        setMatch(newMatch)
+    }, [location.pathname, routes])
+
+    return match
+}

--- a/client/web/src/nav/Feedback/FeedbackPrompt.story.tsx
+++ b/client/web/src/nav/Feedback/FeedbackPrompt.story.tsx
@@ -8,9 +8,14 @@ const history = createBrowserHistory()
 
 const { add } = storiesOf('web/nav', module)
 
-add('Feedback Widget', () => <WebStory>{() => <FeedbackPrompt open={true} history={history} />}</WebStory>, {
-    design: {
-        type: 'figma',
-        url: 'https://www.figma.com/file/9FprSCL6roIZotcWMvJZuE/Improving-user-feedback-channels?node-id=300%3A3555',
-    },
-})
+add(
+    'Feedback Widget',
+    () => <WebStory>{() => <FeedbackPrompt open={true} history={history} routes={[]} />}</WebStory>,
+    {
+        design: {
+            type: 'figma',
+            url:
+                'https://www.figma.com/file/9FprSCL6roIZotcWMvJZuE/Improving-user-feedback-channels?node-id=300%3A3555',
+        },
+    }
+)

--- a/client/web/src/nav/Feedback/FeedbackPrompt.test.tsx
+++ b/client/web/src/nav/Feedback/FeedbackPrompt.test.tsx
@@ -6,6 +6,7 @@ import { createMemoryHistory } from 'history'
 import { FeedbackPrompt, HAPPINESS_FEEDBACK_OPTIONS } from './FeedbackPrompt'
 import { SubmitHappinessFeedbackResult, SubmitHappinessFeedbackVariables } from '../../graphql-operations'
 import { MutationResult } from '../../hooks/useMutation'
+import { routes } from '../../routes'
 
 let mockResponse: MutationResult<SubmitHappinessFeedbackResult> = { loading: false }
 const mockSubmitFn = sinon.spy((parameters: SubmitHappinessFeedbackVariables) => undefined)
@@ -13,7 +14,7 @@ const history = createMemoryHistory()
 
 jest.mock('../../hooks', () => ({
     useMutation: () => [mockSubmitFn, mockResponse],
-    useRouteMatch: () => '/some-route',
+    useRoutesMatch: () => '/some-route',
 }))
 
 describe('FeedbackPrompt', () => {
@@ -24,7 +25,7 @@ describe('FeedbackPrompt', () => {
     })
 
     beforeEach(() => {
-        queries = render(<FeedbackPrompt history={history} />)
+        queries = render(<FeedbackPrompt history={history} routes={routes} />)
     })
 
     test('Renders heading correctly', () => {

--- a/client/web/src/nav/Feedback/FeedbackPrompt.test.tsx
+++ b/client/web/src/nav/Feedback/FeedbackPrompt.test.tsx
@@ -11,8 +11,9 @@ let mockResponse: MutationResult<SubmitHappinessFeedbackResult> = { loading: fal
 const mockSubmitFn = sinon.spy((parameters: SubmitHappinessFeedbackVariables) => undefined)
 const history = createMemoryHistory()
 
-jest.mock('../../hooks/useMutation', () => ({
+jest.mock('../../hooks', () => ({
     useMutation: () => [mockSubmitFn, mockResponse],
+    useRouteMatch: () => '/some-route',
 }))
 
 describe('FeedbackPrompt', () => {
@@ -67,7 +68,7 @@ describe('FeedbackPrompt', () => {
                 input: {
                     score: 4,
                     feedback: 'Lorem ipsum dolor sit amet',
-                    currentURL: 'http://localhost/',
+                    currentPath: '/some-route',
                 },
             })
         })

--- a/client/web/src/nav/Feedback/FeedbackPrompt.tsx
+++ b/client/web/src/nav/Feedback/FeedbackPrompt.tsx
@@ -15,7 +15,7 @@ import { IconRadioButtons } from '../IconRadioButtons'
 import { Happy, Sad, VeryHappy, VerySad } from './FeedbackIcons'
 import { Form } from '../../../../branded/src/components/Form'
 import { ErrorAlert } from '../../components/alerts'
-import { routes } from '../../routes'
+import { LayoutRouteProps } from '../../routes'
 
 export const HAPPINESS_FEEDBACK_OPTIONS = [
     {
@@ -51,13 +51,13 @@ const SUBMIT_HAPPINESS_FEEDBACK_QUERY = gql`
 interface ContentProps {
     closePrompt: () => void
     history: H.History
+    routeMatch?: string
 }
 
 const LOCAL_STORAGE_KEY_RATING = 'feedbackPromptRating'
 const LOCAL_STORAGE_KEY_TEXT = 'feedbackPromptText'
 
-const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePrompt, history }) => {
-    const match = useRoutesMatch(routes)
+const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePrompt, history, routeMatch }) => {
     const [rating, setRating] = useLocalStorage<number | undefined>(LOCAL_STORAGE_KEY_RATING, undefined)
     const [text, setText] = useLocalStorage<string>(LOCAL_STORAGE_KEY_TEXT, '')
     const handleRateChange = useCallback((value: number) => setRating(value), [setRating])
@@ -75,11 +75,11 @@ const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePro
             event.preventDefault()
             if (rating) {
                 return submitFeedback({
-                    input: { score: rating, feedback: text, currentPath: match },
+                    input: { score: rating, feedback: text, currentPath: routeMatch },
                 })
             }
         },
-        [rating, submitFeedback, text, match]
+        [rating, submitFeedback, text, routeMatch]
     )
 
     useEffect(() => {
@@ -160,13 +160,14 @@ const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePro
 interface Props {
     open?: boolean
     history: H.History
+    routes: readonly LayoutRouteProps<{}>[]
 }
 
-export const FeedbackPrompt: React.FunctionComponent<Props> = ({ open, history }) => {
+export const FeedbackPrompt: React.FunctionComponent<Props> = ({ open, history, routes }) => {
     const [isOpen, setIsOpen] = useState(() => !!open)
     const handleToggle = useCallback(() => setIsOpen(open => !open), [])
-
     const forceClose = useCallback(() => setIsOpen(false), [])
+    const match = useRoutesMatch(routes)
 
     return (
         <ButtonDropdown a11y={false} isOpen={isOpen} toggle={handleToggle} className="feedback-prompt" group={false}>
@@ -181,7 +182,7 @@ export const FeedbackPrompt: React.FunctionComponent<Props> = ({ open, history }
                 <span className="d-none d-lg-block">Feedback</span>
             </DropdownToggle>
             <DropdownMenu right={true} className="web-content feedback-prompt__menu">
-                <FeedbackPromptContent closePrompt={forceClose} history={history} />
+                <FeedbackPromptContent closePrompt={forceClose} history={history} routeMatch={match} />
             </DropdownMenu>
         </ButtonDropdown>
     )

--- a/client/web/src/nav/Feedback/FeedbackPrompt.tsx
+++ b/client/web/src/nav/Feedback/FeedbackPrompt.tsx
@@ -10,11 +10,12 @@ import { gql } from '../../../../shared/src/graphql/graphql'
 import { LoaderButton } from '../../components/LoaderButton'
 import { SubmitHappinessFeedbackResult, SubmitHappinessFeedbackVariables } from '../../graphql-operations'
 import { useLocalStorage } from '../../util/useLocalStorage'
-import { useMutation } from '../../hooks/useMutation'
+import { useMutation, useRoutesMatch } from '../../hooks'
 import { IconRadioButtons } from '../IconRadioButtons'
 import { Happy, Sad, VeryHappy, VerySad } from './FeedbackIcons'
 import { Form } from '../../../../branded/src/components/Form'
 import { ErrorAlert } from '../../components/alerts'
+import { routes } from '../../routes'
 
 export const HAPPINESS_FEEDBACK_OPTIONS = [
     {
@@ -56,6 +57,7 @@ const LOCAL_STORAGE_KEY_RATING = 'feedbackPromptRating'
 const LOCAL_STORAGE_KEY_TEXT = 'feedbackPromptText'
 
 const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePrompt, history }) => {
+    const match = useRoutesMatch(routes)
     const [rating, setRating] = useLocalStorage<number | undefined>(LOCAL_STORAGE_KEY_RATING, undefined)
     const [text, setText] = useLocalStorage<string>(LOCAL_STORAGE_KEY_TEXT, '')
     const handleRateChange = useCallback((value: number) => setRating(value), [setRating])
@@ -73,11 +75,11 @@ const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePro
             event.preventDefault()
             if (rating) {
                 return submitFeedback({
-                    input: { score: rating, feedback: text, currentURL: window.location.href },
+                    input: { score: rating, feedback: text, currentPath: match },
                 })
             }
         },
-        [rating, submitFeedback, text]
+        [rating, submitFeedback, text, match]
     )
 
     useEffect(() => {

--- a/client/web/src/nav/GlobalNavbar.story.tsx
+++ b/client/web/src/nav/GlobalNavbar.story.tsx
@@ -61,6 +61,7 @@ const defaultProps = (
     showCampaigns: true,
     activation: undefined,
     hideNavLinks: false,
+    routes: [],
 })
 
 const { add } = storiesOf('web/nav/GlobalNav', module)

--- a/client/web/src/nav/GlobalNavbar.test.tsx
+++ b/client/web/src/nav/GlobalNavbar.test.tsx
@@ -49,6 +49,7 @@ const PROPS: React.ComponentProps<typeof GlobalNavbar> = {
     enableSmartQuery: false,
     showOnboardingTour: false,
     branding: undefined,
+    routes: [],
 }
 
 describe('GlobalNavbar', () => {

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -28,6 +28,7 @@ import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 import { BrandLogo } from '../components/branding/BrandLogo'
 import { LinkOrSpan } from '../../../shared/src/components/LinkOrSpan'
 import { ExtensionAlertAnimationProps } from './UserNavItem'
+import { LayoutRouteProps } from '../routes'
 
 interface Props
     extends SettingsCascadeProps,
@@ -55,6 +56,7 @@ interface Props
     isSourcegraphDotCom: boolean
     isSearchRelatedPage: boolean
     showCampaigns: boolean
+    routes: readonly LayoutRouteProps<{}>[]
 
     // Whether globbing is enabled for filters.
     globbing: boolean

--- a/client/web/src/nav/NavLinks.test.tsx
+++ b/client/web/src/nav/NavLinks.test.tsx
@@ -87,6 +87,7 @@ describe('NavLinks', () => {
                                     showDotComMarketing={showDotComMarketing}
                                     location={H.createLocation(path, history.location)}
                                     isExtensionAlertAnimating={false}
+                                    routes={[]}
                                 />
                             </MemoryRouter>
                         )

--- a/client/web/src/nav/NavLinks.tsx
+++ b/client/web/src/nav/NavLinks.tsx
@@ -27,6 +27,8 @@ import { MenuNavItem } from './MenuNavItem'
 import { StatusMessagesNavItem } from './StatusMessagesNavItem'
 import { ExtensionAlertAnimationProps, UserNavItem } from './UserNavItem'
 import { FeedbackPrompt } from './Feedback/FeedbackPrompt'
+import { LayoutRouteProps } from '../routes'
+
 interface Props
     extends SettingsCascadeProps<Settings>,
         KeyboardShortcutsProps,
@@ -44,6 +46,7 @@ interface Props
     showCampaigns: boolean
     isSourcegraphDotCom: boolean
     minimalNavLinks?: boolean
+    routes: readonly LayoutRouteProps<{}>[]
 }
 
 export class NavLinks extends React.PureComponent<Props> {
@@ -105,7 +108,7 @@ export class NavLinks extends React.PureComponent<Props> {
                 )}
                 {this.props.authenticatedUser && (
                     <li className="nav-item">
-                        <FeedbackPrompt history={this.props.history} />
+                        <FeedbackPrompt history={this.props.history} routes={this.props.routes} />
                     </li>
                 )}
                 {!this.props.authenticatedUser && (

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -81,6 +81,7 @@ exports[`GlobalNavbar default 1`] = `
       parsedSearchQuery="r:golang/oauth2 test f:travis"
       patternType="literal"
       platformContext={Object {}}
+      routes={Array []}
       selectedSearchContextSpec=""
       setCaseSensitivity={[Function]}
       setPatternType={[Function]}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -2800,9 +2800,9 @@ input HappinessFeedbackSubmissionInput {
     """
     feedback: String
     """
-    The URL that the happiness feedback will be submitted from.
+    The path that the happiness feedback will be submitted from.
     """
-    currentURL: String!
+    currentPath: String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2793,9 +2793,9 @@ input HappinessFeedbackSubmissionInput {
     """
     feedback: String
     """
-    The URL that the happiness feedback will be submitted from.
+    The path that the happiness feedback will be submitted from.
     """
-    currentURL: String!
+    currentPath: String
 }
 
 """

--- a/cmd/frontend/graphqlbackend/survey_response.go
+++ b/cmd/frontend/graphqlbackend/survey_response.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
@@ -14,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/hubspot/hubspotutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -132,17 +132,17 @@ type HappinessFeedbackSubmissionInput struct {
 	// Feedback is the answer to "What's going well? What could be better?".
 	Feedback *string
 	// The path that the happiness feedback was submitted from
-	CurrentPath string
+	CurrentPath *string
 }
 
-// type happinessFeedbackSubmissionForHubSpot struct {
-// 	Email       *string `url:"email"`
-// 	Score       int32   `url:"happiness_score"`
-// 	Feedback    *string `url:"happiness_feedback"`
-// 	CurrentPath string  `url:"happiness_current_url"`
-// 	IsTest      bool    `url:"happiness_is_test"`
-// 	SiteID      string  `url:"site_id"`
-// }
+type happinessFeedbackSubmissionForHubSpot struct {
+	Email       *string `url:"email"`
+	Score       int32   `url:"happiness_score"`
+	Feedback    *string `url:"happiness_feedback"`
+	CurrentPath *string `url:"happiness_current_url"`
+	IsTest      bool    `url:"happiness_is_test"`
+	SiteID      string  `url:"site_id"`
+}
 
 // SubmitHappinessFeedback records a new happiness feedback response by the current user.
 func (r *schemaResolver) SubmitHappinessFeedback(ctx context.Context, args *struct {
@@ -168,24 +168,20 @@ func (r *schemaResolver) SubmitHappinessFeedback(ctx context.Context, args *stru
 				email = &e
 			}
 		}
-
-		log.Printf(*email)
 	}
 
-	log.Printf(args.Input.CurrentPath)
-
-	// // Submit form to HubSpot
-	// if err := hubspotutil.Client().SubmitForm(hubspotutil.HappinessFeedbackFormID, &happinessFeedbackSubmissionForHubSpot{
-	// 	Email:       email,
-	// 	Score:       args.Input.Score,
-	// 	Feedback:    args.Input.Feedback,
-	// 	CurrentPath: args.Input.CurrentPath,
-	// 	IsTest:      env.InsecureDev,
-	// 	SiteID:      siteid.Get(),
-	// }); err != nil {
-	// 	// Log an error, but don't return one if the only failure was in submitting feedback results to HubSpot.
-	// 	log15.Error("Unable to submit happiness feedback results to Sourcegraph remote", "error", err)
-	// }
+	// Submit form to HubSpot
+	if err := hubspotutil.Client().SubmitForm(hubspotutil.HappinessFeedbackFormID, &happinessFeedbackSubmissionForHubSpot{
+		Email:       email,
+		Score:       args.Input.Score,
+		Feedback:    args.Input.Feedback,
+		CurrentPath: args.Input.CurrentPath,
+		IsTest:      env.InsecureDev,
+		SiteID:      siteid.Get(),
+	}); err != nil {
+		// Log an error, but don't return one if the only failure was in submitting feedback results to HubSpot.
+		log15.Error("Unable to submit happiness feedback results to Sourcegraph remote", "error", err)
+	}
 
 	return &EmptyResponse{}, nil
 }


### PR DESCRIPTION

<!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
## Overview
Instead of sending specific URLs to HubSpot, we send the matching route pattern. This ensures that we do not risk processing private data.

Example paths:
![image](https://user-images.githubusercontent.com/9516420/109185193-ace65a80-7787-11eb-88ee-e4c3bc1cdede.png)
`:repoRevAndRest+` is when submitting from an actual search result page here (e.g. viewing a diff on a repo)


<!-- Add a reference to the issue that this PR addresses if relevant -->
Closes https://github.com/sourcegraph/sourcegraph/issues/17645


