### PR TITLE
dev/gqltest: separate search tests which can be used for streaming

### DIFF
--- a/dev/gqltest/README.md
+++ b/dev/gqltest/README.md
@@ -1,6 +1,6 @@
 # GraphQL integration tests
 
-This directory contains GraphQL-based integration tests in the form of standard Go tests.
+This directory contains API-based integration tests in the form of standard Go tests. It is called gqltest since most of our API is GraphQL. However, the test suite has been extended to test other endpoints such as streaming search.
 
 ## How to set up credentials
 


### PR DESCRIPTION
This is an initial commit which splits the search tests in two. Those
that can be run against the streaming API and those that won't be part
of streaming. Our gql tests ask for very little from the GQL API, so
luckily we can re-use them. The next commit will add a streaming client
as well as run "testSearchClient" twice. Once with the normal GQL client
and once with the streaming client.