### PR TITLE
Add BatchChange to GraphQL schema and alias Campaign resolver to it

### DIFF
--- a/client/web/src/enterprise/campaigns/Description.tsx
+++ b/client/web/src/enterprise/campaigns/Description.tsx
@@ -2,10 +2,10 @@ import * as H from 'history'
 import React from 'react'
 import { Markdown } from '../../../../shared/src/components/Markdown'
 import { renderMarkdown } from '../../../../shared/src/util/markdown'
-import { CampaignFields } from '../../graphql-operations'
+import { BatchChangeFields } from '../../graphql-operations'
 import classNames from 'classnames'
 
-interface DescriptionProps extends Pick<CampaignFields, 'description'> {
+interface DescriptionProps extends Pick<BatchChangeFields, 'description'> {
     history: H.History
     className?: string
 }

--- a/client/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignCloseChangesetsList.tsx
@@ -4,7 +4,7 @@ import { ThemeProps } from '../../../../../shared/src/theme'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
-import { Scalars, ChangesetFields, CampaignChangesetsResult } from '../../../graphql-operations'
+import { Scalars, ChangesetFields, BatchChangeChangesetsResult } from '../../../graphql-operations'
 import { Subject } from 'rxjs'
 import { FilteredConnectionQueryArguments, FilteredConnection } from '../../../components/FilteredConnection'
 import { repeatWhen, withLatestFrom, filter, map, delay } from 'rxjs/operators'
@@ -35,7 +35,7 @@ interface Props extends ThemeProps, PlatformContextProps, TelemetryProps, Extens
     location: H.Location
     willClose: boolean
     onUpdate?: (
-        connection?: (CampaignChangesetsResult['node'] & { __typename: 'Campaign' })['changesets'] | ErrorLike
+        connection?: (BatchChangeChangesetsResult['node'] & { __typename: 'BatchChange' })['changesets'] | ErrorLike
     ) => void
 
     /** For testing only. */
@@ -72,8 +72,8 @@ export const CampaignCloseChangesetsList: React.FunctionComponent<Props> = ({
                 reviewState: null,
                 first: args.first ?? null,
                 after: args.after ?? null,
-                campaign: campaignID,
-                onlyPublishedByThisCampaign: true,
+                batchChange: campaignID,
+                onlyPublishedByThisBatchChange: true,
                 search: null,
             }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000)))),
         [campaignID, queryChangesets]
