### PR TITLE
search: fix panic when evaluating AND expressions

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -612,6 +612,14 @@ func (r *searchResolver) evaluateAndStream(ctx context.Context, scopeParameters 
 	r2.stream = nil
 
 	result, err := r2.evaluateAnd(ctx, scopeParameters, operands)
+	if err != nil {
+		return nil, err
+	}
+	// evaluateAnd may return result, err = nil, nil because downstream calls return
+	// nil, nil. See further comments in evaluateAnd.
+	if result == nil {
+		return &SearchResultsResolver{}, nil
+	}
 	r.stream.Send(SearchEvent{
 		Results: result.SearchResults,
 		Stats:   result.Stats,
@@ -631,7 +639,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 	start := time.Now()
 
 	if len(operands) == 0 {
-		return nil, nil
+		return &SearchResultsResolver{}, nil
 	}
 
 	var (


### PR DESCRIPTION
We did neither check for err!=nil nor did we check for nil results which
most likely caused the panic on Cloud.

I added a guard against nil results. However a better long term fix would
be not to return nil, nil anywhere in the code.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
