### PR TITLE
search: buffer sender in zoektSearch

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -327,7 +327,9 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 			})
 		}
 
-		return args.Zoekt.Client.StreamSearch(ctx, finalQuery, &searchOpts, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+		// The buffered backend.ZoektStreamFunc allows us to consume events from Zoekt
+		// while we wait for repo resolution.
+		bufSender, cleanup := bufferedSender(30, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 
 			mu.Lock()
 			foundResults = foundResults || event.FileCount != 0 || event.MatchCount != 0
@@ -424,6 +426,9 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 				},
 			})
 		}))
+		defer cleanup()
+
+		return args.Zoekt.Client.StreamSearch(ctx, finalQuery, &searchOpts, bufSender)
 	})
 
 	if err := g.Wait(); err != nil {
@@ -443,6 +448,30 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 		return nil
 	}
 	return nil
+}
+
+// bufferedSender returns a buffered Sender with capacity cap, and a cleanup
+// function which blocks until the buffer is drained. The cleanup function may
+// only be called once. For cap=0, bufferedSender returns the input sender.
+func bufferedSender(cap int, sender zoekt.Sender) (zoekt.Sender, func()) {
+	if cap == 0 {
+		return sender, func() {}
+	}
+	buf := make(chan *zoekt.SearchResult, cap-1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for e := range buf {
+			sender.Send(e)
+		}
+	}()
+	cleanup := func() {
+		close(buf)
+		<-done
+	}
+	return backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+		buf <- event
+	}), cleanup
 }
 
 // zoektSearchReposOnly is used when select:repo is set, in which case we can ask zoekt


### PR DESCRIPTION
We add a buffer to the Sender in `graphqlbackend/zoektSearch` to reduce
the backpressure that Sourcegraph excerts on Zoekt.

In our current code we don't buffer which most likey causes Zoekt to
block until repos are resolved.

The buffer size is hard-coded at 30 `zoekt.SearchResults`, which should
be more than enough to fill the first page.

Co-authored-by: Keegan Carruthers-Smith <keegan.csmith@gmail.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
