### PR TITLE
database: Add GitserverRepoStore

### DIFF
--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -319,30 +319,6 @@ func PostgresDSN(prefix, currentUser string, getenv func(string) string) string 
 	return dsn.String()
 }
 
-// NullTimeColumn returns nil if t is a zero value, otherwise it returns the address of t.
-func NullTimeColumn(t time.Time) *time.Time {
-	if t.IsZero() {
-		return nil
-	}
-	return &t
-}
-
-// NullTimeColumn returns nil if s is a zero value, otherwise it returns the address of s.
-func NullStringColumn(s string) *string {
-	if s == "" {
-		return nil
-	}
-	return &s
-}
-
-// NullInt32Column returns nil if i is a zero value, otherwise it returns the address of i.
-func NullInt32Column(i int32) *int32 {
-	if i == 0 {
-		return nil
-	}
-	return &i
-}
-
 // Scanner captures the Scan method of sql.Rows and sql.Row
 type Scanner interface {
 	Scan(dst ...interface{}) error

--- a/internal/database/dbutil/dbutil.go
+++ b/internal/database/dbutil/dbutil.go
@@ -96,6 +96,14 @@ func (nt NullTime) Value() (driver.Value, error) {
 // sql.NullString. When the scanned value is null, String is set to the zero value.
 type NullString struct{ S *string }
 
+// NewNullString returns a NullString treating zero value as null.
+func NewNullString(s string) NullString {
+	if s == "" {
+		return NullString{}
+	}
+	return NullString{S: &s}
+}
+
 // Scan implements the Scanner interface.
 func (nt *NullString) Scan(value interface{}) error {
 	switch v := value.(type) {
@@ -147,6 +155,14 @@ func (n NullInt32) Value() (driver.Value, error) {
 // sql.Scanner interface so it can be used as a scan destination, similar to
 // sql.NullString. When the scanned value is null, int64 is set to the zero value.
 type NullInt64 struct{ N *int64 }
+
+// NewNullInt64 returns a NullInt64 treating zero value as null.
+func NewNullInt64(i int64) NullInt64 {
+	if i == 0 {
+		return NullInt64{}
+	}
+	return NullInt64{N: &i}
+}
 
 // Scan implements the Scanner interface.
 func (n *NullInt64) Scan(value interface{}) error {

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -17,7 +17,7 @@ type GitserverRepoStore struct {
 	*basestore.Store
 }
 
-// Repos instantiates and returns a new RepoStore with prepared statements.
+// GitserverRepos instantiates and returns a new GitserverRepoStore.
 func GitserverRepos(db dbutil.DB) *GitserverRepoStore {
 	return &GitserverRepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -1,0 +1,127 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/keegancsmith/sqlf"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+// GitserverRepos
+type GitserverRepoStore struct {
+	*basestore.Store
+}
+
+// Repos instantiates and returns a new RepoStore with prepared statements.
+func GitserverRepos(db dbutil.DB) *GitserverRepoStore {
+	return &GitserverRepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
+}
+
+// NewGitserverReposWith instantiates and returns a new GitserverRepoStore using
+// the other store handle.
+func NewGitserverReposWith(other basestore.ShareableStore) *GitserverRepoStore {
+	return &GitserverRepoStore{Store: basestore.NewWithHandle(other.Handle())}
+}
+
+func (s *GitserverRepoStore) With(other basestore.ShareableStore) *GitserverRepoStore {
+	return &GitserverRepoStore{Store: s.Store.With(other)}
+}
+
+func (s *GitserverRepoStore) Transact(ctx context.Context) (*GitserverRepoStore, error) {
+	txBase, err := s.Store.Transact(ctx)
+	return &GitserverRepoStore{Store: txBase}, err
+}
+
+// Create adds a row representing the GitServer status of a repo
+func (s *GitserverRepoStore) Create(ctx context.Context, gr *types.GitserverRepo) error {
+	if gr.ShardID == "" {
+		return errors.New("missing shardID")
+	}
+	var lastExtSvc sql.NullInt64
+	var lastError sql.NullString
+	if gr.LastExternalService > 0 {
+		lastExtSvc.Int64 = gr.LastExternalService
+		lastExtSvc.Valid = true
+	}
+	if gr.LastError != "" {
+		lastError.String = gr.LastError
+		lastError.Valid = true
+	}
+	err := s.Exec(ctx, sqlf.Sprintf(`
+INSERT INTO gitserver_repos(repo_id, clone_status, shard_id, last_external_service, last_error) VALUES (%s,%s,%s,%s,%s)
+`, gr.RepoID, gr.CloneStatus, gr.ShardID, lastExtSvc, lastError))
+
+	return errors.Wrap(err, "creating GitserverRepo")
+}
+
+// IterateRepoGitserverStatus iterates over the status of all repos by joining
+// our repo and gitserver_repos table. It is possible for us not to have a
+// corresponding row in gitserver_repos yet. repoFn will be called once for each
+// row. If it returns an error we'll abort iteration.
+func (s *GitserverRepoStore) IterateRepoGitserverStatus(ctx context.Context, repoFn func(repo types.RepoGitserverStatus) error) error {
+	if repoFn == nil {
+		return errors.New("nil repoFn")
+	}
+
+	q := `
+SELECT repo.id,
+       repo.name,
+       gr.clone_status,
+       gr.shard_id,
+       gr.last_external_service,
+       gr.last_error,
+       gr.updated_at
+FROM repo 
+    LEFT JOIN gitserver_repos gr ON gr.repo_id = repo.id
+ORDER BY repo.id ASC
+`
+
+	rows, err := s.Query(ctx, sqlf.Sprintf(q))
+	if err != nil {
+		return errors.Wrap(err, "fetching gitserver status")
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rgs types.RepoGitserverStatus
+		var cloneStatus sql.NullString
+		var shardID sql.NullString
+		var lastExtSvc sql.NullInt64
+		var lastError sql.NullString
+		var updatedAt sql.NullTime
+
+		if err := rows.Scan(&rgs.ID, &rgs.Name, &cloneStatus, &shardID, &lastExtSvc, &lastError, &updatedAt); err != nil {
+			return errors.Wrap(err, "scanning row")
+		}
+
+		// Clone status will only be null if we don't have a corresponding row in
+		// gitserver_repos
+		if cloneStatus.Valid {
+			rgs.GitserverRepo = &types.GitserverRepo{
+				RepoID:              rgs.ID,
+				ShardID:             shardID.String,
+				CloneStatus:         types.ParseCloneStatus(cloneStatus.String),
+				LastExternalService: lastExtSvc.Int64,
+				LastError:           lastError.String,
+				UpdatedAt:           updatedAt.Time,
+			}
+		}
+
+		err := repoFn(rgs)
+		if err != nil {
+			// Abort
+			return errors.Wrap(err, "calling repoFn")
+		}
+	}
+
+	if rows.Err() != nil {
+		return errors.Wrap(rows.Err(), "iterating rows")
+	}
+
+	return nil
+}

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// GitserverRepos
+// GitserverReposStore is responsible for data stored in the gitserver_repos table.
 type GitserverRepoStore struct {
 	*basestore.Store
 }

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -39,24 +39,9 @@ func (s *GitserverRepoStore) Transact(ctx context.Context) (*GitserverRepoStore,
 
 // Create adds a row representing the GitServer status of a repo
 func (s *GitserverRepoStore) Create(ctx context.Context, gr *types.GitserverRepo) error {
-	var shardID sql.NullString
-	var lastExtSvc sql.NullInt64
-	var lastError sql.NullString
-	if gr.LastExternalService > 0 {
-		lastExtSvc.Int64 = gr.LastExternalService
-		lastExtSvc.Valid = true
-	}
-	if gr.LastError != "" {
-		lastError.String = gr.LastError
-		lastError.Valid = true
-	}
-	if gr.ShardID != "" {
-		shardID.String = gr.ShardID
-		shardID.Valid = true
-	}
 	err := s.Exec(ctx, sqlf.Sprintf(`
 INSERT INTO gitserver_repos(repo_id, clone_status, shard_id, last_external_service, last_error) VALUES (%s,%s,%s,%s,%s)
-`, gr.RepoID, gr.CloneStatus, shardID, lastExtSvc, lastError))
+`, gr.RepoID, gr.CloneStatus, dbutil.NewNullString(gr.ShardID), dbutil.NewNullInt64(gr.LastExternalService), dbutil.NewNullString(gr.LastError)))
 
 	return errors.Wrap(err, "creating GitserverRepo")
 }

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -77,10 +77,10 @@ ORDER BY repo.id ASC
 	for rows.Next() {
 		var rgs types.RepoGitserverStatus
 		var gr types.GitserverRepo
-
 		var cloneStatus string
 
-		if err := rows.Scan(&rgs.ID,
+		if err := rows.Scan(
+			&rgs.ID,
 			&rgs.Name,
 			&dbutil.NullString{S: &cloneStatus},
 			&dbutil.NullString{S: &gr.ShardID},

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -1,0 +1,77 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestIterateRepoGitserverStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	db := dbtesting.GetDB(t)
+	ctx := context.Background()
+
+	repo1 := &types.Repo{
+		Name:         "github.com/sourcegraph/repo1",
+		URI:          "github.com/sourcegraph/repo1",
+		Description:  "",
+		ExternalRepo: api.ExternalRepoSpec{},
+		Sources:      nil,
+	}
+	repo2 := &types.Repo{
+		Name:         "github.com/sourcegraph/repo2",
+		URI:          "github.com/sourcegraph/repo2",
+		Description:  "",
+		ExternalRepo: api.ExternalRepoSpec{},
+		Sources:      nil,
+	}
+
+	// Create two test repos
+	err := Repos(db).Create(ctx, repo1, repo2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitserverRepo := &types.GitserverRepo{
+		RepoID:              repo1.ID,
+		ShardID:             "gitserver1",
+		CloneStatus:         "not_cloned",
+		LastExternalService: 0,
+	}
+
+	// Create one GitServerRepo
+	if err := GitserverRepos(db).Create(ctx, gitserverRepo); err != nil {
+		t.Fatal(err)
+	}
+
+	var repoCount int
+	var statusCount int
+
+	// Iterate
+	err = GitserverRepos(db).IterateRepoGitserverStatus(ctx, func(repo types.RepoGitserverStatus) error {
+		repoCount++
+		if repo.GitserverRepo != nil {
+			statusCount++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantRepoCount := 2
+	if repoCount != wantRepoCount {
+		t.Fatalf("Expected %d repos, got %d", wantRepoCount, repoCount)
+	}
+
+	wantStatusCount := 1
+	if statusCount != wantStatusCount {
+		t.Fatalf("Expected %d statuses, got %d", wantStatusCount, statusCount)
+	}
+}

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -75,3 +75,38 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 		t.Fatalf("Expected %d statuses, got %d", wantStatusCount, statusCount)
 	}
 }
+
+func TestGitserverRepoCreateNullShard(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	db := dbtesting.GetDB(t)
+	ctx := context.Background()
+
+	repo1 := &types.Repo{
+		Name:         "github.com/sourcegraph/repo1",
+		URI:          "github.com/sourcegraph/repo1",
+		Description:  "",
+		ExternalRepo: api.ExternalRepoSpec{},
+		Sources:      nil,
+	}
+
+	// Create two test repos
+	err := Repos(db).Create(ctx, repo1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitserverRepo := &types.GitserverRepo{
+		RepoID:              repo1.ID,
+		ShardID:             "",
+		CloneStatus:         "not_cloned",
+		LastExternalService: 0,
+	}
+
+	// Create one GitServerRepo
+	if err := GitserverRepos(db).Create(ctx, gitserverRepo); err == nil {
+		t.Fatal("Expected an error")
+	}
+}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -49,7 +49,7 @@ func (e *RepoNotFoundErr) NotFound() bool {
 	return true
 }
 
-// RepoStore handles access the the repo table
+// RepoStore handles access to the repo table
 type RepoStore struct {
 	*basestore.Store
 

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -49,7 +49,7 @@ func (e *RepoNotFoundErr) NotFound() bool {
 	return true
 }
 
-// RepoStore is a DB-backed implementation of the Repos.
+// RepoStore handles access the the repo table
 type RepoStore struct {
 	*basestore.Store
 
@@ -61,7 +61,8 @@ func Repos(db dbutil.DB) *RepoStore {
 	return &RepoStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
-// NewRepoStoreWithDB instantiates and returns a new RepoStore using the other store handle.
+// NewRepoStoreWithDB instantiates and returns a new RepoStore using the other
+// store handle.
 func ReposWith(other basestore.ShareableStore) *RepoStore {
 	return &RepoStore{Store: basestore.NewWithHandle(other.Handle())}
 }
@@ -743,7 +744,6 @@ WHERE
 func (s *RepoStore) Create(ctx context.Context, repos ...*types.Repo) (err error) {
 	tr, ctx := trace.New(ctx, "repos.Create", "")
 	defer func() {
-
 		tr.SetError(err)
 		tr.Finish()
 	}()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -386,7 +386,7 @@ type CodeHostRepository struct {
 }
 
 // RepoGitserverStatus includes basic repo data along with the current gitserver
-// status for the repo which may be unknown.
+// status for the repo, which may be unknown.
 type RepoGitserverStatus struct {
 	// ID is the unique numeric ID for this repository.
 	ID api.RepoID

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -385,6 +385,50 @@ type CodeHostRepository struct {
 	Private    bool
 }
 
+// RepoGitserverStatus includes basic repo data along with the current gitserver
+// status for the repo which may be unknown.
+type RepoGitserverStatus struct {
+	// ID is the unique numeric ID for this repository.
+	ID api.RepoID
+	// Name is the name for this repository (e.g., "github.com/user/repo").
+	Name api.RepoName
+
+	// GitserverRepo data if it exists
+	GitserverRepo *GitserverRepo
+}
+
+type CloneStatus string
+
+const (
+	CloneStatusUnknown   CloneStatus = ""
+	CloneStatusNotCloned CloneStatus = "not_cloned"
+	CloneStatusCloning   CloneStatus = "cloning"
+	CloneStatusCloned    CloneStatus = "cloned"
+)
+
+func ParseCloneStatus(s string) CloneStatus {
+	cs := CloneStatus(s)
+	switch cs {
+	case CloneStatusNotCloned, CloneStatusCloning, CloneStatusCloned:
+		return cs
+	default:
+		return CloneStatusUnknown
+	}
+}
+
+// GitserverRepo  represents the data gitserver knows about a repo
+type GitserverRepo struct {
+	RepoID api.RepoID
+	// Usually represented by a gitserver hostname
+	ShardID     string
+	CloneStatus CloneStatus
+	// The last external service used to sync or clone this repo
+	LastExternalService int64
+	// The last error that occured or empty if the last action was successful
+	LastError string
+	UpdatedAt time.Time
+}
+
 // ExternalService is a connection to an external service.
 type ExternalService struct {
 	ID              int64


### PR DESCRIPTION
Add the start of the GitServerRepoStore which allows us to create and
iterate over GitserverRepo rows in the database.

Iteration is used since we plan to select a large number of rows from
the database per query but only need to operate on one at a time.

Also removed some dead code. 