### PR TITLE
gitserver: Extract gitserver sharding logic

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -524,7 +524,7 @@ func serveGitTar(w http.ResponseWriter, r *http.Request) error {
 		Format:  "tar",
 	}
 
-	location := gitserver.DefaultClient.ArchiveURL(r.Context(), repo, opts)
+	location := gitserver.DefaultClient.ArchiveURL(repo, opts)
 
 	w.Header().Set("Location", location.String())
 	w.WriteHeader(http.StatusFound)
@@ -560,7 +560,7 @@ func serveGitExec(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// Find the correct shard to query
-	addr := gitserver.DefaultClient.AddrForRepo(r.Context(), repo.Name)
+	addr := gitserver.DefaultClient.AddrForRepo(repo.Name)
 
 	director := func(req *http.Request) {
 		req.URL.Scheme = "http"
@@ -578,7 +578,7 @@ func serveGitExec(w http.ResponseWriter, r *http.Request) error {
 // gitserver for the repo.
 type gitServiceHandler struct {
 	Gitserver interface {
-		AddrForRepo(context.Context, api.RepoName) string
+		AddrForRepo(api.RepoName) string
 	}
 }
 
@@ -595,7 +595,7 @@ func (s *gitServiceHandler) redirectToGitServer(w http.ResponseWriter, r *http.R
 
 	u := &url.URL{
 		Scheme:   "http",
-		Host:     s.Gitserver.AddrForRepo(r.Context(), api.RepoName(repo)),
+		Host:     s.Gitserver.AddrForRepo(api.RepoName(repo)),
 		Path:     path.Join("/git", repo, gitPath),
 		RawQuery: r.URL.RawQuery,
 	}

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -55,7 +55,7 @@ func TestGitServiceHandlers(t *testing.T) {
 
 type mockAddrForRepo struct{}
 
-func (mockAddrForRepo) AddrForRepo(_ context.Context, name api.RepoName) string {
+func (mockAddrForRepo) AddrForRepo(name api.RepoName) string {
 	return strings.ReplaceAll(string(name), "/", ".") + ".gitserver"
 }
 

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -95,7 +95,7 @@ func (c *Client) AddrForRepo(ctx context.Context, repo api.RepoName) string {
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
-	return AddrForRepo(addrs, repo)
+	return AddrForRepo(repo, addrs)
 }
 
 // addrForKey returns the gitserver address to use for the given string key,
@@ -105,19 +105,19 @@ func (c *Client) addrForKey(ctx context.Context, key string) string {
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
-	return addrForKey(addrs, key)
+	return addrForKey(key, addrs)
 }
 
 // AddrForRepo returns the gitserver address to use for the given repo name.
 // It should never be called with an empty slice.
-func AddrForRepo(addrs []string, repo api.RepoName) string {
+func AddrForRepo(repo api.RepoName, addrs []string) string {
 	repo = protocol.NormalizeRepo(repo) // in case the caller didn't already normalize it
-	return addrForKey(addrs, string(repo))
+	return addrForKey(string(repo), addrs)
 }
 
 // addrForKey returns the gitserver address to use for the given string key,
 // which is hashed for sharding purposes.
-func addrForKey(addrs []string, key string) string {
+func addrForKey(key string, addrs []string) string {
 	sum := md5.Sum([]byte(key))
 	serverIndex := binary.BigEndian.Uint64(sum[:]) % uint64(len(addrs))
 	return addrs[serverIndex]
@@ -496,7 +496,7 @@ func (c *Client) ListCloned(ctx context.Context) ([]string, error) {
 			if len(r) > 0 {
 				filtered := r[:0]
 				for _, repo := range r {
-					if addrForKey(addrs, repo) == addr {
+					if addrForKey(repo, addrs) == addr {
 						filtered = append(filtered, repo)
 					}
 				}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -59,7 +59,7 @@ var DefaultClient = NewClient(&http.Client{Transport: defaultTransport})
 // and httpcli.Doer.
 func NewClient(cli httpcli.Doer) *Client {
 	return &Client{
-		Addrs: func(ctx context.Context) []string {
+		Addrs: func() []string {
 			return conf.Get().ServiceConnections.GitServers
 		},
 		HTTPClient:  cli,
@@ -82,7 +82,7 @@ type Client struct {
 	// Addrs is a function which should return the addresses for gitservers. It
 	// is called each time a request is made. The function must be safe for
 	// concurrent use. It may return different results at different times.
-	Addrs func(ctx context.Context) []string
+	Addrs func() []string
 
 	// UserAgent is a string identifying who the client is. It will be logged in
 	// the telemetry in gitserver.
@@ -90,8 +90,8 @@ type Client struct {
 }
 
 // AddrForRepo returns the gitserver address to use for the given repo name.
-func (c *Client) AddrForRepo(ctx context.Context, repo api.RepoName) string {
-	addrs := c.Addrs(ctx)
+func (c *Client) AddrForRepo(repo api.RepoName) string {
+	addrs := c.Addrs()
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
@@ -100,8 +100,8 @@ func (c *Client) AddrForRepo(ctx context.Context, repo api.RepoName) string {
 
 // addrForKey returns the gitserver address to use for the given string key,
 // which is hashed for sharding purposes.
-func (c *Client) addrForKey(ctx context.Context, key string) string {
-	addrs := c.Addrs(ctx)
+func (c *Client) addrForKey(key string) string {
+	addrs := c.Addrs()
 	if len(addrs) == 0 {
 		panic("unexpected state: no gitserver addresses")
 	}
@@ -157,7 +157,7 @@ func (a *archiveReader) Close() error {
 
 // ArchiveURL returns a URL from which an archive of the given Git repository can
 // be downloaded from.
-func (c *Client) ArchiveURL(ctx context.Context, repo api.RepoName, opt ArchiveOptions) *url.URL {
+func (c *Client) ArchiveURL(repo api.RepoName, opt ArchiveOptions) *url.URL {
 	q := url.Values{
 		"repo":    {string(repo)},
 		"treeish": {opt.Treeish},
@@ -170,7 +170,7 @@ func (c *Client) ArchiveURL(ctx context.Context, repo api.RepoName, opt ArchiveO
 
 	return &url.URL{
 		Scheme:   "http",
-		Host:     c.AddrForRepo(ctx, repo),
+		Host:     c.AddrForRepo(repo),
 		Path:     "/archive",
 		RawQuery: q.Encode(),
 	}
@@ -195,7 +195,7 @@ func (c *Client) Archive(ctx context.Context, repo api.RepoName, opt ArchiveOpti
 		return nil, err
 	}
 
-	u := c.ArchiveURL(ctx, repo, opt)
+	u := c.ArchiveURL(repo, opt)
 	resp, err := c.do(ctx, repo, "GET", u.String(), nil)
 	if err != nil {
 		return nil, err
@@ -419,7 +419,7 @@ func (c *Client) WaitForGitServers(ctx context.Context) error {
 }
 
 func (c *Client) pingAll(ctx context.Context) []error {
-	addrs := c.Addrs(ctx)
+	addrs := c.Addrs()
 
 	ch := make(chan error, len(addrs))
 	for _, addr := range addrs {
@@ -461,7 +461,7 @@ func (c *Client) ping(ctx context.Context, addr string) error {
 func (c *Client) ListGitolite(ctx context.Context, gitoliteHost string) (list []*gitolite.Repo, err error) {
 	// The gitserver calls the shared Gitolite server in response to this request, so
 	// we need to only call a single gitserver (or else we'd get duplicate results).
-	addr := c.addrForKey(ctx, gitoliteHost)
+	addr := c.addrForKey(gitoliteHost)
 	req, err := http.NewRequest("GET", "http://"+addr+"/list-gitolite?gitolite="+url.QueryEscape(gitoliteHost), nil)
 	if err != nil {
 		return nil, err
@@ -485,7 +485,7 @@ func (c *Client) ListCloned(ctx context.Context) ([]string, error) {
 		err   error
 		repos []string
 	)
-	addrs := c.Addrs(ctx)
+	addrs := c.Addrs()
 	for _, addr := range addrs {
 		wg.Add(1)
 		go func(addr string) {
@@ -517,7 +517,7 @@ func (c *Client) ListCloned(ctx context.Context) ([]string, error) {
 // GetGitolitePhabricatorMetadata returns Phabricator metadata for a Gitolite repository fetched via
 // a user-provided command.
 func (c *Client) GetGitolitePhabricatorMetadata(ctx context.Context, gitoliteHost string, repoName api.RepoName) (*protocol.GitolitePhabricatorMetadataResponse, error) {
-	u := "http://" + c.addrForKey(ctx, gitoliteHost) +
+	u := "http://" + c.addrForKey(gitoliteHost) +
 		"/getGitolitePhabricatorMetadata?gitolite=" + url.QueryEscape(gitoliteHost) +
 		"&repo=" + url.QueryEscape(string(repoName))
 
@@ -657,11 +657,11 @@ func (c *Client) IsRepoCloned(ctx context.Context, repo api.RepoName) (bool, err
 }
 
 func (c *Client) RepoCloneProgress(ctx context.Context, repos ...api.RepoName) (*protocol.RepoCloneProgressResponse, error) {
-	numPossibleShards := len(c.Addrs(ctx))
+	numPossibleShards := len(c.Addrs())
 	shards := make(map[string]*protocol.RepoCloneProgressRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
-		addr := c.AddrForRepo(ctx, r)
+		addr := c.AddrForRepo(r)
 		shard := shards[addr]
 
 		if shard == nil {
@@ -734,11 +734,11 @@ func (c *Client) RepoCloneProgress(ctx context.Context, repos ...api.RepoName) (
 // If multiple errors occurred, an incomplete result is returned along with a
 // *multierror.Error.
 func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol.RepoInfoResponse, error) {
-	numPossibleShards := len(c.Addrs(ctx))
+	numPossibleShards := len(c.Addrs())
 	shards := make(map[string]*protocol.RepoInfoRequest, (len(repos)/numPossibleShards)*2) // 2x because it may not be a perfect division
 
 	for _, r := range repos {
-		addr := c.AddrForRepo(ctx, r)
+		addr := c.AddrForRepo(r)
 		shard := shards[addr]
 
 		if shard == nil {
@@ -813,7 +813,7 @@ func (c *Client) RepoInfo(ctx context.Context, repos ...api.RepoName) (*protocol
 func (c *Client) ReposStats(ctx context.Context) (map[string]*protocol.ReposStats, error) {
 	stats := map[string]*protocol.ReposStats{}
 	var allErr error
-	for _, addr := range c.Addrs(ctx) {
+	for _, addr := range c.Addrs() {
 		stat, err := c.doReposStats(ctx, addr)
 		if err != nil {
 			allErr = multierror.Append(allErr, err)
@@ -887,7 +887,7 @@ func (c *Client) do(ctx context.Context, repo api.RepoName, method, op string, p
 
 	uri := op
 	if !strings.HasPrefix(op, "http") {
-		uri = "http://" + c.AddrForRepo(ctx, repo) + "/" + op
+		uri = "http://" + c.AddrForRepo(repo) + "/" + op
 	}
 
 	req, err := http.NewRequest(method, uri, bytes.NewReader(reqBody))

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -29,7 +29,7 @@ import (
 func TestClient_ListCloned(t *testing.T) {
 	addrs := []string{"gitserver-0", "gitserver-1"}
 	cli := &gitserver.Client{
-		Addrs: func(ctx context.Context) []string { return addrs },
+		Addrs: func() []string { return addrs },
 		HTTPClient: httpcli.DoerFunc(func(r *http.Request) (*http.Response, error) {
 			switch r.URL.String() {
 			case "http://gitserver-0/list?cloned":
@@ -103,7 +103,7 @@ func TestClient_Archive(t *testing.T) {
 	defer srv.Close()
 
 	cli := gitserver.NewClient(&http.Client{})
-	cli.Addrs = func(context.Context) []string {
+	cli.Addrs = func() []string {
 		u, _ := url.Parse(srv.URL)
 		return []string{u.Host}
 	}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -249,4 +250,39 @@ func createSimpleGitRepo(t *testing.T, root string) string {
 	}
 
 	return dir
+}
+
+func TestAddrForRepo(t *testing.T) {
+	addrs := []string{"gitserver-1", "gitserver-2"}
+
+	testCases := []struct {
+		name string
+		repo api.RepoName
+		want string
+	}{
+		{
+			name: "repo1",
+			repo: api.RepoName("repo1"),
+			want: "gitserver-1",
+		},
+		{
+			name: "check we normalise",
+			repo: api.RepoName("repo1.git"),
+			want: "gitserver-1",
+		},
+		{
+			name: "another repo",
+			repo: api.RepoName("another-repo"),
+			want: "gitserver-1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gitserver.AddrForRepo(addrs, tc.repo)
+			if got != tc.want {
+				t.Fatalf("Want %q, got %q", tc.want, got)
+			}
+		})
+	}
 }

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -253,7 +253,7 @@ func createSimpleGitRepo(t *testing.T, root string) string {
 }
 
 func TestAddrForRepo(t *testing.T) {
-	addrs := []string{"gitserver-1", "gitserver-2"}
+	addrs := []string{"gitserver-1", "gitserver-2", "gitserver-3"}
 
 	testCases := []struct {
 		name string
@@ -263,23 +263,23 @@ func TestAddrForRepo(t *testing.T) {
 		{
 			name: "repo1",
 			repo: api.RepoName("repo1"),
-			want: "gitserver-1",
+			want: "gitserver-3",
 		},
 		{
 			name: "check we normalise",
 			repo: api.RepoName("repo1.git"),
-			want: "gitserver-1",
+			want: "gitserver-3",
 		},
 		{
 			name: "another repo",
-			repo: api.RepoName("another-repo"),
-			want: "gitserver-1",
+			repo: api.RepoName("github.com/sourcegraph/sourcegraph.git"),
+			want: "gitserver-2",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := gitserver.AddrForRepo(addrs, tc.repo)
+			got := gitserver.AddrForRepo(tc.repo, addrs)
 			if got != tc.want {
 				t.Fatalf("Want %q, got %q", tc.want, got)
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
@@ -365,7 +366,7 @@ func (s *Store) watchAndEvict() {
 func (s *Store) watchConfig() {
 	for {
 		// Allow roughly 10 fetches per gitserver
-		limit := 10 * len(gitserver.DefaultClient.Addrs(context.Background()))
+		limit := 10 * len(gitserver.DefaultClient.Addrs())
 		if limit == 0 {
 			limit = 15
 		}

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
@@ -74,7 +75,7 @@ func init() {
 		}
 	}()
 
-	gitserver.DefaultClient.Addrs = func(ctx context.Context) []string {
+	gitserver.DefaultClient.Addrs = func() []string {
 		return []string{l.Addr().String()}
 	}
 }


### PR DESCRIPTION
So that we can call it from outside the client itself. We need to call
it from gitserver itself shortly so that gitservers know which repos
thet are responsible for.
