### PR TITLE
Prioritize global external services in campaigns syncer

### DIFF
--- a/enterprise/internal/campaigns/syncer/util.go
+++ b/enterprise/internal/campaigns/syncer/util.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"sort"
 
 	"github.com/pkg/errors"
 
@@ -14,10 +15,18 @@ import (
 // The first external service to have a token configured will be returned then.
 // If no external service matching the above criteria is found, an error is returned.
 func loadExternalService(ctx context.Context, esStore ExternalServiceStore, repo *types.Repo) (*types.ExternalService, error) {
-	es, err := esStore.List(ctx, database.ExternalServicesListOptions{IDs: repo.ExternalServiceIDs()})
+	es, err := esStore.List(ctx, database.ExternalServicesListOptions{
+		// Consider all available external services for this repo.
+		IDs: repo.ExternalServiceIDs(),
+	})
 	if err != nil {
 		return nil, err
 	}
+
+	// Sort the external services so user owned external service go last.
+	sort.Slice(es, func(i, j int) bool {
+		return es[i].NamespaceUserID == 0
+	})
 
 	for _, e := range es {
 		cfg, err := e.Configuration()

--- a/enterprise/internal/campaigns/syncer/util_test.go
+++ b/enterprise/internal/campaigns/syncer/util_test.go
@@ -1,0 +1,101 @@
+package syncer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/campaigns/testing"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestLoadExternalService(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	db := dbtesting.GetDB(t)
+	esStore := database.ExternalServices(db)
+	repoStore := database.Repos(db)
+	user := ct.CreateTestUser(t, db, false)
+
+	noToken := types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GitHub no token",
+		Config:      `{"url": "https://github.com", "authorization": {}}`,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	userOwnedWithToken := types.ExternalService{
+		Kind:            extsvc.KindGitHub,
+		DisplayName:     "GitHub user owned",
+		NamespaceUserID: user.ID,
+		Config:          `{"url": "https://github.com", "token": "123", "authorization": {}}`,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	withToken := types.ExternalService{
+		Kind:        extsvc.KindGitHub,
+		DisplayName: "GitHub token",
+		Config:      `{"url": "https://github.com", "token": "123", "authorization": {}}`,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := esStore.Upsert(ctx, &noToken, &userOwnedWithToken, &withToken); err != nil {
+		t.Fatalf("failed to insert external service: %v", err)
+	}
+
+	repo := &types.Repo{
+		Name:    api.RepoName("test-repo"),
+		URI:     "test-repo",
+		Private: true,
+		ExternalRepo: api.ExternalRepoSpec{
+			ID:          "external-id-123",
+			ServiceType: extsvc.TypeGitHub,
+			ServiceID:   "https://github.com/",
+		},
+		Sources: map[string]*types.SourceInfo{
+			noToken.URN(): {
+				ID:       noToken.URN(),
+				CloneURL: "https://github.com/sourcegraph/sourcegraph",
+			},
+			userOwnedWithToken.URN(): {
+				ID:       userOwnedWithToken.URN(),
+				CloneURL: "https://123@github.com/sourcegraph/sourcegraph",
+			},
+			withToken.URN(): {
+				ID:       withToken.URN(),
+				CloneURL: "https://123@github.com/sourcegraph/sourcegraph",
+			},
+		},
+	}
+
+	if err := repoStore.Create(ctx, repo); err != nil {
+		t.Fatalf("failed to insert repo: %v", err)
+	}
+
+	// Expect the public external service with a token to be returned.
+	svc, err := loadExternalService(ctx, esStore, repo)
+	if err != nil {
+		t.Fatalf("invalid error, expected nil, got %v", err)
+	}
+	if have, want := svc.ID, withToken.ID; have != want {
+		t.Fatalf("invalid external service returned, want=%d have=%d", want, have)
+	}
+
+	// Now delete the global external service and expect the user owned external service to be returned.
+	if err := esStore.Delete(ctx, withToken.ID); err != nil {
+		t.Fatalf("failed to delete external service: %v", err)
+	}
+	svc, err = loadExternalService(ctx, esStore, repo)
+	if err != nil {
+		t.Fatalf("invalid error, expected nil, got %v", err)
+	}
+	if have, want := svc.ID, userOwnedWithToken.ID; have != want {
+		t.Fatalf("invalid external service returned, want=%d have=%d", want, have)
+	}
+}


### PR DESCRIPTION
To have as few negative impact on the user provided tokens as possible, until we fix the syncer using global tokens, we can prioritize the global external services over user owned ones.

