### PR TITLE
Only search for endpoints within the same namespace

### DIFF
--- a/cmd/frontend/internal/app/debugproxies/scanner.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner.go
@@ -87,8 +87,7 @@ func (cs *clusterScanner) runEventLoop() {
 func (cs *clusterScanner) watchEndpointEvents() (bool, error) {
 
 	// TODO(Dax): Rewrite this to used NewSharedInformerFactory from k8s/client-go
-
-	watcher, err := cs.client.Endpoints(metav1.NamespaceAll).Watch(metav1.ListOptions{})
+	watcher, err := cs.client.Endpoints(cs.namespace).Watch(metav1.ListOptions{})
 	if err != nil {
 		return false, fmt.Errorf("k8s client.Watch error: %w", err)
 	}
@@ -114,7 +113,7 @@ func (cs *clusterScanner) watchEndpointEvents() (bool, error) {
 // It derives the appropriate port from the prometheus.io/port annotation.
 func (cs *clusterScanner) scanCluster() {
 
-	// Get services from all namespaces
+	// Get services from the current namespace
 	services, err := cs.client.Services(cs.namespace).List(metav1.ListOptions{})
 	if err != nil {
 		log15.Error("k8s failed to list services", "error", err)


### PR DESCRIPTION
<!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
## Overview

Part of https://github.com/sourcegraph/sourcegraph/issues/18583

Changes:
- Do not try to list ALL endpoints in the cluster, we do not have privileges for that by default
- Fixes log line: 
```
k8s client.Watch error: unknown (get endpoints)
```


<!-- Update the implementation steps that should be completed to implement the feature/bug fix/tech debt cleanup -->
## Progress
~~- [ ] No panics in frontend logs~~
- [ ] Approved by a backend engineer (if touching backend code)
