### PR TITLE
search frontend: encode URI for repo with spaces in stream search

### DIFF
--- a/client/web/src/search/stream.test.ts
+++ b/client/web/src/search/stream.test.ts
@@ -1,0 +1,19 @@
+import { toGQLRepositoryMatch, RepositoryMatch } from './stream'
+
+expect.addSnapshotSerializer({
+    serialize: value => JSON.stringify(value),
+    test: () => true,
+})
+
+export const REPO_MATCH_CONTAINING_SPACES: RepositoryMatch = {
+    type: 'repo',
+    repository: 'github.com/save/the andimals',
+}
+
+describe('escapeSpaces', () => {
+    test('escapes spaces in value', () => {
+        expect(toGQLRepositoryMatch(REPO_MATCH_CONTAINING_SPACES).label).toMatchInlineSnapshot(
+            '{"__typename":"Markdown","text":"[github.com/save/the andimals](github.com/save/the%20andimals)"}'
+        )
+    })
+})

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -67,7 +67,7 @@ interface CommitMatch {
     ranges: number[][]
 }
 
-type RepositoryMatch = { type: 'repo' } & Pick<FileMatch, 'repository' | 'branches'>
+export type RepositoryMatch = { type: 'repo' } & Pick<FileMatch, 'repository' | 'branches'>
 
 /**
  * An aggregate type representing a progress update.
@@ -238,17 +238,18 @@ const toMarkdown = (text: string | MarkdownText): GQL.IMarkdown => ({ __typename
 const repoIcon =
     'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K'
 
-function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
+export function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
     const branch = repo?.branches?.[0]
     const revision = branch ? `@${branch}` : ''
     const label = repo.repository + revision
+    const url = encodeURI(label)
 
     // We only need to return the subset defined in IGenericSearchResultInterface
     const gqlRepo: unknown = {
         __typename: 'Repository',
         icon: repoIcon,
-        label: toMarkdown(`[${label}](/${label})`),
-        url: '/' + label,
+        label: toMarkdown(`[${label}](${url})`),
+        url: '/' + url,
         detail: toMarkdown('Repository name match'),
         matches: [],
         name: repo.repository,


### PR DESCRIPTION
Addresses https://github.com/sourcegraph/sourcegraph/pull/18668#issuecomment-786335343 where repos with spaces would not be clickable links:

![image](https://user-images.githubusercontent.com/888624/109351812-1ffada00-7837-11eb-8c99-d0360ca934e5.png)

Thanks @limitedmage you saved me like 15 minutes by pointing out the code :-)

So I'm exporting the function and type to test here because there is no public function I can use to easily test this behavior, there is only `aggregateStreamingSearch` which won't let me inject values. There's probably a more complex way to work around this, unless I'm missing something obvious, but I've allocated enough time to this issue and declare this "good enough"