### PR TITLE
eventLog: update docstring about Sourcegraph.com usage

### DIFF
--- a/client/web/src/user/settings/backend.tsx
+++ b/client/web/src/user/settings/backend.tsx
@@ -122,7 +122,8 @@ export function logUserEvent(event: UserEvent): void {
  * Log a raw user action (used to allow site admins on a Sourcegraph instance
  * to see a count of unique users on a daily, weekly, and monthly basis).
  *
- * Not used at all for public/sourcegraph.com usage.
+ * When invoked on a non-Sourcegraph.com instance, this data is stored in the
+ * instance's database, and not sent to Sourcegraph.com.
  */
 export function logEvent(event: string, eventProperties?: unknown): void {
     requestGraphQL<LogEventResult, LogEventVariables>(


### PR DESCRIPTION
Updated a misleading docstring created ~2 years ago that says we don't use `logEvent` for Sourcegraph.com. We do collect event logs from Sourcegraph.com. Now, it's correct to say that we don't send data directly to Sourcegraph.com when `logEvent` is called on a customer instance. 

However, we do use `logEvent` for Sourcegraph.com events. You can see in the logEvent handler on the backend that we do handle Sourcegraph.com events, and publish these to BigQuery: https://sourcegraph.com/github.com/sourcegraph/sourcegraph@b6c5a617534f7b1b36444bf30bfa00c4ab2596e1/-/blob/internal/usagestats/event_handlers.go#L43-54

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
