### PR TITLE
db: add stub validators for Perforce

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -41,6 +41,7 @@ type ExternalServiceStore struct {
 	GitHubValidators          []func(*schema.GitHubConnection) error
 	GitLabValidators          []func(*schema.GitLabConnection, []schema.AuthProviders) error
 	BitbucketServerValidators []func(*schema.BitbucketServerConnection) error
+	PerforceValidators        []func(connection *schema.PerforceConnection) error
 
 	key encryption.Key
 
@@ -282,6 +283,13 @@ func (e *ExternalServiceStore) ValidateConfig(ctx context.Context, opt ValidateE
 		}
 		err = e.validateBitbucketCloudConnection(ctx, opt.ExternalServiceID, &c)
 
+	case extsvc.KindPerforce:
+		var c schema.PerforceConnection
+		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
+			return nil, err
+		}
+		err = e.validatePerforceConnection(ctx, opt.ExternalServiceID, &c)
+
 	case extsvc.KindOther:
 		var c schema.OtherExternalServiceConnection
 		if err = jsoniter.Unmarshal(normalized, &c); err != nil {
@@ -365,6 +373,14 @@ func (e *ExternalServiceStore) validateBitbucketServerConnection(ctx context.Con
 
 func (e *ExternalServiceStore) validateBitbucketCloudConnection(ctx context.Context, id int64, c *schema.BitbucketCloudConnection) error {
 	return e.validateDuplicateRateLimits(ctx, id, extsvc.KindBitbucketCloud, c)
+}
+
+func (e *ExternalServiceStore) validatePerforceConnection(ctx context.Context, id int64, c *schema.PerforceConnection) error {
+	err := new(multierror.Error)
+	for _, validate := range e.PerforceValidators {
+		err = multierror.Append(err, validate(c))
+	}
+	return err.ErrorOrNil()
 }
 
 // validateDuplicateRateLimits returns an error if given config has duplicated non-default rate limit

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -41,7 +41,7 @@ type ExternalServiceStore struct {
 	GitHubValidators          []func(*schema.GitHubConnection) error
 	GitLabValidators          []func(*schema.GitLabConnection, []schema.AuthProviders) error
 	BitbucketServerValidators []func(*schema.BitbucketServerConnection) error
-	PerforceValidators        []func(connection *schema.PerforceConnection) error
+	PerforceValidators        []func(*schema.PerforceConnection) error
 
 	key encryption.Key
 


### PR DESCRIPTION
This PR adds the "switch case" for the Perforce code host connections (just like any others). Currently the validators for Perforce is always empty, and will be initialized when add Perforce authz.

Subset of #17881 and extracted here for easier review, and part of #16705.