### PR TITLE
Group campaigns graphql schema extension

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -614,162 +614,6 @@ type Mutation {
     scheduleUserPermissionsSync(user: ID!): EmptyResponse!
 
     """
-    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
-    campaign is returned.
-    If a campaign in the same namespace with the same name already exists, an error with the error code
-    ErrMatchingCampaignExists is returned.
-    """
-    createCampaign(
-        """
-        The campaign spec that describes the desired state of the campaign.
-        """
-        campaignSpec: ID!
-    ): Campaign!
-
-    """
-    Create or update a campaign from a campaign spec and locally computed changeset specs. If no
-    campaign exists in the namespace with the name given in the campaign spec, a campaign will be
-    created. Otherwise, the existing campaign will be updated. The campaign is returned.
-    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
-    will be returned.
-    """
-    applyCampaign(
-        """
-        The campaign spec that describes the new desired state of the campaign.
-        """
-        campaignSpec: ID!
-
-        """
-        If set, return an error if the campaign identified using the namespace and campaignSpec
-        parameters does not match the campaign with this ID. This lets callers use a stable ID
-        that refers to a specific campaign during an edit session (and is not susceptible to
-        conflicts if the underlying campaign is moved to a different namespace, renamed, or
-        deleted). The returned error has the error code ErrEnsureCampaignFailed.
-        """
-        ensureCampaign: ID
-    ): Campaign!
-
-    """
-    Move a campaign to a different namespace, or rename it in the current namespace.
-    """
-    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
-
-    """
-    Close a campaign.
-    """
-    closeCampaign(
-        campaign: ID!
-        """
-        Whether to close the changesets associated with this campaign on their respective code
-        hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
-        GitHub and "declined" on Bitbucket Server).
-        """
-        closeChangesets: Boolean = false
-    ): Campaign!
-
-    """
-    Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
-    campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
-    """
-    deleteCampaign(campaign: ID!): EmptyResponse
-
-    """
-    Upload a changeset spec that will be used in a future update to a campaign. The changeset spec
-    is stored and can be referenced by its ID in the applyCampaign mutation. Just uploading the
-    changeset spec does not result in changes to the campaign or any of its changesets; you need
-    to call applyCampaign to use it.
-
-    You can use this mutation to upload large changeset specs (e.g., containing large diffs) in
-    individual HTTP requests. Then, in the eventual applyCampaign call, you just refer to the
-    changeset specs by their IDs. This lets you avoid problems when updating large campaigns where
-    a large HTTP request body (e.g., with many large diffs in the changeset specs) would be
-    rejected by the web server/proxy or would be very slow.
-
-    The returned ChangesetSpec is immutable and expires after a certain period of time (if not
-    used in a call to applyCampaign), which can be queried on ChangesetSpec.expiresAt.
-    """
-    createChangesetSpec(
-        """
-        The raw changeset spec (as JSON). See
-        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/changeset_spec.schema.json
-        for the JSON Schema that describes the structure of this input.
-        """
-        changesetSpec: String!
-    ): ChangesetSpec!
-
-    """
-    Create a campaign spec that will be used to create a campaign (with the createCampaign
-    mutation), or to update a campaign (with the applyCampaign mutation).
-
-    The returned CampaignSpec is immutable and expires after a certain period of time (if not used
-    in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
-
-    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
-    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
-    """
-    createCampaignSpec(
-        """
-        The namespace (either a user or organization). A campaign spec can only be applied to (or
-        used to create) campaigns in this namespace.
-        """
-        namespace: ID!
-
-        """
-        The campaign spec as YAML (or the equivalent JSON). See
-        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/campaign_spec.schema.json
-        for the JSON Schema that describes the structure of this input.
-        """
-        campaignSpec: String!
-
-        """
-        Changeset specs that were locally computed and then uploaded using createChangesetSpec.
-        """
-        changesetSpecs: [ID!]!
-    ): CampaignSpec!
-
-    """
-    Enqueue the given changeset for high-priority syncing.
-    """
-    syncChangeset(changeset: ID!): EmptyResponse!
-
-    """
-    Re-enqueue the changeset for processing by the reconciler. The changeset must be in FAILED state.
-    """
-    reenqueueChangeset(changeset: ID!): Changeset!
-
-    """
-    Create a new credential for the given user for the given code host.
-    If another token for that code host already exists, an error with the error code
-    ErrDuplicateCredential is returned.
-    """
-    createCampaignsCredential(
-        """
-        The user for which to create the credential.
-        """
-        user: ID!
-
-        """
-        The kind of external service being configured.
-        """
-        externalServiceKind: ExternalServiceKind!
-
-        """
-        The URL of the external service being configured.
-        """
-        externalServiceURL: String!
-
-        """
-        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
-        """
-        credential: String!
-    ): CampaignsCredential!
-
-    """
-    Hard-deletes a given campaigns credential.
-    """
-    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
-
-    """
     OBSERVABILITY
 
     Set the status of a test alert of the specified parameters - useful for validating
@@ -879,807 +723,6 @@ type Mutation {
 }
 
 """
-A connection of all code hosts usable with campaigns and accessible by the user
-this is requested on.
-"""
-type CampaignsCodeHostConnection {
-    """
-    A list of code hosts.
-    """
-    nodes: [CampaignsCodeHost!]!
-
-    """
-    The total number of configured external services in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-A code host usable with campaigns. This service is accessible by the user it belongs to.
-"""
-type CampaignsCodeHost {
-    """
-    The kind of external service.
-    """
-    externalServiceKind: ExternalServiceKind!
-
-    """
-    The URL of the external service.
-    """
-    externalServiceURL: String!
-
-    """
-    The configured credential, if any.
-    """
-    credential: CampaignsCredential
-}
-
-"""
-A user token configured for campaigns use on the specified code host.
-"""
-type CampaignsCredential implements Node {
-    """
-    A globally unique identifier.
-    """
-    id: ID!
-
-    """
-    The kind of external service.
-    """
-    externalServiceKind: ExternalServiceKind!
-
-    """
-    The URL of the external service.
-    """
-    externalServiceURL: String!
-
-    """
-    The date and time this token has been created at.
-    """
-    createdAt: DateTime!
-}
-
-"""
-This enum declares all operations supported by the reconciler.
-"""
-enum ChangesetSpecOperation {
-    """
-    Push a new commit to the code host.
-    """
-    PUSH
-    """
-    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
-    not the git commit. For updates to the commit, see 'PUSH'.
-    """
-    UPDATE
-    """
-    Move the existing changeset out of being a draft.
-    """
-    UNDRAFT
-    """
-    Publish a changeset to the codehost.
-    """
-    PUBLISH
-    """
-    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
-    """
-    PUBLISH_DRAFT
-    """
-    Sync the changeset with the current state on the codehost.
-    """
-    SYNC
-    """
-    Import an existing changeset from the code host with the ExternalID from the spec.
-    """
-    IMPORT
-    """
-    Close the changeset on the codehost.
-    """
-    CLOSE
-    """
-    Reopen the changeset on the codehost.
-    """
-    REOPEN
-    """
-    Internal operation to get around slow code host updates.
-    """
-    SLEEP
-    """
-    The changeset is removed from some of the associated campaigns.
-    """
-    DETACH
-}
-
-"""
-Description of the current changeset state vs the changeset spec desired state.
-"""
-type ChangesetSpecDelta {
-    """
-    When run, the title of the changeset will be updated.
-    """
-    titleChanged: Boolean!
-    """
-    When run, the body of the changeset will be updated.
-    """
-    bodyChanged: Boolean!
-    """
-    When run, the changeset will be taken out of draft mode.
-    """
-    undraft: Boolean!
-    """
-    When run, the target branch of the changeset will be updated.
-    """
-    baseRefChanged: Boolean!
-    """
-    When run, a new commit will be created on the branch of the changeset.
-    """
-    diffChanged: Boolean!
-    """
-    When run, a new commit will be created on the branch of the changeset.
-    """
-    commitMessageChanged: Boolean!
-    """
-    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
-    """
-    authorNameChanged: Boolean!
-    """
-    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
-    """
-    authorEmailChanged: Boolean!
-}
-
-"""
-The type of the changeset spec.
-"""
-enum ChangesetSpecType {
-    """
-    References an existing changeset on a code host to be imported.
-    """
-    EXISTING
-    """
-    References a branch and a patch to be applied to create the changeset from.
-    """
-    BRANCH
-}
-
-"""
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
-create a changeset spec, use the createChangesetSpec mutation.
-"""
-interface ChangesetSpec {
-    """
-    The unique ID for a changeset spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
-    even though repository permissions also apply to viewers of changeset specs, because being
-    allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The type of changeset spec.
-    """
-    type: ChangesetSpecType!
-
-    """
-    The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
-    """
-    expiresAt: DateTime
-}
-
-"""
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
-create a changeset spec, use the createChangesetSpec mutation.
-"""
-type HiddenChangesetSpec implements ChangesetSpec & Node {
-    """
-    The unique ID for a changeset spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
-    even though repository permissions also apply to viewers of changeset specs, because being
-    allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The type of changeset spec.
-    """
-    type: ChangesetSpecType!
-
-    """
-    The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
-    """
-    expiresAt: DateTime
-}
-
-"""
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
-create a changeset spec, use the createChangesetSpec mutation.
-"""
-type VisibleChangesetSpec implements ChangesetSpec & Node {
-    """
-    The unique ID for a changeset spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
-    even though repository permissions also apply to viewers of changeset specs, because being
-    allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The type of changeset spec.
-    """
-    type: ChangesetSpecType!
-
-    """
-    The description of the changeset.
-    """
-    description: ChangesetDescription!
-
-    """
-    The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
-    """
-    expiresAt: DateTime
-}
-
-"""
-All possible types of changesets that can be specified in a changeset spec.
-"""
-union ChangesetDescription = ExistingChangesetReference | GitBranchChangesetDescription
-
-"""
-A reference to a changeset that already exists on a code host (and was not created by the
-campaign).
-"""
-type ExistingChangesetReference {
-    """
-    The repository that contains the existing changeset on the code host.
-    """
-    baseRepository: Repository!
-
-    """
-    The ID that uniquely identifies the existing changeset on the code host.
-
-    For GitHub and Bitbucket Server, this is the pull request number (as a string) in the
-    base repository. For example, "1234" for PR 1234.
-    """
-    externalID: String!
-}
-
-"""
-A triple that represents all possible states of the published value: true, false or 'draft'.
-"""
-scalar PublishedValue
-
-"""
-A description of a changeset that represents the proposal to merge one branch into another.
-This is used to describe a pull request (on GitHub and Bitbucket Server).
-"""
-type GitBranchChangesetDescription {
-    """
-    The repository that this changeset spec is proposing to change.
-    """
-    baseRepository: Repository!
-
-    """
-    The full name of the Git ref in the base repository that this changeset is based on (and is
-    proposing to be merged into). This ref must exist on the base repository. For example,
-    "refs/heads/master" or "refs/heads/main".
-    """
-    baseRef: String!
-
-    """
-    The base revision this changeset is based on. It is the latest commit in
-    baseRef at the time when the changeset spec was created.
-    For example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
-    """
-    baseRev: String!
-
-    """
-    The repository that contains the branch with this changeset's changes.
-
-    Fork repositories and cross-repository changesets are not yet supported. Therefore,
-    headRepository must be equal to baseRepository.
-    """
-    headRepository: Repository!
-
-    """
-    The full name of the Git ref that holds the changes proposed by this changeset. This ref will
-    be created or updated with the commits. For example, "refs/heads/fix-foo" (for
-    the Git branch "fix-foo").
-    """
-    headRef: String!
-
-    """
-    The title of the changeset on the code host.
-
-    On Bitbucket Server or GitHub this is the title of the pull request.
-    """
-    title: String!
-
-    """
-    The body of the changeset on the code host.
-
-    On Bitbucket Server or GitHub this is the body/description of the pull request.
-    """
-    body: String!
-
-    """
-    The Git commits with the proposed changes. These commits are pushed to the head ref.
-
-    Only 1 commit is supported.
-    """
-    commits: [GitCommitDescription!]!
-
-    """
-    The total diff of the changeset diff.
-    """
-    diff: PreviewRepositoryComparison!
-
-    """
-    The diffstat of this changeset spec. This data is also available
-    indirectly through the diff field above, but if only the diffStat is
-    required, this field is cheaper to access.
-    """
-    diffStat: DiffStat!
-
-    """
-    Whether or not the changeset described here should be created right after
-    applying the ChangesetSpec this description belongs to.
-
-    If this is false, the changeset will only be created on Sourcegraph and
-    can be previewed.
-
-    Another ChangesetSpec with the same description, but "published: true",
-    can later be applied publish the changeset.
-    """
-    published: PublishedValue!
-}
-
-"""
-A description of a Git commit.
-"""
-type GitCommitDescription {
-    """
-    The full commit message.
-    """
-    message: String!
-
-    """
-    The first line of the commit message.
-    """
-    subject: String!
-
-    """
-    The contents of the commit message after the first line.
-    """
-    body: String
-
-    """
-    The Git commit author.
-    """
-    author: Person!
-
-    """
-    The commit diff (in unified diff format).
-
-    The filenames must not be prefixed (e.g., with 'a/' and 'b/'). Tip: use 'git diff --no-prefix'
-    to omit the prefix.
-    """
-    diff: String!
-}
-
-"""
-A list of changeset specs.
-"""
-type ChangesetSpecConnection {
-    """
-    The total number of changeset specs in the connection.
-    """
-    totalCount: Int!
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-    """
-    A list of changeset specs.
-    """
-    nodes: [ChangesetSpec!]!
-}
-
-"""
-A preview for which actions applyCampaign would result in when called at the point of time this preview was created at.
-"""
-union ChangesetApplyPreview = VisibleChangesetApplyPreview | HiddenChangesetApplyPreview
-
-"""
-A preview entry to a repository to which the user has access.
-"""
-union VisibleApplyPreviewTargets =
-      VisibleApplyPreviewTargetsAttach
-    | VisibleApplyPreviewTargetsUpdate
-    | VisibleApplyPreviewTargetsDetach
-
-"""
-A preview entry where no changeset existed before matching the changeset spec.
-"""
-type VisibleApplyPreviewTargetsAttach {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: VisibleChangesetSpec!
-}
-
-"""
-A preview entry where a changeset matches the changeset spec.
-"""
-type VisibleApplyPreviewTargetsUpdate {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: VisibleChangesetSpec!
-    """
-    The changeset from this entry.
-    """
-    changeset: ExternalChangeset!
-}
-
-"""
-A preview entry where no changeset spec exists for the changeset currently in
-the target campaign.
-"""
-type VisibleApplyPreviewTargetsDetach {
-    """
-    The changeset from this entry.
-    """
-    changeset: ExternalChangeset!
-}
-
-"""
-A preview entry to a repository to which the user has no access.
-"""
-union HiddenApplyPreviewTargets =
-      HiddenApplyPreviewTargetsAttach
-    | HiddenApplyPreviewTargetsUpdate
-    | HiddenApplyPreviewTargetsDetach
-
-"""
-A preview entry where no changeset existed before matching the changeset spec.
-"""
-type HiddenApplyPreviewTargetsAttach {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: HiddenChangesetSpec!
-}
-
-"""
-A preview entry where a changeset matches the changeset spec.
-"""
-type HiddenApplyPreviewTargetsUpdate {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: HiddenChangesetSpec!
-    """
-    The changeset from this entry.
-    """
-    changeset: HiddenExternalChangeset!
-}
-
-"""
-A preview entry where no changeset spec exists for the changeset currently in
-the target campaign.
-"""
-type HiddenApplyPreviewTargetsDetach {
-    """
-    The changeset from this entry.
-    """
-    changeset: HiddenExternalChangeset!
-}
-
-"""
-One preview entry in the list of all previews against a campaign spec. Each mapping
-between changeset specs and current changesets yields one of these. It describes
-which operations are taken against which changeset spec and changeset to ensure the
-desired state is met.
-"""
-type HiddenChangesetApplyPreview {
-    """
-    The operations to take to achieve the desired state.
-    """
-    operations: [ChangesetSpecOperation!]!
-
-    """
-    The delta between the current changeset state and what the new changeset spec
-    envisions the changeset to look like.
-    """
-    delta: ChangesetSpecDelta!
-
-    """
-    The target entities in this preview entry.
-    """
-    targets: HiddenApplyPreviewTargets!
-}
-
-"""
-One preview entry in the list of all previews against a campaign spec. Each mapping
-between changeset specs and current changesets yields one of these. It describes
-which operations are taken against which changeset spec and changeset to ensure the
-desired state is met.
-"""
-type VisibleChangesetApplyPreview {
-    """
-    The operations to take to achieve the desired state.
-    """
-    operations: [ChangesetSpecOperation!]!
-
-    """
-    The delta between the current changeset state and what the new changeset spec
-    envisions the changeset to look like.
-    """
-    delta: ChangesetSpecDelta!
-
-    """
-    The target entities in this preview entry.
-    """
-    targets: VisibleApplyPreviewTargets!
-}
-
-"""
-Aggregated stats on nodes in this connection.
-"""
-type ChangesetApplyPreviewConnectionStats {
-    """
-    Push a new commit to the code host.
-    """
-    push: Int!
-    """
-    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
-    not the git commit. For updates to the commit, see 'PUSH'.
-    """
-    update: Int!
-    """
-    Move the existing changeset out of being a draft.
-    """
-    undraft: Int!
-    """
-    Publish a changeset to the codehost.
-    """
-    publish: Int!
-    """
-    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
-    """
-    publishDraft: Int!
-    """
-    Sync the changeset with the current state on the codehost.
-    """
-    sync: Int!
-    """
-    Import an existing changeset from the code host with the ExternalID from the spec.
-    """
-    import: Int!
-    """
-    Close the changeset on the codehost.
-    """
-    close: Int!
-    """
-    Reopen the changeset on the codehost.
-    """
-    reopen: Int!
-    """
-    Internal operation to get around slow code host updates.
-    """
-    sleep: Int!
-    """
-    The changeset is removed from some of the associated campaigns.
-    """
-    detach: Int!
-
-    """
-    The amount of changesets that are added to the campaign in this operation.
-    """
-    added: Int!
-    """
-    The amount of changesets that are already attached to the campaign and modified in this operation.
-    """
-    modified: Int!
-    """
-    The amount of changesets that are disassociated from the campaign in this operation.
-    """
-    removed: Int!
-}
-
-"""
-A list of preview entries.
-"""
-type ChangesetApplyPreviewConnection {
-    """
-    The total number of entries in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-
-    """
-    A list of preview entries.
-    """
-    nodes: [ChangesetApplyPreview!]!
-
-    """
-    Stats on the elements in this connnection. Does not respect pagination parameters.
-    """
-    stats: ChangesetApplyPreviewConnectionStats!
-}
-
-"""
-A CampaignDescription describes a campaign.
-"""
-type CampaignDescription {
-    """
-    The name as parsed from the input.
-    """
-    name: String!
-
-    """
-    The description as parsed from the input.
-    """
-    description: String!
-}
-
-"""
-A campaign spec is an immutable description of the desired state of a campaign. To create a
-campaign spec, use the createCampaignSpec mutation.
-"""
-type CampaignSpec implements Node {
-    """
-    The unique ID for a campaign spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential).
-    Consider a campaign to fix a security vulnerability: the campaign author may prefer
-    to prepare the campaign, including the description in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The original YAML or JSON input that was used to create this campaign spec.
-    """
-    originalInput: String!
-
-    """
-    The parsed JSON value of the original input. If the original input was YAML, the YAML is
-    converted to the equivalent JSON.
-    """
-    parsedInput: JSONValue!
-
-    """
-    The CampaignDescription that describes this campaign.
-    """
-    description: CampaignDescription!
-
-    """
-    Generates a preview what operations would be performed if the campaign spec would be applied.
-    This preview is not a guarantee, since the state of the changesets can change between the time
-    the preview is generated and when the campaign spec is applied.
-    """
-    applyPreview(
-        """
-        Returns the first n entries from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
-        """
-        search: String
-        """
-        Search for changesets that are currently in this state.
-        """
-        currentState: ChangesetState
-        """
-        Search for changesets that will have the given action performed.
-        """
-        action: ChangesetSpecOperation
-    ): ChangesetApplyPreviewConnection!
-
-    """
-    The specs for changesets associated with this campaign.
-    """
-    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
-
-    """
-    The user who created this campaign spec (or null if the user no longer exists).
-    """
-    creator: User
-
-    """
-    The date when this campaign spec was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The namespace (either a user or organization) of the campaign spec.
-    """
-    namespace: Namespace!
-
-    """
-    The date, if any, when this campaign spec expires and is automatically purged. A campaign spec
-    never expires if it has been applied.
-    """
-    expiresAt: DateTime
-
-    """
-    The URL of a web page that allows applying this campaign spec and
-    displays a preview of which changesets will be created by applying it.
-    """
-    applyURL: String!
-
-    """
-    When true, the viewing user can apply this spec.
-    """
-    viewerCanAdminister: Boolean!
-
-    """
-    The diff stat for all the changeset specs in the campaign spec.
-    """
-    diffStat: DiffStat!
-
-    """
-    The campaign this spec will update when applied. If it's null, the
-    campaign doesn't yet exist.
-    """
-    appliesToCampaign: Campaign
-
-    """
-    The newest version of this campaign spec, as identified by its namespace
-    and name. If this is the newest version, this field will be null.
-    """
-    supersedingCampaignSpec: CampaignSpec
-
-    """
-    The code host connections required for applying this spec. Includes the credentials of the current user.
-    """
-    viewerCampaignsCodeHosts(
-        """
-        Returns the first n code hosts from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only returns the code hosts for which the viewer doesn't have credentials.
-        """
-        onlyWithoutCredential: Boolean = false
-    ): CampaignsCodeHostConnection!
-}
-
-"""
 A user (identified either by username or email address) with its repository permission.
 """
 input UserPermission {
@@ -1693,764 +736,6 @@ input UserPermission {
     The highest level of repository permission.
     """
     permission: RepositoryPermission = READ
-}
-
-"""
-A campaign is a set of related changes to apply to code across one or more repositories.
-"""
-type Campaign implements Node {
-    """
-    The unique ID for the campaign.
-    """
-    id: ID!
-
-    """
-    The namespace where this campaign is defined.
-    """
-    namespace: Namespace!
-
-    """
-    The name of the campaign.
-    """
-    name: String!
-
-    """
-    The description (as Markdown).
-    """
-    description: String
-
-    """
-    The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
-    """
-    specCreator: User
-
-    """
-    The user who created the campaign initially by applying the spec for the first time, or null if the user was deleted.
-    """
-    initialApplier: User
-
-    """
-    The user who last updated the campaign by applying a spec to this campaign.
-    If the campaign hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
-    """
-    lastApplier: User
-
-    """
-    Whether the current user can edit or delete this campaign.
-    """
-    viewerCanAdminister: Boolean!
-
-    """
-    The URL to this campaign.
-    """
-    url: String!
-
-    """
-    The date and time when the campaign was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the campaign was updated. That can be by applying a spec, or by an internal process.
-    For reading the time the campaign spec was changed last, see lastAppliedAt.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the campaign was last updated with a new spec.
-    """
-    lastAppliedAt: DateTime!
-
-    """
-    The date and time when the campaign was closed. If set, applying a spec for this campaign will fail with an error.
-    """
-    closedAt: DateTime
-
-    """
-    Stats on all the changesets that are tracked in this campaign.
-    """
-    changesetsStats: ChangesetsStats!
-
-    """
-    The changesets in this campaign that already exist on the code host.
-    """
-    changesets(
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only include changesets with any of the given reconciler states.
-        """
-        reconcilerState: [ChangesetReconcilerState!]
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given publication state.
-        """
-        publicationState: ChangesetPublicationState
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given external state.
-        """
-        externalState: ChangesetExternalState
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given state.
-        """
-        state: ChangesetState
-        """
-        Only include changesets with the given review state.
-        """
-        reviewState: ChangesetReviewState
-        """
-        Only include changesets with the given check state.
-        """
-        checkState: ChangesetCheckState
-        """
-        Only return changesets that have been published by this campaign. Imported changesets will be omitted.
-        """
-        onlyPublishedByThisCampaign: Boolean
-        """
-        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
-        """
-        search: String
-    ): ChangesetConnection!
-
-    """
-    The changeset counts over time, in 1-day intervals backwards from the point in time given in
-    the "to" parameter.
-    """
-    changesetCountsOverTime(
-        """
-        Only include changeset counts up to this point in time (inclusive). Defaults to Campaign.createdAt.
-        """
-        from: DateTime
-        """
-        Only include changeset counts up to this point in time (inclusive). Defaults to the
-        current time.
-        """
-        to: DateTime
-    ): [ChangesetCounts!]!
-
-    """
-    The diff stat for all the changesets in the campaign.
-    """
-    diffStat: DiffStat!
-
-    """
-    The current campaign spec this campaign reflects.
-    """
-    currentSpec: CampaignSpec!
-}
-
-"""
-The counts of changesets in certain states at a specific point in time.
-"""
-type ChangesetCounts {
-    """
-    The point in time these counts were recorded.
-    """
-    date: DateTime!
-    """
-    The total number of changesets.
-    """
-    total: Int!
-    """
-    The number of merged changesets.
-    """
-    merged: Int!
-    """
-    The number of closed changesets.
-    """
-    closed: Int!
-    """
-    The number of draft changesets (independent of review state).
-    """
-    draft: Int!
-    """
-    The number of open changesets (independent of review state).
-    """
-    open: Int!
-    """
-    The number of changesets that are both open and approved.
-    """
-    openApproved: Int!
-    """
-    The number of changesets that are both open and have requested changes.
-    """
-    openChangesRequested: Int!
-    """
-    The number of changesets that are both open and are pending review.
-    """
-    openPending: Int!
-}
-
-"""
-A list of campaigns.
-"""
-type CampaignConnection {
-    """
-    A list of campaigns.
-    """
-    nodes: [Campaign!]!
-
-    """
-    The total number of campaigns in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-The publication state of a changeset on Sourcegraph
-"""
-enum ChangesetPublicationState {
-    """
-    The changeset has not yet been created on the code host.
-    """
-    UNPUBLISHED
-    """
-    The changeset has been created on the code host.
-    """
-    PUBLISHED
-}
-
-"""
-The reconciler state of a changeset on Sourcegraph
-"""
-enum ChangesetReconcilerState {
-    """
-    The changeset is enqueued for the reconciler to process it.
-    """
-    QUEUED
-
-    """
-    The changeset reconciler is currently computing the delta between the
-    If a delta exists, the reconciler tries to update the state of the
-    changeset on the code host and on Sourcegraph to the desired state.
-    """
-    PROCESSING
-
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset and will retry it for a number of retries.
-    """
-    ERRORED
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset that can't be fixed by retrying.
-    """
-    FAILED
-
-    """
-    The changeset is not enqueued for processing.
-    """
-    COMPLETED
-}
-
-"""
-The state of a changeset on the code host on which it's hosted.
-"""
-enum ChangesetExternalState {
-    DRAFT
-    OPEN
-    CLOSED
-    MERGED
-    DELETED
-}
-
-"""
-The review state of a changeset.
-"""
-enum ChangesetReviewState {
-    APPROVED
-    CHANGES_REQUESTED
-    PENDING
-    COMMENTED
-    DISMISSED
-}
-
-"""
-The state of checks (e.g., for continuous integration) on a changeset.
-"""
-enum ChangesetCheckState {
-    PENDING
-    PASSED
-    FAILED
-}
-
-"""
-A label attached to a changeset on a code host.
-"""
-type ChangesetLabel {
-    """
-    The label's text.
-    """
-    text: String!
-    """
-    The label's color, as a hex color code without the . For example: "93ba13".
-    """
-    color: String!
-    """
-    An optional description of the label.
-    """
-    description: String
-}
-
-"""
-The visual state a changeset is currently in.
-"""
-enum ChangesetState {
-    """
-    The changeset has not been marked as to be published.
-    """
-    UNPUBLISHED
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset that can't be fixed by retrying.
-    """
-    FAILED
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset and will retry it for a number of retries.
-    """
-    RETRYING
-    """
-    The changeset reconciler is currently computing the delta between the
-    If a delta exists, the reconciler tries to update the state of the
-    changeset on the code host and on Sourcegraph to the desired state.
-    """
-    PROCESSING
-    """
-    The changeset is published, not being reconciled and open on the code host.
-    """
-    OPEN
-    """
-    The changeset is published, not being reconciled and in draft state on the code host.
-    """
-    DRAFT
-    """
-    The changeset is published, not being reconciled and closed on the code host.
-    """
-    CLOSED
-    """
-    The changeset is published, not being reconciled and merged on the code host.
-    """
-    MERGED
-    """
-    The changeset is published, not being reconciled and has been deleted on the code host.
-    """
-    DELETED
-}
-
-"""
-A changeset on a codehost.
-"""
-interface Changeset {
-    """
-    The unique ID for the changeset.
-    """
-    id: ID!
-
-    """
-    The campaigns that contain this changeset.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The state of the changeset.
-    """
-    state: ChangesetState!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the changeset was updated.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
-    """
-    nextSyncAt: DateTime
-}
-
-"""
-A changeset on a code host that the user does not have access to.
-"""
-type HiddenExternalChangeset implements Node & Changeset {
-    """
-    The unique ID for the changeset.
-    """
-    id: ID!
-
-    """
-    The campaigns that contain this changeset.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The state of the changeset.
-    """
-    state: ChangesetState!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the changeset was updated.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
-    """
-    nextSyncAt: DateTime
-}
-
-"""
-A changeset on a code host (e.g., a pull request on GitHub).
-"""
-type ExternalChangeset implements Node & Changeset {
-    """
-    The unique ID for the changeset.
-    """
-    id: ID!
-
-    """
-    The external ID that uniquely identifies this ExternalChangeset on the
-    code host. For example, on GitHub this is the pull request number. This is only set once the changeset is published on the code host.
-    """
-    externalID: String
-
-    """
-    The repository changed by this changeset.
-    """
-    repository: Repository!
-
-    """
-    The campaigns that contain this changeset.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    The events belonging to this changeset.
-    """
-    events(first: Int = 50, after: String): ChangesetEventConnection!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the changeset was updated.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the next changeset sync is scheduled, or null if none is scheduled or when the initial sync hasn't happened.
-    """
-    nextSyncAt: DateTime
-
-    """
-    The title of the changeset, or null if the data hasn't been synced from the code host yet.
-    """
-    title: String
-
-    """
-    The body of the changeset, or null if the data hasn't been synced from the code host yet.
-    """
-    body: String
-
-    """
-    The author of the changeset, or null if the data hasn't been synced from the code host yet,
-    or the changeset has not yet been published.
-    """
-    author: Person
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The state of the changeset.
-    """
-    state: ChangesetState!
-
-    """
-    The labels attached to the changeset on the code host.
-    """
-    labels: [ChangesetLabel!]!
-
-    """
-    The external URL of the changeset on the code host. Not set when changeset state is UNPUBLISHED, externalState is DELETED, or the changeset's data hasn't been synced yet.
-    """
-    externalURL: ExternalLink
-
-    """
-    The review state of this changeset. This is only set once the changeset is published on the code host.
-    """
-    reviewState: ChangesetReviewState
-
-    """
-    The diff of this changeset, or null if the changeset is closed (without merging) or is already merged.
-    """
-    diff: RepositoryComparisonInterface
-
-    """
-    The diffstat of this changeset, or null if the changeset is closed
-    (without merging) or is already merged. This data is also available
-    indirectly through the diff field above, but if only the diffStat is
-    required, this field is cheaper to access.
-    """
-    diffStat: DiffStat
-
-    """
-    The state of the checks (e.g., for continuous integration) on this changeset, or null if no
-    checks have been configured.
-    """
-    checkState: ChangesetCheckState
-
-    """
-    An error that has occurred when publishing or updating the changeset. This is only set when the changeset state is ERRORED and the viewer can administer this changeset.
-    """
-    error: String
-
-    """
-    An error that has occured during the last sync of the changeset. Null, if was successful.
-    """
-    syncerError: String
-
-    """
-    The current changeset spec for this changeset.
-
-    Null if the changeset was only imported.
-    """
-    currentSpec: VisibleChangesetSpec
-}
-
-"""
-Used in the campaign page for the overview component.
-"""
-type ChangesetsStats {
-    """
-    The count of unpublished changesets.
-    """
-    unpublished: Int!
-    """
-    The count of externalState: DRAFT changesets.
-    """
-    draft: Int!
-    """
-    The count of externalState: OPEN changesets.
-    """
-    open: Int!
-    """
-    The count of externalState: MERGED changesets.
-    """
-    merged: Int!
-    """
-    The count of externalState: CLOSED changesets.
-    """
-    closed: Int!
-    """
-    The count of externalState: DELETED changesets.
-    """
-    deleted: Int!
-    """
-    The count of changesets in retrying state.
-    """
-    retrying: Int!
-    """
-    The count of changesets in failed state.
-    """
-    failed: Int!
-    """
-    The count of changesets that are currently processing or enqueued to be.
-    """
-    processing: Int!
-    """
-    The count of all changesets.
-    """
-    total: Int!
-}
-
-"""
-A list of changesets.
-"""
-type ChangesetConnection {
-    """
-    A list of changesets.
-    """
-    nodes: [Changeset!]!
-
-    """
-    The total number of changesets in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-A changeset event in a code host (e.g., a comment on a pull request on GitHub).
-"""
-type ChangesetEvent implements Node {
-    """
-    The unique ID for the changeset event.
-    """
-    id: ID!
-
-    """
-    The changeset this event belongs to.
-    """
-    changeset: ExternalChangeset!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-}
-
-"""
-A list of changeset events.
-"""
-type ChangesetEventConnection {
-    """
-    A list of changeset events.
-    """
-    nodes: [ChangesetEvent!]!
-
-    """
-    The total number of changeset events in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
 }
 
 """
@@ -2804,14 +1089,6 @@ input HappinessFeedbackSubmissionInput {
 }
 
 """
-The state of the campaign
-"""
-enum CampaignState {
-    OPEN
-    CLOSED
-}
-
-"""
 A query.
 """
 type Query {
@@ -2823,41 +1100,6 @@ type Query {
     Looks up a node by ID.
     """
     node(id: ID!): Node
-
-    """
-    A list of campaigns.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-    """
-    Looks up a campaign by namespace and campaign name.
-    """
-    campaign(
-        """
-        The namespace where the campaign lives.
-        """
-        namespace: ID!
-        """
-        The campaigns name.
-        """
-        name: String!
-    ): Campaign
 
     """
     EXPERIMENTAL: Queries code insights
@@ -6992,44 +5234,6 @@ type User implements Node & SettingsSubject & Namespace {
     permissionsInfo: PermissionsInfo
 
     """
-    A list of campaigns applied under this user's namespace.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    Returns a connection of configured external services accessible by this user, for usage with campaigns.
-    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
-    connected to CampaignCredential resources, if one has been created for the code host connection before.
-    """
-    campaignsCodeHosts(
-        """
-        Returns the first n code hosts from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-    ): CampaignsCodeHostConnection!
-
-    """
     A list of monitors owned by the user or her organization.
     """
     monitors(
@@ -7415,28 +5619,6 @@ type Org implements Node & SettingsSubject & Namespace {
     The name of this user namespace's component. For organizations, this is the organization's name.
     """
     namespaceName: String!
-
-    """
-    A list of campaigns initially applied in this organization.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
 }
 
 """
@@ -9633,4 +7815,1841 @@ type CodeHostRepository {
     """
     private: Boolean!
 }
+
+############################################################################################
+#                                                                                          #
+#                               Begin campaigns schema                                     #
+#                                                                                          #
+############################################################################################
+"""
+The state of the campaign
+"""
+enum CampaignState {
+    OPEN
+    CLOSED
+}
+
+"""
+A campaign is a set of related changes to apply to code across one or more repositories.
+"""
+type Campaign implements Node {
+    """
+    The unique ID for the campaign.
+    """
+    id: ID!
+
+    """
+    The namespace where this campaign is defined.
+    """
+    namespace: Namespace!
+
+    """
+    The name of the campaign.
+    """
+    name: String!
+
+    """
+    The description (as Markdown).
+    """
+    description: String
+
+    """
+    The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
+    """
+    specCreator: User
+
+    """
+    The user who created the campaign initially by applying the spec for the first time, or null if the user was deleted.
+    """
+    initialApplier: User
+
+    """
+    The user who last updated the campaign by applying a spec to this campaign.
+    If the campaign hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
+    """
+    lastApplier: User
+
+    """
+    Whether the current user can edit or delete this campaign.
+    """
+    viewerCanAdminister: Boolean!
+
+    """
+    The URL to this campaign.
+    """
+    url: String!
+
+    """
+    The date and time when the campaign was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the campaign was updated. That can be by applying a spec, or by an internal process.
+    For reading the time the campaign spec was changed last, see lastAppliedAt.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the campaign was last updated with a new spec.
+    """
+    lastAppliedAt: DateTime!
+
+    """
+    The date and time when the campaign was closed. If set, applying a spec for this campaign will fail with an error.
+    """
+    closedAt: DateTime
+
+    """
+    Stats on all the changesets that are tracked in this campaign.
+    """
+    changesetsStats: ChangesetsStats!
+
+    """
+    The changesets in this campaign that already exist on the code host.
+    """
+    changesets(
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only include changesets with any of the given reconciler states.
+        """
+        reconcilerState: [ChangesetReconcilerState!]
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given publication state.
+        """
+        publicationState: ChangesetPublicationState
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given external state.
+        """
+        externalState: ChangesetExternalState
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given state.
+        """
+        state: ChangesetState
+        """
+        Only include changesets with the given review state.
+        """
+        reviewState: ChangesetReviewState
+        """
+        Only include changesets with the given check state.
+        """
+        checkState: ChangesetCheckState
+        """
+        Only return changesets that have been published by this campaign. Imported changesets will be omitted.
+        """
+        onlyPublishedByThisCampaign: Boolean
+        """
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
+        """
+        search: String
+    ): ChangesetConnection!
+
+    """
+    The changeset counts over time, in 1-day intervals backwards from the point in time given in
+    the "to" parameter.
+    """
+    changesetCountsOverTime(
+        """
+        Only include changeset counts up to this point in time (inclusive). Defaults to Campaign.createdAt.
+        """
+        from: DateTime
+        """
+        Only include changeset counts up to this point in time (inclusive). Defaults to the
+        current time.
+        """
+        to: DateTime
+    ): [ChangesetCounts!]!
+
+    """
+    The diff stat for all the changesets in the campaign.
+    """
+    diffStat: DiffStat!
+
+    """
+    The current campaign spec this campaign reflects.
+    """
+    currentSpec: CampaignSpec!
+}
+
+"""
+The counts of changesets in certain states at a specific point in time.
+"""
+type ChangesetCounts {
+    """
+    The point in time these counts were recorded.
+    """
+    date: DateTime!
+    """
+    The total number of changesets.
+    """
+    total: Int!
+    """
+    The number of merged changesets.
+    """
+    merged: Int!
+    """
+    The number of closed changesets.
+    """
+    closed: Int!
+    """
+    The number of draft changesets (independent of review state).
+    """
+    draft: Int!
+    """
+    The number of open changesets (independent of review state).
+    """
+    open: Int!
+    """
+    The number of changesets that are both open and approved.
+    """
+    openApproved: Int!
+    """
+    The number of changesets that are both open and have requested changes.
+    """
+    openChangesRequested: Int!
+    """
+    The number of changesets that are both open and are pending review.
+    """
+    openPending: Int!
+}
+
+"""
+A list of campaigns.
+"""
+type CampaignConnection {
+    """
+    A list of campaigns.
+    """
+    nodes: [Campaign!]!
+
+    """
+    The total number of campaigns in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+The publication state of a changeset on Sourcegraph
+"""
+enum ChangesetPublicationState {
+    """
+    The changeset has not yet been created on the code host.
+    """
+    UNPUBLISHED
+    """
+    The changeset has been created on the code host.
+    """
+    PUBLISHED
+}
+
+"""
+The reconciler state of a changeset on Sourcegraph
+"""
+enum ChangesetReconcilerState {
+    """
+    The changeset is enqueued for the reconciler to process it.
+    """
+    QUEUED
+
+    """
+    The changeset reconciler is currently computing the delta between the
+    If a delta exists, the reconciler tries to update the state of the
+    changeset on the code host and on Sourcegraph to the desired state.
+    """
+    PROCESSING
+
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset and will retry it for a number of retries.
+    """
+    ERRORED
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset that can't be fixed by retrying.
+    """
+    FAILED
+
+    """
+    The changeset is not enqueued for processing.
+    """
+    COMPLETED
+}
+
+"""
+The state of a changeset on the code host on which it's hosted.
+"""
+enum ChangesetExternalState {
+    DRAFT
+    OPEN
+    CLOSED
+    MERGED
+    DELETED
+}
+
+"""
+The review state of a changeset.
+"""
+enum ChangesetReviewState {
+    APPROVED
+    CHANGES_REQUESTED
+    PENDING
+    COMMENTED
+    DISMISSED
+}
+
+"""
+The state of checks (e.g., for continuous integration) on a changeset.
+"""
+enum ChangesetCheckState {
+    PENDING
+    PASSED
+    FAILED
+}
+
+"""
+A label attached to a changeset on a code host.
+"""
+type ChangesetLabel {
+    """
+    The label's text.
+    """
+    text: String!
+    """
+    The label's color, as a hex color code without the . For example: "93ba13".
+    """
+    color: String!
+    """
+    An optional description of the label.
+    """
+    description: String
+}
+
+"""
+The visual state a changeset is currently in.
+"""
+enum ChangesetState {
+    """
+    The changeset has not been marked as to be published.
+    """
+    UNPUBLISHED
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset that can't be fixed by retrying.
+    """
+    FAILED
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset and will retry it for a number of retries.
+    """
+    RETRYING
+    """
+    The changeset reconciler is currently computing the delta between the
+    If a delta exists, the reconciler tries to update the state of the
+    changeset on the code host and on Sourcegraph to the desired state.
+    """
+    PROCESSING
+    """
+    The changeset is published, not being reconciled and open on the code host.
+    """
+    OPEN
+    """
+    The changeset is published, not being reconciled and in draft state on the code host.
+    """
+    DRAFT
+    """
+    The changeset is published, not being reconciled and closed on the code host.
+    """
+    CLOSED
+    """
+    The changeset is published, not being reconciled and merged on the code host.
+    """
+    MERGED
+    """
+    The changeset is published, not being reconciled and has been deleted on the code host.
+    """
+    DELETED
+}
+
+"""
+A changeset on a codehost.
+"""
+interface Changeset {
+    """
+    The unique ID for the changeset.
+    """
+    id: ID!
+
+    """
+    The campaigns that contain this changeset.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    The publication state of the changeset.
+    """
+    publicationState: ChangesetPublicationState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The reconciler state of the changeset.
+    """
+    reconcilerState: ChangesetReconcilerState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The external state of the changeset, or null when not yet published to the code host.
+    """
+    externalState: ChangesetExternalState
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The state of the changeset.
+    """
+    state: ChangesetState!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the changeset was updated.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
+    """
+    nextSyncAt: DateTime
+}
+
+"""
+A changeset on a code host that the user does not have access to.
+"""
+type HiddenExternalChangeset implements Node & Changeset {
+    """
+    The unique ID for the changeset.
+    """
+    id: ID!
+
+    """
+    The campaigns that contain this changeset.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    The publication state of the changeset.
+    """
+    publicationState: ChangesetPublicationState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The reconciler state of the changeset.
+    """
+    reconcilerState: ChangesetReconcilerState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The external state of the changeset, or null when not yet published to the code host.
+    """
+    externalState: ChangesetExternalState
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The state of the changeset.
+    """
+    state: ChangesetState!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the changeset was updated.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
+    """
+    nextSyncAt: DateTime
+}
+
+"""
+A changeset on a code host (e.g., a pull request on GitHub).
+"""
+type ExternalChangeset implements Node & Changeset {
+    """
+    The unique ID for the changeset.
+    """
+    id: ID!
+
+    """
+    The external ID that uniquely identifies this ExternalChangeset on the
+    code host. For example, on GitHub this is the pull request number. This is only set once the changeset is published on the code host.
+    """
+    externalID: String
+
+    """
+    The repository changed by this changeset.
+    """
+    repository: Repository!
+
+    """
+    The campaigns that contain this changeset.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    The events belonging to this changeset.
+    """
+    events(first: Int = 50, after: String): ChangesetEventConnection!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the changeset was updated.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the next changeset sync is scheduled, or null if none is scheduled or when the initial sync hasn't happened.
+    """
+    nextSyncAt: DateTime
+
+    """
+    The title of the changeset, or null if the data hasn't been synced from the code host yet.
+    """
+    title: String
+
+    """
+    The body of the changeset, or null if the data hasn't been synced from the code host yet.
+    """
+    body: String
+
+    """
+    The author of the changeset, or null if the data hasn't been synced from the code host yet,
+    or the changeset has not yet been published.
+    """
+    author: Person
+
+    """
+    The publication state of the changeset.
+    """
+    publicationState: ChangesetPublicationState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The reconciler state of the changeset.
+    """
+    reconcilerState: ChangesetReconcilerState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The external state of the changeset, or null when not yet published to the code host.
+    """
+    externalState: ChangesetExternalState
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The state of the changeset.
+    """
+    state: ChangesetState!
+
+    """
+    The labels attached to the changeset on the code host.
+    """
+    labels: [ChangesetLabel!]!
+
+    """
+    The external URL of the changeset on the code host. Not set when changeset state is UNPUBLISHED, externalState is DELETED, or the changeset's data hasn't been synced yet.
+    """
+    externalURL: ExternalLink
+
+    """
+    The review state of this changeset. This is only set once the changeset is published on the code host.
+    """
+    reviewState: ChangesetReviewState
+
+    """
+    The diff of this changeset, or null if the changeset is closed (without merging) or is already merged.
+    """
+    diff: RepositoryComparisonInterface
+
+    """
+    The diffstat of this changeset, or null if the changeset is closed
+    (without merging) or is already merged. This data is also available
+    indirectly through the diff field above, but if only the diffStat is
+    required, this field is cheaper to access.
+    """
+    diffStat: DiffStat
+
+    """
+    The state of the checks (e.g., for continuous integration) on this changeset, or null if no
+    checks have been configured.
+    """
+    checkState: ChangesetCheckState
+
+    """
+    An error that has occurred when publishing or updating the changeset. This is only set when the changeset state is ERRORED and the viewer can administer this changeset.
+    """
+    error: String
+
+    """
+    An error that has occured during the last sync of the changeset. Null, if was successful.
+    """
+    syncerError: String
+
+    """
+    The current changeset spec for this changeset.
+
+    Null if the changeset was only imported.
+    """
+    currentSpec: VisibleChangesetSpec
+}
+
+"""
+Used in the campaign page for the overview component.
+"""
+type ChangesetsStats {
+    """
+    The count of unpublished changesets.
+    """
+    unpublished: Int!
+    """
+    The count of externalState: DRAFT changesets.
+    """
+    draft: Int!
+    """
+    The count of externalState: OPEN changesets.
+    """
+    open: Int!
+    """
+    The count of externalState: MERGED changesets.
+    """
+    merged: Int!
+    """
+    The count of externalState: CLOSED changesets.
+    """
+    closed: Int!
+    """
+    The count of externalState: DELETED changesets.
+    """
+    deleted: Int!
+    """
+    The count of changesets in retrying state.
+    """
+    retrying: Int!
+    """
+    The count of changesets in failed state.
+    """
+    failed: Int!
+    """
+    The count of changesets that are currently processing or enqueued to be.
+    """
+    processing: Int!
+    """
+    The count of all changesets.
+    """
+    total: Int!
+}
+
+"""
+A list of changesets.
+"""
+type ChangesetConnection {
+    """
+    A list of changesets.
+    """
+    nodes: [Changeset!]!
+
+    """
+    The total number of changesets in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A changeset event in a code host (e.g., a comment on a pull request on GitHub).
+"""
+type ChangesetEvent implements Node {
+    """
+    The unique ID for the changeset event.
+    """
+    id: ID!
+
+    """
+    The changeset this event belongs to.
+    """
+    changeset: ExternalChangeset!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+}
+
+"""
+A list of changeset events.
+"""
+type ChangesetEventConnection {
+    """
+    A list of changeset events.
+    """
+    nodes: [ChangesetEvent!]!
+
+    """
+    The total number of changeset events in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A connection of all code hosts usable with campaigns and accessible by the user
+this is requested on.
+"""
+type CampaignsCodeHostConnection {
+    """
+    A list of code hosts.
+    """
+    nodes: [CampaignsCodeHost!]!
+
+    """
+    The total number of configured external services in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A code host usable with campaigns. This service is accessible by the user it belongs to.
+"""
+type CampaignsCodeHost {
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The configured credential, if any.
+    """
+    credential: CampaignsCredential
+}
+
+"""
+A user token configured for campaigns use on the specified code host.
+"""
+type CampaignsCredential implements Node {
+    """
+    A globally unique identifier.
+    """
+    id: ID!
+
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The date and time this token has been created at.
+    """
+    createdAt: DateTime!
+}
+
+"""
+This enum declares all operations supported by the reconciler.
+"""
+enum ChangesetSpecOperation {
+    """
+    Push a new commit to the code host.
+    """
+    PUSH
+    """
+    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
+    not the git commit. For updates to the commit, see 'PUSH'.
+    """
+    UPDATE
+    """
+    Move the existing changeset out of being a draft.
+    """
+    UNDRAFT
+    """
+    Publish a changeset to the codehost.
+    """
+    PUBLISH
+    """
+    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
+    """
+    PUBLISH_DRAFT
+    """
+    Sync the changeset with the current state on the codehost.
+    """
+    SYNC
+    """
+    Import an existing changeset from the code host with the ExternalID from the spec.
+    """
+    IMPORT
+    """
+    Close the changeset on the codehost.
+    """
+    CLOSE
+    """
+    Reopen the changeset on the codehost.
+    """
+    REOPEN
+    """
+    Internal operation to get around slow code host updates.
+    """
+    SLEEP
+    """
+    The changeset is removed from some of the associated campaigns.
+    """
+    DETACH
+}
+
+"""
+Description of the current changeset state vs the changeset spec desired state.
+"""
+type ChangesetSpecDelta {
+    """
+    When run, the title of the changeset will be updated.
+    """
+    titleChanged: Boolean!
+    """
+    When run, the body of the changeset will be updated.
+    """
+    bodyChanged: Boolean!
+    """
+    When run, the changeset will be taken out of draft mode.
+    """
+    undraft: Boolean!
+    """
+    When run, the target branch of the changeset will be updated.
+    """
+    baseRefChanged: Boolean!
+    """
+    When run, a new commit will be created on the branch of the changeset.
+    """
+    diffChanged: Boolean!
+    """
+    When run, a new commit will be created on the branch of the changeset.
+    """
+    commitMessageChanged: Boolean!
+    """
+    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
+    """
+    authorNameChanged: Boolean!
+    """
+    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
+    """
+    authorEmailChanged: Boolean!
+}
+
+"""
+The type of the changeset spec.
+"""
+enum ChangesetSpecType {
+    """
+    References an existing changeset on a code host to be imported.
+    """
+    EXISTING
+    """
+    References a branch and a patch to be applied to create the changeset from.
+    """
+    BRANCH
+}
+
+"""
+A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+create a changeset spec, use the createChangesetSpec mutation.
+"""
+interface ChangesetSpec {
+    """
+    The unique ID for a changeset spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    even though repository permissions also apply to viewers of changeset specs, because being
+    allowed to view a repository should not entitle a person to view all not-yet-published
+    changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    campaign author may prefer to prepare all of the changesets in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The type of changeset spec.
+    """
+    type: ChangesetSpecType!
+
+    """
+    The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    spec never expires (and this field is null) if its campaign spec has been applied.
+    """
+    expiresAt: DateTime
+}
+
+"""
+A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+create a changeset spec, use the createChangesetSpec mutation.
+"""
+type HiddenChangesetSpec implements ChangesetSpec & Node {
+    """
+    The unique ID for a changeset spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    even though repository permissions also apply to viewers of changeset specs, because being
+    allowed to view a repository should not entitle a person to view all not-yet-published
+    changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    campaign author may prefer to prepare all of the changesets in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The type of changeset spec.
+    """
+    type: ChangesetSpecType!
+
+    """
+    The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    spec never expires (and this field is null) if its campaign spec has been applied.
+    """
+    expiresAt: DateTime
+}
+
+"""
+A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+create a changeset spec, use the createChangesetSpec mutation.
+"""
+type VisibleChangesetSpec implements ChangesetSpec & Node {
+    """
+    The unique ID for a changeset spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    even though repository permissions also apply to viewers of changeset specs, because being
+    allowed to view a repository should not entitle a person to view all not-yet-published
+    changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    campaign author may prefer to prepare all of the changesets in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The type of changeset spec.
+    """
+    type: ChangesetSpecType!
+
+    """
+    The description of the changeset.
+    """
+    description: ChangesetDescription!
+
+    """
+    The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    spec never expires (and this field is null) if its campaign spec has been applied.
+    """
+    expiresAt: DateTime
+}
+
+"""
+All possible types of changesets that can be specified in a changeset spec.
+"""
+union ChangesetDescription = ExistingChangesetReference | GitBranchChangesetDescription
+
+"""
+A reference to a changeset that already exists on a code host (and was not created by the
+campaign).
+"""
+type ExistingChangesetReference {
+    """
+    The repository that contains the existing changeset on the code host.
+    """
+    baseRepository: Repository!
+
+    """
+    The ID that uniquely identifies the existing changeset on the code host.
+
+    For GitHub and Bitbucket Server, this is the pull request number (as a string) in the
+    base repository. For example, "1234" for PR 1234.
+    """
+    externalID: String!
+}
+
+"""
+A triple that represents all possible states of the published value: true, false or 'draft'.
+"""
+scalar PublishedValue
+
+"""
+A description of a changeset that represents the proposal to merge one branch into another.
+This is used to describe a pull request (on GitHub and Bitbucket Server).
+"""
+type GitBranchChangesetDescription {
+    """
+    The repository that this changeset spec is proposing to change.
+    """
+    baseRepository: Repository!
+
+    """
+    The full name of the Git ref in the base repository that this changeset is based on (and is
+    proposing to be merged into). This ref must exist on the base repository. For example,
+    "refs/heads/master" or "refs/heads/main".
+    """
+    baseRef: String!
+
+    """
+    The base revision this changeset is based on. It is the latest commit in
+    baseRef at the time when the changeset spec was created.
+    For example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
+    """
+    baseRev: String!
+
+    """
+    The repository that contains the branch with this changeset's changes.
+
+    Fork repositories and cross-repository changesets are not yet supported. Therefore,
+    headRepository must be equal to baseRepository.
+    """
+    headRepository: Repository!
+
+    """
+    The full name of the Git ref that holds the changes proposed by this changeset. This ref will
+    be created or updated with the commits. For example, "refs/heads/fix-foo" (for
+    the Git branch "fix-foo").
+    """
+    headRef: String!
+
+    """
+    The title of the changeset on the code host.
+
+    On Bitbucket Server or GitHub this is the title of the pull request.
+    """
+    title: String!
+
+    """
+    The body of the changeset on the code host.
+
+    On Bitbucket Server or GitHub this is the body/description of the pull request.
+    """
+    body: String!
+
+    """
+    The Git commits with the proposed changes. These commits are pushed to the head ref.
+
+    Only 1 commit is supported.
+    """
+    commits: [GitCommitDescription!]!
+
+    """
+    The total diff of the changeset diff.
+    """
+    diff: PreviewRepositoryComparison!
+
+    """
+    The diffstat of this changeset spec. This data is also available
+    indirectly through the diff field above, but if only the diffStat is
+    required, this field is cheaper to access.
+    """
+    diffStat: DiffStat!
+
+    """
+    Whether or not the changeset described here should be created right after
+    applying the ChangesetSpec this description belongs to.
+
+    If this is false, the changeset will only be created on Sourcegraph and
+    can be previewed.
+
+    Another ChangesetSpec with the same description, but "published: true",
+    can later be applied publish the changeset.
+    """
+    published: PublishedValue!
+}
+
+"""
+A description of a Git commit.
+"""
+type GitCommitDescription {
+    """
+    The full commit message.
+    """
+    message: String!
+
+    """
+    The first line of the commit message.
+    """
+    subject: String!
+
+    """
+    The contents of the commit message after the first line.
+    """
+    body: String
+
+    """
+    The Git commit author.
+    """
+    author: Person!
+
+    """
+    The commit diff (in unified diff format).
+
+    The filenames must not be prefixed (e.g., with 'a/' and 'b/'). Tip: use 'git diff --no-prefix'
+    to omit the prefix.
+    """
+    diff: String!
+}
+
+"""
+A list of changeset specs.
+"""
+type ChangesetSpecConnection {
+    """
+    The total number of changeset specs in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of changeset specs.
+    """
+    nodes: [ChangesetSpec!]!
+}
+
+"""
+A preview for which actions applyCampaign would result in when called at the point of time this preview was created at.
+"""
+union ChangesetApplyPreview = VisibleChangesetApplyPreview | HiddenChangesetApplyPreview
+
+"""
+A preview entry to a repository to which the user has access.
+"""
+union VisibleApplyPreviewTargets =
+      VisibleApplyPreviewTargetsAttach
+    | VisibleApplyPreviewTargetsUpdate
+    | VisibleApplyPreviewTargetsDetach
+
+"""
+A preview entry where no changeset existed before matching the changeset spec.
+"""
+type VisibleApplyPreviewTargetsAttach {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: VisibleChangesetSpec!
+}
+
+"""
+A preview entry where a changeset matches the changeset spec.
+"""
+type VisibleApplyPreviewTargetsUpdate {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: VisibleChangesetSpec!
+    """
+    The changeset from this entry.
+    """
+    changeset: ExternalChangeset!
+}
+
+"""
+A preview entry where no changeset spec exists for the changeset currently in
+the target campaign.
+"""
+type VisibleApplyPreviewTargetsDetach {
+    """
+    The changeset from this entry.
+    """
+    changeset: ExternalChangeset!
+}
+
+"""
+A preview entry to a repository to which the user has no access.
+"""
+union HiddenApplyPreviewTargets =
+      HiddenApplyPreviewTargetsAttach
+    | HiddenApplyPreviewTargetsUpdate
+    | HiddenApplyPreviewTargetsDetach
+
+"""
+A preview entry where no changeset existed before matching the changeset spec.
+"""
+type HiddenApplyPreviewTargetsAttach {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: HiddenChangesetSpec!
+}
+
+"""
+A preview entry where a changeset matches the changeset spec.
+"""
+type HiddenApplyPreviewTargetsUpdate {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: HiddenChangesetSpec!
+    """
+    The changeset from this entry.
+    """
+    changeset: HiddenExternalChangeset!
+}
+
+"""
+A preview entry where no changeset spec exists for the changeset currently in
+the target campaign.
+"""
+type HiddenApplyPreviewTargetsDetach {
+    """
+    The changeset from this entry.
+    """
+    changeset: HiddenExternalChangeset!
+}
+
+"""
+One preview entry in the list of all previews against a campaign spec. Each mapping
+between changeset specs and current changesets yields one of these. It describes
+which operations are taken against which changeset spec and changeset to ensure the
+desired state is met.
+"""
+type HiddenChangesetApplyPreview {
+    """
+    The operations to take to achieve the desired state.
+    """
+    operations: [ChangesetSpecOperation!]!
+
+    """
+    The delta between the current changeset state and what the new changeset spec
+    envisions the changeset to look like.
+    """
+    delta: ChangesetSpecDelta!
+
+    """
+    The target entities in this preview entry.
+    """
+    targets: HiddenApplyPreviewTargets!
+}
+
+"""
+One preview entry in the list of all previews against a campaign spec. Each mapping
+between changeset specs and current changesets yields one of these. It describes
+which operations are taken against which changeset spec and changeset to ensure the
+desired state is met.
+"""
+type VisibleChangesetApplyPreview {
+    """
+    The operations to take to achieve the desired state.
+    """
+    operations: [ChangesetSpecOperation!]!
+
+    """
+    The delta between the current changeset state and what the new changeset spec
+    envisions the changeset to look like.
+    """
+    delta: ChangesetSpecDelta!
+
+    """
+    The target entities in this preview entry.
+    """
+    targets: VisibleApplyPreviewTargets!
+}
+
+"""
+Aggregated stats on nodes in this connection.
+"""
+type ChangesetApplyPreviewConnectionStats {
+    """
+    Push a new commit to the code host.
+    """
+    push: Int!
+    """
+    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
+    not the git commit. For updates to the commit, see 'PUSH'.
+    """
+    update: Int!
+    """
+    Move the existing changeset out of being a draft.
+    """
+    undraft: Int!
+    """
+    Publish a changeset to the codehost.
+    """
+    publish: Int!
+    """
+    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
+    """
+    publishDraft: Int!
+    """
+    Sync the changeset with the current state on the codehost.
+    """
+    sync: Int!
+    """
+    Import an existing changeset from the code host with the ExternalID from the spec.
+    """
+    import: Int!
+    """
+    Close the changeset on the codehost.
+    """
+    close: Int!
+    """
+    Reopen the changeset on the codehost.
+    """
+    reopen: Int!
+    """
+    Internal operation to get around slow code host updates.
+    """
+    sleep: Int!
+    """
+    The changeset is removed from some of the associated campaigns.
+    """
+    detach: Int!
+
+    """
+    The amount of changesets that are added to the campaign in this operation.
+    """
+    added: Int!
+    """
+    The amount of changesets that are already attached to the campaign and modified in this operation.
+    """
+    modified: Int!
+    """
+    The amount of changesets that are disassociated from the campaign in this operation.
+    """
+    removed: Int!
+}
+
+"""
+A list of preview entries.
+"""
+type ChangesetApplyPreviewConnection {
+    """
+    The total number of entries in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+
+    """
+    A list of preview entries.
+    """
+    nodes: [ChangesetApplyPreview!]!
+
+    """
+    Stats on the elements in this connnection. Does not respect pagination parameters.
+    """
+    stats: ChangesetApplyPreviewConnectionStats!
+}
+
+"""
+A CampaignDescription describes a campaign.
+"""
+type CampaignDescription {
+    """
+    The name as parsed from the input.
+    """
+    name: String!
+
+    """
+    The description as parsed from the input.
+    """
+    description: String!
+}
+
+"""
+A campaign spec is an immutable description of the desired state of a campaign. To create a
+campaign spec, use the createCampaignSpec mutation.
+"""
+type CampaignSpec implements Node {
+    """
+    The unique ID for a campaign spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential).
+    Consider a campaign to fix a security vulnerability: the campaign author may prefer
+    to prepare the campaign, including the description in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The original YAML or JSON input that was used to create this campaign spec.
+    """
+    originalInput: String!
+
+    """
+    The parsed JSON value of the original input. If the original input was YAML, the YAML is
+    converted to the equivalent JSON.
+    """
+    parsedInput: JSONValue!
+
+    """
+    The CampaignDescription that describes this campaign.
+    """
+    description: CampaignDescription!
+
+    """
+    Generates a preview what operations would be performed if the campaign spec would be applied.
+    This preview is not a guarantee, since the state of the changesets can change between the time
+    the preview is generated and when the campaign spec is applied.
+    """
+    applyPreview(
+        """
+        Returns the first n entries from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
+        """
+        search: String
+        """
+        Search for changesets that are currently in this state.
+        """
+        currentState: ChangesetState
+        """
+        Search for changesets that will have the given action performed.
+        """
+        action: ChangesetSpecOperation
+    ): ChangesetApplyPreviewConnection!
+
+    """
+    The specs for changesets associated with this campaign.
+    """
+    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
+
+    """
+    The user who created this campaign spec (or null if the user no longer exists).
+    """
+    creator: User
+
+    """
+    The date when this campaign spec was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The namespace (either a user or organization) of the campaign spec.
+    """
+    namespace: Namespace!
+
+    """
+    The date, if any, when this campaign spec expires and is automatically purged. A campaign spec
+    never expires if it has been applied.
+    """
+    expiresAt: DateTime
+
+    """
+    The URL of a web page that allows applying this campaign spec and
+    displays a preview of which changesets will be created by applying it.
+    """
+    applyURL: String!
+
+    """
+    When true, the viewing user can apply this spec.
+    """
+    viewerCanAdminister: Boolean!
+
+    """
+    The diff stat for all the changeset specs in the campaign spec.
+    """
+    diffStat: DiffStat!
+
+    """
+    The campaign this spec will update when applied. If it's null, the
+    campaign doesn't yet exist.
+    """
+    appliesToCampaign: Campaign
+
+    """
+    The newest version of this campaign spec, as identified by its namespace
+    and name. If this is the newest version, this field will be null.
+    """
+    supersedingCampaignSpec: CampaignSpec
+
+    """
+    The code host connections required for applying this spec. Includes the credentials of the current user.
+    """
+    viewerCampaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only returns the code hosts for which the viewer doesn't have credentials.
+        """
+        onlyWithoutCredential: Boolean = false
+    ): CampaignsCodeHostConnection!
+}
+
+extend type Mutation {
+    """
+    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
+    campaign is returned.
+    If a campaign in the same namespace with the same name already exists, an error with the error code
+    ErrMatchingCampaignExists is returned.
+    """
+    createCampaign(
+        """
+        The campaign spec that describes the desired state of the campaign.
+        """
+        campaignSpec: ID!
+    ): Campaign!
+
+    """
+    Create or update a campaign from a campaign spec and locally computed changeset specs. If no
+    campaign exists in the namespace with the name given in the campaign spec, a campaign will be
+    created. Otherwise, the existing campaign will be updated. The campaign is returned.
+    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
+    will be returned.
+    """
+    applyCampaign(
+        """
+        The campaign spec that describes the new desired state of the campaign.
+        """
+        campaignSpec: ID!
+
+        """
+        If set, return an error if the campaign identified using the namespace and campaignSpec
+        parameters does not match the campaign with this ID. This lets callers use a stable ID
+        that refers to a specific campaign during an edit session (and is not susceptible to
+        conflicts if the underlying campaign is moved to a different namespace, renamed, or
+        deleted). The returned error has the error code ErrEnsureCampaignFailed.
+        """
+        ensureCampaign: ID
+    ): Campaign!
+
+    """
+    Move a campaign to a different namespace, or rename it in the current namespace.
+    """
+    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
+
+    """
+    Close a campaign.
+    """
+    closeCampaign(
+        campaign: ID!
+        """
+        Whether to close the changesets associated with this campaign on their respective code
+        hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
+        GitHub and "declined" on Bitbucket Server).
+        """
+        closeChangesets: Boolean = false
+    ): Campaign!
+
+    """
+    Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
+    campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
+    """
+    deleteCampaign(campaign: ID!): EmptyResponse
+
+    """
+    Upload a changeset spec that will be used in a future update to a campaign. The changeset spec
+    is stored and can be referenced by its ID in the applyCampaign mutation. Just uploading the
+    changeset spec does not result in changes to the campaign or any of its changesets; you need
+    to call applyCampaign to use it.
+
+    You can use this mutation to upload large changeset specs (e.g., containing large diffs) in
+    individual HTTP requests. Then, in the eventual applyCampaign call, you just refer to the
+    changeset specs by their IDs. This lets you avoid problems when updating large campaigns where
+    a large HTTP request body (e.g., with many large diffs in the changeset specs) would be
+    rejected by the web server/proxy or would be very slow.
+
+    The returned ChangesetSpec is immutable and expires after a certain period of time (if not
+    used in a call to applyCampaign), which can be queried on ChangesetSpec.expiresAt.
+    """
+    createChangesetSpec(
+        """
+        The raw changeset spec (as JSON). See
+        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/changeset_spec.schema.json
+        for the JSON Schema that describes the structure of this input.
+        """
+        changesetSpec: String!
+    ): ChangesetSpec!
+
+    """
+    Create a campaign spec that will be used to create a campaign (with the createCampaign
+    mutation), or to update a campaign (with the applyCampaign mutation).
+
+    The returned CampaignSpec is immutable and expires after a certain period of time (if not used
+    in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
+
+    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
+    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
+    """
+    createCampaignSpec(
+        """
+        The namespace (either a user or organization). A campaign spec can only be applied to (or
+        used to create) campaigns in this namespace.
+        """
+        namespace: ID!
+
+        """
+        The campaign spec as YAML (or the equivalent JSON). See
+        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/campaign_spec.schema.json
+        for the JSON Schema that describes the structure of this input.
+        """
+        campaignSpec: String!
+
+        """
+        Changeset specs that were locally computed and then uploaded using createChangesetSpec.
+        """
+        changesetSpecs: [ID!]!
+    ): CampaignSpec!
+
+    """
+    Enqueue the given changeset for high-priority syncing.
+    """
+    syncChangeset(changeset: ID!): EmptyResponse!
+
+    """
+    Re-enqueue the changeset for processing by the reconciler. The changeset must be in FAILED state.
+    """
+    reenqueueChangeset(changeset: ID!): Changeset!
+
+    """
+    Create a new credential for the given user for the given code host.
+    If another token for that code host already exists, an error with the error code
+    ErrDuplicateCredential is returned.
+    """
+    createCampaignsCredential(
+        """
+        The user for which to create the credential.
+        """
+        user: ID!
+
+        """
+        The kind of external service being configured.
+        """
+        externalServiceKind: ExternalServiceKind!
+
+        """
+        The URL of the external service being configured.
+        """
+        externalServiceURL: String!
+
+        """
+        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
+        """
+        credential: String!
+    ): CampaignsCredential!
+
+    """
+    Hard-deletes a given campaigns credential.
+    """
+    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
+}
+
+extend type Org {
+    """
+    A list of campaigns initially applied in this organization.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+}
+
+extend type User {
+    """
+    A list of campaigns applied under this user's namespace.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    Returns a connection of configured external services accessible by this user, for usage with campaigns.
+    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
+    connected to CampaignCredential resources, if one has been created for the code host connection before.
+    """
+    campaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): CampaignsCodeHostConnection!
+}
+
+extend type Query {
+    """
+    A list of campaigns.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+    """
+    Looks up a campaign by namespace and campaign name.
+    """
+    campaign(
+        """
+        The namespace where the campaign lives.
+        """
+        namespace: ID!
+        """
+        The campaigns name.
+        """
+        name: String!
+    ): Campaign
+}
+
+############################################################################################
+#                                                                                          #
+#                                 End campaigns schema                                     #
+#                                                                                          #
+############################################################################################
 `

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -609,162 +609,6 @@ type Mutation {
     scheduleUserPermissionsSync(user: ID!): EmptyResponse!
 
     """
-    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
-    campaign is returned.
-    If a campaign in the same namespace with the same name already exists, an error with the error code
-    ErrMatchingCampaignExists is returned.
-    """
-    createCampaign(
-        """
-        The campaign spec that describes the desired state of the campaign.
-        """
-        campaignSpec: ID!
-    ): Campaign!
-
-    """
-    Create or update a campaign from a campaign spec and locally computed changeset specs. If no
-    campaign exists in the namespace with the name given in the campaign spec, a campaign will be
-    created. Otherwise, the existing campaign will be updated. The campaign is returned.
-    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
-    will be returned.
-    """
-    applyCampaign(
-        """
-        The campaign spec that describes the new desired state of the campaign.
-        """
-        campaignSpec: ID!
-
-        """
-        If set, return an error if the campaign identified using the namespace and campaignSpec
-        parameters does not match the campaign with this ID. This lets callers use a stable ID
-        that refers to a specific campaign during an edit session (and is not susceptible to
-        conflicts if the underlying campaign is moved to a different namespace, renamed, or
-        deleted). The returned error has the error code ErrEnsureCampaignFailed.
-        """
-        ensureCampaign: ID
-    ): Campaign!
-
-    """
-    Move a campaign to a different namespace, or rename it in the current namespace.
-    """
-    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
-
-    """
-    Close a campaign.
-    """
-    closeCampaign(
-        campaign: ID!
-        """
-        Whether to close the changesets associated with this campaign on their respective code
-        hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
-        GitHub and "declined" on Bitbucket Server).
-        """
-        closeChangesets: Boolean = false
-    ): Campaign!
-
-    """
-    Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
-    campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
-    """
-    deleteCampaign(campaign: ID!): EmptyResponse
-
-    """
-    Upload a changeset spec that will be used in a future update to a campaign. The changeset spec
-    is stored and can be referenced by its ID in the applyCampaign mutation. Just uploading the
-    changeset spec does not result in changes to the campaign or any of its changesets; you need
-    to call applyCampaign to use it.
-
-    You can use this mutation to upload large changeset specs (e.g., containing large diffs) in
-    individual HTTP requests. Then, in the eventual applyCampaign call, you just refer to the
-    changeset specs by their IDs. This lets you avoid problems when updating large campaigns where
-    a large HTTP request body (e.g., with many large diffs in the changeset specs) would be
-    rejected by the web server/proxy or would be very slow.
-
-    The returned ChangesetSpec is immutable and expires after a certain period of time (if not
-    used in a call to applyCampaign), which can be queried on ChangesetSpec.expiresAt.
-    """
-    createChangesetSpec(
-        """
-        The raw changeset spec (as JSON). See
-        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/changeset_spec.schema.json
-        for the JSON Schema that describes the structure of this input.
-        """
-        changesetSpec: String!
-    ): ChangesetSpec!
-
-    """
-    Create a campaign spec that will be used to create a campaign (with the createCampaign
-    mutation), or to update a campaign (with the applyCampaign mutation).
-
-    The returned CampaignSpec is immutable and expires after a certain period of time (if not used
-    in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
-
-    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
-    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
-    """
-    createCampaignSpec(
-        """
-        The namespace (either a user or organization). A campaign spec can only be applied to (or
-        used to create) campaigns in this namespace.
-        """
-        namespace: ID!
-
-        """
-        The campaign spec as YAML (or the equivalent JSON). See
-        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/campaign_spec.schema.json
-        for the JSON Schema that describes the structure of this input.
-        """
-        campaignSpec: String!
-
-        """
-        Changeset specs that were locally computed and then uploaded using createChangesetSpec.
-        """
-        changesetSpecs: [ID!]!
-    ): CampaignSpec!
-
-    """
-    Enqueue the given changeset for high-priority syncing.
-    """
-    syncChangeset(changeset: ID!): EmptyResponse!
-
-    """
-    Re-enqueue the changeset for processing by the reconciler. The changeset must be in FAILED state.
-    """
-    reenqueueChangeset(changeset: ID!): Changeset!
-
-    """
-    Create a new credential for the given user for the given code host.
-    If another token for that code host already exists, an error with the error code
-    ErrDuplicateCredential is returned.
-    """
-    createCampaignsCredential(
-        """
-        The user for which to create the credential.
-        """
-        user: ID!
-
-        """
-        The kind of external service being configured.
-        """
-        externalServiceKind: ExternalServiceKind!
-
-        """
-        The URL of the external service being configured.
-        """
-        externalServiceURL: String!
-
-        """
-        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
-        """
-        credential: String!
-    ): CampaignsCredential!
-
-    """
-    Hard-deletes a given campaigns credential.
-    """
-    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
-
-    """
     OBSERVABILITY
 
     Set the status of a test alert of the specified parameters - useful for validating
@@ -874,807 +718,6 @@ type Mutation {
 }
 
 """
-A connection of all code hosts usable with campaigns and accessible by the user
-this is requested on.
-"""
-type CampaignsCodeHostConnection {
-    """
-    A list of code hosts.
-    """
-    nodes: [CampaignsCodeHost!]!
-
-    """
-    The total number of configured external services in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-A code host usable with campaigns. This service is accessible by the user it belongs to.
-"""
-type CampaignsCodeHost {
-    """
-    The kind of external service.
-    """
-    externalServiceKind: ExternalServiceKind!
-
-    """
-    The URL of the external service.
-    """
-    externalServiceURL: String!
-
-    """
-    The configured credential, if any.
-    """
-    credential: CampaignsCredential
-}
-
-"""
-A user token configured for campaigns use on the specified code host.
-"""
-type CampaignsCredential implements Node {
-    """
-    A globally unique identifier.
-    """
-    id: ID!
-
-    """
-    The kind of external service.
-    """
-    externalServiceKind: ExternalServiceKind!
-
-    """
-    The URL of the external service.
-    """
-    externalServiceURL: String!
-
-    """
-    The date and time this token has been created at.
-    """
-    createdAt: DateTime!
-}
-
-"""
-This enum declares all operations supported by the reconciler.
-"""
-enum ChangesetSpecOperation {
-    """
-    Push a new commit to the code host.
-    """
-    PUSH
-    """
-    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
-    not the git commit. For updates to the commit, see 'PUSH'.
-    """
-    UPDATE
-    """
-    Move the existing changeset out of being a draft.
-    """
-    UNDRAFT
-    """
-    Publish a changeset to the codehost.
-    """
-    PUBLISH
-    """
-    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
-    """
-    PUBLISH_DRAFT
-    """
-    Sync the changeset with the current state on the codehost.
-    """
-    SYNC
-    """
-    Import an existing changeset from the code host with the ExternalID from the spec.
-    """
-    IMPORT
-    """
-    Close the changeset on the codehost.
-    """
-    CLOSE
-    """
-    Reopen the changeset on the codehost.
-    """
-    REOPEN
-    """
-    Internal operation to get around slow code host updates.
-    """
-    SLEEP
-    """
-    The changeset is removed from some of the associated campaigns.
-    """
-    DETACH
-}
-
-"""
-Description of the current changeset state vs the changeset spec desired state.
-"""
-type ChangesetSpecDelta {
-    """
-    When run, the title of the changeset will be updated.
-    """
-    titleChanged: Boolean!
-    """
-    When run, the body of the changeset will be updated.
-    """
-    bodyChanged: Boolean!
-    """
-    When run, the changeset will be taken out of draft mode.
-    """
-    undraft: Boolean!
-    """
-    When run, the target branch of the changeset will be updated.
-    """
-    baseRefChanged: Boolean!
-    """
-    When run, a new commit will be created on the branch of the changeset.
-    """
-    diffChanged: Boolean!
-    """
-    When run, a new commit will be created on the branch of the changeset.
-    """
-    commitMessageChanged: Boolean!
-    """
-    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
-    """
-    authorNameChanged: Boolean!
-    """
-    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
-    """
-    authorEmailChanged: Boolean!
-}
-
-"""
-The type of the changeset spec.
-"""
-enum ChangesetSpecType {
-    """
-    References an existing changeset on a code host to be imported.
-    """
-    EXISTING
-    """
-    References a branch and a patch to be applied to create the changeset from.
-    """
-    BRANCH
-}
-
-"""
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
-create a changeset spec, use the createChangesetSpec mutation.
-"""
-interface ChangesetSpec {
-    """
-    The unique ID for a changeset spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
-    even though repository permissions also apply to viewers of changeset specs, because being
-    allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The type of changeset spec.
-    """
-    type: ChangesetSpecType!
-
-    """
-    The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
-    """
-    expiresAt: DateTime
-}
-
-"""
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
-create a changeset spec, use the createChangesetSpec mutation.
-"""
-type HiddenChangesetSpec implements ChangesetSpec & Node {
-    """
-    The unique ID for a changeset spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
-    even though repository permissions also apply to viewers of changeset specs, because being
-    allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The type of changeset spec.
-    """
-    type: ChangesetSpecType!
-
-    """
-    The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
-    """
-    expiresAt: DateTime
-}
-
-"""
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
-create a changeset spec, use the createChangesetSpec mutation.
-"""
-type VisibleChangesetSpec implements ChangesetSpec & Node {
-    """
-    The unique ID for a changeset spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
-    even though repository permissions also apply to viewers of changeset specs, because being
-    allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The type of changeset spec.
-    """
-    type: ChangesetSpecType!
-
-    """
-    The description of the changeset.
-    """
-    description: ChangesetDescription!
-
-    """
-    The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
-    """
-    expiresAt: DateTime
-}
-
-"""
-All possible types of changesets that can be specified in a changeset spec.
-"""
-union ChangesetDescription = ExistingChangesetReference | GitBranchChangesetDescription
-
-"""
-A reference to a changeset that already exists on a code host (and was not created by the
-campaign).
-"""
-type ExistingChangesetReference {
-    """
-    The repository that contains the existing changeset on the code host.
-    """
-    baseRepository: Repository!
-
-    """
-    The ID that uniquely identifies the existing changeset on the code host.
-
-    For GitHub and Bitbucket Server, this is the pull request number (as a string) in the
-    base repository. For example, "1234" for PR 1234.
-    """
-    externalID: String!
-}
-
-"""
-A triple that represents all possible states of the published value: true, false or 'draft'.
-"""
-scalar PublishedValue
-
-"""
-A description of a changeset that represents the proposal to merge one branch into another.
-This is used to describe a pull request (on GitHub and Bitbucket Server).
-"""
-type GitBranchChangesetDescription {
-    """
-    The repository that this changeset spec is proposing to change.
-    """
-    baseRepository: Repository!
-
-    """
-    The full name of the Git ref in the base repository that this changeset is based on (and is
-    proposing to be merged into). This ref must exist on the base repository. For example,
-    "refs/heads/master" or "refs/heads/main".
-    """
-    baseRef: String!
-
-    """
-    The base revision this changeset is based on. It is the latest commit in
-    baseRef at the time when the changeset spec was created.
-    For example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
-    """
-    baseRev: String!
-
-    """
-    The repository that contains the branch with this changeset's changes.
-
-    Fork repositories and cross-repository changesets are not yet supported. Therefore,
-    headRepository must be equal to baseRepository.
-    """
-    headRepository: Repository!
-
-    """
-    The full name of the Git ref that holds the changes proposed by this changeset. This ref will
-    be created or updated with the commits. For example, "refs/heads/fix-foo" (for
-    the Git branch "fix-foo").
-    """
-    headRef: String!
-
-    """
-    The title of the changeset on the code host.
-
-    On Bitbucket Server or GitHub this is the title of the pull request.
-    """
-    title: String!
-
-    """
-    The body of the changeset on the code host.
-
-    On Bitbucket Server or GitHub this is the body/description of the pull request.
-    """
-    body: String!
-
-    """
-    The Git commits with the proposed changes. These commits are pushed to the head ref.
-
-    Only 1 commit is supported.
-    """
-    commits: [GitCommitDescription!]!
-
-    """
-    The total diff of the changeset diff.
-    """
-    diff: PreviewRepositoryComparison!
-
-    """
-    The diffstat of this changeset spec. This data is also available
-    indirectly through the diff field above, but if only the diffStat is
-    required, this field is cheaper to access.
-    """
-    diffStat: DiffStat!
-
-    """
-    Whether or not the changeset described here should be created right after
-    applying the ChangesetSpec this description belongs to.
-
-    If this is false, the changeset will only be created on Sourcegraph and
-    can be previewed.
-
-    Another ChangesetSpec with the same description, but "published: true",
-    can later be applied publish the changeset.
-    """
-    published: PublishedValue!
-}
-
-"""
-A description of a Git commit.
-"""
-type GitCommitDescription {
-    """
-    The full commit message.
-    """
-    message: String!
-
-    """
-    The first line of the commit message.
-    """
-    subject: String!
-
-    """
-    The contents of the commit message after the first line.
-    """
-    body: String
-
-    """
-    The Git commit author.
-    """
-    author: Person!
-
-    """
-    The commit diff (in unified diff format).
-
-    The filenames must not be prefixed (e.g., with 'a/' and 'b/'). Tip: use 'git diff --no-prefix'
-    to omit the prefix.
-    """
-    diff: String!
-}
-
-"""
-A list of changeset specs.
-"""
-type ChangesetSpecConnection {
-    """
-    The total number of changeset specs in the connection.
-    """
-    totalCount: Int!
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-    """
-    A list of changeset specs.
-    """
-    nodes: [ChangesetSpec!]!
-}
-
-"""
-A preview for which actions applyCampaign would result in when called at the point of time this preview was created at.
-"""
-union ChangesetApplyPreview = VisibleChangesetApplyPreview | HiddenChangesetApplyPreview
-
-"""
-A preview entry to a repository to which the user has access.
-"""
-union VisibleApplyPreviewTargets =
-      VisibleApplyPreviewTargetsAttach
-    | VisibleApplyPreviewTargetsUpdate
-    | VisibleApplyPreviewTargetsDetach
-
-"""
-A preview entry where no changeset existed before matching the changeset spec.
-"""
-type VisibleApplyPreviewTargetsAttach {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: VisibleChangesetSpec!
-}
-
-"""
-A preview entry where a changeset matches the changeset spec.
-"""
-type VisibleApplyPreviewTargetsUpdate {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: VisibleChangesetSpec!
-    """
-    The changeset from this entry.
-    """
-    changeset: ExternalChangeset!
-}
-
-"""
-A preview entry where no changeset spec exists for the changeset currently in
-the target campaign.
-"""
-type VisibleApplyPreviewTargetsDetach {
-    """
-    The changeset from this entry.
-    """
-    changeset: ExternalChangeset!
-}
-
-"""
-A preview entry to a repository to which the user has no access.
-"""
-union HiddenApplyPreviewTargets =
-      HiddenApplyPreviewTargetsAttach
-    | HiddenApplyPreviewTargetsUpdate
-    | HiddenApplyPreviewTargetsDetach
-
-"""
-A preview entry where no changeset existed before matching the changeset spec.
-"""
-type HiddenApplyPreviewTargetsAttach {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: HiddenChangesetSpec!
-}
-
-"""
-A preview entry where a changeset matches the changeset spec.
-"""
-type HiddenApplyPreviewTargetsUpdate {
-    """
-    The changeset spec from this entry.
-    """
-    changesetSpec: HiddenChangesetSpec!
-    """
-    The changeset from this entry.
-    """
-    changeset: HiddenExternalChangeset!
-}
-
-"""
-A preview entry where no changeset spec exists for the changeset currently in
-the target campaign.
-"""
-type HiddenApplyPreviewTargetsDetach {
-    """
-    The changeset from this entry.
-    """
-    changeset: HiddenExternalChangeset!
-}
-
-"""
-One preview entry in the list of all previews against a campaign spec. Each mapping
-between changeset specs and current changesets yields one of these. It describes
-which operations are taken against which changeset spec and changeset to ensure the
-desired state is met.
-"""
-type HiddenChangesetApplyPreview {
-    """
-    The operations to take to achieve the desired state.
-    """
-    operations: [ChangesetSpecOperation!]!
-
-    """
-    The delta between the current changeset state and what the new changeset spec
-    envisions the changeset to look like.
-    """
-    delta: ChangesetSpecDelta!
-
-    """
-    The target entities in this preview entry.
-    """
-    targets: HiddenApplyPreviewTargets!
-}
-
-"""
-One preview entry in the list of all previews against a campaign spec. Each mapping
-between changeset specs and current changesets yields one of these. It describes
-which operations are taken against which changeset spec and changeset to ensure the
-desired state is met.
-"""
-type VisibleChangesetApplyPreview {
-    """
-    The operations to take to achieve the desired state.
-    """
-    operations: [ChangesetSpecOperation!]!
-
-    """
-    The delta between the current changeset state and what the new changeset spec
-    envisions the changeset to look like.
-    """
-    delta: ChangesetSpecDelta!
-
-    """
-    The target entities in this preview entry.
-    """
-    targets: VisibleApplyPreviewTargets!
-}
-
-"""
-Aggregated stats on nodes in this connection.
-"""
-type ChangesetApplyPreviewConnectionStats {
-    """
-    Push a new commit to the code host.
-    """
-    push: Int!
-    """
-    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
-    not the git commit. For updates to the commit, see 'PUSH'.
-    """
-    update: Int!
-    """
-    Move the existing changeset out of being a draft.
-    """
-    undraft: Int!
-    """
-    Publish a changeset to the codehost.
-    """
-    publish: Int!
-    """
-    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
-    """
-    publishDraft: Int!
-    """
-    Sync the changeset with the current state on the codehost.
-    """
-    sync: Int!
-    """
-    Import an existing changeset from the code host with the ExternalID from the spec.
-    """
-    import: Int!
-    """
-    Close the changeset on the codehost.
-    """
-    close: Int!
-    """
-    Reopen the changeset on the codehost.
-    """
-    reopen: Int!
-    """
-    Internal operation to get around slow code host updates.
-    """
-    sleep: Int!
-    """
-    The changeset is removed from some of the associated campaigns.
-    """
-    detach: Int!
-
-    """
-    The amount of changesets that are added to the campaign in this operation.
-    """
-    added: Int!
-    """
-    The amount of changesets that are already attached to the campaign and modified in this operation.
-    """
-    modified: Int!
-    """
-    The amount of changesets that are disassociated from the campaign in this operation.
-    """
-    removed: Int!
-}
-
-"""
-A list of preview entries.
-"""
-type ChangesetApplyPreviewConnection {
-    """
-    The total number of entries in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-
-    """
-    A list of preview entries.
-    """
-    nodes: [ChangesetApplyPreview!]!
-
-    """
-    Stats on the elements in this connnection. Does not respect pagination parameters.
-    """
-    stats: ChangesetApplyPreviewConnectionStats!
-}
-
-"""
-A CampaignDescription describes a campaign.
-"""
-type CampaignDescription {
-    """
-    The name as parsed from the input.
-    """
-    name: String!
-
-    """
-    The description as parsed from the input.
-    """
-    description: String!
-}
-
-"""
-A campaign spec is an immutable description of the desired state of a campaign. To create a
-campaign spec, use the createCampaignSpec mutation.
-"""
-type CampaignSpec implements Node {
-    """
-    The unique ID for a campaign spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential).
-    Consider a campaign to fix a security vulnerability: the campaign author may prefer
-    to prepare the campaign, including the description in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The original YAML or JSON input that was used to create this campaign spec.
-    """
-    originalInput: String!
-
-    """
-    The parsed JSON value of the original input. If the original input was YAML, the YAML is
-    converted to the equivalent JSON.
-    """
-    parsedInput: JSONValue!
-
-    """
-    The CampaignDescription that describes this campaign.
-    """
-    description: CampaignDescription!
-
-    """
-    Generates a preview what operations would be performed if the campaign spec would be applied.
-    This preview is not a guarantee, since the state of the changesets can change between the time
-    the preview is generated and when the campaign spec is applied.
-    """
-    applyPreview(
-        """
-        Returns the first n entries from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
-        """
-        search: String
-        """
-        Search for changesets that are currently in this state.
-        """
-        currentState: ChangesetState
-        """
-        Search for changesets that will have the given action performed.
-        """
-        action: ChangesetSpecOperation
-    ): ChangesetApplyPreviewConnection!
-
-    """
-    The specs for changesets associated with this campaign.
-    """
-    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
-
-    """
-    The user who created this campaign spec (or null if the user no longer exists).
-    """
-    creator: User
-
-    """
-    The date when this campaign spec was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The namespace (either a user or organization) of the campaign spec.
-    """
-    namespace: Namespace!
-
-    """
-    The date, if any, when this campaign spec expires and is automatically purged. A campaign spec
-    never expires if it has been applied.
-    """
-    expiresAt: DateTime
-
-    """
-    The URL of a web page that allows applying this campaign spec and
-    displays a preview of which changesets will be created by applying it.
-    """
-    applyURL: String!
-
-    """
-    When true, the viewing user can apply this spec.
-    """
-    viewerCanAdminister: Boolean!
-
-    """
-    The diff stat for all the changeset specs in the campaign spec.
-    """
-    diffStat: DiffStat!
-
-    """
-    The campaign this spec will update when applied. If it's null, the
-    campaign doesn't yet exist.
-    """
-    appliesToCampaign: Campaign
-
-    """
-    The newest version of this campaign spec, as identified by its namespace
-    and name. If this is the newest version, this field will be null.
-    """
-    supersedingCampaignSpec: CampaignSpec
-
-    """
-    The code host connections required for applying this spec. Includes the credentials of the current user.
-    """
-    viewerCampaignsCodeHosts(
-        """
-        Returns the first n code hosts from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only returns the code hosts for which the viewer doesn't have credentials.
-        """
-        onlyWithoutCredential: Boolean = false
-    ): CampaignsCodeHostConnection!
-}
-
-"""
 A user (identified either by username or email address) with its repository permission.
 """
 input UserPermission {
@@ -1688,764 +731,6 @@ input UserPermission {
     The highest level of repository permission.
     """
     permission: RepositoryPermission = READ
-}
-
-"""
-A campaign is a set of related changes to apply to code across one or more repositories.
-"""
-type Campaign implements Node {
-    """
-    The unique ID for the campaign.
-    """
-    id: ID!
-
-    """
-    The namespace where this campaign is defined.
-    """
-    namespace: Namespace!
-
-    """
-    The name of the campaign.
-    """
-    name: String!
-
-    """
-    The description (as Markdown).
-    """
-    description: String
-
-    """
-    The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
-    """
-    specCreator: User
-
-    """
-    The user who created the campaign initially by applying the spec for the first time, or null if the user was deleted.
-    """
-    initialApplier: User
-
-    """
-    The user who last updated the campaign by applying a spec to this campaign.
-    If the campaign hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
-    """
-    lastApplier: User
-
-    """
-    Whether the current user can edit or delete this campaign.
-    """
-    viewerCanAdminister: Boolean!
-
-    """
-    The URL to this campaign.
-    """
-    url: String!
-
-    """
-    The date and time when the campaign was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the campaign was updated. That can be by applying a spec, or by an internal process.
-    For reading the time the campaign spec was changed last, see lastAppliedAt.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the campaign was last updated with a new spec.
-    """
-    lastAppliedAt: DateTime!
-
-    """
-    The date and time when the campaign was closed. If set, applying a spec for this campaign will fail with an error.
-    """
-    closedAt: DateTime
-
-    """
-    Stats on all the changesets that are tracked in this campaign.
-    """
-    changesetsStats: ChangesetsStats!
-
-    """
-    The changesets in this campaign that already exist on the code host.
-    """
-    changesets(
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only include changesets with any of the given reconciler states.
-        """
-        reconcilerState: [ChangesetReconcilerState!]
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given publication state.
-        """
-        publicationState: ChangesetPublicationState
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given external state.
-        """
-        externalState: ChangesetExternalState
-            @deprecated(
-                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
-            )
-        """
-        Only include changesets with the given state.
-        """
-        state: ChangesetState
-        """
-        Only include changesets with the given review state.
-        """
-        reviewState: ChangesetReviewState
-        """
-        Only include changesets with the given check state.
-        """
-        checkState: ChangesetCheckState
-        """
-        Only return changesets that have been published by this campaign. Imported changesets will be omitted.
-        """
-        onlyPublishedByThisCampaign: Boolean
-        """
-        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
-        """
-        search: String
-    ): ChangesetConnection!
-
-    """
-    The changeset counts over time, in 1-day intervals backwards from the point in time given in
-    the "to" parameter.
-    """
-    changesetCountsOverTime(
-        """
-        Only include changeset counts up to this point in time (inclusive). Defaults to Campaign.createdAt.
-        """
-        from: DateTime
-        """
-        Only include changeset counts up to this point in time (inclusive). Defaults to the
-        current time.
-        """
-        to: DateTime
-    ): [ChangesetCounts!]!
-
-    """
-    The diff stat for all the changesets in the campaign.
-    """
-    diffStat: DiffStat!
-
-    """
-    The current campaign spec this campaign reflects.
-    """
-    currentSpec: CampaignSpec!
-}
-
-"""
-The counts of changesets in certain states at a specific point in time.
-"""
-type ChangesetCounts {
-    """
-    The point in time these counts were recorded.
-    """
-    date: DateTime!
-    """
-    The total number of changesets.
-    """
-    total: Int!
-    """
-    The number of merged changesets.
-    """
-    merged: Int!
-    """
-    The number of closed changesets.
-    """
-    closed: Int!
-    """
-    The number of draft changesets (independent of review state).
-    """
-    draft: Int!
-    """
-    The number of open changesets (independent of review state).
-    """
-    open: Int!
-    """
-    The number of changesets that are both open and approved.
-    """
-    openApproved: Int!
-    """
-    The number of changesets that are both open and have requested changes.
-    """
-    openChangesRequested: Int!
-    """
-    The number of changesets that are both open and are pending review.
-    """
-    openPending: Int!
-}
-
-"""
-A list of campaigns.
-"""
-type CampaignConnection {
-    """
-    A list of campaigns.
-    """
-    nodes: [Campaign!]!
-
-    """
-    The total number of campaigns in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-The publication state of a changeset on Sourcegraph
-"""
-enum ChangesetPublicationState {
-    """
-    The changeset has not yet been created on the code host.
-    """
-    UNPUBLISHED
-    """
-    The changeset has been created on the code host.
-    """
-    PUBLISHED
-}
-
-"""
-The reconciler state of a changeset on Sourcegraph
-"""
-enum ChangesetReconcilerState {
-    """
-    The changeset is enqueued for the reconciler to process it.
-    """
-    QUEUED
-
-    """
-    The changeset reconciler is currently computing the delta between the
-    If a delta exists, the reconciler tries to update the state of the
-    changeset on the code host and on Sourcegraph to the desired state.
-    """
-    PROCESSING
-
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset and will retry it for a number of retries.
-    """
-    ERRORED
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset that can't be fixed by retrying.
-    """
-    FAILED
-
-    """
-    The changeset is not enqueued for processing.
-    """
-    COMPLETED
-}
-
-"""
-The state of a changeset on the code host on which it's hosted.
-"""
-enum ChangesetExternalState {
-    DRAFT
-    OPEN
-    CLOSED
-    MERGED
-    DELETED
-}
-
-"""
-The review state of a changeset.
-"""
-enum ChangesetReviewState {
-    APPROVED
-    CHANGES_REQUESTED
-    PENDING
-    COMMENTED
-    DISMISSED
-}
-
-"""
-The state of checks (e.g., for continuous integration) on a changeset.
-"""
-enum ChangesetCheckState {
-    PENDING
-    PASSED
-    FAILED
-}
-
-"""
-A label attached to a changeset on a code host.
-"""
-type ChangesetLabel {
-    """
-    The label's text.
-    """
-    text: String!
-    """
-    The label's color, as a hex color code without the . For example: "93ba13".
-    """
-    color: String!
-    """
-    An optional description of the label.
-    """
-    description: String
-}
-
-"""
-The visual state a changeset is currently in.
-"""
-enum ChangesetState {
-    """
-    The changeset has not been marked as to be published.
-    """
-    UNPUBLISHED
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset that can't be fixed by retrying.
-    """
-    FAILED
-    """
-    The changeset reconciler ran into a problem while processing the
-    changeset and will retry it for a number of retries.
-    """
-    RETRYING
-    """
-    The changeset reconciler is currently computing the delta between the
-    If a delta exists, the reconciler tries to update the state of the
-    changeset on the code host and on Sourcegraph to the desired state.
-    """
-    PROCESSING
-    """
-    The changeset is published, not being reconciled and open on the code host.
-    """
-    OPEN
-    """
-    The changeset is published, not being reconciled and in draft state on the code host.
-    """
-    DRAFT
-    """
-    The changeset is published, not being reconciled and closed on the code host.
-    """
-    CLOSED
-    """
-    The changeset is published, not being reconciled and merged on the code host.
-    """
-    MERGED
-    """
-    The changeset is published, not being reconciled and has been deleted on the code host.
-    """
-    DELETED
-}
-
-"""
-A changeset on a codehost.
-"""
-interface Changeset {
-    """
-    The unique ID for the changeset.
-    """
-    id: ID!
-
-    """
-    The campaigns that contain this changeset.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The state of the changeset.
-    """
-    state: ChangesetState!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the changeset was updated.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
-    """
-    nextSyncAt: DateTime
-}
-
-"""
-A changeset on a code host that the user does not have access to.
-"""
-type HiddenExternalChangeset implements Node & Changeset {
-    """
-    The unique ID for the changeset.
-    """
-    id: ID!
-
-    """
-    The campaigns that contain this changeset.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The state of the changeset.
-    """
-    state: ChangesetState!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the changeset was updated.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
-    """
-    nextSyncAt: DateTime
-}
-
-"""
-A changeset on a code host (e.g., a pull request on GitHub).
-"""
-type ExternalChangeset implements Node & Changeset {
-    """
-    The unique ID for the changeset.
-    """
-    id: ID!
-
-    """
-    The external ID that uniquely identifies this ExternalChangeset on the
-    code host. For example, on GitHub this is the pull request number. This is only set once the changeset is published on the code host.
-    """
-    externalID: String
-
-    """
-    The repository changed by this changeset.
-    """
-    repository: Repository!
-
-    """
-    The campaigns that contain this changeset.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    The events belonging to this changeset.
-    """
-    events(first: Int = 50, after: String): ChangesetEventConnection!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The date and time when the changeset was updated.
-    """
-    updatedAt: DateTime!
-
-    """
-    The date and time when the next changeset sync is scheduled, or null if none is scheduled or when the initial sync hasn't happened.
-    """
-    nextSyncAt: DateTime
-
-    """
-    The title of the changeset, or null if the data hasn't been synced from the code host yet.
-    """
-    title: String
-
-    """
-    The body of the changeset, or null if the data hasn't been synced from the code host yet.
-    """
-    body: String
-
-    """
-    The author of the changeset, or null if the data hasn't been synced from the code host yet,
-    or the changeset has not yet been published.
-    """
-    author: Person
-
-    """
-    The publication state of the changeset.
-    """
-    publicationState: ChangesetPublicationState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The reconciler state of the changeset.
-    """
-    reconcilerState: ChangesetReconcilerState!
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The external state of the changeset, or null when not yet published to the code host.
-    """
-    externalState: ChangesetExternalState
-        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
-
-    """
-    The state of the changeset.
-    """
-    state: ChangesetState!
-
-    """
-    The labels attached to the changeset on the code host.
-    """
-    labels: [ChangesetLabel!]!
-
-    """
-    The external URL of the changeset on the code host. Not set when changeset state is UNPUBLISHED, externalState is DELETED, or the changeset's data hasn't been synced yet.
-    """
-    externalURL: ExternalLink
-
-    """
-    The review state of this changeset. This is only set once the changeset is published on the code host.
-    """
-    reviewState: ChangesetReviewState
-
-    """
-    The diff of this changeset, or null if the changeset is closed (without merging) or is already merged.
-    """
-    diff: RepositoryComparisonInterface
-
-    """
-    The diffstat of this changeset, or null if the changeset is closed
-    (without merging) or is already merged. This data is also available
-    indirectly through the diff field above, but if only the diffStat is
-    required, this field is cheaper to access.
-    """
-    diffStat: DiffStat
-
-    """
-    The state of the checks (e.g., for continuous integration) on this changeset, or null if no
-    checks have been configured.
-    """
-    checkState: ChangesetCheckState
-
-    """
-    An error that has occurred when publishing or updating the changeset. This is only set when the changeset state is ERRORED and the viewer can administer this changeset.
-    """
-    error: String
-
-    """
-    An error that has occured during the last sync of the changeset. Null, if was successful.
-    """
-    syncerError: String
-
-    """
-    The current changeset spec for this changeset.
-
-    Null if the changeset was only imported.
-    """
-    currentSpec: VisibleChangesetSpec
-}
-
-"""
-Used in the campaign page for the overview component.
-"""
-type ChangesetsStats {
-    """
-    The count of unpublished changesets.
-    """
-    unpublished: Int!
-    """
-    The count of externalState: DRAFT changesets.
-    """
-    draft: Int!
-    """
-    The count of externalState: OPEN changesets.
-    """
-    open: Int!
-    """
-    The count of externalState: MERGED changesets.
-    """
-    merged: Int!
-    """
-    The count of externalState: CLOSED changesets.
-    """
-    closed: Int!
-    """
-    The count of externalState: DELETED changesets.
-    """
-    deleted: Int!
-    """
-    The count of changesets in retrying state.
-    """
-    retrying: Int!
-    """
-    The count of changesets in failed state.
-    """
-    failed: Int!
-    """
-    The count of changesets that are currently processing or enqueued to be.
-    """
-    processing: Int!
-    """
-    The count of all changesets.
-    """
-    total: Int!
-}
-
-"""
-A list of changesets.
-"""
-type ChangesetConnection {
-    """
-    A list of changesets.
-    """
-    nodes: [Changeset!]!
-
-    """
-    The total number of changesets in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-A changeset event in a code host (e.g., a comment on a pull request on GitHub).
-"""
-type ChangesetEvent implements Node {
-    """
-    The unique ID for the changeset event.
-    """
-    id: ID!
-
-    """
-    The changeset this event belongs to.
-    """
-    changeset: ExternalChangeset!
-
-    """
-    The date and time when the changeset was created.
-    """
-    createdAt: DateTime!
-}
-
-"""
-A list of changeset events.
-"""
-type ChangesetEventConnection {
-    """
-    A list of changeset events.
-    """
-    nodes: [ChangesetEvent!]!
-
-    """
-    The total number of changeset events in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
 }
 
 """
@@ -2799,14 +1084,6 @@ input HappinessFeedbackSubmissionInput {
 }
 
 """
-The state of the campaign
-"""
-enum CampaignState {
-    OPEN
-    CLOSED
-}
-
-"""
 A query.
 """
 type Query {
@@ -2818,41 +1095,6 @@ type Query {
     Looks up a node by ID.
     """
     node(id: ID!): Node
-
-    """
-    A list of campaigns.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-    """
-    Looks up a campaign by namespace and campaign name.
-    """
-    campaign(
-        """
-        The namespace where the campaign lives.
-        """
-        namespace: ID!
-        """
-        The campaigns name.
-        """
-        name: String!
-    ): Campaign
 
     """
     EXPERIMENTAL: Queries code insights
@@ -6987,44 +5229,6 @@ type User implements Node & SettingsSubject & Namespace {
     permissionsInfo: PermissionsInfo
 
     """
-    A list of campaigns applied under this user's namespace.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-
-    """
-    Returns a connection of configured external services accessible by this user, for usage with campaigns.
-    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
-    connected to CampaignCredential resources, if one has been created for the code host connection before.
-    """
-    campaignsCodeHosts(
-        """
-        Returns the first n code hosts from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-    ): CampaignsCodeHostConnection!
-
-    """
     A list of monitors owned by the user or her organization.
     """
     monitors(
@@ -7410,28 +5614,6 @@ type Org implements Node & SettingsSubject & Namespace {
     The name of this user namespace's component. For organizations, this is the organization's name.
     """
     namespaceName: String!
-
-    """
-    A list of campaigns initially applied in this organization.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
 }
 
 """
@@ -9628,3 +7810,1840 @@ type CodeHostRepository {
     """
     private: Boolean!
 }
+
+############################################################################################
+#                                                                                          #
+#                               Begin campaigns schema                                     #
+#                                                                                          #
+############################################################################################
+"""
+The state of the campaign
+"""
+enum CampaignState {
+    OPEN
+    CLOSED
+}
+
+"""
+A campaign is a set of related changes to apply to code across one or more repositories.
+"""
+type Campaign implements Node {
+    """
+    The unique ID for the campaign.
+    """
+    id: ID!
+
+    """
+    The namespace where this campaign is defined.
+    """
+    namespace: Namespace!
+
+    """
+    The name of the campaign.
+    """
+    name: String!
+
+    """
+    The description (as Markdown).
+    """
+    description: String
+
+    """
+    The user that created the initial spec. In an org, this will be different from the namespace, or null if the user was deleted.
+    """
+    specCreator: User
+
+    """
+    The user who created the campaign initially by applying the spec for the first time, or null if the user was deleted.
+    """
+    initialApplier: User
+
+    """
+    The user who last updated the campaign by applying a spec to this campaign.
+    If the campaign hasn't been updated, the lastApplier is the initialApplier, or null if the user was deleted.
+    """
+    lastApplier: User
+
+    """
+    Whether the current user can edit or delete this campaign.
+    """
+    viewerCanAdminister: Boolean!
+
+    """
+    The URL to this campaign.
+    """
+    url: String!
+
+    """
+    The date and time when the campaign was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the campaign was updated. That can be by applying a spec, or by an internal process.
+    For reading the time the campaign spec was changed last, see lastAppliedAt.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the campaign was last updated with a new spec.
+    """
+    lastAppliedAt: DateTime!
+
+    """
+    The date and time when the campaign was closed. If set, applying a spec for this campaign will fail with an error.
+    """
+    closedAt: DateTime
+
+    """
+    Stats on all the changesets that are tracked in this campaign.
+    """
+    changesetsStats: ChangesetsStats!
+
+    """
+    The changesets in this campaign that already exist on the code host.
+    """
+    changesets(
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only include changesets with any of the given reconciler states.
+        """
+        reconcilerState: [ChangesetReconcilerState!]
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given publication state.
+        """
+        publicationState: ChangesetPublicationState
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given external state.
+        """
+        externalState: ChangesetExternalState
+            @deprecated(
+                reason: "Use state instead. This field is deprecated, has no effect, and will be removed in a future release."
+            )
+        """
+        Only include changesets with the given state.
+        """
+        state: ChangesetState
+        """
+        Only include changesets with the given review state.
+        """
+        reviewState: ChangesetReviewState
+        """
+        Only include changesets with the given check state.
+        """
+        checkState: ChangesetCheckState
+        """
+        Only return changesets that have been published by this campaign. Imported changesets will be omitted.
+        """
+        onlyPublishedByThisCampaign: Boolean
+        """
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
+        """
+        search: String
+    ): ChangesetConnection!
+
+    """
+    The changeset counts over time, in 1-day intervals backwards from the point in time given in
+    the "to" parameter.
+    """
+    changesetCountsOverTime(
+        """
+        Only include changeset counts up to this point in time (inclusive). Defaults to Campaign.createdAt.
+        """
+        from: DateTime
+        """
+        Only include changeset counts up to this point in time (inclusive). Defaults to the
+        current time.
+        """
+        to: DateTime
+    ): [ChangesetCounts!]!
+
+    """
+    The diff stat for all the changesets in the campaign.
+    """
+    diffStat: DiffStat!
+
+    """
+    The current campaign spec this campaign reflects.
+    """
+    currentSpec: CampaignSpec!
+}
+
+"""
+The counts of changesets in certain states at a specific point in time.
+"""
+type ChangesetCounts {
+    """
+    The point in time these counts were recorded.
+    """
+    date: DateTime!
+    """
+    The total number of changesets.
+    """
+    total: Int!
+    """
+    The number of merged changesets.
+    """
+    merged: Int!
+    """
+    The number of closed changesets.
+    """
+    closed: Int!
+    """
+    The number of draft changesets (independent of review state).
+    """
+    draft: Int!
+    """
+    The number of open changesets (independent of review state).
+    """
+    open: Int!
+    """
+    The number of changesets that are both open and approved.
+    """
+    openApproved: Int!
+    """
+    The number of changesets that are both open and have requested changes.
+    """
+    openChangesRequested: Int!
+    """
+    The number of changesets that are both open and are pending review.
+    """
+    openPending: Int!
+}
+
+"""
+A list of campaigns.
+"""
+type CampaignConnection {
+    """
+    A list of campaigns.
+    """
+    nodes: [Campaign!]!
+
+    """
+    The total number of campaigns in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+The publication state of a changeset on Sourcegraph
+"""
+enum ChangesetPublicationState {
+    """
+    The changeset has not yet been created on the code host.
+    """
+    UNPUBLISHED
+    """
+    The changeset has been created on the code host.
+    """
+    PUBLISHED
+}
+
+"""
+The reconciler state of a changeset on Sourcegraph
+"""
+enum ChangesetReconcilerState {
+    """
+    The changeset is enqueued for the reconciler to process it.
+    """
+    QUEUED
+
+    """
+    The changeset reconciler is currently computing the delta between the
+    If a delta exists, the reconciler tries to update the state of the
+    changeset on the code host and on Sourcegraph to the desired state.
+    """
+    PROCESSING
+
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset and will retry it for a number of retries.
+    """
+    ERRORED
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset that can't be fixed by retrying.
+    """
+    FAILED
+
+    """
+    The changeset is not enqueued for processing.
+    """
+    COMPLETED
+}
+
+"""
+The state of a changeset on the code host on which it's hosted.
+"""
+enum ChangesetExternalState {
+    DRAFT
+    OPEN
+    CLOSED
+    MERGED
+    DELETED
+}
+
+"""
+The review state of a changeset.
+"""
+enum ChangesetReviewState {
+    APPROVED
+    CHANGES_REQUESTED
+    PENDING
+    COMMENTED
+    DISMISSED
+}
+
+"""
+The state of checks (e.g., for continuous integration) on a changeset.
+"""
+enum ChangesetCheckState {
+    PENDING
+    PASSED
+    FAILED
+}
+
+"""
+A label attached to a changeset on a code host.
+"""
+type ChangesetLabel {
+    """
+    The label's text.
+    """
+    text: String!
+    """
+    The label's color, as a hex color code without the . For example: "93ba13".
+    """
+    color: String!
+    """
+    An optional description of the label.
+    """
+    description: String
+}
+
+"""
+The visual state a changeset is currently in.
+"""
+enum ChangesetState {
+    """
+    The changeset has not been marked as to be published.
+    """
+    UNPUBLISHED
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset that can't be fixed by retrying.
+    """
+    FAILED
+    """
+    The changeset reconciler ran into a problem while processing the
+    changeset and will retry it for a number of retries.
+    """
+    RETRYING
+    """
+    The changeset reconciler is currently computing the delta between the
+    If a delta exists, the reconciler tries to update the state of the
+    changeset on the code host and on Sourcegraph to the desired state.
+    """
+    PROCESSING
+    """
+    The changeset is published, not being reconciled and open on the code host.
+    """
+    OPEN
+    """
+    The changeset is published, not being reconciled and in draft state on the code host.
+    """
+    DRAFT
+    """
+    The changeset is published, not being reconciled and closed on the code host.
+    """
+    CLOSED
+    """
+    The changeset is published, not being reconciled and merged on the code host.
+    """
+    MERGED
+    """
+    The changeset is published, not being reconciled and has been deleted on the code host.
+    """
+    DELETED
+}
+
+"""
+A changeset on a codehost.
+"""
+interface Changeset {
+    """
+    The unique ID for the changeset.
+    """
+    id: ID!
+
+    """
+    The campaigns that contain this changeset.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    The publication state of the changeset.
+    """
+    publicationState: ChangesetPublicationState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The reconciler state of the changeset.
+    """
+    reconcilerState: ChangesetReconcilerState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The external state of the changeset, or null when not yet published to the code host.
+    """
+    externalState: ChangesetExternalState
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The state of the changeset.
+    """
+    state: ChangesetState!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the changeset was updated.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
+    """
+    nextSyncAt: DateTime
+}
+
+"""
+A changeset on a code host that the user does not have access to.
+"""
+type HiddenExternalChangeset implements Node & Changeset {
+    """
+    The unique ID for the changeset.
+    """
+    id: ID!
+
+    """
+    The campaigns that contain this changeset.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    The publication state of the changeset.
+    """
+    publicationState: ChangesetPublicationState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The reconciler state of the changeset.
+    """
+    reconcilerState: ChangesetReconcilerState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The external state of the changeset, or null when not yet published to the code host.
+    """
+    externalState: ChangesetExternalState
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The state of the changeset.
+    """
+    state: ChangesetState!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the changeset was updated.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the next changeset sync is scheduled, or null if none is scheduled.
+    """
+    nextSyncAt: DateTime
+}
+
+"""
+A changeset on a code host (e.g., a pull request on GitHub).
+"""
+type ExternalChangeset implements Node & Changeset {
+    """
+    The unique ID for the changeset.
+    """
+    id: ID!
+
+    """
+    The external ID that uniquely identifies this ExternalChangeset on the
+    code host. For example, on GitHub this is the pull request number. This is only set once the changeset is published on the code host.
+    """
+    externalID: String
+
+    """
+    The repository changed by this changeset.
+    """
+    repository: Repository!
+
+    """
+    The campaigns that contain this changeset.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    The events belonging to this changeset.
+    """
+    events(first: Int = 50, after: String): ChangesetEventConnection!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The date and time when the changeset was updated.
+    """
+    updatedAt: DateTime!
+
+    """
+    The date and time when the next changeset sync is scheduled, or null if none is scheduled or when the initial sync hasn't happened.
+    """
+    nextSyncAt: DateTime
+
+    """
+    The title of the changeset, or null if the data hasn't been synced from the code host yet.
+    """
+    title: String
+
+    """
+    The body of the changeset, or null if the data hasn't been synced from the code host yet.
+    """
+    body: String
+
+    """
+    The author of the changeset, or null if the data hasn't been synced from the code host yet,
+    or the changeset has not yet been published.
+    """
+    author: Person
+
+    """
+    The publication state of the changeset.
+    """
+    publicationState: ChangesetPublicationState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The reconciler state of the changeset.
+    """
+    reconcilerState: ChangesetReconcilerState!
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The external state of the changeset, or null when not yet published to the code host.
+    """
+    externalState: ChangesetExternalState
+        @deprecated(reason: "Use state instead. This field is deprecated and will be removed in a future release.")
+
+    """
+    The state of the changeset.
+    """
+    state: ChangesetState!
+
+    """
+    The labels attached to the changeset on the code host.
+    """
+    labels: [ChangesetLabel!]!
+
+    """
+    The external URL of the changeset on the code host. Not set when changeset state is UNPUBLISHED, externalState is DELETED, or the changeset's data hasn't been synced yet.
+    """
+    externalURL: ExternalLink
+
+    """
+    The review state of this changeset. This is only set once the changeset is published on the code host.
+    """
+    reviewState: ChangesetReviewState
+
+    """
+    The diff of this changeset, or null if the changeset is closed (without merging) or is already merged.
+    """
+    diff: RepositoryComparisonInterface
+
+    """
+    The diffstat of this changeset, or null if the changeset is closed
+    (without merging) or is already merged. This data is also available
+    indirectly through the diff field above, but if only the diffStat is
+    required, this field is cheaper to access.
+    """
+    diffStat: DiffStat
+
+    """
+    The state of the checks (e.g., for continuous integration) on this changeset, or null if no
+    checks have been configured.
+    """
+    checkState: ChangesetCheckState
+
+    """
+    An error that has occurred when publishing or updating the changeset. This is only set when the changeset state is ERRORED and the viewer can administer this changeset.
+    """
+    error: String
+
+    """
+    An error that has occured during the last sync of the changeset. Null, if was successful.
+    """
+    syncerError: String
+
+    """
+    The current changeset spec for this changeset.
+
+    Null if the changeset was only imported.
+    """
+    currentSpec: VisibleChangesetSpec
+}
+
+"""
+Used in the campaign page for the overview component.
+"""
+type ChangesetsStats {
+    """
+    The count of unpublished changesets.
+    """
+    unpublished: Int!
+    """
+    The count of externalState: DRAFT changesets.
+    """
+    draft: Int!
+    """
+    The count of externalState: OPEN changesets.
+    """
+    open: Int!
+    """
+    The count of externalState: MERGED changesets.
+    """
+    merged: Int!
+    """
+    The count of externalState: CLOSED changesets.
+    """
+    closed: Int!
+    """
+    The count of externalState: DELETED changesets.
+    """
+    deleted: Int!
+    """
+    The count of changesets in retrying state.
+    """
+    retrying: Int!
+    """
+    The count of changesets in failed state.
+    """
+    failed: Int!
+    """
+    The count of changesets that are currently processing or enqueued to be.
+    """
+    processing: Int!
+    """
+    The count of all changesets.
+    """
+    total: Int!
+}
+
+"""
+A list of changesets.
+"""
+type ChangesetConnection {
+    """
+    A list of changesets.
+    """
+    nodes: [Changeset!]!
+
+    """
+    The total number of changesets in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A changeset event in a code host (e.g., a comment on a pull request on GitHub).
+"""
+type ChangesetEvent implements Node {
+    """
+    The unique ID for the changeset event.
+    """
+    id: ID!
+
+    """
+    The changeset this event belongs to.
+    """
+    changeset: ExternalChangeset!
+
+    """
+    The date and time when the changeset was created.
+    """
+    createdAt: DateTime!
+}
+
+"""
+A list of changeset events.
+"""
+type ChangesetEventConnection {
+    """
+    A list of changeset events.
+    """
+    nodes: [ChangesetEvent!]!
+
+    """
+    The total number of changeset events in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A connection of all code hosts usable with campaigns and accessible by the user
+this is requested on.
+"""
+type CampaignsCodeHostConnection {
+    """
+    A list of code hosts.
+    """
+    nodes: [CampaignsCodeHost!]!
+
+    """
+    The total number of configured external services in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A code host usable with campaigns. This service is accessible by the user it belongs to.
+"""
+type CampaignsCodeHost {
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The configured credential, if any.
+    """
+    credential: CampaignsCredential
+}
+
+"""
+A user token configured for campaigns use on the specified code host.
+"""
+type CampaignsCredential implements Node {
+    """
+    A globally unique identifier.
+    """
+    id: ID!
+
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The date and time this token has been created at.
+    """
+    createdAt: DateTime!
+}
+
+"""
+This enum declares all operations supported by the reconciler.
+"""
+enum ChangesetSpecOperation {
+    """
+    Push a new commit to the code host.
+    """
+    PUSH
+    """
+    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
+    not the git commit. For updates to the commit, see 'PUSH'.
+    """
+    UPDATE
+    """
+    Move the existing changeset out of being a draft.
+    """
+    UNDRAFT
+    """
+    Publish a changeset to the codehost.
+    """
+    PUBLISH
+    """
+    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
+    """
+    PUBLISH_DRAFT
+    """
+    Sync the changeset with the current state on the codehost.
+    """
+    SYNC
+    """
+    Import an existing changeset from the code host with the ExternalID from the spec.
+    """
+    IMPORT
+    """
+    Close the changeset on the codehost.
+    """
+    CLOSE
+    """
+    Reopen the changeset on the codehost.
+    """
+    REOPEN
+    """
+    Internal operation to get around slow code host updates.
+    """
+    SLEEP
+    """
+    The changeset is removed from some of the associated campaigns.
+    """
+    DETACH
+}
+
+"""
+Description of the current changeset state vs the changeset spec desired state.
+"""
+type ChangesetSpecDelta {
+    """
+    When run, the title of the changeset will be updated.
+    """
+    titleChanged: Boolean!
+    """
+    When run, the body of the changeset will be updated.
+    """
+    bodyChanged: Boolean!
+    """
+    When run, the changeset will be taken out of draft mode.
+    """
+    undraft: Boolean!
+    """
+    When run, the target branch of the changeset will be updated.
+    """
+    baseRefChanged: Boolean!
+    """
+    When run, a new commit will be created on the branch of the changeset.
+    """
+    diffChanged: Boolean!
+    """
+    When run, a new commit will be created on the branch of the changeset.
+    """
+    commitMessageChanged: Boolean!
+    """
+    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
+    """
+    authorNameChanged: Boolean!
+    """
+    When run, a new commit in the name of the specified author will be created on the branch of the changeset.
+    """
+    authorEmailChanged: Boolean!
+}
+
+"""
+The type of the changeset spec.
+"""
+enum ChangesetSpecType {
+    """
+    References an existing changeset on a code host to be imported.
+    """
+    EXISTING
+    """
+    References a branch and a patch to be applied to create the changeset from.
+    """
+    BRANCH
+}
+
+"""
+A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+create a changeset spec, use the createChangesetSpec mutation.
+"""
+interface ChangesetSpec {
+    """
+    The unique ID for a changeset spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    even though repository permissions also apply to viewers of changeset specs, because being
+    allowed to view a repository should not entitle a person to view all not-yet-published
+    changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    campaign author may prefer to prepare all of the changesets in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The type of changeset spec.
+    """
+    type: ChangesetSpecType!
+
+    """
+    The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    spec never expires (and this field is null) if its campaign spec has been applied.
+    """
+    expiresAt: DateTime
+}
+
+"""
+A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+create a changeset spec, use the createChangesetSpec mutation.
+"""
+type HiddenChangesetSpec implements ChangesetSpec & Node {
+    """
+    The unique ID for a changeset spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    even though repository permissions also apply to viewers of changeset specs, because being
+    allowed to view a repository should not entitle a person to view all not-yet-published
+    changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    campaign author may prefer to prepare all of the changesets in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The type of changeset spec.
+    """
+    type: ChangesetSpecType!
+
+    """
+    The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    spec never expires (and this field is null) if its campaign spec has been applied.
+    """
+    expiresAt: DateTime
+}
+
+"""
+A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+create a changeset spec, use the createChangesetSpec mutation.
+"""
+type VisibleChangesetSpec implements ChangesetSpec & Node {
+    """
+    The unique ID for a changeset spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
+    even though repository permissions also apply to viewers of changeset specs, because being
+    allowed to view a repository should not entitle a person to view all not-yet-published
+    changesets for that repository. Consider a campaign to fix a security vulnerability: the
+    campaign author may prefer to prepare all of the changesets in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The type of changeset spec.
+    """
+    type: ChangesetSpecType!
+
+    """
+    The description of the changeset.
+    """
+    description: ChangesetDescription!
+
+    """
+    The date, if any, when this changeset spec expires and is automatically purged. A changeset
+    spec never expires (and this field is null) if its campaign spec has been applied.
+    """
+    expiresAt: DateTime
+}
+
+"""
+All possible types of changesets that can be specified in a changeset spec.
+"""
+union ChangesetDescription = ExistingChangesetReference | GitBranchChangesetDescription
+
+"""
+A reference to a changeset that already exists on a code host (and was not created by the
+campaign).
+"""
+type ExistingChangesetReference {
+    """
+    The repository that contains the existing changeset on the code host.
+    """
+    baseRepository: Repository!
+
+    """
+    The ID that uniquely identifies the existing changeset on the code host.
+
+    For GitHub and Bitbucket Server, this is the pull request number (as a string) in the
+    base repository. For example, "1234" for PR 1234.
+    """
+    externalID: String!
+}
+
+"""
+A triple that represents all possible states of the published value: true, false or 'draft'.
+"""
+scalar PublishedValue
+
+"""
+A description of a changeset that represents the proposal to merge one branch into another.
+This is used to describe a pull request (on GitHub and Bitbucket Server).
+"""
+type GitBranchChangesetDescription {
+    """
+    The repository that this changeset spec is proposing to change.
+    """
+    baseRepository: Repository!
+
+    """
+    The full name of the Git ref in the base repository that this changeset is based on (and is
+    proposing to be merged into). This ref must exist on the base repository. For example,
+    "refs/heads/master" or "refs/heads/main".
+    """
+    baseRef: String!
+
+    """
+    The base revision this changeset is based on. It is the latest commit in
+    baseRef at the time when the changeset spec was created.
+    For example: "4095572721c6234cd72013fd49dff4fb48f0f8a4"
+    """
+    baseRev: String!
+
+    """
+    The repository that contains the branch with this changeset's changes.
+
+    Fork repositories and cross-repository changesets are not yet supported. Therefore,
+    headRepository must be equal to baseRepository.
+    """
+    headRepository: Repository!
+
+    """
+    The full name of the Git ref that holds the changes proposed by this changeset. This ref will
+    be created or updated with the commits. For example, "refs/heads/fix-foo" (for
+    the Git branch "fix-foo").
+    """
+    headRef: String!
+
+    """
+    The title of the changeset on the code host.
+
+    On Bitbucket Server or GitHub this is the title of the pull request.
+    """
+    title: String!
+
+    """
+    The body of the changeset on the code host.
+
+    On Bitbucket Server or GitHub this is the body/description of the pull request.
+    """
+    body: String!
+
+    """
+    The Git commits with the proposed changes. These commits are pushed to the head ref.
+
+    Only 1 commit is supported.
+    """
+    commits: [GitCommitDescription!]!
+
+    """
+    The total diff of the changeset diff.
+    """
+    diff: PreviewRepositoryComparison!
+
+    """
+    The diffstat of this changeset spec. This data is also available
+    indirectly through the diff field above, but if only the diffStat is
+    required, this field is cheaper to access.
+    """
+    diffStat: DiffStat!
+
+    """
+    Whether or not the changeset described here should be created right after
+    applying the ChangesetSpec this description belongs to.
+
+    If this is false, the changeset will only be created on Sourcegraph and
+    can be previewed.
+
+    Another ChangesetSpec with the same description, but "published: true",
+    can later be applied publish the changeset.
+    """
+    published: PublishedValue!
+}
+
+"""
+A description of a Git commit.
+"""
+type GitCommitDescription {
+    """
+    The full commit message.
+    """
+    message: String!
+
+    """
+    The first line of the commit message.
+    """
+    subject: String!
+
+    """
+    The contents of the commit message after the first line.
+    """
+    body: String
+
+    """
+    The Git commit author.
+    """
+    author: Person!
+
+    """
+    The commit diff (in unified diff format).
+
+    The filenames must not be prefixed (e.g., with 'a/' and 'b/'). Tip: use 'git diff --no-prefix'
+    to omit the prefix.
+    """
+    diff: String!
+}
+
+"""
+A list of changeset specs.
+"""
+type ChangesetSpecConnection {
+    """
+    The total number of changeset specs in the connection.
+    """
+    totalCount: Int!
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+    """
+    A list of changeset specs.
+    """
+    nodes: [ChangesetSpec!]!
+}
+
+"""
+A preview for which actions applyCampaign would result in when called at the point of time this preview was created at.
+"""
+union ChangesetApplyPreview = VisibleChangesetApplyPreview | HiddenChangesetApplyPreview
+
+"""
+A preview entry to a repository to which the user has access.
+"""
+union VisibleApplyPreviewTargets =
+      VisibleApplyPreviewTargetsAttach
+    | VisibleApplyPreviewTargetsUpdate
+    | VisibleApplyPreviewTargetsDetach
+
+"""
+A preview entry where no changeset existed before matching the changeset spec.
+"""
+type VisibleApplyPreviewTargetsAttach {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: VisibleChangesetSpec!
+}
+
+"""
+A preview entry where a changeset matches the changeset spec.
+"""
+type VisibleApplyPreviewTargetsUpdate {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: VisibleChangesetSpec!
+    """
+    The changeset from this entry.
+    """
+    changeset: ExternalChangeset!
+}
+
+"""
+A preview entry where no changeset spec exists for the changeset currently in
+the target campaign.
+"""
+type VisibleApplyPreviewTargetsDetach {
+    """
+    The changeset from this entry.
+    """
+    changeset: ExternalChangeset!
+}
+
+"""
+A preview entry to a repository to which the user has no access.
+"""
+union HiddenApplyPreviewTargets =
+      HiddenApplyPreviewTargetsAttach
+    | HiddenApplyPreviewTargetsUpdate
+    | HiddenApplyPreviewTargetsDetach
+
+"""
+A preview entry where no changeset existed before matching the changeset spec.
+"""
+type HiddenApplyPreviewTargetsAttach {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: HiddenChangesetSpec!
+}
+
+"""
+A preview entry where a changeset matches the changeset spec.
+"""
+type HiddenApplyPreviewTargetsUpdate {
+    """
+    The changeset spec from this entry.
+    """
+    changesetSpec: HiddenChangesetSpec!
+    """
+    The changeset from this entry.
+    """
+    changeset: HiddenExternalChangeset!
+}
+
+"""
+A preview entry where no changeset spec exists for the changeset currently in
+the target campaign.
+"""
+type HiddenApplyPreviewTargetsDetach {
+    """
+    The changeset from this entry.
+    """
+    changeset: HiddenExternalChangeset!
+}
+
+"""
+One preview entry in the list of all previews against a campaign spec. Each mapping
+between changeset specs and current changesets yields one of these. It describes
+which operations are taken against which changeset spec and changeset to ensure the
+desired state is met.
+"""
+type HiddenChangesetApplyPreview {
+    """
+    The operations to take to achieve the desired state.
+    """
+    operations: [ChangesetSpecOperation!]!
+
+    """
+    The delta between the current changeset state and what the new changeset spec
+    envisions the changeset to look like.
+    """
+    delta: ChangesetSpecDelta!
+
+    """
+    The target entities in this preview entry.
+    """
+    targets: HiddenApplyPreviewTargets!
+}
+
+"""
+One preview entry in the list of all previews against a campaign spec. Each mapping
+between changeset specs and current changesets yields one of these. It describes
+which operations are taken against which changeset spec and changeset to ensure the
+desired state is met.
+"""
+type VisibleChangesetApplyPreview {
+    """
+    The operations to take to achieve the desired state.
+    """
+    operations: [ChangesetSpecOperation!]!
+
+    """
+    The delta between the current changeset state and what the new changeset spec
+    envisions the changeset to look like.
+    """
+    delta: ChangesetSpecDelta!
+
+    """
+    The target entities in this preview entry.
+    """
+    targets: VisibleApplyPreviewTargets!
+}
+
+"""
+Aggregated stats on nodes in this connection.
+"""
+type ChangesetApplyPreviewConnectionStats {
+    """
+    Push a new commit to the code host.
+    """
+    push: Int!
+    """
+    Update the existing changeset on the codehost. This is purely the changeset resource on the code host,
+    not the git commit. For updates to the commit, see 'PUSH'.
+    """
+    update: Int!
+    """
+    Move the existing changeset out of being a draft.
+    """
+    undraft: Int!
+    """
+    Publish a changeset to the codehost.
+    """
+    publish: Int!
+    """
+    Publish a changeset to the codehost as a draft changeset. (Only on supported code hosts).
+    """
+    publishDraft: Int!
+    """
+    Sync the changeset with the current state on the codehost.
+    """
+    sync: Int!
+    """
+    Import an existing changeset from the code host with the ExternalID from the spec.
+    """
+    import: Int!
+    """
+    Close the changeset on the codehost.
+    """
+    close: Int!
+    """
+    Reopen the changeset on the codehost.
+    """
+    reopen: Int!
+    """
+    Internal operation to get around slow code host updates.
+    """
+    sleep: Int!
+    """
+    The changeset is removed from some of the associated campaigns.
+    """
+    detach: Int!
+
+    """
+    The amount of changesets that are added to the campaign in this operation.
+    """
+    added: Int!
+    """
+    The amount of changesets that are already attached to the campaign and modified in this operation.
+    """
+    modified: Int!
+    """
+    The amount of changesets that are disassociated from the campaign in this operation.
+    """
+    removed: Int!
+}
+
+"""
+A list of preview entries.
+"""
+type ChangesetApplyPreviewConnection {
+    """
+    The total number of entries in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+
+    """
+    A list of preview entries.
+    """
+    nodes: [ChangesetApplyPreview!]!
+
+    """
+    Stats on the elements in this connnection. Does not respect pagination parameters.
+    """
+    stats: ChangesetApplyPreviewConnectionStats!
+}
+
+"""
+A CampaignDescription describes a campaign.
+"""
+type CampaignDescription {
+    """
+    The name as parsed from the input.
+    """
+    name: String!
+
+    """
+    The description as parsed from the input.
+    """
+    description: String!
+}
+
+"""
+A campaign spec is an immutable description of the desired state of a campaign. To create a
+campaign spec, use the createCampaignSpec mutation.
+"""
+type CampaignSpec implements Node {
+    """
+    The unique ID for a campaign spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential).
+    Consider a campaign to fix a security vulnerability: the campaign author may prefer
+    to prepare the campaign, including the description in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The original YAML or JSON input that was used to create this campaign spec.
+    """
+    originalInput: String!
+
+    """
+    The parsed JSON value of the original input. If the original input was YAML, the YAML is
+    converted to the equivalent JSON.
+    """
+    parsedInput: JSONValue!
+
+    """
+    The CampaignDescription that describes this campaign.
+    """
+    description: CampaignDescription!
+
+    """
+    Generates a preview what operations would be performed if the campaign spec would be applied.
+    This preview is not a guarantee, since the state of the changesets can change between the time
+    the preview is generated and when the campaign spec is applied.
+    """
+    applyPreview(
+        """
+        Returns the first n entries from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
+        """
+        search: String
+        """
+        Search for changesets that are currently in this state.
+        """
+        currentState: ChangesetState
+        """
+        Search for changesets that will have the given action performed.
+        """
+        action: ChangesetSpecOperation
+    ): ChangesetApplyPreviewConnection!
+
+    """
+    The specs for changesets associated with this campaign.
+    """
+    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
+
+    """
+    The user who created this campaign spec (or null if the user no longer exists).
+    """
+    creator: User
+
+    """
+    The date when this campaign spec was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The namespace (either a user or organization) of the campaign spec.
+    """
+    namespace: Namespace!
+
+    """
+    The date, if any, when this campaign spec expires and is automatically purged. A campaign spec
+    never expires if it has been applied.
+    """
+    expiresAt: DateTime
+
+    """
+    The URL of a web page that allows applying this campaign spec and
+    displays a preview of which changesets will be created by applying it.
+    """
+    applyURL: String!
+
+    """
+    When true, the viewing user can apply this spec.
+    """
+    viewerCanAdminister: Boolean!
+
+    """
+    The diff stat for all the changeset specs in the campaign spec.
+    """
+    diffStat: DiffStat!
+
+    """
+    The campaign this spec will update when applied. If it's null, the
+    campaign doesn't yet exist.
+    """
+    appliesToCampaign: Campaign
+
+    """
+    The newest version of this campaign spec, as identified by its namespace
+    and name. If this is the newest version, this field will be null.
+    """
+    supersedingCampaignSpec: CampaignSpec
+
+    """
+    The code host connections required for applying this spec. Includes the credentials of the current user.
+    """
+    viewerCampaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only returns the code hosts for which the viewer doesn't have credentials.
+        """
+        onlyWithoutCredential: Boolean = false
+    ): CampaignsCodeHostConnection!
+}
+
+extend type Mutation {
+    """
+    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
+    campaign is returned.
+    If a campaign in the same namespace with the same name already exists, an error with the error code
+    ErrMatchingCampaignExists is returned.
+    """
+    createCampaign(
+        """
+        The campaign spec that describes the desired state of the campaign.
+        """
+        campaignSpec: ID!
+    ): Campaign!
+
+    """
+    Create or update a campaign from a campaign spec and locally computed changeset specs. If no
+    campaign exists in the namespace with the name given in the campaign spec, a campaign will be
+    created. Otherwise, the existing campaign will be updated. The campaign is returned.
+    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
+    will be returned.
+    """
+    applyCampaign(
+        """
+        The campaign spec that describes the new desired state of the campaign.
+        """
+        campaignSpec: ID!
+
+        """
+        If set, return an error if the campaign identified using the namespace and campaignSpec
+        parameters does not match the campaign with this ID. This lets callers use a stable ID
+        that refers to a specific campaign during an edit session (and is not susceptible to
+        conflicts if the underlying campaign is moved to a different namespace, renamed, or
+        deleted). The returned error has the error code ErrEnsureCampaignFailed.
+        """
+        ensureCampaign: ID
+    ): Campaign!
+
+    """
+    Move a campaign to a different namespace, or rename it in the current namespace.
+    """
+    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
+
+    """
+    Close a campaign.
+    """
+    closeCampaign(
+        campaign: ID!
+        """
+        Whether to close the changesets associated with this campaign on their respective code
+        hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
+        GitHub and "declined" on Bitbucket Server).
+        """
+        closeChangesets: Boolean = false
+    ): Campaign!
+
+    """
+    Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
+    campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
+    """
+    deleteCampaign(campaign: ID!): EmptyResponse
+
+    """
+    Upload a changeset spec that will be used in a future update to a campaign. The changeset spec
+    is stored and can be referenced by its ID in the applyCampaign mutation. Just uploading the
+    changeset spec does not result in changes to the campaign or any of its changesets; you need
+    to call applyCampaign to use it.
+
+    You can use this mutation to upload large changeset specs (e.g., containing large diffs) in
+    individual HTTP requests. Then, in the eventual applyCampaign call, you just refer to the
+    changeset specs by their IDs. This lets you avoid problems when updating large campaigns where
+    a large HTTP request body (e.g., with many large diffs in the changeset specs) would be
+    rejected by the web server/proxy or would be very slow.
+
+    The returned ChangesetSpec is immutable and expires after a certain period of time (if not
+    used in a call to applyCampaign), which can be queried on ChangesetSpec.expiresAt.
+    """
+    createChangesetSpec(
+        """
+        The raw changeset spec (as JSON). See
+        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/changeset_spec.schema.json
+        for the JSON Schema that describes the structure of this input.
+        """
+        changesetSpec: String!
+    ): ChangesetSpec!
+
+    """
+    Create a campaign spec that will be used to create a campaign (with the createCampaign
+    mutation), or to update a campaign (with the applyCampaign mutation).
+
+    The returned CampaignSpec is immutable and expires after a certain period of time (if not used
+    in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
+
+    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
+    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
+    """
+    createCampaignSpec(
+        """
+        The namespace (either a user or organization). A campaign spec can only be applied to (or
+        used to create) campaigns in this namespace.
+        """
+        namespace: ID!
+
+        """
+        The campaign spec as YAML (or the equivalent JSON). See
+        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/campaign_spec.schema.json
+        for the JSON Schema that describes the structure of this input.
+        """
+        campaignSpec: String!
+
+        """
+        Changeset specs that were locally computed and then uploaded using createChangesetSpec.
+        """
+        changesetSpecs: [ID!]!
+    ): CampaignSpec!
+
+    """
+    Enqueue the given changeset for high-priority syncing.
+    """
+    syncChangeset(changeset: ID!): EmptyResponse!
+
+    """
+    Re-enqueue the changeset for processing by the reconciler. The changeset must be in FAILED state.
+    """
+    reenqueueChangeset(changeset: ID!): Changeset!
+
+    """
+    Create a new credential for the given user for the given code host.
+    If another token for that code host already exists, an error with the error code
+    ErrDuplicateCredential is returned.
+    """
+    createCampaignsCredential(
+        """
+        The user for which to create the credential.
+        """
+        user: ID!
+
+        """
+        The kind of external service being configured.
+        """
+        externalServiceKind: ExternalServiceKind!
+
+        """
+        The URL of the external service being configured.
+        """
+        externalServiceURL: String!
+
+        """
+        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
+        """
+        credential: String!
+    ): CampaignsCredential!
+
+    """
+    Hard-deletes a given campaigns credential.
+    """
+    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
+}
+
+extend type Org {
+    """
+    A list of campaigns initially applied in this organization.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+}
+
+extend type User {
+    """
+    A list of campaigns applied under this user's namespace.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+
+    """
+    Returns a connection of configured external services accessible by this user, for usage with campaigns.
+    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
+    connected to CampaignCredential resources, if one has been created for the code host connection before.
+    """
+    campaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): CampaignsCodeHostConnection!
+}
+
+extend type Query {
+    """
+    A list of campaigns.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+    """
+    Looks up a campaign by namespace and campaign name.
+    """
+    campaign(
+        """
+        The namespace where the campaign lives.
+        """
+        namespace: ID!
+        """
+        The campaigns name.
+        """
+        name: String!
+    ): Campaign
+}
+
+############################################################################################
+#                                                                                          #
+#                                 End campaigns schema                                     #
+#                                                                                          #
+############################################################################################


### PR DESCRIPTION
Using the extend keyword, we can make it so all campaigns resolvers are in one place in this file. This should make it easier for us to split it up in three sections as a follow-up:
- Deprecated
- New
- Untouched
and in the future, we can simply cut out the deprecated section. Therefore, we can make use of the fact that extend can be used multiple times.
