### PR TITLE
authz: change FetchUserPerms to return RepoIDType

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer.go
@@ -246,7 +246,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 			return errors.Wrap(err, "wait for rate limiter")
 		}
 
-		extIDs, err := provider.FetchUserPerms(ctx, acct)
+		extIDs, _, err := provider.FetchUserPerms(ctx, acct)
 		if err != nil {
 			// The "401 Unauthorized" is returned by code hosts when the token is no longer valid
 			unauthorized := errcode.IsUnauthorized(errors.Cause(err))

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -67,7 +67,7 @@ type mockProvider struct {
 	serviceType string
 	serviceID   string
 
-	fetchUserPerms func(context.Context, *extsvc.Account) ([]extsvc.RepoID, error)
+	fetchUserPerms func(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error)
 	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error)
 }
 
@@ -80,7 +80,7 @@ func (p *mockProvider) ServiceID() string   { return p.serviceID }
 func (p *mockProvider) URN() string         { return extsvc.URN(p.serviceType, p.id) }
 func (*mockProvider) Validate() []string    { return nil }
 
-func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) ([]extsvc.RepoID, error) {
+func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
 	return p.fetchUserPerms(ctx, acct)
 }
 
@@ -156,8 +156,8 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p.fetchUserPerms = func(context.Context, *extsvc.Account) ([]extsvc.RepoID, error) {
-				return []extsvc.RepoID{"1"}, test.fetchErr
+			p.fetchUserPerms = func(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+				return []extsvc.RepoID{"1"}, extsvc.RepoIDExact, test.fetchErr
 			}
 
 			err := s.syncUserPerms(context.Background(), 1, test.noPerms)
@@ -215,8 +215,8 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 			return nil
 		}
 
-		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
-			return nil, &github.APIError{Code: http.StatusUnauthorized}
+		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+			return nil, extsvc.RepoIDExact, &github.APIError{Code: http.StatusUnauthorized}
 		}
 
 		err := s.syncUserPerms(context.Background(), 1, false)
@@ -236,8 +236,8 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 			return nil
 		}
 
