### PR TITLE
Add a few syntax highlighting changes

### DIFF
--- a/internal/highlight/syntect_language_map.go
+++ b/internal/highlight/syntect_language_map.go
@@ -230,6 +230,8 @@ var SyntectLanguageMap = map[string]string{
 	"psd1":                 "psd1",
 	"python":               "py",
 	"py":                   "py",
+	"pyst":                 "py",
+	"pyst-include":         "py",
 	"py3":                  "py3",
 	"pyw":                  "pyw",
 	"pyi":                  "pyi",

--- a/internal/highlight/syntect_language_map.go
+++ b/internal/highlight/syntect_language_map.go
@@ -14,6 +14,7 @@ var SyntectLanguageMap = map[string]string{
 	"bat":                  "bat",
 	"cmd":                  "cmd",
 	"build":                "build",
+	"build.in":             "build",
 	"c#":                   "cs",
 	"cs":                   "cs",
 	"csx":                  "csx",


### PR DESCRIPTION
`BUILD.in`: at Dropbox we generate `BUILD` files from simpler inputs, would be great to highlight them the same.
`pyst/pyst-include`: supporting the [Pystachio](https://github.com/wickman/pystachio) templating library