### PR TITLE
Fix goimports that changed between PR and merge

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
-	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/utils"
+	codeintelutils "github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/utils"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"


### PR DESCRIPTION
I merged the `goimports` enforcement (#18748), but forgot that things could have changed since I made the PR, so broke CI on main. 
This just runs `goimports -w .`

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
