### PR TITLE
graphqlbackend: removed deprecated search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
--
+- Removed the deprecated GraphQL fields `SearchResults.repositoriesSearched` and `SearchResults.indexedRepositoriesSearched`.
 
 ## 3.25.1
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3609,25 +3609,6 @@ type SearchResults {
     """
     repositoriesCount: Int!
     """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Repositories that were actually searched. Excludes repositories that would have been searched but were not
-    because a timeout or error occurred while performing the search, or because the result limit was already
-    reached, or because they were excluded due to being forks or archives.
-    In paginated search requests, this represents the set of repositories searched for the
-    individual paginated request / input cursor and not the global set of repositories that
-    would be searched if further requests were made.
-    """
-    repositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Indexed repositories searched. This is a subset of repositoriesSearched.
-    """
-    indexedRepositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
     Repositories that are busy cloning onto gitserver.
     In paginated search requests, some repositories may be cloning. These are reported here
     and you may choose to retry the paginated request with the same cursor after they have

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3602,25 +3602,6 @@ type SearchResults {
     """
     repositoriesCount: Int!
     """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Repositories that were actually searched. Excludes repositories that would have been searched but were not
-    because a timeout or error occurred while performing the search, or because the result limit was already
-    reached, or because they were excluded due to being forks or archives.
-    In paginated search requests, this represents the set of repositories searched for the
-    individual paginated request / input cursor and not the global set of repositories that
-    would be searched if further requests were made.
-    """
-    repositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Indexed repositories searched. This is a subset of repositoriesSearched.
-    """
-    indexedRepositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
     Repositories that are busy cloning onto gitserver.
     In paginated search requests, some repositories may be cloning. These are reported here
     and you may choose to retry the paginated request with the same cursor after they have

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -81,14 +81,6 @@ func (c *SearchResultsResolver) repositoryResolvers(mask search.RepoStatus) []*R
 	return resolvers
 }
 
-func (c *SearchResultsResolver) RepositoriesSearched() []*RepositoryResolver {
-	return c.repositoryResolvers(search.RepoStatusSearched)
-}
-
-func (c *SearchResultsResolver) IndexedRepositoriesSearched() []*RepositoryResolver {
-	return c.repositoryResolvers(search.RepoStatusIndexed)
-}
-
 func (c *SearchResultsResolver) Cloning() []*RepositoryResolver {
 	return c.repositoryResolvers(search.RepoStatusCloning)
 }


### PR DESCRIPTION
repositoriesSearched and indexedRepositoriesSearched were deprecated in
v3.24. Slated to be removed in v3.26, which tree is now open.