### PR TITLE
Document a helpful troubleshooting comment

### DIFF
--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -122,3 +122,13 @@ Again please then upload the `sourcegraph-metrics-dump.tgz` for Sourcegraph supp
 ### Generating pprof profiles
 
 Please follow [these instructions](pprof.md) to generate pprof profiles.
+
+### Sourcegraph is not returning results from a repository unless "repo:" is included
+
+If you can get repository results when you explicitly include `repo:{your repository}` in your search, but don't see any results from that repository when you don't, there are a few possible causes: 
+
+- The repository is a fork repository (excluded from search results by default) and `fork:yes` is not specified in the search query.
+- The repository is an archived repository (excluded from search results by default) and `archived:yes` is not specified in the search query.
+- Your site config file does not include `"search.index.enabled": true`. It should be included, and you should set it to true; if it's false, it means Sourcegraph won't index anything and will only search in real-time.
+- There is an issue indexing the repository: check the logs of repo-updater and/or search-indexer.
+- The search index is unavailable for some reason: try the search query `repo:<the_repository> index:only`. If it returns no results, the repository has not been indexed.


### PR DESCRIPTION

This information originally comes from [this GH comment](https://github.com/sourcegraph/sourcegraph/issues/13840#issuecomment-740956690) by @slimsag . 

We know our troubleshooting docs need a revamp/reframing around "problem? solutions..." type formatting, but for now I wanted to get this into the docs. [We'll be moving towards](https://sourcegraph.slack.com/archives/C0C324C91/p1613005946135700?thread_ts=1612805303.109900&cid=C0C324C91) docs built up that way now that we have a customer support team!