### PR TITLE
Implement UI part for campaigns SSH support

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -42,6 +42,11 @@ $green: $oc-green-7;
 $teal: $oc-teal-7;
 $cyan: $oc-cyan-3;
 
+// Logo colors
+$logo-orange: #f96216;
+$logo-blue: #00b4f2;
+$logo-purple: #b200f8;
+
 $primary: $blue;
 $secondary: #2b3750;
 $success: $green;
@@ -78,6 +83,9 @@ $text-muted: var(--text-muted);
     --danger: #{$danger};
     --merged: #{$merged};
     --color-border-active: #329af0;
+    --logo-orange: #{$logo-orange};
+    --logo-blue: #{$logo-blue};
+    --logo-purple: #{$logo-purple};
 }
 .theme-light {
     // Affects default browser styles

--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -31,6 +31,7 @@
 @import './enterprise/campaigns/list/CampaignListIntro';
 @import './enterprise/campaigns/list/CampaignListPage';
 @import './enterprise/campaigns/list/CampaignNode';
+@import './enterprise/campaigns/settings/AddCredentialModal';
 @import './enterprise/extensions/registry/RegistryArea';
 @import './enterprise/extensions/registry/RegistryNewExtensionPage';
 @import './enterprise/extensions/extension/RegistryExtensionManagePage';

--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.scss
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.scss
@@ -1,0 +1,16 @@
+.add-credential-modal {
+    &__modal-step-ruler {
+        height: 0.125rem;
+        width: 100%;
+        border-radius: 0.125rem;
+        &--purple {
+            background-color: $logo-purple;
+        }
+        &--blue {
+            background-color: $logo-blue;
+        }
+        &--gray {
+            background-color: var(--border-color);
+        }
+    }
+}

--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.story.tsx
@@ -1,7 +1,9 @@
+import { select } from '@storybook/addon-knobs'
+import { useCallback } from '@storybook/addons'
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 import React from 'react'
-import { ExternalServiceKind } from '../../../graphql-operations'
+import { CampaignsCredentialFields, ExternalServiceKind } from '../../../graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 import { AddCredentialModal } from './AddCredentialModal'
 
@@ -14,6 +16,59 @@ const { add } = storiesOf('web/campaigns/settings/AddCredentialModal', module)
         },
     })
 
