### PR TITLE
search: implement a display limit

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -321,6 +321,11 @@ func (r *RepositoryResolver) ResultCount() int32 {
 	return 1
 }
 
+func (r *RepositoryResolver) Limit(limit int) int {
+	// Always represents one result and limit > 0 so we just return limit - 1.
+	return limit - 1
+}
+
 func (r *RepositoryResolver) Type(ctx context.Context) (*types.Repo, error) {
 	return r.repo(ctx)
 }

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -53,6 +53,16 @@ func (r *CommitSearchResult) ResultCount() int {
 	return 1
 }
 
+func (r *CommitSearchResult) Limit(limit int) int {
+	if len(r.highlights) == 0 {
+		return limit - 1 // just counting the commit
+	} else if len(r.highlights) > limit {
+		r.highlights = r.highlights[:limit]
+		return 0
+	}
+	return limit - len(r.highlights)
+}
+
 // CommitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
 type CommitSearchResultResolver struct {
 	CommitSearchResult

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
@@ -310,4 +311,38 @@ func searchCommitsInRepo(ctx context.Context, db dbutil.DB, op search.CommitPara
 		err = event.Error
 	}
 	return results, limitHit, timedOut, err
+}
+
+func TestCommitSearchResult_Limit(t *testing.T) {
+	f := func(nHighlights []int, limitInput uint32) bool {
+		cr := &CommitSearchResult{
+			highlights: make([]*highlightedRange, len(nHighlights)),
+		}
+
+		// It isn't interesting to test limit > ResultCount, so we bound it to
+		// [1, ResultCount]
+		count := cr.ResultCount()
+		limit := (int(limitInput) % count) + 1
+
+		after := cr.Limit(limit)
+		newCount := cr.ResultCount()
+
+		if after == 0 && newCount == limit {
+			return true
+		}
+
+		t.Logf("failed limit=%d count=%d => after=%d newCount=%d", limit, count, after, newCount)
+		return false
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Error("quick check failed")
+	}
+
+	for nSymbols := 0; nSymbols <= 3; nSymbols++ {
+		for limit := 0; limit <= nSymbols; limit++ {
+			if !f(make([]int, nSymbols), uint32(limit)) {
+				t.Error("small exhaustive check failed")
+			}
+		}
+	}
 }

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -397,6 +398,79 @@ func TestLimitSearcherRepos(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotLimited, tst.wantLimited) {
 				t.Errorf("got limited %+v want %+v", gotLimited, tst.wantLimited)
+			}
+		})
+	}
+}
+
+func TestFileMatch_Limit(t *testing.T) {
+	desc := func(fm *FileMatch) string {
+		parts := []string{fmt.Sprintf("symbols=%d", len(fm.Symbols))}
+		for _, lm := range fm.LineMatches {
+			parts = append(parts, fmt.Sprintf("lm=%d", len(lm.OffsetAndLengths)))
+		}
+		return strings.Join(parts, " ")
+	}
+
+	f := func(lineMatches []LineMatch, symbols []int, limitInput uint32) bool {
+		fm := &FileMatch{
+			// SearchSymbolResult fails to generate due to private fields. So
+			// we just generate a slice of ints and use its length. This is
+			// fine for limit which only looks at the slice and not in it.
+			Symbols: make([]*SearchSymbolResult, len(symbols)),
+		}
+		// We don't use *LineMatch as args since quick can generate nil.
+		for _, lm := range lineMatches {
+			lm := lm
+			fm.LineMatches = append(fm.LineMatches, &lm)
+		}
+		beforeDesc := desc(fm)
+
+		// It isn't interesting to test limit > ResultCount, so we bound it to
+		// [1, ResultCount]
+		count := fm.ResultCount()
+		limit := (int(limitInput) % count) + 1
+
+		after := fm.Limit(limit)
+		newCount := fm.ResultCount()
+
+		if after == 0 && newCount == limit {
+			return true
+		}
+
+		afterDesc := desc(fm)
+		t.Logf("failed limit=%d count=%d => after=%d newCount=%d:\nbeforeDesc: %s\nafterDesc:  %s", limit, count, after, newCount, beforeDesc, afterDesc)
+		return false
+	}
+	t.Run("quick", func(t *testing.T) {
+		if err := quick.Check(f, nil); err != nil {
+			t.Error("quick check failed")
+		}
+	})
+
+	cases := []struct {
+		Name        string
+		LineMatches []LineMatch
+		Symbols     int
+		Limit       int
+	}{{
+		Name: "1 line match",
+		LineMatches: []LineMatch{{
+			OffsetAndLengths: [][2]int32{{1, 1}},
+		}},
+		Limit: 1,
+	}, {
+		Name:  "file path match",
+		Limit: 1,
+	}, {
+		Name:  "file path match 2",
+		Limit: 2,
+	}}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			if !f(c.LineMatches, make([]int, c.Symbols), uint32(c.Limit)) {
+				t.Error("failed")
 			}
 		})
 	}

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -29,6 +29,8 @@ func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
 	p.Dirty = true
 	p.Stats.Update(&event.Stats)
 	for _, result := range event.Results {
+		// We use a different result count in streaming than graphql. We don't
+		// want to break existing graphql clients like saved searches.
 		if crs, ok := result.ToCommitSearchResult(); ok {
 			p.MatchCount += crs.CommitSearchResult.ResultCount()
 			continue


### PR DESCRIPTION
Some clients are not interested in all results, but would still like
accurate progress result counts. This commit implements a "display"
limit which stops sending results once we hit it, but still continues to
search. While searching we will continue to send progress updates and
will only stop when we hit match limits or a timeout.

Right now no client is specifying display limit. However, this still
improves the UX since previously we could send more than the match
limit results down. Now we never send more than match limits.

Display is implemented as an URL query argument to the streaming
endpoint.

Fixes https://github.com/sourcegraph/sourcegraph/issues/18076

Co-authored-by: @stefanhengl 