### PR TITLE
Appease and enforce goimports lint

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -13,10 +13,6 @@ linters:
     - unconvert
     - goimports
 
-linters-settings:
-  goimports:
-    local-prefixes: github.com/sourcegraph/sourcegraph
-
 run:
   timeout: 5m
 

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -2,6 +2,7 @@
 # Eventually, the goal is to unify this with .golangci.yml. 
 # https://github.com/sourcegraph/sourcegraph/issues/18720
 
+
 # See explanation of linters at https://golangci-lint.run/usage/linters/
 linters:
   disable-all: true
@@ -10,6 +11,11 @@ linters:
     - typecheck
     - nolintlint
     - unconvert
+    - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/sourcegraph/sourcegraph
 
 run:
   timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,8 +14,6 @@ linters-settings:
       - octalLiteral
       - whyNoLint
       - wrapperFunc
-  goimports:
-    local-prefixes: github.com/sourcegraph/sourcegraph
   golint:
     min-confidence: 0
   govet:

--- a/cmd/frontend/auth/providers/providers.go
+++ b/cmd/frontend/auth/providers/providers.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -13,11 +13,12 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 var MockCountGoImporters func(ctx context.Context, repo api.RepoName) (int, error)

--- a/cmd/frontend/backend/inventory.go
+++ b/cmd/frontend/backend/inventory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"

--- a/cmd/frontend/graphqlbackend/observability.go
+++ b/cmd/frontend/graphqlbackend/observability.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 )
 

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/graph-gophers/graphql-go/gqltesting"
 
 	"github.com/hexops/autogold"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"sync"
 
+	"go.uber.org/atomic"
+
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"go.uber.org/atomic"
 )
 
 // SearchEvent is an event on a search stream. It contains fields which can be

--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -4,17 +4,19 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+
 	"github.com/graph-gophers/graphql-go/gqltesting"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"io/ioutil"
-	"net/http"
-	"reflect"
-	"testing"
 )
 
 func TestSetExternalServiceRepos(t *testing.T) {

--- a/cmd/frontend/graphqlbackend/site_reload.go
+++ b/cmd/frontend/graphqlbackend/site_reload.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/processrestart"

--- a/cmd/frontend/graphqlbackend/virtual_file_test.go
+++ b/cmd/frontend/graphqlbackend/virtual_file_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/highlight"
 )
 

--- a/cmd/frontend/internal/app/assetsutil/handler.go
+++ b/cmd/frontend/internal/app/assetsutil/handler.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/shurcooL/httpgzip"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/assets"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"

--- a/cmd/frontend/internal/app/badge.go
+++ b/cmd/frontend/internal/app/badge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/gorilla/mux"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/routevar"
 )

--- a/cmd/frontend/internal/app/debugproxies/handler.go
+++ b/cmd/frontend/internal/app/debugproxies/handler.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/gorilla/mux"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/errorutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"

--- a/cmd/frontend/internal/app/debugproxies/handler_test.go
+++ b/cmd/frontend/internal/app/debugproxies/handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/router"
 )

--- a/cmd/frontend/internal/app/errorutil/handlers.go
+++ b/cmd/frontend/internal/app/errorutil/handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace"

--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -19,15 +19,17 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/ctxvfs"
+	"golang.org/x/tools/go/buildutil"
+
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/vfsutil"
-	"golang.org/x/tools/go/buildutil"
 
 	"github.com/sourcegraph/go-lsp"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"

--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/sourcegraph/ctxvfs"
 	"github.com/sourcegraph/go-langserver/pkg/lsp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 

--- a/cmd/frontend/internal/app/opensearch.go
+++ b/cmd/frontend/internal/app/opensearch.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 )
 

--- a/cmd/frontend/internal/app/templates/gen/data_generate.go
+++ b/cmd/frontend/internal/app/templates/gen/data_generate.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/shurcooL/vfsgen"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/templates"
 )
 

--- a/cmd/frontend/internal/app/ui/landing.go
+++ b/cmd/frontend/internal/app/ui/landing.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"

--- a/cmd/frontend/internal/auth/userpasswd/config.go
+++ b/cmd/frontend/internal/auth/userpasswd/config.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/cmd/frontend/internal/bg/check_redis_cache_eviction_policy.go
+++ b/cmd/frontend/internal/bg/check_redis_cache_eviction_policy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 

