### PR TITLE
gitserver: Read hostname from environment

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -39,6 +39,8 @@ var (
 	reposDir        = env.Get("SRC_REPOS_DIR", "/data/repos", "Root dir containing repos.")
 	wantPctFree     = env.Get("SRC_REPOS_DESIRED_PERCENT_FREE", "10", "Target percentage of free space on disk.")
 	janitorInterval = env.Get("SRC_REPOS_JANITOR_INTERVAL", "1m", "Interval between cleanup runs")
+	envNodeName     = env.Get("NODE_NAME", "", "Node name, usually set in k8s")
+	envHostname     = env.Get("HOSTNAME", "", "Hostname override")
 )
 
 func main() {
@@ -116,6 +118,7 @@ func main() {
 			}
 			return &server.GitRepoSyncer{}, nil
 		},
+		Hostname: hostnameBestEffort(),
 	}
 	gitserver.RegisterMetrics()
 
@@ -178,6 +181,17 @@ func main() {
 	// The most important thing this does is kill all our clones. If we just
 	// shutdown they will be orphaned and continue running.
 	gitserver.Stop()
+}
+
+func hostnameBestEffort() string {
+	if envNodeName != "" {
+		return envNodeName
+	}
+	if envHostname != "" {
+		return envHostname
+	}
+	h, _ := os.Hostname()
+	return h
 }
 
 func parsePercent(s string) (int, error) {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -131,6 +131,11 @@ type Server struct {
 	// usually set to return a GitRepoSyncer.
 	GetVCSSyncer func(context.Context, api.RepoName) (VCSSyncer, error)
 
+	// Hostname is how we identify this instance of gitserver. Generally it is the
+	// actual hostname can also be overridden by the NODE_NAME or HOSTNAME
+	// environment variables.
+	Hostname string
+
 	// skipCloneForTests is set by tests to avoid clones.
 	skipCloneForTests bool
 

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -1,4 +1,4 @@
-gitserver: gitserver
+gitserver: env HOSTNAME=$SRC_GIT_SERVER_1 gitserver
 query-runner: query-runner
 repo-updater: repo-updater
 searcher: searcher

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -72,7 +72,9 @@ export SRC_LOG_FORMAT=${SRC_LOG_FORMAT:-condensed}
 export GITHUB_BASE_URL=${GITHUB_BASE_URL:-http://127.0.0.1:3180}
 export SRC_REPOS_DIR=$HOME/.sourcegraph/repos
 export INSECURE_DEV=1
-export SRC_GIT_SERVERS=127.0.0.1:3178
+# In dev we only expect to have one gitserver instance
+export SRC_GIT_SERVER_1=127.0.0.1:3178
+export SRC_GIT_SERVERS=$SRC_GIT_SERVER_1
 export GOLANGSERVER_SRC_GIT_SERVERS=host.docker.internal:3178
 export SEARCHER_URL=http://127.0.0.1:3181
 export REPO_UPDATER_URL=http://127.0.0.1:3182


### PR DESCRIPTION
This will allow gitserver instances to know their own identity within
the SRC_GIT_SERVERS list.
