### PR TITLE
Fix user settings sidebar width

### DIFF
--- a/client/web/src/user/settings/UserSettingsArea.scss
+++ b/client/web/src/user/settings/UserSettingsArea.scss
@@ -1,3 +1,4 @@
 @import './profile/UserProfileFormFields';
 @import './profile/UserSettingsProfilePage.scss';
 @import './repositories/UserSettingsRepositoriesPage';
+@import './UserSettingsSidebar';

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -76,7 +76,11 @@ export const UserSettingsArea = withAuthenticatedUser(
 
             return (
                 <div className="d-flex">
-                    <UserSettingsSidebar items={this.props.sideBarItems} {...this.props} className="flex-0 mr-3" />
+                    <UserSettingsSidebar
+                        items={this.props.sideBarItems}
+                        {...this.props}
+                        className="flex-0 mr-3 user-settings-sidebar"
+                    />
                     <div className="flex-1">
                         <ErrorBoundary location={this.props.location}>
                             <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>

--- a/client/web/src/user/settings/UserSettingsSidebar.scss
+++ b/client/web/src/user/settings/UserSettingsSidebar.scss
@@ -1,0 +1,3 @@
+.user-settings-sidebar {
+    max-width: 12rem;
+}


### PR DESCRIPTION
<!-- Describe the purpose of the PR so that if you looked at it in 6 months time it would be clear from the overview why this was created -->
## Overview
Fixes the width of the content below the sidebar in this screenshot:
![image](https://user-images.githubusercontent.com/9516420/109651934-0d461500-7b57-11eb-91af-9d9eea5621af.png)

We have to set this to ensure the version text knows when to break onto a new line, and not just keep pushing the content of the page away


## Progress
- [ ] Approved by a frontend engineer (if touching frontend code)