-		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
-			return nil, &github.APIError{
+		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+			return nil, extsvc.RepoIDExact, &github.APIError{
 				URL:     "https://api.github.com/user/repos",
 				Code:    http.StatusForbidden,
 				Message: "Sorry. Your account was suspended",

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -48,7 +48,7 @@ func (m gitlabAuthzProviderParams) URN() string {
 
 func (m gitlabAuthzProviderParams) Validate() []string { return nil }
 
-func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, error) {
+func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
 	panic("should never be called")
 }
 

--- a/internal/authz/bitbucketserver/provider_test.go
+++ b/internal/authz/bitbucketserver/provider_test.go
@@ -197,7 +197,7 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 
 				tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", cli.URL.String())
 
-				ids, err := p.FetchUserPerms(tc.ctx, tc.acct)
+				ids, _, err := p.FetchUserPerms(tc.ctx, tc.acct)
 
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("error:\nhave: %q\nwant: %q", have, want)

--- a/internal/authz/github/github.go
+++ b/internal/authz/github/github.go
@@ -68,19 +68,19 @@ func (p *Provider) Validate() (problems []string) {
 // callers to decide whether to discard.
 //
 // API docs: https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-user
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
 	if account == nil {
-		return nil, errors.New("no account provided")
+		return nil, extsvc.RepoIDExact, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
-		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
+		return nil, extsvc.RepoIDExact, fmt.Errorf("not a code host of the account: want %q but have %q",
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := github.GetExternalAccountData(&account.AccountData)
 	if err != nil {
-		return nil, errors.Wrap(err, "get external account data")
+		return nil, extsvc.RepoIDExact, errors.Wrap(err, "get external account data")
 	} else if tok == nil {
-		return nil, errors.New("no token found in the external account data")
+		return nil, extsvc.RepoIDExact, errors.New("no token found in the external account data")
 	}
 
 	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
@@ -94,7 +94,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		var repos []*github.Repository
 		repos, hasNextPage, _, err = client.ListAffiliatedRepositories(ctx, github.VisibilityPrivate, page)
 		if err != nil {
-			return repoIDs, err
+			return repoIDs, extsvc.RepoIDExact, err
 		}
 
 		for _, r := range repos {
@@ -102,7 +102,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		}
 	}
 
-	return repoIDs, nil
+	return repoIDs, extsvc.RepoIDExact, nil
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/internal/authz/github/github_test.go
+++ b/internal/authz/github/github_test.go
@@ -25,7 +25,7 @@ func mustURL(t *testing.T, u string) *url.URL {
 func TestProvider_FetchUserPerms(t *testing.T) {
 	t.Run("nil account", func(t *testing.T) {
 		p := NewProvider("", mustURL(t, "https://github.com"), "admin_token", nil)
-		_, err := p.FetchUserPerms(context.Background(), nil)
+		_, _, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -35,7 +35,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("not the code host of the account", func(t *testing.T) {
 		p := NewProvider("", mustURL(t, "https://github.com"), "admin_token", nil)
-		_, err := p.FetchUserPerms(context.Background(),
+		_, _, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "gitlab",
@@ -52,7 +52,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("no token found in account data", func(t *testing.T) {
 		p := NewProvider("", mustURL(t, "https://github.com"), "admin_token", nil)
-		_, err := p.FetchUserPerms(context.Background(),
+		_, _, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "github",
@@ -95,7 +95,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 	p.client = mockClient
 
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
-	repoIDs, err := p.FetchUserPerms(context.Background(),
+	repoIDs, _, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
 			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "github",

--- a/internal/authz/gitlab/oauth.go
+++ b/internal/authz/gitlab/oauth.go
@@ -79,19 +79,19 @@ func (p *OAuthProvider) FetchAccount(ctx context.Context, user *types.User, curr
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error) {
+func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
 	if account == nil {
-		return nil, errors.New("no account provided")
+		return nil, extsvc.RepoIDExact, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
-		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
+		return nil, extsvc.RepoIDExact, fmt.Errorf("not a code host of the account: want %q but have %q",
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := gitlab.GetExternalAccountData(&account.AccountData)
 	if err != nil {
-		return nil, errors.Wrap(err, "get external account data")
+		return nil, extsvc.RepoIDExact, errors.Wrap(err, "get external account data")
 	} else if tok == nil {
-		return nil, errors.New("no token found in the external account data")
+		return nil, extsvc.RepoIDExact, errors.New("no token found in the external account data")
 	}
 
 	client := p.clientProvider.GetOAuthClient(tok.AccessToken)

--- a/internal/authz/gitlab/oauth_test.go
+++ b/internal/authz/gitlab/oauth_test.go
@@ -28,7 +28,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, err := p.FetchUserPerms(context.Background(), nil)
+		_, _, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -40,7 +40,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, err := p.FetchUserPerms(context.Background(),
+		_, _, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: extsvc.TypeGitHub,
@@ -89,7 +89,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	)
 
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
-	repoIDs, err := p.FetchUserPerms(context.Background(),
+	repoIDs, _, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
 			AccountSpec: extsvc.AccountSpec{
 				ServiceType: extsvc.TypeGitLab,

--- a/internal/authz/gitlab/sudo_test.go
+++ b/internal/authz/gitlab/sudo_test.go
@@ -228,7 +228,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, err := p.FetchUserPerms(context.Background(), nil)
+		_, _, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -240,7 +240,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, err := p.FetchUserPerms(context.Background(),
+		_, _, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: extsvc.TypeGitHub,
@@ -295,7 +295,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	)
 
 	accountData := json.RawMessage(`{"id": 999}`)
-	repoIDs, err := p.FetchUserPerms(context.Background(),
+	repoIDs, _, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
 			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -33,15 +33,19 @@ type Provider interface {
 	// provided user, implementations should return nil, nil.
 	FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error)
 
-	// FetchUserPerms returns a list of repository/project IDs (on code host) that the
-	// given account has read access on the code host. The repository ID should be the
-	// same value as it would be used as api.ExternalRepoSpec.ID. The returned list
-	// should only include private repositories/project IDs.
+	// FetchUserPerms returns a list of repository/project IDs (on code host) that
+	// the given account has read access on the code host. The repository/project ID
+	// should be the same value as it would be used as or prefix of
+	// api.ExternalRepoSpec.ID. The returned list should only include private
+	// repositories/project IDs.
+	//
+	// The second return value (extsvc.RepoIDType) should indicate whether the
+	// returned list of extsvc.RepoID contain exact matches or prefix matches.
 	//
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, error)
+	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error)
 
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 	// the given repository/project on the code host. The user ID should be the same value

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -38,8 +38,8 @@ func (p *fakeProvider) ServiceID() string             { return p.codeHost.Servic
 func (p *fakeProvider) URN() string                   { return extsvc.URN(p.codeHost.ServiceType, 0) }
 func (p *fakeProvider) Validate() (problems []string) { return nil }
 
-func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, error) {
-	return nil, nil
+func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+	return nil, extsvc.RepoIDExact, nil
 }
 
 func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -246,6 +246,19 @@ type AccountID string
 // Server) or a GraphQL ID (e.g. GitHub) depends on the code host type.
 type RepoID string
 
+// RepoIDType indicates the type of the RepoID.
+type RepoIDType string
+
+const (
+	// RepoIDExact indicates the RepoID is an exact match, e.g.
+	// "github.com/alice/repo" can only identify itself.
+	RepoIDExact RepoIDType = "exact"
+	// RepoIDPrefix indicates the RepoID is a prefix match, e.g. "//Sourcegraph/"
+	// can identify "//Sourcegraph/CoreApp", "//Sourcegraph/Backend" and everything
+	// starts with it.
+	RepoIDPrefix RepoIDType = "prefix"
+)
+
 // ParseConfig attempts to unmarshal the given JSON config into a configuration struct defined in the schema package.
 func ParseConfig(kind, config string) (cfg interface{}, _ error) {
 	switch strings.ToUpper(kind) {


### PR DESCRIPTION
This PRs changes the signature of our `authz.Provider.FetchUserPerms` to include an indication of whether the returned list contains exact matches or prefix matches. This change is needed for upcoming Perforce authz provider, which can only provide information via prefix-matching.

Subset of #17881 and extracted here for easier review, and part of #16705.