### PR TITLE
dev: build without custom build tags

### DIFF
--- a/dev/check/go-lint.sh
+++ b/dev/check/go-lint.sh
@@ -15,9 +15,5 @@ else
   pkgs=("$@")
 fi
 
-echo "--- go install"
-go install -tags=dev -buildmode=archive "${pkgs[@]}"
-asdf reshim
-
 echo "--- lint"
 "./dev/golangci-lint.sh" --config .golangci.enforced.yml run "${pkgs[@]}"

--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -66,11 +66,9 @@ fi
 tmpdir="$(mktemp -d -t src-binaries.XXXXXXXX)"
 trap 'rm -rf "$tmpdir"' EXIT
 
-TAGS='dev'
 if [ -n "$DELVE" ]; then
   echo -e "Building Go code with optimizations disabled (for debugging)." >&2
   GCFLAGS='all=-N -l'
-  TAGS="$TAGS delve"
 fi
 
 # build a list of "cmd,true" and "cmd,false" pairs to indicate whether each command
@@ -133,7 +131,7 @@ do_install() {
   # believes it hasn't changed.
   do_md5 "${cmdlist[@]}" >"${tmpdir}/digest.txt"
 
-  if (go install -v -gcflags="$GCFLAGS" -tags "$TAGS" -race="$race" "${cmds[@]}"); then
+  if (go install -v -gcflags="$GCFLAGS" -race="$race" "${cmds[@]}"); then
     if $verbose; then
       # Add the digests after compilation
       do_md5 "${cmdlist[@]}" >>"${tmpdir}/digest.txt"


### PR DESCRIPTION
None of our go files specify the dev or delve build tag. It is possible
a dependency specifies the delve tag, but I don't see any recommendation
in the delve README about this. If it does, we can add back build tag
support for delve. I think we originally added this tag back in the day
for how we shipped delve support (predates OSS).

Depends on https://github.com/sourcegraph/sourcegraph/pull/18773