### PR TITLE
Consistently use the same clock in campaigns

### DIFF
--- a/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_apply_preview_connection.go
@@ -84,7 +84,7 @@ func (r *changesetApplyPreviewConnectionResolver) Nodes(ctx context.Context) ([]
 			return nil, err
 		}
 		for _, d := range syncData {
-			scheduledSyncs[d.ChangesetID] = syncer.NextSync(time.Now, d)
+			scheduledSyncs[d.ChangesetID] = syncer.NextSync(r.store.Clock(), d)
 		}
 	}
 

--- a/enterprise/internal/campaigns/resolvers/changeset_connection.go
+++ b/enterprise/internal/campaigns/resolvers/changeset_connection.go
@@ -50,7 +50,7 @@ func (r *changesetsConnectionResolver) Nodes(ctx context.Context) ([]graphqlback
 			return nil, err
 		}
 		for _, d := range syncData {
-			scheduledSyncs[d.ChangesetID] = syncer.NextSync(time.Now, d)
+			scheduledSyncs[d.ChangesetID] = syncer.NextSync(r.store.Clock(), d)
 		}
 	}
 

--- a/enterprise/internal/campaigns/store/store.go
+++ b/enterprise/internal/campaigns/store/store.go
@@ -19,7 +19,7 @@ import (
 
 // seededRand is used to populate the RandID fields on CampaignSpec and
 // ChangesetSpec when creating them.
-var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+var seededRand *rand.Rand = rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 // ErrNoResults is returned by Store method calls that found no results.
 var ErrNoResults = errors.New("no results")

--- a/enterprise/internal/campaigns/syncer/sync_test.go
+++ b/enterprise/internal/campaigns/syncer/sync_test.go
@@ -1,0 +1,85 @@
+package syncer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/campaigns"
+)
+
+func TestNextSync(t *testing.T) {
+	t.Parallel()
+
+	clock := func() time.Time { return time.Date(2020, 01, 01, 01, 01, 01, 01, time.UTC) }
+	tests := []struct {
+		name string
+		h    *campaigns.ChangesetSyncData
+		want time.Time
+	}{
+		{
+			name: "No time passed",
+			h: &campaigns.ChangesetSyncData{
+				UpdatedAt:         clock(),
+				ExternalUpdatedAt: clock(),
+			},
+			want: clock().Add(minSyncDelay),
+		},
+		{
+			name: "Linear backoff",
+			h: &campaigns.ChangesetSyncData{
+				UpdatedAt:         clock(),
+				ExternalUpdatedAt: clock().Add(-1 * time.Hour),
+			},
+			want: clock().Add(1 * time.Hour),
+		},
+		{
+			name: "Use max of ExternalUpdateAt and LatestEvent",
+			h: &campaigns.ChangesetSyncData{
+				UpdatedAt:         clock(),
+				ExternalUpdatedAt: clock().Add(-2 * time.Hour),
+				LatestEvent:       clock().Add(-1 * time.Hour),
+			},
+			want: clock().Add(1 * time.Hour),
+		},
+		{
+			name: "Diff max is capped",
+			h: &campaigns.ChangesetSyncData{
+				UpdatedAt:         clock(),
+				ExternalUpdatedAt: clock().Add(-2 * maxSyncDelay),
+			},
+			want: clock().Add(maxSyncDelay),
+		},
+		{
+			name: "Diff min is capped",
+			h: &campaigns.ChangesetSyncData{
+				UpdatedAt:         clock(),
+				ExternalUpdatedAt: clock().Add(-1 * minSyncDelay / 2),
+			},
+			want: clock().Add(minSyncDelay),
+		},
+		{
+			name: "Event arrives after sync",
+			h: &campaigns.ChangesetSyncData{
+				UpdatedAt:         clock(),
+				ExternalUpdatedAt: clock().Add(-1 * maxSyncDelay / 2),
+				LatestEvent:       clock().Add(10 * time.Minute),
+			},
+			want: clock().Add(10 * time.Minute).Add(minSyncDelay),
+		},
+		{
+			name: "Never synced",
+			h:    &campaigns.ChangesetSyncData{},
+			want: clock(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NextSync(clock, tt.h)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Fatal(diff)
+			}
+		})
+	}
+}

