### PR TITLE
Add CHANGELOG for Go 1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - A repository's `remote.origin.url` is not stored on gitserver disk anymore. Note: if you use the experimental feature `customGitFetch` your setting may need to be updated to specify the remote URL. [#18535](https://github.com/sourcegraph/sourcegraph/pull/18535)
-- Repositories and files containing spaces will now render with escaped spaces in the query bar rather than being quoted. [#18642](https://github.com/sourcegraph/sourcegraph/pull/18642)
+- Repositories and files containing spaces will now render with escaped spaces in the query bar rather than being
+  quoted. [#18642](https://github.com/sourcegraph/sourcegraph/pull/18642)
+- Sourcegraph is now built with Go 1.16. [#18447](https://github.com/sourcegraph/sourcegraph/pull/18447)
 
 ### Fixed
 


### PR DESCRIPTION
Missed this in https://github.com/sourcegraph/sourcegraph/pull/18447

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