--- a/cmd/frontend/internal/bg/delete_old_cache_data_in_redis.go
+++ b/cmd/frontend/internal/bg/delete_old_cache_data_in_redis.go
@@ -3,6 +3,7 @@ package bg
 import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )

--- a/cmd/frontend/internal/bg/delete_old_event_logs_in_postgres.go
+++ b/cmd/frontend/internal/bg/delete_old_event_logs_in_postgres.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )
 

--- a/cmd/frontend/internal/httpapi/repo_shield.go
+++ b/cmd/frontend/internal/httpapi/repo_shield.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/routevar"
 )

--- a/cmd/frontend/internal/httpapi/router/router.go
+++ b/cmd/frontend/internal/httpapi/router/router.go
@@ -3,6 +3,7 @@ package router
 
 import (
 	"github.com/gorilla/mux"
+
 	"github.com/sourcegraph/sourcegraph/internal/routevar"
 )
 

--- a/cmd/frontend/internal/httpapi/src_cli.go
+++ b/cmd/frontend/internal/httpapi/src_cli.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
+
 	srccli "github.com/sourcegraph/sourcegraph/internal/src-cli"
 )
 

--- a/cmd/frontend/internal/inventory/entries_test.go
+++ b/cmd/frontend/internal/inventory/entries_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
 )
 

--- a/cmd/frontend/registry/extension_remote_graphql.go
+++ b/cmd/frontend/registry/extension_remote_graphql.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/graph-gophers/graphql-go"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/ui/router"
 	"github.com/sourcegraph/sourcegraph/internal/registry"

--- a/cmd/gitserver/server/customfetch_test.go
+++ b/cmd/gitserver/server/customfetch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/cmd/gitserver/server/gitolite-phabricator.go
+++ b/cmd/gitserver/server/gitolite-phabricator.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"

--- a/cmd/gitserver/server/list-gitolite_test.go
+++ b/cmd/gitserver/server/list-gitolite_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )

--- a/cmd/gitserver/server/repo_info_test.go
+++ b/cmd/gitserver/server/repo_info_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 )

--- a/cmd/gitserver/server/servermetrics.go
+++ b/cmd/gitserver/server/servermetrics.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 )
 

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 

--- a/cmd/query-runner/all_saved_queries.go
+++ b/cmd/query-runner/all_saved_queries.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/query-runner/queryrunnerapi"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )

--- a/cmd/query-runner/email.go
+++ b/cmd/query-runner/email.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/txemail"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"

--- a/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
+++ b/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )

--- a/cmd/repo-updater/repoupdater/observability.go
+++ b/cmd/repo-updater/repoupdater/observability.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/metrics"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )

--- a/cmd/searcher/search/filter.go
+++ b/cmd/searcher/search/filter.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/zoekt/ignore"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"

--- a/cmd/searcher/search/filter_test.go
+++ b/cmd/searcher/search/filter_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/zoekt/ignore"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -22,10 +22,11 @@ import (
 
 	"github.com/inconshreveable/log15"
 
+	nettrace "golang.org/x/net/trace"
+
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/store"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	nettrace "golang.org/x/net/trace"
 
 	"github.com/pkg/errors"
 

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/comby"

--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hexops/autogold"
+
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -20,6 +20,7 @@ import (
 	zoektquery "github.com/google/zoekt/query"
 	zoektrpc "github.com/google/zoekt/rpc"
 	"github.com/opentracing/opentracing-go/log"
+
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"

--- a/cmd/server/shared/nginx.go
+++ b/cmd/server/shared/nginx.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/server/shared/assets"
 )
 

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/joho/godotenv"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goreman"
 )

--- a/cmd/symbols/internal/symbols/ctags.go
+++ b/cmd/symbols/internal/symbols/ctags.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	ctags "github.com/sourcegraph/go-ctags"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 

--- a/cmd/symbols/internal/symbols/fetch.go
+++ b/cmd/symbols/internal/symbols/fetch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )

--- a/cmd/symbols/internal/symbols/parse.go
+++ b/cmd/symbols/internal/symbols/parse.go
@@ -13,10 +13,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	ctags "github.com/sourcegraph/go-ctags"
+	nettrace "golang.org/x/net/trace"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	nettrace "golang.org/x/net/trace"
 )
 
 // startParsers starts the parser process pool.