--- a/enterprise/internal/campaigns/syncer/syncer_test.go
+++ b/enterprise/internal/campaigns/syncer/syncer_test.go
@@ -16,81 +16,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func TestNextSync(t *testing.T) {
-	t.Parallel()
-
-	clock := func() time.Time { return time.Date(2020, 01, 01, 01, 01, 01, 01, time.UTC) }
-	tests := []struct {
-		name string
-		h    *campaigns.ChangesetSyncData
-		want time.Time
-	}{
-		{
-			name: "No time passed",
-			h: &campaigns.ChangesetSyncData{
-				UpdatedAt:         clock(),
-				ExternalUpdatedAt: clock(),
-			},
-			want: clock().Add(minSyncDelay),
-		},
-		{
-			name: "Linear backoff",
-			h: &campaigns.ChangesetSyncData{
-				UpdatedAt:         clock(),
-				ExternalUpdatedAt: clock().Add(-1 * time.Hour),
-			},
-			want: clock().Add(1 * time.Hour),
-		},
-		{
-			name: "Use max of ExternalUpdateAt and LatestEvent",
-			h: &campaigns.ChangesetSyncData{
-				UpdatedAt:         clock(),
-				ExternalUpdatedAt: clock().Add(-2 * time.Hour),
-				LatestEvent:       clock().Add(-1 * time.Hour),
-			},
-			want: clock().Add(1 * time.Hour),
-		},
-		{
-			name: "Diff max is capped",
-			h: &campaigns.ChangesetSyncData{
-				UpdatedAt:         clock(),
-				ExternalUpdatedAt: clock().Add(-2 * maxSyncDelay),
-			},
-			want: clock().Add(maxSyncDelay),
-		},
-		{
-			name: "Diff min is capped",
-			h: &campaigns.ChangesetSyncData{
-				UpdatedAt:         clock(),
-				ExternalUpdatedAt: clock().Add(-1 * minSyncDelay / 2),
-			},
-			want: clock().Add(minSyncDelay),
-		},
-		{
-			name: "Event arrives after sync",
-			h: &campaigns.ChangesetSyncData{
-				UpdatedAt:         clock(),
-				ExternalUpdatedAt: clock().Add(-1 * maxSyncDelay / 2),
-				LatestEvent:       clock().Add(10 * time.Minute),
-			},
-			want: clock().Add(10 * time.Minute).Add(minSyncDelay),
-		},
-		{
-			name: "Never synced",
-			h:    &campaigns.ChangesetSyncData{},
-			want: clock(),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := NextSync(clock, tt.h)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
 func TestChangesetPriorityQueue(t *testing.T) {
 	t.Parallel()
 
@@ -444,6 +369,12 @@ func (m MockSyncStore) Transact(ctx context.Context) (*store.Store, error) {
 
 func (m MockSyncStore) Repos() *database.RepoStore {
 	return database.GlobalRepos
+}
+
+func (m MockSyncStore) Clock() func() time.Time {
+	return func() time.Time {
+		return time.Now()
+	}
 }
 
 func (m MockSyncStore) ListCodeHosts(ctx context.Context, opts store.ListCodeHostsOpts) ([]*campaigns.CodeHost, error) {

--- a/enterprise/internal/campaigns/webhooks/webhooks.go
+++ b/enterprise/internal/campaigns/webhooks/webhooks.go
@@ -741,30 +741,30 @@ func (*GitHubWebhook) pullRequestReviewCommentEvent(e *gh.PullRequestReviewComme
 	return &comment
 }
 
-func (*GitHubWebhook) commitStatusEvent(e *gh.StatusEvent) *github.CommitStatus {
+func (h *GitHubWebhook) commitStatusEvent(e *gh.StatusEvent) *github.CommitStatus {
 	return &github.CommitStatus{
 		SHA:        e.GetSHA(),
 		State:      e.GetState(),
 		Context:    e.GetContext(),
-		ReceivedAt: time.Now(),
+		ReceivedAt: h.Now(),
 	}
 }
 
-func (*GitHubWebhook) checkSuiteEvent(cs *gh.CheckSuite) *github.CheckSuite {
+func (h *GitHubWebhook) checkSuiteEvent(cs *gh.CheckSuite) *github.CheckSuite {
 	return &github.CheckSuite{
 		ID:         cs.GetNodeID(),
 		Status:     cs.GetStatus(),
 		Conclusion: cs.GetConclusion(),
-		ReceivedAt: time.Now(),
+		ReceivedAt: h.Now(),
 	}
 }
 
-func (*GitHubWebhook) checkRunEvent(cr *gh.CheckRun) *github.CheckRun {
+func (h *GitHubWebhook) checkRunEvent(cr *gh.CheckRun) *github.CheckRun {
 	return &github.CheckRun{
 		ID:         cr.GetNodeID(),
 		Status:     cr.GetStatus(),
 		Conclusion: cr.GetConclusion(),
-		ReceivedAt: time.Now(),
+		ReceivedAt: h.Now(),
 	}
 }
 


### PR DESCRIPTION
Before time.Now and timeutil.Now were used in conjunction, which may cause problems if the server is not running in UTC.