### PR TITLE
search frontend: fix resize detection on MonacoQueryInput

### DIFF
--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -356,12 +356,12 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
     }
     return (
         <>
-            <div ref={setContainer} className="monaco-query-input-container">
+            <div className="monaco-query-input-container">
                 {props.showSearchContext && (
                     <SearchContextDropdown query={queryState.query} submitSearch={submitSearch} {...props} />
                 )}
                 <div className="monaco-query-input-container__focus-container flex-shrink-past-contents">
-                    <div className="flex-grow-1 flex-shrink-past-contents" onFocus={onFocus}>
+                    <div ref={setContainer} className="flex-grow-1 flex-shrink-past-contents" onFocus={onFocus}>
                         <MonacoEditor
                             id="monaco-query-input"
                             language={SOURCEGRAPH_SEARCH}


### PR DESCRIPTION
Fixes #18750

Resize detection is now done on the direct parent of `MonacoEditor`.