--- a/cmd/symbols/internal/symbols/search.go
+++ b/cmd/symbols/internal/symbols/search.go
@@ -16,9 +16,10 @@ import (
 	"github.com/keegancsmith/sqlf"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
+	nettrace "golang.org/x/net/trace"
+
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	nettrace "golang.org/x/net/trace"
 )
 
 // maxFileSize is the limit on file size in bytes. Only files smaller than this are processed.

--- a/cmd/symbols/internal/symbols/search_test.go
+++ b/cmd/symbols/internal/symbols/search_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"

--- a/cmd/symbols/internal/symbols/service.go
+++ b/cmd/symbols/internal/symbols/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	ctags "github.com/sourcegraph/go-ctags"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"
 )

--- a/cmd/symbols/internal/symbols/service_test.go
+++ b/cmd/symbols/internal/symbols/service_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	ctags "github.com/sourcegraph/go-ctags"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"

--- a/dev/generate.sh
+++ b/dev/generate.sh
@@ -6,3 +6,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 # We'll exclude generating the CLI reference documentation by default due to the
 # relatively high cost of fetching and building src-cli.
 go list ./... | grep -v 'doc/cli/references' | xargs go generate -x
+goimports -w -local github.com/sourcegraph/sourcegraph .

--- a/dev/generate.sh
+++ b/dev/generate.sh
@@ -6,4 +6,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 # We'll exclude generating the CLI reference documentation by default due to the
 # relatively high cost of fetching and building src-cli.
 go list ./... | grep -v 'doc/cli/references' | xargs go generate -x
-goimports -w -local github.com/sourcegraph/sourcegraph .
+go get golang.org/x/tools/cmd/goimports && goimports -w .

--- a/dev/migrate-vanity.go
+++ b/dev/migrate-vanity.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/tools/imports"
 
 	"github.com/fatih/astrewrite"
+
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 

--- a/docker-images/prometheus/cmd/prom-wrapper/change.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/change.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/alertmanager/api/v2/client/silence"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	amconfig "github.com/prometheus/alertmanager/config"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/docker-images/prometheus/cmd/prom-wrapper/mocks/prometheus_mock.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/mocks/prometheus_mock.go
@@ -4,10 +4,11 @@ package mocks
 
 import (
 	"context"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
-	model "github.com/prometheus/common/model"
 	"sync"
 	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	model "github.com/prometheus/common/model"
 )
 
 // MockAPI is a mock implementation of the API interface (from the package

--- a/enterprise/cmd/executor/internal/worker/mock_command_runner_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_command_runner_test.go
@@ -4,8 +4,9 @@ package worker
 
 import (
 	"context"
-	command "github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
 	"sync"
+
+	command "github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
 )
 
 // MockRunner is a mock implementation of the Runner interface (from the

