### PR TITLE
internal/vcs/git: add CommitsOptions.Before

### DIFF
--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -69,6 +69,7 @@ type CommitsOptions struct {
 
 	Author string // include only commits whose author matches this
 	After  string // include only commits after this date
+	Before string // include only commits before this date
 
 	Path string // only commits modifying the given path are selected (optional)
 
@@ -258,6 +259,9 @@ func commitLogArgs(initialArgs []string, opt CommitsOptions) (args []string, err
 
 	if opt.After != "" {
 		args = append(args, "--after="+opt.After)
+	}
+	if opt.Before != "" {
+		args = append(args, "--before="+opt.Before)
 	}
 
 	if opt.MessageQuery != "" {

--- a/internal/vcs/git/commits_test.go
+++ b/internal/vcs/git/commits_test.go
@@ -329,6 +329,24 @@ func TestRepository_Commits_options(t *testing.T) {
 			wantCommits: wantGitCommits2,
 			wantTotal:   1,
 		},
+		"before": {
+			repo: MakeGitRepository(t, gitCommands...),
+			opt: CommitsOptions{
+				Before: "2006-01-02T15:04:07Z",
+				Range:  "HEAD",
+				N:      1,
+			},
+			wantCommits: []*Commit{
+				{
+					ID:        "b266c7e3ca00b1a17ad0b1449825d0854225c007",
+					Author:    Signature{Name: "a", Email: "a@a.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:06Z")},
+					Committer: &Signature{Name: "c", Email: "c@c.com", Date: MustParseTime(time.RFC3339, "2006-01-02T15:04:07Z")},
+					Message:   "bar",
+					Parents:   []api.CommitID{"ea167fe3d76b1e5fd3ed8ca44cbd2fe3897684f8"},
+				},
+			},
+			wantTotal: 1,
+		},
 	}
 
 	for label, test := range tests {


### PR DESCRIPTION
For building historical data of search insights, I need a way to locate the commit
in a repository closest to some given point in time. For this, I am using `git.Commits`
with `Before` and `After`  to find 1 commit before and after the target time, and then
determining which is closer.

Helps #18398

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>