### PR TITLE
search: support selecting symbol kind

### DIFF
--- a/cmd/frontend/graphqlbackend/select_symbols.go
+++ b/cmd/frontend/graphqlbackend/select_symbols.go
@@ -1,0 +1,93 @@
+package graphqlbackend
+
+import (
+	"strings"
+)
+
+// toSelectKind maps an internal symbol kind (cf. ctagsKind) to a corresponding
+// symbol selector kind value in select.go. The single selector value `kind`
+// corresponds 1-to-1 with LSP symbol kinds.
+var toSelectKind = map[string]string{
+	"file":            "file",
+	"module":          "module",
+	"namespace":       "namespace",
+	"package":         "package",
+	"packagename":     "package",
+	"subprogspec":     "package",
+	"class":           "class",
+	"type":            "class",
+	"service":         "class",
+	"typedef":         "class",
+	"union":           "class",
+	"section":         "class",
+	"subtype":         "class",
+	"component":       "class",
+	"method":          "method",
+	"methodspec":      "method",
+	"property":        "property",
+	"field":           "field",
+	"member":          "field",
+	"anonmember":      "field",
+	"recordfield":     "field",
+	"constructor":     "constructor",
+	"interface":       "interface",
+	"function":        "function",
+	"func":            "function",
+	"subroutine":      "function",
+	"macro":           "function",
+	"subprogram":      "function",
+	"procedure":       "function",
+	"command":         "function",
+	"singletonmethod": "function",
+	"variable":        "variable",
+	"var":             "variable",
+	"functionvar":     "variable",
+	"define":          "variable",
+	"alias":           "variable",
+	"val":             "variable",
+	"constant":        "constant",
+	"const":           "constant",
+	"string":          "string",
+	"message":         "string",
+	"heredoc":         "string",
+	"number":          "number",
+	"boolean":         "boolean",
+	"bool":            "boolean",
+	"array":           "array",
+	"object":          "object",
+	"literal":         "object",
+	"map":             "object",
+	"key":             "key",
+	"label":           "key",
+	"target":          "key",
+	"selector":        "key",
+	"id":              "key",
+	"tag":             "key",
+	"null":            "null",
+	"enum member":     "enum-member",
+	"enumconstant":    "enum-member",
+	"struct":          "struct",
+	"event":           "event",
+	"operator":        "operator",
+	"type parameter":  "type-parameter",
+	"annotation":      "type-parameter",
+}
+
+func pick(symbols []*SearchSymbolResult, satisfy func(*SearchSymbolResult) bool) []*SearchSymbolResult {
+	var result []*SearchSymbolResult
+	for _, symbol := range symbols {
+		if satisfy(symbol) {
+			result = append(result, symbol)
+		}
+	}
+	return result
+}
+
+func SelectKind(symbols []*SearchSymbolResult, field string) []*SearchSymbolResult {
+	return pick(symbols, func(s *SearchSymbolResult) bool {
+		if field == toSelectKind[strings.ToLower(s.symbol.Kind)] {
+			return true
+		}
+		return false
+	})
+}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -144,7 +144,7 @@ func (fm *FileMatchResolver) Select(t filter.SelectPath) SearchResultResolver {
 		if len(fm.FileMatch.Symbols) > 0 {
 			fm.FileMatch.LineMatches = nil // Only return symbol match if symbols exist
 			if len(t.Fields) > 0 {
-				filteredSymbols := SelectKind(fm.FileMatch.Symbols, t.Fields[0])
+				filteredSymbols := filter.SelectSymbolKind(fm.FileMatch.Symbols, t.Fields[0])
 				if len(filteredSymbols) == 0 {
 					return nil // Remove file match if there are no symbol results after filtering
 				}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -141,9 +141,15 @@ func (fm *FileMatchResolver) Select(t filter.SelectPath) SearchResultResolver {
 		fm.FileMatch.Symbols = nil
 		return fm
 	case filter.Symbol:
-		// Only return file match if symbols exist
 		if len(fm.FileMatch.Symbols) > 0 {
-			fm.FileMatch.LineMatches = nil
+			fm.FileMatch.LineMatches = nil // Only return symbol match if symbols exist
+			if len(t.Fields) > 0 {
+				filteredSymbols := SelectKind(fm.FileMatch.Symbols, t.Fields[0])
+				if len(filteredSymbols) == 0 {
+					return nil // Remove file match if there are no symbol results after filtering
+				}
+				fm.FileMatch.Symbols = filteredSymbols
+			}
 			return fm
 		}
 		return nil

--- a/internal/search/filter/select.go
+++ b/internal/search/filter/select.go
@@ -25,17 +25,13 @@ func (sp SelectPath) String() string {
 	return string(sp.Type)
 }
 
-var validSelectors = map[SelectType]struct{}{
+var validSelectors = map[SelectType]map[string]interface{}{
 	Commit:     {},
 	Content:    {},
 	File:       {},
 	Repository: {},
-	Symbol:     {},
-}
-
-var validFields = map[SelectType]interface{}{
-	/* cf. SymbolKind https://microsoft.github.io/language-server-protocol/specification */
-	Symbol: map[string]interface{}{
+	Symbol: {
+		/* cf. SymbolKind https://microsoft.github.io/language-server-protocol/specification */
 		"file":           struct{}{},
 		"module":         struct{}{},
 		"namespace":      struct{}{},
@@ -76,7 +72,7 @@ func SelectPathFromString(s string) (SelectPath, error) {
 		return SelectPath{}, fmt.Errorf("invalid select type '%s'", s)
 	}
 	if len(fields) > 0 {
-		if _, ok := validFields[SelectType(selector)].(map[string]interface{})[fields[0]]; !ok {
+		if _, ok := validSelectors[SelectType(selector)][fields[0]]; !ok {
 			return SelectPath{}, fmt.Errorf("invalid field '%s' on select type '%s'", fields[0], selector)
 		}
 	}

--- a/internal/search/filter/select_symbol.go
+++ b/internal/search/filter/select_symbol.go
@@ -1,7 +1,9 @@
-package graphqlbackend
+package filter
 
 import (
 	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // toSelectKind maps an internal symbol kind (cf. ctagsKind) to a corresponding
@@ -73,8 +75,8 @@ var toSelectKind = map[string]string{
 	"annotation":      "type-parameter",
 }
 
-func pick(symbols []*SearchSymbolResult, satisfy func(*SearchSymbolResult) bool) []*SearchSymbolResult {
-	var result []*SearchSymbolResult
+func pick(symbols []*result.SearchSymbolResult, satisfy func(*result.SearchSymbolResult) bool) []*result.SearchSymbolResult {
+	var result []*result.SearchSymbolResult
 	for _, symbol := range symbols {
 		if satisfy(symbol) {
 			result = append(result, symbol)
@@ -83,9 +85,9 @@ func pick(symbols []*SearchSymbolResult, satisfy func(*SearchSymbolResult) bool)
 	return result
 }
 
-func SelectKind(symbols []*SearchSymbolResult, field string) []*SearchSymbolResult {
-	return pick(symbols, func(s *SearchSymbolResult) bool {
-		if field == toSelectKind[strings.ToLower(s.symbol.Kind)] {
+func SelectSymbolKind(symbols []*result.SearchSymbolResult, field string) []*result.SearchSymbolResult {
+	return pick(symbols, func(s *result.SearchSymbolResult) bool {
+		if field == toSelectKind[strings.ToLower(s.Symbol.Kind)] {
 			return true
 		}
 		return false

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -91,6 +91,10 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			input: "-context:a",
 			want:  `field "context" does not support negation`,
 		},
+		{
+			input: "type:symbol select:symbol.timelime",
+			want:  "invalid field 'timelime' on select type 'symbol'",
+		},
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {


### PR DESCRIPTION
Allows to specify `select:symbol.<kind>`. Part of https://github.com/sourcegraph/sourcegraph/issues/18002.

https://user-images.githubusercontent.com/888624/109730916-8bb2af00-7b77-11eb-9cd9-a52386b63e91.mp4

I've chosen `kind` to be based on the reduced set of LSP-like values, and not the varied and aliased ctags values that we actually label symbols as internally. E.g., there's little benefit of supporting both `func` and `function` and we can cut down on suggested values when I support this in frontend.

I will add another unit test and integration test later but this is ready for review.