--- a/enterprise/cmd/executor/internal/worker/mock_store_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_store_test.go
@@ -4,8 +4,9 @@ package worker
 
 import (
 	"context"
-	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"sync"
+
+	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
 // MockStore is a mock implementation of the Store interface (from the

--- a/enterprise/cmd/frontend/auth/githuboauth/config.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/config.go
@@ -2,6 +2,7 @@ package githuboauth
 
 import (
 	"github.com/dghubble/gologin"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/enterprise/cmd/frontend/auth/githuboauth/config_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/config_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/oauth2"
 )
 
 func TestParseConfig(t *testing.T) {

--- a/enterprise/cmd/frontend/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider.go
@@ -5,12 +5,13 @@ import (
 	"net/url"
 
 	"github.com/dghubble/gologin/github"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/oauth2"
 )
 
 const sessionKey = "githuboauth@0"

--- a/enterprise/cmd/frontend/auth/githuboauth/provider_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/enterprise/cmd/frontend/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/auth/githuboauth/session_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	githubsvc "github.com/sourcegraph/sourcegraph/internal/extsvc/github"
-	"golang.org/x/oauth2"
 )
 
 func init() {

--- a/enterprise/cmd/frontend/auth/gitlaboauth/config_test.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/config_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/sergi/go-diff/diffmatchpatch"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/oauth2"
 )
 
 func TestParseConfig(t *testing.T) {

--- a/enterprise/cmd/frontend/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/provider.go
@@ -5,11 +5,12 @@ import (
 	"net/url"
 
 	"github.com/dghubble/gologin"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/oauth2"
 )
 
 const sessionKey = "gitlaboauth@0"

--- a/enterprise/cmd/frontend/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/auth/gitlaboauth/session.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/oauth"

--- a/enterprise/cmd/frontend/auth/httpheader/middleware.go
+++ b/enterprise/cmd/frontend/auth/httpheader/middleware.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/enterprise/cmd/frontend/auth/init.go
+++ b/enterprise/cmd/frontend/auth/init.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/app"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/auth/githuboauth"

--- a/enterprise/cmd/frontend/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/auth/oauth/middleware.go
@@ -13,13 +13,14 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/oauth2"
 )
 
 func NewHandler(serviceType, authPrefix string, isAPIHandler bool, next http.Handler) http.Handler {

--- a/enterprise/cmd/frontend/auth/oauth/provider.go
+++ b/enterprise/cmd/frontend/auth/oauth/provider.go
@@ -15,9 +15,10 @@ import (
 	"github.com/dghubble/gologin"
 	goauth2 "github.com/dghubble/gologin/oauth2"
 	"github.com/inconshreveable/log15"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/oauth2"
 )
 
 type Provider struct {

--- a/enterprise/cmd/frontend/auth/openidconnect/config.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/config.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/enterprise/cmd/frontend/auth/openidconnect/config_watch.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/config_watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/enterprise/cmd/frontend/auth/openidconnect/provider.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/provider.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context/ctxhttp"
+	"golang.org/x/oauth2"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/globals"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/net/context/ctxhttp"
-	"golang.org/x/oauth2"
 )
 
 const providerType = "openidconnect"

--- a/enterprise/cmd/frontend/auth/openidconnect/session.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/session.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/external/session"
 )

--- a/enterprise/cmd/frontend/auth/openidconnect/user.go
+++ b/enterprise/cmd/frontend/auth/openidconnect/user.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/coreos/go-oidc"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/enterprise/cmd/frontend/auth/saml/config.go
+++ b/enterprise/cmd/frontend/auth/saml/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"

--- a/enterprise/cmd/frontend/auth/saml/config_watch.go
+++ b/enterprise/cmd/frontend/auth/saml/config_watch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/enterprise/cmd/frontend/auth/saml/provider.go
+++ b/enterprise/cmd/frontend/auth/saml/provider.go
@@ -19,11 +19,12 @@ import (
 	saml2 "github.com/russellhaering/gosaml2"
 	"github.com/russellhaering/gosaml2/types"
 	dsig "github.com/russellhaering/goxmldsig"
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 const providerType = "saml"

--- a/enterprise/cmd/frontend/auth/saml/session.go
+++ b/enterprise/cmd/frontend/auth/saml/session.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/beevik/etree"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/enterprise/cmd/frontend/auth/saml/user.go
+++ b/enterprise/cmd/frontend/auth/saml/user.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	saml2 "github.com/russellhaering/gosaml2"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"

--- a/enterprise/cmd/frontend/auth/saml/user_test.go
+++ b/enterprise/cmd/frontend/auth/saml/user_test.go
@@ -10,6 +10,7 @@ import (
 
 	saml2 "github.com/russellhaering/gosaml2"
 	dsig "github.com/russellhaering/goxmldsig"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 

--- a/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/mock_iface_test.go
@@ -4,10 +4,11 @@ package commitgraph
 
 import (
 	"context"
-	gitserver "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
-	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"sync"
 	"time"
+
+	gitserver "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
+	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/mock_iface_test.go
@@ -4,10 +4,11 @@ package indexing
 
 import (
 	"context"
-	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"regexp"
 	"sync"
 	"time"
+
+	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/auth_github.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 )

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
@@ -4,8 +4,9 @@ package httpapi
 
 import (
 	"context"
-	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"sync"
+
+	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/hover.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/hover.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"github.com/sourcegraph/go-lsp"
+
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 )
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/graph-gophers/graphql-go"
+
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 )

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/graph-gophers/graphql-go"
+
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/util.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/util.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"github.com/sourcegraph/go-lsp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 )
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4,12 +4,13 @@ package resolvers
 
 import (
 	"context"
+	"sync"
+	"time"
+
 	config "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 	gitserver "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
-	"sync"
-	"time"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_position_adjuster_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_position_adjuster_test.go
@@ -4,8 +4,9 @@ package resolvers
 
 import (
 	"context"
-	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"sync"
+
+	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 )
 
 // MockPositionAdjuster is a mock implementation of the PositionAdjuster

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
@@ -4,9 +4,10 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	resolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
-	"sync"
 )
 
 // MockQueryResolver is a mock implementation of the QueryResolver interface

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -4,10 +4,11 @@ package mocks
 
 import (
 	"context"
+	"sync"
+
 	graphqlbackend "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	resolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	"sync"
 )
 
 // MockResolver is a mock implementation of the Resolver interface (from the

--- a/enterprise/cmd/frontend/internal/dotcom/billing/subscriptions.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/subscriptions.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/stripe/stripe-go"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 )
 
 // ToSubscriptionItemsParams converts a value of GraphQL type ProductSubscriptionInput into a

--- a/enterprise/cmd/frontend/internal/executor/internal_proxy_handler.go
+++ b/enterprise/cmd/frontend/internal/executor/internal_proxy_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )

--- a/enterprise/cmd/frontend/internal/registry/extension_bundle.go
+++ b/enterprise/cmd/frontend/internal/registry/extension_bundle.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	frontendregistry "github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
 	"github.com/sourcegraph/sourcegraph/internal/conf"

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/registry"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"

--- a/enterprise/cmd/frontend/internal/registry/publishers_db.go
+++ b/enterprise/cmd/frontend/internal/registry/publishers_db.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
@@ -4,9 +4,10 @@ package worker
 
 import (
 	"context"
+	"sync"
+
 	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"sync"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
@@ -4,12 +4,14 @@ package worker
 
 import (
 	"context"
+	"sync"
+	"time"
+
 	sqlf "github.com/keegancsmith/sqlf"
+
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 	store "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
-	"sync"
-	"time"
 )
 
 // MockWorkerStore is a mock implementation of the Store interface (from the

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	sqlf "github.com/keegancsmith/sqlf"
-
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 	store "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"

--- a/enterprise/internal/campaigns/resolvers/changeset_event.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_event.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/store"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"

--- a/enterprise/internal/campaigns/resolvers/credential.go
+++ b/enterprise/internal/campaigns/resolvers/credential.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/enterprise/internal/campaigns/testing/changeset_source.go
+++ b/enterprise/internal/campaigns/testing/changeset_source.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/repos"

--- a/enterprise/internal/campaigns/testing/mock_sync_state.go
+++ b/enterprise/internal/campaigns/testing/mock_sync_state.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"

--- a/enterprise/internal/campaigns/testing/specs.go
+++ b/enterprise/internal/campaigns/testing/specs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 )
 

--- a/enterprise/internal/codeintel/autoindex/enqueuer/mock_iface.go
+++ b/enterprise/internal/codeintel/autoindex/enqueuer/mock_iface.go
@@ -4,11 +4,12 @@ package enqueuer
 
 import (
 	"context"
-	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"regexp"
 	"sync"
 	"time"
+
+	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/internal/codeintel/autoindex/inference/go_test.go
+++ b/enterprise/internal/codeintel/autoindex/inference/go_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 )
 

--- a/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
+++ b/enterprise/internal/codeintel/autoindex/inference/typescript_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 )
 

--- a/enterprise/internal/codeintel/commitgraph/commit_graph_test.go
+++ b/enterprise/internal/codeintel/commitgraph/commit_graph_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 )
 

