### PR TITLE
dev/gqltest: instructions to get secrets from cli

### DIFF
--- a/dev/gqltest/README.md
+++ b/dev/gqltest/README.md
@@ -26,6 +26,12 @@ export BITBUCKET_SERVER_USERNAME=<REDACTED>
 
 You need to run `direnv allow` after editing the `.envrc` file.
 
+Alternatively you can use the 1password CLI tool:
+
+``` sh
+eval $(op get item 5q5lnpirajegt7uifngeabrak4 | jq -r '.details.sections[] | .fields[] | @sh "export \(.t)=\(.v)")
+```
+
 ## How to run tests
 
 GraphQL-based integration tests are running against a live Sourcegraph instance, the eaiset way to make one is by booting up a single Docker container:

--- a/dev/gqltest/README.md
+++ b/dev/gqltest/README.md
@@ -29,7 +29,10 @@ You need to run `direnv allow` after editing the `.envrc` file.
 Alternatively you can use the 1password CLI tool:
 
 ``` sh
-eval $(op get item 5q5lnpirajegt7uifngeabrak4 | jq -r '.details.sections[] | .fields[] | @sh "export \(.t)=\(.v)")
+# dev-private token for ghe.sgdev.org
+op get item bw4nttlfqve3rc6xqzbqq7l7pm | jq -r '.. | select(.t? == "token name: dev-private") | @sh "export GITHUB_TOKEN=\(.v)"'
+# AWS and Bitbucket tokens
+op get item 5q5lnpirajegt7uifngeabrak4 | jq -r '.details.sections[] | .fields[] | @sh "export \(.t)=\(.v)"
 ```
 
 ## How to run tests

--- a/dev/gqltest/README.md
+++ b/dev/gqltest/README.md
@@ -28,7 +28,7 @@ You need to run `direnv allow` after editing the `.envrc` file.
 
 Alternatively you can use the 1password CLI tool:
 
-``` sh
+```sh
 # dev-private token for ghe.sgdev.org
 op get item bw4nttlfqve3rc6xqzbqq7l7pm | jq -r '.. | select(.t? == "token name: dev-private") | @sh "export GITHUB_TOKEN=\(.v)"'
 # AWS and Bitbucket tokens


### PR DESCRIPTION
We may want to somehow make this the default, but unsure how well the
1password cli works. For now others can try out this command to get the
relevant export statements.