### PR TITLE
Enforce unconvert lint

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -9,6 +9,7 @@ linters:
     - ineffassign
     - typecheck
     - nolintlint
+    - unconvert
 
 run:
   timeout: 5m

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -81,7 +81,7 @@ func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err er
 	// addressed in the future. See https://github.com/sourcegraph/sourcegraph/issues/2663.
 	for _, pkg := range goPackages {
 		// Assumes the import path is the same as the repo name - not always true!
-		response, err := ctxhttp.Get(ctx, countGoImportersHTTPClient, "https://api.godoc.org/importers/"+string(pkg))
+		response, err := ctxhttp.Get(ctx, countGoImportersHTTPClient, "https://api.godoc.org/importers/"+pkg)
 		if err != nil {
 			return 0, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -160,7 +160,7 @@ func (r *RepositoryComparisonResolver) Commits(
 ) *gitCommitConnectionResolver {
 	return &gitCommitConnectionResolver{
 		db:            r.db,
-		revisionRange: string(r.baseRevspec) + ".." + string(r.headRevspec),
+		revisionRange: r.baseRevspec + ".." + r.headRevspec,
 		first:         args.First,
 		repo:          r.repo,
 	}

--- a/cmd/frontend/graphqlbackend/settings_cascade.go
+++ b/cmd/frontend/graphqlbackend/settings_cascade.go
@@ -126,7 +126,7 @@ func (r *settingsCascade) Merged(ctx context.Context) (_ *configurationResolver,
 	if err != nil {
 		messages = append(messages, err.Error())
 	}
-	return &configurationResolver{contents: string(s), messages: messages}, nil
+	return &configurationResolver{contents: s, messages: messages}, nil
 }
 
 // deeplyMergedSettingsFields contains the names of top-level settings fields whose values should be

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -522,7 +522,7 @@ func escape(s string) string {
 		}
 	}
 	if count == 0 {
-		return string(s)
+		return s
 	}
 
 	escaped := make([]rune, 0, len(s)+count)

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -102,7 +102,7 @@ func serveGoSymbolURL(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	location, err := symbolLocation(r.Context(), vfs, commitID, importPath, path.Join("/", dir.RepoPrefix, strings.TrimPrefix(dir.ImportPath, string(dir.ProjectRoot))), receiver, symbolName)
+	location, err := symbolLocation(r.Context(), vfs, commitID, importPath, path.Join("/", dir.RepoPrefix, strings.TrimPrefix(dir.ImportPath, dir.ProjectRoot)), receiver, symbolName)
 	if err != nil {
 		return err
 	}
@@ -192,7 +192,7 @@ func symbolLocation(ctx context.Context, vfs ctxvfs.FileSystem, commitID api.Com
 
 	position := fileSet.Position(*pos)
 	location := lsp.Location{
-		URI: lsp.DocumentURI("https://" + string(importPath) + "?" + string(commitID) + "#" + position.Filename),
+		URI: lsp.DocumentURI("https://" + importPath + "?" + string(commitID) + "#" + position.Filename),
 		Range: lsp.Range{
 			Start: lsp.Position{
 				Line:      position.Line - 1,

--- a/cmd/frontend/internal/httpapi/httpapi.go
+++ b/cmd/frontend/internal/httpapi/httpapi.go
@@ -197,7 +197,7 @@ func (h *errorHandler) Handle(w http.ResponseWriter, r *http.Request, status int
 
 	var displayErrBody string
 	if h.WriteErrBody {
-		displayErrBody = string(errBody)
+		displayErrBody = errBody
 	}
 	http.Error(w, displayErrBody, status)
 	traceSpan := opentracing.SpanFromContext(r.Context())

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -132,7 +132,7 @@ func packetWrite(str string) []byte {
 // means we can fetch a 1 GiB archive in ~8.5 seconds.
 func flowrateWriter(w io.Writer) io.Writer {
 	const megabit = int64(1000 * 1000)
-	const limit = int64(1000 * megabit) // 1 Gbps
+	const limit = 1000 * megabit // 1 Gbps
 	return flowrate.NewWriter(w, limit)
 }
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -256,7 +256,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
 
 	dir := filepath.Join(tmp, ".git")
 	gitDir := GitDir(dir)
-	if err := os.Mkdir(string(dir), 0700); err != nil {
+	if err := os.Mkdir(dir, 0700); err != nil {
 		b.Fatal(err)
 	}
 
@@ -334,7 +334,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_unpacked_refs(b *testing.B) 
 
 	dir := filepath.Join(tmp, ".git")
 	gitDir := GitDir(dir)
-	if err := os.Mkdir(string(dir), 0700); err != nil {
+	if err := os.Mkdir(dir, 0700); err != nil {
 		b.Fatal(err)
 	}
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -165,7 +165,7 @@ func (s *Server) handleExcludeRepo(w http.ResponseWriter, r *http.Request) {
 		tmp[i] = &types.Repo{
 			ID:           r.ID,
 			ExternalRepo: r.ExternalRepo,
-			Name:         api.RepoName(r.Name),
+			Name:         r.Name,
 			Private:      r.Private,
 			URI:          r.URI,
 			Description:  r.Description,
@@ -641,7 +641,7 @@ func newRepoInfo(r *types.Repo) (*protocol.RepoInfo, error) {
 	}
 
 	info := protocol.RepoInfo{
-		Name:         api.RepoName(r.Name),
+		Name:         r.Name,
 		Description:  r.Description,
 		Fork:         r.Fork,
 		Archived:     r.Archived,

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -304,7 +304,7 @@ func testServerSetRepoEnabled(t *testing.T, store *repos.Store) func(t *testing.
 						tmp := &types.Repo{
 							ID:           k.repo.ID,
 							ExternalRepo: k.repo.ExternalRepo,
-							Name:         api.RepoName(k.repo.Name),
+							Name:         k.repo.Name,
 							Private:      k.repo.Private,
 							URI:          k.repo.URI,
 							Description:  k.repo.Description,
@@ -957,7 +957,7 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(
 				{
 					name: "Private repos are not supported on sourcegraph.com",
 					args: protocol.RepoLookupArgs{
-						Repo: api.RepoName(githubRepository.Name),
+						Repo: githubRepository.Name,
 					},
 					githubDotComSource: &fakeRepoSource{
 						repo: githubRepository.With(func(r *types.Repo) {
@@ -965,12 +965,12 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(
 						}),
 					},
 					result: &protocol.RepoLookupResult{ErrorNotFound: true},
-					err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", api.RepoName(githubRepository.Name), true),
+					err:    fmt.Sprintf("repository not found (name=%s notfound=%v)", githubRepository.Name, true),
 				},
 				{
 					name: "Private repos that used to be public should be removed asynchronously",
 					args: protocol.RepoLookupArgs{
-						Repo: api.RepoName(githubRepository.Name),
+						Repo: githubRepository.Name,
 					},
 					githubDotComSource: &fakeRepoSource{
 						err: github.ErrRepoNotFound,

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -401,7 +401,7 @@ func TestSearch_badrequest(t *testing.T) {
 func doSearch(u string, p *protocol.Request) ([]protocol.FileMatch, error) {
 	form := url.Values{
 		"Repo":            []string{string(p.Repo)},
-		"URL":             []string{string(p.URL)},
+		"URL":             []string{p.URL},
 		"Commit":          []string{string(p.Commit)},
 		"Pattern":         []string{p.Pattern},
 		"FetchTimeout":    []string{p.FetchTimeout},

--- a/enterprise/cmd/frontend/auth/saml/provider.go
+++ b/enterprise/cmd/frontend/auth/saml/provider.go
@@ -262,7 +262,7 @@ func readProviderConfig(pc *schema.SAMLAuthProvider) (*providerConfig, error) {
 
 func readIdentityProviderMetadata(ctx context.Context, c *providerConfig) ([]byte, error) {
 	if c.identityProviderMetadata != nil {
-		return []byte(c.identityProviderMetadata), nil
+		return c.identityProviderMetadata, nil
 	}
 
 	resp, err := ctxhttp.Get(ctx, nil, c.identityProviderMetadataURL.String())

--- a/enterprise/cmd/frontend/auth/saml/session.go
+++ b/enterprise/cmd/frontend/auth/saml/session.go
@@ -29,7 +29,7 @@ func SignOut(w http.ResponseWriter, r *http.Request) (logoutURL string, err erro
 	}
 	{
 		if data, err := doc.WriteToString(); err == nil {
-			traceLog(fmt.Sprintf("LogoutRequest: %s", p.ConfigID().ID), string(data))
+			traceLog(fmt.Sprintf("LogoutRequest: %s", p.ConfigID().ID), data)
 		}
 	}
 	return p.samlSP.BuildAuthURLRedirect("/", doc)

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -150,7 +150,7 @@ func (r *productSubscription) URL(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return *accountUser.SettingsURL() + "/subscriptions/" + string(r.v.ID), nil
+	return *accountUser.SettingsURL() + "/subscriptions/" + r.v.ID, nil
 }
 
 func (r *productSubscription) URLForSiteAdmin(ctx context.Context) *string {

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -238,7 +238,7 @@ func (o dbExtensionsListOptions) sqlConditions() []*sqlf.Query {
 func (o dbExtensionsListOptions) sqlOrder() []*sqlf.Query {
 	ids := make([]*sqlf.Query, len(o.PrioritizeExtensionIDs)+1)
 	for i, id := range o.PrioritizeExtensionIDs {
-		ids[i] = sqlf.Sprintf("%v", string(id))
+		ids[i] = sqlf.Sprintf("%v", id)
 	}
 	ids[len(o.PrioritizeExtensionIDs)] = sqlf.Sprintf("NULL")
 	return []*sqlf.Query{sqlf.Sprintf(extensionIDExpr+` IN (%v) ASC`, sqlf.Join(ids, ","))}

--- a/enterprise/internal/codeintel/bloomfilter/bloom_filter.go
+++ b/enterprise/internal/codeintel/bloomfilter/bloom_filter.go
@@ -138,16 +138,16 @@ func index(b int32) (int32, int32) {
 func hashLocations(v string, m, k int32) []int32 {
 	a := fowlerNollVo1a(v, 0)
 	b := fowlerNollVo1a(v, 1576284489) // The seed value is chosen randomly
-	x := a % int32(m)
+	x := a % m
 	r := make([]int32, k)
 
 	for i := int32(0); i < k; i++ {
 		if x < 0 {
-			r[i] = x + int32(m)
+			r[i] = x + m
 		} else {
 			r[i] = x
 		}
-		x = (x + b) % int32(m)
+		x = (x + b) % m
 	}
 
 	return r
@@ -164,7 +164,7 @@ func fowlerNollVo1a(v string, seed int32) int32 {
 	for _, r := range utf16Runes(v) {
 		c := int64(r)
 		if d := c & 0xff00; d != 0 {
-			a = fowlerNollVoMultiply(int32(a ^ int64(d>>8)))
+			a = fowlerNollVoMultiply(int32(a ^ d>>8))
 		}
 		a = fowlerNollVoMultiply(int32(a) ^ int32(c&0xff))
 	}

--- a/enterprise/internal/codemonitors/action_jobs.go
+++ b/enterprise/internal/codemonitors/action_jobs.go
@@ -30,7 +30,7 @@ type ActionJob struct {
 }
 
 func (a *ActionJob) RecordID() int {
-	return int(a.Id)
+	return a.Id
 }
 
 type ActionJobMetadata struct {

--- a/enterprise/internal/licensing/user_count.go
+++ b/enterprise/internal/licensing/user_count.go
@@ -92,7 +92,7 @@ func checkMaxUsers(ctx context.Context, s UsersStore, signature string) error {
 		log15.Error("licensing.checkMaxUsers: error getting user count", "error", err)
 		return err
 	}
-	err = setMaxUsers(signature, int(count))
+	err = setMaxUsers(signature, count)
 	if err != nil {
 		log15.Error("licensing.checkMaxUsers: error setting new max users", "error", err)
 		return err

--- a/internal/encryption/cloudkms/cloud_kms.go
+++ b/internal/encryption/cloudkms/cloud_kms.go
@@ -117,5 +117,5 @@ type encryptedValue struct {
 
 func crc32Sum(data []byte) uint32 {
 	t := crc32.MakeTable(crc32.Castagnoli)
-	return crc32.Checksum([]byte(data), t)
+	return crc32.Checksum(data, t)
 }

--- a/internal/jsonc/jsonc.go
+++ b/internal/jsonc/jsonc.go
@@ -36,7 +36,7 @@ func Parse(text string) ([]byte, error) {
 // Normalize is like Parse, except it ignores errors and always returns valid JSON, even if that
 // JSON is a subset of the input.
 func Normalize(input string) []byte {
-	output, _ := jsonx.Parse(string(input), jsonx.ParseOptions{Comments: true, TrailingCommas: true})
+	output, _ := jsonx.Parse(input, jsonx.ParseOptions{Comments: true, TrailingCommas: true})
 	if len(output) == 0 {
 		return []byte("{}")
 	}

--- a/internal/repos/gitolite.go
+++ b/internal/repos/gitolite.go
@@ -193,7 +193,7 @@ func (s *GitolitePhabricatorMetadataSyncer) Sync(ctx context.Context, repos []*t
 		}
 
 		for _, r := range grouped[e.ID] {
-			name := api.RepoName(r.Name)
+			name := r.Name
 
 			metadata, err := gitserver.DefaultClient.GetGitolitePhabricatorMetadata(ctx, conf.Host, name)
 			if err != nil {

--- a/internal/repos/phabricator.go
+++ b/internal/repos/phabricator.go
@@ -234,7 +234,7 @@ func updatePhabRepos(ctx context.Context, repos []*types.Repo) error {
 		repo := r.Metadata.(*phabricator.Repo)
 		err := api.InternalClient.PhabricatorRepoCreate(
 			ctx,
-			api.RepoName(r.Name),
+			r.Name,
 			repo.Callsign,
 			r.ExternalRepo.ServiceID,
 		)

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -438,7 +438,7 @@ func TestExternalService_Exclude(t *testing.T) {
 				tmp[i] = &types.Repo{
 					ID:           r.ID,
 					ExternalRepo: r.ExternalRepo,
-					Name:         api.RepoName(r.Name),
+					Name:         r.Name,
 					Private:      r.Private,
 					URI:          r.URI,
 					Description:  r.Description,

--- a/internal/repotrackutil/repouri_test.go
+++ b/internal/repotrackutil/repouri_test.go
@@ -34,7 +34,7 @@ func TestGetTrackedRepo(t *testing.T) {
 	}
 	// a trackedRepo must always be tracked
 	for _, r := range trackedRepo {
-		if GetTrackedRepo(api.RepoName(r)) != string(r) {
+		if GetTrackedRepo(api.RepoName(r)) != r {
 			t.Errorf("Repo should be tracked: %v", r)
 		}
 	}

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -57,7 +57,7 @@ func Search(ctx context.Context, searcherURLs *endpoint.Map, repo api.RepoName, 
 	q := url.Values{
 		"Repo":            []string{string(repo)},
 		"Commit":          []string{string(commit)},
-		"Branch":          []string{string(branch)},
+		"Branch":          []string{branch},
 		"Pattern":         []string{p.Pattern},
 		"ExcludePattern":  []string{p.ExcludePattern},
 		"IncludePatterns": p.IncludePatterns,

--- a/internal/vcs/git/blame.go
+++ b/internal/vcs/git/blame.go
@@ -87,8 +87,8 @@ func blameFileCmd(ctx context.Context, command cmdFunc, path string, opt *BlameO
 		nLines, _ := strconv.Atoi(hunkHeader[3])
 		hunk := &Hunk{
 			CommitID:  api.CommitID(commitID),
-			StartLine: int(lineNoCur),
-			EndLine:   int(lineNoCur + nLines),
+			StartLine: lineNoCur,
+			EndLine:   lineNoCur + nLines,
 			StartByte: byteOffset,
 		}
 

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -297,7 +297,7 @@ func lsTreeUncached(ctx context.Context, repo api.RepoName, commit api.CommitID,
 
 		fis[i] = &util.FileInfo{
 			Name_: name, // full path relative to root (not just basename)
-			Mode_: os.FileMode(mode),
+			Mode_: mode,
 			Size_: size,
 			Sys_:  sys,
 		}


### PR DESCRIPTION
This commit fixes all warnings emitted by the `unconvert` lint, and adds
it to the list of enforced linters.

This should be pretty low risk. All changes are simply removing redundant type conversions. 

Progresses #18720 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