--- a/enterprise/internal/codeintel/lsif/correlation/canonicalize_test.go
+++ b/enterprise/internal/codeintel/lsif/correlation/canonicalize_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/lsif/datastructures"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/lsif/lsif"
 )

--- a/enterprise/internal/codeintel/lsif/correlation/prune_test.go
+++ b/enterprise/internal/codeintel/lsif/correlation/prune_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/lsif/datastructures"
 )
 

--- a/enterprise/internal/codeintel/lsif/correlation/util.go
+++ b/enterprise/internal/codeintel/lsif/correlation/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 )
 

--- a/enterprise/internal/codeintel/stores/dbstore/index_configuration_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/index_configuration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )

--- a/enterprise/internal/codeintel/stores/dbstore/indexable_repos_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexable_repos_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 

--- a/enterprise/internal/codeintel/stores/dbstore/repo_usage_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/repo_usage_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )

--- a/enterprise/internal/codeintel/stores/lsifstore/clear_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/clear_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client.go
@@ -11,10 +11,11 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+	"google.golang.org/api/option"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
-	"google.golang.org/api/option"
 )
 
 type gcsStore struct {

--- a/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
@@ -3,10 +3,11 @@
 package uploadstore
 
 import (
-	storage "cloud.google.com/go/storage"
 	"context"
 	"io"
 	"sync"
+
+	storage "cloud.google.com/go/storage"
 )
 
 // MockGcsAPI is a mock implementation of the gcsAPI interface (from the

--- a/enterprise/internal/codeintel/stores/uploadstore/mock_s3_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mock_s3_api_test.go
@@ -4,9 +4,10 @@ package uploadstore
 
 import (
 	"context"
+	"sync"
+
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	s3manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"sync"
 )
 
 // MockS3API is a mock implementation of the s3API interface (from the

--- a/enterprise/internal/codeintel/stores/uploadstore/mocks/mock_store.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mocks/mock_store.go
@@ -4,9 +4,10 @@ package mocks
 
 import (
 	"context"
-	uploadstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 	"io"
 	"sync"
+
+	uploadstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 )
 
 // MockStore is a mock implementation of the Store interface (from the

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/observation"

--- a/enterprise/internal/insights/discovery/mock_setting_store.go
+++ b/enterprise/internal/insights/discovery/mock_setting_store.go
@@ -4,8 +4,9 @@ package discovery
 
 import (
 	"context"
-	api "github.com/sourcegraph/sourcegraph/internal/api"
 	"sync"
+
+	api "github.com/sourcegraph/sourcegraph/internal/api"
 )
 
 // MockSettingStore is a mock implementation of the SettingStore interface

--- a/enterprise/internal/license/generate-license.go
+++ b/enterprise/internal/license/generate-license.go
@@ -26,8 +26,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 )
 
 var (

--- a/enterprise/internal/license/read-license.go
+++ b/enterprise/internal/license/read-license.go
@@ -16,8 +16,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/license"
 )
 
 type noopPublicKey struct{}

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -11,12 +11,13 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 var frontendInternal = env.Get("SRC_FRONTEND_INTERNAL", "sourcegraph-frontend-internal", "HTTP address for internal frontend HTTP API.")

