### PR TITLE
search: Explicitly ignore unused value

### DIFF
--- a/internal/comby/translate.go
+++ b/internal/comby/translate.go
@@ -89,7 +89,7 @@ func parseTemplate(buf []byte) []Term {
 				// Look ahead and see if this is the start of a hole.
 				if r, _ = utf8.DecodeRune(buf); r == '[' {
 					// It is the start of a hole, consume the '['.
-					r = next()
+					_ = next()
 					open++
 					appendTerm(Literal(token))
 					// Persist the literal token scanned up to this point.


### PR DESCRIPTION
This is part of an effort to get rid of all ineffassign lint errors so
we can experiment with enforced linting.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
