### PR TITLE
search: remove RepoStatus Searched and Indexed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Removed
 
--
+- Removed the deprecated GraphQL fields `SearchResults.repositoriesSearched` and `SearchResults.indexedRepositoriesSearched`.
 
 ## 3.25.1
 

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -3609,25 +3609,6 @@ type SearchResults {
     """
     repositoriesCount: Int!
     """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Repositories that were actually searched. Excludes repositories that would have been searched but were not
-    because a timeout or error occurred while performing the search, or because the result limit was already
-    reached, or because they were excluded due to being forks or archives.
-    In paginated search requests, this represents the set of repositories searched for the
-    individual paginated request / input cursor and not the global set of repositories that
-    would be searched if further requests were made.
-    """
-    repositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Indexed repositories searched. This is a subset of repositoriesSearched.
-    """
-    indexedRepositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
     Repositories that are busy cloning onto gitserver.
     In paginated search requests, some repositories may be cloning. These are reported here
     and you may choose to retry the paginated request with the same cursor after they have

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3602,25 +3602,6 @@ type SearchResults {
     """
     repositoriesCount: Int!
     """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Repositories that were actually searched. Excludes repositories that would have been searched but were not
-    because a timeout or error occurred while performing the search, or because the result limit was already
-    reached, or because they were excluded due to being forks or archives.
-    In paginated search requests, this represents the set of repositories searched for the
-    individual paginated request / input cursor and not the global set of repositories that
-    would be searched if further requests were made.
-    """
-    repositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
-    DEPRECATED in v3.24. Will be removed in v3.26.
-
-    Indexed repositories searched. This is a subset of repositoriesSearched.
-    """
-    indexedRepositoriesSearched: [Repository!]!
-        @deprecated(reason: "expensive to calculate and unused by official clients. Will be removed in v3.26.")
-    """
     Repositories that are busy cloning onto gitserver.
     In paginated search requests, some repositories may be cloning. These are reported here
     and you may choose to retry the paginated request with the same cursor after they have

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -563,8 +563,6 @@ func handleRepoSearchResult(repoRev *search.RepositoryRevisions, limitHit, timed
 		status |= search.RepoStatusTimedout
 	} else if searchErr != nil {
 		fatalErr = searchErr
-	} else {
-		status |= search.RepoStatusSearched
 	}
 	return streaming.Stats{
 		Status:     search.RepoStatusSingleton(repoRev.Repo.ID, status),

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -81,14 +81,6 @@ func (c *SearchResultsResolver) repositoryResolvers(mask search.RepoStatus) []*R
 	return resolvers
 }
 
-func (c *SearchResultsResolver) RepositoriesSearched() []*RepositoryResolver {
-	return c.repositoryResolvers(search.RepoStatusSearched)
-}
-
-func (c *SearchResultsResolver) IndexedRepositoriesSearched() []*RepositoryResolver {
-	return c.repositoryResolvers(search.RepoStatusIndexed)
-}
-
 func (c *SearchResultsResolver) Cloning() []*RepositoryResolver {
 	return c.repositoryResolvers(search.RepoStatusCloning)
 }

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -100,7 +100,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, db dbutil.DB, args *search.Te
 
 	// Set all repos to "timed out"
 	if since(t0) >= searchOpts.MaxWallTime {
-		c.Send(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout | search.RepoStatusIndexed)}})
+		c.Send(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
 	}
 
 	// We always return approximate results (limitHit true) unless we run the branch to perform a more complete search.
@@ -117,7 +117,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, db dbutil.DB, args *search.Te
 			return err
 		}
 		if since(t0) >= searchOpts.MaxWallTime {
-			c.Send(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout | search.RepoStatusIndexed)}})
+			c.Send(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
 		}
 		// This is the only place limitHit can be set false, meaning we covered everything.
 		limitHit = resp.FilesSkipped+resp.ShardsSkipped > 0

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -97,13 +97,9 @@ func TestSearchFilesInRepos(t *testing.T) {
 	}
 	assertReposStatus(t, repoNames, common.Status, map[string]search.RepoStatus{
 		"foo/cloning":          search.RepoStatusCloning,
-		"foo/empty":            search.RepoStatusSearched,
 		"foo/missing":          search.RepoStatusMissing,
 		"foo/missing-database": search.RepoStatusMissing,
-		"foo/no-rev":           0,
-		"foo/one":              search.RepoStatusSearched,
 		"foo/timedout":         search.RepoStatusTimedout,
-		"foo/two":              search.RepoStatusSearched,
 	})
 
 	// If we specify a rev and it isn't found, we fail the whole search since

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -82,12 +82,6 @@ func TestIndexedSearch(t *testing.T) {
 				useFullDeadline: false,
 				since:           func(time.Time) time.Duration { return time.Second - time.Millisecond },
 			},
-			wantCommon: streaming.Stats{
-				Status: mkStatusMap(map[string]search.RepoStatus{
-					"foo/bar":    search.RepoStatusSearched | search.RepoStatusIndexed,
-					"foo/foobar": search.RepoStatusSearched | search.RepoStatusIndexed,
-				}),
-			},
 			wantErr: false,
 		},
 		{
@@ -101,8 +95,8 @@ func TestIndexedSearch(t *testing.T) {
 			},
 			wantCommon: streaming.Stats{
 				Status: mkStatusMap(map[string]search.RepoStatus{
-					"foo/bar":    search.RepoStatusIndexed | search.RepoStatusTimedout,
-					"foo/foobar": search.RepoStatusIndexed | search.RepoStatusTimedout,
+					"foo/bar":    search.RepoStatusTimedout,
+					"foo/foobar": search.RepoStatusTimedout,
 				}),
 			},
 		},
@@ -171,12 +165,6 @@ func TestIndexedSearch(t *testing.T) {
 				"",
 				"",
 			},
-			wantCommon: streaming.Stats{
-				Status: mkStatusMap(map[string]search.RepoStatus{
-					"foo/bar":    search.RepoStatusSearched | search.RepoStatusIndexed,
-					"foo/foobar": search.RepoStatusSearched | search.RepoStatusIndexed,
-				}),
-			},
 			wantErr: false,
 		},
 		{
@@ -202,11 +190,6 @@ func TestIndexedSearch(t *testing.T) {
 				since: func(time.Time) time.Duration { return 0 },
 			},
 			wantMatchCount: 3,
-			wantCommon: streaming.Stats{
-				Status: mkStatusMap(map[string]search.RepoStatus{
-					"foo/bar": search.RepoStatusSearched | search.RepoStatusIndexed,
-				}),
-			},
 			wantMatchURLs: []string{
 				"git://foo/bar?HEAD#baz.go",
 				"git://foo/bar?dev#baz.go",
@@ -236,11 +219,6 @@ func TestIndexedSearch(t *testing.T) {
 						FileName:   "baz.go",
 					},
 				},
-			},
-			wantCommon: streaming.Stats{
-				Status: mkStatusMap(map[string]search.RepoStatus{
-					"foo/bar": search.RepoStatusSearched | search.RepoStatusIndexed,
-				}),
 			},
 			wantUnindexed: makeRepositoryRevisions("foo/bar@unindexed"),
 			wantMatchURLs: []string{

--- a/internal/search/repo_status.go
+++ b/internal/search/repo_status.go
@@ -12,9 +12,7 @@ import (
 type RepoStatus uint8
 
 const (
-	RepoStatusSearched RepoStatus = 1 << iota // was searched
-	RepoStatusIndexed                         // searched using an index
-	RepoStatusCloning                         // could not be searched because they were still being cloned
+	RepoStatusCloning  RepoStatus = 1 << iota // could not be searched because they were still being cloned
 	RepoStatusMissing                         // could not be searched because they do not exist
 	RepoStatusLimitHit                        // searched, but have results that were not returned due to exceeded limits
 	RepoStatusTimedout                        // repos that were not searched due to timeout
@@ -24,8 +22,6 @@ var repoStatusName = []struct {
 	status RepoStatus
 	name   string
 }{
-	{RepoStatusSearched, "searched"},
-	{RepoStatusIndexed, "indexed"},
 	{RepoStatusCloning, "cloning"},
 	{RepoStatusMissing, "missing"},
 	{RepoStatusLimitHit, "limithit"},

--- a/internal/search/repo_status.go
+++ b/internal/search/repo_status.go
@@ -146,6 +146,9 @@ func (m *RepoStatusMap) String() string {
 // RepoStatusSingleton is a convenience function to contain a RepoStatusMap
 // with one entry.
 func RepoStatusSingleton(id api.RepoID, status RepoStatus) RepoStatusMap {
+	if status == 0 {
+		return RepoStatusMap{}
+	}
 	return RepoStatusMap{
 		m:      map[api.RepoID]RepoStatus{id: status},
 		status: status,

--- a/internal/search/repo_status_test.go
+++ b/internal/search/repo_status_test.go
@@ -11,44 +11,44 @@ import (
 
 func TestRepoStatusMap(t *testing.T) {
 	aM := map[api.RepoID]RepoStatus{
-		1: RepoStatusSearched,
+		1: RepoStatusTimedout,
 		2: RepoStatusCloning,
-		3: RepoStatusSearched | RepoStatusIndexed,
-		4: RepoStatusIndexed,
+		3: RepoStatusTimedout | RepoStatusLimitHit,
+		4: RepoStatusLimitHit,
 	}
 	a := mkStatusMap(aM)
 	b := mkStatusMap(map[api.RepoID]RepoStatus{
 		2: RepoStatusCloning,
-		4: RepoStatusSearched,
+		4: RepoStatusTimedout,
 		5: RepoStatusMissing,
 	})
 	c := mkStatusMap(map[api.RepoID]RepoStatus{
-		8: RepoStatusSearched | RepoStatusIndexed,
-		9: RepoStatusSearched,
+		8: RepoStatusTimedout | RepoStatusLimitHit,
+		9: RepoStatusTimedout,
 	})
 
 	// Get
 	if got, want := a.Get(10), RepoStatus(0); got != want {
 		t.Errorf("a.Get(10) got %s want %s", got, want)
 	}
-	if got, want := a.Get(3), RepoStatusSearched|RepoStatusIndexed; got != want {
+	if got, want := a.Get(3), RepoStatusTimedout|RepoStatusLimitHit; got != want {
 		t.Errorf("a.Get(3) got %s want %s", got, want)
 	}
 
 	// Any
-	if !c.Any(RepoStatusIndexed) {
-		t.Error("c.Any(RepoStatusIndexed) should be true")
+	if !c.Any(RepoStatusLimitHit) {
+		t.Error("c.Any(RepoStatusLimitHit) should be true")
 	}
 	if c.Any(RepoStatusCloning) {
 		t.Error("c.Any(RepoStatusCloning) should be false")
 	}
 
 	// All
-	if !c.All(RepoStatusSearched) {
-		t.Error("c.All(RepoStatusSearched) should be true")
+	if !c.All(RepoStatusTimedout) {
+		t.Error("c.All(RepoStatusTimedout) should be true")
 	}
-	if c.All(RepoStatusIndexed) {
-		t.Error("c.All(RepoStatusIndexed) should be false")
+	if c.All(RepoStatusLimitHit) {
+		t.Error("c.All(RepoStatusLimitHit) should be false")
 	}
 
 	// Len
@@ -57,8 +57,8 @@ func TestRepoStatusMap(t *testing.T) {
 	}
 
 	// Update
-	c.Update(9, RepoStatusIndexed)
-	if got, want := c.Get(9), RepoStatusSearched|RepoStatusIndexed; got != want {
+	c.Update(9, RepoStatusLimitHit)
+	if got, want := c.Get(9), RepoStatusTimedout|RepoStatusLimitHit; got != want {
 		t.Errorf("c.Get(9) got %s want %s", got, want)
 	}
 
@@ -92,8 +92,8 @@ func TestRepoStatusMap(t *testing.T) {
 			t.Errorf("a.Filter(%s) diff (-want, +got):\n%s", status, d)
 		}
 	}
-	assertAFilter(RepoStatusSearched, []int{1, 3})
-	assertAFilter(RepoStatusTimedout, []int{})
+	assertAFilter(RepoStatusTimedout, []int{1, 3})
+	assertAFilter(RepoStatusMissing, []int{})
 
 	// Union
 	t.Logf("%s", &a)
@@ -101,10 +101,10 @@ func TestRepoStatusMap(t *testing.T) {
 	b.Union(&a)
 	t.Logf("%s", &b)
 	abUnionWant := mkStatusMap(map[api.RepoID]RepoStatus{
-		1: RepoStatusSearched,
+		1: RepoStatusTimedout,
 		2: RepoStatusCloning,
-		3: RepoStatusSearched | RepoStatusIndexed,
-		4: RepoStatusSearched | RepoStatusIndexed,
+		3: RepoStatusTimedout | RepoStatusLimitHit,
+		4: RepoStatusTimedout | RepoStatusLimitHit,
 		5: RepoStatusMissing,
 	})
 	assertReposStatusEqual(t, abUnionWant, b)
@@ -122,16 +122,16 @@ func TestRepoStatusMap_nil(t *testing.T) {
 	x.Iterate(func(api.RepoID, RepoStatus) {
 		t.Error("Iterate should be empty")
 	})
-	x.Filter(RepoStatusSearched, func(api.RepoID) {
+	x.Filter(RepoStatusTimedout, func(api.RepoID) {
 		t.Error("Filter should be empty")
 	})
 	if got, want := x.Get(10), RepoStatus(0); got != want {
 		t.Errorf("Get got %s want %s", got, want)
 	}
-	if x.Any(RepoStatusSearched) {
+	if x.Any(RepoStatusTimedout) {
 		t.Error("Any should be false")
 	}
-	if x.All(RepoStatusSearched) {
+	if x.All(RepoStatusTimedout) {
 		t.Error("All should be false")
 	}
 	if got, want := x.Len(), 0; got != want {
@@ -140,9 +140,9 @@ func TestRepoStatusMap_nil(t *testing.T) {
 }
 
 func TestRepoStatusSingleton(t *testing.T) {
-	x := RepoStatusSingleton(123, RepoStatusSearched|RepoStatusIndexed)
+	x := RepoStatusSingleton(123, RepoStatusTimedout|RepoStatusLimitHit)
 	want := mkStatusMap(map[api.RepoID]RepoStatus{
-		123: RepoStatusSearched | RepoStatusIndexed,
+		123: RepoStatusTimedout | RepoStatusLimitHit,
 	})
 	assertReposStatusEqual(t, want, x)
 }


### PR DESCRIPTION
No one reads these values now. This avoids an O(N) allocation(s) we did
for every search creating a map of repositories we have searched.

Stacked on https://github.com/sourcegraph/sourcegraph/pull/18722