--- a/internal/authz/gitlab/oauth_test.go
+++ b/internal/authz/gitlab/oauth_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"

--- a/internal/campaigns/campaign_spec.go
+++ b/internal/campaigns/campaign_spec.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sourcegraph/campaignutils/env"
 	"github.com/sourcegraph/campaignutils/overridable"
 	"github.com/sourcegraph/campaignutils/yaml"
+
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 

--- a/internal/campaigns/changeset_event.go
+++ b/internal/campaigns/changeset_event.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"

--- a/internal/campaigns/changeset_event_test.go
+++ b/internal/campaigns/changeset_event_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"

--- a/internal/campaigns/changeset_spec.go
+++ b/internal/campaigns/changeset_spec.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	jsonutil "github.com/sourcegraph/campaignutils/json"
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/schema"
 )

--- a/internal/cmd/ghe-feeder/progress.go
+++ b/internal/cmd/ghe-feeder/progress.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	_ "github.com/mattn/go-sqlite3"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 

--- a/internal/cmd/init-sg/repos.go
+++ b/internal/cmd/init-sg/repos.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
+
 	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
 

--- a/internal/cmd/precise-code-intel-tester/query.go
+++ b/internal/cmd/precise-code-intel-tester/query.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/cmd/precise-code-intel-tester/util"
 )
 

--- a/internal/cmd/tracking-issue/main_test.go
+++ b/internal/cmd/tracking-issue/main_test.go
@@ -12,8 +12,9 @@ import (
 	"time"
 
 	"github.com/machinebox/graphql"
-	"github.com/sourcegraph/sourcegraph/internal/testutil"
 	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/sourcegraph/internal/testutil"
 )
 
 var (

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 

--- a/internal/conf/client.go
+++ b/internal/conf/client.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/jsonx"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/schema"

--- a/internal/conf/reposource/common.go
+++ b/internal/conf/reposource/common.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"

--- a/internal/conf/reposource/custom.go
+++ b/internal/conf/reposource/custom.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 )

--- a/internal/conf/server.go
+++ b/internal/conf/server.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/jsonx"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 

--- a/internal/conf/store.go
+++ b/internal/conf/store.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
 )
 

--- a/internal/database/basestore/savepoint.go
+++ b/internal/database/basestore/savepoint.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 

--- a/internal/database/batch/batch_test.go
+++ b/internal/database/batch/batch_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )

--- a/internal/database/confdb/confdb.go
+++ b/internal/database/confdb/confdb.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/sourcegraph/jsonx"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/confdefaults"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 )

