### PR TITLE
migration: Add gitserver_repos table

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -563,6 +563,22 @@ Triggers:
 
 ```
 
+# Table "public.gitserver_repos"
+```
+        Column         |           Type           |              Modifiers              
+-----------------------+--------------------------+-------------------------------------
+ repo_id               | integer                  | not null
+ clone_status          | text                     | not null default 'not_cloned'::text
+ last_external_service | bigint                   | 
+ last_error            | text                     | 
+ updated_at            | timestamp with time zone | not null default now()
+Indexes:
+    "gitserver_repos_pkey" PRIMARY KEY, btree (repo_id)
+Foreign-key constraints:
+    "gitserver_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id)
+
+```
+
 # Table "public.global_state"
 ```
          Column          |  Type   |         Modifiers         
@@ -1223,6 +1239,7 @@ Referenced by:
     TABLE "default_repos" CONSTRAINT "default_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "discussion_threads_target_repo" CONSTRAINT "discussion_threads_target_repo_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
+    TABLE "gitserver_repos" CONSTRAINT "gitserver_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id)
     TABLE "lsif_index_configuration" CONSTRAINT "lsif_index_configuration_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
 Triggers:
     trig_delete_repo_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON repo FOR EACH ROW EXECUTE PROCEDURE delete_repo_ref_on_external_service_repos()

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -570,6 +570,7 @@ Triggers:
  repo_id               | integer                  | not null
  clone_status          | text                     | not null default 'not_cloned'::text
  last_external_service | bigint                   | 
+ shard_id              | text                     | not null
  last_error            | text                     | 
  updated_at            | timestamp with time zone | not null default now()
 Indexes:

--- a/migrations/frontend/1528395790_create_gitserver_repos.down.sql
+++ b/migrations/frontend/1528395790_create_gitserver_repos.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS gitserver_repos;
+
+COMMIT;

--- a/migrations/frontend/1528395790_create_gitserver_repos.up.sql
+++ b/migrations/frontend/1528395790_create_gitserver_repos.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS gitserver_repos
+(
+    repo_id int REFERENCES repo(id) PRIMARY KEY,
+    clone_status text NOT NULL default 'not_cloned',
+    last_external_service bigint,
+    shard_id text NOT NULL,
+    last_error text,
+    updated_at timestamp WITH TIME ZONE default now() not null
+);
+
+COMMIT;

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -114,6 +114,8 @@
 // 1528395788_campaigns_ssh_key_migration.up.sql (272B)
 // 1528395789_add_encryption_key_ident.down.sql (88B)
 // 1528395789_add_encryption_key_ident.up.sql (116B)
+// 1528395790_create_gitserver_repos.down.sql (55B)
+// 1528395790_create_gitserver_repos.up.sql (313B)
 
 package migrations
 