@@ -138,7 +138,7 @@ export const CampaignCloseChangesetsList: React.FunctionComponent<Props> = ({
             <FilteredConnection<
                 ChangesetFields,
                 Omit<ChangesetCloseNodeProps, 'node'>,
-                (CampaignChangesetsResult['node'] & { __typename: 'Campaign' })['changesets']
+                (BatchChangeChangesetsResult['node'] & { __typename: 'BatchChange' })['changesets']
             >
                 className="mt-2"
                 nodeComponent={ChangesetCloseNode}

--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -5,16 +5,16 @@ import { CampaignClosePage } from './CampaignClosePage'
 import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs,
-    fetchCampaignByNamespace,
+    fetchBatchChangeByNamespace,
 } from '../detail/backend'
 import { of } from 'rxjs'
 import { subDays } from 'date-fns'
 import {
     ChangesetCheckState,
     ChangesetReviewState,
-    CampaignFields,
     ChangesetSpecType,
     ChangesetState,
+    BatchChangeFields,
 } from '../../../graphql-operations'
 import { useMemo, useCallback } from '@storybook/addons'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
@@ -29,8 +29,8 @@ const { add } = storiesOf('web/campaigns/close/CampaignClosePage', module)
 
 const now = new Date()
 
-const campaignDefaults: CampaignFields = {
-    __typename: 'Campaign',
+const batchChangeDefaults: BatchChangeFields = {
+    __typename: 'BatchChange',
     changesetsStats: {
         closed: 1,
         deleted: 1,
@@ -200,14 +200,14 @@ const queryEmptyExternalChangesetWithFileDiffs: typeof queryExternalChangesetWit
 
 add('Overview', () => {
     const viewerCanAdminister = boolean('viewerCanAdminister', true)
-    const campaign: CampaignFields = useMemo(
+    const batchChange: BatchChangeFields = useMemo(
         () => ({
-            ...campaignDefaults,
+            ...batchChangeDefaults,
             viewerCanAdminister,
         }),
         [viewerCanAdminister]
     )
-    const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
+    const fetchBatchChange: typeof fetchBatchChangeByNamespace = useCallback(() => of(batchChange), [batchChange])
     return (
         <EnterpriseWebStory>
             {props => (
@@ -216,8 +216,8 @@ add('Overview', () => {
                     queryChangesets={queryChangesets}
                     queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
                     namespaceID="n123"
-                    campaignName="c123"
-                    fetchCampaignByNamespace={fetchCampaign}
+                    batchChangeName="c123"
+                    fetchBatchChangeByNamespace={fetchBatchChange}
                     extensionsController={{} as any}
                     platformContext={{} as any}
                 />
@@ -227,8 +227,8 @@ add('Overview', () => {
 })
 
 add('No open changesets', () => {
-    const campaign: CampaignFields = useMemo(() => campaignDefaults, [])
-    const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
+    const batchChange: BatchChangeFields = useMemo(() => batchChangeDefaults, [])
+    const fetchBatchChange: typeof fetchBatchChangeByNamespace = useCallback(() => of(batchChange), [batchChange])
     const queryEmptyChangesets = useCallback(
         () =>
             of({
@@ -249,8 +249,8 @@ add('No open changesets', () => {
                     queryChangesets={queryEmptyChangesets}
                     queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
                     namespaceID="n123"
-                    campaignName="c123"
-                    fetchCampaignByNamespace={fetchCampaign}
+                    batchChangeName="c123"
+                    fetchBatchChangeByNamespace={fetchBatchChange}
                     extensionsController={{} as any}
                     platformContext={{} as any}
                 />

--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.story.tsx
@@ -64,7 +64,7 @@ const batchChangeDefaults: BatchChangeFields = {
     },
     currentSpec: {
         originalInput: 'name: awesome-campaign\ndescription: somestring',
-        supersedingCampaignSpec: null,
+        supersedingBatchSpec: null,
     },
 }
 

--- a/client/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignClosePage.tsx
@@ -2,11 +2,11 @@ import React, { useState, useMemo, useCallback } from 'react'
 import * as H from 'history'
 import { PageTitle } from '../../../components/PageTitle'
 import { CampaignCloseAlert } from './CampaignCloseAlert'
-import { CampaignChangesetsResult, CampaignFields, Scalars } from '../../../graphql-operations'
+import { BatchChangeChangesetsResult, BatchChangeFields, Scalars } from '../../../graphql-operations'
 import {
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
     queryChangesets as _queryChangesets,
-    fetchCampaignByNamespace as _fetchCampaignByNamespace,
+    fetchBatchChangeByNamespace as _fetchCampaignByNamespace,
 } from '../detail/backend'
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
@@ -33,14 +33,14 @@ export interface CampaignClosePageProps
      */
     namespaceID: Scalars['ID']
     /**
-     * The campaign name.
+     * The batch change name.
      */
-    campaignName: CampaignFields['name']
+    batchChangeName: BatchChangeFields['name']
     history: H.History
     location: H.Location
 
     /** For testing only. */
-    fetchCampaignByNamespace?: typeof _fetchCampaignByNamespace
+    fetchBatchChangeByNamespace?: typeof _fetchCampaignByNamespace
     /** For testing only. */
     queryChangesets?: typeof _queryChangesets
     /** For testing only. */
@@ -51,14 +51,14 @@ export interface CampaignClosePageProps
 
 export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> = ({
     namespaceID,
-    campaignName,
+    batchChangeName: campaignName,
     history,
     location,
     extensionsController,
     isLightTheme,
     platformContext,
     telemetryService,
-    fetchCampaignByNamespace = _fetchCampaignByNamespace,
+    fetchBatchChangeByNamespace: fetchCampaignByNamespace = _fetchCampaignByNamespace,
     queryChangesets,
     queryExternalChangesetWithFileDiffs,
     closeCampaign,
@@ -75,7 +75,9 @@ export const CampaignClosePage: React.FunctionComponent<CampaignClosePageProps> 
     const [totalCount, setTotalCount] = useState<number>()
 
     const onFetchChangesets = useCallback(
-        (connection?: (CampaignChangesetsResult['node'] & { __typename: 'Campaign' })['changesets'] | ErrorLike) => {
+        (
+            connection?: (BatchChangeChangesetsResult['node'] & { __typename: 'BatchChange' })['changesets'] | ErrorLike
+        ) => {
             if (!connection || isErrorLike(connection)) {
                 return
             }

--- a/client/web/src/enterprise/campaigns/detail/BurndownChart.tsx
+++ b/client/web/src/enterprise/campaigns/detail/BurndownChart.tsx
@@ -74,13 +74,13 @@ const tooltipItemSorter = ({ dataKey }: TooltipPayload): number =>
  * A burndown chart showing progress of the campaigns changesets.
  */
 export const CampaignBurndownChart: React.FunctionComponent<Props> = ({
-    campaignID,
+    campaignID: batchChangeID,
     queryChangesetCountsOverTime = _queryChangesetCountsOverTime,
     width = '100%',
 }) => {
     const changesetCountsOverTime: ChangesetCountsOverTimeFields[] | undefined = useObservable(
-        useMemo(() => queryChangesetCountsOverTime({ campaign: campaignID }), [
-            campaignID,
+        useMemo(() => queryChangesetCountsOverTime({ batchChange: batchChangeID }), [
+            batchChangeID,
             queryChangesetCountsOverTime,
         ])
     )

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -4,14 +4,14 @@ import React from 'react'
 import { CampaignDetailsPage } from './CampaignDetailsPage'
 import { of } from 'rxjs'
 import {
-    CampaignFields,
+    BatchChangeFields,
     ChangesetCheckState,
     ChangesetReviewState,
     ChangesetSpecType,
     ChangesetState,
 } from '../../../graphql-operations'
 import {
-    fetchCampaignByNamespace,
+    fetchBatchChangeByNamespace,
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
@@ -30,8 +30,8 @@ const { add } = storiesOf('web/campaigns/details/CampaignDetailsPage', module)
 
 const now = new Date()
 
-const campaignDefaults: CampaignFields = {
-    __typename: 'Campaign',
+const batchChangeDefaults: BatchChangeFields = {
+    __typename: 'BatchChange',
     changesetsStats: {
         closed: 1,
         deleted: 1,
@@ -285,11 +285,11 @@ for (const [name, { url, supersededCampaignSpec }] of Object.entries(stories)) {
         const supersedingCampaignSpec = boolean('supersedingCampaignSpec', !!supersededCampaignSpec)
         const viewerCanAdminister = boolean('viewerCanAdminister', true)
         const isClosed = boolean('isClosed', false)
-        const campaign: CampaignFields = useMemo(
+        const batchChange: BatchChangeFields = useMemo(
             () => ({
-                ...campaignDefaults,
+                ...batchChangeDefaults,
                 currentSpec: {
-                    originalInput: campaignDefaults.currentSpec.originalInput,
+                    originalInput: batchChangeDefaults.currentSpec.originalInput,
                     supersedingCampaignSpec: supersedingCampaignSpec
                         ? {
                               createdAt: subDays(new Date(), 1).toISOString(),
@@ -303,15 +303,15 @@ for (const [name, { url, supersededCampaignSpec }] of Object.entries(stories)) {
             [supersedingCampaignSpec, viewerCanAdminister, isClosed]
         )
 
-        const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
+        const fetchBatchChange: typeof fetchBatchChangeByNamespace = useCallback(() => of(batchChange), [batchChange])
         return (
             <EnterpriseWebStory initialEntries={[url]}>
                 {props => (
                     <CampaignDetailsPage
                         {...props}
                         namespaceID="namespace123"
-                        campaignName="awesome-campaign"
-                        fetchCampaignByNamespace={fetchCampaign}
+                        batchChangeName="awesome-campaign"
+                        fetchBatchChangeByNamespace={fetchBatchChange}
                         queryChangesets={queryChangesets}
                         queryChangesetCountsOverTime={queryChangesetCountsOverTime}
                         queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
@@ -326,9 +326,9 @@ for (const [name, { url, supersededCampaignSpec }] of Object.entries(stories)) {
 }
 
 add('Empty changesets', () => {
-    const campaign: CampaignFields = useMemo(() => campaignDefaults, [])
+    const batchChange: BatchChangeFields = useMemo(() => batchChangeDefaults, [])
 
-    const fetchCampaign: typeof fetchCampaignByNamespace = useCallback(() => of(campaign), [campaign])
+    const fetchBatchChange: typeof fetchBatchChangeByNamespace = useCallback(() => of(batchChange), [batchChange])
 
     const queryEmptyChangesets = useCallback(
         () =>
@@ -348,8 +348,8 @@ add('Empty changesets', () => {
                 <CampaignDetailsPage
                     {...props}
                     namespaceID="namespace123"
-                    campaignName="awesome-campaign"
-                    fetchCampaignByNamespace={fetchCampaign}
+                    batchChangeName="awesome-campaign"
+                    fetchBatchChangeByNamespace={fetchBatchChange}
                     queryChangesets={queryEmptyChangesets}
                     queryChangesetCountsOverTime={queryChangesetCountsOverTime}
                     queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.story.tsx
@@ -64,7 +64,7 @@ const batchChangeDefaults: BatchChangeFields = {
     },
     currentSpec: {
         originalInput: 'name: awesome-campaign\ndescription: somestring',
-        supersedingCampaignSpec: null,
+        supersedingBatchSpec: null,
     },
     diffStat: { added: 1000, changed: 2000, deleted: 1000 },
 }
@@ -282,7 +282,7 @@ const stories: Record<string, { url: string; supersededCampaignSpec?: boolean }>
 
 for (const [name, { url, supersededCampaignSpec }] of Object.entries(stories)) {
     add(name, () => {
-        const supersedingCampaignSpec = boolean('supersedingCampaignSpec', !!supersededCampaignSpec)
+        const supersedingBatchSpec = boolean('supersedingBatchSpec', !!supersededCampaignSpec)
         const viewerCanAdminister = boolean('viewerCanAdminister', true)
         const isClosed = boolean('isClosed', false)
         const batchChange: BatchChangeFields = useMemo(
@@ -290,7 +290,7 @@ for (const [name, { url, supersededCampaignSpec }] of Object.entries(stories)) {
                 ...batchChangeDefaults,
                 currentSpec: {
                     originalInput: batchChangeDefaults.currentSpec.originalInput,
-                    supersedingCampaignSpec: supersedingCampaignSpec
+                    supersedingBatchSpec: supersedingBatchSpec
                         ? {
                               createdAt: subDays(new Date(), 1).toISOString(),
                               applyURL: '/users/alice/campaigns/apply/newspecid',
@@ -300,7 +300,7 @@ for (const [name, { url, supersededCampaignSpec }] of Object.entries(stories)) {
                 viewerCanAdminister,
                 closedAt: isClosed ? subDays(now, 1).toISOString() : null,
             }),
-            [supersedingCampaignSpec, viewerCanAdminister, isClosed]
+            [supersedingBatchSpec, viewerCanAdminister, isClosed]
         )
 
         const fetchBatchChange: typeof fetchBatchChangeByNamespace = useCallback(() => of(batchChange), [batchChange])

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -5,7 +5,7 @@ import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
 import { isEqual } from 'lodash'
 import {
-    fetchCampaignByNamespace as _fetchCampaignByNamespace,
+    fetchBatchChangeByNamespace as _fetchCampaignByNamespace,
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
@@ -18,7 +18,7 @@ import { ThemeProps } from '../../../../../shared/src/theme'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
-import { CampaignFields, Scalars } from '../../../graphql-operations'
+import { BatchChangeFields, Scalars } from '../../../graphql-operations'
 import { Description } from '../Description'
 import { CampaignStatsCard } from './CampaignStatsCard'
 import { CampaignTabs } from './CampaignTabs'
@@ -40,14 +40,14 @@ export interface CampaignDetailsPageProps
      */
     namespaceID: Scalars['ID']
     /**
-     * The campaign name.
+     * The batch change name.
      */
-    campaignName: CampaignFields['name']
+    batchChangeName: BatchChangeFields['name']
     history: H.History
     location: H.Location
 
     /** For testing only. */
-    fetchCampaignByNamespace?: typeof _fetchCampaignByNamespace
+    fetchBatchChangeByNamespace?: typeof _fetchCampaignByNamespace
     /** For testing only. */
     queryChangesets?: typeof _queryChangesets
     /** For testing only. */
@@ -63,14 +63,14 @@ export interface CampaignDetailsPageProps
  */
 export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPageProps> = ({
     namespaceID,
-    campaignName,
+    batchChangeName,
     history,
     location,
     isLightTheme,
     extensionsController,
     platformContext,
     telemetryService,
-    fetchCampaignByNamespace = _fetchCampaignByNamespace,
+    fetchBatchChangeByNamespace: fetchBatchChangeByNamespace = _fetchCampaignByNamespace,
     queryChangesets,
     queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime,
@@ -80,19 +80,19 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
         telemetryService.logViewEvent('CampaignDetailsPagePage')
     }, [telemetryService])
 
-    const campaign: CampaignFields | null | undefined = useObservable(
+    const batchChange: BatchChangeFields | null | undefined = useObservable(
         useMemo(
             () =>
-                fetchCampaignByNamespace(namespaceID, campaignName).pipe(
+                fetchBatchChangeByNamespace(namespaceID, batchChangeName).pipe(
                     repeatWhen(notifier => notifier.pipe(delay(5000))),
                     distinctUntilChanged((a, b) => isEqual(a, b))
                 ),
-            [namespaceID, campaignName, fetchCampaignByNamespace]
+            [namespaceID, batchChangeName, fetchBatchChangeByNamespace]
         )
     )
 
     // Is loading.
-    if (campaign === undefined) {
+    if (batchChange === undefined) {
         return (
             <div className="text-center">
                 <LoadingSpinner className="icon-inline mx-auto my-4" />
@@ -100,57 +100,57 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
         )
     }
     // Campaign was not found
-    if (campaign === null) {
+    if (batchChange === null) {
         return <HeroPage icon={AlertCircleIcon} title="Campaign not found" />
     }
 
     return (
         <>
-            <PageTitle title={campaign.name} />
+            <PageTitle title={batchChange.name} />
             <PageHeader
                 path={[
                     {
                         icon: CampaignsIcon,
                         to: '/campaigns',
                     },
-                    { to: `${campaign.namespace.url}/campaigns`, text: campaign.namespace.namespaceName },
-                    { text: campaign.name },
+                    { to: `${batchChange.namespace.url}/campaigns`, text: batchChange.namespace.namespaceName },
+                    { text: batchChange.name },
                 ]}
                 byline={
                     <CampaignInfoByline
-                        createdAt={campaign.createdAt}
-                        initialApplier={campaign.initialApplier}
-                        lastAppliedAt={campaign.lastAppliedAt}
-                        lastApplier={campaign.lastApplier}
+                        createdAt={batchChange.createdAt}
+                        initialApplier={batchChange.initialApplier}
+                        lastAppliedAt={batchChange.lastAppliedAt}
+                        lastApplier={batchChange.lastApplier}
                     />
                 }
                 actions={
                     <CampaignDetailsActionSection
-                        campaignID={campaign.id}
-                        campaignClosed={!!campaign.closedAt}
+                        campaignID={batchChange.id}
+                        campaignClosed={!!batchChange.closedAt}
                         deleteCampaign={deleteCampaign}
-                        campaignNamespaceURL={campaign.namespace.url}
+                        campaignNamespaceURL={batchChange.namespace.url}
                         history={history}
                     />
                 }
                 className="test-campaign-details-page mb-3"
             />
-            <SupersedingCampaignSpecAlert spec={campaign.currentSpec.supersedingCampaignSpec} />
-            <ClosedNotice closedAt={campaign.closedAt} className="mb-3" />
+            <SupersedingCampaignSpecAlert spec={batchChange.currentSpec.supersedingCampaignSpec} />
+            <ClosedNotice closedAt={batchChange.closedAt} className="mb-3" />
             <UnpublishedNotice
-                unpublished={campaign.changesetsStats.unpublished}
-                total={campaign.changesetsStats.total}
+                unpublished={batchChange.changesetsStats.unpublished}
+                total={batchChange.changesetsStats.total}
                 className="mb-3"
             />
             <CampaignStatsCard
-                closedAt={campaign.closedAt}
-                stats={campaign.changesetsStats}
-                diff={campaign.diffStat}
+                closedAt={batchChange.closedAt}
+                stats={batchChange.changesetsStats}
+                diff={batchChange.diffStat}
                 className="mb-3"
             />
-            <Description history={history} description={campaign.description} />
+            <Description history={history} description={batchChange.description} />
             <CampaignTabs
-                campaign={campaign}
+                batchChange={batchChange}
                 extensionsController={extensionsController}
                 history={history}
                 isLightTheme={isLightTheme}

--- a/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignDetailsPage.tsx
@@ -135,7 +135,7 @@ export const CampaignDetailsPage: React.FunctionComponent<CampaignDetailsPagePro
                 }
                 className="test-campaign-details-page mb-3"
             />
-            <SupersedingCampaignSpecAlert spec={batchChange.currentSpec.supersedingCampaignSpec} />
+            <SupersedingCampaignSpecAlert spec={batchChange.currentSpec.supersedingBatchSpec} />
             <ClosedNotice closedAt={batchChange.closedAt} className="mb-3" />
             <UnpublishedNotice
                 unpublished={batchChange.changesetsStats.unpublished}

--- a/client/web/src/enterprise/campaigns/detail/CampaignInfoByline.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignInfoByline.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { CampaignFields } from '../../../graphql-operations'
+import { BatchChangeFields } from '../../../graphql-operations'
 import { Link } from '../../../../../shared/src/components/Link'
 import { Timestamp } from '../../../components/time/Timestamp'
 
-interface Props extends Pick<CampaignFields, 'createdAt' | 'initialApplier' | 'lastAppliedAt' | 'lastApplier'> {}
+interface Props extends Pick<BatchChangeFields, 'createdAt' | 'initialApplier' | 'lastAppliedAt' | 'lastApplier'> {}
 
 /**
  * The created/updated byline in the campaign header.

--- a/client/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignSpecTab.tsx
@@ -3,11 +3,11 @@ import React, { useMemo } from 'react'
 import { Link } from '../../../../../shared/src/components/Link'
 import { CodeSnippet } from '../../../../../branded/src/components/CodeSnippet'
 import { Timestamp } from '../../../components/time/Timestamp'
-import { CampaignFields } from '../../../graphql-operations'
+import { BatchChangeFields } from '../../../graphql-operations'
 
 export interface CampaignSpecTabProps {
-    campaign: Pick<CampaignFields, 'name' | 'createdAt' | 'lastApplier' | 'lastAppliedAt'>
-    originalInput: CampaignFields['currentSpec']['originalInput']
+    campaign: Pick<BatchChangeFields, 'name' | 'createdAt' | 'lastApplier' | 'lastAppliedAt'>
+    originalInput: BatchChangeFields['currentSpec']['originalInput']
 }
 
 /** Reports whether str is a valid JSON document. */

--- a/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignStatsCard.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ProgressCheckIcon from 'mdi-react/ProgressCheckIcon'
 import CheckCircleOutlineIcon from 'mdi-react/CheckCircleOutlineIcon'
 import classNames from 'classnames'
-import { CampaignFields, ChangesetsStatsFields, DiffStatFields } from '../../../graphql-operations'
+import { BatchChangeFields, ChangesetsStatsFields, DiffStatFields } from '../../../graphql-operations'
 import { CampaignStateBadge } from './CampaignStateBadge'
 import {
     ChangesetStatusUnpublished,
@@ -17,7 +17,7 @@ import { DiffStat } from '../../../components/diff/DiffStat'
 interface CampaignStatsCardProps {
     stats: ChangesetsStatsFields
     diff: DiffStatFields
-    closedAt: CampaignFields['closedAt']
+    closedAt: BatchChangeFields['closedAt']
     className?: string
 }
 

--- a/client/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
+++ b/client/web/src/enterprise/campaigns/detail/CampaignTabs.tsx
@@ -4,7 +4,7 @@ import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/
 import { ThemeProps } from '../../../../../shared/src/theme'
 import { PlatformContextProps } from '../../../../../shared/src/platform/context'
 import { TelemetryProps } from '../../../../../shared/src/telemetry/telemetryService'
-import { CampaignFields } from '../../../graphql-operations'
+import { BatchChangeFields } from '../../../graphql-operations'
 import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs as _queryExternalChangesetWithFileDiffs,
@@ -21,7 +21,7 @@ import { CampaignSpecTab } from './CampaignSpecTab'
 type SelectedTab = 'changesets' | 'chart' | 'spec'
 
 export interface CampaignTabsProps extends ExtensionsControllerProps, ThemeProps, PlatformContextProps, TelemetryProps {
-    campaign: CampaignFields
+    batchChange: BatchChangeFields
     history: H.History
     location: H.Location
     /** For testing only. */
@@ -39,7 +39,7 @@ export const CampaignTabs: React.FunctionComponent<CampaignTabsProps> = ({
     location,
     platformContext,
     telemetryService,
-    campaign,
+    batchChange: campaign,
     queryChangesets,
     queryChangesetCountsOverTime,
     queryExternalChangesetWithFileDiffs,

--- a/client/web/src/enterprise/campaigns/detail/ClosedNotice.tsx
+++ b/client/web/src/enterprise/campaigns/detail/ClosedNotice.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import classNames from 'classnames'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
-import { CampaignFields } from '../../../graphql-operations'
+import { BatchChangeFields } from '../../../graphql-operations'
 
 interface ClosedNoticeProps {
-    closedAt: CampaignFields['closedAt']
+    closedAt: BatchChangeFields['closedAt']
     className?: string
 }
 

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -3,9 +3,11 @@ import { dataOrThrowErrors, gql } from '../../../../../shared/src/graphql/graphq
 import { Observable } from 'rxjs'
 import { diffStatFields, fileDiffFields } from '../../../backend/diff'
 import {
-    CampaignFields,
-    CampaignChangesetsVariables,
-    CampaignChangesetsResult,
+    BatchChangeChangesetsVariables,
+    BatchChangeChangesetsResult,
+    BatchChangeFields,
+    BatchChangeByNamespaceResult,
+    BatchChangeByNamespaceVariables,
     ExternalChangesetFileDiffsResult,
     ExternalChangesetFileDiffsVariables,
     ExternalChangesetFileDiffsFields,
@@ -17,8 +19,6 @@ import {
     ChangesetCountsOverTimeResult,
     DeleteCampaignResult,
     DeleteCampaignVariables,
-    CampaignByNamespaceResult,
-    CampaignByNamespaceVariables,
     ChangesetDiffResult,
     ChangesetDiffVariables,
     ReenqueueChangesetVariables,
@@ -39,8 +39,8 @@ const changesetsStatsFragment = gql`
     }
 `
 
-const campaignFragment = gql`
-    fragment CampaignFields on Campaign {
+const batchChangeFragment = gql`
+    fragment BatchChangeFields on BatchChange {
         __typename
         id
         url
@@ -97,27 +97,27 @@ const changesetLabelFragment = gql`
     }
 `
 
-export const fetchCampaignByNamespace = (
+export const fetchBatchChangeByNamespace = (
     namespaceID: Scalars['ID'],
-    campaign: CampaignFields['name']
-): Observable<CampaignFields | null> =>
-    requestGraphQL<CampaignByNamespaceResult, CampaignByNamespaceVariables>(
+    batchChange: BatchChangeFields['name']
+): Observable<BatchChangeFields | null> =>
+    requestGraphQL<BatchChangeByNamespaceResult, BatchChangeByNamespaceVariables>(
         gql`
-            query CampaignByNamespace($namespaceID: ID!, $campaign: String!) {
-                campaign(namespace: $namespaceID, name: $campaign) {
-                    ...CampaignFields
+            query BatchChangeByNamespace($namespaceID: ID!, $batchChange: String!) {
+                batchChange(namespace: $namespaceID, name: $batchChange) {
+                    ...BatchChangeFields
                 }
             }
-            ${campaignFragment}
+            ${batchChangeFragment}
         `,
-        { namespaceID, campaign }
+        { namespaceID, batchChange }
     ).pipe(
         map(dataOrThrowErrors),
-        map(({ campaign }) => {
-            if (!campaign) {
+        map(({ batchChange }) => {
+            if (!batchChange) {
                 return null
             }
-            return campaign
+            return batchChange
         })
     )
 
@@ -194,39 +194,39 @@ export const changesetFieldsFragment = gql`
 `
 
 export const queryChangesets = ({
-    campaign,
+    batchChange,
     first,
     after,
     state,
     reviewState,
     checkState,
-    onlyPublishedByThisCampaign,
+    onlyPublishedByThisBatchChange,
     search,
-}: CampaignChangesetsVariables): Observable<
-    (CampaignChangesetsResult['node'] & { __typename: 'Campaign' })['changesets']
+}: BatchChangeChangesetsVariables): Observable<
+    (BatchChangeChangesetsResult['node'] & { __typename: 'BatchChange' })['changesets']
 > =>
-    requestGraphQL<CampaignChangesetsResult, CampaignChangesetsVariables>(
+    requestGraphQL<BatchChangeChangesetsResult, BatchChangeChangesetsVariables>(
         gql`
-            query CampaignChangesets(
-                $campaign: ID!
+            query BatchChangeChangesets(
+                $batchChange: ID!
                 $first: Int
                 $after: String
                 $state: ChangesetState
                 $reviewState: ChangesetReviewState
                 $checkState: ChangesetCheckState
-                $onlyPublishedByThisCampaign: Boolean
+                $onlyPublishedByThisBatchChange: Boolean
                 $search: String
             ) {
-                node(id: $campaign) {
+                node(id: $batchChange) {
                     __typename
-                    ... on Campaign {
+                    ... on BatchChange {
                         changesets(
                             first: $first
                             after: $after
                             state: $state
                             reviewState: $reviewState
                             checkState: $checkState
-                            onlyPublishedByThisCampaign: $onlyPublishedByThisCampaign
+                            onlyPublishedByThisBatchChange: $onlyPublishedByThisBatchChange
                             search: $search
                         ) {
                             totalCount
@@ -245,23 +245,23 @@ export const queryChangesets = ({
             ${changesetFieldsFragment}
         `,
         {
-            campaign,
+            batchChange,
             first,
             after,
             state,
             reviewState,
             checkState,
-            onlyPublishedByThisCampaign,
+            onlyPublishedByThisBatchChange,
             search,
         }
     ).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {
             if (!node) {
-                throw new Error(`Campaign with ID ${campaign} does not exist`)
+                throw new Error(`Batch change with ID ${batchChange} does not exist`)
             }
-            if (node.__typename !== 'Campaign') {
-                throw new Error(`The given ID is a ${node.__typename}, not a Campaign`)
+            if (node.__typename !== 'BatchChange') {
+                throw new Error(`The given ID is a ${node.__typename}, not a BatchChange`)
             }
             return node.changesets
         })

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -416,14 +416,14 @@ const changesetCountsOverTimeFragment = gql`
 `
 
 export const queryChangesetCountsOverTime = ({
-    campaign,
+    batchChange,
 }: ChangesetCountsOverTimeVariables): Observable<ChangesetCountsOverTimeFields[]> =>
     requestGraphQL<ChangesetCountsOverTimeResult, ChangesetCountsOverTimeVariables>(
         gql`
-            query ChangesetCountsOverTime($campaign: ID!) {
-                node(id: $campaign) {
+            query ChangesetCountsOverTime($batchChange: ID!) {
+                node(id: $batchChange) {
                     __typename
-                    ... on Campaign {
+                    ... on BatchChange {
                         changesetCountsOverTime {
                             ...ChangesetCountsOverTimeFields
                         }
@@ -433,15 +433,15 @@ export const queryChangesetCountsOverTime = ({
 
             ${changesetCountsOverTimeFragment}
         `,
-        { campaign }
+        { batchChange }
     ).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {
             if (!node) {
-                throw new Error(`Campaign with ID ${campaign} does not exist`)
+                throw new Error(`BatchChange with ID ${batchChange} does not exist`)
             }
-            if (node.__typename !== 'Campaign') {
-                throw new Error(`The given ID is a ${node.__typename}, not a Campaign`)
+            if (node.__typename !== 'BatchChange') {
+                throw new Error(`The given ID is a ${node.__typename}, not a BatchChange`)
             }
             return node.changesetCountsOverTime
         })

--- a/client/web/src/enterprise/campaigns/detail/backend.ts
+++ b/client/web/src/enterprise/campaigns/detail/backend.ts
@@ -77,7 +77,7 @@ const batchChangeFragment = gql`
 
         currentSpec {
             originalInput
-            supersedingCampaignSpec {
+            supersedingBatchSpec {
                 createdAt
                 applyURL
             }

--- a/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/CampaignChangesets.tsx
@@ -75,8 +75,8 @@ export const CampaignChangesets: React.FunctionComponent<Props> = ({
                 checkState: changesetFilters.checkState,
                 first: args.first ?? null,
                 after: args.after ?? null,
-                campaign: campaignID,
-                onlyPublishedByThisCampaign: null,
+                batchChange: campaignID,
+                onlyPublishedByThisBatchChange: null,
                 search: changesetFilters.search,
             }).pipe(repeatWhen(notifier => notifier.pipe(delay(5000)))),
         [

--- a/client/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
+++ b/client/web/src/enterprise/campaigns/global/GlobalCampaignsArea.tsx
@@ -106,24 +106,24 @@ export const NamespaceCampaignsArea = withAuthenticatedUser<
             />
             <Route path={`${match.url}/create`} render={props => <CreateCampaignPage {...outerProps} {...props} />} />
             <Route
-                path={`${match.url}/:campaignName/close`}
-                render={({ match, ...props }: RouteComponentProps<{ campaignName: string }>) => (
+                path={`${match.url}/:batchChangeName/close`}
+                render={({ match, ...props }: RouteComponentProps<{ batchChangeName: string }>) => (
                     <CampaignClosePage
                         {...outerProps}
                         {...props}
                         namespaceID={namespaceID}
-                        campaignName={match.params.campaignName}
+                        batchChangeName={match.params.batchChangeName}
                     />
                 )}
             />
             <Route
-                path={`${match.url}/:campaignName`}
-                render={({ match, ...props }: RouteComponentProps<{ campaignName: string }>) => (
+                path={`${match.url}/:batchChangeName`}
+                render={({ match, ...props }: RouteComponentProps<{ batchChangeName: string }>) => (
                     <CampaignDetailsPage
                         {...outerProps}
                         {...props}
                         namespaceID={namespaceID}
-                        campaignName={match.params.campaignName}
+                        batchChangeName={match.params.batchChangeName}
                     />
                 )}
             />

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -11,14 +11,14 @@ import {
     ChangesetCountsOverTimeResult,
     ExternalChangesetFileDiffsVariables,
     ExternalChangesetFileDiffsResult,
-    CampaignChangesetsVariables,
-    CampaignChangesetsResult,
     WebGraphQlOperations,
     ExternalChangesetFileDiffsFields,
     DiffHunkLineType,
     ChangesetSpecType,
     ListCampaign,
-    CampaignByNamespaceResult,
+    BatchChangeByNamespaceResult,
+    BatchChangeChangesetsVariables,
+    BatchChangeChangesetsResult,
 } from '../graphql-operations'
 import {
     ChangesetSpecOperation,
@@ -156,9 +156,9 @@ const ExternalChangesetFileDiffs: (
     },
 })
 
-const CampaignChangesets: (variables: CampaignChangesetsVariables) => CampaignChangesetsResult = () => ({
+const BatchChangeChangesets: (variables: BatchChangeChangesetsVariables) => BatchChangeChangesetsResult = () => ({
     node: {
-        __typename: 'Campaign',
+        __typename: 'BatchChange',
         changesets: {
             totalCount: 1,
             pageInfo: {
@@ -216,7 +216,7 @@ const CampaignChangesets: (variables: CampaignChangesetsVariables) => CampaignCh
 
 function mockCommonGraphQLResponses(
     entityType: 'user' | 'org',
-    campaignOverrides?: Partial<NonNullable<CampaignByNamespaceResult['campaign']>>
+    campaignOverrides?: Partial<NonNullable<BatchChangeByNamespaceResult['batchChange']>>
 ): Partial<WebGraphQlOperations & SharedGraphQlOperations> {
     const namespaceURL = entityType === 'user' ? '/users/alice' : '/organizations/test-org'
     return {
@@ -254,15 +254,15 @@ function mockCommonGraphQLResponses(
                 tags: [],
             },
         }),
-        CampaignByNamespace: () => ({
-            campaign: {
-                __typename: 'Campaign',
+        BatchChangeByNamespace: () => ({
+            batchChange: {
+                __typename: 'BatchChange',
                 id: 'campaign123',
                 changesetsStats: { closed: 2, deleted: 1, merged: 3, open: 8, total: 19, unpublished: 3, draft: 2 },
                 closedAt: null,
                 createdAt: subDays(new Date(), 5).toISOString(),
                 updatedAt: subDays(new Date(), 5).toISOString(),
-                description: '### Very cool campaign',
+                description: '### Very cool batch change',
                 initialApplier: {
                     url: '/users/alice',
                     username: 'alice',
@@ -440,7 +440,7 @@ describe('Campaigns', () => {
                     ...commonWebGraphQlResults,
                     ...campaignLicenseGraphQlResults,
                     ...mockCommonGraphQLResponses(entityType),
-                    CampaignChangesets,
+                    BatchChangeChangesets,
                     ChangesetCountsOverTime,
                     ExternalChangesetFileDiffs,
                 })
@@ -475,7 +475,7 @@ describe('Campaigns', () => {
                     ...commonWebGraphQlResults,
                     ...campaignLicenseGraphQlResults,
                     ...mockCommonGraphQLResponses(entityType, { closedAt: subDays(new Date(), 1).toISOString() }),
-                    CampaignChangesets,
+                    BatchChangeChangesets,
                     ChangesetCountsOverTime,
                     ExternalChangesetFileDiffs,
                     DeleteCampaign: () => ({
@@ -695,7 +695,7 @@ describe('Campaigns', () => {
                 testContext.overrideGraphQL({
                     ...commonWebGraphQlResults,
                     ...mockCommonGraphQLResponses(entityType),
-                    CampaignChangesets,
+                    BatchChangeChangesets,
                     ExternalChangesetFileDiffs,
                     CloseCampaign: () => ({
                         closeCampaign: {

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -121,7 +121,7 @@ const mockDiff: NonNullable<ExternalChangesetFileDiffsFields['diff']> = {
 
 const ChangesetCountsOverTime: (variables: ChangesetCountsOverTimeVariables) => ChangesetCountsOverTimeResult = () => ({
     node: {
-        __typename: 'Campaign',
+        __typename: 'BatchChange',
         changesetCountsOverTime: [
             {
                 closed: 12,

--- a/client/web/src/integration/campaigns.test.ts
+++ b/client/web/src/integration/campaigns.test.ts
@@ -282,7 +282,7 @@ function mockCommonGraphQLResponses(
                 },
                 currentSpec: {
                     originalInput: 'name: awesome-campaign\ndescription: somesttring',
-                    supersedingCampaignSpec: null,
+                    supersedingBatchSpec: null,
                 },
                 ...campaignOverrides,
             },

--- a/client/web/src/search/panels/utils.ts
+++ b/client/web/src/search/panels/utils.ts
@@ -61,6 +61,12 @@ export const org: IOrg = {
         totalCount: 0,
         pageInfo: { __typename: 'PageInfo', endCursor: null, hasNextPage: false },
     },
+    batchChanges: {
+        __typename: 'BatchChangeConnection',
+        nodes: [],
+        totalCount: 0,
+        pageInfo: { __typename: 'PageInfo', endCursor: null, hasNextPage: false },
+    },
 }
 
 export const _fetchSavedSearches = (): Observable<ISavedSearch[]> =>

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -133,13 +133,13 @@ type CampaignsResolver interface {
 
 	// Queries
 
-	// Old:
-	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
+	// Deprecated
 	Campaign(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
 	// New:
 	BatchChange(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
 	BatchChangeByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error)
 
+	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
 
 	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
@@ -393,6 +393,11 @@ type BatchChangeResolver interface {
 	ClosedAt() *DateTime
 	DiffStat(ctx context.Context) (*DiffStat, error)
 	CurrentSpec(ctx context.Context) (CampaignSpecResolver, error)
+
+	// TODO: This should be removed once we remove campaigns.
+	// It's here so that in the NodeResolver we can have the same resolver,
+	// BatchChangeResolver, act as a Campaign and a BatchChange.
+	ActAsCampaign() bool
 }
 
 type CampaignsConnectionResolver interface {

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 )
 
+// DEPRECATED
 type CreateCampaignArgs struct {
 	CampaignSpec graphql.ID
 }
@@ -30,7 +31,7 @@ type MoveCampaignArgs struct {
 	NewNamespace *graphql.ID
 }
 
-type ListCampaignsArgs struct {
+type ListBatchChangesArgs struct {
 	First               int32
 	After               *string
 	State               *string
@@ -139,15 +140,16 @@ type CampaignsResolver interface {
 
 	// Deprecated:
 	Campaign(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
+	Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
 	// TODO: To-be-deprecated (these need to be marked as deprecated and use
 	// the code for the new implementations) and then moved up to "Deprecated:"
-	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
 	CampaignsCredentialByID(ctx context.Context, id graphql.ID) (CampaignsCredentialResolver, error)
 	CampaignsCodeHosts(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
 	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
 	// New:
 	BatchChange(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
 	BatchChangeByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error)
+	BatchChanges(cx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
 
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
 	ChangesetSpecByID(ctx context.Context, id graphql.ID) (ChangesetSpecResolver, error)
@@ -404,7 +406,7 @@ type BatchChangeResolver interface {
 	ActAsCampaign() bool
 }
 
-type CampaignsConnectionResolver interface {
+type BatchChangesConnectionResolver interface {
 	Nodes(ctx context.Context) ([]BatchChangeResolver, error)
 	TotalCount(ctx context.Context) (int32, error)
 	PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error)
@@ -447,7 +449,7 @@ type ChangesetResolver interface {
 	ReconcilerState() campaigns.ReconcilerState
 	ExternalState() *campaigns.ChangesetExternalState
 	State() (campaigns.ChangesetState, error)
-	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
+	Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
 
 	ToExternalChangeset() (ExternalChangesetResolver, bool)
 	ToHiddenExternalChangeset() (HiddenExternalChangesetResolver, bool)
@@ -519,6 +521,7 @@ type defaultCampaignsResolver struct{}
 var DefaultCampaignsResolver CampaignsResolver = defaultCampaignsResolver{}
 
 // Mutations
+// DEPRECATED
 func (defaultCampaignsResolver) CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
@@ -568,11 +571,17 @@ func (defaultCampaignsResolver) DeleteCampaignsCredential(ctx context.Context, a
 }
 
 // Queries
-func (defaultCampaignsResolver) BatchChangeByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error) {
+// DEPRECATED
+func (defaultCampaignsResolver) Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
+// DEPRECATED
 func (defaultCampaignsResolver) Campaign(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+func (defaultCampaignsResolver) BatchChangeByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
@@ -580,7 +589,7 @@ func (defaultCampaignsResolver) BatchChange(ctx context.Context, args *BatchChan
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error) {
+func (defaultCampaignsResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -551,7 +551,9 @@ type ChangesetResolver interface {
 	ReconcilerState() campaigns.ReconcilerState
 	ExternalState() *campaigns.ChangesetExternalState
 	State() (campaigns.ChangesetState, error)
+	// TODO(campaigns-deprecation):
 	Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
+	BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
 
 	ToExternalChangeset() (ExternalChangesetResolver, bool)
 	ToHiddenExternalChangeset() (HiddenExternalChangesetResolver, bool)

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -36,6 +36,13 @@ type CloseCampaignArgs struct {
 	CloseChangesets bool
 }
 
+// TODO(campaigns-deprecation)
+type MoveCampaignArgs struct {
+	Campaign     graphql.ID
+	NewName      *string
+	NewNamespace *graphql.ID
+}
+
 type CreateBatchChangeArgs struct {
 	BatchSpec graphql.ID
 }
@@ -43,12 +50,6 @@ type CreateBatchChangeArgs struct {
 type ApplyBatchChangeArgs struct {
 	BatchSpec         graphql.ID
 	EnsureBatchChange *graphql.ID
-}
-
-type MoveCampaignArgs struct {
-	Campaign     graphql.ID
-	NewName      *string
-	NewNamespace *graphql.ID
 }
 
 type ListBatchChangesArgs struct {
@@ -63,6 +64,12 @@ type ListBatchChangesArgs struct {
 type CloseBatchChangeArgs struct {
 	BatchChange     graphql.ID
 	CloseChangesets bool
+}
+
+type MoveBatchChangeArgs struct {
+	BatchChange  graphql.ID
+	NewName      *string
+	NewNamespace *graphql.ID
 }
 
 type DeleteCampaignArgs struct {
@@ -143,9 +150,9 @@ type CampaignsResolver interface {
 	CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (BatchSpecResolver, error)
 	ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error)
 	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error)
+	MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error)
 	// TODO: To-be-deprecated (these need to be marked as deprecated and use
 	// the code for the new implementations) and then moved up to "Deprecated:"
-	MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error)
 	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
 	CreateCampaignsCredential(ctx context.Context, args *CreateCampaignsCredentialArgs) (CampaignsCredentialResolver, error)
 	DeleteCampaignsCredential(ctx context.Context, args *DeleteCampaignsCredentialArgs) (*EmptyResponse, error)
@@ -154,6 +161,7 @@ type CampaignsResolver interface {
 	CreateBatchSpec(ctx context.Context, args *CreateBatchSpecArgs) (BatchSpecResolver, error)
 	ApplyBatchChange(ctx context.Context, args *ApplyBatchChangeArgs) (BatchChangeResolver, error)
 	CloseBatchChange(ctx context.Context, args *CloseBatchChangeArgs) (BatchChangeResolver, error)
+	MoveBatchChange(ctx context.Context, args *MoveBatchChangeArgs) (BatchChangeResolver, error)
 
 	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
@@ -579,6 +587,11 @@ func (defaultCampaignsResolver) CloseCampaign(ctx context.Context, args *CloseCa
 	return nil, campaignsOnlyInEnterprise
 }
 
+// TODO(campaigns-deprecation):
+func (defaultCampaignsResolver) MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
 func (defaultCampaignsResolver) CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
@@ -594,11 +607,12 @@ func (defaultCampaignsResolver) ApplyBatchChange(ctx context.Context, args *Appl
 func (defaultCampaignsResolver) CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
-func (defaultCampaignsResolver) MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error) {
+
+func (defaultCampaignsResolver) CloseBatchChange(ctx context.Context, args *CloseBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) CloseBatchChange(ctx context.Context, args *CloseBatchChangeArgs) (BatchChangeResolver, error) {
+func (defaultCampaignsResolver) MoveBatchChange(ctx context.Context, args *MoveBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -30,6 +30,12 @@ type ApplyCampaignArgs struct {
 	EnsureCampaign *graphql.ID
 }
 
+// TODO(campaigns-deprecation)
+type CloseCampaignArgs struct {
+	Campaign        graphql.ID
+	CloseChangesets bool
+}
+
 type CreateBatchChangeArgs struct {
 	BatchSpec graphql.ID
 }
@@ -54,8 +60,8 @@ type ListBatchChangesArgs struct {
 	Namespace *graphql.ID
 }
 
-type CloseCampaignArgs struct {
-	Campaign        graphql.ID
+type CloseBatchChangeArgs struct {
+	BatchChange     graphql.ID
 	CloseChangesets bool
 }
 
@@ -136,10 +142,10 @@ type CampaignsResolver interface {
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (BatchChangeResolver, error)
 	CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (BatchSpecResolver, error)
 	ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error)
+	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error)
 	// TODO: To-be-deprecated (these need to be marked as deprecated and use
 	// the code for the new implementations) and then moved up to "Deprecated:"
 	MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error)
-	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error)
 	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
 	CreateCampaignsCredential(ctx context.Context, args *CreateCampaignsCredentialArgs) (CampaignsCredentialResolver, error)
 	DeleteCampaignsCredential(ctx context.Context, args *DeleteCampaignsCredentialArgs) (*EmptyResponse, error)
@@ -147,10 +153,15 @@ type CampaignsResolver interface {
 	CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error)
 	CreateBatchSpec(ctx context.Context, args *CreateBatchSpecArgs) (BatchSpecResolver, error)
 	ApplyBatchChange(ctx context.Context, args *ApplyBatchChangeArgs) (BatchChangeResolver, error)
+	CloseBatchChange(ctx context.Context, args *CloseBatchChangeArgs) (BatchChangeResolver, error)
 
 	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
 	ReenqueueChangeset(ctx context.Context, args *ReenqueueChangesetArgs) (ChangesetResolver, error)
+
+	// TODO: To-be-deprecated
+	// User.campaigns
+	// Org.campaigns
 
 	// Queries
 
@@ -563,6 +574,10 @@ func (defaultCampaignsResolver) ApplyCampaign(ctx context.Context, args *ApplyCa
 	return nil, campaignsOnlyInEnterprise
 }
 
+// TODO(campaigns-deprecation):
+func (defaultCampaignsResolver) CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
 
 func (defaultCampaignsResolver) CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
@@ -583,7 +598,7 @@ func (defaultCampaignsResolver) MoveCampaign(ctx context.Context, args *MoveCamp
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error) {
+func (defaultCampaignsResolver) CloseBatchChange(ctx context.Context, args *CloseBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -200,10 +200,6 @@ type CampaignsResolver interface {
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
 	ReenqueueChangeset(ctx context.Context, args *ReenqueueChangesetArgs) (ChangesetResolver, error)
 
-	// TODO: To-be-deprecated
-	// User.campaigns
-	// Org.campaigns
-
 	// Queries
 
 	// TODO(campaigns-deprecation)

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -132,9 +132,14 @@ type CampaignsResolver interface {
 	DeleteCampaignsCredential(ctx context.Context, args *DeleteCampaignsCredentialArgs) (*EmptyResponse, error)
 
 	// Queries
+
+	// Old:
 	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
 	Campaign(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
+	// New:
+	BatchChange(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
 	BatchChangeByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error)
+
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
 
 	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
@@ -554,10 +559,6 @@ func (defaultCampaignsResolver) DeleteCampaignsCredential(ctx context.Context, a
 }
 
 // Queries
-func (defaultCampaignsResolver) CampaignByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error) {
-	return nil, campaignsOnlyInEnterprise
-}
-
 func (defaultCampaignsResolver) BatchChangeByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -114,39 +114,43 @@ type ListViewerCampaignsCodeHostsArgs struct {
 }
 
 type CampaignsResolver interface {
-	// Mutations
-	// OLD
+	//
+	// MUTATIONS
+	//
+	// Deprecated:
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (BatchChangeResolver, error)
-	// NEW
-	CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error)
-
+	// TODO: To-be-deprecated (these need to be marked as deprecated and use
+	// the code for the new implementations) and then moved up to "Deprecated:"
 	ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error)
 	MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error)
 	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error)
 	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
-	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (CampaignSpecResolver, error)
-	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
-	ReenqueueChangeset(ctx context.Context, args *ReenqueueChangesetArgs) (ChangesetResolver, error)
 	CreateCampaignsCredential(ctx context.Context, args *CreateCampaignsCredentialArgs) (CampaignsCredentialResolver, error)
 	DeleteCampaignsCredential(ctx context.Context, args *DeleteCampaignsCredentialArgs) (*EmptyResponse, error)
+	// New:
+	CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error)
+
+	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
+	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
+	ReenqueueChangeset(ctx context.Context, args *ReenqueueChangesetArgs) (ChangesetResolver, error)
 
 	// Queries
 
-	// Deprecated
+	// Deprecated:
 	Campaign(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
+	// TODO: To-be-deprecated (these need to be marked as deprecated and use
+	// the code for the new implementations) and then moved up to "Deprecated:"
+	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
+	CampaignsCredentialByID(ctx context.Context, id graphql.ID) (CampaignsCredentialResolver, error)
+	CampaignsCodeHosts(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
+	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
 	// New:
 	BatchChange(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
 	BatchChangeByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error)
 
-	Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error)
 	ChangesetByID(ctx context.Context, id graphql.ID) (ChangesetResolver, error)
-
-	CampaignSpecByID(ctx context.Context, id graphql.ID) (CampaignSpecResolver, error)
 	ChangesetSpecByID(ctx context.Context, id graphql.ID) (ChangesetSpecResolver, error)
-
-	CampaignsCredentialByID(ctx context.Context, id graphql.ID) (CampaignsCredentialResolver, error)
-	CampaignsCodeHosts(ctx context.Context, args *ListCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
 }
 
 type CampaignSpecResolver interface {
@@ -394,7 +398,7 @@ type BatchChangeResolver interface {
 	DiffStat(ctx context.Context) (*DiffStat, error)
 	CurrentSpec(ctx context.Context) (CampaignSpecResolver, error)
 
-	// TODO: This should be removed once we remove campaigns.
+	// NOTE: This should be removed once we remove campaigns.
 	// It's here so that in the NodeResolver we can have the same resolver,
 	// BatchChangeResolver, act as a Campaign and a BatchChange.
 	ActAsCampaign() bool

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -43,6 +43,11 @@ type MoveCampaignArgs struct {
 	NewNamespace *graphql.ID
 }
 
+// TODO(campaigns-deprecation)
+type DeleteCampaignArgs struct {
+	Campaign graphql.ID
+}
+
 type CreateBatchChangeArgs struct {
 	BatchSpec graphql.ID
 }
@@ -72,8 +77,8 @@ type MoveBatchChangeArgs struct {
 	NewNamespace *graphql.ID
 }
 
-type DeleteCampaignArgs struct {
-	Campaign graphql.ID
+type DeleteBatchChangeArgs struct {
+	BatchChange graphql.ID
 }
 
 type SyncChangesetArgs struct {
@@ -151,9 +156,9 @@ type CampaignsResolver interface {
 	ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error)
 	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error)
 	MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error)
+	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
 	// TODO: To-be-deprecated (these need to be marked as deprecated and use
 	// the code for the new implementations) and then moved up to "Deprecated:"
-	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
 	CreateCampaignsCredential(ctx context.Context, args *CreateCampaignsCredentialArgs) (CampaignsCredentialResolver, error)
 	DeleteCampaignsCredential(ctx context.Context, args *DeleteCampaignsCredentialArgs) (*EmptyResponse, error)
 	// New:
@@ -162,6 +167,7 @@ type CampaignsResolver interface {
 	ApplyBatchChange(ctx context.Context, args *ApplyBatchChangeArgs) (BatchChangeResolver, error)
 	CloseBatchChange(ctx context.Context, args *CloseBatchChangeArgs) (BatchChangeResolver, error)
 	MoveBatchChange(ctx context.Context, args *MoveBatchChangeArgs) (BatchChangeResolver, error)
+	DeleteBatchChange(ctx context.Context, args *DeleteBatchChangeArgs) (*EmptyResponse, error)
 
 	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
@@ -592,6 +598,11 @@ func (defaultCampaignsResolver) MoveCampaign(ctx context.Context, args *MoveCamp
 	return nil, campaignsOnlyInEnterprise
 }
 
+// TODO(campaigns-deprecation):
+func (defaultCampaignsResolver) DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
 func (defaultCampaignsResolver) CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
@@ -616,15 +627,15 @@ func (defaultCampaignsResolver) MoveBatchChange(ctx context.Context, args *MoveB
 	return nil, campaignsOnlyInEnterprise
 }
 
+func (defaultCampaignsResolver) DeleteBatchChange(ctx context.Context, args *DeleteBatchChangeArgs) (*EmptyResponse, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
 func (defaultCampaignsResolver) SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
 func (defaultCampaignsResolver) ReenqueueChangeset(ctx context.Context, args *ReenqueueChangesetArgs) (ChangesetResolver, error) {
-	return nil, campaignsOnlyInEnterprise
-}
-
-func (defaultCampaignsResolver) DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -11,9 +11,17 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 )
 
-// DEPRECATED
+// TODO(campaigns-deprecation)
 type CreateCampaignArgs struct {
 	CampaignSpec graphql.ID
+}
+
+// TODO(campaigns-deprecation)
+type CreateCampaignSpecArgs struct {
+	Namespace graphql.ID
+
+	CampaignSpec   string
+	ChangesetSpecs []graphql.ID
 }
 
 type CreateBatchChangeArgs struct {
@@ -59,14 +67,6 @@ type ReenqueueChangesetArgs struct {
 
 type CreateChangesetSpecArgs struct {
 	ChangesetSpec string
-}
-
-// DEPRECATED
-type CreateCampaignSpecArgs struct {
-	Namespace graphql.ID
-
-	CampaignSpec   string
-	ChangesetSpecs []graphql.ID
 }
 
 type CreateBatchSpecArgs struct {
@@ -126,7 +126,7 @@ type CampaignsResolver interface {
 	//
 	// MUTATIONS
 	//
-	// Deprecated:
+	// TODO(campaigns-deprecation)
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (BatchChangeResolver, error)
 	CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (BatchSpecResolver, error)
 	// TODO: To-be-deprecated (these need to be marked as deprecated and use
@@ -147,7 +147,7 @@ type CampaignsResolver interface {
 
 	// Queries
 
-	// Deprecated:
+	// TODO(campaigns-deprecation)
 	Campaign(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error)
 	Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error)
 	CampaignByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error)
@@ -188,7 +188,8 @@ type BatchSpecResolver interface {
 
 	DiffStat(ctx context.Context) (*DiffStat, error)
 
-	// Deprecated (defined so that BatchSpecResolver can act as a CampaignSpec):
+	// TODO(campaigns-deprecation)
+	// Defined so that BatchSpecResolver can act as a CampaignSpec:
 	AppliesToCampaign(ctx context.Context) (BatchChangeResolver, error)
 	SupersedingCampaignSpec(context.Context) (BatchSpecResolver, error)
 	// New:
@@ -197,9 +198,9 @@ type BatchSpecResolver interface {
 
 	ViewerCampaignsCodeHosts(ctx context.Context, args *ListViewerCampaignsCodeHostsArgs) (CampaignsCodeHostConnectionResolver, error)
 
-	// TODO: This should be removed once we remove campaigns.
-	// It's here so that in the NodeResolver we can have the same resolver,
-	// BatchChangeResolver, act as a Campaign and a BatchChange.
+	// TODO(campaigns-deprecation): This should be removed once we remove
+	// campaigns. It's here so that in the NodeResolver we can have the same
+	// resolver, BatchChangeResolver, act as a Campaign and a BatchChange.
 	ActAsCampaignSpec() bool
 }
 
@@ -419,7 +420,7 @@ type BatchChangeResolver interface {
 	DiffStat(ctx context.Context) (*DiffStat, error)
 	CurrentSpec(ctx context.Context) (BatchSpecResolver, error)
 
-	// TODO: This should be removed once we remove campaigns.
+	// TODO(campaigns-deprecation): This should be removed once we remove campaigns.
 	// It's here so that in the NodeResolver we can have the same resolver,
 	// BatchChangeResolver, act as a Campaign and a BatchChange.
 	ActAsCampaign() bool
@@ -540,12 +541,12 @@ type defaultCampaignsResolver struct{}
 var DefaultCampaignsResolver CampaignsResolver = defaultCampaignsResolver{}
 
 // Mutations
-// DEPRECATED
+// TODO(campaigns-deprecation):
 func (defaultCampaignsResolver) CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
-// DEPRECATED
+// TODO(campaigns-deprecation):
 func (defaultCampaignsResolver) CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (BatchSpecResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
@@ -594,22 +595,22 @@ func (defaultCampaignsResolver) DeleteCampaignsCredential(ctx context.Context, a
 }
 
 // Queries
-// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+// TODO(campaigns-deprecation)
 func (defaultCampaignsResolver) Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
-// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+// TODO(campaigns-deprecation)
 func (defaultCampaignsResolver) Campaign(ctx context.Context, args *BatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
-// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+// TODO(campaigns-deprecation)
 func (defaultCampaignsResolver) CampaignSpecByID(ctx context.Context, id graphql.ID) (BatchSpecResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 
-// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+// TODO(campaigns-deprecation)
 func (defaultCampaignsResolver) CampaignByID(ctx context.Context, id graphql.ID) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }

--- a/cmd/frontend/graphqlbackend/campaigns.go
+++ b/cmd/frontend/graphqlbackend/campaigns.go
@@ -24,13 +24,19 @@ type CreateCampaignSpecArgs struct {
 	ChangesetSpecs []graphql.ID
 }
 
+// TODO(campaigns-deprecation)
+type ApplyCampaignArgs struct {
+	CampaignSpec   graphql.ID
+	EnsureCampaign *graphql.ID
+}
+
 type CreateBatchChangeArgs struct {
 	BatchSpec graphql.ID
 }
 
-type ApplyCampaignArgs struct {
-	CampaignSpec   graphql.ID
-	EnsureCampaign *graphql.ID
+type ApplyBatchChangeArgs struct {
+	BatchSpec         graphql.ID
+	EnsureBatchChange *graphql.ID
 }
 
 type MoveCampaignArgs struct {
@@ -129,9 +135,9 @@ type CampaignsResolver interface {
 	// TODO(campaigns-deprecation)
 	CreateCampaign(ctx context.Context, args *CreateCampaignArgs) (BatchChangeResolver, error)
 	CreateCampaignSpec(ctx context.Context, args *CreateCampaignSpecArgs) (BatchSpecResolver, error)
+	ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error)
 	// TODO: To-be-deprecated (these need to be marked as deprecated and use
 	// the code for the new implementations) and then moved up to "Deprecated:"
-	ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error)
 	MoveCampaign(ctx context.Context, args *MoveCampaignArgs) (BatchChangeResolver, error)
 	CloseCampaign(ctx context.Context, args *CloseCampaignArgs) (BatchChangeResolver, error)
 	DeleteCampaign(ctx context.Context, args *DeleteCampaignArgs) (*EmptyResponse, error)
@@ -140,6 +146,7 @@ type CampaignsResolver interface {
 	// New:
 	CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error)
 	CreateBatchSpec(ctx context.Context, args *CreateBatchSpecArgs) (BatchSpecResolver, error)
+	ApplyBatchChange(ctx context.Context, args *ApplyBatchChangeArgs) (BatchChangeResolver, error)
 
 	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
@@ -551,6 +558,12 @@ func (defaultCampaignsResolver) CreateCampaignSpec(ctx context.Context, args *Cr
 	return nil, campaignsOnlyInEnterprise
 }
 
+// TODO(campaigns-deprecation):
+func (defaultCampaignsResolver) ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error) {
+	return nil, campaignsOnlyInEnterprise
+}
+
+
 func (defaultCampaignsResolver) CreateBatchChange(ctx context.Context, args *CreateBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
@@ -559,7 +572,7 @@ func (defaultCampaignsResolver) CreateBatchSpec(ctx context.Context, args *Creat
 	return nil, campaignsOnlyInEnterprise
 }
 
-func (defaultCampaignsResolver) ApplyCampaign(ctx context.Context, args *ApplyCampaignArgs) (BatchChangeResolver, error) {
+func (defaultCampaignsResolver) ApplyBatchChange(ctx context.Context, args *ApplyBatchChangeArgs) (BatchChangeResolver, error) {
 	return nil, campaignsOnlyInEnterprise
 }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -427,8 +427,13 @@ func (r *NodeResolver) ToMonitorTriggerEvent() (MonitorTriggerEventResolver, boo
 	return n, ok
 }
 
-func (r *NodeResolver) ToCampaign() (CampaignResolver, bool) {
-	n, ok := r.Node.(CampaignResolver)
+func (r *NodeResolver) ToCampaign() (BatchChangeResolver, bool) {
+	n, ok := r.Node.(BatchChangeResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToBatchChange() (BatchChangeResolver, bool) {
+	n, ok := r.Node.(BatchChangeResolver)
 	return n, ok
 }
 
@@ -617,8 +622,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 	switch relay.UnmarshalKind(id) {
 	case "AccessToken":
 		return accessTokenByID(ctx, r.db, id)
-	case "Campaign":
-		return r.CampaignByID(ctx, id)
+	case "Campaign", "BatchChange":
+		return r.BatchChangeByID(ctx, id)
 	case "CampaignSpec":
 		return r.CampaignSpecByID(ctx, id)
 	case "ChangesetSpec":

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -492,8 +492,14 @@ func (r *NodeResolver) ToVisibleChangesetSpec() (VisibleChangesetSpecResolver, b
 	return n.ToVisibleChangesetSpec()
 }
 
+// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
 func (r *NodeResolver) ToCampaignsCredential() (CampaignsCredentialResolver, bool) {
 	n, ok := r.Node.(CampaignsCredentialResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToBatchChangesCredential() (BatchChangesCredentialResolver, bool) {
+	n, ok := r.Node.(BatchChangesCredentialResolver)
 	return n, ok
 }
 
@@ -649,6 +655,8 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 		return r.ChangesetByID(ctx, id)
 	case "CampaignsCredential":
 		return r.CampaignsCredentialByID(ctx, id)
+	case "BatchChangesCredential":
+		return r.BatchChangesCredentialByID(ctx, id)
 	case "ProductLicense":
 		if f := ProductLicenseByID; f != nil {
 			return f(ctx, r.db, id)

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -429,30 +429,34 @@ func (r *NodeResolver) ToMonitorTriggerEvent() (MonitorTriggerEventResolver, boo
 
 // TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
 func (r *NodeResolver) ToCampaign() (BatchChangeResolver, bool) {
-	n, ok := r.Node.(BatchChangeResolver)
-	if !ok {
-		return nil, false
+	if n, ok := r.Node.(BatchChangeResolver); ok {
+		return n, n.ActAsCampaign()
 	}
-	return n, n.ActAsCampaign()
+	return nil, false
 }
 
 // TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
 func (r *NodeResolver) ToCampaignSpec() (BatchSpecResolver, bool) {
-	n, ok := r.Node.(BatchSpecResolver)
-	if !ok {
-		return nil, false
+	if n, ok := r.Node.(BatchSpecResolver); ok {
+		return n, n.ActAsCampaignSpec()
 	}
-	return n, n.ActAsCampaignSpec()
+	return nil, false
 }
 
 func (r *NodeResolver) ToBatchChange() (BatchChangeResolver, bool) {
-	n, ok := r.Node.(BatchChangeResolver)
-	return n, n.ActAsCampaign()
+	if n, ok := r.Node.(BatchChangeResolver); ok {
+		// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+		return n, !n.ActAsCampaign()
+	}
+	return nil, false
 }
 
 func (r *NodeResolver) ToBatchSpec() (BatchSpecResolver, bool) {
-	n, ok := r.Node.(BatchSpecResolver)
-	return n, n.ActAsCampaignSpec()
+	if n, ok := r.Node.(BatchSpecResolver); ok {
+		// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+		return n, !n.ActAsCampaignSpec()
+	}
+	return nil, false
 }
 
 func (r *NodeResolver) ToExternalChangeset() (ExternalChangesetResolver, bool) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -452,7 +452,7 @@ func (r *NodeResolver) ToBatchChange() (BatchChangeResolver, bool) {
 
 func (r *NodeResolver) ToBatchSpec() (BatchSpecResolver, bool) {
 	n, ok := r.Node.(BatchSpecResolver)
-	return n, ok
+	return n, n.ActAsCampaignSpec()
 }
 
 func (r *NodeResolver) ToExternalChangeset() (ExternalChangesetResolver, bool) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -447,7 +447,7 @@ func (r *NodeResolver) ToCampaignSpec() (BatchSpecResolver, bool) {
 
 func (r *NodeResolver) ToBatchChange() (BatchChangeResolver, bool) {
 	n, ok := r.Node.(BatchChangeResolver)
-	return n, ok
+	return n, n.ActAsCampaign()
 }
 
 func (r *NodeResolver) ToBatchSpec() (BatchSpecResolver, bool) {

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -427,6 +427,7 @@ func (r *NodeResolver) ToMonitorTriggerEvent() (MonitorTriggerEventResolver, boo
 	return n, ok
 }
 
+// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
 func (r *NodeResolver) ToCampaign() (BatchChangeResolver, bool) {
 	n, ok := r.Node.(BatchChangeResolver)
 	if !ok {
@@ -435,8 +436,22 @@ func (r *NodeResolver) ToCampaign() (BatchChangeResolver, bool) {
 	return n, n.ActAsCampaign()
 }
 
+// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+func (r *NodeResolver) ToCampaignSpec() (BatchSpecResolver, bool) {
+	n, ok := r.Node.(BatchSpecResolver)
+	if !ok {
+		return nil, false
+	}
+	return n, n.ActAsCampaignSpec()
+}
+
 func (r *NodeResolver) ToBatchChange() (BatchChangeResolver, bool) {
 	n, ok := r.Node.(BatchChangeResolver)
+	return n, ok
+}
+
+func (r *NodeResolver) ToBatchSpec() (BatchSpecResolver, bool) {
+	n, ok := r.Node.(BatchSpecResolver)
 	return n, ok
 }
 
@@ -458,11 +473,6 @@ func (r *NodeResolver) ToHiddenExternalChangeset() (HiddenExternalChangesetResol
 
 func (r *NodeResolver) ToChangesetEvent() (ChangesetEventResolver, bool) {
 	n, ok := r.Node.(ChangesetEventResolver)
-	return n, ok
-}
-
-func (r *NodeResolver) ToCampaignSpec() (CampaignSpecResolver, bool) {
-	n, ok := r.Node.(CampaignSpecResolver)
 	return n, ok
 }
 
@@ -625,10 +635,14 @@ func (r *schemaResolver) nodeByID(ctx context.Context, id graphql.ID) (Node, err
 	switch relay.UnmarshalKind(id) {
 	case "AccessToken":
 		return accessTokenByID(ctx, r.db, id)
-	case "Campaign", "BatchChange":
+	case "Campaign":
+		return r.CampaignByID(ctx, id)
+	case "BatchChange":
 		return r.BatchChangeByID(ctx, id)
 	case "CampaignSpec":
 		return r.CampaignSpecByID(ctx, id)
+	case "BatchSpec":
+		return r.BatchSpecByID(ctx, id)
 	case "ChangesetSpec":
 		return r.ChangesetSpecByID(ctx, id)
 	case "Changeset":

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -429,7 +429,10 @@ func (r *NodeResolver) ToMonitorTriggerEvent() (MonitorTriggerEventResolver, boo
 
 func (r *NodeResolver) ToCampaign() (BatchChangeResolver, bool) {
 	n, ok := r.Node.(BatchChangeResolver)
-	return n, ok
+	if !ok {
+		return nil, false
+	}
+	return n, n.ActAsCampaign()
 }
 
 func (r *NodeResolver) ToBatchChange() (BatchChangeResolver, bool) {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -174,10 +174,17 @@ func (o *OrgResolver) ViewerIsMember(ctx context.Context) (bool, error) {
 
 func (o *OrgResolver) NamespaceName() string { return o.org.Name }
 
+// TODO(campaigns-deprecation):
 func (o *OrgResolver) Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	id := o.ID()
 	args.Namespace = &id
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)
+}
+
+func (o *OrgResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
+	id := o.ID()
+	args.Namespace = &id
+	return EnterpriseResolvers.campaignsResolver.BatchChanges(ctx, args)
 }
 
 func (r *schemaResolver) CreateOrganization(ctx context.Context, args *struct {

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -174,7 +174,7 @@ func (o *OrgResolver) ViewerIsMember(ctx context.Context) (bool, error) {
 
 func (o *OrgResolver) NamespaceName() string { return o.org.Name }
 
-func (o *OrgResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error) {
+func (o *OrgResolver) Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	id := o.ID()
 	args.Namespace = &id
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9509,7 +9509,7 @@ extend type Mutation {
         Changeset specs that were locally computed and then uploaded using createChangesetSpec.
         """
         changesetSpecs: [ID!]!
-    ): CampaignSpec!
+    ): CampaignSpec! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchSpec instead.")
 
     """
     Enqueue the given changeset for high-priority syncing.
@@ -9674,6 +9674,36 @@ extend type Mutation {
         """
         batchSpec: ID!
     ): BatchChange!
+
+    """
+    Create a batch spec that will be used to create a campaign (with the createCampaign
+    mutation), or to update a campaign (with the applyCampaign mutation).
+
+    The returned BatchSpec is immutable and expires after a certain period of time (if not used
+    in a call to applyCampaign), which can be queried on BatchSpec.expiresAt.
+
+    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
+    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
+    """
+    createBatchSpec(
+        """
+        The namespace (either a user or organization). A batch spec can only be applied to (or
+        used to create) campaigns in this namespace.
+        """
+        namespace: ID!
+
+        """
+        The batch spec as YAML (or the equivalent JSON). See
+        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/campaign_spec.schema.json
+        for the JSON Schema that describes the structure of this input.
+        """
+        batchSpec: String!
+
+        """
+        Changeset specs that were locally computed and then uploaded using createChangesetSpec.
+        """
+        changesetSpecs: [ID!]!
+    ): BatchSpec! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchSpec instead.")
 }
 
 extend type Query {
@@ -9874,4 +9904,137 @@ type BatchChange implements Node {
     The current change spec this change reflects.
     """
     currentSpec: CampaignSpec!
+}
+
+
+"""
+A batch spec is an immutable description of the desired state of a campaign. To create a
+batch spec, use the createBatchSpec mutation.
+"""
+type BatchSpec implements Node {
+    """
+    The unique ID for a batch spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential).
+    Consider a campaign to fix a security vulnerability: the campaign author may prefer
+    to prepare the campaign, including the description in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The original YAML or JSON input that was used to create this batch spec.
+    """
+    originalInput: String!
+
+    """
+    The parsed JSON value of the original input. If the original input was YAML, the YAML is
+    converted to the equivalent JSON.
+    """
+    parsedInput: JSONValue!
+
+    """
+    The CampaignDescription that describes this campaign.
+    """
+    description: CampaignDescription!
+
+    """
+    Generates a preview what operations would be performed if the batch spec would be applied.
+    This preview is not a guarantee, since the state of the changesets can change between the time
+    the preview is generated and when the batch spec is applied.
+    """
+    applyPreview(
+        """
+        Returns the first n entries from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
+        """
+        search: String
+        """
+        Search for changesets that are currently in this state.
+        """
+        currentState: ChangesetState
+        """
+        Search for changesets that will have the given action performed.
+        """
+        action: ChangesetSpecOperation
+    ): ChangesetApplyPreviewConnection!
+
+    """
+    The specs for changesets associated with this campaign.
+    """
+    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
+
+    """
+    The user who created this batch spec (or null if the user no longer exists).
+    """
+    creator: User
+
+    """
+    The date when this batch spec was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The namespace (either a user or organization) of the batch spec.
+    """
+    namespace: Namespace!
+
+    """
+    The date, if any, when this batch spec expires and is automatically purged. A batch spec
+    never expires if it has been applied.
+    """
+    expiresAt: DateTime
+
+    """
+    The URL of a web page that allows applying this batch spec and
+    displays a preview of which changesets will be created by applying it.
+    """
+    applyURL: String!
+
+    """
+    When true, the viewing user can apply this spec.
+    """
+    viewerCanAdminister: Boolean!
+
+    """
+    The diff stat for all the changeset specs in the batch spec.
+    """
+    diffStat: DiffStat!
+
+    """
+    The campaign this spec will update when applied. If it's null, the
+    campaign doesn't yet exist.
+    """
+    appliesToBatchChange: BatchChange
+
+    """
+    The newest version of this batch spec, as identified by its namespace
+    and name. If this is the newest version, this field will be null.
+    """
+    supersedingBatchSpec: BatchSpec
+
+    """
+    The code host connections required for applying this spec. Includes the credentials of the current user.
+    """
+    viewerCampaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only returns the code hosts for which the viewer doesn't have credentials.
+        """
+        onlyWithoutCredential: Boolean = false
+    ): CampaignsCodeHostConnection!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10119,7 +10119,73 @@ type BatchSpec implements Node {
     ): BatchChangesCodeHostConnection!
 }
 
+"""
+A list of batch changes.
+"""
+type BatchChangeConnection {
+    """
+    A list of batch changes.
+    """
+    nodes: [BatchChange!]!
+
+    """
+    The total number of batch changes in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+extend type Org {
+    """
+    A list of batch changes initially applied in this organization.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): BatchChangeConnection!
+}
+
 extend type User {
+    """
+    A list of batch changes applied under this user's namespace.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): BatchChangeConnection!
+
     """
     Returns a connection of configured external services accessible by this user, for usage with batch changes.
     These are all code hosts configured on the Sourcegraph instance that are supported by batch changes. They are
@@ -10213,4 +10279,12 @@ type BatchChangesCredential implements Node {
     The date and time this token has been created at.
     """
     createdAt: DateTime!
+}
+
+"""
+The state of the batch change.
+"""
+enum BatchChangeState {
+    OPEN
+    CLOSED
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9753,6 +9753,38 @@ extend type Mutation {
     batch change's changesets are kept as-is; to close them, use the closeBatchChange mutation first.
     """
     deleteBatchChange(batchChange: ID!): EmptyResponse
+
+    """
+    Create a new credential for the given user for the given code host.
+    If another token for that code host already exists, an error with the error code
+    ErrDuplicateCredential is returned.
+    """
+    createBatchChangesCredential(
+        """
+        The user for which to create the credential.
+        """
+        user: ID!
+
+        """
+        The kind of external service being configured.
+        """
+        externalServiceKind: ExternalServiceKind!
+
+        """
+        The URL of the external service being configured.
+        """
+        externalServiceURL: String!
+
+        """
+        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
+        """
+        credential: String!
+    ): BatchChangesCredential!
+
+    """
+    Hard-deletes a given credential.
+    """
+    deleteBatchChangesCredential(batchChangesCredential: ID!): EmptyResponse!
 }
 
 extend type Query {
@@ -10071,7 +10103,7 @@ type BatchSpec implements Node {
     """
     The code host connections required for applying this spec. Includes the credentials of the current user.
     """
-    viewerCampaignsCodeHosts(
+    viewerBatchChangesCodeHosts(
         """
         Returns the first n code hosts from the list.
         """
@@ -10084,5 +10116,101 @@ type BatchSpec implements Node {
         Only returns the code hosts for which the viewer doesn't have credentials.
         """
         onlyWithoutCredential: Boolean = false
-    ): CampaignsCodeHostConnection!
+    ): BatchChangesCodeHostConnection!
+}
+
+extend type User {
+    """
+    Returns a connection of configured external services accessible by this user, for usage with batch changes.
+    These are all code hosts configured on the Sourcegraph instance that are supported by batch changes. They are
+    connected to BatchChangesCredential resources, if one has been created for the code host connection before.
+    """
+    batchChangesCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): BatchChangesCodeHostConnection!
+}
+
+"""
+A connection of all code hosts usable with batch changes and accessible by the user
+this is requested on.
+"""
+type BatchChangesCodeHostConnection {
+    """
+    A list of code hosts.
+    """
+    nodes: [CampaignsCodeHost!]!
+
+    """
+    The total number of configured external services in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A code host usable with batch changes. This service is accessible by the user it belongs to.
+"""
+type BatchChangesCodeHost {
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The configured credential, if any.
+    """
+    credential: BatchChangesCredential
+
+    """
+    If true, some of the repositories on this code host require
+    an SSH key to be configured.
+    """
+    requiresSSH: Boolean!
+}
+
+"""
+A user token configured for batch changes use on the specified code host.
+"""
+type BatchChangesCredential implements Node {
+    """
+    A globally unique identifier.
+    """
+    id: ID!
+
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The public key to use on the external service for SSH keypair authentication.
+    Not set if the credential doesn't support SSH access.
+    """
+    sshPublicKey: String
+
+    """
+    The date and time this token has been created at.
+    """
+    createdAt: DateTime!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -8213,6 +8213,29 @@ interface Changeset {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
+
+    """
+    The batch changes that contain this changeset.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): BatchChangeConnection!
 
     """
     The publication state of the changeset.
@@ -8283,6 +8306,29 @@ type HiddenExternalChangeset implements Node & Changeset {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
+
+    """
+    The batch changes that contain this changeset.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): BatchChangeConnection!
 
     """
     The publication state of the changeset.
@@ -8364,6 +8410,29 @@ type ExternalChangeset implements Node & Changeset {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
+
+    """
+    The batch changes that contain this changeset.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): BatchChangeConnection!
 
     """
     The events belonging to this changeset.
@@ -9548,11 +9617,13 @@ extend type Mutation {
         """
         credential: String!
     ): CampaignsCredential!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
 
     """
     Hard-deletes a given campaigns credential.
     """
     deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
 }
 
 extend type Org {
@@ -9577,6 +9648,7 @@ extend type Org {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
 }
 
 extend type User {
@@ -9601,6 +9673,7 @@ extend type User {
         """
         viewerCanAdminister: Boolean
     ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
 
     """
     Returns a connection of configured external services accessible by this user, for usage with campaigns.
@@ -9617,6 +9690,7 @@ extend type User {
         """
         after: String
     ): CampaignsCodeHostConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
 }
 
 extend type Query {
@@ -9705,7 +9779,7 @@ extend type Mutation {
         Changeset specs that were locally computed and then uploaded using createChangesetSpec.
         """
         changesetSpecs: [ID!]!
-    ): BatchSpec! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchSpec instead.")
+    ): BatchSpec!
 
     """
     Create or update a batch change from a batch spec and locally computed changeset specs. If no
@@ -9808,7 +9882,7 @@ extend type Query {
         Only include batch changes that the viewer can administer.
         """
         viewerCanAdminister: Boolean
-    ): CampaignConnection!
+    ): BatchChangeConnection!
     """
     Looks up a batch change by namespace and campaign name.
     """
@@ -9984,7 +10058,7 @@ type BatchChange implements Node {
     """
     The current change spec this change reflects.
     """
-    currentSpec: CampaignSpec!
+    currentSpec: BatchSpec!
 }
 
 """
@@ -10014,9 +10088,9 @@ type BatchSpec implements Node {
     parsedInput: JSONValue!
 
     """
-    The CampaignDescription that describes this campaign.
+    The BatchChangeDescription that describes this batch change.
     """
-    description: CampaignDescription!
+    description: BatchChangeDescription!
 
     """
     Generates a preview what operations would be performed if the batch spec would be applied.
@@ -10211,7 +10285,7 @@ type BatchChangesCodeHostConnection {
     """
     A list of code hosts.
     """
-    nodes: [CampaignsCodeHost!]!
+    nodes: [BatchChangesCodeHost!]!
 
     """
     The total number of configured external services in the connection.
@@ -10287,4 +10361,19 @@ The state of the batch change.
 enum BatchChangeState {
     OPEN
     CLOSED
+}
+
+"""
+A BatchChangeDescription describes a batch change.
+"""
+type BatchChangeDescription {
+    """
+    The name as parsed from the input.
+    """
+    name: String!
+
+    """
+    The description as parsed from the input.
+    """
+    description: String!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9639,7 +9639,7 @@ extend type Query {
         Only include campaigns that the viewer can administer.
         """
         viewerCanAdminister: Boolean
-    ): CampaignConnection!
+    ): CampaignConnection! @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
     """
     Looks up a campaign by namespace and campaign name.
     """
@@ -9678,6 +9678,27 @@ extend type Mutation {
 
 extend type Query {
     """
+    A list of batch changes.
+    """
+    batchChanges(
+        """
+        Returns the first n batch changes from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return batch changes in this state.
+        """
+        state: BatchChangeState
+        """
+        Only include batch changes that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+    """
     Looks up a batch change by namespace and campaign name.
     """
     batchChange(
@@ -9690,6 +9711,14 @@ extend type Query {
         """
         name: String!
     ): BatchChange
+}
+
+"""
+The state of the batch change
+"""
+enum BatchChangeState {
+    OPEN
+    CLOSED
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9899,7 +9899,7 @@ extend type Query {
 }
 
 """
-The state of the batch change
+The state of the batch change.
 """
 enum BatchChangeState {
     OPEN
@@ -10353,14 +10353,6 @@ type BatchChangesCredential implements Node {
     The date and time this token has been created at.
     """
     createdAt: DateTime!
-}
-
-"""
-The state of the batch change.
-"""
-enum BatchChangeState {
-    OPEN
-    CLOSED
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9396,7 +9396,6 @@ type CampaignSpec implements Node {
 }
 
 extend type Mutation {
-
     """
     Create a campaign from a campaign spec and locally computed changeset specs. The newly created
     campaign is returned.
@@ -9408,7 +9407,7 @@ extend type Mutation {
         The campaign spec that describes the desired state of the campaign.
         """
         campaignSpec: ID!
-    ): Campaign!  @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchChange instead.")
+    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchChange instead.")
 
     """
     Create or update a campaign from a campaign spec and locally computed changeset specs. If no
@@ -9639,7 +9638,8 @@ extend type Query {
         Only include campaigns that the viewer can administer.
         """
         viewerCanAdminister: Boolean
-    ): CampaignConnection! @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
+    ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
     """
     Looks up a campaign by namespace and campaign name.
     """
@@ -9928,7 +9928,6 @@ type BatchChange implements Node {
     """
     currentSpec: CampaignSpec!
 }
-
 
 """
 A batch spec is an immutable description of the desired state of a campaign. To create a

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9431,7 +9431,7 @@ extend type Mutation {
         deleted). The returned error has the error code ErrEnsureCampaignFailed.
         """
         ensureCampaign: ID
-    ): Campaign!
+    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use applyBatchChange instead.")
 
     """
     Move a campaign to a different namespace, or rename it in the current namespace.
@@ -9704,6 +9704,29 @@ extend type Mutation {
         """
         changesetSpecs: [ID!]!
     ): BatchSpec! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchSpec instead.")
+
+    """
+    Create or update a batch change from a batch spec and locally computed changeset specs. If no
+    batch change exists in the namespace with the name given in the batch spec, a batch change will be
+    created. Otherwise, the existing batch change will be updated. The batch change is returned.
+    Closed batch changes cannot be applied to. In that case, an error with the error code ErrApplyClosedbatch change
+    will be returned.
+    """
+    applyBatchChange(
+        """
+        The batch spec that describes the new desired state of the batch change.
+        """
+        batchSpec: ID!
+
+        """
+        If set, return an error if the batch change identified using the namespace and batch changeSpec
+        parameters does not match the batch change with this ID. This lets callers use a stable ID
+        that refers to a specific batch change during an edit session (and is not susceptible to
+        conflicts if the underlying batch change is moved to a different namespace, renamed, or
+        deleted). The returned error has the error code ErrEnsureBatchChangeFailed.
+        """
+        ensureBatchChange: ID
+    ): BatchChange!
 }
 
 extend type Query {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9448,7 +9448,7 @@ extend type Mutation {
         GitHub and "declined" on Bitbucket Server).
         """
         closeChangesets: Boolean = false
-    ): Campaign!
+    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use closeBatchChange instead.")
 
     """
     Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
@@ -9726,6 +9726,19 @@ extend type Mutation {
         deleted). The returned error has the error code ErrEnsureBatchChangeFailed.
         """
         ensureBatchChange: ID
+    ): BatchChange!
+
+    """
+    Close a batch change.
+    """
+    closeBatchChange(
+        batchChange: ID!
+        """
+        Whether to close the changesets associated with this batch change on their respective code
+        hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
+        GitHub and "declined" on Bitbucket Server).
+        """
+        closeChangesets: Boolean = false
     ): BatchChange!
 }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9454,7 +9454,7 @@ extend type Mutation {
     Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
     campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
     """
-    deleteCampaign(campaign: ID!): EmptyResponse
+    deleteCampaign(campaign: ID!): EmptyResponse @deprecated(reason: "campaigns have been renamed to batch changes. Use deleteBatchChange instead.")
 
     """
     Upload a changeset spec that will be used in a future update to a campaign. The changeset spec
@@ -9745,6 +9745,12 @@ extend type Mutation {
     Move a batch change to a different namespace, or rename it in the current namespace.
     """
     moveBatchChange(batchChange: ID!, newName: String, newNamespace: ID): BatchChange!
+
+    """
+    Delete a batch change. A deleted batch change is completely removed and can't be un-deleted. The
+    batch change's changesets are kept as-is; to close them, use the closeBatchChange mutation first.
+    """
+    deleteBatchChange(batchChange: ID!): EmptyResponse
 }
 
 extend type Query {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9435,7 +9435,7 @@ extend type Mutation {
     """
     Move a campaign to a different namespace, or rename it in the current namespace.
     """
-    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
+    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use moveBatchChange instead.")
 
     """
     Close a campaign.
@@ -9740,6 +9740,11 @@ extend type Mutation {
         """
         closeChangesets: Boolean = false
     ): BatchChange!
+
+    """
+    Move a batch change to a different namespace, or rename it in the current namespace.
+    """
+    moveBatchChange(batchChange: ID!, newName: String, newNamespace: ID): BatchChange!
 }
 
 extend type Query {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9435,7 +9435,8 @@ extend type Mutation {
     """
     Move a campaign to a different namespace, or rename it in the current namespace.
     """
-    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use moveBatchChange instead.")
+    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use moveBatchChange instead.")
 
     """
     Close a campaign.
@@ -9454,7 +9455,8 @@ extend type Mutation {
     Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
     campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
     """
-    deleteCampaign(campaign: ID!): EmptyResponse @deprecated(reason: "campaigns have been renamed to batch changes. Use deleteBatchChange instead.")
+    deleteCampaign(campaign: ID!): EmptyResponse
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use deleteBatchChange instead.")
 
     """
     Upload a changeset spec that will be used in a future update to a campaign. The changeset spec

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -9396,6 +9396,7 @@ type CampaignSpec implements Node {
 }
 
 extend type Mutation {
+
     """
     Create a campaign from a campaign spec and locally computed changeset specs. The newly created
     campaign is returned.
@@ -9407,7 +9408,7 @@ extend type Mutation {
         The campaign spec that describes the desired state of the campaign.
         """
         campaignSpec: ID!
-    ): Campaign!
+    ): Campaign!  @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchChange instead.")
 
     """
     Create or update a campaign from a campaign spec and locally computed changeset specs. If no
@@ -9651,7 +9652,7 @@ extend type Query {
         The campaigns name.
         """
         name: String!
-    ): Campaign
+    ): Campaign @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChange instead.")
 }
 
 ############################################################################################
@@ -9659,3 +9660,189 @@ extend type Query {
 #                                 End campaigns schema                                     #
 #                                                                                          #
 ############################################################################################
+
+extend type Mutation {
+    """
+    Create a batch change from a batch spec and locally computed changeset specs. The newly created
+    batch change is returned.
+    If a batch change in the same namespace with the same name already exists,
+    an error with the error code ErrMatchingBatchChangeExists is returned.
+    """
+    createBatchChange(
+        """
+        The batch spec that describes the desired state of the batch change.
+        """
+        batchSpec: ID!
+    ): BatchChange!
+}
+
+extend type Query {
+    """
+    Looks up a batch change by namespace and campaign name.
+    """
+    batchChange(
+        """
+        The namespace where the batch change lives.
+        """
+        namespace: ID!
+        """
+        The batch changes name.
+        """
+        name: String!
+    ): BatchChange
+}
+
+"""
+A batch change is a set of related changes to apply to code across one or more repositories.
+"""
+type BatchChange implements Node {
+    """
+    The unique ID for the batch change.
+    """
+    id: ID!
+
+    """
+    The namespace where this batch change is defined.
+    """
+    namespace: Namespace!
+
+    """
+    The name of the batch change.
+    """
+    name: String!
+
+    """
+    The description (as Markdown).
+    """
+    description: String
+
+    """
+    The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
+    """
+    specCreator: User
+
+    """
+    The user who created the batch change initially by applying the spec for the first time, or null if the user was deleted.
+    """
+    initialApplier: User
+
+    """
+    The user who last updated the batch change by applying a spec to this batch change.
+    If the batch change hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
+    """
+    lastApplier: User
+
+    """
+    Whether the current user can edit or delete this batch change.
+    """
+    viewerCanAdminister: Boolean!
+
+    """
+    The URL to this batch change.
+    """
+    url: String!
+
+    """
+    The date and time when the batch change was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the batch change was updated. That can be by applying a spec, or by an internal process.
+    For reading the time the batch change spec was changed last, see lastAppliedAt.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the batch change was last updated with a new spec.
+    """
+    lastAppliedAt: DateTime!
+
+    """
+    The date and time when the batch change was closed. If set, applying a spec for this batch change will fail with an error.
+    """
+    closedAt: DateTime
+
+    """
+    Stats on all the changesets that are tracked in this batch change.
+    """
+    changesetsStats: ChangesetsStats!
+
+    """
+    The changesets in this batch change that already exist on the code host.
+    """
+    changesets(
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only include changesets with any of the given reconciler states.
+        """
+        reconcilerState: [ChangesetReconcilerState!]
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given publication state.
+        """
+        publicationState: ChangesetPublicationState
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given external state.
+        """
+        externalState: ChangesetExternalState
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given state.
+        """
+        state: ChangesetState
+        """
+        Only include changesets with the given review state.
+        """
+        reviewState: ChangesetReviewState
+        """
+        Only include changesets with the given check state.
+        """
+        checkState: ChangesetCheckState
+        """
+        Only return changesets that have been published by this batch change. Imported changesets will be omitted.
+        """
+        onlyPublishedByThisBatchChange: Boolean
+        """
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
+        """
+        search: String
+    ): ChangesetConnection!
+
+    """
+    The changeset counts over time, in 1-day intervals backwards from the point in time given in
+    the "to" parameter.
+    """
+    changesetCountsOverTime(
+        """
+        Only include changeset counts up to this point in time (inclusive). Defaults to BatchChange.createdAt.
+        """
+        from: DateTime
+        """
+        Only include changeset counts up to this point in time (inclusive). Defaults to the
+        current time.
+        """
+        to: DateTime
+    ): [ChangesetCounts!]!
+
+    """
+    The diff stat for all the changesets in the batch change.
+    """
+    diffStat: DiffStat!
+
+    """
+    The current change spec this change reflects.
+    """
+    currentSpec: CampaignSpec!
+}

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -434,6 +434,11 @@ func (r *UserResolver) CampaignsCodeHosts(ctx context.Context, args *ListCampaig
 	return EnterpriseResolvers.campaignsResolver.CampaignsCodeHosts(ctx, args)
 }
 
+func (r *UserResolver) BatchChangesCodeHosts(ctx context.Context, args *ListBatchChangesCodeHostsArgs) (BatchChangesCodeHostConnectionResolver, error) {
+	args.UserID = r.user.ID
+	return EnterpriseResolvers.campaignsResolver.BatchChangesCodeHosts(ctx, args)
+}
+
 func viewerCanChangeUsername(ctx context.Context, userID int32) bool {
 	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
 		return false

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -350,7 +350,7 @@ func (r *UserResolver) ViewerCanChangeUsername(ctx context.Context) bool {
 	return viewerCanChangeUsername(ctx, r.user.ID)
 }
 
-func (r *UserResolver) Campaigns(ctx context.Context, args *ListCampaignsArgs) (CampaignsConnectionResolver, error) {
+func (r *UserResolver) Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	id := r.ID()
 	args.Namespace = &id
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -350,10 +350,17 @@ func (r *UserResolver) ViewerCanChangeUsername(ctx context.Context) bool {
 	return viewerCanChangeUsername(ctx, r.user.ID)
 }
 
+// TODO(campaigns-deprecation):
 func (r *UserResolver) Campaigns(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
 	id := r.ID()
 	args.Namespace = &id
 	return EnterpriseResolvers.campaignsResolver.Campaigns(ctx, args)
+}
+
+func (r *UserResolver) BatchChanges(ctx context.Context, args *ListBatchChangesArgs) (BatchChangesConnectionResolver, error) {
+	id := r.ID()
+	args.Namespace = &id
+	return EnterpriseResolvers.campaignsResolver.BatchChanges(ctx, args)
 }
 
 type ListUserRepositoriesArgs struct {

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -52,7 +52,7 @@ type User struct {
 	DatabaseID int32
 	SiteAdmin  bool
 
-	Campaigns          CampaignConnection
+	Campaigns          BatchChangeConnection
 	CampaignsCodeHosts CampaignsCodeHostsConnection
 }
 
@@ -60,7 +60,7 @@ type Org struct {
 	ID   string
 	Name string
 
-	Campaigns CampaignConnection
+	Campaigns BatchChangeConnection
 }
 
 type UserOrg struct {
@@ -70,7 +70,7 @@ type UserOrg struct {
 	Name       string
 }
 
-type Campaign struct {
+type BatchChange struct {
 	ID                      string
 	Name                    string
 	Description             string
@@ -90,8 +90,8 @@ type Campaign struct {
 	DiffStat                DiffStat
 }
 
-type CampaignConnection struct {
-	Nodes      []Campaign
+type BatchChangeConnection struct {
+	Nodes      []BatchChange
 	TotalCount int
 	PageInfo   PageInfo
 }
@@ -120,22 +120,22 @@ type ExternalURL struct {
 }
 
 type Changeset struct {
-	Typename    string `json:"__typename"`
-	ID          string
-	Repository  Repository
-	Campaigns   CampaignConnection
-	CreatedAt   string
-	UpdatedAt   string
-	NextSyncAt  string
-	Title       string
-	Body        string
-	Error       string
-	State       string
-	ExternalID  string
-	ExternalURL ExternalURL
-	ReviewState string
-	CheckState  string
-	Events      ChangesetEventConnection
+	Typename     string `json:"__typename"`
+	ID           string
+	Repository   Repository
+	Campaigns BatchChangeConnection
+	CreatedAt    string
+	UpdatedAt    string
+	NextSyncAt   string
+	Title        string
+	Body         string
+	Error        string
+	State        string
+	ExternalID   string
+	ExternalURL  ExternalURL
+	ReviewState  string
+	CheckState   string
+	Events       ChangesetEventConnection
 
 	Diff Comparison
 
@@ -202,7 +202,7 @@ type CampaignSpec struct {
 
 	DiffStat DiffStat
 
-	AppliesToCampaign Campaign
+	AppliesToCampaign BatchChange
 
 	ViewerCampaignsCodeHosts CampaignsCodeHostsConnection
 	// Alias for the above.

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -120,22 +120,22 @@ type ExternalURL struct {
 }
 
 type Changeset struct {
-	Typename     string `json:"__typename"`
-	ID           string
-	Repository   Repository
-	Campaigns BatchChangeConnection
-	CreatedAt    string
-	UpdatedAt    string
-	NextSyncAt   string
-	Title        string
-	Body         string
-	Error        string
-	State        string
-	ExternalID   string
-	ExternalURL  ExternalURL
-	ReviewState  string
-	CheckState   string
-	Events       ChangesetEventConnection
+	Typename    string `json:"__typename"`
+	ID          string
+	Repository  Repository
+	Campaigns   BatchChangeConnection
+	CreatedAt   string
+	UpdatedAt   string
+	NextSyncAt  string
+	Title       string
+	Body        string
+	Error       string
+	State       string
+	ExternalID  string
+	ExternalURL ExternalURL
+	ReviewState string
+	CheckState  string
+	Events      ChangesetEventConnection
 
 	Diff Comparison
 
@@ -183,7 +183,7 @@ type ChangesetCounts struct {
 	OpenPending          int32
 }
 
-type CampaignSpec struct {
+type BatchSpec struct {
 	Typename string `json:"__typename"`
 	ID       string
 
@@ -202,8 +202,6 @@ type CampaignSpec struct {
 
 	DiffStat DiffStat
 
-	AppliesToCampaign BatchChange
-
 	ViewerCampaignsCodeHosts CampaignsCodeHostsConnection
 	// Alias for the above.
 	AllCodeHosts CampaignsCodeHostsConnection
@@ -213,7 +211,12 @@ type CampaignSpec struct {
 	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
 
-	SupersedingCampaignSpec *CampaignSpec
+	// DEPRECATED
+	SupersedingCampaignSpec *BatchSpec
+	AppliesToCampaign       BatchChange
+	// NEW
+	SupersedingBatchSpec *BatchSpec
+	AppliesToBatchChange BatchChange
 }
 
 // ChangesetSpecDelta is the delta between two ChangesetSpecs describing the same Changeset.

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -52,8 +52,8 @@ type User struct {
 	DatabaseID int32
 	SiteAdmin  bool
 
-	Campaigns          BatchChangeConnection
-	CampaignsCodeHosts CampaignsCodeHostsConnection
+	Campaigns             BatchChangeConnection
+	BatchChangesCodeHosts BatchChangesCodeHostsConnection
 }
 
 type Org struct {
@@ -202,11 +202,10 @@ type BatchSpec struct {
 
 	DiffStat DiffStat
 
-	ViewerCampaignsCodeHosts CampaignsCodeHostsConnection
 	// Alias for the above.
-	AllCodeHosts CampaignsCodeHostsConnection
+	AllCodeHosts BatchChangesCodeHostsConnection
 	// Alias for the above.
-	OnlyWithoutCredential CampaignsCodeHostsConnection
+	OnlyWithoutCredential BatchChangesCodeHostsConnection
 
 	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
@@ -335,7 +334,7 @@ type EmptyResponse struct {
 	AlwaysNil string
 }
 
-type CampaignsCodeHostsConnection struct {
+type BatchChangesCodeHostsConnection struct {
 	PageInfo   PageInfo
 	Nodes      []CampaignsCodeHost
 	TotalCount int

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -320,7 +320,7 @@ type Person struct {
 	User  *User
 }
 
-type CampaignsCredential struct {
+type BatchChangesCredential struct {
 	ID                  string
 	ExternalServiceKind string
 	ExternalServiceURL  string
@@ -333,12 +333,12 @@ type EmptyResponse struct {
 
 type BatchChangesCodeHostsConnection struct {
 	PageInfo   PageInfo
-	Nodes      []CampaignsCodeHost
+	Nodes      []BatchChangesCodeHost
 	TotalCount int
 }
 
-type CampaignsCodeHost struct {
+type BatchChangesCodeHost struct {
 	ExternalServiceKind string
 	ExternalServiceURL  string
-	Credential          CampaignsCredential
+	Credential          BatchChangesCredential
 }

--- a/enterprise/internal/campaigns/resolvers/apitest/types.go
+++ b/enterprise/internal/campaigns/resolvers/apitest/types.go
@@ -52,7 +52,7 @@ type User struct {
 	DatabaseID int32
 	SiteAdmin  bool
 
-	Campaigns             BatchChangeConnection
+	BatchChanges          BatchChangeConnection
 	BatchChangesCodeHosts BatchChangesCodeHostsConnection
 }
 
@@ -60,7 +60,7 @@ type Org struct {
 	ID   string
 	Name string
 
-	Campaigns BatchChangeConnection
+	BatchChanges BatchChangeConnection
 }
 
 type UserOrg struct {
@@ -120,22 +120,22 @@ type ExternalURL struct {
 }
 
 type Changeset struct {
-	Typename    string `json:"__typename"`
-	ID          string
-	Repository  Repository
-	Campaigns   BatchChangeConnection
-	CreatedAt   string
-	UpdatedAt   string
-	NextSyncAt  string
-	Title       string
-	Body        string
-	Error       string
-	State       string
-	ExternalID  string
-	ExternalURL ExternalURL
-	ReviewState string
-	CheckState  string
-	Events      ChangesetEventConnection
+	Typename     string `json:"__typename"`
+	ID           string
+	Repository   Repository
+	BatchChanges BatchChangeConnection
+	CreatedAt    string
+	UpdatedAt    string
+	NextSyncAt   string
+	Title        string
+	Body         string
+	Error        string
+	State        string
+	ExternalID   string
+	ExternalURL  ExternalURL
+	ReviewState  string
+	CheckState   string
+	Events       ChangesetEventConnection
 
 	Diff Comparison
 
@@ -210,9 +210,6 @@ type BatchSpec struct {
 	CreatedAt graphqlbackend.DateTime
 	ExpiresAt *graphqlbackend.DateTime
 
-	// DEPRECATED
-	SupersedingCampaignSpec *BatchSpec
-	AppliesToCampaign       BatchChange
 	// NEW
 	SupersedingBatchSpec *BatchSpec
 	AppliesToBatchChange BatchChange

--- a/enterprise/internal/campaigns/resolvers/batch_change.go
+++ b/enterprise/internal/campaigns/resolvers/batch_change.go
@@ -28,10 +28,11 @@ type batchChangeResolver struct {
 	namespaceErr  error
 }
 
-const campaignIDKind = "Campaign"
+// TODO: We need to marshal the ID depending on how we landed here
+const batchChangeIDKind = "BatchChange"
 
 func marshalCampaignID(id int64) graphql.ID {
-	return relay.MarshalID(campaignIDKind, id)
+	return relay.MarshalID(batchChangeIDKind, id)
 }
 
 func unmarshalCampaignID(id graphql.ID) (campaignID int64, err error) {

--- a/enterprise/internal/campaigns/resolvers/batch_change.go
+++ b/enterprise/internal/campaigns/resolvers/batch_change.go
@@ -28,7 +28,7 @@ type batchChangeResolver struct {
 	namespace     graphqlbackend.NamespaceResolver
 	namespaceErr  error
 
-	// TODO: This should be removed once we remove campaigns completely
+	// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
 	shouldActAsCampaign bool
 }
 
@@ -240,12 +240,12 @@ func (r *batchChangeResolver) DiffStat(ctx context.Context) (*graphqlbackend.Dif
 	return graphqlbackend.NewDiffStat(*diffStat), nil
 }
 
-func (r *batchChangeResolver) CurrentSpec(ctx context.Context) (graphqlbackend.CampaignSpecResolver, error) {
+func (r *batchChangeResolver) CurrentSpec(ctx context.Context) (graphqlbackend.BatchSpecResolver, error) {
 	campaignSpec, err := r.store.GetCampaignSpec(ctx, store.GetCampaignSpecOpts{ID: r.batchChange.CampaignSpecID})
 	if err != nil {
 		// This spec should always exist, so fail hard on not found errors as well.
 		return nil, err
 	}
 
-	return &campaignSpecResolver{store: r.store, campaignSpec: campaignSpec}, nil
+	return &batchSpecResolver{store: r.store, campaignSpec: campaignSpec}, nil
 }

--- a/enterprise/internal/campaigns/resolvers/batch_change_connection.go
+++ b/enterprise/internal/campaigns/resolvers/batch_change_connection.go
@@ -11,20 +11,20 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 )
 
-var _ graphqlbackend.CampaignsConnectionResolver = &campaignsConnectionResolver{}
+var _ graphqlbackend.BatchChangesConnectionResolver = &batchChangesConnectionResolver{}
 
-type campaignsConnectionResolver struct {
+type batchChangesConnectionResolver struct {
 	store *store.Store
 	opts  store.ListCampaignsOpts
 
 	// cache results because they are used by multiple fields
-	once      sync.Once
-	campaigns []*campaigns.Campaign
-	next      int64
-	err       error
+	once         sync.Once
+	batchChanges []*campaigns.Campaign
+	next         int64
+	err          error
 }
 
-func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.BatchChangeResolver, error) {
+func (r *batchChangesConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.BatchChangeResolver, error) {
 	nodes, _, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacke
 	return resolvers, nil
 }
 
-func (r *campaignsConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+func (r *batchChangesConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	opts := store.CountCampaignsOpts{
 		ChangesetID:      r.opts.ChangesetID,
 		State:            r.opts.State,
@@ -48,7 +48,7 @@ func (r *campaignsConnectionResolver) TotalCount(ctx context.Context) (int32, er
 	return int32(count), err
 }
 
-func (r *campaignsConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+func (r *batchChangesConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
 	_, next, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
@@ -59,9 +59,9 @@ func (r *campaignsConnectionResolver) PageInfo(ctx context.Context) (*graphqluti
 	return graphqlutil.HasNextPage(false), nil
 }
 
-func (r *campaignsConnectionResolver) compute(ctx context.Context) ([]*campaigns.Campaign, int64, error) {
+func (r *batchChangesConnectionResolver) compute(ctx context.Context) ([]*campaigns.Campaign, int64, error) {
 	r.once.Do(func() {
-		r.campaigns, r.next, r.err = r.store.ListCampaigns(ctx, r.opts)
+		r.batchChanges, r.next, r.err = r.store.ListCampaigns(ctx, r.opts)
 	})
-	return r.campaigns, r.next, r.err
+	return r.batchChanges, r.next, r.err
 }

--- a/enterprise/internal/campaigns/resolvers/batch_change_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_change_connection_test.go
@@ -232,7 +232,7 @@ func TestBatchChangesListing(t *testing.T) {
 
 		want := apitest.User{
 			ID: userAPIID,
-			Campaigns: apitest.BatchChangeConnection{
+			BatchChanges: apitest.BatchChangeConnection{
 				TotalCount: 1,
 				Nodes: []apitest.BatchChange{
 					{ID: string(marshalBatchChangeID(campaign.ID))},
@@ -265,7 +265,7 @@ func TestBatchChangesListing(t *testing.T) {
 
 		want := apitest.Org{
 			ID: orgAPIID,
-			Campaigns: apitest.BatchChangeConnection{
+			BatchChanges: apitest.BatchChangeConnection{
 				TotalCount: 1,
 				Nodes: []apitest.BatchChange{
 					{ID: string(marshalBatchChangeID(campaign.ID))},
@@ -284,7 +284,7 @@ query($node: ID!) {
   node(id: $node) {
     ... on User {
       id
-      campaigns {
+      batchChanges {
         totalCount
         nodes {
           id
@@ -294,7 +294,7 @@ query($node: ID!) {
 
     ... on Org {
       id
-      campaigns {
+      batchChanges {
         totalCount
         nodes {
           id

--- a/enterprise/internal/campaigns/resolvers/batch_change_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_change_connection_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
-func TestCampaignConnectionResolver(t *testing.T) {
+func TestBatchChangeConnectionResolver(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -33,7 +33,7 @@ func TestCampaignConnectionResolver(t *testing.T) {
 	repoStore := database.ReposWith(cstore)
 	esStore := database.ExternalServicesWith(cstore)
 
-	repo := newGitHubTestRepo("github.com/sourcegraph/campaign-connection-test", newGitHubExternalService(t, esStore))
+	repo := newGitHubTestRepo("github.com/sourcegraph/batch-change-connection-test", newGitHubExternalService(t, esStore))
 	if err := repoStore.Create(ctx, repo); err != nil {
 		t.Fatal(err)
 	}
@@ -82,12 +82,12 @@ func TestCampaignConnectionResolver(t *testing.T) {
 	}
 
 	// Campaigns are returned in reverse order.
-	nodes := []apitest.Campaign{
+	nodes := []apitest.BatchChange{
 		{
-			ID: string(marshalCampaignID(campaign2.ID)),
+			ID: string(marshalBatchChangeID(campaign2.ID)),
 		},
 		{
-			ID: string(marshalCampaignID(campaign1.ID)),
+			ID: string(marshalBatchChangeID(campaign1.ID)),
 		},
 	}
 
@@ -95,7 +95,7 @@ func TestCampaignConnectionResolver(t *testing.T) {
 		firstParam      int
 		wantHasNextPage bool
 		wantTotalCount  int
-		wantNodes       []apitest.Campaign
+		wantNodes       []apitest.BatchChange
 	}{
 		{firstParam: 1, wantHasNextPage: true, wantTotalCount: 2, wantNodes: nodes[:1]},
 		{firstParam: 2, wantHasNextPage: false, wantTotalCount: 2, wantNodes: nodes},
@@ -105,21 +105,21 @@ func TestCampaignConnectionResolver(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("first=%d", tc.firstParam), func(t *testing.T) {
 			input := map[string]interface{}{"first": int64(tc.firstParam)}
-			var response struct{ Campaigns apitest.CampaignConnection }
+			var response struct{ BatchChanges apitest.BatchChangeConnection }
 			apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryCampaignsConnection)
 
-			wantConnection := apitest.CampaignConnection{
+			wantConnection := apitest.BatchChangeConnection{
 				TotalCount: tc.wantTotalCount,
 				PageInfo: apitest.PageInfo{
 					HasNextPage: tc.wantHasNextPage,
 					// We don't test on the cursor here.
-					EndCursor: response.Campaigns.PageInfo.EndCursor,
+					EndCursor: response.BatchChanges.PageInfo.EndCursor,
 				},
 				Nodes: tc.wantNodes,
 			}
 
-			if diff := cmp.Diff(wantConnection, response.Campaigns); diff != "" {
-				t.Fatalf("wrong campaigns response (-want +got):\n%s", diff)
+			if diff := cmp.Diff(wantConnection, response.BatchChanges); diff != "" {
+				t.Fatalf("wrong batchChanges response (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -133,22 +133,22 @@ func TestCampaignConnectionResolver(t *testing.T) {
 			}
 			wantHasNextPage := i != len(nodes)-1
 
-			var response struct{ Campaigns apitest.CampaignConnection }
+			var response struct{ BatchChanges apitest.BatchChangeConnection }
 			apitest.MustExec(ctx, t, s, input, &response, queryCampaignsConnection)
 
-			if diff := cmp.Diff(1, len(response.Campaigns.Nodes)); diff != "" {
+			if diff := cmp.Diff(1, len(response.BatchChanges.Nodes)); diff != "" {
 				t.Fatalf("unexpected number of nodes (-want +got):\n%s", diff)
 			}
 
-			if diff := cmp.Diff(len(nodes), response.Campaigns.TotalCount); diff != "" {
+			if diff := cmp.Diff(len(nodes), response.BatchChanges.TotalCount); diff != "" {
 				t.Fatalf("unexpected total count (-want +got):\n%s", diff)
 			}
 
-			if diff := cmp.Diff(wantHasNextPage, response.Campaigns.PageInfo.HasNextPage); diff != "" {
+			if diff := cmp.Diff(wantHasNextPage, response.BatchChanges.PageInfo.HasNextPage); diff != "" {
 				t.Fatalf("unexpected hasNextPage (-want +got):\n%s", diff)
 			}
 
-			endCursor = response.Campaigns.PageInfo.EndCursor
+			endCursor = response.BatchChanges.PageInfo.EndCursor
 			if want, have := wantHasNextPage, endCursor != nil; have != want {
 				t.Fatalf("unexpected endCursor existence. want=%t, have=%t", want, have)
 			}
@@ -158,7 +158,7 @@ func TestCampaignConnectionResolver(t *testing.T) {
 
 const queryCampaignsConnection = `
 query($first: Int, $after: String) {
-  campaigns(first: $first, after: $after) {
+  batchChanges(first: $first, after: $after) {
     totalCount
     pageInfo {
 	  hasNextPage
@@ -171,7 +171,7 @@ query($first: Int, $after: String) {
 }
 `
 
-func TestCampaignsListing(t *testing.T) {
+func TestBatchChangesListing(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -212,7 +212,7 @@ func TestCampaignsListing(t *testing.T) {
 		}
 	}
 
-	t.Run("listing a users campaigns", func(t *testing.T) {
+	t.Run("listing a users batch changes", func(t *testing.T) {
 		spec := &campaigns.CampaignSpec{}
 		createCampaignSpec(t, spec)
 
@@ -232,10 +232,10 @@ func TestCampaignsListing(t *testing.T) {
 
 		want := apitest.User{
 			ID: userAPIID,
-			Campaigns: apitest.CampaignConnection{
+			Campaigns: apitest.BatchChangeConnection{
 				TotalCount: 1,
-				Nodes: []apitest.Campaign{
-					{ID: string(marshalCampaignID(campaign.ID))},
+				Nodes: []apitest.BatchChange{
+					{ID: string(marshalBatchChangeID(campaign.ID))},
 				},
 			},
 		}
@@ -265,10 +265,10 @@ func TestCampaignsListing(t *testing.T) {
 
 		want := apitest.Org{
 			ID: orgAPIID,
-			Campaigns: apitest.CampaignConnection{
+			Campaigns: apitest.BatchChangeConnection{
 				TotalCount: 1,
-				Nodes: []apitest.Campaign{
-					{ID: string(marshalCampaignID(campaign.ID))},
+				Nodes: []apitest.BatchChange{
+					{ID: string(marshalBatchChangeID(campaign.ID))},
 				},
 			},
 		}

--- a/enterprise/internal/campaigns/resolvers/batch_change_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_change_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
-func TestCampaignResolver(t *testing.T) {
+func TestBatchChangeResolver(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -62,10 +62,10 @@ func TestCampaignResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	campaignAPIID := string(marshalCampaignID(campaign.ID))
+	campaignAPIID := string(marshalBatchChangeID(campaign.ID))
 	namespaceAPIID := string(graphqlbackend.MarshalOrgID(orgID))
 	apiUser := &apitest.User{DatabaseID: userID, SiteAdmin: true}
-	wantCampaign := apitest.Campaign{
+	wantCampaign := apitest.BatchChange{
 		ID:             campaignAPIID,
 		Name:           campaign.Name,
 		Description:    campaign.Description,
@@ -81,27 +81,27 @@ func TestCampaignResolver(t *testing.T) {
 		ClosedAt: "",
 	}
 
-	input := map[string]interface{}{"campaign": campaignAPIID}
+	input := map[string]interface{}{"batchChange": campaignAPIID}
 	{
-		var response struct{ Node apitest.Campaign }
-		apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
+		var response struct{ Node apitest.BatchChange }
+		apitest.MustExec(ctx, t, s, input, &response, queryBatchChange)
 
 		if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
-			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+			t.Fatalf("wrong batch change response (-want +got):\n%s", diff)
 		}
 	}
 	// Test resolver by namespace and name
 	byNameInput := map[string]interface{}{"name": campaign.Name, "namespace": namespaceAPIID}
 	{
-		var response struct{ Campaign apitest.Campaign }
-		apitest.MustExec(ctx, t, s, byNameInput, &response, queryCampaignByName)
+		var response struct{ BatchChange apitest.BatchChange }
+		apitest.MustExec(ctx, t, s, byNameInput, &response, queryBatchChangeByName)
 
-		if diff := cmp.Diff(wantCampaign, response.Campaign); diff != "" {
-			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+		if diff := cmp.Diff(wantCampaign, response.BatchChange); diff != "" {
+			t.Fatalf("wrong batch change response (-want +got):\n%s", diff)
 		}
 	}
 
-	// Now soft-delete the user and check we can still access the campaign in the org namespace.
+	// Now soft-delete the user and check we can still access the batch change in the org namespace.
 	err = database.UsersWith(cstore).Delete(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
@@ -112,36 +112,36 @@ func TestCampaignResolver(t *testing.T) {
 	wantCampaign.SpecCreator = nil
 
 	{
-		var response struct{ Node apitest.Campaign }
-		apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
+		var response struct{ Node apitest.BatchChange }
+		apitest.MustExec(ctx, t, s, input, &response, queryBatchChange)
 
 		if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
-			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+			t.Fatalf("wrong batch change response (-want +got):\n%s", diff)
 		}
 	}
 
-	// Now hard-delete the user and check we can still access the campaign in the org namespace.
+	// Now hard-delete the user and check we can still access the batch change in the org namespace.
 	err = database.UsersWith(cstore).HardDelete(ctx, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	{
-		var response struct{ Node apitest.Campaign }
-		apitest.MustExec(ctx, t, s, input, &response, queryCampaign)
+		var response struct{ Node apitest.BatchChange }
+		apitest.MustExec(ctx, t, s, input, &response, queryBatchChange)
 
 		if diff := cmp.Diff(wantCampaign, response.Node); diff != "" {
-			t.Fatalf("wrong campaign response (-want +got):\n%s", diff)
+			t.Fatalf("wrong batch change response (-want +got):\n%s", diff)
 		}
 	}
 }
 
-const queryCampaign = `
+const queryBatchChange = `
 fragment u on User { databaseID, siteAdmin }
 fragment o on Org  { id, name }
 
-query($campaign: ID!){
-  node(id: $campaign) {
-    ... on Campaign {
+query($batchChange: ID!){
+  node(id: $batchChange) {
+    ... on BatchChange {
       id, name, description
       initialApplier { ...u }
       lastApplier    { ...u }
@@ -159,12 +159,12 @@ query($campaign: ID!){
   }
 }
 `
-const queryCampaignByName = `
+const queryBatchChangeByName = `
 fragment u on User { databaseID, siteAdmin }
 fragment o on Org  { id, name }
 
 query($namespace: ID!, $name: String!){
-  campaign(namespace: $namespace, name: $name) {
+  batchChange(namespace: $namespace, name: $name) {
     id, name, description
     initialApplier { ...u }
     lastApplier    { ...u }

--- a/enterprise/internal/campaigns/resolvers/batch_change_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_change_test.go
@@ -36,7 +36,7 @@ func TestBatchChangeResolver(t *testing.T) {
 	cstore := store.NewWithClock(db, clock)
 
 	campaignSpec := &campaigns.CampaignSpec{
-		RawSpec:        ct.TestRawCampaignSpec,
+		RawSpec:        ct.TestRawBatchSpec,
 		UserID:         userID,
 		NamespaceOrgID: orgID,
 	}

--- a/enterprise/internal/campaigns/resolvers/batch_spec.go
+++ b/enterprise/internal/campaigns/resolvers/batch_spec.go
@@ -287,7 +287,20 @@ func (r *batchSpecResolver) SupersedingBatchSpec(ctx context.Context) (graphqlba
 	return resolver, nil
 }
 
+// TODO(campaigns-deprecation): Remove when campaigns are fully removed
 func (r *batchSpecResolver) ViewerCampaignsCodeHosts(ctx context.Context, args *graphqlbackend.ListViewerCampaignsCodeHostsArgs) (graphqlbackend.CampaignsCodeHostConnectionResolver, error) {
+	res, err := r.ViewerBatchChangesCodeHosts(ctx, &graphqlbackend.ListViewerBatchChangesCodeHostsArgs{
+		First:                 args.First,
+		After:                 args.After,
+		OnlyWithoutCredential: args.OnlyWithoutCredential,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &campaignsCodeHostConnectionResolver{BatchChangesCodeHostConnectionResolver: res}, nil
+}
+
+func (r *batchSpecResolver) ViewerBatchChangesCodeHosts(ctx context.Context, args *graphqlbackend.ListViewerBatchChangesCodeHostsArgs) (graphqlbackend.BatchChangesCodeHostConnectionResolver, error) {
 	actor := actor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return nil, backend.ErrNotAuthenticated
@@ -297,7 +310,7 @@ func (r *batchSpecResolver) ViewerCampaignsCodeHosts(ctx context.Context, args *
 	if args.OnlyWithoutCredential {
 		if authErr := backend.CheckCurrentUserIsSiteAdmin(ctx); authErr == nil {
 			// For site-admins never return anything
-			return &emptyCampaignsCodeHostConnectionResolver{}, nil
+			return &emptyBatchChangesCodeHostConnectionResolver{}, nil
 		} else if authErr != nil && authErr != backend.ErrMustBeSiteAdmin {
 			return nil, authErr
 		}
@@ -316,7 +329,7 @@ func (r *batchSpecResolver) ViewerCampaignsCodeHosts(ctx context.Context, args *
 		}
 	}
 
-	return &campaignsCodeHostConnectionResolver{
+	return &batchChangesCodeHostConnectionResolver{
 		userID:                actor.UID,
 		onlyWithoutCredential: args.OnlyWithoutCredential,
 		store:                 r.store,

--- a/enterprise/internal/campaigns/resolvers/batch_spec.go
+++ b/enterprise/internal/campaigns/resolvers/batch_spec.go
@@ -20,18 +20,18 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
 
-func marshalCampaignSpecRandID(id string) graphql.ID {
-	return relay.MarshalID("CampaignSpec", id)
+func marshalBatchSpecRandID(id string) graphql.ID {
+	return relay.MarshalID("BatchSpec", id)
 }
 
-func unmarshalCampaignSpecID(id graphql.ID) (campaignSpecRandID string, err error) {
+func unmarshalBatchSpecID(id graphql.ID) (campaignSpecRandID string, err error) {
 	err = relay.UnmarshalSpec(id, &campaignSpecRandID)
 	return
 }
 
-var _ graphqlbackend.CampaignSpecResolver = &campaignSpecResolver{}
+var _ graphqlbackend.BatchSpecResolver = &batchSpecResolver{}
 
-type campaignSpecResolver struct {
+type batchSpecResolver struct {
 	store *store.Store
 
 	campaignSpec       *campaigns.CampaignSpec
@@ -41,23 +41,30 @@ type campaignSpecResolver struct {
 	namespaceOnce sync.Once
 	namespace     *graphqlbackend.NamespaceResolver
 	namespaceErr  error
+
+	// TODO(campaigns-deprecation): This should be removed once we remove campaigns completely
+	shouldActAsCampaignSpec bool
 }
 
-func (r *campaignSpecResolver) ID() graphql.ID {
+func (r *batchSpecResolver) ActAsCampaignSpec() bool {
+	return r.shouldActAsCampaignSpec
+}
+
+func (r *batchSpecResolver) ID() graphql.ID {
 	// 🚨 SECURITY: This needs to be the RandID! We can't expose the
 	// sequential, guessable ID.
-	return marshalCampaignSpecRandID(r.campaignSpec.RandID)
+	return marshalBatchSpecRandID(r.campaignSpec.RandID)
 }
 
-func (r *campaignSpecResolver) OriginalInput() (string, error) {
+func (r *batchSpecResolver) OriginalInput() (string, error) {
 	return r.campaignSpec.RawSpec, nil
 }
 
-func (r *campaignSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
+func (r *batchSpecResolver) ParsedInput() (graphqlbackend.JSONValue, error) {
 	return graphqlbackend.JSONValue{Value: r.campaignSpec.Spec}, nil
 }
 
-func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
+func (r *batchSpecResolver) ChangesetSpecs(ctx context.Context, args *graphqlbackend.ChangesetSpecsConnectionArgs) (graphqlbackend.ChangesetSpecConnectionResolver, error) {
 	opts := store.ListChangesetSpecsOpts{}
 	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
@@ -78,7 +85,7 @@ func (r *campaignSpecResolver) ChangesetSpecs(ctx context.Context, args *graphql
 	}, nil
 }
 
-func (r *campaignSpecResolver) ApplyPreview(ctx context.Context, args *graphqlbackend.ChangesetApplyPreviewConnectionArgs) (graphqlbackend.ChangesetApplyPreviewConnectionResolver, error) {
+func (r *batchSpecResolver) ApplyPreview(ctx context.Context, args *graphqlbackend.ChangesetApplyPreviewConnectionArgs) (graphqlbackend.ChangesetApplyPreviewConnectionResolver, error) {
 	if err := validateFirstParamDefaults(args.First); err != nil {
 		return nil, err
 	}
@@ -111,14 +118,14 @@ func (r *campaignSpecResolver) ApplyPreview(ctx context.Context, args *graphqlba
 	}, nil
 }
 
-func (r *campaignSpecResolver) Description() graphqlbackend.CampaignDescriptionResolver {
+func (r *batchSpecResolver) Description() graphqlbackend.CampaignDescriptionResolver {
 	return &campaignDescriptionResolver{
 		name:        r.campaignSpec.Spec.Name,
 		description: r.campaignSpec.Spec.Description,
 	}
 }
 
-func (r *campaignSpecResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+func (r *batchSpecResolver) Creator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
 	user, err := graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.campaignSpec.UserID)
 	if errcode.IsNotFound(err) {
 		return nil, nil
@@ -126,11 +133,11 @@ func (r *campaignSpecResolver) Creator(ctx context.Context) (*graphqlbackend.Use
 	return user, err
 }
 
-func (r *campaignSpecResolver) Namespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
+func (r *batchSpecResolver) Namespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
 	return r.computeNamespace(ctx)
 }
 
-func (r *campaignSpecResolver) computeNamespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
+func (r *batchSpecResolver) computeNamespace(ctx context.Context) (*graphqlbackend.NamespaceResolver, error) {
 	r.namespaceOnce.Do(func() {
 		if r.preloadedNamespace != nil {
 			r.namespace = r.preloadedNamespace
@@ -159,7 +166,7 @@ func (r *campaignSpecResolver) computeNamespace(ctx context.Context) (*graphqlba
 	return r.namespace, r.namespaceErr
 }
 
-func (r *campaignSpecResolver) ApplyURL(ctx context.Context) (string, error) {
+func (r *batchSpecResolver) ApplyURL(ctx context.Context) (string, error) {
 	n, err := r.computeNamespace(ctx)
 	if err != nil {
 		return "", err
@@ -167,15 +174,15 @@ func (r *campaignSpecResolver) ApplyURL(ctx context.Context) (string, error) {
 	return campaignsApplyURL(n, r), nil
 }
 
-func (r *campaignSpecResolver) CreatedAt() graphqlbackend.DateTime {
+func (r *batchSpecResolver) CreatedAt() graphqlbackend.DateTime {
 	return graphqlbackend.DateTime{Time: r.campaignSpec.CreatedAt}
 }
 
-func (r *campaignSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
+func (r *batchSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
 	return &graphqlbackend.DateTime{Time: r.campaignSpec.ExpiresAt()}
 }
 
-func (r *campaignSpecResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
+func (r *batchSpecResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
 	return checkSiteAdminOrSameUser(ctx, r.campaignSpec.UserID)
 }
 
@@ -191,7 +198,7 @@ func (r *campaignDescriptionResolver) Description() string {
 	return r.description
 }
 
-func (r *campaignSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffStat, error) {
+func (r *batchSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.DiffStat, error) {
 	specsConnection := &changesetSpecConnectionResolver{
 		store:          r.store,
 		campaignSpecID: r.campaignSpec.ID,
@@ -223,7 +230,11 @@ func (r *campaignSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.Di
 	return totalStat, nil
 }
 
-func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlbackend.BatchChangeResolver, error) {
+func (r *batchSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlbackend.BatchChangeResolver, error) {
+	return r.AppliesToBatchChange(ctx)
+}
+
+func (r *batchSpecResolver) AppliesToBatchChange(ctx context.Context) (graphqlbackend.BatchChangeResolver, error) {
 	svc := service.New(r.store)
 	batchChange, err := svc.GetCampaignMatchingCampaignSpec(ctx, r.campaignSpec)
 	if err != nil {
@@ -239,7 +250,11 @@ func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlba
 	}, nil
 }
 
-func (r *campaignSpecResolver) SupersedingCampaignSpec(ctx context.Context) (graphqlbackend.CampaignSpecResolver, error) {
+func (r *batchSpecResolver) SupersedingCampaignSpec(ctx context.Context) (graphqlbackend.BatchSpecResolver, error) {
+	return r.SupersedingBatchSpec(ctx)
+}
+
+func (r *batchSpecResolver) SupersedingBatchSpec(ctx context.Context) (graphqlbackend.BatchSpecResolver, error) {
 	namespace, err := r.computeNamespace(ctx)
 	if err != nil {
 		return nil, err
@@ -263,7 +278,7 @@ func (r *campaignSpecResolver) SupersedingCampaignSpec(ctx context.Context) (gra
 	}
 
 	// Create our new resolver, reusing as many fields as we can from this one.
-	resolver := &campaignSpecResolver{
+	resolver := &batchSpecResolver{
 		store:              r.store,
 		campaignSpec:       newest,
 		preloadedNamespace: namespace,
@@ -272,7 +287,7 @@ func (r *campaignSpecResolver) SupersedingCampaignSpec(ctx context.Context) (gra
 	return resolver, nil
 }
 
-func (r *campaignSpecResolver) ViewerCampaignsCodeHosts(ctx context.Context, args *graphqlbackend.ListViewerCampaignsCodeHostsArgs) (graphqlbackend.CampaignsCodeHostConnectionResolver, error) {
+func (r *batchSpecResolver) ViewerCampaignsCodeHosts(ctx context.Context, args *graphqlbackend.ListViewerCampaignsCodeHostsArgs) (graphqlbackend.CampaignsCodeHostConnectionResolver, error) {
 	actor := actor.FromContext(ctx)
 	if !actor.IsAuthenticated() {
 		return nil, backend.ErrNotAuthenticated

--- a/enterprise/internal/campaigns/resolvers/batch_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_spec_test.go
@@ -134,11 +134,11 @@ func TestBatchSpecResolver(t *testing.T) {
 			ID: string(marshalBatchChangeID(matchingCampaign.ID)),
 		},
 
-		AllCodeHosts: apitest.CampaignsCodeHostsConnection{
+		AllCodeHosts: apitest.BatchChangesCodeHostsConnection{
 			TotalCount: 1,
 			Nodes:      []apitest.CampaignsCodeHost{{ExternalServiceKind: extsvc.KindGitHub, ExternalServiceURL: "https://github.com/"}},
 		},
-		OnlyWithoutCredential: apitest.CampaignsCodeHostsConnection{
+		OnlyWithoutCredential: apitest.BatchChangesCodeHostsConnection{
 			TotalCount: 1,
 			Nodes:      []apitest.CampaignsCodeHost{{ExternalServiceKind: extsvc.KindGitHub, ExternalServiceURL: "https://github.com/"}},
 		},
@@ -218,7 +218,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		// Expect creator to not be returned anymore.
 		want.Creator = nil
 		// Expect all set for admin user.
-		want.OnlyWithoutCredential = apitest.CampaignsCodeHostsConnection{
+		want.OnlyWithoutCredential = apitest.BatchChangesCodeHostsConnection{
 			Nodes: []apitest.CampaignsCodeHost{},
 		}
 		// Expect no superseding campaign spec, since this request is run as a
@@ -242,7 +242,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		// Expect creator to not be returned anymore.
 		want.Creator = nil
 		// Expect all set for admin user.
-		want.OnlyWithoutCredential = apitest.CampaignsCodeHostsConnection{
+		want.OnlyWithoutCredential = apitest.BatchChangesCodeHostsConnection{
 			Nodes: []apitest.CampaignsCodeHost{},
 		}
 
@@ -282,7 +282,7 @@ query($batchSpec: ID!) {
 	  appliesToBatchChange { id }
 	  supersedingBatchSpec { id }
 
-	  allCodeHosts: viewerCampaignsCodeHosts {
+	  allCodeHosts: viewerBatchChangesCodeHosts {
 		totalCount
 		  nodes {
 			  externalServiceKind
@@ -290,7 +290,7 @@ query($batchSpec: ID!) {
 		  }
 	  }
 
-	  onlyWithoutCredential: viewerCampaignsCodeHosts(onlyWithoutCredential: true) {
+	  onlyWithoutCredential: viewerBatchChangesCodeHosts(onlyWithoutCredential: true) {
 		  totalCount
 		  nodes {
 			  externalServiceKind

--- a/enterprise/internal/campaigns/resolvers/batch_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_spec_test.go
@@ -136,11 +136,11 @@ func TestBatchSpecResolver(t *testing.T) {
 
 		AllCodeHosts: apitest.BatchChangesCodeHostsConnection{
 			TotalCount: 1,
-			Nodes:      []apitest.CampaignsCodeHost{{ExternalServiceKind: extsvc.KindGitHub, ExternalServiceURL: "https://github.com/"}},
+			Nodes:      []apitest.BatchChangesCodeHost{{ExternalServiceKind: extsvc.KindGitHub, ExternalServiceURL: "https://github.com/"}},
 		},
 		OnlyWithoutCredential: apitest.BatchChangesCodeHostsConnection{
 			TotalCount: 1,
-			Nodes:      []apitest.CampaignsCodeHost{{ExternalServiceKind: extsvc.KindGitHub, ExternalServiceURL: "https://github.com/"}},
+			Nodes:      []apitest.BatchChangesCodeHost{{ExternalServiceKind: extsvc.KindGitHub, ExternalServiceURL: "https://github.com/"}},
 		},
 	}
 
@@ -219,7 +219,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		want.Creator = nil
 		// Expect all set for admin user.
 		want.OnlyWithoutCredential = apitest.BatchChangesCodeHostsConnection{
-			Nodes: []apitest.CampaignsCodeHost{},
+			Nodes: []apitest.BatchChangesCodeHost{},
 		}
 		// Expect no superseding campaign spec, since this request is run as a
 		// different user.
@@ -243,7 +243,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		want.Creator = nil
 		// Expect all set for admin user.
 		want.OnlyWithoutCredential = apitest.BatchChangesCodeHostsConnection{
-			Nodes: []apitest.CampaignsCodeHost{},
+			Nodes: []apitest.BatchChangesCodeHost{},
 		}
 
 		if diff := cmp.Diff(want, response.Node); diff != "" {

--- a/enterprise/internal/campaigns/resolvers/batch_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_spec_test.go
@@ -223,7 +223,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		}
 		// Expect no superseding campaign spec, since this request is run as a
 		// different user.
-		want.SupersedingCampaignSpec = nil
+		want.SupersedingBatchSpec = nil
 
 		if diff := cmp.Diff(want, response.Node); diff != "" {
 			t.Fatalf("unexpected response (-want +got):\n%s", diff)

--- a/enterprise/internal/campaigns/resolvers/batch_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/batch_spec_test.go
@@ -44,7 +44,7 @@ func TestBatchSpecResolver(t *testing.T) {
 	adminID := ct.CreateTestUser(t, db, true).ID
 	orgID := ct.InsertTestOrg(t, db, orgname)
 
-	spec, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawCampaignSpec)
+	spec, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawBatchSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,7 +156,7 @@ func TestBatchSpecResolver(t *testing.T) {
 
 	// Now create an updated changeset spec and check that we get a superseding
 	// campaign spec.
-	sup, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawCampaignSpec)
+	sup, err := campaigns.NewCampaignSpecFromRaw(ct.TestRawBatchSpec)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/campaigns/resolvers/campaign_connection.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection.go
@@ -24,14 +24,14 @@ type campaignsConnectionResolver struct {
 	err       error
 }
 
-func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.CampaignResolver, error) {
+func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.BatchChangeResolver, error) {
 	nodes, _, err := r.compute(ctx)
 	if err != nil {
 		return nil, err
 	}
-	resolvers := make([]graphqlbackend.CampaignResolver, 0, len(nodes))
+	resolvers := make([]graphqlbackend.BatchChangeResolver, 0, len(nodes))
 	for _, c := range nodes {
-		resolvers = append(resolvers, &campaignResolver{store: r.store, Campaign: c})
+		resolvers = append(resolvers, &batchChangeResolver{store: r.store, Campaign: c})
 	}
 	return resolvers, nil
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_connection.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_connection.go
@@ -31,7 +31,7 @@ func (r *campaignsConnectionResolver) Nodes(ctx context.Context) ([]graphqlbacke
 	}
 	resolvers := make([]graphqlbackend.BatchChangeResolver, 0, len(nodes))
 	for _, c := range nodes {
-		resolvers = append(resolvers, &batchChangeResolver{store: r.store, Campaign: c})
+		resolvers = append(resolvers, &batchChangeResolver{store: r.store, batchChange: c})
 	}
 	return resolvers, nil
 }

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -223,7 +223,7 @@ func (r *campaignSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.Di
 	return totalStat, nil
 }
 
-func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlbackend.CampaignResolver, error) {
+func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlbackend.BatchChangeResolver, error) {
 	svc := service.New(r.store)
 	campaign, err := svc.GetCampaignMatchingCampaignSpec(ctx, r.campaignSpec)
 	if err != nil {
@@ -233,7 +233,7 @@ func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlba
 		return nil, nil
 	}
 
-	return &campaignResolver{
+	return &batchChangeResolver{
 		store:    r.store,
 		Campaign: campaign,
 	}, nil

--- a/enterprise/internal/campaigns/resolvers/campaign_spec.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec.go
@@ -225,17 +225,17 @@ func (r *campaignSpecResolver) DiffStat(ctx context.Context) (*graphqlbackend.Di
 
 func (r *campaignSpecResolver) AppliesToCampaign(ctx context.Context) (graphqlbackend.BatchChangeResolver, error) {
 	svc := service.New(r.store)
-	campaign, err := svc.GetCampaignMatchingCampaignSpec(ctx, r.campaignSpec)
+	batchChange, err := svc.GetCampaignMatchingCampaignSpec(ctx, r.campaignSpec)
 	if err != nil {
 		return nil, err
 	}
-	if campaign == nil {
+	if batchChange == nil {
 		return nil, nil
 	}
 
 	return &batchChangeResolver{
-		store:    r.store,
-		Campaign: campaign,
+		store:       r.store,
+		batchChange: batchChange,
 	}, nil
 }
 

--- a/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
+++ b/enterprise/internal/campaigns/resolvers/campaign_spec_test.go
@@ -130,8 +130,8 @@ func TestCampaignSpecResolver(t *testing.T) {
 			Deleted: changesetSpec.DiffStatDeleted,
 		},
 
-		AppliesToCampaign: apitest.Campaign{
-			ID: string(marshalCampaignID(matchingCampaign.ID)),
+		AppliesToCampaign: apitest.BatchChange{
+			ID: string(marshalBatchChangeID(matchingCampaign.ID)),
 		},
 
 		AllCodeHosts: apitest.CampaignsCodeHostsConnection{

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -162,7 +162,7 @@ func (r *changesetResolver) Repository(ctx context.Context) *graphqlbackend.Repo
 	return r.repoResolver
 }
 
-func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignsArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
+func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListBatchChangesArgs) (graphqlbackend.BatchChangesConnectionResolver, error) {
 	opts := store.ListCampaignsOpts{
 		ChangesetID: r.changeset.ID,
 	}
@@ -196,7 +196,7 @@ func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.
 		}
 	}
 
-	return &campaignsConnectionResolver{store: r.store, opts: opts}, nil
+	return &batchChangesConnectionResolver{store: r.store, opts: opts}, nil
 }
 
 func (r *changesetResolver) CreatedAt() graphqlbackend.DateTime {

--- a/enterprise/internal/campaigns/resolvers/changeset.go
+++ b/enterprise/internal/campaigns/resolvers/changeset.go
@@ -163,6 +163,10 @@ func (r *changesetResolver) Repository(ctx context.Context) *graphqlbackend.Repo
 }
 
 func (r *changesetResolver) Campaigns(ctx context.Context, args *graphqlbackend.ListBatchChangesArgs) (graphqlbackend.BatchChangesConnectionResolver, error) {
+	return r.BatchChanges(ctx, args)
+}
+
+func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbackend.ListBatchChangesArgs) (graphqlbackend.BatchChangesConnectionResolver, error) {
 	opts := store.ListCampaignsOpts{
 		ChangesetID: r.changeset.ID,
 	}

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection_test.go
@@ -76,7 +76,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	apiID := string(marshalCampaignSpecRandID(campaignSpec.RandID))
+	apiID := string(marshalBatchSpecRandID(campaignSpec.RandID))
 
 	tests := []struct {
 		first int
@@ -90,8 +90,8 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		input := map[string]interface{}{"campaignSpec": apiID, "first": tc.first}
-		var response struct{ Node apitest.CampaignSpec }
+		input := map[string]interface{}{"batchSpec": apiID, "first": tc.first}
+		var response struct{ Node apitest.BatchSpec }
 		apitest.MustExec(ctx, t, s, input, &response, queryChangesetApplyPreviewConnection)
 
 		specs := response.Node.ApplyPreview
@@ -106,13 +106,13 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range changesetSpecs {
-		input := map[string]interface{}{"campaignSpec": apiID, "first": 1}
+		input := map[string]interface{}{"batchSpec": apiID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}
 		wantHasNextPage := i != len(changesetSpecs)-1
 
-		var response struct{ Node apitest.CampaignSpec }
+		var response struct{ Node apitest.BatchSpec }
 		apitest.MustExec(ctx, t, s, input, &response, queryChangesetApplyPreviewConnection)
 
 		specs := response.Node.ApplyPreview
@@ -136,11 +136,11 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 }
 
 const queryChangesetApplyPreviewConnection = `
-query($campaignSpec: ID!, $first: Int!, $after: String) {
-  node(id: $campaignSpec) {
+query($batchSpec: ID!, $first: Int!, $after: String) {
+  node(id: $batchSpec) {
     __typename
 
-    ... on CampaignSpec {
+    ... on BatchSpec {
       id
 
       applyPreview(first: $first, after: $after) {

--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_test.go
@@ -102,10 +102,10 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	apiID := string(marshalCampaignSpecRandID(campaignSpec.RandID))
+	apiID := string(marshalBatchSpecRandID(campaignSpec.RandID))
 
-	input := map[string]interface{}{"campaignSpec": apiID}
-	var response struct{ Node apitest.CampaignSpec }
+	input := map[string]interface{}{"batchSpec": apiID}
+	var response struct{ Node apitest.BatchSpec }
 	apitest.MustExec(ctx, t, s, input, &response, queryChangesetApplyPreview)
 
 	haveApplyPreview := response.Node.ApplyPreview.Nodes
@@ -144,10 +144,10 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 }
 
 const queryChangesetApplyPreview = `
-query ($campaignSpec: ID!) {
-    node(id: $campaignSpec) {
+query ($batchSpec: ID!) {
+    node(id: $batchSpec) {
       __typename
-      ... on CampaignSpec {
+      ... on BatchSpec {
         id
         applyPreview {
           totalCount

--- a/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection_test.go
@@ -114,7 +114,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	campaignAPIID := string(marshalCampaignID(campaign.ID))
+	campaignAPIID := string(marshalBatchChangeID(campaign.ID))
 	nodes := []apitest.Changeset{
 		{
 			Typename:   "ExternalChangeset",
@@ -158,11 +158,11 @@ func TestChangesetConnectionResolver(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("Unsafe opts %t, first %d", tc.useUnsafeOpts, tc.firstParam), func(t *testing.T) {
-			input := map[string]interface{}{"campaign": campaignAPIID, "first": int64(tc.firstParam)}
+			input := map[string]interface{}{"batchChange": campaignAPIID, "first": int64(tc.firstParam)}
 			if tc.useUnsafeOpts {
 				input["reviewState"] = campaigns.ChangesetReviewStatePending
 			}
-			var response struct{ Node apitest.Campaign }
+			var response struct{ Node apitest.BatchChange }
 			apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryChangesetConnection)
 
 			var wantEndCursor *string
@@ -187,13 +187,13 @@ func TestChangesetConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range nodes {
-		input := map[string]interface{}{"campaign": campaignAPIID, "first": 1}
+		input := map[string]interface{}{"batchChange": campaignAPIID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}
 		wantHasNextPage := i != len(nodes)-1
 
-		var response struct{ Node apitest.Campaign }
+		var response struct{ Node apitest.BatchChange }
 		apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryChangesetConnection)
 
 		changesets := response.Node.Changesets
@@ -217,9 +217,9 @@ func TestChangesetConnectionResolver(t *testing.T) {
 }
 
 const queryChangesetConnection = `
-query($campaign: ID!, $first: Int, $after: String, $reviewState: ChangesetReviewState){
-  node(id: $campaign) {
-    ... on Campaign {
+query($batchChange: ID!, $first: Int, $after: String, $reviewState: ChangesetReviewState){
+  node(id: $batchChange) {
+    ... on BatchChange {
       changesets(first: $first, after: $after, reviewState: $reviewState) {
         totalCount
         nodes {

--- a/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_counts_test.go
@@ -186,12 +186,12 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	}
 
 	input := map[string]interface{}{
-		"campaign": string(marshalCampaignID(campaign.ID)),
-		"from":     start,
-		"to":       end,
+		"batchChange": string(marshalBatchChangeID(campaign.ID)),
+		"from":        start,
+		"to":          end,
 	}
 
-	var response struct{ Node apitest.Campaign }
+	var response struct{ Node apitest.BatchChange }
 
 	apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryChangesetCountsConnection)
 
@@ -210,9 +210,9 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 }
 
 const queryChangesetCountsConnection = `
-query($campaign: ID!, $from: DateTime!, $to: DateTime!) {
-  node(id: $campaign) {
-    ... on Campaign {
+query($batchChange: ID!, $from: DateTime!, $to: DateTime!) {
+  node(id: $batchChange) {
+    ... on BatchChange {
 	  changesetCountsOverTime(from: $from, to: $to) {
         date
         total

--- a/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_spec_connection_test.go
@@ -74,7 +74,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	apiID := string(marshalCampaignSpecRandID(campaignSpec.RandID))
+	apiID := string(marshalBatchSpecRandID(campaignSpec.RandID))
 
 	tests := []struct {
 		first int
@@ -88,8 +88,8 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		input := map[string]interface{}{"campaignSpec": apiID, "first": tc.first}
-		var response struct{ Node apitest.CampaignSpec }
+		input := map[string]interface{}{"batchSpec": apiID, "first": tc.first}
+		var response struct{ Node apitest.BatchSpec }
 		apitest.MustExec(ctx, t, s, input, &response, queryChangesetSpecConnection)
 
 		specs := response.Node.ChangesetSpecs
@@ -104,13 +104,13 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 
 	var endCursor *string
 	for i := range changesetSpecs {
-		input := map[string]interface{}{"campaignSpec": apiID, "first": 1}
+		input := map[string]interface{}{"batchSpec": apiID, "first": 1}
 		if endCursor != nil {
 			input["after"] = *endCursor
 		}
 		wantHasNextPage := i != len(changesetSpecs)-1
 
-		var response struct{ Node apitest.CampaignSpec }
+		var response struct{ Node apitest.BatchSpec }
 		apitest.MustExec(ctx, t, s, input, &response, queryChangesetSpecConnection)
 
 		specs := response.Node.ChangesetSpecs
@@ -134,11 +134,11 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 }
 
 const queryChangesetSpecConnection = `
-query($campaignSpec: ID!, $first: Int!, $after: String) {
-  node(id: $campaignSpec) {
+query($batchSpec: ID!, $first: Int!, $after: String) {
+  node(id: $batchSpec) {
     __typename
 
-    ... on CampaignSpec {
+    ... on BatchSpec {
       id
 
       changesetSpecs(first: $first, after: $after) {

--- a/enterprise/internal/campaigns/resolvers/code_host.go
+++ b/enterprise/internal/campaigns/resolvers/code_host.go
@@ -7,28 +7,52 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
-type campaignsCodeHostResolver struct {
+type batchChangesCodeHostResolver struct {
 	codeHost   *campaigns.CodeHost
 	credential *database.UserCredential
+}
+
+var _ graphqlbackend.BatchChangesCodeHostResolver = &batchChangesCodeHostResolver{}
+
+func (c *batchChangesCodeHostResolver) ExternalServiceKind() string {
+	return extsvc.TypeToKind(c.codeHost.ExternalServiceType)
+}
+
+func (c *batchChangesCodeHostResolver) ExternalServiceURL() string {
+	return c.codeHost.ExternalServiceID
+}
+
+func (c *batchChangesCodeHostResolver) Credential() graphqlbackend.BatchChangesCredentialResolver {
+	if c.credential != nil {
+		return &batchChangesCredentialResolver{credential: c.credential}
+	}
+	return nil
+}
+
+func (c *batchChangesCodeHostResolver) RequiresSSH() bool {
+	return c.codeHost.RequiresSSH
+}
+
+// TODO(campaigns-deprecation): Remove this wrapper type. It just exists to fulfil the interface
+// of graphqlbackend.CampaignsCodeHostConnectionResolver.
+type campaignsCodeHostResolver struct {
+	graphqlbackend.BatchChangesCodeHostResolver
 }
 
 var _ graphqlbackend.CampaignsCodeHostResolver = &campaignsCodeHostResolver{}
 
 func (c *campaignsCodeHostResolver) ExternalServiceKind() string {
-	return extsvc.TypeToKind(c.codeHost.ExternalServiceType)
+	return c.BatchChangesCodeHostResolver.ExternalServiceKind()
 }
 
 func (c *campaignsCodeHostResolver) ExternalServiceURL() string {
-	return c.codeHost.ExternalServiceID
+	return c.BatchChangesCodeHostResolver.ExternalServiceURL()
 }
 
 func (c *campaignsCodeHostResolver) Credential() graphqlbackend.CampaignsCredentialResolver {
-	if c.credential != nil {
-		return &campaignsCredentialResolver{credential: c.credential}
-	}
-	return nil
+	return c.BatchChangesCodeHostResolver.Credential()
 }
 
 func (c *campaignsCodeHostResolver) RequiresSSH() bool {
-	return c.codeHost.RequiresSSH
+	return c.BatchChangesCodeHostResolver.RequiresSSH()
 }

--- a/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
@@ -57,7 +57,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 	}
 
 	userAPIID := string(graphqlbackend.MarshalUserID(userID))
-	nodes := []apitest.CampaignsCodeHost{
+	nodes := []apitest.BatchChangesCodeHost{
 		{
 			ExternalServiceURL:  bbsRepo.ExternalRepo.ServiceID,
 			ExternalServiceKind: extsvc.TypeToKind(bbsRepo.ExternalRepo.ServiceType),
@@ -65,7 +65,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 		{
 			ExternalServiceURL:  ghRepo.ExternalRepo.ServiceID,
 			ExternalServiceKind: extsvc.TypeToKind(ghRepo.ExternalRepo.ServiceType),
-			Credential: apitest.CampaignsCredential{
+			Credential: apitest.BatchChangesCredential{
 				ID:                  string(marshalBatchChangesCredentialID(cred.ID)),
 				ExternalServiceKind: extsvc.TypeToKind(cred.ExternalServiceType),
 				ExternalServiceURL:  cred.ExternalServiceID,
@@ -83,7 +83,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 		wantHasNextPage bool
 		wantEndCursor   string
 		wantTotalCount  int
-		wantNodes       []apitest.CampaignsCodeHost
+		wantNodes       []apitest.BatchChangesCodeHost
 	}{
 		{firstParam: 1, wantHasNextPage: true, wantEndCursor: "1", wantTotalCount: 3, wantNodes: nodes[:1]},
 		{firstParam: 2, wantHasNextPage: true, wantEndCursor: "2", wantTotalCount: 3, wantNodes: nodes[:2]},

--- a/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/campaigns/resolvers/code_host_connection_test.go
@@ -66,7 +66,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 			ExternalServiceURL:  ghRepo.ExternalRepo.ServiceID,
 			ExternalServiceKind: extsvc.TypeToKind(ghRepo.ExternalRepo.ServiceType),
 			Credential: apitest.CampaignsCredential{
-				ID:                  string(marshalCampaignsCredentialID(cred.ID)),
+				ID:                  string(marshalBatchChangesCredentialID(cred.ID)),
 				ExternalServiceKind: extsvc.TypeToKind(cred.ExternalServiceType),
 				ExternalServiceURL:  cred.ExternalServiceID,
 				CreatedAt:           cred.CreatedAt.Format(time.RFC3339),
@@ -101,7 +101,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 				wantEndCursor = &tc.wantEndCursor
 			}
 
-			wantChangesets := apitest.CampaignsCodeHostsConnection{
+			wantChangesets := apitest.BatchChangesCodeHostsConnection{
 				TotalCount: tc.wantTotalCount,
 				PageInfo: apitest.PageInfo{
 					EndCursor:   wantEndCursor,
@@ -110,7 +110,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 				Nodes: tc.wantNodes,
 			}
 
-			if diff := cmp.Diff(wantChangesets, response.Node.CampaignsCodeHosts); diff != "" {
+			if diff := cmp.Diff(wantChangesets, response.Node.BatchChangesCodeHosts); diff != "" {
 				t.Fatalf("wrong changesets response (-want +got):\n%s", diff)
 			}
 		})
@@ -127,7 +127,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 		var response struct{ Node apitest.User }
 		apitest.MustExec(actor.WithActor(context.Background(), actor.FromUser(userID)), t, s, input, &response, queryCodeHostConnection)
 
-		hosts := response.Node.CampaignsCodeHosts
+		hosts := response.Node.BatchChangesCodeHosts
 		if diff := cmp.Diff(1, len(hosts.Nodes)); diff != "" {
 			t.Fatalf("unexpected number of nodes (-want +got):\n%s", diff)
 		}
@@ -151,7 +151,7 @@ const queryCodeHostConnection = `
 query($user: ID!, $first: Int, $after: String){
   node(id: $user) {
     ... on User {
-      campaignsCodeHosts(first: $first, after: $after) {
+      batchChangesCodeHosts(first: $first, after: $after) {
         totalCount
         nodes {
 		  externalServiceKind

--- a/enterprise/internal/campaigns/resolvers/credential.go
+++ b/enterprise/internal/campaigns/resolvers/credential.go
@@ -10,37 +10,37 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
 
-const campaignsCredentialIDKind = "CampaignsCredential"
+const batchChangesCredentialIDKind = "BatchChangesCredential"
 
-func marshalCampaignsCredentialID(id int64) graphql.ID {
-	return relay.MarshalID(campaignsCredentialIDKind, id)
+func marshalBatchChangesCredentialID(id int64) graphql.ID {
+	return relay.MarshalID(batchChangesCredentialIDKind, id)
 }
 
-func unmarshalCampaignsCredentialID(id graphql.ID) (cid int64, err error) {
+func unmarshalBatchChangesCredentialID(id graphql.ID) (cid int64, err error) {
 	err = relay.UnmarshalSpec(id, &cid)
 	return
 }
 
-type campaignsCredentialResolver struct {
+type batchChangesCredentialResolver struct {
 	credential *database.UserCredential
 }
 
-var _ graphqlbackend.CampaignsCredentialResolver = &campaignsCredentialResolver{}
+var _ graphqlbackend.BatchChangesCredentialResolver = &batchChangesCredentialResolver{}
 
-func (c *campaignsCredentialResolver) ID() graphql.ID {
-	return marshalCampaignsCredentialID(c.credential.ID)
+func (c *batchChangesCredentialResolver) ID() graphql.ID {
+	return marshalBatchChangesCredentialID(c.credential.ID)
 }
 
-func (c *campaignsCredentialResolver) ExternalServiceKind() string {
+func (c *batchChangesCredentialResolver) ExternalServiceKind() string {
 	return extsvc.TypeToKind(c.credential.ExternalServiceType)
 }
 
-func (c *campaignsCredentialResolver) ExternalServiceURL() string {
+func (c *batchChangesCredentialResolver) ExternalServiceURL() string {
 	// This is usually the code host URL.
 	return c.credential.ExternalServiceID
 }
 
-func (c *campaignsCredentialResolver) SSHPublicKey() *string {
+func (c *batchChangesCredentialResolver) SSHPublicKey() *string {
 	if a, ok := c.credential.Credential.(auth.AuthenticatorWithSSH); ok {
 		publicKey := a.SSHPublicKey()
 		return &publicKey
@@ -48,6 +48,6 @@ func (c *campaignsCredentialResolver) SSHPublicKey() *string {
 	return nil
 }
 
-func (c *campaignsCredentialResolver) CreatedAt() graphqlbackend.DateTime {
+func (c *batchChangesCredentialResolver) CreatedAt() graphqlbackend.DateTime {
 	return graphqlbackend.DateTime{Time: c.credential.CreatedAt}
 }

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -137,7 +137,7 @@ func TestPermissionLevels(t *testing.T) {
 		userCampaignSpec, userCampaignSpecID := createCampaignSpec(t, cstore, userID)
 		userCampaign := createCampaign(t, cstore, "user", userID, userCampaignSpecID)
 
-		t.Run("CampaignByID", func(t *testing.T) {
+		t.Run("BatchChangeByID", func(t *testing.T) {
 			tests := []struct {
 				name                    string
 				currentUser             int32

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -496,7 +496,7 @@ func TestPermissionLevels(t *testing.T) {
 					node(id: %q) {
 						id
 						... on ExternalChangeset {
-							campaigns(viewerCanAdminister: %t) { totalCount, nodes { id } }
+							batchChanges(viewerCanAdminister: %t) { totalCount, nodes { id } }
 						}
 					}
 					}`, tc.viewerCanAdminister, marshalChangesetID(changeset.ID), tc.viewerCanAdminister)
@@ -505,7 +505,7 @@ func TestPermissionLevels(t *testing.T) {
 						Node         apitest.Changeset
 					}
 					apitest.MustExec(actorCtx, t, s, nil, &res, query)
-					for _, conn := range []apitest.BatchChangeConnection{res.BatchChanges, res.Node.Campaigns} {
+					for _, conn := range []apitest.BatchChangeConnection{res.BatchChanges, res.Node.BatchChanges} {
 						if have, want := conn.TotalCount, len(tc.wantCampaigns); have != want {
 							t.Fatalf("wrong count of campaigns returned, want=%d have=%d", want, have)
 						}
@@ -1088,7 +1088,7 @@ func testChangesetResponse(t *testing.T, s *graphql.Schema, ctx context.Context,
 		t.Fatalf("changeset has wrong state. want=%q, have=%q", want, have)
 	}
 
-	if have, want := res.Node.Campaigns.TotalCount, 1; have != want {
+	if have, want := res.Node.BatchChanges.TotalCount, 1; have != want {
 		t.Fatalf("changeset has wrong campaigns totalcount. want=%d, have=%d", want, have)
 	}
 
@@ -1117,7 +1117,7 @@ query {
 	  createdAt
 	  updatedAt
 	  nextSyncAt
-	  campaigns {
+	  batchChanges {
 	    totalCount
 	  }
     }
@@ -1128,7 +1128,7 @@ query {
 	  createdAt
 	  updatedAt
 	  nextSyncAt
-	  campaigns {
+	  batchChanges {
 	    totalCount
 	  }
 

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -348,21 +348,21 @@ func TestPermissionLevels(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					graphqlID := string(marshalCampaignsCredentialID(cred.ID))
+					graphqlID := string(marshalBatchChangesCredentialID(cred.ID))
 
 					var res struct{ Node apitest.CampaignsCredential }
 
 					input := map[string]interface{}{"id": graphqlID}
 					queryCodeHosts := `
 				  query($id: ID!) {
-				    node(id: $id) { ... on CampaignsCredential { id } }
+				    node(id: $id) { ... on BatchChangesCredential { id } }
 				  }
                 `
 
 					actorCtx := actor.WithActor(ctx, actor.FromUser(tc.currentUser))
 					errors := apitest.Exec(actorCtx, t, s, input, &res, queryCodeHosts)
 					if !tc.wantErr && len(errors) != 0 {
-						t.Fatal("got error but didn't expect one")
+						t.Fatalf("got error but didn't expect one: %v", errors)
 					} else if tc.wantErr && len(errors) == 0 {
 						t.Fatal("expected error but got none")
 					}
@@ -375,7 +375,7 @@ func TestPermissionLevels(t *testing.T) {
 			}
 		})
 
-		t.Run("DeleteCampaignsCredential", func(t *testing.T) {
+		t.Run("DeleteBatchChangesCredential", func(t *testing.T) {
 			tests := []struct {
 				name        string
 				currentUser int32
@@ -419,16 +419,16 @@ func TestPermissionLevels(t *testing.T) {
 					var res struct{ Node apitest.CampaignsCredential }
 
 					input := map[string]interface{}{
-						"campaignsCredential": marshalCampaignsCredentialID(cred.ID),
+						"batchChangesCredential": marshalBatchChangesCredentialID(cred.ID),
 					}
-					mutationDeleteCampaignsCredential := `
-					mutation($campaignsCredential: ID!) {
-						deleteCampaignsCredential(campaignsCredential: $campaignsCredential) { alwaysNil }
+					mutationDeleteBatchChangesCredential := `
+					mutation($batchChangesCredential: ID!) {
+						deleteBatchChangesCredential(batchChangesCredential: $batchChangesCredential) { alwaysNil }
 					}
                 `
 
 					actorCtx := actor.WithActor(ctx, actor.FromUser(tc.currentUser))
-					errors := apitest.Exec(actorCtx, t, s, input, &res, mutationDeleteCampaignsCredential)
+					errors := apitest.Exec(actorCtx, t, s, input, &res, mutationDeleteBatchChangesCredential)
 					if tc.wantAuthErr {
 						if len(errors) != 1 {
 							t.Fatalf("expected 1 error, but got %d: %s", len(errors), errors)

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -920,7 +920,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		testCampaignResponse(t, s, userCtx, input, wantCheckStateResponse)
 
 		input = map[string]interface{}{
-			"batchChange":    string(marshalBatchChangeID(campaign.ID)),
+			"batchChange": string(marshalBatchChangeID(campaign.ID)),
 			"reviewState": string(campaigns.ChangesetReviewStateChangesRequested),
 		}
 		wantReviewStateResponse := wantCheckStateResponse

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -855,7 +855,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		userCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
 		input := map[string]interface{}{
-			"campaign": string(marshalBatchChangeID(campaign.ID)),
+			"batchChange": string(marshalBatchChangeID(campaign.ID)),
 		}
 		testCampaignResponse(t, s, userCtx, input, wantCampaignResponse{
 			changesetTypes:  map[string]int{"ExternalChangeset": 2},
@@ -908,8 +908,8 @@ func TestRepositoryPermissions(t *testing.T) {
 		// should not be returned, since that would leak information about the
 		// hidden changesets.
 		input = map[string]interface{}{
-			"campaign":   string(marshalBatchChangeID(campaign.ID)),
-			"checkState": string(campaigns.ChangesetCheckStatePassed),
+			"batchChange": string(marshalBatchChangeID(campaign.ID)),
+			"checkState":  string(campaigns.ChangesetCheckStatePassed),
 		}
 		wantCheckStateResponse := want
 		wantCheckStateResponse.changesetsCount = 1
@@ -920,7 +920,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		testCampaignResponse(t, s, userCtx, input, wantCheckStateResponse)
 
 		input = map[string]interface{}{
-			"campaign":    string(marshalBatchChangeID(campaign.ID)),
+			"batchChange":    string(marshalBatchChangeID(campaign.ID)),
 			"reviewState": string(campaigns.ChangesetReviewStateChangesRequested),
 		}
 		wantReviewStateResponse := wantCheckStateResponse
@@ -1015,10 +1015,10 @@ func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, 
 	t.Helper()
 
 	var response struct{ Node apitest.BatchChange }
-	apitest.MustExec(ctx, t, s, in, &response, queryCampaignPermLevels)
+	apitest.MustExec(ctx, t, s, in, &response, queryBatchChangePermLevels)
 
-	if have, want := response.Node.ID, in["campaign"]; have != want {
-		t.Fatalf("campaign id is wrong. have %q, want %q", have, want)
+	if have, want := response.Node.ID, in["batchChange"]; have != want {
+		t.Fatalf("batch change id is wrong. have %q, want %q", have, want)
 	}
 
 	if diff := cmp.Diff(w.changesetsCount, response.Node.Changesets.TotalCount); diff != "" {
@@ -1038,13 +1038,13 @@ func testCampaignResponse(t *testing.T, s *graphql.Schema, ctx context.Context, 
 	}
 
 	if diff := cmp.Diff(w.campaignDiffStat, response.Node.DiffStat); diff != "" {
-		t.Fatalf("unexpected campaign diff stat (-want +got):\n%s", diff)
+		t.Fatalf("unexpected batch change diff stat (-want +got):\n%s", diff)
 	}
 }
 
-const queryCampaignPermLevels = `
-query($campaign: ID!, $reviewState: ChangesetReviewState, $checkState: ChangesetCheckState) {
-  node(id: $campaign) {
+const queryBatchChangePermLevels = `
+query($batchChange: ID!, $reviewState: ChangesetReviewState, $checkState: ChangesetCheckState) {
+  node(id: $batchChange) {
     ... on BatchChange {
 	  id
 

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -350,7 +350,9 @@ func TestPermissionLevels(t *testing.T) {
 					}
 					graphqlID := string(marshalBatchChangesCredentialID(cred.ID))
 
-					var res struct{ Node apitest.CampaignsCredential }
+					var res struct {
+						Node apitest.BatchChangesCredential
+					}
 
 					input := map[string]interface{}{"id": graphqlID}
 					queryCodeHosts := `
@@ -416,7 +418,9 @@ func TestPermissionLevels(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					var res struct{ Node apitest.CampaignsCredential }
+					var res struct {
+						Node apitest.BatchChangesCredential
+					}
 
 					input := map[string]interface{}{
 						"batchChangesCredential": marshalBatchChangesCredentialID(cred.ID),

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -559,9 +559,9 @@ func TestPermissionLevels(t *testing.T) {
 				},
 			},
 			{
-				name: "applyCampaign",
+				name: "applyBatchChange",
 				mutationFunc: func(campaignID, changesetID, campaignSpecID string) string {
-					return fmt.Sprintf(`mutation { applyCampaign(campaignSpec: %q) { id } }`, campaignSpecID)
+					return fmt.Sprintf(`mutation { applyBatchChange(batchSpec: %q) { id } }`, campaignSpecID)
 				},
 			},
 			{

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -535,9 +535,9 @@ func TestPermissionLevels(t *testing.T) {
 				},
 			},
 			{
-				name: "closeCampaign",
+				name: "closeBatchChange",
 				mutationFunc: func(campaignID, changesetID, campaignSpecID string) string {
-					return fmt.Sprintf(`mutation { closeCampaign(campaign: %q, closeChangesets: false) { id } }`, campaignID)
+					return fmt.Sprintf(`mutation { closeBatchChange(batchChange: %q, closeChangesets: false) { id } }`, campaignID)
 				},
 			},
 			{

--- a/enterprise/internal/campaigns/resolvers/permissions_test.go
+++ b/enterprise/internal/campaigns/resolvers/permissions_test.go
@@ -196,49 +196,49 @@ func TestPermissionLevels(t *testing.T) {
 			}
 		})
 
-		t.Run("CampaignSpecByID", func(t *testing.T) {
+		t.Run("BatchSpecByID", func(t *testing.T) {
 			tests := []struct {
 				name                    string
 				currentUser             int32
-				campaignSpec            string
+				batchSpec               string
 				wantViewerCanAdminister bool
 			}{
 				{
 					name:                    "site-admin viewing own campaign spec",
 					currentUser:             adminID,
-					campaignSpec:            adminCampaignSpec,
+					batchSpec:               adminCampaignSpec,
 					wantViewerCanAdminister: true,
 				},
 				{
 					name:                    "non-site-admin viewing other's campaign spec",
 					currentUser:             userID,
-					campaignSpec:            adminCampaignSpec,
+					batchSpec:               adminCampaignSpec,
 					wantViewerCanAdminister: false,
 				},
 				{
 					name:                    "site-admin viewing other's campaign spec",
 					currentUser:             adminID,
-					campaignSpec:            userCampaignSpec,
+					batchSpec:               userCampaignSpec,
 					wantViewerCanAdminister: true,
 				},
 				{
 					name:                    "non-site-admin viewing own campaign spec",
 					currentUser:             userID,
-					campaignSpec:            userCampaignSpec,
+					batchSpec:               userCampaignSpec,
 					wantViewerCanAdminister: true,
 				},
 			}
 
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {
-					graphqlID := string(marshalCampaignSpecRandID(tc.campaignSpec))
+					graphqlID := string(marshalBatchSpecRandID(tc.batchSpec))
 
-					var res struct{ Node apitest.CampaignSpec }
+					var res struct{ Node apitest.BatchSpec }
 
-					input := map[string]interface{}{"campaignSpec": graphqlID}
+					input := map[string]interface{}{"batchSpec": graphqlID}
 					queryCampaignSpec := `
-				  query($campaignSpec: ID!) {
-				    node(id: $campaignSpec) { ... on CampaignSpec { id, viewerCanAdminister } }
+				  query($batchSpec: ID!) {
+				    node(id: $batchSpec) { ... on BatchSpec { id, viewerCanAdminister } }
 				  }
                 `
 
@@ -627,7 +627,7 @@ func TestPermissionLevels(t *testing.T) {
 							mutation := m.mutationFunc(
 								string(marshalBatchChangeID(campaignID)),
 								string(marshalChangesetID(changeset.ID)),
-								string(marshalCampaignSpecRandID(campaignSpecRandID)),
+								string(marshalBatchSpecRandID(campaignSpecRandID)),
 							)
 
 							actorCtx := actor.WithActor(ctx, actor.FromUser(tc.currentUser))
@@ -1153,14 +1153,14 @@ func testCampaignSpecResponse(t *testing.T, s *graphql.Schema, ctx context.Conte
 	t.Helper()
 
 	in := map[string]interface{}{
-		"campaignSpec": string(marshalCampaignSpecRandID(campaignSpecRandID)),
+		"batchSpec": string(marshalBatchSpecRandID(campaignSpecRandID)),
 	}
 
-	var response struct{ Node apitest.CampaignSpec }
+	var response struct{ Node apitest.BatchSpec }
 	apitest.MustExec(ctx, t, s, in, &response, queryCampaignSpecPermLevels)
 
-	if have, want := response.Node.ID, in["campaignSpec"]; have != want {
-		t.Fatalf("campaignSpec id is wrong. have %q, want %q", have, want)
+	if have, want := response.Node.ID, in["batchSpec"]; have != want {
+		t.Fatalf("batch spec id is wrong. have %q, want %q", have, want)
 	}
 
 	if diff := cmp.Diff(w.changesetSpecsCount, response.Node.ChangesetSpecs.TotalCount); diff != "" {
@@ -1189,9 +1189,9 @@ func testCampaignSpecResponse(t *testing.T, s *graphql.Schema, ctx context.Conte
 }
 
 const queryCampaignSpecPermLevels = `
-query($campaignSpec: ID!) {
-  node(id: $campaignSpec) {
-    ... on CampaignSpec {
+query($batchSpec: ID!) {
+  node(id: $batchSpec) {
+    ... on BatchSpec {
       id
 
       applyPreview(first: 100) {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -288,7 +288,7 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 // New
 func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.CreateBatchChangeArgs) (graphqlbackend.BatchChangeResolver, error) {
 	var err error
-	tr, _ := trace.New(ctx, "Resolver.CreateCampaign", fmt.Sprintf("CampaignSpec %s", args.BatchSpec))
+	tr, _ := trace.New(ctx, "Resolver.CreateBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -329,8 +329,15 @@ func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.C
 }
 
 func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.ApplyCampaignArgs) (graphqlbackend.BatchChangeResolver, error) {
+	return r.ApplyBatchChange(ctx, &graphqlbackend.ApplyBatchChangeArgs{
+		BatchSpec:         args.CampaignSpec,
+		EnsureBatchChange: args.EnsureCampaign,
+	})
+}
+
+func (r *Resolver) ApplyBatchChange(ctx context.Context, args *graphqlbackend.ApplyBatchChangeArgs) (graphqlbackend.BatchChangeResolver, error) {
 	var err error
-	tr, ctx := trace.New(ctx, "Resolver.ApplyCampaign", fmt.Sprintf("CampaignSpec %s", args.CampaignSpec))
+	tr, ctx := trace.New(ctx, "Resolver.ApplyBatchChange", fmt.Sprintf("BatchSpec %s", args.BatchSpec))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -342,7 +349,7 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 
 	opts := service.ApplyCampaignOpts{}
 
-	opts.CampaignSpecRandID, err = unmarshalBatchSpecID(args.CampaignSpec)
+	opts.CampaignSpecRandID, err = unmarshalBatchSpecID(args.BatchSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -351,8 +358,8 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 		return nil, ErrIDIsZero{}
 	}
 
-	if args.EnsureCampaign != nil {
-		opts.EnsureCampaignID, err = unmarshalBatchChangeID(*args.EnsureCampaign)
+	if args.EnsureBatchChange != nil {
+		opts.EnsureCampaignID, err = unmarshalBatchChangeID(*args.EnsureBatchChange)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -547,7 +547,8 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 	return &graphqlbackend.EmptyResponse{}, err
 }
 
-func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampaignsArgs) (graphqlbackend.CampaignsConnectionResolver, error) {
+func (r *Resolver) BatchChanges(ctx context.Context, args *graphqlbackend.ListBatchChangesArgs) (graphqlbackend.BatchChangesConnectionResolver, error) {
+	fmt.Printf("we are here!")
 	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
@@ -590,10 +591,14 @@ func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListCampa
 		}
 	}
 
-	return &campaignsConnectionResolver{
+	return &batchChangesConnectionResolver{
 		store: r.store,
 		opts:  opts,
 	}, nil
+}
+
+func (r *Resolver) Campaigns(ctx context.Context, args *graphqlbackend.ListBatchChangesArgs) (graphqlbackend.BatchChangesConnectionResolver, error) {
+	return r.BatchChanges(ctx, args)
 }
 
 func (r *Resolver) CampaignsCodeHosts(ctx context.Context, args *graphqlbackend.ListCampaignsCodeHostsArgs) (graphqlbackend.CampaignsCodeHostConnectionResolver, error) {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -778,7 +778,14 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, batchCha
 }
 
 func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.CloseCampaignArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.CloseCampaign", fmt.Sprintf("Campaign: %q", args.Campaign))
+	return r.CloseBatchChange(ctx, &graphqlbackend.CloseBatchChangeArgs{
+		BatchChange:     args.Campaign,
+		CloseChangesets: args.CloseChangesets,
+	})
+}
+
+func (r *Resolver) CloseBatchChange(ctx context.Context, args *graphqlbackend.CloseBatchChangeArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.CloseBatchChange", fmt.Sprintf("BatchChange: %q", args.BatchChange))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -788,7 +795,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 		return nil, err
 	}
 
-	batchChangeID, err := unmarshalBatchChangeID(args.Campaign)
+	batchChangeID, err := unmarshalBatchChangeID(args.BatchChange)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshaling campaign id")
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -120,7 +120,7 @@ func (r *Resolver) ChangesetByID(ctx context.Context, id graphql.ID) (graphqlbac
 	return NewChangesetResolver(r.store, changeset, repo), nil
 }
 
-func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignResolver, error) {
+func (r *Resolver) BatchChangeByID(ctx context.Context, id graphql.ID) (graphqlbackend.BatchChangeResolver, error) {
 	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
@@ -142,10 +142,14 @@ func (r *Resolver) CampaignByID(ctx context.Context, id graphql.ID) (graphqlback
 		return nil, err
 	}
 
-	return &campaignResolver{store: r.store, Campaign: campaign}, nil
+	return &batchChangeResolver{store: r.store, Campaign: campaign}, nil
 }
 
-func (r *Resolver) Campaign(ctx context.Context, args *graphqlbackend.CampaignArgs) (graphqlbackend.CampaignResolver, error) {
+func (r *Resolver) Campaign(ctx context.Context, args *graphqlbackend.BatchChangeArgs) (graphqlbackend.BatchChangeResolver, error) {
+	return r.BatchChange(ctx, args)
+}
+
+func (r *Resolver) BatchChange(ctx context.Context, args *graphqlbackend.BatchChangeArgs) (graphqlbackend.BatchChangeResolver, error) {
 	if err := campaignsEnabled(ctx); err != nil {
 		return nil, err
 	}
@@ -165,7 +169,7 @@ func (r *Resolver) Campaign(ctx context.Context, args *graphqlbackend.CampaignAr
 		return nil, err
 	}
 
-	return &campaignResolver{store: r.store, Campaign: campaign}, nil
+	return &batchChangeResolver{store: r.store, Campaign: campaign}, nil
 }
 
 func (r *Resolver) CampaignSpecByID(ctx context.Context, id graphql.ID) (graphqlbackend.CampaignSpecResolver, error) {
@@ -249,9 +253,16 @@ func (r *Resolver) CampaignsCredentialByID(ctx context.Context, id graphql.ID) (
 	return &campaignsCredentialResolver{credential: cred}, nil
 }
 
-func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.CreateCampaignArgs) (graphqlbackend.CampaignResolver, error) {
+// Old
+func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.CreateCampaignArgs) (graphqlbackend.BatchChangeResolver, error) {
+	newArgs := &graphqlbackend.CreateBatchChangeArgs{BatchSpec: args.CampaignSpec}
+	return r.CreateBatchChange(ctx, newArgs)
+}
+
+// New
+func (r *Resolver) CreateBatchChange(ctx context.Context, args *graphqlbackend.CreateBatchChangeArgs) (graphqlbackend.BatchChangeResolver, error) {
 	var err error
-	tr, _ := trace.New(ctx, "Resolver.CreateCampaign", fmt.Sprintf("CampaignSpec %s", args.CampaignSpec))
+	tr, _ := trace.New(ctx, "Resolver.CreateCampaign", fmt.Sprintf("CampaignSpec %s", args.BatchSpec))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -266,7 +277,7 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 		FailIfCampaignExists: true,
 	}
 
-	opts.CampaignSpecRandID, err = unmarshalCampaignSpecID(args.CampaignSpec)
+	opts.CampaignSpecRandID, err = unmarshalCampaignSpecID(args.BatchSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -288,10 +299,10 @@ func (r *Resolver) CreateCampaign(ctx context.Context, args *graphqlbackend.Crea
 		return nil, err
 	}
 
-	return &campaignResolver{store: r.store, Campaign: campaign}, nil
+	return &batchChangeResolver{store: r.store, Campaign: campaign}, nil
 }
 
-func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.ApplyCampaignArgs) (graphqlbackend.CampaignResolver, error) {
+func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.ApplyCampaignArgs) (graphqlbackend.BatchChangeResolver, error) {
 	var err error
 	tr, ctx := trace.New(ctx, "Resolver.ApplyCampaign", fmt.Sprintf("CampaignSpec %s", args.CampaignSpec))
 	defer func() {
@@ -336,7 +347,7 @@ func (r *Resolver) ApplyCampaign(ctx context.Context, args *graphqlbackend.Apply
 		return nil, err
 	}
 
-	return &campaignResolver{store: r.store, Campaign: campaign}, nil
+	return &batchChangeResolver{store: r.store, Campaign: campaign}, nil
 }
 
 func (r *Resolver) CreateCampaignSpec(ctx context.Context, args *graphqlbackend.CreateCampaignSpecArgs) (graphqlbackend.CampaignSpecResolver, error) {
@@ -449,7 +460,7 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 	return NewChangesetSpecResolver(ctx, r.store, spec)
 }
 
-func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCampaignArgs) (graphqlbackend.CampaignResolver, error) {
+func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCampaignArgs) (graphqlbackend.BatchChangeResolver, error) {
 	var err error
 	tr, ctx := trace.New(ctx, "Resolver.MoveCampaign", fmt.Sprintf("Campaign %s", args.Campaign))
 	defer func() {
@@ -492,7 +503,7 @@ func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCa
 		return nil, err
 	}
 
-	return &campaignResolver{store: r.store, Campaign: campaign}, nil
+	return &batchChangeResolver{store: r.store, Campaign: campaign}, nil
 }
 
 func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.DeleteCampaignArgs) (_ *graphqlbackend.EmptyResponse, err error) {
@@ -697,7 +708,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 		// changesets, since that would leak information.
 		safe = false
 	}
-	if args.OnlyPublishedByThisCampaign != nil {
+	if args.OnlyPublishedByThisCampaign != nil || args.OnlyPublishedByThisBatchChange != nil {
 		published := campaigns.ChangesetPublicationStatePublished
 
 		opts.OwnedByCampaignID = campaignID
@@ -718,7 +729,7 @@ func listChangesetOptsFromArgs(args *graphqlbackend.ListChangesetsArgs, campaign
 	return opts, safe, nil
 }
 
-func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.CloseCampaignArgs) (_ graphqlbackend.CampaignResolver, err error) {
+func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.CloseCampaignArgs) (_ graphqlbackend.BatchChangeResolver, err error) {
 	tr, ctx := trace.New(ctx, "Resolver.CloseCampaign", fmt.Sprintf("Campaign: %q", args.Campaign))
 	defer func() {
 		tr.SetError(err)
@@ -745,7 +756,7 @@ func (r *Resolver) CloseCampaign(ctx context.Context, args *graphqlbackend.Close
 		return nil, errors.Wrap(err, "closing campaign")
 	}
 
-	return &campaignResolver{store: r.store, Campaign: campaign}, nil
+	return &batchChangeResolver{store: r.store, Campaign: campaign}, nil
 }
 
 func (r *Resolver) SyncChangeset(ctx context.Context, args *graphqlbackend.SyncChangesetArgs) (_ *graphqlbackend.EmptyResponse, err error) {

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -504,8 +504,16 @@ func (r *Resolver) CreateChangesetSpec(ctx context.Context, args *graphqlbackend
 }
 
 func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCampaignArgs) (graphqlbackend.BatchChangeResolver, error) {
+	return r.MoveBatchChange(ctx, &graphqlbackend.MoveBatchChangeArgs{
+		BatchChange:  args.Campaign,
+		NewName:      args.NewName,
+		NewNamespace: args.NewNamespace,
+	})
+}
+
+func (r *Resolver) MoveBatchChange(ctx context.Context, args *graphqlbackend.MoveBatchChangeArgs) (graphqlbackend.BatchChangeResolver, error) {
 	var err error
-	tr, ctx := trace.New(ctx, "Resolver.MoveCampaign", fmt.Sprintf("Campaign %s", args.Campaign))
+	tr, ctx := trace.New(ctx, "Resolver.MoveBatchChange", fmt.Sprintf("Campaign %s", args.BatchChange))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -515,7 +523,7 @@ func (r *Resolver) MoveCampaign(ctx context.Context, args *graphqlbackend.MoveCa
 		return nil, err
 	}
 
-	batchChangeID, err := unmarshalBatchChangeID(args.Campaign)
+	batchChangeID, err := unmarshalBatchChangeID(args.BatchChange)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver.go
+++ b/enterprise/internal/campaigns/resolvers/resolver.go
@@ -558,7 +558,13 @@ func (r *Resolver) MoveBatchChange(ctx context.Context, args *graphqlbackend.Mov
 }
 
 func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.DeleteCampaignArgs) (_ *graphqlbackend.EmptyResponse, err error) {
-	tr, ctx := trace.New(ctx, "Resolver.DeleteCampaign", fmt.Sprintf("Campaign: %q", args.Campaign))
+	return r.DeleteBatchChange(ctx, &graphqlbackend.DeleteBatchChangeArgs{
+		BatchChange: args.Campaign,
+	})
+}
+
+func (r *Resolver) DeleteBatchChange(ctx context.Context, args *graphqlbackend.DeleteBatchChangeArgs) (_ *graphqlbackend.EmptyResponse, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.DeleteCampaign", fmt.Sprintf("BatchChange: %q", args.BatchChange))
 	defer func() {
 		tr.SetError(err)
 		tr.Finish()
@@ -567,7 +573,7 @@ func (r *Resolver) DeleteCampaign(ctx context.Context, args *graphqlbackend.Dele
 		return nil, err
 	}
 
-	batchChangeID, err := unmarshalBatchChangeID(args.Campaign)
+	batchChangeID, err := unmarshalBatchChangeID(args.BatchChange)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -745,6 +745,17 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 				OwnedByCampaignID: campaignID,
 			},
 		},
+		// Setting OnlyPublishedByThisBatchChange true.
+		{
+			args: &graphqlbackend.ListChangesetsArgs{
+				OnlyPublishedByThisBatchChange: &wantOnlyPublishedByThisCampaign[0],
+			},
+			wantSafe: true,
+			wantParsed: store.ListChangesetsOpts{
+				PublicationState:  &wantPublicationStates[0],
+				OwnedByCampaignID: campaignID,
+			},
+		},
 		// Setting a positive search.
 		{
 			args: &graphqlbackend.ListChangesetsArgs{

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -828,7 +828,9 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 		"credential":          "SOSECRET",
 	}
 
-	var response struct{ CreateBatchChangesCredential apitest.CampaignsCredential }
+	var response struct {
+		CreateBatchChangesCredential apitest.BatchChangesCredential
+	}
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
 	// First time it should work, because no credential exists

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -44,7 +44,7 @@ func TestNullIDResilience(t *testing.T) {
 	ids := []graphql.ID{
 		marshalBatchChangeID(0),
 		marshalChangesetID(0),
-		marshalCampaignSpecRandID(""),
+		marshalBatchSpecRandID(""),
 		marshalChangesetSpecRandID(""),
 		marshalCampaignsCredentialID(0),
 	}
@@ -65,8 +65,8 @@ func TestNullIDResilience(t *testing.T) {
 		fmt.Sprintf(`mutation { deleteCampaign(campaign: %q) { alwaysNil } }`, marshalBatchChangeID(0)),
 		fmt.Sprintf(`mutation { syncChangeset(changeset: %q) { alwaysNil } }`, marshalChangesetID(0)),
 		fmt.Sprintf(`mutation { reenqueueChangeset(changeset: %q) { id } }`, marshalChangesetID(0)),
-		fmt.Sprintf(`mutation { applyCampaign(campaignSpec: %q) { id } }`, marshalCampaignSpecRandID("")),
-		fmt.Sprintf(`mutation { createCampaign(campaignSpec: %q) { id } }`, marshalCampaignSpecRandID("")),
+		fmt.Sprintf(`mutation { applyCampaign(campaignSpec: %q) { id } }`, marshalBatchSpecRandID("")),
+		fmt.Sprintf(`mutation { createBatchChange(batchSpec: %q) { id } }`, marshalBatchSpecRandID("")),
 		fmt.Sprintf(`mutation { moveCampaign(campaign: %q, newName: "foobar") { id } }`, marshalBatchChangeID(0)),
 		fmt.Sprintf(`mutation { createCampaignsCredential(externalServiceKind: GITHUB, externalServiceURL: "http://test", credential: "123123", user: %q) { id } }`, graphqlbackend.MarshalUserID(0)),
 		fmt.Sprintf(`mutation { deleteCampaignsCredential(campaignsCredential: %q) { alwaysNil } }`, marshalCampaignsCredentialID(0)),
@@ -84,7 +84,7 @@ func TestNullIDResilience(t *testing.T) {
 	}
 }
 
-func TestCreateCampaignSpec(t *testing.T) {
+func TestCreateBatchSpec(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -171,14 +171,14 @@ func TestCreateCampaignSpec(t *testing.T) {
 
 			input := map[string]interface{}{
 				"namespace":      userAPIID,
-				"campaignSpec":   rawSpec,
+				"batchSpec":      rawSpec,
 				"changesetSpecs": changesetSpecIDs,
 			}
 
-			var response struct{ CreateCampaignSpec apitest.CampaignSpec }
+			var response struct{ CreateBatchSpec apitest.BatchSpec }
 
 			actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
-			errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateCampaignSpec)
+			errs := apitest.Exec(actorCtx, t, s, input, &response, mutationCreateBatchSpec)
 			if tc.wantErr {
 				if errs == nil {
 					t.Error("unexpected lack of errors")
@@ -193,7 +193,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				have := response.CreateCampaignSpec
+				have := response.CreateBatchSpec
 
 				wantNodes := make([]apitest.ChangesetSpec, len(changesetSpecIDs))
 				for i, id := range changesetSpecIDs {
@@ -203,7 +203,7 @@ func TestCreateCampaignSpec(t *testing.T) {
 					}
 				}
 
-				want := apitest.CampaignSpec{
+				want := apitest.BatchSpec{
 					ID:            have.ID,
 					CreatedAt:     have.CreatedAt,
 					ExpiresAt:     have.ExpiresAt,
@@ -225,12 +225,12 @@ func TestCreateCampaignSpec(t *testing.T) {
 	}
 }
 
-const mutationCreateCampaignSpec = `
+const mutationCreateBatchSpec = `
 fragment u on User { id, databaseID, siteAdmin }
 fragment o on Org  { id, name }
 
-mutation($namespace: ID!, $campaignSpec: String!, $changesetSpecs: [ID!]!){
-  createCampaignSpec(namespace: $namespace, campaignSpec: $campaignSpec, changesetSpecs: $changesetSpecs) {
+mutation($namespace: ID!, $batchSpec: String!, $changesetSpecs: [ID!]!){
+  createBatchSpec(namespace: $namespace, batchSpec: $batchSpec, changesetSpecs: $changesetSpecs) {
     id
     originalInput
     parsedInput
@@ -396,7 +396,7 @@ func TestApplyCampaign(t *testing.T) {
 
 	userAPIID := string(graphqlbackend.MarshalUserID(userID))
 	input := map[string]interface{}{
-		"campaignSpec": string(marshalCampaignSpecRandID(campaignSpec.RandID)),
+		"campaignSpec": string(marshalBatchSpecRandID(campaignSpec.RandID)),
 	}
 
 	var response struct{ ApplyCampaign apitest.BatchChange }
@@ -520,7 +520,7 @@ func TestCreateCampaign(t *testing.T) {
 	}
 
 	input := map[string]interface{}{
-		"campaignSpec": string(marshalCampaignSpecRandID(campaignSpec.RandID)),
+		"campaignSpec": string(marshalBatchSpecRandID(campaignSpec.RandID)),
 	}
 
 	var response struct{ CreateCampaign apitest.BatchChange }

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -62,7 +62,7 @@ func TestNullIDResilience(t *testing.T) {
 
 	mutations := []string{
 		fmt.Sprintf(`mutation { closeBatchChange(batchChange: %q) { id } }`, marshalBatchChangeID(0)),
-		fmt.Sprintf(`mutation { deleteCampaign(campaign: %q) { alwaysNil } }`, marshalBatchChangeID(0)),
+		fmt.Sprintf(`mutation { deleteBatchChange(batchChange: %q) { alwaysNil } }`, marshalBatchChangeID(0)),
 		fmt.Sprintf(`mutation { syncChangeset(changeset: %q) { alwaysNil } }`, marshalChangesetID(0)),
 		fmt.Sprintf(`mutation { reenqueueChangeset(changeset: %q) { id } }`, marshalChangesetID(0)),
 		fmt.Sprintf(`mutation { applyBatchChange(batchSpec: %q) { id } }`, marshalBatchSpecRandID("")),

--- a/enterprise/internal/campaigns/resolvers/resolver_test.go
+++ b/enterprise/internal/campaigns/resolvers/resolver_test.go
@@ -46,7 +46,7 @@ func TestNullIDResilience(t *testing.T) {
 		marshalChangesetID(0),
 		marshalBatchSpecRandID(""),
 		marshalChangesetSpecRandID(""),
-		marshalCampaignsCredentialID(0),
+		marshalBatchChangesCredentialID(0),
 	}
 
 	for _, id := range ids {
@@ -68,8 +68,8 @@ func TestNullIDResilience(t *testing.T) {
 		fmt.Sprintf(`mutation { applyBatchChange(batchSpec: %q) { id } }`, marshalBatchSpecRandID("")),
 		fmt.Sprintf(`mutation { createBatchChange(batchSpec: %q) { id } }`, marshalBatchSpecRandID("")),
 		fmt.Sprintf(`mutation { moveBatchChange(batchChange: %q, newName: "foobar") { id } }`, marshalBatchChangeID(0)),
-		fmt.Sprintf(`mutation { createCampaignsCredential(externalServiceKind: GITHUB, externalServiceURL: "http://test", credential: "123123", user: %q) { id } }`, graphqlbackend.MarshalUserID(0)),
-		fmt.Sprintf(`mutation { deleteCampaignsCredential(campaignsCredential: %q) { alwaysNil } }`, marshalCampaignsCredentialID(0)),
+		fmt.Sprintf(`mutation { createBatchChangesCredential(externalServiceKind: GITHUB, externalServiceURL: "http://test", credential: "123123", user: %q) { id } }`, graphqlbackend.MarshalUserID(0)),
+		fmt.Sprintf(`mutation { deleteBatchChangesCredential(batchChangesCredential: %q) { alwaysNil } }`, marshalBatchChangesCredentialID(0)),
 	}
 
 	for _, m := range mutations {
@@ -801,7 +801,7 @@ func TestListChangesetOptsFromArgs(t *testing.T) {
 	}
 }
 
-func TestCreateCampaignsCredential(t *testing.T) {
+func TestCreateBatchChangesCredential(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -828,13 +828,13 @@ func TestCreateCampaignsCredential(t *testing.T) {
 		"credential":          "SOSECRET",
 	}
 
-	var response struct{ CreateCampaignsCredential apitest.CampaignsCredential }
+	var response struct{ CreateBatchChangesCredential apitest.CampaignsCredential }
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
 	// First time it should work, because no credential exists
 	apitest.MustExec(actorCtx, t, s, input, &response, mutationCreateCredential)
 
-	if response.CreateCampaignsCredential.ID == "" {
+	if response.CreateBatchChangesCredential.ID == "" {
 		t.Fatalf("expected credential to be created, but was not")
 	}
 
@@ -851,11 +851,11 @@ func TestCreateCampaignsCredential(t *testing.T) {
 
 const mutationCreateCredential = `
 mutation($user: ID!, $externalServiceKind: ExternalServiceKind!, $externalServiceURL: String!, $credential: String!) {
-  createCampaignsCredential(user: $user, externalServiceKind: $externalServiceKind, externalServiceURL: $externalServiceURL, credential: $credential) { id }
+  createBatchChangesCredential(user: $user, externalServiceKind: $externalServiceKind, externalServiceURL: $externalServiceURL, credential: $credential) { id }
 }
 `
 
-func TestDeleteCampaignsCredential(t *testing.T) {
+func TestDeleteBatchChangesCredential(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -886,10 +886,10 @@ func TestDeleteCampaignsCredential(t *testing.T) {
 	}
 
 	input := map[string]interface{}{
-		"campaignsCredential": marshalCampaignsCredentialID(cred.ID),
+		"batchChangesCredential": marshalBatchChangesCredentialID(cred.ID),
 	}
 
-	var response struct{ DeleteCampaignsCredential apitest.EmptyResponse }
+	var response struct{ DeleteBatchChangesCredential apitest.EmptyResponse }
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))
 
 	// First time it should work, because a credential exists
@@ -907,8 +907,8 @@ func TestDeleteCampaignsCredential(t *testing.T) {
 }
 
 const mutationDeleteCredential = `
-mutation($campaignsCredential: ID!) {
-  deleteCampaignsCredential(campaignsCredential: $campaignsCredential) { alwaysNil }
+mutation($batchChangesCredential: ID!) {
+  deleteBatchChangesCredential(batchChangesCredential: $batchChangesCredential) { alwaysNil }
 }
 `
 

--- a/enterprise/internal/campaigns/resolvers/urls.go
+++ b/enterprise/internal/campaigns/resolvers/urls.go
@@ -8,7 +8,7 @@ func campaignsApplyURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignSpec
 	return n.URL() + "/campaigns/apply/" + string(c.ID())
 }
 
-func campaignURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignResolver) string {
+func campaignURL(n graphqlbackend.Namespace, c graphqlbackend.BatchChangeResolver) string {
 	// This needs to be kept consistent with campaigns.campaignURL().
 	return n.URL() + "/campaigns/" + c.Name()
 }

--- a/enterprise/internal/campaigns/resolvers/urls.go
+++ b/enterprise/internal/campaigns/resolvers/urls.go
@@ -4,7 +4,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 )
 
-func campaignsApplyURL(n graphqlbackend.Namespace, c graphqlbackend.CampaignSpecResolver) string {
+func campaignsApplyURL(n graphqlbackend.Namespace, c graphqlbackend.BatchSpecResolver) string {
 	return n.URL() + "/campaigns/apply/" + string(c.ID())
 }
 

--- a/enterprise/internal/campaigns/service/service.go
+++ b/enterprise/internal/campaigns/service/service.go
@@ -288,6 +288,9 @@ func (s *Service) MoveCampaign(ctx context.Context, opts MoveCampaignOpts) (camp
 	return campaign, tx.UpdateCampaign(ctx, campaign)
 }
 
+// TODO(campaigns-deprecation): this needs to be renamed, but cast to
+// "EnsureCampaignFailed" if the applycampaign mutation was used.
+//
 // ErrEnsureCampaignFailed is returned by ApplyCampaign when a ensureCampaignID
 // is provided but a campaign with the name specified the campaignSpec exists
 // in the given namespace but has a different ID.

--- a/enterprise/internal/campaigns/service/service_test.go
+++ b/enterprise/internal/campaigns/service/service_test.go
@@ -385,7 +385,7 @@ func TestService(t *testing.T) {
 		t.Run("success", func(t *testing.T) {
 			opts := CreateCampaignSpecOpts{
 				NamespaceUserID:      admin.ID,
-				RawSpec:              ct.TestRawCampaignSpec,
+				RawSpec:              ct.TestRawBatchSpec,
 				ChangesetSpecRandIDs: changesetSpecRandIDs,
 			}
 
@@ -426,7 +426,7 @@ func TestService(t *testing.T) {
 		t.Run("success with YAML raw spec", func(t *testing.T) {
 			opts := CreateCampaignSpecOpts{
 				NamespaceUserID: admin.ID,
-				RawSpec:         ct.TestRawCampaignSpecYAML,
+				RawSpec:         ct.TestRawBatchSpecYAML,
 			}
 
 			spec, err := svc.CreateCampaignSpec(adminCtx, opts)
@@ -439,7 +439,7 @@ func TestService(t *testing.T) {
 			}
 
 			var wantFields campaigns.CampaignSpecFields
-			if err := json.Unmarshal([]byte(ct.TestRawCampaignSpec), &wantFields); err != nil {
+			if err := json.Unmarshal([]byte(ct.TestRawBatchSpec), &wantFields); err != nil {
 				t.Fatal(err)
 			}
 
@@ -453,7 +453,7 @@ func TestService(t *testing.T) {
 
 			opts := CreateCampaignSpecOpts{
 				NamespaceUserID:      user.ID,
-				RawSpec:              ct.TestRawCampaignSpec,
+				RawSpec:              ct.TestRawBatchSpec,
 				ChangesetSpecRandIDs: changesetSpecRandIDs,
 			}
 
@@ -466,7 +466,7 @@ func TestService(t *testing.T) {
 			containsInvalidID := []string{changesetSpecRandIDs[0], "foobar"}
 			opts := CreateCampaignSpecOpts{
 				NamespaceUserID:      admin.ID,
-				RawSpec:              ct.TestRawCampaignSpec,
+				RawSpec:              ct.TestRawBatchSpec,
 				ChangesetSpecRandIDs: containsInvalidID,
 			}
 
@@ -480,7 +480,7 @@ func TestService(t *testing.T) {
 
 			opts := CreateCampaignSpecOpts{
 				NamespaceUserID: admin.ID,
-				RawSpec:         ct.TestRawCampaignSpecYAML,
+				RawSpec:         ct.TestRawBatchSpecYAML,
 			}
 
 			_, err := svc.CreateCampaignSpec(userCtx, opts)
@@ -504,7 +504,7 @@ func TestService(t *testing.T) {
 
 			opts := CreateCampaignSpecOpts{
 				NamespaceOrgID:       orgID,
-				RawSpec:              ct.TestRawCampaignSpec,
+				RawSpec:              ct.TestRawBatchSpec,
 				ChangesetSpecRandIDs: changesetSpecRandIDs,
 			}
 
@@ -532,7 +532,7 @@ func TestService(t *testing.T) {
 			// without accidently attaching the existing ChangesetSpecs.
 			opts := CreateCampaignSpecOpts{
 				NamespaceUserID:      admin.ID,
-				RawSpec:              ct.TestRawCampaignSpec,
+				RawSpec:              ct.TestRawBatchSpec,
 				ChangesetSpecRandIDs: []string{},
 			}
 

--- a/enterprise/internal/campaigns/testing/specs.go
+++ b/enterprise/internal/campaigns/testing/specs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 )
 
-const TestRawCampaignSpec = `{
+const TestRawBatchSpec = `{
   "name": "my-unique-name",
   "description": "My description",
   "on": [
@@ -29,7 +29,7 @@ const TestRawCampaignSpec = `{
   ],
   "changesetTemplate": {
     "title": "Hello World",
-    "body": "My first campaign!",
+    "body": "My first batch change!",
     "branch": "hello-world",
     "commit": {
       "message": "Append Hello World to all README.md files"
@@ -38,7 +38,7 @@ const TestRawCampaignSpec = `{
   }
 }`
 
-const TestRawCampaignSpecYAML = `
+const TestRawBatchSpecYAML = `
 name: my-unique-name
 description: My description
 'on':
@@ -51,7 +51,7 @@ steps:
     PATH: "/work/foobar:$PATH"
 changesetTemplate:
   title: Hello World
-  body: My first campaign!
+  body: My first batch change!
   branch: hello-world
   commit:
     message: Append Hello World to all README.md files


### PR DESCRIPTION
First PR for https://github.com/sourcegraph/sourcegraph/issues/18771

This adds the new GraphQL mutations/queries names to the schema while keeping backwards compatibility.

In order to see that it works, small parts of the frontend code have also been migrated.

But this PR should now just be about the Go GraphQL layer, we can then migrate the frontend afterwards.