### PR TITLE
frontend: remove session upon signout

### DIFF
--- a/cmd/frontend/internal/app/sign_out.go
+++ b/cmd/frontend/internal/app/sign_out.go
@@ -30,7 +30,7 @@ func RegisterSSOSignOutHandler(f func(w http.ResponseWriter, r *http.Request)) {
 func serveSignOut(w http.ResponseWriter, r *http.Request) {
 	// Invalidate all user sessions first
 	// This way, any other signout failures should not leave a valid session
-	if err := session.InvalidateSessionCurrentUser(r); err != nil {
+	if err := session.InvalidateSessionCurrentUser(w, r); err != nil {
 		log15.Error("Error in signout.", "err", err)
 	}
 	if err := session.SetActor(w, r, nil, 0, time.Time{}); err != nil {


### PR DESCRIPTION
This change deletes both the session cookie and the Redis session key when the client logs out.
Currently, when a user logs out, the session is invalidated but not deleted. Whenever a client
logs in with the same browser, the old session [is reused](https://sourcegraph.com/github.com/gorilla/sessions/-/blob/sessions.go#L136-143) by https://github.com/gorilla/sessions
which can lead to authentication bypass.

Note: The issue still remains when an admin [manually invalidates a user session](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@as/remove-session-upon-signout/-/blob/cmd/frontend/internal/session/session.go?utm_source=VSCode-1.2.3#L285-288).
@ElizabethStirling any thoughts?

Related to https://github.com/sourcegraph/security-issues/issues/136