@@ -2462,6 +2464,46 @@ func _1528395789_add_encryption_key_identUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395790_create_gitserver_reposDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x72\x75\xf7\xf4\xb3\xe6\xe2\x72\x09\xf2\x0f\x50\x08\x71\x74\xf2\x71\x55\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\xcf\x2c\x29\x4e\x2d\x2a\x4b\x2d\x8a\x2f\x4a\x2d\xc8\x2f\xb6\xe6\xe2\x72\xf6\xf7\xf5\xf5\x0c\xb1\xe6\x02\x04\x00\x00\xff\xff\xfd\x48\x48\x12\x37\x00\x00\x00")
+
+func _1528395790_create_gitserver_reposDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395790_create_gitserver_reposDownSql,
+		"1528395790_create_gitserver_repos.down.sql",
+	)
+}
+
+func _1528395790_create_gitserver_reposDownSql() (*asset, error) {
+	bytes, err := _1528395790_create_gitserver_reposDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395790_create_gitserver_repos.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x52, 0xaf, 0xd8, 0x12, 0x54, 0x35, 0x92, 0xf, 0xc5, 0xa0, 0x21, 0xee, 0x20, 0x6a, 0x2f, 0xe0, 0x2e, 0x36, 0xc9, 0x61, 0x45, 0x38, 0x66, 0xc2, 0x93, 0x47, 0xc7, 0x84, 0x21, 0x1e, 0x70, 0x8e}}
+	return a, nil
+}
+
+var __1528395790_create_gitserver_reposUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x54\x90\xcd\x4a\x03\x31\x14\x85\xf7\x79\x8a\xb3\x6b\x0b\xbe\x41\x57\x6d\xb9\xd5\xe0\xfc\xc8\x4c\x44\xeb\x26\xc4\x26\xd6\x40\x9a\x0c\xc9\x1d\xed\xe3\xcb\xcc\x80\xe8\x2e\x9c\x9c\xef\xde\x8f\xbb\xa7\x7b\xd9\x6c\x85\x38\x74\xb4\x53\x04\xb5\xdb\x57\x04\x79\x44\xd3\x2a\xd0\xab\xec\x55\x8f\x8b\xe7\xe2\xf2\x97\xcb\x3a\xbb\x21\x15\xb1\x16\x00\x30\xbd\xb5\xb7\xf0\x91\xd1\xd1\x91\x3a\x6a\x0e\xd4\xcf\xf1\xda\xdb\x0d\x9e\x3a\x59\xef\xba\x13\x1e\xe9\x74\x37\x03\xe7\x90\xa2\xd3\x85\x0d\x8f\x05\xec\x6e\x3c\xef\x68\x9e\xab\x0a\xd6\x7d\x98\x31\x30\x56\x31\xb1\x9e\x7b\x76\xb5\x40\xc1\x14\xd6\xee\xc6\x2e\x47\x13\xf4\xa4\xe1\xcf\x0e\xef\xfe\xe2\x23\x2f\x8d\xf2\x69\xb2\x9d\x44\xfe\x8d\xfc\x4b\xe7\x9c\xf2\xfc\xbb\x84\xe3\x60\x0d\x3b\xab\x0d\x83\xfd\xd5\x15\x36\xd7\x01\x2f\x52\x3d\x40\xc9\x9a\xf0\xd6\x36\xf4\x2b\x14\xd3\xf7\x7a\x83\x98\x18\x71\x0c\x41\x6c\xa6\x43\xb5\x75\x2d\xd5\x56\xfc\x04\x00\x00\xff\xff\x9a\xea\x43\x6d\x39\x01\x00\x00")
+
+func _1528395790_create_gitserver_reposUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395790_create_gitserver_reposUpSql,
+		"1528395790_create_gitserver_repos.up.sql",
+	)
+}
+
+func _1528395790_create_gitserver_reposUpSql() (*asset, error) {
+	bytes, err := _1528395790_create_gitserver_reposUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395790_create_gitserver_repos.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x20, 0x5a, 0xce, 0x50, 0x7b, 0xee, 0xb1, 0xa2, 0x48, 0xed, 0xbd, 0x5, 0x59, 0x84, 0xef, 0x97, 0x83, 0x10, 0xd3, 0x1, 0x5c, 0xf5, 0x62, 0x66, 0xd8, 0x9a, 0xff, 0xa1, 0xb9, 0x54, 0x60, 0x8d}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2667,6 +2709,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395788_campaigns_ssh_key_migration.up.sql":                                          _1528395788_campaigns_ssh_key_migrationUpSql,
 	"1528395789_add_encryption_key_ident.down.sql":                                           _1528395789_add_encryption_key_identDownSql,
 	"1528395789_add_encryption_key_ident.up.sql":                                             _1528395789_add_encryption_key_identUpSql,
+	"1528395790_create_gitserver_repos.down.sql":                                             _1528395790_create_gitserver_reposDownSql,
+	"1528395790_create_gitserver_repos.up.sql":                                               _1528395790_create_gitserver_reposUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -2827,6 +2871,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395788_campaigns_ssh_key_migration.up.sql":                                          {_1528395788_campaigns_ssh_key_migrationUpSql, map[string]*bintree{}},
 	"1528395789_add_encryption_key_ident.down.sql":                                           {_1528395789_add_encryption_key_identDownSql, map[string]*bintree{}},
 	"1528395789_add_encryption_key_ident.up.sql":                                             {_1528395789_add_encryption_key_identUpSql, map[string]*bintree{}},
+	"1528395790_create_gitserver_repos.down.sql":                                             {_1528395790_create_gitserver_reposDownSql, map[string]*bintree{}},
+	"1528395790_create_gitserver_repos.up.sql":                                               {_1528395790_create_gitserver_reposUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
This will allow us to: 

* Query the clone state of repo
* Query the sync state of a repo
* Query the most recent sync error
* Round robin schedule the choice of clone_url from external_services 

Part of: https://github.com/sourcegraph/sourcegraph/issues/16670