### PR TITLE
ci: specify env in the pipeline once

### DIFF
--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -42,10 +42,6 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		env["PERCY_TARGET_BRANCH"] = c.branch
 	}
 
-	for k, v := range env {
-		bk.BeforeEveryStepOpts = append(bk.BeforeEveryStepOpts, bk.Env(k, v))
-	}
-
 	if c.profilingEnabled {
 		bk.AfterEveryStepOpts = append(bk.AfterEveryStepOpts, func(s *bk.Step) {
 			// wrap "time -v" around each command for CPU/RAM utilization information
@@ -151,7 +147,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 	}
 
 	// Construct pipeline
-	pipeline := &bk.Pipeline{}
+	pipeline := &bk.Pipeline{
+		Env: env,
+	}
 	for _, p := range pipelineOperations {
 		p(pipeline)
 	}

--- a/internal/buildkite/buildkite.go
+++ b/internal/buildkite/buildkite.go
@@ -13,7 +13,8 @@ import (
 )
 
 type Pipeline struct {
-	Steps []interface{} `json:"steps"`
+	Env   map[string]string `json:"env,omitempty"`
+	Steps []interface{}     `json:"steps"`
 }
 
 type BuildOptions struct {


### PR DESCRIPTION
Currently we add the common env to each step. Instead we can specify it
once. This makes it much easier to read the generated pipeline.