--- a/internal/database/query/query_test.go
+++ b/internal/database/query/query_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/query"
 )
 

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 

--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/schema"
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
 

--- a/internal/extsvc/awscodecommit/client.go
+++ b/internal/extsvc/awscodecommit/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/awserr"
 	"github.com/aws/aws-sdk-go-v2/service/codecommit"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
 

--- a/internal/extsvc/awscodecommit/codehost.go
+++ b/internal/extsvc/awscodecommit/codehost.go
@@ -2,6 +2,7 @@ package awscodecommit
 
 import (
 	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )

--- a/internal/extsvc/bitbucketserver/testing.go
+++ b/internal/extsvc/bitbucketserver/testing.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/dnaeon/go-vcr/cassette"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 
 	"github.com/google/go-github/github"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 func GetExternalAccountData(data *extsvc.AccountData) (usr *github.User, tok *oauth2.Token, err error) {

--- a/internal/extsvc/github/v3_test.go
+++ b/internal/extsvc/github/v3_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/testutil"

--- a/internal/extsvc/gitlab/user.go
+++ b/internal/extsvc/gitlab/user.go
@@ -1,8 +1,9 @@
 package gitlab
 
 import (
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"golang.org/x/oauth2"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
 // GetExternalAccountData returns the deserialized user and token from the external account data

--- a/internal/extsvc/gitlab/webhooks/events.go
+++ b/internal/extsvc/gitlab/webhooks/events.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 )
 

--- a/internal/extsvc/gitlab/webhooks/merge_requests.go
+++ b/internal/extsvc/gitlab/webhooks/merge_requests.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 )
 

--- a/internal/extsvc/gitlab/webhooks/merge_requests_test.go
+++ b/internal/extsvc/gitlab/webhooks/merge_requests_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 )
 

--- a/internal/extsvc/phabricator/client.go
+++ b/internal/extsvc/phabricator/client.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/uber/gonduit"
 	"github.com/uber/gonduit/core"
 	"github.com/uber/gonduit/requests"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 
 var requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{

--- a/internal/extsvc/phabricator/client_test.go
+++ b/internal/extsvc/phabricator/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sergi/go-diff/diffmatchpatch"
+
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -26,6 +26,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"

--- a/internal/gitserver/proxy.go
+++ b/internal/gitserver/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httputil"
 
 	"github.com/neelance/parallel"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -3,6 +3,7 @@ package gqltestutil
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/pkg/errors"
 )
 

--- a/internal/httpcli/client.go
+++ b/internal/httpcli/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gregjones/httpcache"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 )
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 

--- a/internal/rcache/rcache.go
+++ b/internal/rcache/rcache.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gomodule/redigo/redis"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )

--- a/internal/redispool/redispool.go
+++ b/internal/redispool/redispool.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )

--- a/internal/redispool/sysreq.go
+++ b/internal/redispool/sysreq.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gomodule/redigo/redis"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/sysreq"
 )

--- a/internal/registry/client.go
+++ b/internal/registry/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 )
 

--- a/internal/repos/awscodecommit.go
+++ b/internal/repos/awscodecommit.go
@@ -10,13 +10,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/defaults"
 	"github.com/aws/aws-sdk-go-v2/aws/endpoints"
 	"github.com/inconshreveable/log15"
+	"golang.org/x/net/http2"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
-	"golang.org/x/net/http2"
 )
 
 // An AWSCodeCommitSource yields repositories from a single AWS Code Commit

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/campaigns"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/types"

--- a/internal/repos/scheduler.go
+++ b/internal/repos/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"

--- a/internal/repos/scheduler_test.go
+++ b/internal/repos/scheduler_test.go
@@ -3,14 +3,16 @@ package repos
 import (
 	"container/heap"
 	"context"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-	"github.com/sourcegraph/sourcegraph/schema"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/schema"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	gitserverprotocol "github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/google/go-cmp/cmp"
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"

--- a/internal/repos/testing.go
+++ b/internal/repos/testing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-multierror"
+
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/google/zoekt"
+
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
+
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 

--- a/internal/search/env.go
+++ b/internal/search/env.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/zoekt"
 	"github.com/google/zoekt/query"
 	"github.com/google/zoekt/rpc"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/env"

--- a/internal/search/repo_status_test.go
+++ b/internal/search/repo_status_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/opentracing-contrib/go-stdlib/nethttp"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/cmd/searcher/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"

--- a/internal/sqliteutil/register.go
+++ b/internal/sqliteutil/register.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-sqlite3"
+
 	"github.com/sourcegraph/sourcegraph/internal/env"
 )
 

