### PR TITLE
search: Minor comby translation perf improvement

### DIFF
--- a/internal/comby/translate.go
+++ b/internal/comby/translate.go
@@ -73,7 +73,8 @@ func parseTemplate(buf []byte) []Term {
 
 	appendTerm := func(term Term) {
 		result = append(result, term)
-		token = []rune{}
+		// Reset token, but reuse the backing memory
+		token = token[:0]
 	}
 
 	for len(buf) > 0 {


### PR DESCRIPTION
Just a small perf improvement I noticed when looking through this section for unrelated reasons. 

Reuses the backing array for token. Reduces allocations for the test
case `1. :[1] 2. :[[2]] 3. :[3.] 4. :[4\n] 5. :[ ] 6. :[ 6] done.` from
110 to 82 allocations per op.

<details>

```
~/src/sourcegraph/sourcegraph ineff-assign-comby:master-dry-run/cc/ineff-assign-comby !4 ?1
❯ go test ./internal/comby -bench=. -run=XXX -benchmem
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/internal/comby
BenchmarkStructural-16            189723              6380 ns/op            1980 B/op         82 allocs/op
PASS
ok      github.com/sourcegraph/sourcegraph/internal/comby       1.289s

~/src/sourcegraph/sourcegraph ineff-assign-comby:master-dry-run/cc/ineff-assign-comby !4 ?1
❯ go test ./internal/comby -bench=. -run=XXX -benchmem
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/internal/comby
BenchmarkStructural-16            150374              6977 ns/op            2414 B/op        110 allocs/op
PASS
ok      github.com/sourcegraph/sourcegraph/internal/comby       1.144s
```

</details>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
