### PR TITLE
search: Explicitly ignore unused context

### DIFF
--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -242,7 +242,7 @@ func zoektSearch(ctx context.Context, args *search.TextPatternInfo, repoBranches
 
 func writeZip(ctx context.Context, w io.Writer, fileMatches []zoekt.FileMatch) (err error) {
 	bytesWritten := 0
-	span, ctx := ot.StartSpanFromContext(ctx, "WriteZip")
+	span, _ := ot.StartSpanFromContext(ctx, "WriteZip")
 	defer func() {
 		span.LogFields(log.Int("bytes_written", bytesWritten))
 		span.Finish()


### PR DESCRIPTION
This is part of an effort to remove all ineffassign lints so we can
experiment with enforced linting.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
