### PR TITLE
Fix installing goimports

### DIFF
--- a/dev/generate.sh
+++ b/dev/generate.sh
@@ -6,4 +6,4 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.." # cd to repo root dir
 # We'll exclude generating the CLI reference documentation by default due to the
 # relatively high cost of fetching and building src-cli.
 go list ./... | grep -v 'doc/cli/references' | xargs go generate -x
-go get golang.org/x/tools/cmd/goimports && goimports -w .
+GOBIN="$PWD/.bin" go get golang.org/x/tools/cmd/goimports && ./.bin/goimports -w .


### PR DESCRIPTION
Apparently, the standard `GOBIN` isn't in the path on CI. Causing failures in #18794 

I'm not sure why CI on #18790 passed, but is failing now


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
