### PR TITLE
search frontend: simplify stream type definitions

### DIFF
--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -36,8 +36,12 @@ interface LineMatch {
     offsetAndLengths: number[][]
 }
 
-interface FileSymbolMatch extends Omit<FileMatch, 'lineMatches' | 'type'> {
+interface FileSymbolMatch {
     type: 'symbol'
+    name: string
+    repository: string
+    branches?: string[]
+    version?: string
     symbols: SymbolMatch[]
 }
 
@@ -67,7 +71,11 @@ interface CommitMatch {
     ranges: number[][]
 }
 
-export type RepositoryMatch = { type: 'repo' } & Pick<FileMatch, 'repository' | 'branches'>
+export interface RepositoryMatch {
+    type: 'repo'
+    repository: string
+    branches?: string[]
+}
 
 /**
  * An aggregate type representing a progress update.


### PR DESCRIPTION
Stacked on #18705.

The amount of mental gymnastics needed to understand these types is too high 😄  Don't get me wrong, utility types are cool to play with but I think this is too fancy and the combination of set intersect and set difference on `FileMatch` only indicates that there isn't a close enough relation to define one in terms of the other. There is no harm in keeping it simple.

The only real opportunity here is if we defined a top level `repo` type and then extended it for other types [similar to what I did for decorated tokens](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/search/query/decoratedToken.ts#L29-55), but even this is overkill for this small amount of definitions.