### PR TITLE
Enforce typecheck and nolintlint

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -7,6 +7,8 @@ linters:
   disable-all: true
   enable:
     - ineffassign
+    - typecheck
+    - nolintlint
 
 run:
   timeout: 5m


### PR DESCRIPTION
Adds `typecheck` and `nolintlint` to the list of enforced linters since
they have no current warnings.

Progresses #18720

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