+add('Requires SSH - step 1', () => {
+    const createCampaignsCredential = useCallback(
+        (): Promise<CampaignsCredentialFields> =>
+            Promise.resolve({
+                id: '123',
+                createdAt: new Date().toISOString(),
+                sshPublicKey:
+                    'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+            }),
+        []
+    )
+    return (
+        <EnterpriseWebStory>
+            {props => (
+                <AddCredentialModal
+                    {...props}
+                    userID="user-id-1"
+                    externalServiceKind={select(
+                        'External service kind',
+                        Object.values(ExternalServiceKind),
+                        ExternalServiceKind.GITHUB
+                    )}
+                    externalServiceURL="https://github.com/"
+                    requiresSSH={true}
+                    afterCreate={noop}
+                    onCancel={noop}
+                    createCampaignsCredential={createCampaignsCredential}
+                />
+            )}
+        </EnterpriseWebStory>
+    )
+})
+add('Requires SSH - step 2', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <AddCredentialModal
+                {...props}
+                userID="user-id-1"
+                externalServiceKind={select(
+                    'External service kind',
+                    Object.values(ExternalServiceKind),
+                    ExternalServiceKind.GITHUB
+                )}
+                externalServiceURL="https://github.com/"
+                requiresSSH={true}
+                afterCreate={noop}
+                onCancel={noop}
+                initialStep="get-ssh-key"
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
 add('GitHub', () => (
     <EnterpriseWebStory>
         {props => (
@@ -22,6 +77,7 @@ add('GitHub', () => (
                 userID="user-id-1"
                 externalServiceKind={ExternalServiceKind.GITHUB}
                 externalServiceURL="https://github.com/"
+                requiresSSH={false}
                 afterCreate={noop}
                 onCancel={noop}
             />
@@ -37,6 +93,7 @@ add('GitLab', () => (
                 userID="user-id-1"
                 externalServiceKind={ExternalServiceKind.GITLAB}
                 externalServiceURL="https://gitlab.com/"
+                requiresSSH={false}
                 afterCreate={noop}
                 onCancel={noop}
             />
@@ -52,6 +109,7 @@ add('Bitbucket Server', () => (
                 userID="user-id-1"
                 externalServiceKind={ExternalServiceKind.BITBUCKETSERVER}
                 externalServiceURL="https://bitbucket.sgdev.org/"
+                requiresSSH={false}
                 afterCreate={noop}
                 onCancel={noop}
             />

--- a/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CampaignsSettingsArea.story.tsx
@@ -5,7 +5,7 @@ import { ExternalServiceKind } from '../../../graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 import { CampaignsSettingsArea } from './CampaignsSettingsArea'
 
-const { add } = storiesOf('web/campaigns/CampaignsSettingsArea', module).addDecorator(story => (
+const { add } = storiesOf('web/campaigns/settings/CampaignsSettingsArea', module).addDecorator(story => (
     <div className="p-3 container web-content">{story()}</div>
 ))
 
@@ -27,16 +27,19 @@ add('Overview', () => (
                                 credential: null,
                                 externalServiceKind: ExternalServiceKind.GITHUB,
                                 externalServiceURL: 'https://github.com/',
+                                requiresSSH: false,
                             },
                             {
                                 credential: null,
                                 externalServiceKind: ExternalServiceKind.GITLAB,
                                 externalServiceURL: 'https://gitlab.com/',
+                                requiresSSH: false,
                             },
                             {
                                 credential: null,
                                 externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
                                 externalServiceURL: 'https://bitbucket.sgdev.org/',
+                                requiresSSH: true,
                             },
                         ],
                     })
@@ -64,25 +67,34 @@ add('Config added', () => (
                                 credential: {
                                     id: '123',
                                     createdAt: new Date().toISOString(),
+                                    sshPublicKey:
+                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
                                 },
                                 externalServiceKind: ExternalServiceKind.GITHUB,
                                 externalServiceURL: 'https://github.com/',
+                                requiresSSH: false,
                             },
                             {
                                 credential: {
                                     id: '123',
                                     createdAt: new Date().toISOString(),
+                                    sshPublicKey:
+                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
                                 },
                                 externalServiceKind: ExternalServiceKind.GITLAB,
                                 externalServiceURL: 'https://gitlab.com/',
+                                requiresSSH: false,
                             },
                             {
                                 credential: {
                                     id: '123',
                                     createdAt: new Date().toISOString(),
+                                    sshPublicKey:
+                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
                                 },
                                 externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
                                 externalServiceURL: 'https://bitbucket.sgdev.org/',
+                                requiresSSH: true,
                             },
                         ],
                     })

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
@@ -7,6 +7,7 @@ import { CampaignsCodeHostFields, Scalars } from '../../../graphql-operations'
 import { AddCredentialModal } from './AddCredentialModal'
 import { RemoveCredentialModal } from './RemoveCredentialModal'
 import { Subject } from 'rxjs'
+import { ViewCredentialModal } from './ViewCredentialModal'
 
 export interface CodeHostConnectionNodeProps {
     node: CampaignsCodeHostFields
@@ -15,7 +16,7 @@ export interface CodeHostConnectionNodeProps {
     updateList: Subject<void>
 }
 
-type OpenModal = 'add' | 'delete'
+type OpenModal = 'add' | 'view' | 'delete'
 
 export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionNodeProps> = ({
     node,
@@ -33,7 +34,11 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
         event.preventDefault()
         setOpenModal('delete')
     }, [])
-    const onCancel = useCallback(() => {
+    const onClickView = useCallback<React.MouseEventHandler>(event => {
+        event.preventDefault()
+        setOpenModal('view')
+    }, [])
+    const closeModal = useCallback(() => {
         setOpenModal(undefined)
     }, [])
     const afterAction = useCallback(() => {
@@ -64,13 +69,20 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                     </h3>
                     <div className="mb-0">
                         {isEnabled && (
-                            <a
-                                href=""
-                                className="btn btn-link text-danger test-code-host-connection-node-btn-remove"
-                                onClick={onClickRemove}
-                            >
-                                Remove
-                            </a>
+                            <>
+                                <a
+                                    href=""
+                                    className="btn btn-link text-danger test-code-host-connection-node-btn-remove"
+                                    onClick={onClickRemove}
+                                >
+                                    Remove
+                                </a>
+                                {node.requiresSSH && (
+                                    <button type="button" onClick={onClickView} className="btn btn-secondary ml-2">
+                                        View public key
+                                    </button>
+                                )}
+                            </>
                         )}
                         {!isEnabled && (
                             <button
@@ -78,7 +90,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                                 className="btn btn-success test-code-host-connection-node-btn-add"
                                 onClick={onClickAdd}
                             >
-                                Add token
+                                Add credentials
                             </button>
                         )}
                     </div>
@@ -86,19 +98,24 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
             </li>
             {openModal === 'delete' && (
                 <RemoveCredentialModal
-                    onCancel={onCancel}
+                    onCancel={closeModal}
                     afterDelete={afterAction}
-                    credentialID={node.credential!.id}
+                    codeHost={node}
+                    credential={node.credential!}
                 />
+            )}
+            {openModal === 'view' && (
+                <ViewCredentialModal onClose={closeModal} codeHost={node} credential={node.credential!} />
             )}
             {openModal === 'add' && (
                 <AddCredentialModal
-                    onCancel={onCancel}
+                    onCancel={closeModal}
                     afterCreate={afterAction}
                     history={history}
                     userID={userID}
                     externalServiceKind={node.externalServiceKind}
                     externalServiceURL={node.externalServiceURL}
+                    requiresSSH={node.requiresSSH}
                 />
             )}
         </>

--- a/client/web/src/enterprise/campaigns/settings/CodeHostSshPublicKey.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostSshPublicKey.tsx
@@ -1,0 +1,61 @@
+import copy from 'copy-to-clipboard'
+import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
+import React, { useCallback, useState } from 'react'
+import { ExternalServiceKind } from '../../../graphql-operations'
+
+const configInstructionLinks: Record<ExternalServiceKind, string> = {
+    [ExternalServiceKind.GITHUB]:
+        'https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account',
+    [ExternalServiceKind.GITLAB]: 'https://docs.gitlab.com/ee/ssh/#add-an-ssh-key-to-your-gitlab-account',
+    [ExternalServiceKind.BITBUCKETSERVER]:
+        'https://confluence.atlassian.com/bitbucketserver/ssh-user-keys-for-personal-use-776639793.html',
+    [ExternalServiceKind.AWSCODECOMMIT]: 'unsupported',
+    [ExternalServiceKind.BITBUCKETCLOUD]: 'unsupported',
+    [ExternalServiceKind.GITOLITE]: 'unsupported',
+    [ExternalServiceKind.OTHER]: 'unsupported',
+    [ExternalServiceKind.PERFORCE]: 'unsupported',
+    [ExternalServiceKind.PHABRICATOR]: 'unsupported',
+}
+
+export interface CodeHostSshPublicKeyProps {
+    externalServiceKind: ExternalServiceKind
+    sshPublicKey: string
+    label?: string
+    showInstructionsLink?: boolean
+    showCopyButton?: boolean
+}
+
+export const CodeHostSshPublicKey: React.FunctionComponent<CodeHostSshPublicKeyProps> = ({
+    externalServiceKind,
+    sshPublicKey,
+    showInstructionsLink = true,
+    showCopyButton = true,
+    label = 'Public SSH key',
+}) => {
+    const [copied, setCopied] = useState<boolean>(false)
+    const onCopy = useCallback(() => {
+        copy(sshPublicKey)
+        setCopied(true)
+    }, [sshPublicKey])
+    return (
+        <>
+            <div className="d-flex justify-content-between align-items-end mb-2">
+                <h4 className="mb-1">{label}</h4>
+                {showCopyButton && (
+                    <button type="button" className="btn btn-secondary" onClick={onCopy}>
+                        <ContentCopyIcon className="icon-inline" />
+                        {copied ? 'Copied!' : 'Copy'}
+                    </button>
+                )}
+            </div>
+            <textarea className="form-control text-monospace mb-3" rows={5} value={sshPublicKey} />
+            {showInstructionsLink && (
+                <p>
+                    <a href={configInstructionLinks[externalServiceKind]} target="_blank" rel="noopener">
+                        Configuration instructions
+                    </a>
+                </p>
+            )}
+        </>
+    )
+}

--- a/client/web/src/enterprise/campaigns/settings/ModalHeader.tsx
+++ b/client/web/src/enterprise/campaigns/settings/ModalHeader.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { defaultExternalServices } from '../../../components/externalServices/externalServices'
+import { ExternalServiceKind } from '../../../graphql-operations'
+
+export interface ModalHeaderProps {
+    id: string
+    externalServiceKind: ExternalServiceKind
+    externalServiceURL: string
+}
+
+export const ModalHeader: React.FunctionComponent<ModalHeaderProps> = ({
+    id,
+    externalServiceKind,
+    externalServiceURL,
+}) => (
+    <>
+        <h3 id={id}>Campaigns credentials: {defaultExternalServices[externalServiceKind].defaultDisplayName}</h3>
+        <p className="mb-4">{externalServiceURL}</p>
+    </>
+)

--- a/client/web/src/enterprise/campaigns/settings/RemoveCredentialModal.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/RemoveCredentialModal.story.tsx
@@ -1,6 +1,7 @@
 import { storiesOf } from '@storybook/react'
 import { noop } from 'lodash'
 import React from 'react'
+import { ExternalServiceKind } from '../../../../../shared/src/graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 import { RemoveCredentialModal } from './RemoveCredentialModal'
 
@@ -13,8 +14,47 @@ const { add } = storiesOf('web/campaigns/settings/RemoveCredentialModal', module
         },
     })
 
-add('Confirmation', () => (
+const credential = {
+    id: '123',
+    createdAt: new Date().toISOString(),
+    sshPublicKey:
+        'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+}
+
+add('No ssh', () => (
     <EnterpriseWebStory>
-        {props => <RemoveCredentialModal {...props} credentialID="123" afterDelete={noop} onCancel={noop} />}
+        {props => (
+            <RemoveCredentialModal
+                {...props}
+                codeHost={{
+                    credential,
+                    requiresSSH: false,
+                    externalServiceKind: ExternalServiceKind.GITHUB,
+                    externalServiceURL: 'https://github.com/',
+                }}
+                credential={credential}
+                afterDelete={noop}
+                onCancel={noop}
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
+add('Requires ssh', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <RemoveCredentialModal
+                {...props}
+                codeHost={{
+                    credential,
+                    requiresSSH: true,
+                    externalServiceKind: ExternalServiceKind.GITHUB,
+                    externalServiceURL: 'https://github.com/',
+                }}
+                credential={credential}
+                afterDelete={noop}
+                onCancel={noop}
+            />
+        )}
     </EnterpriseWebStory>
 ))

--- a/client/web/src/enterprise/campaigns/settings/RemoveCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/RemoveCredentialModal.tsx
@@ -4,17 +4,21 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { ErrorAlert } from '../../../components/alerts'
 import { deleteCampaignsCredential } from './backend'
-import { Scalars } from '../../../graphql-operations'
+import { CampaignsCodeHostFields, CampaignsCredentialFields } from '../../../graphql-operations'
+import { CodeHostSshPublicKey } from './CodeHostSshPublicKey'
+import { ModalHeader } from './ModalHeader'
 
 export interface RemoveCredentialModalProps {
-    credentialID: Scalars['ID']
+    codeHost: CampaignsCodeHostFields
+    credential: CampaignsCredentialFields
 
     onCancel: () => void
     afterDelete: () => void
 }
 
 export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModalProps> = ({
-    credentialID,
+    codeHost,
+    credential,
     onCancel,
     afterDelete,
 }) => {
@@ -23,12 +27,12 @@ export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModa
     const onDelete = useCallback<React.MouseEventHandler>(async () => {
         setIsLoading(true)
         try {
-            await deleteCampaignsCredential(credentialID)
+            await deleteCampaignsCredential(credential.id)
             afterDelete()
         } catch (error) {
             setIsLoading(asError(error))
         }
-    }, [afterDelete, credentialID])
+    }, [afterDelete, credential.id])
     return (
         <Dialog
             className="modal-body modal-body--top-third p-4 rounded border"
@@ -36,15 +40,32 @@ export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModa
             aria-labelledby={labelId}
         >
             <div className="web-content test-remove-credential-modal">
-                <h3 className="text-danger" id={labelId}>
-                    Remove campaigns token?
-                </h3>
+                <ModalHeader
+                    id={labelId}
+                    externalServiceKind={codeHost.externalServiceKind}
+                    externalServiceURL={codeHost.externalServiceURL}
+                />
+
+                <h3 className="text-danger mb-4">Removing credentials is irreversible</h3>
 
                 {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
 
-                <p>You will not be able to create changesets on this code host if this token is removed.</p>
+                <p>
+                    To create changesets on this code host after removing credentials, you will need to repeat the 'Add
+                    credentials' process.
+                </p>
 
-                <div className="d-flex justify-content-end pt-5">
+                {codeHost.requiresSSH && (
+                    <CodeHostSshPublicKey
+                        externalServiceKind={codeHost.externalServiceKind}
+                        sshPublicKey={credential.sshPublicKey!}
+                        showInstructionsLink={false}
+                        showCopyButton={false}
+                        label="Public key to remove"
+                    />
+                )}
+
+                <div className="d-flex justify-content-end pt-1">
                     <button
                         type="button"
                         disabled={isLoading === true}
@@ -60,7 +81,7 @@ export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModa
                         onClick={onDelete}
                     >
                         {isLoading === true && <LoadingSpinner className="icon-inline" />}
-                        Yes, remove connection
+                        Remove credentials
                     </button>
                 </div>
             </div>

--- a/client/web/src/enterprise/campaigns/settings/ViewCredentialModal.story.tsx
+++ b/client/web/src/enterprise/campaigns/settings/ViewCredentialModal.story.tsx
@@ -1,0 +1,40 @@
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+import { CampaignsCredentialFields, ExternalServiceKind } from '../../../graphql-operations'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { ViewCredentialModal } from './ViewCredentialModal'
+
+const { add } = storiesOf('web/campaigns/settings/ViewCredentialModal', module)
+    .addDecorator(story => <div className="p-3 container web-content">{story()}</div>)
+    .addParameters({
+        chromatic: {
+            // Delay screenshot taking, so the modal has opened by the time the screenshot is taken.
+            delay: 2000,
+        },
+    })
+
+const credential: CampaignsCredentialFields = {
+    id: '123',
+    createdAt: new Date().toISOString(),
+    sshPublicKey:
+        'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
+}
+
+add('View', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <ViewCredentialModal
+                {...props}
+                codeHost={{
+                    credential,
+                    externalServiceKind: ExternalServiceKind.GITHUB,
+                    externalServiceURL: 'https://github.com/',
+                    requiresSSH: true,
+                }}
+                credential={credential}
+                onClose={noop}
+            />
+        )}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/campaigns/settings/ViewCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/ViewCredentialModal.tsx
@@ -1,0 +1,58 @@
+import Dialog from '@reach/dialog'
+import React from 'react'
+import { CampaignsCodeHostFields, CampaignsCredentialFields } from '../../../graphql-operations'
+import { CodeHostSshPublicKey } from './CodeHostSshPublicKey'
+import { ModalHeader } from './ModalHeader'
+
+interface ViewCredentialModalProps {
+    codeHost: CampaignsCodeHostFields
+    credential: CampaignsCredentialFields
+
+    onClose: () => void
+}
+
+export const ViewCredentialModal: React.FunctionComponent<ViewCredentialModalProps> = ({
+    credential,
+    codeHost,
+    onClose,
+}) => {
+    const labelId = 'viewCredential'
+    return (
+        <Dialog
+            className="modal-body modal-body--top-third p-4 rounded border"
+            onDismiss={onClose}
+            aria-labelledby={labelId}
+        >
+            <div className="web-content">
+                <ModalHeader
+                    id={labelId}
+                    externalServiceKind={codeHost.externalServiceKind}
+                    externalServiceURL={codeHost.externalServiceURL}
+                />
+
+                <h4>Personal access token</h4>
+                <div className="form-group">
+                    <input
+                        type="text"
+                        value="PATs cannot be viewed after entering."
+                        className="form-control"
+                        disabled={true}
+                    />
+                </div>
+
+                <hr className="mb-3" />
+
+                <CodeHostSshPublicKey
+                    externalServiceKind={codeHost.externalServiceKind}
+                    sshPublicKey={credential.sshPublicKey!}
+                />
+
+                <div className="d-flex justify-content-end">
+                    <button type="button" className="btn btn-outline-secondary" onClick={onClose}>
+                        Close
+                    </button>
+                </div>
+            </div>
+        </Dialog>
+    )
+}

--- a/client/web/src/enterprise/campaigns/settings/backend.ts
+++ b/client/web/src/enterprise/campaigns/settings/backend.ts
@@ -4,6 +4,7 @@ import { dataOrThrowErrors, gql } from '../../../../../shared/src/graphql/graphq
 import { requestGraphQL } from '../../../backend/graphql'
 import {
     CampaignsCodeHostsFields,
+    CampaignsCredentialFields,
     CreateCampaignsCredentialResult,
     CreateCampaignsCredentialVariables,
     DeleteCampaignsCredentialResult,
@@ -17,10 +18,13 @@ export const campaignsCredentialFieldsFragment = gql`
     fragment CampaignsCredentialFields on CampaignsCredential {
         id
         createdAt
+        sshPublicKey
     }
 `
 
-export function createCampaignsCredential(args: CreateCampaignsCredentialVariables): Promise<void> {
+export function createCampaignsCredential(
+    args: CreateCampaignsCredentialVariables
+): Promise<CampaignsCredentialFields> {
     return requestGraphQL<CreateCampaignsCredentialResult, CreateCampaignsCredentialVariables>(
         gql`
             mutation CreateCampaignsCredential(
@@ -43,7 +47,10 @@ export function createCampaignsCredential(args: CreateCampaignsCredentialVariabl
         `,
         args
     )
-        .pipe(map(dataOrThrowErrors), mapTo(undefined))
+        .pipe(
+            map(dataOrThrowErrors),
+            map(data => data.createCampaignsCredential)
+        )
         .toPromise()
 }
 
@@ -94,6 +101,7 @@ export const queryUserCampaignsCodeHosts = ({
             fragment CampaignsCodeHostFields on CampaignsCodeHost {
                 externalServiceKind
                 externalServiceURL
+                requiresSSH
                 credential {
                     ...CampaignsCredentialFields
                 }

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -752,7 +752,14 @@ describe('Campaigns', () => {
                                 {
                                     externalServiceKind: ExternalServiceKind.GITHUB,
                                     externalServiceURL: 'https://github.com/',
-                                    credential: isCreated ? { id: '123', createdAt: new Date().toISOString() } : null,
+                                    credential: isCreated
+                                        ? {
+                                              id: '123',
+                                              createdAt: new Date().toISOString(),
+                                              sshPublicKey: 'ssh-rsa randorandorandorando',
+                                          }
+                                        : null,
+                                    requiresSSH: false,
                                 },
                             ],
                         },
@@ -764,6 +771,7 @@ describe('Campaigns', () => {
                         createCampaignsCredential: {
                             id: '123',
                             createdAt: new Date().toISOString(),
+                            sshPublicKey: 'ssh-rsa randorandorandorando',
                         },
                     }
                 },

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -328,6 +328,7 @@ type CampaignsCodeHostConnectionResolver interface {
 type CampaignsCodeHostResolver interface {
 	ExternalServiceKind() string
 	ExternalServiceURL() string
+	RequiresSSH() bool
 	Credential() CampaignsCredentialResolver
 }
 
@@ -335,6 +336,7 @@ type CampaignsCredentialResolver interface {
 	ID() graphql.ID
 	ExternalServiceKind() string
 	ExternalServiceURL() string
+	SSHPublicKey() *string
 	CreatedAt() DateTime
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8621,6 +8621,12 @@ type CampaignsCodeHost {
     The configured credential, if any.
     """
     credential: CampaignsCredential
+
+    """
+    If true, some of the repositories on this code host require
+    an SSH key to be configured.
+    """
+    requiresSSH: Boolean!
 }
 
 """
@@ -8641,6 +8647,12 @@ type CampaignsCredential implements Node {
     The URL of the external service.
     """
     externalServiceURL: String!
+
+    """
+    The public key to use on the external service for SSH keypair authentication.
+    Not set if the credential doesn't support SSH access.
+    """
+    sshPublicKey: String
 
     """
     The date and time this token has been created at.

--- a/enterprise/internal/campaigns/resolvers/code_host.go
+++ b/enterprise/internal/campaigns/resolvers/code_host.go
@@ -2,23 +2,24 @@ package resolvers
 
 import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 type campaignsCodeHostResolver struct {
-	externalServiceKind string
-	externalServiceURL  string
-	credential          *database.UserCredential
+	codeHost   *campaigns.CodeHost
+	credential *database.UserCredential
 }
 
 var _ graphqlbackend.CampaignsCodeHostResolver = &campaignsCodeHostResolver{}
 
 func (c *campaignsCodeHostResolver) ExternalServiceKind() string {
-	return c.externalServiceKind
+	return extsvc.TypeToKind(c.codeHost.ExternalServiceType)
 }
 
 func (c *campaignsCodeHostResolver) ExternalServiceURL() string {
-	return c.externalServiceURL
+	return c.codeHost.ExternalServiceID
 }
 
 func (c *campaignsCodeHostResolver) Credential() graphqlbackend.CampaignsCredentialResolver {
@@ -26,4 +27,8 @@ func (c *campaignsCodeHostResolver) Credential() graphqlbackend.CampaignsCredent
 		return &campaignsCredentialResolver{credential: c.credential}
 	}
 	return nil
+}
+
+func (c *campaignsCodeHostResolver) RequiresSSH() bool {
+	return c.codeHost.RequiresSSH
 }

--- a/enterprise/internal/campaigns/resolvers/code_host_connection.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 type campaignsCodeHostConnectionResolver struct {
@@ -64,7 +63,7 @@ func (c *campaignsCodeHostConnectionResolver) Nodes(ctx context.Context) ([]grap
 			externalServiceType: ch.ExternalServiceType,
 		}
 		cred := credsByIDType[t]
-		nodes[i] = &campaignsCodeHostResolver{externalServiceKind: extsvc.TypeToKind(ch.ExternalServiceType), externalServiceURL: ch.ExternalServiceID, credential: cred}
+		nodes[i] = &campaignsCodeHostResolver{codeHost: ch, credential: cred}
 	}
 
 	return nodes, nil

--- a/enterprise/internal/campaigns/resolvers/credential.go
+++ b/enterprise/internal/campaigns/resolvers/credential.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
 
 const campaignsCredentialIDKind = "CampaignsCredential"
@@ -37,6 +38,14 @@ func (c *campaignsCredentialResolver) ExternalServiceKind() string {
 func (c *campaignsCredentialResolver) ExternalServiceURL() string {
 	// This is usually the code host URL.
 	return c.credential.ExternalServiceID
+}
+
+func (c *campaignsCredentialResolver) SSHPublicKey() *string {
+	if a, ok := c.credential.Credential.(auth.AuthenticatorWithSSH); ok {
+		publicKey := a.SSHPublicKey()
+		return &publicKey
+	}
+	return nil
 }
 
 func (c *campaignsCredentialResolver) CreatedAt() graphqlbackend.DateTime {

--- a/enterprise/internal/campaigns/resolvers/errors.go
+++ b/enterprise/internal/campaigns/resolvers/errors.go
@@ -1,5 +1,7 @@
 package resolvers
 
+import "fmt"
+
 type ErrIDIsZero struct{}
 
 func (e ErrIDIsZero) Error() string {
@@ -86,4 +88,16 @@ func (e ErrDuplicateCredential) Error() string {
 
 func (e ErrDuplicateCredential) Extensions() map[string]interface{} {
 	return map[string]interface{}{"code": "ErrDuplicateCredential"}
+}
+
+type ErrVerifyCredentialFailed struct {
+	SourceErr error
+}
+
+func (e ErrVerifyCredentialFailed) Error() string {
+	return fmt.Sprintf("Failed to verify the credential:\n```\n%s\n```\n", e.SourceErr)
+}
+
+func (e ErrVerifyCredentialFailed) Extensions() map[string]interface{} {
+	return map[string]interface{}{"code": "ErrVerifyCredentialFailed"}
 }

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/usagestats"
 )
@@ -866,6 +867,9 @@ func (r *Resolver) CreateCampaignsCredential(ctx context.Context, args *graphqlb
 		svc := service.New(r.store)
 		username, err := svc.FetchUsernameForBitbucketServerToken(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), args.Credential)
 		if err != nil {
+			if bitbucketserver.IsUnauthorized(err) {
+				return nil, &ErrVerifyCredentialFailed{SourceErr: err}
+			}
 			return nil, err
 		}
 		a = &auth.BasicAuthWithSSH{

--- a/enterprise/internal/campaigns/store/codehost_test.go
+++ b/enterprise/internal/campaigns/store/codehost_test.go
@@ -21,6 +21,11 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock ct.Clo
 
 	repo := ct.TestRepo(t, es, extsvc.KindGitHub)
 	otherRepo := ct.TestRepo(t, es, extsvc.KindGitHub)
+
+	gh, _ := ct.CreateGitHubSSHTestRepos(t, ctx, s.DB(), 1)
+	bbs, _ := ct.CreateBbsSSHTestRepos(t, ctx, s.DB(), 1)
+	sshRepos := []*types.Repo{gh[0], bbs[0]}
+
 	gitlabRepo := ct.TestRepo(t, es, extsvc.KindGitLab)
 	bitbucketRepo := ct.TestRepo(t, es, extsvc.KindBitbucketServer)
 	awsRepo := ct.TestRepo(t, es, extsvc.KindAWSCodeCommit)
@@ -43,10 +48,12 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock ct.Clo
 				{
 					ExternalServiceType: extsvc.TypeBitbucketServer,
 					ExternalServiceID:   "https://bitbucketserver.com/",
+					RequiresSSH:         true,
 				},
 				{
 					ExternalServiceType: extsvc.TypeGitHub,
 					ExternalServiceID:   "https://github.com/",
+					RequiresSSH:         true,
 				},
 				{
 					ExternalServiceType: extsvc.TypeGitLab,
@@ -76,7 +83,7 @@ func testStoreCodeHost(t *testing.T, ctx context.Context, s *Store, clock ct.Clo
 	})
 
 	t.Run("GetExternalServiceID", func(t *testing.T) {
-		for _, repo := range []*types.Repo{repo, otherRepo, gitlabRepo, bitbucketRepo} {
+		for _, repo := range []*types.Repo{repo, otherRepo, gitlabRepo, bitbucketRepo, sshRepos[0], sshRepos[1]} {
 			id, err := s.GetExternalServiceID(ctx, GetExternalServiceIDOpts{
 				ExternalServiceType: repo.ExternalRepo.ServiceType,
 				ExternalServiceID:   repo.ExternalRepo.ServiceID,

--- a/internal/campaigns/code_host.go
+++ b/internal/campaigns/code_host.go
@@ -6,6 +6,7 @@ import "github.com/sourcegraph/sourcegraph/internal/extsvc"
 type CodeHost struct {
 	ExternalServiceType string
 	ExternalServiceID   string
+	RequiresSSH         bool
 }
 
 // IsSupported returns true, when this code host is supported by

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1291,6 +1291,15 @@ func IsNotFound(err error) bool {
 	return false
 }
 
+// IsUnauthorized reports whether err is a Bitbucket Server API 401 error.
+func IsUnauthorized(err error) bool {
+	switch e := errors.Cause(err).(type) {
+	case *httpError:
+		return e.Unauthorized()
+	}
+	return false
+}
+
 // IsNoSuchLabel reports whether err is a Bitbucket Server API "No Such Label"
 // error.
 func IsNoSuchLabel(err error) bool {


### PR DESCRIPTION
This implements the GraphQL API and UI bits and pieces required to make the new SSH credentials workflow complete.

Closes https://github.com/sourcegraph/sourcegraph/issues/16894
Closes https://github.com/sourcegraph/sourcegraph/issues/16893