### PR TITLE
search: encode repo names with spaces in markdown -> HTML conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Auto complete suggestions for repositories and files containing spaces will now be automatically escaped when accepting the suggestion. [#18635](https://github.com/sourcegraph/sourcegraph/issues/18635)
+- An issue causing repository results containing spaces to not be clickable in some cases. [#18668](https://github.com/sourcegraph/sourcegraph/pull/18668)
 
 ### Removed
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -299,7 +299,7 @@ func (r *RepositoryResolver) Label() (Markdown, error) {
 	} else {
 		label = r.Name()
 	}
-	text := "[" + label + "](/" + label + ")"
+	text := "[" + label + "](" + r.URL() + ")"
 	return Markdown(text), nil
 }
 

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go/gqltesting"
 
+	"github.com/hexops/autogold"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -144,4 +145,18 @@ func assertRepoResolverHydrated(ctx context.Context, t *testing.T, r *Repository
 	if uri != hydrated.URI {
 		t.Fatalf("wrong URI. want=%q, have=%q", hydrated.URI, uri)
 	}
+}
+
+func TestRepositoryLabel(t *testing.T) {
+	test := func(name string) string {
+		r := &RepositoryResolver{
+			name: api.RepoName(name),
+			id:   api.RepoID(0),
+		}
+		result, _ := r.Label()
+		return result.HTML()
+	}
+
+	autogold.Want("encodes spaces for URL in HTML", `<p><a href="/repo%20with%20spaces" rel="nofollow">repo with spaces</a></p>
+`).Equal(t, test("repo with spaces"))
 }


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/18634

Previously, a repo would not be clickable (no link) if it is just a repo result and contained spaces, it would just be rendered as text:

![Screen Shot 2021-02-25 at 5 06 51 PM](https://user-images.githubusercontent.com/888624/109235939-e28d4280-778b-11eb-9828-f6623b99aeae.png)

But now, clickable and redirects correctly to the repo

![Screen Shot 2021-02-25 at 5 06 32 PM](https://user-images.githubusercontent.com/888624/109236037-110b1d80-778c-11eb-8634-77ee2a67eefa.png)

The mysterious thing was that the repo link renders just fine for file matches, just not "Repository name match". After going through the frontend code, I see that we are using a different value based on label/markdown for repository results. Then I found that the value is actually coming from the backend.

Turns out we were always using the label value for the name and URL in the markdown syntax `[label](label)`, where the URL in `label` would not encode spaces as `%20`. Because the encoding didn't happen on this value, the markdown was not detecting it as a valid URL to convert to an HTML with appropriate `<a>` tags, and instead just wrapped the value in `<p>` tags. So the fix just requires us to use the URL-encoded value here.

Good bug, I give it a 7/10 difficulty rating.