### PR TITLE
Add minimal enforced linting rules

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -1,0 +1,14 @@
+# See explanation of linters at https://golangci-lint.run/usage/linters/
+linters:
+  disable-all: true
+  enable:
+    - ineffassign
+
+run:
+  timeout: 5m
+
+  skip-dirs:
+    - client
+    - ui
+    - vendor
+    - node_modules

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -1,3 +1,7 @@
+# This file contains the configuration of the enforced linters for the project.
+# Eventually, the goal is to unify this with .golangci.yml. 
+# https://github.com/sourcegraph/sourcegraph/issues/18720
+
 # See explanation of linters at https://golangci-lint.run/usage/linters/
 linters:
   disable-all: true

--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -20,11 +20,4 @@ go install -tags=dev -buildmode=archive "${pkgs[@]}"
 asdf reshim
 
 echo "--- lint"
-
-# TODO when we add back golangci-lint use the same pattern we use for
-# docsite.sh. We don't want to include its dependencies in our go.mod,
-# especially since it is GPL code.
-
-echo "go lint is disabled until we can get it to use less resources. https://github.com/sourcegraph/sourcegraph/issues/9193"
-# Disable unused since it uses too much CPU/mem
-#golangci-lint run -e unused ${pkgs}
+"./dev/golangci-lint.sh" --config .golangci.enforced.yml run "${pkgs[@]}"

--- a/dev/golangci-lint.sh
+++ b/dev/golangci-lint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null
+
+mkdir -p .bin
+
+version="1.37.1"
+suffix="${version}-$(go env GOOS)-$(go env GOARCH)"
+target="$PWD/.bin/golangci-lint-${suffix}"
+url="https://github.com/golangci/golangci-lint/releases/download/v${version}/golangci-lint-${suffix}.tar.gz"
+
+if [ ! -f "${target}" ]; then
+  echo "downloading ${url}" 1>&2
+  curl -sS -L -f "${url}" -o "${target}.tar.gz"
+  tar xzf "${target}.tar.gz"
+  mv "golangci-lint-${suffix}/golangci-lint" "${target}"
+  rm -f "${target}.tar.gz"
+  rm -rf "golangci-lint-${suffix}"
+fi
+
+chmod +x "${target}"
+
+popd >/dev/null
+
+exec "${target}" "$@"


### PR DESCRIPTION
Adds a minimal `golangci-lint` configuration to enforce linting across
the project. Currently, the only lint it enforces is `ineffassign` since
there were only a couple of instances to change for that, and it allows
us to experiment with enforced linting with a pretty low barrier.

A separate configuration (`.golangci.enforced.yml`) was added so linting
behavior for people who have it set up as an editor integration does not
change. I think that ideally, we should aim to unify these, but for now
this strikes a nice balance between nagging lints and lints that cause CI
to fail.

Motivation: Linting occasionally helps me catch significant issues in my code,
and currently, linting is not enforced so the default `.golangci.yml` configuration
gives results that are too noisy to be useful. If we start enforcing linting, it
forces us to either explicitly ignore lints with `//nolint` or to fix them so that 
running a linter only gives results which are relevant to your current changes. 
Reviewdog is nice in that it only shows lints for the files touched in a PR, but 
that doesn't help the local development experience since there are still loads 
of ignored lints.

I'll be keeping this open for a few days to allow for questions/comments/concerns.

Note that the build should fail until the following PRs are merged:
- ~~#18699~~
- ~~#18701~~ 

Prior discussion:
- #9193
- #10858

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
