### PR TITLE
Move most result types to internal/search/results

### DIFF
--- a/cmd/frontend/graphqlbackend/result_deduper.go
+++ b/cmd/frontend/graphqlbackend/result_deduper.go
@@ -20,11 +20,11 @@ func NewDeduper() *searchResultDeduper {
 // a previously added SearchResultResolver if the URL has already been seen
 func (d *searchResultDeduper) Add(r SearchResultResolver) {
 	if fileMatch, ok := r.ToFileMatch(); ok {
-		if prev, seen := d.seenFileMatches[fileMatch.uri]; seen {
+		if prev, seen := d.seenFileMatches[fileMatch.URI]; seen {
 			prev.appendMatches(fileMatch)
 			return
 		}
-		d.seenFileMatches[fileMatch.uri] = fileMatch
+		d.seenFileMatches[fileMatch.URI] = fileMatch
 		return
 	}
 
@@ -58,7 +58,7 @@ func (d *searchResultDeduper) Add(r SearchResultResolver) {
 func (d *searchResultDeduper) Seen(r SearchResultResolver) (ok bool) {
 	switch v := r.(type) {
 	case *FileMatchResolver:
-		_, ok = d.seenFileMatches[v.uri]
+		_, ok = d.seenFileMatches[v.URI]
 	case *RepositoryResolver:
 		_, ok = d.seenRepoMatches[v.URL()]
 	case *CommitSearchResultResolver:

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -72,11 +72,11 @@ func TestSearchCommitsInRepo(t *testing.T) {
 	want := []*CommitSearchResultResolver{{
 		db: db,
 		CommitSearchResult: CommitSearchResult{
-			commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
-			repoName:    types.RepoName{ID: 1, Name: "repo"},
-			diffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-			body:        "```diff\nx```",
-			highlights:  []*highlightedRange{},
+			Commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
+			RepoName:    types.RepoName{ID: 1, Name: "repo"},
+			DiffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
+			Body:        "```diff\nx```",
+			Highlights:  []*highlightedRange{},
 		},
 	}}
 
@@ -116,7 +116,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 }
 
 func (r *CommitSearchResultResolver) String() string {
-	return fmt.Sprintf("{commit: %+v diffPreview: %+v messagePreview: %+v}", r.Commit(), r.diffPreview, r.messagePreview)
+	return fmt.Sprintf("{commit: %+v diffPreview: %+v messagePreview: %+v}", r.Commit(), r.DiffPreview(), r.MessagePreview())
 }
 
 func TestExpandUsernamesToEmails(t *testing.T) {
@@ -316,7 +316,7 @@ func searchCommitsInRepo(ctx context.Context, db dbutil.DB, op search.CommitPara
 func TestCommitSearchResult_Limit(t *testing.T) {
 	f := func(nHighlights []int, limitInput uint32) bool {
 		cr := &CommitSearchResult{
-			highlights: make([]*highlightedRange, len(nHighlights)),
+			Highlights: make([]*highlightedRange, len(nHighlights)),
 		}
 
 		// It isn't interesting to test limit > ResultCount, so we bound it to

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -266,7 +266,7 @@ func paginatedSearchFilesInRepos(ctx context.Context, db dbutil.DB, args *search
 		// fileResults is not sorted so we must sort it now. fileCommon may or
 		// may not be sorted, but we do not rely on its order.
 		sort.Slice(fileResults, func(i, j int) bool {
-			return fileResults[i].uri < fileResults[j].uri
+			return fileResults[i].URI < fileResults[j].URI
 		})
 		results := make([]SearchResultResolver, 0, len(fileResults))
 		for _, r := range fileResults {

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -42,15 +43,15 @@ func TestSearchRepositories(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, FileMatch{
-					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
+				mkFileMatchResolver(db, results.FileMatch{
+					URI:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
 			}, &streaming.Stats{}, nil
 		case "bar/one":
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, FileMatch{
-					uri:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
+				mkFileMatchResolver(db, results.FileMatch{
+					URI:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &types.RepoName{ID: 789},
 				}),
 			}, &streaming.Stats{}, nil
@@ -148,8 +149,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, FileMatch{
-					uri:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
+				mkFileMatchResolver(db, results.FileMatch{
+					URI:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
 			}, &streaming.Stats{}, nil
@@ -166,8 +167,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *streaming.Stats, err error) {
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, FileMatch{
-					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+				mkFileMatchResolver(db, results.FileMatch{
+					URI:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
 			}, &streaming.Stats{}, nil
@@ -201,8 +202,8 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *streaming.Stats, err error) {
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, FileMatch{
-					uri:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
+				mkFileMatchResolver(db, results.FileMatch{
+					URI:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
 			}, &streaming.Stats{}, nil
@@ -309,7 +310,7 @@ func BenchmarkSearchRepositories(b *testing.B) {
 	}
 }
 
-func mkFileMatchResolver(db dbutil.DB, fm FileMatch) *FileMatchResolver {
+func mkFileMatchResolver(db dbutil.DB, fm results.FileMatch) *FileMatchResolver {
 	var repo *RepositoryResolver
 	if fm.Repo != nil {
 		repo = NewRepositoryResolver(db, fm.Repo.ToRepo())

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -43,14 +43,14 @@ func TestSearchRepositories(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, results.FileMatch{
+				mkFileMatchResolver(db, result.FileMatch{
 					URI:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
 			}, &streaming.Stats{}, nil
 		case "bar/one":
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, results.FileMatch{
+				mkFileMatchResolver(db, result.FileMatch{
 					URI:  "git://" + string(repoName) + "?1a2b3c#" + "f.go",
 					Repo: &types.RepoName{ID: 789},
 				}),
@@ -149,7 +149,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		switch repoName {
 		case "foo/one":
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, results.FileMatch{
+				mkFileMatchResolver(db, result.FileMatch{
 					URI:  "git://" + string(repoName) + "?1a2b3c#" + "foo.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
@@ -167,7 +167,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *streaming.Stats, err error) {
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, results.FileMatch{
+				mkFileMatchResolver(db, result.FileMatch{
 					URI:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
@@ -202,7 +202,7 @@ func TestRepoShouldBeAdded(t *testing.T) {
 		repo := &search.RepositoryRevisions{Repo: &types.RepoName{ID: 123, Name: "foo/one"}, Revs: []search.RevisionSpecifier{{RevSpec: ""}}}
 		mockSearchFilesInRepos = func(args *search.TextParameters) (matches []*FileMatchResolver, common *streaming.Stats, err error) {
 			return []*FileMatchResolver{
-				mkFileMatchResolver(db, results.FileMatch{
+				mkFileMatchResolver(db, result.FileMatch{
 					URI:  "git://" + string(repo.Repo.Name) + "?1a2b3c#" + "foo.go",
 					Repo: &types.RepoName{ID: 123},
 				}),
@@ -310,7 +310,7 @@ func BenchmarkSearchRepositories(b *testing.B) {
 	}
 }
 
-func mkFileMatchResolver(db dbutil.DB, fm results.FileMatch) *FileMatchResolver {
+func mkFileMatchResolver(db dbutil.DB, fm result.FileMatch) *FileMatchResolver {
 	var repo *RepositoryResolver
 	if fm.Repo != nil {
 		repo = NewRepositoryResolver(db, fm.Repo.ToRepo())

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -556,7 +556,7 @@ func intersectMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 	rightFileMatches := make(map[string]*FileMatchResolver)
 	for _, r := range right.SearchResults {
 		if fileMatch, ok := r.ToFileMatch(); ok {
-			rightFileMatches[fileMatch.uri] = fileMatch
+			rightFileMatches[fileMatch.URI] = fileMatch
 		}
 	}
 
@@ -567,7 +567,7 @@ func intersectMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 			continue
 		}
 
-		rightFileMatch := rightFileMatches[leftFileMatch.uri]
+		rightFileMatch := rightFileMatches[leftFileMatch.URI]
 		if rightFileMatch == nil {
 			continue
 		}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -59,9 +60,9 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	defer git.ResetMocks()
 
 	fileMatch := func(path string, lineNumbers ...int32) *FileMatchResolver {
-		var lines []*LineMatch
+		var lines []*results.LineMatch
 		for _, n := range lineNumbers {
-			lines = append(lines, &LineMatch{LineNumber: n})
+			lines = append(lines, &results.LineMatch{LineNumber: n})
 		}
 		return mkFileMatchResolver(db, FileMatch{
 			Path:        path,

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -60,11 +60,11 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	defer git.ResetMocks()
 
 	fileMatch := func(path string, lineNumbers ...int32) *FileMatchResolver {
-		var lines []*results.LineMatch
+		var lines []*result.LineMatch
 		for _, n := range lineNumbers {
-			lines = append(lines, &results.LineMatch{LineNumber: n})
+			lines = append(lines, &result.LineMatch{LineNumber: n})
 		}
-		return mkFileMatchResolver(db, results.FileMatch{
+		return mkFileMatchResolver(db, result.FileMatch{
 			Path:        path,
 			LineMatches: lines,
 			Repo:        &types.RepoName{Name: "r"},

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -64,7 +64,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 		for _, n := range lineNumbers {
 			lines = append(lines, &results.LineMatch{LineNumber: n})
 		}
-		return mkFileMatchResolver(db, FileMatch{
+		return mkFileMatchResolver(db, results.FileMatch{
 			Path:        path,
 			LineMatches: lines,
 			Repo:        &types.RepoName{Name: "r"},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1460,7 +1460,7 @@ func commitResult(urlKey string) *CommitSearchResultResolver {
 func diffResult(urlKey string) *CommitSearchResultResolver {
 	return &CommitSearchResultResolver{
 		CommitSearchResult: CommitSearchResult{
-			diffPreview: &highlightedString{},
+			DiffPreview: &highlightedString{},
 		},
 		gitCommitResolver: &GitCommitResolver{
 			repoResolver: &RepositoryResolver{
@@ -1494,7 +1494,7 @@ func resultToString(r SearchResultResolver) string {
 	case *RepositoryResolver:
 		return fmt.Sprintf("Repository:%s", v.URL())
 	case *CommitSearchResultResolver:
-		if v.diffPreview != nil {
+		if v.DiffPreview() != nil {
 			return fmt.Sprintf("Diff:%s", v.Commit().URL())
 		}
 		return fmt.Sprintf("Commit:%s", v.Commit().URL())
@@ -1708,7 +1708,7 @@ func searchResultResolversToString(srrs []SearchResultResolver) string {
 			}
 			return fmt.Sprintf("File{url:%s,symbols:[%s],lineMatches:[%s]}", v.URI, strings.Join(symbols, ","), strings.Join(lines, ","))
 		case *CommitSearchResultResolver:
-			if v.diffPreview != nil {
+			if v.DiffPreview() != nil {
 				return fmt.Sprintf("Diff:%s", v.URL())
 			}
 			return fmt.Sprintf("Commit:%s", v.URL())

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -1039,7 +1040,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 					&FileMatchResolver{
 						db: db,
 						FileMatch: FileMatch{
-							Symbols: []*SearchSymbolResult{
+							Symbols: []*results.SearchSymbolResult{
 								// 1
 								{},
 								// 2
@@ -1059,7 +1060,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 					&FileMatchResolver{
 						db: db,
 						FileMatch: FileMatch{
-							Symbols: []*SearchSymbolResult{
+							Symbols: []*results.SearchSymbolResult{
 								// 1
 								{},
 								// 2
@@ -1475,7 +1476,7 @@ func repoResult(db dbutil.DB, url string) *RepositoryResolver {
 	})
 }
 
-func fileResult(db dbutil.DB, uri string, lineMatches []*LineMatch, symbolMatches []*SearchSymbolResult) *FileMatchResolver {
+func fileResult(db dbutil.DB, uri string, lineMatches []*LineMatch, symbolMatches []*results.SearchSymbolResult) *FileMatchResolver {
 	return &FileMatchResolver{
 		db: db,
 		FileMatch: FileMatch{
@@ -1614,7 +1615,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", nil, []*SearchSymbolResult{
+					fileResult(db, "a", nil, []*results.SearchSymbolResult{
 						{Symbol: protocol.Symbol{Name: "a"}},
 						{Symbol: protocol.Symbol{Name: "b"}},
 					}),
@@ -1622,7 +1623,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", nil, []*SearchSymbolResult{
+					fileResult(db, "a", nil, []*results.SearchSymbolResult{
 						{Symbol: protocol.Symbol{Name: "c"}},
 						{Symbol: protocol.Symbol{Name: "d"}},
 					}),

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1039,7 +1039,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 				results: []SearchResultResolver{
 					&FileMatchResolver{
 						db: db,
-						FileMatch: FileMatch{
+						FileMatch: results.FileMatch{
 							Symbols: []*results.SearchSymbolResult{
 								// 1
 								{},
@@ -1059,7 +1059,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 				results: []SearchResultResolver{
 					&FileMatchResolver{
 						db: db,
-						FileMatch: FileMatch{
+						FileMatch: results.FileMatch{
 							Symbols: []*results.SearchSymbolResult{
 								// 1
 								{},
@@ -1151,7 +1151,7 @@ func TestCompareSearchResults(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
 	makeResult := func(repo, file string) *FileMatchResolver {
-		return mkFileMatchResolver(db, FileMatch{
+		return mkFileMatchResolver(db, results.FileMatch{
 			Repo: &types.RepoName{Name: api.RepoName(repo)},
 			Path: file,
 		})
@@ -1479,8 +1479,8 @@ func repoResult(db dbutil.DB, url string) *RepositoryResolver {
 func fileResult(db dbutil.DB, uri string, lineMatches []*results.LineMatch, symbolMatches []*results.SearchSymbolResult) *FileMatchResolver {
 	return &FileMatchResolver{
 		db: db,
-		FileMatch: FileMatch{
-			uri:         uri,
+		FileMatch: results.FileMatch{
+			URI:         uri,
 			LineMatches: lineMatches,
 			Symbols:     symbolMatches,
 		},
@@ -1490,7 +1490,7 @@ func fileResult(db dbutil.DB, uri string, lineMatches []*results.LineMatch, symb
 func resultToString(r SearchResultResolver) string {
 	switch v := r.(type) {
 	case *FileMatchResolver:
-		return fmt.Sprintf("File:%s", v.uri)
+		return fmt.Sprintf("File:%s", v.URI)
 	case *RepositoryResolver:
 		return fmt.Sprintf("Repository:%s", v.URL())
 	case *CommitSearchResultResolver:
@@ -1706,7 +1706,7 @@ func searchResultResolversToString(srrs []SearchResultResolver) string {
 			for _, line := range v.FileMatch.LineMatches {
 				lines = append(lines, line.Preview)
 			}
-			return fmt.Sprintf("File{url:%s,symbols:[%s],lineMatches:[%s]}", v.uri, strings.Join(symbols, ","), strings.Join(lines, ","))
+			return fmt.Sprintf("File{url:%s,symbols:[%s],lineMatches:[%s]}", v.URI, strings.Join(symbols, ","), strings.Join(lines, ","))
 		case *CommitSearchResultResolver:
 			if v.diffPreview != nil {
 				return fmt.Sprintf("Diff:%s", v.URL())

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -1039,8 +1039,8 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 				results: []SearchResultResolver{
 					&FileMatchResolver{
 						db: db,
-						FileMatch: results.FileMatch{
-							Symbols: []*results.SearchSymbolResult{
+						FileMatch: result.FileMatch{
+							Symbols: []*result.SearchSymbolResult{
 								// 1
 								{},
 								// 2
@@ -1059,8 +1059,8 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 				results: []SearchResultResolver{
 					&FileMatchResolver{
 						db: db,
-						FileMatch: results.FileMatch{
-							Symbols: []*results.SearchSymbolResult{
+						FileMatch: result.FileMatch{
+							Symbols: []*result.SearchSymbolResult{
 								// 1
 								{},
 								// 2
@@ -1151,7 +1151,7 @@ func TestCompareSearchResults(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
 	makeResult := func(repo, file string) *FileMatchResolver {
-		return mkFileMatchResolver(db, results.FileMatch{
+		return mkFileMatchResolver(db, result.FileMatch{
 			Repo: &types.RepoName{Name: api.RepoName(repo)},
 			Path: file,
 		})
@@ -1476,10 +1476,10 @@ func repoResult(db dbutil.DB, url string) *RepositoryResolver {
 	})
 }
 
-func fileResult(db dbutil.DB, uri string, lineMatches []*results.LineMatch, symbolMatches []*results.SearchSymbolResult) *FileMatchResolver {
+func fileResult(db dbutil.DB, uri string, lineMatches []*result.LineMatch, symbolMatches []*result.SearchSymbolResult) *FileMatchResolver {
 	return &FileMatchResolver{
 		db: db,
-		FileMatch: results.FileMatch{
+		FileMatch: result.FileMatch{
 			URI:         uri,
 			LineMatches: lineMatches,
 			Symbols:     symbolMatches,
@@ -1577,7 +1577,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*results.LineMatch{
+					fileResult(db, "b", []*result.LineMatch{
 						{Preview: "a"},
 						{Preview: "b"},
 					}, nil),
@@ -1585,7 +1585,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*results.LineMatch{
+					fileResult(db, "b", []*result.LineMatch{
 						{Preview: "c"},
 						{Preview: "d"},
 					}, nil),
@@ -1596,7 +1596,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", []*results.LineMatch{
+					fileResult(db, "a", []*result.LineMatch{
 						{Preview: "a"},
 						{Preview: "b"},
 					}, nil),
@@ -1604,7 +1604,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*results.LineMatch{
+					fileResult(db, "b", []*result.LineMatch{
 						{Preview: "c"},
 						{Preview: "d"},
 					}, nil),
@@ -1615,7 +1615,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", nil, []*results.SearchSymbolResult{
+					fileResult(db, "a", nil, []*result.SearchSymbolResult{
 						{Symbol: protocol.Symbol{Name: "a"}},
 						{Symbol: protocol.Symbol{Name: "b"}},
 					}),
@@ -1623,7 +1623,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", nil, []*results.SearchSymbolResult{
+					fileResult(db, "a", nil, []*result.SearchSymbolResult{
 						{Symbol: protocol.Symbol{Name: "c"}},
 						{Symbol: protocol.Symbol{Name: "d"}},
 					}),

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1476,7 +1476,7 @@ func repoResult(db dbutil.DB, url string) *RepositoryResolver {
 	})
 }
 
-func fileResult(db dbutil.DB, uri string, lineMatches []*LineMatch, symbolMatches []*results.SearchSymbolResult) *FileMatchResolver {
+func fileResult(db dbutil.DB, uri string, lineMatches []*results.LineMatch, symbolMatches []*results.SearchSymbolResult) *FileMatchResolver {
 	return &FileMatchResolver{
 		db: db,
 		FileMatch: FileMatch{
@@ -1577,7 +1577,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*LineMatch{
+					fileResult(db, "b", []*results.LineMatch{
 						{Preview: "a"},
 						{Preview: "b"},
 					}, nil),
@@ -1585,7 +1585,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*LineMatch{
+					fileResult(db, "b", []*results.LineMatch{
 						{Preview: "c"},
 						{Preview: "d"},
 					}, nil),
@@ -1596,7 +1596,7 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "a", []*LineMatch{
+					fileResult(db, "a", []*results.LineMatch{
 						{Preview: "a"},
 						{Preview: "b"},
 					}, nil),
@@ -1604,7 +1604,7 @@ func TestUnionMerge(t *testing.T) {
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					fileResult(db, "b", []*LineMatch{
+					fileResult(db, "b", []*results.LineMatch{
 						{Preview: "c"},
 						{Preview: "d"},
 					}, nil),

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1514,7 +1514,7 @@ func sortResultResolvers(rs []SearchResultResolver) {
 			})
 			syms := fm.FileMatch.Symbols
 			sort.Slice(syms, func(i, j int) bool {
-				return syms[i].symbol.Name < syms[j].symbol.Name
+				return syms[i].Symbol.Name < syms[j].Symbol.Name
 			})
 		}
 	}
@@ -1615,16 +1615,16 @@ func TestUnionMerge(t *testing.T) {
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
 					fileResult(db, "a", nil, []*SearchSymbolResult{
-						{symbol: protocol.Symbol{Name: "a"}},
-						{symbol: protocol.Symbol{Name: "b"}},
+						{Symbol: protocol.Symbol{Name: "a"}},
+						{Symbol: protocol.Symbol{Name: "b"}},
 					}),
 				},
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
 					fileResult(db, "a", nil, []*SearchSymbolResult{
-						{symbol: protocol.Symbol{Name: "c"}},
-						{symbol: protocol.Symbol{Name: "d"}},
+						{Symbol: protocol.Symbol{Name: "c"}},
+						{Symbol: protocol.Symbol{Name: "d"}},
 					}),
 				},
 			},
@@ -1699,7 +1699,7 @@ func searchResultResolversToString(srrs []SearchResultResolver) string {
 		case *FileMatchResolver:
 			symbols := []string{}
 			for _, symbol := range v.FileMatch.Symbols {
-				symbols = append(symbols, symbol.symbol.Name)
+				symbols = append(symbols, symbol.Symbol.Name)
 			}
 			lines := []string{}
 			for _, line := range v.FileMatch.LineMatches {

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -161,7 +161,7 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, db dbutil.DB, args *search.Te
 		}
 		matches[i] = &FileMatchResolver{
 			db: db,
-			FileMatch: results.FileMatch{
+			FileMatch: result.FileMatch{
 				Path:     file.FileName,
 				LimitHit: fileLimitHit,
 				URI:      fileMatchURI(repoRev.Repo.Name, "", file.FileName),

--- a/cmd/frontend/graphqlbackend/search_structural.go
+++ b/cmd/frontend/graphqlbackend/search_structural.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/comby"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -160,10 +161,10 @@ func zoektSearchHEADOnlyFiles(ctx context.Context, db dbutil.DB, args *search.Te
 		}
 		matches[i] = &FileMatchResolver{
 			db: db,
-			FileMatch: FileMatch{
+			FileMatch: results.FileMatch{
 				Path:     file.FileName,
 				LimitHit: fileLimitHit,
-				uri:      fileMatchURI(repoRev.Repo.Name, "", file.FileName),
+				URI:      fileMatchURI(repoRev.Repo.Name, "", file.FileName),
 				Repo:     repoRev.Repo,
 				CommitID: api.CommitID(file.Version),
 			},

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -110,16 +110,16 @@ type symbolSuggestionResolver struct {
 
 func (s symbolSuggestionResolver) Score() int { return s.score }
 func (s symbolSuggestionResolver) Length() int {
-	return len(s.symbol.symbol.Name) + len(s.symbol.symbol.Parent)
+	return len(s.symbol.Symbol.Name) + len(s.symbol.Symbol.Parent)
 }
 func (s symbolSuggestionResolver) Label() string {
-	return s.symbol.symbol.Name + " " + s.symbol.symbol.Parent
+	return s.symbol.Symbol.Name + " " + s.symbol.Symbol.Parent
 }
 func (s symbolSuggestionResolver) ToSymbol() (*symbolResolver, bool) { return &s.symbol, true }
 func (s symbolSuggestionResolver) Key() suggestionKey {
 	return suggestionKey{
-		uri:    s.symbol.uri(),
-		symbol: s.symbol.symbol.Name + s.symbol.symbol.Parent,
+		uri:    s.symbol.URI(),
+		symbol: s.symbol.Symbol.Name + s.symbol.Symbol.Parent,
 	}
 }
 
@@ -381,19 +381,19 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			}
 			for _, sr := range fileMatch.Symbols() {
 				score := 20
-				if sr.symbol.Parent == "" {
+				if sr.Symbol.Parent == "" {
 					score++
 				}
-				if len(sr.symbol.Name) < 12 {
+				if len(sr.Symbol.Name) < 12 {
 					score++
 				}
-				switch ctagsKindToLSPSymbolKind(sr.symbol.Kind) {
+				switch ctagsKindToLSPSymbolKind(sr.Symbol.Kind) {
 				case lsp.SKFunction, lsp.SKMethod:
 					score += 2
 				case lsp.SKClass:
 					score += 3
 				}
-				if len(sr.symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.uri().String()), strings.ToLower(sr.symbol.Name)) {
+				if len(sr.Symbol.Name) >= 4 && strings.Contains(strings.ToLower(sr.URI().String()), strings.ToLower(sr.Symbol.Name)) {
 					score++
 				}
 				results = append(results, symbolSuggestionResolver{

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -113,7 +113,7 @@ func TestSearchSuggestions(t *testing.T) {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			fm := mkFileMatch(db, &types.RepoName{Name: "repo"}, "dir/file")
-			fm.uri = "git://repo?rev#dir/file"
+			fm.URI = "git://repo?rev#dir/file"
 			fm.CommitID = "rev"
 			return []*FileMatchResolver{fm}, &streaming.Stats{}, nil
 		}
@@ -173,7 +173,7 @@ func TestSearchSuggestions(t *testing.T) {
 			}
 			mk := func(name api.RepoName, path string) *FileMatchResolver {
 				fm := mkFileMatch(db, &types.RepoName{Name: name}, path)
-				fm.uri = fileMatchURI(name, "rev", path)
+				fm.URI = fileMatchURI(name, "rev", path)
 				fm.CommitID = "rev"
 				return fm
 			}

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -190,7 +190,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 	fileMatches := make([]*FileMatchResolver, 0)
 
 	for _, symbol := range symbols {
-		symbolRes := &results.SearchSymbolResult{
+		symbolRes := &result.SearchSymbolResult{
 			Symbol:  symbol,
 			BaseURI: baseURI,
 			Lang:    strings.ToLower(symbol.Language),
@@ -201,9 +201,9 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 		} else {
 			fileMatch := &FileMatchResolver{
 				db: db,
-				FileMatch: results.FileMatch{
+				FileMatch: result.FileMatch{
 					Path:     symbolRes.Symbol.Path,
-					Symbols:  []*results.SearchSymbolResult{symbolRes},
+					Symbols:  []*result.SearchSymbolResult{symbolRes},
 					URI:      uri,
 					Repo:     repoRevs.Repo,
 					CommitID: commitID,

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -28,13 +28,13 @@ import (
 
 // SearchSymbolResult is a result from symbol search.
 type SearchSymbolResult struct {
-	symbol  protocol.Symbol
-	baseURI *gituri.URI
-	lang    string
+	Symbol  protocol.Symbol
+	BaseURI *gituri.URI
+	Lang    string
 }
 
-func (s *SearchSymbolResult) uri() *gituri.URI {
-	return s.baseURI.WithFilePath(s.symbol.Path)
+func (s *SearchSymbolResult) URI() *gituri.URI {
+	return s.BaseURI.WithFilePath(s.Symbol.Path)
 }
 
 var mockSearchSymbols func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, stats *streaming.Stats, err error)
@@ -201,18 +201,18 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 
 	for _, symbol := range symbols {
 		symbolRes := &SearchSymbolResult{
-			symbol:  symbol,
-			baseURI: baseURI,
-			lang:    strings.ToLower(symbol.Language),
+			Symbol:  symbol,
+			BaseURI: baseURI,
+			Lang:    strings.ToLower(symbol.Language),
 		}
-		uri := makeFileMatchURI(repoResolver.URL(), inputRev, symbolRes.uri().Fragment)
+		uri := makeFileMatchURI(repoResolver.URL(), inputRev, symbolRes.URI().Fragment)
 		if fileMatch, ok := fileMatchesByURI[uri]; ok {
 			fileMatch.FileMatch.Symbols = append(fileMatch.FileMatch.Symbols, symbolRes)
 		} else {
 			fileMatch := &FileMatchResolver{
 				db: db,
 				FileMatch: FileMatch{
-					Path:     symbolRes.symbol.Path,
+					Path:     symbolRes.Symbol.Path,
 					Symbols:  []*SearchSymbolResult{symbolRes},
 					uri:      uri,
 					Repo:     repoRevs.Repo,

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -19,23 +19,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
-
-// SearchSymbolResult is a result from symbol search.
-type SearchSymbolResult struct {
-	Symbol  protocol.Symbol
-	BaseURI *gituri.URI
-	Lang    string
-}
-
-func (s *SearchSymbolResult) URI() *gituri.URI {
-	return s.BaseURI.WithFilePath(s.Symbol.Path)
-}
 
 var mockSearchSymbols func(ctx context.Context, args *search.TextParameters, limit int) (res []*FileMatchResolver, stats *streaming.Stats, err error)
 
@@ -200,7 +190,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 	fileMatches := make([]*FileMatchResolver, 0)
 
 	for _, symbol := range symbols {
-		symbolRes := &SearchSymbolResult{
+		symbolRes := &results.SearchSymbolResult{
 			Symbol:  symbol,
 			BaseURI: baseURI,
 			Lang:    strings.ToLower(symbol.Language),
@@ -213,7 +203,7 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 				db: db,
 				FileMatch: FileMatch{
 					Path:     symbolRes.Symbol.Path,
-					Symbols:  []*SearchSymbolResult{symbolRes},
+					Symbols:  []*results.SearchSymbolResult{symbolRes},
 					uri:      uri,
 					Repo:     repoRevs.Repo,
 					CommitID: commitID,

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -201,10 +201,10 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 		} else {
 			fileMatch := &FileMatchResolver{
 				db: db,
-				FileMatch: FileMatch{
+				FileMatch: results.FileMatch{
 					Path:     symbolRes.Symbol.Path,
 					Symbols:  []*results.SearchSymbolResult{symbolRes},
-					uri:      uri,
+					URI:      uri,
 					Repo:     repoRevs.Repo,
 					CommitID: commitID,
 				},

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -230,7 +230,7 @@ func TestSymbolRange(t *testing.T) {
 func mkSymbolFileMatchResolvers(db dbutil.DB, symbols ...[]*results.SearchSymbolResult) []*FileMatchResolver {
 	var resolvers []*FileMatchResolver
 	for _, s := range symbols {
-		resolvers = append(resolvers, mkFileMatchResolver(db, FileMatch{
+		resolvers = append(resolvers, mkFileMatchResolver(db, results.FileMatch{
 			Symbols: s,
 		}))
 	}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -27,7 +27,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	baseURI, _ := gituri.Parse("https://github.com/foo/bar")
 
 	repoResolver := NewRepositoryResolver(db, &types.Repo{ID: 1, Name: "repo"})
-	sr := &results.SearchSymbolResult{symbol, baseURI, "go"}
+	sr := &result.SearchSymbolResult{symbol, baseURI, "go"}
 
 	tests := []struct {
 		rev  string
@@ -67,7 +67,7 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("one file match, one symbol", func(t *testing.T) {
-		res := mkSymbolFileMatchResolvers(db, []*results.SearchSymbolResult{{
+		res := mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{{
 			Symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
@@ -96,11 +96,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, one symbol per file", func(t *testing.T) {
-		res := mkSymbolFileMatchResolvers(db, []*results.SearchSymbolResult{{
+		res := mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{{
 			Symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
-		}}, []*results.SearchSymbolResult{{
+		}}, []*result.SearchSymbolResult{{
 			Symbol: protocol.Symbol{
 				Name: "symbol-name-2",
 			},
@@ -137,10 +137,10 @@ func TestLimitingSymbolResults(t *testing.T) {
 	})
 
 	t.Run("two file matches, multiple symbols per file", func(t *testing.T) {
-		res := mkSymbolFileMatchResolvers(db, []*results.SearchSymbolResult{
+		res := mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
 			{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
 			{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
-		}, []*results.SearchSymbolResult{
+		}, []*result.SearchSymbolResult{
 			{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
 			{Symbol: protocol.Symbol{Name: "symbol-name-4"}},
 		})
@@ -164,14 +164,14 @@ func TestLimitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 1 => one file match with one symbol",
 				limit: 1,
-				want: mkSymbolFileMatchResolvers(db, []*results.SearchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
 					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
 				}),
 			},
 			{
 				name:  "limit 2 => one file match with all symbols",
 				limit: 2,
-				want: mkSymbolFileMatchResolvers(db, []*results.SearchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
 					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
 					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}),
@@ -179,20 +179,20 @@ func TestLimitingSymbolResults(t *testing.T) {
 			{
 				name:  "limit 3 => two file matches with three symbols",
 				limit: 3,
-				want: mkSymbolFileMatchResolvers(db, []*results.SearchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
 					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
 					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
-				}, []*results.SearchSymbolResult{
+				}, []*result.SearchSymbolResult{
 					{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
 				}),
 			},
 			{
 				name:  "limit 4 => two file matches with all symbols",
 				limit: 4,
-				want: mkSymbolFileMatchResolvers(db, []*results.SearchSymbolResult{
+				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
 					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
 					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
-				}, []*results.SearchSymbolResult{
+				}, []*result.SearchSymbolResult{
 					{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
 					{Symbol: protocol.Symbol{Name: "symbol-name-4"}},
 				}),
@@ -227,10 +227,10 @@ func TestSymbolRange(t *testing.T) {
 	})
 }
 
-func mkSymbolFileMatchResolvers(db dbutil.DB, symbols ...[]*results.SearchSymbolResult) []*FileMatchResolver {
+func mkSymbolFileMatchResolvers(db dbutil.DB, symbols ...[]*result.SearchSymbolResult) []*FileMatchResolver {
 	var resolvers []*FileMatchResolver
 	for _, s := range symbols {
-		resolvers = append(resolvers, mkFileMatchResolver(db, results.FileMatch{
+		resolvers = append(resolvers, mkFileMatchResolver(db, result.FileMatch{
 			Symbols: s,
 		}))
 	}

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -37,7 +37,7 @@ func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		got := makeFileMatchURI(repoResolver.URL(), test.rev, sr.uri().Fragment)
+		got := makeFileMatchURI(repoResolver.URL(), test.rev, sr.URI().Fragment)
 		if got != test.want {
 			t.Errorf("rev(%v) got %v want %v", test.rev, got, test.want)
 		}
@@ -67,7 +67,7 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("one file match, one symbol", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{{
-			symbol: protocol.Symbol{
+			Symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
 		}})
@@ -96,11 +96,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("two file matches, one symbol per file", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{{
-			symbol: protocol.Symbol{
+			Symbol: protocol.Symbol{
 				Name: "symbol-name-1",
 			},
 		}}, []*SearchSymbolResult{{
-			symbol: protocol.Symbol{
+			Symbol: protocol.Symbol{
 				Name: "symbol-name-2",
 			},
 		}})
@@ -137,11 +137,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("two file matches, multiple symbols per file", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
-			{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-			{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+			{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
+			{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
 		}, []*SearchSymbolResult{
-			{symbol: protocol.Symbol{Name: "symbol-name-3"}},
-			{symbol: protocol.Symbol{Name: "symbol-name-4"}},
+			{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
+			{Symbol: protocol.Symbol{Name: "symbol-name-4"}},
 		})
 
 		t.Run("symbol count is 4", func(t *testing.T) {
@@ -164,36 +164,36 @@ func TestLimitingSymbolResults(t *testing.T) {
 				name:  "limit 1 => one file match with one symbol",
 				limit: 1,
 				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
 				}),
 			},
 			{
 				name:  "limit 2 => one file match with all symbols",
 				limit: 2,
 				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}),
 			},
 			{
 				name:  "limit 3 => two file matches with three symbols",
 				limit: 3,
 				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}, []*SearchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
 				}),
 			},
 			{
 				name:  "limit 4 => two file matches with all symbols",
 				limit: 4,
 				want: mkSymbolFileMatchResolvers(db, []*SearchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
 				}, []*SearchSymbolResult{
-					{symbol: protocol.Symbol{Name: "symbol-name-3"}},
-					{symbol: protocol.Symbol{Name: "symbol-name-4"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
+					{Symbol: protocol.Symbol{Name: "symbol-name-4"}},
 				}),
 			},
 		}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -563,8 +563,8 @@ func mkFileMatch(db dbutil.DB, repo *types.RepoName, path string, lineNumbers ..
 	for _, n := range lineNumbers {
 		lines = append(lines, &results.LineMatch{LineNumber: n})
 	}
-	return mkFileMatchResolver(db, FileMatch{
-		uri:         fileMatchURI(repo.Name, "", path),
+	return mkFileMatchResolver(db, results.FileMatch{
+		URI:         fileMatchURI(repo.Name, "", path),
 		Path:        path,
 		LineMatches: lines,
 		Repo:        repo,

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -558,9 +559,9 @@ func mkFileMatch(db dbutil.DB, repo *types.RepoName, path string, lineNumbers ..
 			Name: "repo",
 		}
 	}
-	var lines []*LineMatch
+	var lines []*results.LineMatch
 	for _, n := range lineNumbers {
-		lines = append(lines, &LineMatch{LineNumber: n})
+		lines = append(lines, &results.LineMatch{LineNumber: n})
 	}
 	return mkFileMatchResolver(db, FileMatch{
 		uri:         fileMatchURI(repo.Name, "", path),

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -251,7 +251,7 @@ func testStringResult(result SearchSuggestionResolver) string {
 	case languageSuggestionResolver:
 		name = "lang:" + r.lang.name
 	case symbolSuggestionResolver:
-		name = "symbol:" + r.symbol.symbol.Name
+		name = "symbol:" + r.symbol.Symbol.Name
 	default:
 		panic("never here")
 	}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -559,11 +559,11 @@ func mkFileMatch(db dbutil.DB, repo *types.RepoName, path string, lineNumbers ..
 			Name: "repo",
 		}
 	}
-	var lines []*results.LineMatch
+	var lines []*result.LineMatch
 	for _, n := range lineNumbers {
-		lines = append(lines, &results.LineMatch{LineNumber: n})
+		lines = append(lines, &result.LineMatch{LineNumber: n})
 	}
-	return mkFileMatchResolver(db, results.FileMatch{
+	return mkFileMatchResolver(db, result.FileMatch{
 		URI:         fileMatchURI(repo.Name, "", path),
 		Path:        path,
 		LineMatches: lines,

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -154,7 +154,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 				res = append(res, toSymbolResolver(
 					db,
 					commit,
-					&results.SearchSymbolResult{
+					&result.SearchSymbolResult{
 						Symbol: protocol.Symbol{
 							Name:       m.SymbolInfo.Sym,
 							Kind:       m.SymbolInfo.Kind,
@@ -211,7 +211,7 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	}
 	resolvers := make([]symbolResolver, 0, len(symbols))
 	for _, symbol := range symbols {
-		sr := results.SearchSymbolResult{
+		sr := result.SearchSymbolResult{
 			Symbol:  symbol,
 			BaseURI: baseURI,
 			Lang:    strings.ToLower(symbol.Language),
@@ -222,7 +222,7 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	return resolvers, err
 }
 
-func toSymbolResolver(db dbutil.DB, commit *GitCommitResolver, sr *results.SearchSymbolResult) symbolResolver {
+func toSymbolResolver(db dbutil.DB, commit *GitCommitResolver, sr *result.SearchSymbolResult) symbolResolver {
 	return symbolResolver{
 		db:                 db,
 		commit:             commit,
@@ -245,7 +245,7 @@ func (r *symbolConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 type symbolResolver struct {
 	db     dbutil.DB
 	commit *GitCommitResolver
-	*results.SearchSymbolResult
+	*result.SearchSymbolResult
 }
 
 func (r symbolResolver) Name() string { return r.Symbol.Name }

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -154,7 +154,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 					db,
 					commit,
 					&SearchSymbolResult{
-						symbol: protocol.Symbol{
+						Symbol: protocol.Symbol{
 							Name:       m.SymbolInfo.Sym,
 							Kind:       m.SymbolInfo.Kind,
 							Parent:     m.SymbolInfo.Parent,
@@ -162,8 +162,8 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 							Path:       file.FileName,
 							Line:       l.LineNumber,
 						},
-						baseURI: baseURI,
-						lang:    strings.ToLower(file.Language),
+						BaseURI: baseURI,
+						Lang:    strings.ToLower(file.Language),
 					},
 				))
 			}
@@ -211,9 +211,9 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	resolvers := make([]symbolResolver, 0, len(symbols))
 	for _, symbol := range symbols {
 		sr := SearchSymbolResult{
-			symbol:  symbol,
-			baseURI: baseURI,
-			lang:    strings.ToLower(symbol.Language),
+			Symbol:  symbol,
+			BaseURI: baseURI,
+			Lang:    strings.ToLower(symbol.Language),
 		}
 		resolver := toSymbolResolver(db, commit, &sr)
 		resolvers = append(resolvers, resolver)
@@ -247,29 +247,29 @@ type symbolResolver struct {
 	*SearchSymbolResult
 }
 
-func (r symbolResolver) Name() string { return r.symbol.Name }
+func (r symbolResolver) Name() string { return r.Symbol.Name }
 
 func (r symbolResolver) ContainerName() *string {
-	if r.symbol.Parent == "" {
+	if r.Symbol.Parent == "" {
 		return nil
 	}
-	return &r.symbol.Parent
+	return &r.Symbol.Parent
 }
 
 func (r symbolResolver) Kind() string /* enum SymbolKind */ {
-	kind := ctagsKindToLSPSymbolKind(r.symbol.Kind)
+	kind := ctagsKindToLSPSymbolKind(r.Symbol.Kind)
 	if kind == 0 {
 		return "UNKNOWN"
 	}
 	return strings.ToUpper(kind.String())
 }
 
-func (r symbolResolver) Language() string { return r.symbol.Language }
+func (r symbolResolver) Language() string { return r.Symbol.Language }
 
 func (r symbolResolver) Location() *locationResolver {
-	uri := r.baseURI.WithFilePath(r.symbol.Path)
+	uri := r.BaseURI.WithFilePath(r.Symbol.Path)
 	stat := CreateFileInfo(uri.Fragment, false)
-	sr := symbolRange(r.symbol)
+	sr := symbolRange(r.Symbol)
 	return &locationResolver{
 		resource: NewGitTreeEntryResolver(r.commit, r.db, stat),
 		lspRange: &sr,
@@ -280,4 +280,4 @@ func (r symbolResolver) URL(ctx context.Context) (string, error) { return r.Loca
 
 func (r symbolResolver) CanonicalURL() (string, error) { return r.Location().CanonicalURL() }
 
-func (r symbolResolver) FileLocal() bool { return r.symbol.FileLimited }
+func (r symbolResolver) FileLocal() bool { return r.Symbol.FileLimited }

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -153,7 +154,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 				res = append(res, toSymbolResolver(
 					db,
 					commit,
-					&SearchSymbolResult{
+					&results.SearchSymbolResult{
 						Symbol: protocol.Symbol{
 							Name:       m.SymbolInfo.Sym,
 							Kind:       m.SymbolInfo.Kind,
@@ -210,7 +211,7 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	}
 	resolvers := make([]symbolResolver, 0, len(symbols))
 	for _, symbol := range symbols {
-		sr := SearchSymbolResult{
+		sr := results.SearchSymbolResult{
 			Symbol:  symbol,
 			BaseURI: baseURI,
 			Lang:    strings.ToLower(symbol.Language),
@@ -221,7 +222,7 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	return resolvers, err
 }
 
-func toSymbolResolver(db dbutil.DB, commit *GitCommitResolver, sr *SearchSymbolResult) symbolResolver {
+func toSymbolResolver(db dbutil.DB, commit *GitCommitResolver, sr *results.SearchSymbolResult) symbolResolver {
 	return symbolResolver{
 		db:                 db,
 		commit:             commit,
@@ -244,7 +245,7 @@ func (r *symbolConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.P
 type symbolResolver struct {
 	db     dbutil.DB
 	commit *GitCommitResolver
-	*SearchSymbolResult
+	*results.SearchSymbolResult
 }
 
 func (r symbolResolver) Name() string { return r.Symbol.Name }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -36,70 +36,9 @@ const maxUnindexedRepoRevSearchesPerQuery = 200
 // A global limiter on number of concurrent searcher searches.
 var textSearchLimiter = mutablelimiter.New(32)
 
-type FileMatch struct {
-	Path        string
-	LineMatches []*results.LineMatch
-	LimitHit    bool
-
-	Symbols  []*results.SearchSymbolResult `json:"-"`
-	uri      string                        `json:"-"`
-	Repo     *types.RepoName               `json:"-"`
-	CommitID api.CommitID                  `json:"-"`
-	// InputRev is the Git revspec that the user originally requested to search. It is used to
-	// preserve the original revision specifier from the user instead of navigating them to the
-	// absolute commit ID when they select a result.
-	InputRev *string `json:"-"`
-}
-
-func (fm *FileMatch) ResultCount() int {
-	rc := len(fm.Symbols)
-	for _, m := range fm.LineMatches {
-		rc += len(m.OffsetAndLengths)
-	}
-	if rc == 0 {
-		return 1 // 1 to count "empty" results like type:path results
-	}
-	return rc
-}
-
-// appendMatches appends the line matches from src as well as updating match
-// counts and limit.
-func (fm *FileMatch) appendMatches(src *FileMatch) {
-	fm.LineMatches = append(fm.LineMatches, src.LineMatches...)
-	fm.Symbols = append(fm.Symbols, src.Symbols...)
-	fm.LimitHit = fm.LimitHit || src.LimitHit
-}
-
-// Limit will mutate fm such that it only has limit results. limit is a number
-// greater than 0.
-//
-//   if limit >= ResultCount then nothing is done and we return limit - ResultCount.
-//   if limit < ResultCount then ResultCount becomes limit and we return 0.
-func (fm *FileMatch) Limit(limit int) int {
-	// Check if we need to limit.
-	if after := limit - fm.ResultCount(); after >= 0 {
-		return after
-	}
-
-	// Invariant: limit > 0
-	for i, m := range fm.LineMatches {
-		after := limit - len(m.OffsetAndLengths)
-		if after <= 0 {
-			fm.Symbols = nil
-			fm.LineMatches = fm.LineMatches[:i+1]
-			m.OffsetAndLengths = m.OffsetAndLengths[:limit]
-			return 0
-		}
-		limit = after
-	}
-
-	fm.Symbols = fm.Symbols[:limit]
-	return 0
-}
-
 // FileMatchResolver is a resolver for the GraphQL type `FileMatch`
 type FileMatchResolver struct {
-	FileMatch
+	results.FileMatch
 
 	RepoResolver *RepositoryResolver
 	db           dbutil.DB
@@ -110,7 +49,7 @@ func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 }
 
 func (fm *FileMatchResolver) Key() string {
-	return fm.uri
+	return fm.URI
 }
 
 func (fm *FileMatchResolver) File() *GitTreeEntryResolver {
@@ -147,7 +86,7 @@ func (fm *FileMatchResolver) RevSpec() *gitRevSpec {
 }
 
 func (fm *FileMatchResolver) Resource() string {
-	return fm.uri
+	return fm.URI
 }
 
 func (fm *FileMatchResolver) Symbols() []symbolResolver {
@@ -186,7 +125,7 @@ func (fm *FileMatchResolver) path() string {
 // appendMatches appends the line matches from src as well as updating match
 // counts and limit.
 func (fm *FileMatchResolver) appendMatches(src *FileMatchResolver) {
-	fm.FileMatch.appendMatches(&src.FileMatch)
+	fm.FileMatch.AppendMatches(&src.FileMatch)
 }
 
 func (fm *FileMatchResolver) ResultCount() int32 {
@@ -304,12 +243,12 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 
 		resolvers = append(resolvers, &FileMatchResolver{
 			db: db,
-			FileMatch: FileMatch{
+			FileMatch: results.FileMatch{
 				Path:        fm.Path,
 				LineMatches: lineMatches,
 				LimitHit:    fm.LimitHit,
 				Repo:        repo,
-				uri:         workspace + fm.Path,
+				URI:         workspace + fm.Path,
 				CommitID:    commit,
 				InputRev:    &rev,
 			},

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -38,7 +38,7 @@ var textSearchLimiter = mutablelimiter.New(32)
 
 type FileMatch struct {
 	Path        string
-	LineMatches []*LineMatch
+	LineMatches []*results.LineMatch
 	LimitHit    bool
 
 	Symbols  []*results.SearchSymbolResult `json:"-"`
@@ -221,16 +221,8 @@ func (fm *FileMatchResolver) Select(t filter.SelectPath) SearchResultResolver {
 	return nil
 }
 
-// LineMatch is the struct used by vscode to receive search results for a line
-type LineMatch struct {
-	Preview          string
-	OffsetAndLengths [][2]int32
-	LineNumber       int32
-	LimitHit         bool
-}
-
 type lineMatchResolver struct {
-	*LineMatch
+	*results.LineMatch
 }
 
 func (lm lineMatchResolver) Preview() string {
@@ -296,13 +288,13 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 	repoResolver := NewRepositoryResolver(db, repo.ToRepo())
 	resolvers := make([]*FileMatchResolver, 0, len(matches))
 	for _, fm := range matches {
-		lineMatches := make([]*LineMatch, 0, len(fm.LineMatches))
+		lineMatches := make([]*results.LineMatch, 0, len(fm.LineMatches))
 		for _, lm := range fm.LineMatches {
 			ranges := make([][2]int32, 0, len(lm.OffsetAndLengths))
 			for _, ol := range lm.OffsetAndLengths {
 				ranges = append(ranges, [2]int32{int32(ol[0]), int32(ol[1])})
 			}
-			lineMatches = append(lineMatches, &LineMatch{
+			lineMatches = append(lineMatches, &results.LineMatch{
 				Preview:          lm.Preview,
 				OffsetAndLengths: ranges,
 				LineNumber:       int32(lm.LineNumber),

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -40,10 +41,10 @@ type FileMatch struct {
 	LineMatches []*LineMatch
 	LimitHit    bool
 
-	Symbols  []*SearchSymbolResult `json:"-"`
-	uri      string                `json:"-"`
-	Repo     *types.RepoName       `json:"-"`
-	CommitID api.CommitID          `json:"-"`
+	Symbols  []*results.SearchSymbolResult `json:"-"`
+	uri      string                        `json:"-"`
+	Repo     *types.RepoName               `json:"-"`
+	CommitID api.CommitID                  `json:"-"`
 	// InputRev is the Git revspec that the user originally requested to search. It is used to
 	// preserve the original revision specifier from the user instead of navigating them to the
 	// absolute commit ID when they select a result.

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -40,12 +40,12 @@ func TestSearchFilesInRepos(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/empty":
 			return nil, false, nil
@@ -129,16 +129,16 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/three":
-			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		default:
 			return nil, false, errors.New("Unexpected repo")
@@ -203,8 +203,8 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
-			return []*FileMatchResolver{mkFileMatchResolver(db, FileMatch{
-				uri: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
+			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		default:
 			panic("unexpected repo")
@@ -245,7 +245,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 
 	resultURIs := make([]string, len(results))
 	for i, result := range results {
-		resultURIs[i] = result.uri
+		resultURIs[i] = result.URI
 	}
 	sort.Strings(resultURIs)
 
@@ -401,7 +401,7 @@ func TestLimitSearcherRepos(t *testing.T) {
 }
 
 func TestFileMatch_Limit(t *testing.T) {
-	desc := func(fm *FileMatch) string {
+	desc := func(fm *results.FileMatch) string {
 		parts := []string{fmt.Sprintf("symbols=%d", len(fm.Symbols))}
 		for _, lm := range fm.LineMatches {
 			parts = append(parts, fmt.Sprintf("lm=%d", len(lm.OffsetAndLengths)))
@@ -410,7 +410,7 @@ func TestFileMatch_Limit(t *testing.T) {
 	}
 
 	f := func(lineMatches []results.LineMatch, symbols []int, limitInput uint32) bool {
-		fm := &FileMatch{
+		fm := &results.FileMatch{
 			// SearchSymbolResult fails to generate due to private fields. So
 			// we just generate a slice of ints and use its length. This is
 			// fine for limit which only looks at the slice and not in it.

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -413,7 +414,7 @@ func TestFileMatch_Limit(t *testing.T) {
 			// SearchSymbolResult fails to generate due to private fields. So
 			// we just generate a slice of ints and use its length. This is
 			// fine for limit which only looks at the slice and not in it.
-			Symbols: make([]*SearchSymbolResult, len(symbols)),
+			Symbols: make([]*results.SearchSymbolResult, len(symbols)),
 		}
 		// We don't use *LineMatch as args since quick can generate nil.
 		for _, lm := range lineMatches {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
@@ -40,11 +40,11 @@ func TestSearchFilesInRepos(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
 				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
 				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/empty":
@@ -129,15 +129,15 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
 				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
 				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		case "foo/three":
-			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
 				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		default:
@@ -203,7 +203,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
-			return []*FileMatchResolver{mkFileMatchResolver(db, results.FileMatch{
+			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
 				URI: "git://" + string(repoName) + "?" + rev + "#" + "main.go",
 			})}, false, nil
 		default:
@@ -401,7 +401,7 @@ func TestLimitSearcherRepos(t *testing.T) {
 }
 
 func TestFileMatch_Limit(t *testing.T) {
-	desc := func(fm *results.FileMatch) string {
+	desc := func(fm *result.FileMatch) string {
 		parts := []string{fmt.Sprintf("symbols=%d", len(fm.Symbols))}
 		for _, lm := range fm.LineMatches {
 			parts = append(parts, fmt.Sprintf("lm=%d", len(lm.OffsetAndLengths)))
@@ -409,12 +409,12 @@ func TestFileMatch_Limit(t *testing.T) {
 		return strings.Join(parts, " ")
 	}
 
-	f := func(lineMatches []results.LineMatch, symbols []int, limitInput uint32) bool {
-		fm := &results.FileMatch{
+	f := func(lineMatches []result.LineMatch, symbols []int, limitInput uint32) bool {
+		fm := &result.FileMatch{
 			// SearchSymbolResult fails to generate due to private fields. So
 			// we just generate a slice of ints and use its length. This is
 			// fine for limit which only looks at the slice and not in it.
-			Symbols: make([]*results.SearchSymbolResult, len(symbols)),
+			Symbols: make([]*result.SearchSymbolResult, len(symbols)),
 		}
 		// We don't use *LineMatch as args since quick can generate nil.
 		for _, lm := range lineMatches {
@@ -447,12 +447,12 @@ func TestFileMatch_Limit(t *testing.T) {
 
 	cases := []struct {
 		Name        string
-		LineMatches []results.LineMatch
+		LineMatches []result.LineMatch
 		Symbols     int
 		Limit       int
 	}{{
 		Name: "1 line match",
-		LineMatches: []results.LineMatch{{
+		LineMatches: []result.LineMatch{{
 			OffsetAndLengths: [][2]int32{{1, 1}},
 		}},
 		Limit: 1,

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -409,7 +409,7 @@ func TestFileMatch_Limit(t *testing.T) {
 		return strings.Join(parts, " ")
 	}
 
-	f := func(lineMatches []LineMatch, symbols []int, limitInput uint32) bool {
+	f := func(lineMatches []results.LineMatch, symbols []int, limitInput uint32) bool {
 		fm := &FileMatch{
 			// SearchSymbolResult fails to generate due to private fields. So
 			// we just generate a slice of ints and use its length. This is
@@ -447,12 +447,12 @@ func TestFileMatch_Limit(t *testing.T) {
 
 	cases := []struct {
 		Name        string
-		LineMatches []LineMatch
+		LineMatches []results.LineMatch
 		Symbols     int
 		Limit       int
 	}{{
 		Name: "1 line match",
-		LineMatches: []LineMatch{{
+		LineMatches: []results.LineMatch{{
 			OffsetAndLengths: [][2]int32{{1, 1}},
 		}},
 		Limit: 1,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
@@ -396,7 +397,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 				for _, inputRev := range inputRevs {
 					inputRev := inputRev // copy so we can take the pointer
 
-					var symbols []*SearchSymbolResult
+					var symbols []*results.SearchSymbolResult
 					if typ == symbolRequest {
 						symbols = zoektFileMatchToSymbolResults(repoResolver, inputRev, &file)
 					}
@@ -564,14 +565,14 @@ func escape(s string) string {
 	return string(escaped)
 }
 
-func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*SearchSymbolResult {
+func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, file *zoekt.FileMatch) []*results.SearchSymbolResult {
 	// Symbol search returns a resolver so we need to pass in some
 	// extra stuff. This is a sign that we can probably restructure
 	// resolvers to avoid this.
 	baseURI := &gituri.URI{URL: url.URL{Scheme: "git", Host: repo.Name(), RawQuery: url.QueryEscape(inputRev)}}
 	lang := strings.ToLower(file.Language)
 
-	symbols := make([]*SearchSymbolResult, 0, len(file.LineMatches))
+	symbols := make([]*results.SearchSymbolResult, 0, len(file.LineMatches))
 	for _, l := range file.LineMatches {
 		if l.FileName {
 			continue
@@ -582,7 +583,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 				continue
 			}
 
-			symbols = append(symbols, &SearchSymbolResult{
+			symbols = append(symbols, &results.SearchSymbolResult{
 				Symbol: protocol.Symbol{
 					Name:       m.SymbolInfo.Sym,
 					Kind:       m.SymbolInfo.Kind,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -389,7 +389,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 					repoResolvers[repo.Name] = repoResolver
 				}
 
-				var lines []*LineMatch
+				var lines []*results.LineMatch
 				if typ != symbolRequest {
 					lines = zoektFileMatchToLineMatches(maxLineFragmentMatches, &file)
 				}
@@ -506,8 +506,8 @@ func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoek
 	return nil
 }
 
-func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) []*LineMatch {
-	lines := make([]*LineMatch, 0, len(file.LineMatches))
+func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMatch) []*results.LineMatch {
+	lines := make([]*results.LineMatch, 0, len(file.LineMatches))
 
 	for _, l := range file.LineMatches {
 		if l.FileName {
@@ -523,7 +523,7 @@ func zoektFileMatchToLineMatches(maxLineFragmentMatches int, file *zoekt.FileMat
 			length := utf8.RuneCount(l.Line[m.LineOffset : m.LineOffset+m.MatchLength])
 			offsets[k] = [2]int32{int32(offset), int32(length)}
 		}
-		lines = append(lines, &LineMatch{
+		lines = append(lines, &results.LineMatch{
 			Preview:          string(l.Line),
 			LineNumber:       int32(l.LineNumber - 1),
 			OffsetAndLengths: offsets,

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -403,11 +403,11 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 					}
 					fm := &FileMatchResolver{
 						db: db,
-						FileMatch: FileMatch{
+						FileMatch: results.FileMatch{
 							Path:        file.FileName,
 							LineMatches: lines,
 							LimitHit:    fileLimitHit,
-							uri:         fileMatchURI(repo.Name, inputRev, file.FileName),
+							URI:         fileMatchURI(repo.Name, inputRev, file.FileName),
 							Symbols:     symbols,
 							Repo:        repo,
 							CommitID:    api.CommitID(file.Version),

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -583,7 +583,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 			}
 
 			symbols = append(symbols, &SearchSymbolResult{
-				symbol: protocol.Symbol{
+				Symbol: protocol.Symbol{
 					Name:       m.SymbolInfo.Sym,
 					Kind:       m.SymbolInfo.Kind,
 					Parent:     m.SymbolInfo.Parent,
@@ -596,8 +596,8 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 					// It must escape `/` or `\` in the line.
 					Pattern: fmt.Sprintf("/^%s$/", escape(string(l.Line))),
 				},
-				lang:    lang,
-				baseURI: baseURI,
+				Lang:    lang,
+				BaseURI: baseURI,
 			})
 		}
 	}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -1022,14 +1022,14 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 	var symbols []protocol.Symbol
 	for _, res := range results {
 		// Check the fields which are not specific to the symbol
-		if got, want := res.lang, "go"; got != want {
+		if got, want := res.Lang, "go"; got != want {
 			t.Fatalf("lang: got %q want %q", got, want)
 		}
-		if got, want := res.baseURI.URL.String(), "git://foo?master"; got != want {
+		if got, want := res.BaseURI.URL.String(), "git://foo?master"; got != want {
 			t.Fatalf("baseURI: got %q want %q", got, want)
 		}
 
-		symbols = append(symbols, res.symbol)
+		symbols = append(symbols, res.Symbol)
 	}
 
 	want := []protocol.Symbol{{

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -15,6 +15,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/search/results"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -332,7 +333,7 @@ func fromStrPtr(s *string) string {
 	return *s
 }
 
-func fromFileMatch(fm *graphqlbackend.FileMatch) *streamhttp.EventFileMatch {
+func fromFileMatch(fm *results.FileMatch) *streamhttp.EventFileMatch {
 	lineMatches := make([]streamhttp.EventLineMatch, 0, len(fm.LineMatches))
 	for _, lm := range fm.LineMatches {
 		lineMatches = append(lineMatches, streamhttp.EventLineMatch{

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -15,7 +15,7 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	"github.com/sourcegraph/sourcegraph/internal/search/results"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 )
@@ -333,7 +333,7 @@ func fromStrPtr(s *string) string {
 	return *s
 }
 
-func fromFileMatch(fm *results.FileMatch) *streamhttp.EventFileMatch {
+func fromFileMatch(fm *result.FileMatch) *streamhttp.EventFileMatch {
 	lineMatches := make([]streamhttp.EventLineMatch, 0, len(fm.LineMatches))
 	for _, lm := range fm.LineMatches {
 		lineMatches = append(lineMatches, streamhttp.EventLineMatch{

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -1,4 +1,4 @@
-package results
+package result
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -1,4 +1,4 @@
-package results
+package result
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"

--- a/internal/search/results/file.go
+++ b/internal/search/results/file.go
@@ -1,0 +1,9 @@
+package results
+
+// LineMatch is the struct used by vscode to receive search results for a line
+type LineMatch struct {
+	Preview          string
+	OffsetAndLengths [][2]int32
+	LineNumber       int32
+	LimitHit         bool
+}

--- a/internal/search/results/file.go
+++ b/internal/search/results/file.go
@@ -1,5 +1,72 @@
 package results
 
+import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type FileMatch struct {
+	Path        string
+	LineMatches []*LineMatch
+	LimitHit    bool
+
+	Symbols  []*SearchSymbolResult `json:"-"`
+	URI      string                `json:"-"`
+	Repo     *types.RepoName       `json:"-"`
+	CommitID api.CommitID          `json:"-"`
+
+	// InputRev is the Git revspec that the user originally requested to search. It is used to
+	// preserve the original revision specifier from the user instead of navigating them to the
+	// absolute commit ID when they select a result.
+	InputRev *string `json:"-"`
+}
+
+func (fm *FileMatch) ResultCount() int {
+	rc := len(fm.Symbols)
+	for _, m := range fm.LineMatches {
+		rc += len(m.OffsetAndLengths)
+	}
+	if rc == 0 {
+		return 1 // 1 to count "empty" results like type:path results
+	}
+	return rc
+}
+
+// AppendMatches appends the line matches from src as well as updating match
+// counts and limit.
+func (fm *FileMatch) AppendMatches(src *FileMatch) {
+	fm.LineMatches = append(fm.LineMatches, src.LineMatches...)
+	fm.Symbols = append(fm.Symbols, src.Symbols...)
+	fm.LimitHit = fm.LimitHit || src.LimitHit
+}
+
+// Limit will mutate fm such that it only has limit results. limit is a number
+// greater than 0.
+//
+//   if limit >= ResultCount then nothing is done and we return limit - ResultCount.
+//   if limit < ResultCount then ResultCount becomes limit and we return 0.
+func (fm *FileMatch) Limit(limit int) int {
+	// Check if we need to limit.
+	if after := limit - fm.ResultCount(); after >= 0 {
+		return after
+	}
+
+	// Invariant: limit > 0
+	for i, m := range fm.LineMatches {
+		after := limit - len(m.OffsetAndLengths)
+		if after <= 0 {
+			fm.Symbols = nil
+			fm.LineMatches = fm.LineMatches[:i+1]
+			m.OffsetAndLengths = m.OffsetAndLengths[:limit]
+			return 0
+		}
+		limit = after
+	}
+
+	fm.Symbols = fm.Symbols[:limit]
+	return 0
+}
+
 // LineMatch is the struct used by vscode to receive search results for a line
 type LineMatch struct {
 	Preview          string

--- a/internal/search/results/symbol.go
+++ b/internal/search/results/symbol.go
@@ -1,0 +1,17 @@
+package results
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/gituri"
+	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
+)
+
+// SearchSymbolResult is a result from symbol search.
+type SearchSymbolResult struct {
+	Symbol  protocol.Symbol
+	BaseURI *gituri.URI
+	Lang    string
+}
+
+func (s *SearchSymbolResult) URI() *gituri.URI {
+	return s.BaseURI.WithFilePath(s.Symbol.Path)
+}


### PR DESCRIPTION
This PR moves file match results and symbol results into `internal/search/results`. It stops short of moving `CommitSearchResult` because I realized during my attempted move that the highlighted strings on the result type are actually graphql resolvers, and should be split out. That's a separate bit of work, so I'll do that in a later PR. This change does, however, include a commit that makes `CommitSearchResult` fields public in preparation for moving it out of `graphqlbackend`. 

Each commit is self-contained, so it is probably worth looking this over by commit.

Progresses #18348 
~~Depends on #18798  (CI will fail otherwise)~~
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