--- a/internal/src-cli/version.go
+++ b/internal/src-cli/version.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/linkheader"
 )
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/diskcache"

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -15,13 +15,14 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context/ctxhttp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 var symbolsURL = env.Get("SYMBOLS_URL", "k8s+http://symbols:3184", "symbols service URL")

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -11,8 +11,9 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	nettrace "golang.org/x/net/trace"
+
+	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
 var spanURL atomic.Value

--- a/internal/tracer/tracer.go
+++ b/internal/tracer/tracer.go
@@ -14,11 +14,12 @@ import (
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+	"go.uber.org/automaxprocs/maxprocs"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
-	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go"

--- a/internal/txemail/template.go
+++ b/internal/txemail/template.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jordan-wright/email"
 	"github.com/microcosm-cc/bluemonday"
 	gfm "github.com/shurcooL/github_flavored_markdown"
+
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 )
 

--- a/internal/txemail/template_test.go
+++ b/internal/txemail/template_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jordan-wright/email"
+
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 )
 

--- a/internal/txemail/txemail.go
+++ b/internal/txemail/txemail.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/jordan-wright/email"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 )

--- a/internal/txemail/txemail_test.go
+++ b/internal/txemail/txemail_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jordan-wright/email"
+
 	"github.com/sourcegraph/sourcegraph/internal/txemail/txtypes"
 )
 

--- a/internal/usagestats/all_time_stats.go
+++ b/internal/usagestats/all_time_stats.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/gomodule/redigo/redis"
+
 	"github.com/sourcegraph/sourcegraph/internal/redispool"
 )
 

--- a/internal/usagestats/main_test.go
+++ b/internal/usagestats/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 

--- a/internal/usagestats/repositories.go
+++ b/internal/usagestats/repositories.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/zoekt/query"
+
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 )

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"

--- a/internal/vcs/git/diff.go
+++ b/internal/vcs/git/diff.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 

--- a/internal/vcs/git/diff_filter.go
+++ b/internal/vcs/git/diff_filter.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/sourcegraph/go-diff/diff"
+
 	"github.com/sourcegraph/sourcegraph/internal/pathmatch"
 )
 

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/pathmatch"

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/cmd/gitserver/server"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"

--- a/internal/vcs/git/merge_base.go
+++ b/internal/vcs/git/merge_base.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"

--- a/internal/vcs/git/object.go
+++ b/internal/vcs/git/object.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"

--- a/internal/vcs/git/refs_test.go
+++ b/internal/vcs/git/refs_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 )
 

--- a/internal/vcs/git/revisions.go
+++ b/internal/vcs/git/revisions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/golang/groupcache/lru"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"

--- a/internal/vfsutil/github_archive.go
+++ b/internal/vfsutil/github_archive.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 

--- a/internal/vfsutil/gitserver.go
+++ b/internal/vfsutil/gitserver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"

--- a/internal/vfsutil/zip.go
+++ b/internal/vfsutil/zip.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 
 	"github.com/opentracing/opentracing-go/ext"

--- a/internal/workerutil/dbworker/store/mocks/mock_store.go
+++ b/internal/workerutil/dbworker/store/mocks/mock_store.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	sqlf "github.com/keegancsmith/sqlf"
-
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 	store "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"

--- a/internal/workerutil/dbworker/store/mocks/mock_store.go
+++ b/internal/workerutil/dbworker/store/mocks/mock_store.go
@@ -4,12 +4,14 @@ package mocks
 
 import (
 	"context"
+	"sync"
+	"time"
+
 	sqlf "github.com/keegancsmith/sqlf"
+
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 	store "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
-	"sync"
-	"time"
 )
 
 // MockStore is a mock implementation of the Store interface (from the

--- a/internal/workerutil/dbworker/store_shim.go
+++ b/internal/workerutil/dbworker/store_shim.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/keegancsmith/sqlf"
+
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
 )


### PR DESCRIPTION
This commit fixes all goimports lint errors by running `goimports -w .`
and enables goimports as an enforced lint.

Also adds a goimports call to `generate.sh` so generated code doesn't trigger lints.

Progresses #18720 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
