### PR TITLE
web: refactor ErrorMessage to use useHistory hook instead of prop

### DIFF
--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -128,11 +128,7 @@ export class ApiConsole extends React.PureComponent<Props, State> {
                         <LoadingSpinner className="icon-inline" /> Loading…
                     </span>
                 ) : isErrorLike(this.state.graphiqlOrError) ? (
-                    <ErrorAlert
-                        prefix="Error loading API console"
-                        error={this.state.graphiqlOrError}
-                        history={this.props.history}
-                    />
+                    <ErrorAlert prefix="Error loading API console" error={this.state.graphiqlOrError} />
                 ) : (
                     this.renderGraphiQL()
                 )}

--- a/client/web/src/auth/ResetPasswordPage.tsx
+++ b/client/web/src/auth/ResetPasswordPage.tsx
@@ -54,7 +54,7 @@ class ResetPasswordInitForm extends React.PureComponent<ResetPasswordInitFormPro
         return (
             <>
                 {isErrorLike(this.state.submitOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.submitOrError} history={this.props.history} />
+                    <ErrorAlert className="mt-2" error={this.state.submitOrError} />
                 )}
                 <Form
                     className="reset-password-page__form signin-signup-form border rounded p-4 mb-3"
@@ -168,7 +168,7 @@ class ResetPasswordCodeForm extends React.PureComponent<ResetPasswordCodeFormPro
         return (
             <>
                 {isErrorLike(this.state.submitOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.submitOrError} history={this.props.history} />
+                    <ErrorAlert className="mt-2" error={this.state.submitOrError} />
                 )}
                 <Form
                     className="reset-password-page__form signin-signup-form border rounded p-4 mb-3"

--- a/client/web/src/auth/SignInPage.tsx
+++ b/client/web/src/auth/SignInPage.tsx
@@ -47,9 +47,7 @@ export const SignInPage: React.FunctionComponent<SignInPageProps> = props => {
             </div>
         ) : (
             <div className="mb-4 signin-page__container pb-5">
-                {error && (
-                    <ErrorAlert className="mt-4 mb-0 text-left" error={error} icon={false} history={props.history} />
-                )}
+                {error && <ErrorAlert className="mt-4 mb-0 text-left" error={error} icon={false} />}
                 <div
                     className={classNames(
                         'signin-signup-form signin-form test-signin-form rounded p-4 my-3',

--- a/client/web/src/auth/SignUpForm.tsx
+++ b/client/web/src/auth/SignUpForm.tsx
@@ -6,7 +6,6 @@ import { enterpriseTrial, signupTerms } from '../util/features'
 import { EmailInput, PasswordInput, UsernameInput } from './SignInSignUpCommon'
 import { ErrorAlert } from '../components/alerts'
 import classNames from 'classnames'
-import * as H from 'history'
 import { OrDivider } from './OrDivider'
 import GithubIcon from 'mdi-react/GithubIcon'
 import { Observable, of } from 'rxjs'
@@ -38,7 +37,6 @@ interface SignUpFormProps {
     doSignUp: (args: SignUpArguments) => Promise<void>
 
     buttonLabel?: string
-    history: H.History
     context: Pick<SourcegraphContext, 'authProviders' | 'sourcegraphDotComMode'>
 }
 
@@ -47,13 +45,7 @@ const preventDefault = (event: React.FormEvent): void => event.preventDefault()
 /**
  * The form for creating an account
  */
-export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
-    doSignUp,
-    history,
-    buttonLabel,
-    className,
-    context,
-}) => {
+export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({ doSignUp, buttonLabel, className, context }) => {
     const [loading, setLoading] = useState(false)
     const [requestedTrial, setRequestedTrial] = useState(false)
     const [error, setError] = useState<Error | null>(null)
@@ -121,7 +113,7 @@ export const SignUpForm: React.FunctionComponent<SignUpFormProps> = ({
 
     return (
         <>
-            {error && <ErrorAlert className="mt-4 mb-0" error={error} history={history} />}
+            {error && <ErrorAlert className="mt-4 mb-0" error={error} />}
             {/* Using  <form /> to set 'valid' + 'is-invaild' at the input level */}
             {/* eslint-disable-next-line react/forbid-elements */}
             <form

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -880,7 +880,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                     <div className="alert alert-danger filtered-connection__error">
                         {errors.map((error, index) => (
                             <React.Fragment key={index}>
-                                <ErrorMessage error={error} history={this.props.history} />
+                                <ErrorMessage error={error} />
                             </React.Fragment>
                         ))}
                     </div>

--- a/client/web/src/components/alerts.test.tsx
+++ b/client/web/src/components/alerts.test.tsx
@@ -1,40 +1,23 @@
 import renderer from 'react-test-renderer'
 import { ErrorAlert } from './alerts'
 import React from 'react'
-import { createMemoryHistory } from 'history'
 
 jest.mock('mdi-react/AlertCircleIcon', () => 'AlertCircleIcon')
 
 describe('ErrorAlert', () => {
     it('should render an Error object as an alert', () => {
-        expect(
-            renderer
-                .create(<ErrorAlert error={new Error('an error happened')} history={createMemoryHistory()} />)
-                .toJSON()
-        ).toMatchSnapshot()
+        expect(renderer.create(<ErrorAlert error={new Error('an error happened')} />).toJSON()).toMatchSnapshot()
     })
 
     it('should add a prefix if given', () => {
         expect(
-            renderer
-                .create(
-                    <ErrorAlert
-                        error={new Error('an error happened')}
-                        prefix="An error happened"
-                        history={createMemoryHistory()}
-                    />
-                )
-                .toJSON()
+            renderer.create(<ErrorAlert error={new Error('an error happened')} prefix="An error happened" />).toJSON()
         ).toMatchSnapshot()
     })
 
     it('should omit the icon if icon={false}', () => {
         expect(
-            renderer
-                .create(
-                    <ErrorAlert error={new Error('an error happened')} icon={false} history={createMemoryHistory()} />
-                )
-                .toJSON()
+            renderer.create(<ErrorAlert error={new Error('an error happened')} icon={false} />).toJSON()
         ).toMatchSnapshot()
     })
 
@@ -48,7 +31,6 @@ describe('ErrorAlert', () => {
                                 '- Additional property asdasd is not allowed\n- projectQuery.0: String length must be greater than or equal to 1\n'
                             )
                         }
-                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()

--- a/client/web/src/components/alerts.tsx
+++ b/client/web/src/components/alerts.tsx
@@ -5,7 +5,7 @@ import { upperFirst } from 'lodash'
 import { Markdown } from '../../../shared/src/components/Markdown'
 import { renderMarkdown } from '../../../shared/src/util/markdown'
 import classNames from 'classnames'
-import * as H from 'history'
+import { useHistory } from 'react-router'
 
 const renderError = (error: unknown): string =>
     renderMarkdown(upperFirst((asError(error).message || 'Unknown Error').replace(/\t/g, '')), { breaks: true })
@@ -13,9 +13,11 @@ const renderError = (error: unknown): string =>
         .replace(/^<p>/, '')
         .replace(/<\/p>$/, '')
 
-export const ErrorMessage: React.FunctionComponent<{ error: unknown; history: H.History }> = ({ error, history }) => (
-    <Markdown wrapper="span" dangerousInnerHTML={renderError(error)} history={history} />
-)
+export const ErrorMessage: React.FunctionComponent<{ error: unknown }> = ({ error }) => {
+    const history = useHistory()
+
+    return <Markdown wrapper="span" dangerousInnerHTML={renderError(error)} history={history} />
+}
 
 /**
  * Renders a given `Error` object in a Bootstrap danger alert.
@@ -44,13 +46,12 @@ export const ErrorAlert: React.FunctionComponent<{
 
     className?: string
     style?: React.CSSProperties
-    history: H.History
-}> = ({ error, className, icon = true, prefix, history, ...rest }) => {
+}> = ({ error, className, icon = true, prefix, ...rest }) => {
     prefix = prefix?.trim().replace(/:+$/, '')
     return (
         <div className={classNames('alert', 'alert-danger', className)} {...rest}>
             {icon && <AlertCircleIcon className="icon icon-inline" />} {prefix && <strong>{prefix}:</strong>}{' '}
-            <ErrorMessage error={error} history={history} />
+            <ErrorMessage error={error} />
         </div>
     )
 }

--- a/client/web/src/components/externalServices/ExternalServiceForm.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceForm.tsx
@@ -59,11 +59,11 @@ export const ExternalServiceForm: React.FunctionComponent<Props> = ({
     )
     return (
         <Form className="external-service-form" onSubmit={onSubmit}>
-            {error && <ErrorAlert error={error} history={history} />}
+            {error && <ErrorAlert error={error} />}
             {warning && (
                 <div className="alert alert-warning">
                     <h4>Warning</h4>
-                    <ErrorMessage error={warning} history={history} />
+                    <ErrorMessage error={warning} />
                 </div>
             )}
             {hideDisplayNameField || (

--- a/client/web/src/components/externalServices/ExternalServiceNode.tsx
+++ b/client/web/src/components/externalServices/ExternalServiceNode.tsx
@@ -65,7 +65,7 @@ export const ExternalServiceNode: React.FunctionComponent<ExternalServiceNodePro
                     </button>
                 </div>
             </div>
-            {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} history={history} />}
+            {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} />}
         </li>
     )
 }

--- a/client/web/src/components/externalServices/ExternalServicePage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.tsx
@@ -126,9 +126,7 @@ export const ExternalServicePage: React.FunctionComponent<Props> = ({
             )}
             <h2>Update synced repositories</h2>
             {externalServiceOrError === undefined && <LoadingSpinner className="icon-inline" />}
-            {isErrorLike(externalServiceOrError) && (
-                <ErrorAlert className="mb-3" error={externalServiceOrError} history={history} />
-            )}
+            {isErrorLike(externalServiceOrError) && <ErrorAlert className="mb-3" error={externalServiceOrError} />}
             {externalServiceCategory && (
                 <div className="mb-3">
                     <ExternalServiceCard {...externalServiceCategory} />

--- a/client/web/src/enterprise/campaigns/close/CampaignCloseAlert.tsx
+++ b/client/web/src/enterprise/campaigns/close/CampaignCloseAlert.tsx
@@ -104,7 +104,7 @@ export const CampaignCloseAlert: React.FunctionComponent<CampaignCloseAlertProps
                     </div>
                 </div>
             </div>
-            {isErrorLike(isClosing) && <ErrorAlert error={isClosing} history={history} />}
+            {isErrorLike(isClosing) && <ErrorAlert error={isClosing} />}
         </>
     )
 }

--- a/client/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.tsx
+++ b/client/web/src/enterprise/campaigns/close/ExternalChangesetCloseNode.tsx
@@ -104,7 +104,7 @@ export const ExternalChangesetCloseNode: React.FunctionComponent<ExternalChanges
             </button>
             {isExpanded && (
                 <div className="external-changeset-close-node__expanded-section p-2">
-                    {node.error && <ErrorAlert error={node.error} history={history} />}
+                    {node.error && <ErrorAlert error={node.error} />}
                     <ChangesetFileDiff
                         changesetID={node.id}
                         isLightTheme={isLightTheme}

--- a/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/campaigns/detail/changesets/ExternalChangesetNode.tsx
@@ -145,15 +145,14 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                                     node={node}
                                     setNode={setNode}
                                     viewerCanAdminister={viewerCanAdminister}
-                                    history={history}
                                 />
                             )}
                             {node.currentSpec?.type === ChangesetSpecType.BRANCH && (
                                 <DownloadDiffButton changesetID={node.id} />
                             )}
                         </div>
-                        {node.syncerError && <SyncerError syncerError={node.syncerError} history={history} />}
-                        <ChangesetError node={node} history={history} />
+                        {node.syncerError && <SyncerError syncerError={node.syncerError} />}
+                        <ChangesetError node={node} />
                         <ChangesetFileDiff
                             changesetID={node.id}
                             isLightTheme={isLightTheme}
@@ -172,16 +171,13 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
     )
 }
 
-const SyncerError: React.FunctionComponent<{ syncerError: string; history: H.History }> = ({
-    syncerError,
-    history,
-}) => (
+const SyncerError: React.FunctionComponent<{ syncerError: string }> = ({ syncerError }) => (
     <div className="alert alert-danger" role="alert">
         <h4 className="alert-heading">
             <AlertCircleIcon className="icon icon-inline" /> Encountered error during last attempt to sync changeset
             data from code host
         </h4>
-        <ErrorMessage error={syncerError} history={history} />
+        <ErrorMessage error={syncerError} />
         <hr className="my-2" />
         <p className="mb-0">
             <small>This might be an ephemeral error that resolves itself at the next sync.</small>
@@ -191,8 +187,7 @@ const SyncerError: React.FunctionComponent<{ syncerError: string; history: H.His
 
 const ChangesetError: React.FunctionComponent<{
     node: ExternalChangesetFields
-    history: H.History
-}> = ({ node, history }) => {
+}> = ({ node }) => {
     if (!node.error) {
         return null
     }
@@ -202,7 +197,7 @@ const ChangesetError: React.FunctionComponent<{
             <h4 className="alert-heading">
                 <AlertCircleIcon className="icon icon-inline" /> Failed to run operations on changeset
             </h4>
-            <ErrorMessage error={node.error} history={history} />
+            <ErrorMessage error={node.error} />
         </div>
     )
 }
@@ -211,8 +206,7 @@ const RetryChangesetButton: React.FunctionComponent<{
     node: ExternalChangesetFields
     setNode: (node: ExternalChangesetFields) => void
     viewerCanAdminister: boolean
-    history: H.History
-}> = ({ node, setNode, history }) => {
+}> = ({ node, setNode }) => {
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
     const onRetry = useCallback(async () => {
         setIsLoading(true)
@@ -229,9 +223,7 @@ const RetryChangesetButton: React.FunctionComponent<{
     }, [node.id, setNode])
     return (
         <>
-            {isErrorLike(isLoading) && (
-                <ErrorAlert error={isLoading} prefix="Error re-enqueueing changeset" history={history} />
-            )}
+            {isErrorLike(isLoading) && <ErrorAlert error={isLoading} prefix="Error re-enqueueing changeset" />}
             <button className="btn btn-link mb-1" type="button" onClick={onRetry} disabled={isLoading === true}>
                 <SyncIcon
                     className={classNames(

--- a/client/web/src/enterprise/campaigns/preview/CreateUpdateCampaignAlert.tsx
+++ b/client/web/src/enterprise/campaigns/preview/CreateUpdateCampaignAlert.tsx
@@ -78,7 +78,7 @@ export const CreateUpdateCampaignAlert: React.FunctionComponent<CreateUpdateCamp
                     </button>
                 </div>
             </div>
-            {isErrorLike(isLoading) && <ErrorAlert error={isLoading} history={history} />}
+            {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
         </>
     )
 }

--- a/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/AddCredentialModal.tsx
@@ -119,7 +119,7 @@ export const AddCredentialModal: React.FunctionComponent<AddCredentialModalProps
                 <h3 id={labelId}>
                     {modalTitles[externalServiceKind]} campaigns token for {externalServiceURL}
                 </h3>
-                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} history={history} />}
+                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
                 <Form onSubmit={onSubmit}>
                     <div className="form-group">
                         <label htmlFor="token">Personal access token</label>

--- a/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/campaigns/settings/CodeHostConnectionNode.tsx
@@ -88,7 +88,6 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                 <RemoveCredentialModal
                     onCancel={onCancel}
                     afterDelete={afterAction}
-                    history={history}
                     credentialID={node.credential!.id}
                 />
             )}

--- a/client/web/src/enterprise/campaigns/settings/RemoveCredentialModal.tsx
+++ b/client/web/src/enterprise/campaigns/settings/RemoveCredentialModal.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useState } from 'react'
-import * as H from 'history'
 import Dialog from '@reach/dialog'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
@@ -12,15 +11,12 @@ export interface RemoveCredentialModalProps {
 
     onCancel: () => void
     afterDelete: () => void
-
-    history: H.History
 }
 
 export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModalProps> = ({
     credentialID,
     onCancel,
     afterDelete,
-    history,
 }) => {
     const labelId = 'removeCredential'
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
@@ -44,7 +40,7 @@ export const RemoveCredentialModal: React.FunctionComponent<RemoveCredentialModa
                     Remove campaigns token?
                 </h3>
 
-                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} history={history} />}
+                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
 
                 <p>You will not be able to create changesets on this code host if this token is removed.</p>
 

--- a/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.tsx
+++ b/client/web/src/enterprise/codeintel/configuration/CodeIntelIndexConfigurationPage.tsx
@@ -102,7 +102,7 @@ export const CodeIntelIndexConfigurationPage: FunctionComponent<CodeIntelIndexCo
     }
 
     return fetchError ? (
-        <ErrorAlert prefix="Error fetching index configuration" error={fetchError} history={history} />
+        <ErrorAlert prefix="Error fetching index configuration" error={fetchError} />
     ) : (
         <div className="code-intel-index-configuration web-content">
             <PageTitle title="Precise code intelligence index configuration" />
@@ -115,7 +115,7 @@ export const CodeIntelIndexConfigurationPage: FunctionComponent<CodeIntelIndexCo
                 .
             </p>
 
-            {saveError && <ErrorAlert prefix="Error saving index configuration" error={saveError} history={history} />}
+            {saveError && <ErrorAlert prefix="Error saving index configuration" error={saveError} />}
 
             <DynamicallyImportedMonacoSettingsEditor
                 value={configuration || ''}

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelIndexPage.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelIndexPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import * as H from 'history'
 import DeleteIcon from 'mdi-react/DeleteIcon'
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
@@ -23,7 +22,6 @@ export interface CodeIntelIndexPageProps extends RouteComponentProps<{ id: strin
     now?: () => Date
     /** Scheduler for the refresh timer */
     scheduler?: SchedulerLike
-    history: H.History
 }
 
 const REFRESH_INTERVAL_MS = 5000
@@ -38,7 +36,6 @@ export const CodeIntelIndexPage: FunctionComponent<CodeIntelIndexPageProps> = ({
     match: {
         params: { id },
     },
-    history,
     telemetryService,
     fetchLsifIndex = defaultFetchLsifIndex,
     now,
@@ -85,12 +82,12 @@ export const CodeIntelIndexPage: FunctionComponent<CodeIntelIndexPageProps> = ({
     return deletionOrError === 'deleted' ? (
         <Redirect to="." />
     ) : isErrorLike(deletionOrError) ? (
-        <ErrorAlert prefix="Error deleting LSIF index record" error={deletionOrError} history={history} />
+        <ErrorAlert prefix="Error deleting LSIF index record" error={deletionOrError} />
     ) : (
         <div className="site-admin-lsif-index-page w-100 web-content">
             <PageTitle title="Code intelligence - auto-indexing" />
             {isErrorLike(indexOrError) ? (
-                <ErrorAlert prefix="Error loading LSIF index" error={indexOrError} history={history} />
+                <ErrorAlert prefix="Error loading LSIF index" error={indexOrError} />
             ) : !indexOrError ? (
                 <LoadingSpinner className="icon-inline" />
             ) : (
@@ -119,7 +116,6 @@ export const CodeIntelIndexPage: FunctionComponent<CodeIntelIndexPageProps> = ({
                         failure={indexOrError.failure}
                         typeName="index"
                         pluralTypeName="indexes"
-                        history={history}
                         className={classNamesByState.get(indexOrError.state)}
                     />
                     <div className="card mb-3">

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
@@ -1,5 +1,4 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import * as H from 'history'
 import DeleteIcon from 'mdi-react/DeleteIcon'
 import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 import React, { FunctionComponent, useCallback, useEffect, useMemo, useState } from 'react'
@@ -24,7 +23,6 @@ export interface CodeIntelUploadPageProps extends RouteComponentProps<{ id: stri
     now?: () => Date
     /** Scheduler for the refresh timer */
     scheduler?: SchedulerLike
-    history: H.History
 }
 
 const REFRESH_INTERVAL_MS = 5000
@@ -39,7 +37,6 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
     match: {
         params: { id },
     },
-    history,
     fetchLsifUpload = defaultFetchUpload,
     telemetryService,
     now,
@@ -91,12 +88,12 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
     return deletionOrError === 'deleted' ? (
         <Redirect to="." />
     ) : isErrorLike(deletionOrError) ? (
-        <ErrorAlert prefix="Error deleting LSIF upload" error={deletionOrError} history={history} />
+        <ErrorAlert prefix="Error deleting LSIF upload" error={deletionOrError} />
     ) : (
         <div className="site-admin-lsif-upload-page w-100 web-content">
             <PageTitle title="Code intelligence - uploads" />
             {isErrorLike(uploadOrError) ? (
-                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} history={history} />
+                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} />
             ) : !uploadOrError ? (
                 <LoadingSpinner className="icon-inline" />
             ) : (
@@ -135,7 +132,6 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                         failure={uploadOrError.failure}
                         typeName="upload"
                         pluralTypeName="uploads"
-                        history={history}
                         className={classNamesByState.get(uploadOrError.state)}
                     />
                     {uploadOrError.isLatestForRepo && (

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelStateBanner.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelStateBanner.tsx
@@ -1,5 +1,4 @@
 import classNames from 'classnames'
-import * as H from 'history'
 import React, { FunctionComponent } from 'react'
 import { LSIFIndexState, LSIFUploadState } from '../../../graphql-operations'
 import { CodeIntelStateDescription } from './CodeIntelStateDescription'
@@ -12,7 +11,6 @@ export interface CodeIntelStateBannerProps {
     placeInQueue?: number | null
     failure?: string | null
     className?: string
-    history: H.History
 }
 
 export const CodeIntelStateBanner: FunctionComponent<CodeIntelStateBannerProps> = ({
@@ -22,7 +20,6 @@ export const CodeIntelStateBanner: FunctionComponent<CodeIntelStateBannerProps> 
     placeInQueue,
     failure,
     className = 'alert-primary',
-    history,
 }) => (
     <div className={classNames('alert', className)}>
         <span className="icon-inline">
@@ -35,7 +32,6 @@ export const CodeIntelStateBanner: FunctionComponent<CodeIntelStateBannerProps> 
                 failure={failure}
                 typeName={typeName}
                 pluralTypeName={pluralTypeName}
-                history={history}
             />
         </span>
     </div>

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelStateDescription.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelStateDescription.tsx
@@ -1,4 +1,3 @@
-import * as H from 'history'
 import { upperFirst } from 'lodash'
 import React, { FunctionComponent } from 'react'
 import { ErrorMessage } from '../../../components/alerts'
@@ -11,7 +10,6 @@ export interface CodeIntelStateDescriptionProps {
     placeInQueue?: number | null
     failure?: string | null
     className?: string
-    history: H.History
 }
 
 export const CodeIntelStateDescription: FunctionComponent<CodeIntelStateDescriptionProps> = ({
@@ -21,7 +19,6 @@ export const CodeIntelStateDescription: FunctionComponent<CodeIntelStateDescript
     placeInQueue,
     failure,
     className,
-    history,
 }) =>
     state === LSIFUploadState.UPLOADING ? (
         <span className={className}>Still uploading...</span>
@@ -36,7 +33,7 @@ export const CodeIntelStateDescription: FunctionComponent<CodeIntelStateDescript
         <span className={className}>{upperFirst(typeName)} processed successfully.</span>
     ) : state === LSIFUploadState.ERRORED || state === LSIFIndexState.ERRORED ? (
         <span className={className}>
-            {upperFirst(typeName)} failed to complete: <ErrorMessage error={failure} history={history} />
+            {upperFirst(typeName)} failed to complete: <ErrorMessage error={failure} />
         </span>
     ) : (
         <></>

--- a/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.test.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.test.tsx
@@ -3,7 +3,6 @@ import * as GQL from '../../../../../shared/src/graphql/schema'
 import renderer, { act } from 'react-test-renderer'
 import { ProductPlanFormControl } from './ProductPlanFormControl'
 import { of } from 'rxjs'
-import { createMemoryHistory } from 'history'
 
 jest.mock('./ProductPlanPrice', () => ({
     ProductPlanPrice: 'ProductPlanPrice',
@@ -47,7 +46,6 @@ describe('ProductPlanFormControl', () => {
                         },
                     ])
                 }
-                history={createMemoryHistory()}
             />
         )
         act(() => undefined)

--- a/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
+++ b/client/web/src/enterprise/dotcom/productPlans/ProductPlanFormControl.tsx
@@ -9,7 +9,6 @@ import { queryGraphQL } from '../../../backend/graphql'
 import { ProductPlanPrice } from './ProductPlanPrice'
 import { ErrorAlert } from '../../../components/alerts'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
-import * as H from 'history'
 
 interface Props {
     /** The selected plan's billing ID. */
@@ -20,7 +19,6 @@ interface Props {
 
     disabled?: boolean
     className?: string
-    history: H.History
 
     /** For mocking in tests only. */
     _queryProductPlans?: typeof queryProductPlans
@@ -36,7 +34,6 @@ export const ProductPlanFormControl: React.FunctionComponent<Props> = ({
     onChange,
     disabled,
     className = '',
-    history,
     _queryProductPlans = queryProductPlans,
 }) => {
     const noPlanSelected = value === null // don't recompute observable below on every value change
@@ -76,7 +73,7 @@ export const ProductPlanFormControl: React.FunctionComponent<Props> = ({
             {plans === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(plans) ? (
-                <ErrorAlert error={plans.message} history={history} />
+                <ErrorAlert error={plans.message} />
             ) : (
                 <>
                     <div className="list-group">

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionForm.tsx
@@ -7,7 +7,6 @@ import {
     RegistryPublisher,
 } from '../../../extensions/extension/extension'
 import { ErrorAlert } from '../../../components/alerts'
-import * as H from 'history'
 import { Scalars } from '../../../../../shared/src/graphql-operations'
 
 export const RegistryPublisherFormGroup: React.FunctionComponent<{
@@ -21,12 +20,11 @@ export const RegistryPublisherFormGroup: React.FunctionComponent<{
 
     disabled?: boolean
     onChange?: React.FormEventHandler<HTMLSelectElement>
-    history: H.History
-}> = ({ className = '', value, publishersOrError, disabled, onChange, history }) => (
+}> = ({ className = '', value, publishersOrError, disabled, onChange }) => (
     <div className={`form-group ${className}`}>
         <label htmlFor="extension-registry-create-extension-page__publisher">Publisher</label>
         {isErrorLike(publishersOrError) ? (
-            <ErrorAlert error={publishersOrError} history={history} />
+            <ErrorAlert error={publishersOrError} />
         ) : (
             <select
                 id="extension-registry-create-extension-page__publisher"

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionManagePage.tsx
@@ -155,7 +155,6 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                             value={publisher.id}
                             publishersOrError={[publisher]}
                             disabled={true}
-                            history={this.props.history}
                         />
                         <RegistryExtensionNameFormGroup
                             className="registry-extension-manage-page__input"
@@ -185,9 +184,7 @@ export const RegistryExtensionManagePage = withAuthenticatedUser(
                             )}
                         </button>
                     </Form>
-                    {isErrorLike(this.state.updateOrError) && (
-                        <ErrorAlert error={this.state.updateOrError} history={this.props.history} />
-                    )}
+                    {isErrorLike(this.state.updateOrError) && <ErrorAlert error={this.state.updateOrError} />}
                     <div className="card mt-5 registry-extension-manage-page__other-actions">
                         <div className="card-header">Other actions</div>
                         <div className="card-body">

--- a/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
+++ b/client/web/src/enterprise/extensions/extension/RegistryExtensionNewReleasePage.tsx
@@ -180,7 +180,7 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
                                                 <LoadingSpinner className="icon-inline" />
                                             </div>
                                         ) : isErrorLike(bundleOrError) ? (
-                                            <ErrorAlert error={bundleOrError} history={history} />
+                                            <ErrorAlert error={bundleOrError} />
                                         ) : (
                                             <DynamicallyImportedMonacoSettingsEditor
                                                 id="registry-extension-new-release-page__bundle"
@@ -218,7 +218,7 @@ export const RegistryExtensionNewReleasePage = withAuthenticatedUser<Props>(
                                         </span>
                                     ))}
                             </div>
-                            {isErrorLike(updateOrError) && <ErrorAlert error={updateOrError} history={history} />}
+                            {isErrorLike(updateOrError) && <ErrorAlert error={updateOrError} />}
                         </Form>
                     </>
                 ) : (

--- a/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryNewExtensionPage.tsx
@@ -182,7 +182,6 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                                 publishersOrError={this.state.publishersOrError}
                                 onChange={this.onPublisherChange}
                                 disabled={this.state.creationOrError === 'loading'}
-                                history={this.props.history}
                             />
                             <RegistryExtensionNameFormGroup
                                 value={this.state.name}
@@ -223,11 +222,7 @@ export const RegistryNewExtensionPage = withAuthenticatedUser(
                             </button>
                         </Form>
                         {isErrorLike(this.state.creationOrError) && (
-                            <ErrorAlert
-                                className="mt-3"
-                                error={this.state.creationOrError}
-                                history={this.props.history}
-                            />
+                            <ErrorAlert className="mt-3" error={this.state.creationOrError} />
                         )}
                     </ModalPage>
                 </>

--- a/client/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminExternalAccountsPage.tsx
@@ -45,7 +45,6 @@ export class SiteAdminExternalAccountsPage extends React.Component<Props> {
         const nodeProps: Omit<ExternalAccountNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateExternalAccount,
             showUser: true,
-            history: this.props.history,
         }
 
         return (

--- a/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminLsifUploadPage.tsx
@@ -15,7 +15,6 @@ interface Props extends RouteComponentProps<{ id: string }> {}
  * A page displaying metadata about an LSIF upload.
  */
 export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
-    history,
     match: {
         params: { id },
     },
@@ -32,13 +31,9 @@ export const SiteAdminLsifUploadPage: FunctionComponent<Props> = ({
             {!uploadOrError ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(uploadOrError) ? (
-                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} history={history} />
+                <ErrorAlert prefix="Error loading LSIF upload" error={uploadOrError} />
             ) : !uploadOrError.projectRoot ? (
-                <ErrorAlert
-                    prefix="Error loading LSIF upload"
-                    error={{ message: 'Cannot resolve project root' }}
-                    history={history}
-                />
+                <ErrorAlert prefix="Error loading LSIF upload" error={{ message: 'Cannot resolve project root' }} />
             ) : (
                 <Redirect
                     to={`${uploadOrError.projectRoot.repository.url}/-/settings/code-intelligence/lsif-uploads/${id}`}

--- a/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
+++ b/client/web/src/enterprise/site-admin/SiteAdminRegistryExtensionsPage.tsx
@@ -123,7 +123,7 @@ class RegistryExtensionNodeSiteAdminRow extends React.PureComponent<
                     </div>
                 </div>
                 {isErrorLike(this.state.deletionOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.deletionOrError} history={this.props.history} />
+                    <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
                 )}
             </li>
         )

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { SiteAdminGenerateProductLicenseForSubscriptionForm } from './SiteAdminGenerateProductLicenseForSubscriptionForm'
-import { createMemoryHistory } from 'history'
 
 describe('SiteAdminGenerateProductLicenseForSubscriptionForm', () => {
     test('renders', () => {
@@ -11,7 +10,6 @@ describe('SiteAdminGenerateProductLicenseForSubscriptionForm', () => {
                     <SiteAdminGenerateProductLicenseForSubscriptionForm
                         subscriptionID="s"
                         onGenerate={() => undefined}
-                        history={createMemoryHistory()}
                     />
                 )
                 .toJSON()

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminGenerateProductLicenseForSubscriptionForm.tsx
@@ -11,13 +11,11 @@ import { Form } from '../../../../../../branded/src/components/Form'
 import { ExpirationDate } from '../../../productSubscription/ExpirationDate'
 import { ErrorAlert } from '../../../../components/alerts'
 import { useEventObservable } from '../../../../../../shared/src/util/useObservable'
-import * as H from 'history'
 import { Scalars } from '../../../../../../shared/src/graphql-operations'
 
 interface Props {
     subscriptionID: Scalars['ID']
     onGenerate: () => void
-    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -54,7 +52,6 @@ const DURATION_LINKS = [
 export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionComponent<Props> = ({
     subscriptionID,
     onGenerate,
-    history,
 }) => {
     const [formData, setFormData] = useState<FormData>(EMPTY_FORM_DATA)
 
@@ -227,7 +224,7 @@ export const SiteAdminGenerateProductLicenseForSubscriptionForm: React.FunctionC
                     </button>
                 </Form>
             )}
-            {isErrorLike(creation) && <ErrorAlert className="mt-3" error={creation} history={history} />}
+            {isErrorLike(creation) && <ErrorAlert className="mt-3" error={creation} />}
         </div>
     )
 }

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/SiteAdminProductSubscriptionPage.tsx
@@ -138,7 +138,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<Props> = 
             {productSubscription === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(productSubscription) ? (
-                <ErrorAlert className="my-2" error={productSubscription} history={history} />
+                <ErrorAlert className="my-2" error={productSubscription} />
             ) : (
                 <>
                     <h2>Product subscription {productSubscription.name}</h2>
@@ -151,7 +151,7 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<Props> = 
                         >
                             Archive
                         </button>
-                        {isErrorLike(archival) && <ErrorAlert className="mt-2" error={archival} history={history} />}
+                        {isErrorLike(archival) && <ErrorAlert className="mt-2" error={archival} />}
                     </div>
                     <div className="card mt-3">
                         <div className="card-header">Details</div>
@@ -219,7 +219,6 @@ export const SiteAdminProductSubscriptionPage: React.FunctionComponent<Props> = 
                                 <SiteAdminGenerateProductLicenseForSubscriptionForm
                                     subscriptionID={productSubscription.id}
                                     onGenerate={onLicenseUpdate}
-                                    history={history}
                                 />
                             </div>
                         )}

--- a/client/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
+++ b/client/web/src/enterprise/site-admin/productSubscription/ProductSubscriptionStatus.tsx
@@ -15,7 +15,6 @@ import { TrueUpStatusSummary } from '../../productSubscription/TrueUpStatusSumma
 import { ErrorAlert } from '../../../components/alerts'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
-import * as H from 'history'
 
 const queryProductLicenseInfo = (): Observable<{
     productSubscription: GQL.IProductSubscriptionStatus
@@ -58,13 +57,12 @@ interface Props {
      *
      */
     showTrueUpStatus?: boolean
-    history: H.History
 }
 
 /**
  * A component displaying information about and the status of the product subscription.
  */
-export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ className, showTrueUpStatus, history }) => {
+export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ className, showTrueUpStatus }) => {
     /** The product subscription status, or an error, or undefined while loading. */
     const statusOrError = useObservable(
         useMemo(() => queryProductLicenseInfo().pipe(catchError((error): [ErrorLike] => [asError(error)])), [])
@@ -77,7 +75,7 @@ export const ProductSubscriptionStatus: React.FunctionComponent<Props> = ({ clas
         )
     }
     if (isErrorLike(statusOrError)) {
-        return <ErrorAlert error={statusOrError} prefix="Error checking product license" history={history} />
+        return <ErrorAlert error={statusOrError} prefix="Error checking product license" />
     }
 
     const {

--- a/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/ProductSubscriptionForm.tsx
@@ -205,7 +205,7 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
                     <div className="col-md-6">
                         <ProductSubscriptionUserCountFormControl value={userCount} onChange={setUserCount} />
                         <h4 className="mt-2 mb-0">Plan</h4>
-                        <ProductPlanFormControl value={billingPlanID} onChange={setBillingPlanID} history={history} />
+                        <ProductPlanFormControl value={billingPlanID} onChange={setBillingPlanID} />
                     </div>
                     <div className="col-md-6 mt-3 mt-md-0">
                         <h3 className="mt-2 mb-0">Billing</h3>
@@ -266,8 +266,8 @@ const _ProductSubscriptionForm: React.FunctionComponent<Props & ReactStripeEleme
                     </div>
                 </div>
             </Form>
-            {isErrorLike(paymentToken) && <ErrorAlert className="mt-3" error={paymentToken} history={history} />}
-            {isErrorLike(submissionState) && <ErrorAlert className="mt-3" error={submissionState} history={history} />}
+            {isErrorLike(paymentToken) && <ErrorAlert className="mt-3" error={paymentToken} />}
+            {isErrorLike(submissionState) && <ErrorAlert className="mt-3" error={submissionState} />}
         </div>
     )
 }

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsEditProductSubscriptionPage.tsx
@@ -99,7 +99,7 @@ export const UserSubscriptionsEditProductSubscriptionPage: React.FunctionCompone
             {productSubscription === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(productSubscription) ? (
-                <ErrorAlert className="my-2" error={productSubscription} history={history} />
+                <ErrorAlert className="my-2" error={productSubscription} />
             ) : (
                 <>
                     <Link to={productSubscription.url} className="btn btn-link btn-sm mb-3">

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -77,7 +77,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<P
             {productSubscription === LOADING ? (
                 <LoadingSpinner className="icon-inline" />
             ) : isErrorLike(productSubscription) ? (
-                <ErrorAlert className="my-2" error={productSubscription} history={history} />
+                <ErrorAlert className="my-2" error={productSubscription} />
             ) : (
                 <>
                     <h2>Subscription {productSubscription.name}</h2>

--- a/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
+++ b/client/web/src/enterprise/user/productSubscriptions/__snapshots__/ProductSubscriptionForm.test.tsx.snap
@@ -25,38 +25,6 @@ exports[`ProductSubscriptionForm edit existing subscription 1`] = `
           Plan
         </h4>
         <ProductPlanFormControl
-          history={
-            Object {
-              "action": "POP",
-              "block": [Function],
-              "canGo": [Function],
-              "createHref": [Function],
-              "entries": Array [
-                Object {
-                  "hash": "",
-                  "key": undefined,
-                  "pathname": "/",
-                  "search": "",
-                  "state": undefined,
-                },
-              ],
-              "go": [Function],
-              "goBack": [Function],
-              "goForward": [Function],
-              "index": 0,
-              "length": 1,
-              "listen": [Function],
-              "location": Object {
-                "hash": "",
-                "key": undefined,
-                "pathname": "/",
-                "search": "",
-                "state": undefined,
-              },
-              "push": [Function],
-              "replace": [Function],
-            }
-          }
           onChange={[Function]}
           value="p"
         />
@@ -140,38 +108,6 @@ exports[`ProductSubscriptionForm new subscription for anonymous viewer (no accou
           Plan
         </h4>
         <ProductPlanFormControl
-          history={
-            Object {
-              "action": "POP",
-              "block": [Function],
-              "canGo": [Function],
-              "createHref": [Function],
-              "entries": Array [
-                Object {
-                  "hash": "",
-                  "key": undefined,
-                  "pathname": "/",
-                  "search": "",
-                  "state": undefined,
-                },
-              ],
-              "go": [Function],
-              "goBack": [Function],
-              "goForward": [Function],
-              "index": 0,
-              "length": 1,
-              "listen": [Function],
-              "location": Object {
-                "hash": "",
-                "key": undefined,
-                "pathname": "/",
-                "search": "",
-                "state": undefined,
-              },
-              "push": [Function],
-              "replace": [Function],
-            }
-          }
           onChange={[Function]}
           value={null}
         />
@@ -274,38 +210,6 @@ exports[`ProductSubscriptionForm new subscription for existing account 1`] = `
           Plan
         </h4>
         <ProductPlanFormControl
-          history={
-            Object {
-              "action": "POP",
-              "block": [Function],
-              "canGo": [Function],
-              "createHref": [Function],
-              "entries": Array [
-                Object {
-                  "hash": "",
-                  "key": undefined,
-                  "pathname": "/",
-                  "search": "",
-                  "state": undefined,
-                },
-              ],
-              "go": [Function],
-              "goBack": [Function],
-              "goForward": [Function],
-              "index": 0,
-              "length": 1,
-              "listen": [Function],
-              "location": Object {
-                "hash": "",
-                "key": undefined,
-                "pathname": "/",
-                "search": "",
-                "state": undefined,
-              },
-              "push": [Function],
-              "replace": [Function],
-            }
-          }
           onChange={[Function]}
           value={null}
         />

--- a/client/web/src/enterprise/user/settings/ExternalAccountNode.tsx
+++ b/client/web/src/enterprise/user/settings/ExternalAccountNode.tsx
@@ -9,7 +9,6 @@ import { requestGraphQL } from '../../../backend/graphql'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { userURL } from '../../../user'
 import { ErrorAlert } from '../../../components/alerts'
-import * as H from 'history'
 import { DeleteExternalAccountResult, DeleteExternalAccountVariables, Scalars } from '../../../graphql-operations'
 
 export const externalAccountFragment = gql`
@@ -49,7 +48,6 @@ export interface ExternalAccountNodeProps {
     showUser: boolean
 
     onDidUpdate: () => void
-    history: H.History
 }
 
 interface ExternalAccountNodeState {
@@ -150,11 +148,7 @@ export class ExternalAccountNode extends React.PureComponent<ExternalAccountNode
                             Delete
                         </button>
                         {isErrorLike(this.state.deletionOrError) && (
-                            <ErrorAlert
-                                className="mt-2"
-                                error={this.state.deletionOrError}
-                                history={this.props.history}
-                            />
+                            <ErrorAlert className="mt-2" error={this.state.deletionOrError} />
                         )}
                     </div>
                 </div>

--- a/client/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
+++ b/client/web/src/enterprise/user/settings/UserSettingsExternalAccountsPage.tsx
@@ -35,7 +35,6 @@ export class UserSettingsExternalAccountsPage extends React.Component<Props> {
         const nodeProps: Omit<ExternalAccountNodeProps, 'node'> = {
             onDidUpdate: this.onDidUpdateExternalAccount,
             showUser: false,
-            history: this.props.history,
         }
 
         return (

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -20,7 +20,6 @@ interface Props
         ThemeProps {
     subject: Pick<SettingsSubject, 'id' | 'viewerCanAdminister'>
     location: H.Location
-    history: H.History
 
     data: ExtensionListData | undefined
     selectedCategories: ExtensionCategory[]
@@ -35,7 +34,6 @@ const LOADING = 'loading' as const
  * Displays a list of extensions.
  */
 export const ExtensionsList: React.FunctionComponent<Props> = ({
-    history,
     subject,
     settingsCascade,
     platformContext,
@@ -60,7 +58,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
     }
 
     if (isErrorLike(data)) {
-        return <ErrorAlert error={data} history={history} />
+        return <ErrorAlert error={data} />
     }
 
     const { error, extensions, extensionIDsByCategory } = data
@@ -68,7 +66,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
     if (Object.keys(extensions).length === 0) {
         return (
             <>
-                {error && <ErrorAlert className="mb-2" error={error} history={history} />}
+                {error && <ErrorAlert className="mb-2" error={error} />}
                 {query ? (
                     <div className="text-muted">
                         No extensions match <strong>{query}</strong>.
@@ -122,7 +120,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
 
     return (
         <>
-            {error && <ErrorAlert className="mb-2" error={error} history={history} />}
+            {error && <ErrorAlert className="mb-2" error={error} />}
             {categorySections.length > 0 ? (
                 categorySections
             ) : (

--- a/client/web/src/extensions/extension/ExtensionArea.tsx
+++ b/client/web/src/extensions/extension/ExtensionArea.tsx
@@ -192,7 +192,7 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.extensionOrError} history={this.props.history} />}
+                    subtitle={<ErrorMessage error={this.state.extensionOrError} />}
                 />
             )
         }

--- a/client/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionContributionsPage.tsx
@@ -38,7 +38,7 @@ const ContributionsTable: React.FunctionComponent<{ contributionGroups: Contribu
                         <h3>
                             {group.title} ({group.rows.length})
                         </h3>
-                        {group.error && <ErrorAlert className="mt-1" error={group.error} history={history} />}
+                        {group.error && <ErrorAlert className="mt-1" error={group.error} />}
                         <table className="table mb-5">
                             <thead>
                                 <tr>
@@ -159,11 +159,7 @@ export class RegistryExtensionContributionsPage extends React.PureComponent<Prop
                     {this.props.extension.manifest === null ? (
                         <ExtensionNoManifestAlert extension={this.props.extension} />
                     ) : isErrorLike(this.props.extension.manifest) ? (
-                        <ErrorAlert
-                            error={this.props.extension.manifest}
-                            prefix="Error parsing extension manifest"
-                            history={this.props.history}
-                        />
+                        <ErrorAlert error={this.props.extension.manifest} prefix="Error parsing extension manifest" />
                     ) : (
                         <ContributionsTable
                             contributionGroups={toContributionsGroups(this.props.extension.manifest)}

--- a/client/web/src/nav/Feedback/FeedbackPrompt.tsx
+++ b/client/web/src/nav/Feedback/FeedbackPrompt.tsx
@@ -135,13 +135,7 @@ const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePro
                         disabled={loading}
                     />
                     {error && (
-                        <ErrorAlert
-                            error={error}
-                            history={history}
-                            icon={false}
-                            className="mt-3"
-                            prefix="Error submitting feedback"
-                        />
+                        <ErrorAlert error={error} icon={false} className="mt-3" prefix="Error submitting feedback" />
                     )}
                     <LoaderButton
                         role="menuitem"

--- a/client/web/src/nav/StatusMessagesNavItem.tsx
+++ b/client/web/src/nav/StatusMessagesNavItem.tsx
@@ -232,7 +232,6 @@ export class StatusMessagesNavItem extends React.PureComponent<Props, State> {
                                 className="status-messages-nav-item__entry"
                                 prefix="Failed to load status messages"
                                 error={this.state.messagesOrError}
-                                history={this.props.history}
                             />
                         ) : this.state.messagesOrError.length > 0 ? (
                             this.state.messagesOrError.map((message, index) => this.renderMessage(message, index))

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -19,7 +19,6 @@ import { OrgInvitationPage } from './OrgInvitationPage'
 import { PatternTypeProps } from '../../search'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorMessage } from '../../components/alerts'
-import * as H from 'history'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { AuthenticatedUser } from '../../auth'
 import { BreadcrumbsProps, BreadcrumbSetters } from '../../components/Breadcrumbs'
@@ -93,7 +92,6 @@ interface Props
      * The currently authenticated user.
      */
     authenticatedUser: AuthenticatedUser | null
-    history: H.History
     isSourcegraphDotCom: boolean
 }
 
@@ -211,7 +209,7 @@ export class OrgArea extends React.Component<Props> {
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.orgOrError} history={this.props.history} />}
+                    subtitle={<ErrorMessage error={this.state.orgOrError} />}
                 />
             )
         }
@@ -235,13 +233,7 @@ export class OrgArea extends React.Component<Props> {
 
         if (this.props.location.pathname === `${this.props.match.url}/invitation`) {
             // The OrgInvitationPage is displayed without the OrgHeader because it is modal-like.
-            return (
-                <OrgInvitationPage
-                    {...context}
-                    onDidRespondToInvitation={this.onDidRespondToInvitation}
-                    history={this.props.history}
-                />
-            )
+            return <OrgInvitationPage {...context} onDidRespondToInvitation={this.onDidRespondToInvitation} />
         }
 
         return (

--- a/client/web/src/org/area/OrgInvitationPage.tsx
+++ b/client/web/src/org/area/OrgInvitationPage.tsx
@@ -18,7 +18,6 @@ import { userURL } from '../../user'
 import { OrgAvatar } from '../OrgAvatar'
 import { OrgAreaPageProps } from './OrgArea'
 import { ErrorAlert } from '../../components/alerts'
-import * as H from 'history'
 import { OrganizationInvitationResponseType } from '../../../../shared/src/graphql-operations'
 import {
     RespondToOrganizationInvitationResult,
@@ -30,7 +29,6 @@ interface Props extends OrgAreaPageProps {
 
     /** Called when the viewer responds to the invitation. */
     onDidRespondToInvitation: () => void
-    history: H.History
 }
 
 interface State {
@@ -164,11 +162,7 @@ export const OrgInvitationPage = withAuthenticatedUser(
                                     </button>
                                 </div>
                                 {isErrorLike(this.state.submissionOrError) && (
-                                    <ErrorAlert
-                                        className="my-2"
-                                        error={this.state.submissionOrError}
-                                        history={this.props.history}
-                                    />
+                                    <ErrorAlert className="my-2" error={this.state.submissionOrError} />
                                 )}
                                 {this.state.submissionOrError === 'loading' && (
                                     <LoadingSpinner className="icon-inline" />

--- a/client/web/src/org/new/NewOrganizationPage.tsx
+++ b/client/web/src/org/new/NewOrganizationPage.tsx
@@ -60,7 +60,7 @@ export const NewOrganizationPage: React.FunctionComponent<Props> = ({ history })
                     <Link to="/help/admin/organizations">Sourcegraph documentation</Link> for information about
                     configuring organizations.
                 </p>
-                {isErrorLike(loading) && <ErrorAlert className="mb-3" error={loading} history={history} />}
+                {isErrorLike(loading) && <ErrorAlert className="mb-3" error={loading} />}
                 <div className="form-group">
                     <label htmlFor="new-org-page__form-name">Organization name</label>
                     <input

--- a/client/web/src/org/settings/members/InviteForm.tsx
+++ b/client/web/src/org/settings/members/InviteForm.tsx
@@ -12,7 +12,6 @@ import { DismissibleAlert } from '../../../components/DismissibleAlert'
 import { Form } from '../../../../../branded/src/components/Form'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { ErrorAlert } from '../../../components/alerts'
-import * as H from 'history'
 import { AuthenticatedUser } from '../../../auth'
 import { Scalars } from '../../../../../shared/src/graphql-operations'
 import {
@@ -39,13 +38,11 @@ interface Props {
     onDidUpdateOrganizationMembers: () => void
 
     onOrganizationUpdate: () => void
-    history: H.History
 }
 
 export const InviteForm: React.FunctionComponent<Props> = ({
     orgID,
     authenticatedUser,
-    history,
     onDidUpdateOrganizationMembers,
     onOrganizationUpdate,
 }) => {
@@ -194,7 +191,7 @@ export const InviteForm: React.FunctionComponent<Props> = ({
                 />
                 /* eslint-enable react/jsx-no-bind */
             ))}
-            {isErrorLike(loading) && <ErrorAlert className="invite-form__alert" error={loading} history={history} />}
+            {isErrorLike(loading) && <ErrorAlert className="invite-form__alert" error={loading} />}
         </div>
     )
 }

--- a/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
+++ b/client/web/src/org/settings/members/OrgSettingsMembersPage.tsx
@@ -116,7 +116,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                     </div>
                 </div>
                 {isErrorLike(this.state.removalOrError) && (
-                    <ErrorAlert className="mt-2" error={this.state.removalOrError} history={this.props.history} />
+                    <ErrorAlert className="mt-2" error={this.state.removalOrError} />
                 )}
             </li>
         )
@@ -192,7 +192,6 @@ export class OrgSettingsMembersPage extends React.PureComponent<Props, State> {
                         authenticatedUser={this.props.authenticatedUser}
                         onOrganizationUpdate={this.props.onOrganizationUpdate}
                         onDidUpdateOrganizationMembers={this.onDidUpdateOrganizationMembers}
-                        history={this.props.history}
                     />
                 )}
                 <FilteredConnection<GQL.IUser, Omit<UserNodeProps, 'node'>>

--- a/client/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
+++ b/client/web/src/org/settings/profile/OrgSettingsProfilePage.tsx
@@ -1,6 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import React, { useCallback, useEffect, useState } from 'react'
-import { RouteComponentProps } from 'react-router'
 import { ORG_DISPLAY_NAME_MAX_LENGTH } from '../..'
 import { Form } from '../../../../../branded/src/components/Form'
 import { PageTitle } from '../../../components/PageTitle'
@@ -12,14 +11,12 @@ import { asError, isErrorLike } from '../../../../../shared/src/util/errors'
 import { Timestamp } from '../../../components/time/Timestamp'
 import { PageHeader } from '../../../components/PageHeader'
 
-interface Props
-    extends Pick<OrgAreaPageProps, 'org' | 'onOrganizationUpdate'>,
-        Pick<RouteComponentProps<{}>, 'history'> {}
+interface Props extends Pick<OrgAreaPageProps, 'org' | 'onOrganizationUpdate'> {}
 
 /**
  * The organization profile settings page.
  */
-export const OrgSettingsProfilePage: React.FunctionComponent<Props> = ({ history, org, onOrganizationUpdate }) => {
+export const OrgSettingsProfilePage: React.FunctionComponent<Props> = ({ org, onOrganizationUpdate }) => {
     useEffect(() => {
         eventLogger.logViewEvent('OrgSettingsProfile')
     }, [org.id])
@@ -111,7 +108,7 @@ export const OrgSettingsProfilePage: React.FunctionComponent<Props> = ({ history
                 >
                     <small>Updated!</small>
                 </div>
-                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} history={history} />}
+                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
             </Form>
         </div>
     )

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -334,13 +334,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
         if (isRepoNotFoundErrorLike(repoOrError)) {
             return <RepositoryNotFoundPage repo={repoName} viewerCanAdminister={viewerCanAdminister} />
         }
-        return (
-            <HeroPage
-                icon={AlertCircleIcon}
-                title="Error"
-                subtitle={<ErrorMessage error={repoOrError} history={props.history} />}
-            />
-        )
+        return <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={repoOrError} />} />
     }
 
     const repoMatchURL = '/' + encodeURIPathComponent(repoName)

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -207,7 +207,7 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
             <HeroPage
                 icon={AlertCircleIcon}
                 title="Error"
-                subtitle={<ErrorMessage error={props.resolvedRevisionOrError} history={props.history} />}
+                subtitle={<ErrorMessage error={props.resolvedRevisionOrError} />}
             />
         )
     }

--- a/client/web/src/repo/RepositoryGitDataContainer.tsx
+++ b/client/web/src/repo/RepositoryGitDataContainer.tsx
@@ -15,7 +15,6 @@ import { HeroPage } from '../components/HeroPage'
 import { resolveRevision } from './backend'
 import { DirectImportRepoAlert } from './DirectImportRepoAlert'
 import { ErrorMessage } from '../components/alerts'
-import * as H from 'history'
 
 export const RepositoryCloningInProgressPage: React.FunctionComponent<{ repoName: string; progress?: string }> = ({
     repoName,
@@ -41,7 +40,6 @@ interface Props {
 
     /** The fragment to render if the repository's Git data is accessible. */
     children: React.ReactNode
-    history: H.History
 }
 
 interface State {
@@ -135,7 +133,7 @@ export class RepositoryGitDataContainer extends React.PureComponent<Props, State
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.gitDataPresentOrError} history={this.props.history} />}
+                    subtitle={<ErrorMessage error={this.state.gitDataPresentOrError} />}
                 />
             )
         }

--- a/client/web/src/repo/blob/BlobPage.tsx
+++ b/client/web/src/repo/blob/BlobPage.tsx
@@ -273,11 +273,7 @@ export const BlobPage: React.FunctionComponent<Props> = props => {
         return (
             <>
                 {alwaysRender}
-                <HeroPage
-                    icon={AlertCircleIcon}
-                    title="Error"
-                    subtitle={<ErrorMessage error={blobInfoOrError} history={props.history} />}
-                />
+                <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={blobInfoOrError} />} />
             </>
         )
     }

--- a/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesOverviewPage.tsx
@@ -14,7 +14,6 @@ import { eventLogger } from '../../tracking/eventLogger'
 import { gitReferenceFragments, GitReferenceNode } from '../GitReference'
 import { RepositoryBranchesAreaPageProps } from './RepositoryBranchesArea'
 import { ErrorAlert } from '../../components/alerts'
-import * as H from 'history'
 import { Scalars } from '../../../../shared/src/graphql-operations'
 
 interface Data {
@@ -69,9 +68,7 @@ const queryGitBranches = memoizeObservable(
     args => `${args.repo}:${args.first}`
 )
 
-interface Props extends RepositoryBranchesAreaPageProps, RouteComponentProps<{}> {
-    history: H.History
-}
+interface Props extends RepositoryBranchesAreaPageProps, RouteComponentProps<{}> {}
 
 interface State {
     /** The page content, undefined while loading, or an error. */
@@ -124,7 +121,7 @@ export class RepositoryBranchesOverviewPage extends React.PureComponent<Props, S
                 {this.state.dataOrError === undefined ? (
                     <LoadingSpinner className="icon-inline mt-2" />
                 ) : isErrorLike(this.state.dataOrError) ? (
-                    <ErrorAlert className="mt-2" error={this.state.dataOrError} history={this.props.history} />
+                    <ErrorAlert className="mt-2" error={this.state.dataOrError} />
                 ) : (
                     <div className="repository-branches-page__cards">
                         {this.state.dataOrError.defaultBranch && (

--- a/client/web/src/repo/commit/RepositoryCommitPage.tsx
+++ b/client/web/src/repo/commit/RepositoryCommitPage.tsx
@@ -229,7 +229,7 @@ export class RepositoryCommitPage extends React.Component<Props, State> {
                 {this.state.commitOrError === undefined ? (
                     <LoadingSpinner className="icon-inline mt-2" />
                 ) : isErrorLike(this.state.commitOrError) ? (
-                    <ErrorAlert className="mt-2" error={this.state.commitOrError} history={this.props.history} />
+                    <ErrorAlert className="mt-2" error={this.state.commitOrError} />
                 ) : (
                     <>
                         <div className="card repository-commit-page__card">

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -166,11 +166,7 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
     public render(): JSX.Element | null {
         if (this.state.error) {
             return (
-                <HeroPage
-                    icon={AlertCircleIcon}
-                    title="Error"
-                    subtitle={<ErrorMessage error={this.state.error} history={this.props.history} />}
-                />
+                <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={this.state.error} />} />
             )
         }
 

--- a/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareOverviewPage.tsx
@@ -20,7 +20,6 @@ import { RepositoryCompareCommitsPage } from './RepositoryCompareCommitsPage'
 import { RepositoryCompareDiffPage } from './RepositoryCompareDiffPage'
 import { ThemeProps } from '../../../../shared/src/theme'
 import { ErrorAlert } from '../../components/alerts'
-import * as H from 'history'
 import { Scalars } from '../../graphql-operations'
 
 function queryRepositoryComparison(args: {
@@ -88,7 +87,6 @@ interface Props
     /** The head of the comparison. */
     head: { repoName: string; repoID: Scalars['ID']; revision?: string | null }
     hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
-    history: H.History
 }
 
 interface State {
@@ -157,7 +155,7 @@ export class RepositoryCompareOverviewPage extends React.PureComponent<Props, St
                 ) : this.state.rangeOrError === undefined ? (
                     <LoadingSpinner className="icon-inline" />
                 ) : isErrorLike(this.state.rangeOrError) ? (
-                    <ErrorAlert className="mt-2" error={this.state.rangeOrError} history={this.props.history} />
+                    <ErrorAlert className="mt-2" error={this.state.rangeOrError} />
                 ) : (
                     <>
                         <RepositoryCompareCommitsPage {...this.props} />

--- a/client/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/client/web/src/repo/settings/RepoSettingsArea.tsx
@@ -11,7 +11,6 @@ import { RepoSettingsSidebar, RepoSettingsSideBarGroups } from './RepoSettingsSi
 import { RouteDescriptor } from '../../util/contributions'
 import { ErrorMessage } from '../../components/alerts'
 import { asError, ErrorLike, isErrorLike } from '../../../../shared/src/util/errors'
-import * as H from 'history'
 import { useObservable } from '../../../../shared/src/util/useObservable'
 import { BreadcrumbSetters } from '../../components/Breadcrumbs'
 import { AuthenticatedUser } from '../../auth'
@@ -38,7 +37,6 @@ interface Props extends RouteComponentProps<{}>, BreadcrumbSetters, ThemeProps, 
     repoSettingsSidebarGroups: RepoSettingsSideBarGroups
     repo: RepositoryFields
     authenticatedUser: AuthenticatedUser | null
-    history: H.History
 }
 
 /**
@@ -63,13 +61,7 @@ export const RepoSettingsArea: React.FunctionComponent<Props> = ({
         return null
     }
     if (isErrorLike(repoOrError)) {
-        return (
-            <HeroPage
-                icon={AlertCircleIcon}
-                title="Error"
-                subtitle={<ErrorMessage error={repoOrError.message} history={props.history} />}
-            />
-        )
+        return <HeroPage icon={AlertCircleIcon} title="Error" subtitle={<ErrorMessage error={repoOrError.message} />} />
     }
     if (repoOrError === null) {
         return <NotFoundPage />

--- a/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsIndexPage.tsx
@@ -16,7 +16,6 @@ import { PageTitle } from '../../components/PageTitle'
 import { Timestamp } from '../../components/time/Timestamp'
 import { eventLogger } from '../../tracking/eventLogger'
 import { ErrorAlert } from '../../components/alerts'
-import * as H from 'history'
 import { Scalars, SettingsAreaRepositoryFields } from '../../graphql-operations'
 
 /**
@@ -115,7 +114,6 @@ const TextSearchIndexedReference: React.FunctionComponent<{
 
 interface Props extends RouteComponentProps<{}> {
     repo: SettingsAreaRepositoryFields
-    history: H.History
 }
 
 interface State {
@@ -161,11 +159,7 @@ export class RepoSettingsIndexPage extends React.PureComponent<Props, State> {
                 <h2>Indexing</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
                 {this.state.error && (
-                    <ErrorAlert
-                        prefix="Error getting repository index status"
-                        error={this.state.error}
-                        history={this.props.history}
-                    />
+                    <ErrorAlert prefix="Error getting repository index status" error={this.state.error} />
                 )}
                 {!this.state.error &&
                     !this.state.loading &&

--- a/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsMirrorPage.tsx
@@ -204,11 +204,7 @@ class CheckMirrorRepositoryConnectionActionContainer extends React.PureComponent
                 details={
                     <>
                         {this.state.errorDescription && (
-                            <ErrorAlert
-                                className="action-container__alert"
-                                error={this.state.errorDescription}
-                                history={this.props.history}
-                            />
+                            <ErrorAlert className="action-container__alert" error={this.state.errorDescription} />
                         )}
                         {this.state.loading && (
                             <div className="alert alert-primary action-container__alert">
@@ -299,7 +295,7 @@ export class RepoSettingsMirrorPage extends React.PureComponent<
                 <PageTitle title="Mirror settings" />
                 <h2>Mirroring and cloning</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <ErrorAlert error={this.state.error} history={this.props.history} />}
+                {this.state.error && <ErrorAlert error={this.state.error} />}
                 <div className="form-group">
                     <label>
                         Remote repository URL{' '}

--- a/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
+++ b/client/web/src/repo/settings/RepoSettingsOptionsPage.tsx
@@ -11,12 +11,10 @@ import { fetchSettingsAreaRepository } from './backend'
 import { ErrorAlert } from '../../components/alerts'
 import { defaultExternalServices } from '../../components/externalServices/externalServices'
 import { asError } from '../../../../shared/src/util/errors'
-import * as H from 'history'
 import { SettingsAreaRepositoryFields } from '../../graphql-operations'
 
 interface Props extends RouteComponentProps<{}> {
     repo: SettingsAreaRepositoryFields
-    history: H.History
 }
 
 interface State {
@@ -67,7 +65,7 @@ export class RepoSettingsOptionsPage extends React.PureComponent<Props, State> {
                 <PageTitle title="Repository settings" />
                 <h2>Settings</h2>
                 {this.state.loading && <LoadingSpinner className="icon-inline" />}
-                {this.state.error && <ErrorAlert error={this.state.error} history={this.props.history} />}
+                {this.state.error && <ErrorAlert error={this.state.error} />}
                 {services.length > 0 && (
                     <div className="mb-4">
                         {services.map(service => (

--- a/client/web/src/repo/settings/components/ActionContainer.tsx
+++ b/client/web/src/repo/settings/components/ActionContainer.tsx
@@ -96,7 +96,7 @@ export class ActionContainer extends React.PureComponent<Props, State> {
                 details={
                     <>
                         {this.state.error ? (
-                            <ErrorAlert className="mb-0 mt-3" error={this.state.error} history={this.props.history} />
+                            <ErrorAlert className="mb-0 mt-3" error={this.state.error} />
                         ) : (
                             this.props.info
                         )}

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -322,7 +322,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                 /not a directory/i.test(treeOrError.message) ? (
                     <Redirect to={toPrettyBlobURL({ repoName: repo.name, revision, commitID, filePath })} />
                 ) : (
-                    <ErrorAlert error={treeOrError} history={props.history} />
+                    <ErrorAlert error={treeOrError} />
                 )
             ) : (
                 <>

--- a/client/web/src/repo/tree/ViewGrid.tsx
+++ b/client/web/src/repo/tree/ViewGrid.tsx
@@ -4,7 +4,6 @@ import classNames from 'classnames'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { ErrorAlert } from '../../components/alerts'
 import { ViewContent, ViewContentProps } from '../../views/ViewContent'
-import * as H from 'history'
 import { WidthProvider, Responsive, Layout as ReactGridLayout, Layouts as ReactGridLayouts } from 'react-grid-layout'
 import { ViewProviderResult } from '../../../../shared/src/api/client/services/viewService'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
@@ -18,7 +17,6 @@ export interface ViewGridProps
         TelemetryProps {
     views: ViewProviderResult[]
     className?: string
-    history: H.History
 }
 
 const breakpointNames = ['xs', 'sm', 'md', 'lg'] as const
@@ -89,7 +87,7 @@ export const ViewGrid: React.FunctionComponent<ViewGridProps> = props => {
                                 <LoadingSpinner /> Loading code insight
                             </div>
                         ) : isErrorLike(view) ? (
-                            <ErrorAlert className="m-0" error={view} history={props.history} />
+                            <ErrorAlert className="m-0" error={view} />
                         ) : (
                             <>
                                 <h3 className="view-grid__view-title">{view.title}</h3>

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -1,4 +1,3 @@
-import * as H from 'history'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router'
 import { Omit } from 'utility-types'
@@ -18,8 +17,6 @@ export interface SavedQueryFields {
 }
 
 interface Props extends RouteComponentProps<{}>, NamespaceProps {
-    location: H.Location
-    history: H.History
     authenticatedUser: AuthenticatedUser | null
     defaultValues?: Partial<SavedQueryFields>
     title?: string
@@ -171,7 +168,7 @@ export class SavedSearchForm extends React.Component<Props, State> {
                         {this.props.submitLabel}
                     </button>
                     {this.props.error && !this.props.loading && (
-                        <ErrorAlert className="mb-3" error={this.props.error} history={this.props.history} />
+                        <ErrorAlert className="mb-3" error={this.props.error} />
                     )}
                 </Form>
             </div>

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -14,7 +14,6 @@ import { NamespaceProps } from '../namespaces'
 import { deleteSavedSearch, fetchSavedSearches } from '../search/backend'
 import { PatternTypeProps } from '../search'
 import { ErrorAlert } from '../components/alerts'
-import * as H from 'history'
 import { eventLogger } from '../tracking/eventLogger'
 
 interface NodeProps extends RouteComponentProps, Omit<PatternTypeProps, 'setPatternType'> {
@@ -107,9 +106,7 @@ interface State {
     savedSearchesOrError?: GQL.ISavedSearch[] | ErrorLike
 }
 
-interface Props extends RouteComponentProps<{}>, NamespaceProps, Omit<PatternTypeProps, 'setPatternType'> {
-    history: H.History
-}
+interface Props extends RouteComponentProps<{}>, NamespaceProps, Omit<PatternTypeProps, 'setPatternType'> {}
 
 export class SavedSearchListPage extends React.Component<Props, State> {
     public subscriptions = new Subscription()
@@ -155,7 +152,7 @@ export class SavedSearchListPage extends React.Component<Props, State> {
                     </div>
                 </div>
                 {this.state.savedSearchesOrError && isErrorLike(this.state.savedSearchesOrError) && (
-                    <ErrorAlert className="mb-3" error={this.state.savedSearchesOrError} history={this.props.history} />
+                    <ErrorAlert className="mb-3" error={this.state.savedSearchesOrError} />
                 )}
                 <div className="list-group list-group-flush">
                     {this.state.savedSearchesOrError &&

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -359,7 +359,6 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                             className="m-2"
                             data-testid="search-results-list-error"
                             error={this.props.resultsOrError}
-                            history={this.props.history}
                         />
                     ) : (
                         (() => {

--- a/client/web/src/search/results/streaming/StreamingSearchResultsFooter.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsFooter.tsx
@@ -1,19 +1,12 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import * as H from 'history'
 import SearchIcon from 'mdi-react/SearchIcon'
 import React from 'react'
 import { ErrorAlert } from '../../../components/alerts'
 import { AggregateStreamingSearchResults } from '../../stream'
 import { StreamingProgressCount } from './progress/StreamingProgressCount'
 
-interface StreamingSearchResultsListFooterProps {
-    results?: AggregateStreamingSearchResults
-    history: H.History
-}
-
-export const StreamingSearchResultFooter: React.FunctionComponent<StreamingSearchResultsListFooterProps> = ({
+export const StreamingSearchResultFooter: React.FunctionComponent<{ results?: AggregateStreamingSearchResults }> = ({
     results,
-    history,
 }) => (
     <div className="d-flex flex-column align-items-center">
         {(!results || results?.state === 'loading') && (
@@ -27,12 +20,7 @@ export const StreamingSearchResultFooter: React.FunctionComponent<StreamingSearc
         )}
 
         {results?.state === 'error' && (
-            <ErrorAlert
-                className="m-3"
-                data-testid="search-results-list-error"
-                error={results.error}
-                history={history}
-            />
+            <ErrorAlert className="m-3" data-testid="search-results-list-error" error={results.error} />
         )}
 
         {results?.state === 'complete' && !results.alert && results?.results.length === 0 && (

--- a/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
@@ -105,9 +105,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                 renderItem={renderResult}
             />
 
-            {itemsToShow >= (results?.results.length || 0) && (
-                <StreamingSearchResultFooter results={results} history={history} />
-            )}
+            {itemsToShow >= (results?.results.length || 0) && <StreamingSearchResultFooter results={results} />}
         </>
     )
 }

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -18,7 +18,6 @@ import { eventLogger } from '../tracking/eventLogger'
 import { mergeSettingsSchemas } from './configuration'
 import { SettingsPage } from './SettingsPage'
 import { ErrorMessage } from '../components/alerts'
-import * as H from 'history'
 import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 import { AuthenticatedUser } from '../auth'
 import { Scalars } from '../../../shared/src/graphql-operations'
@@ -53,7 +52,6 @@ export interface SettingsAreaPageProps extends SettingsAreaPageCommonProps {
 interface Props extends SettingsAreaPageCommonProps, RouteComponentProps<{}> {
     className?: string
     extraHeader?: JSX.Element
-    history: H.History
 }
 
 const LOADING = 'loading' as const
@@ -125,7 +123,7 @@ export class SettingsArea extends React.Component<Props, State> {
                 <HeroPage
                     icon={AlertCircleIcon}
                     title="Error"
-                    subtitle={<ErrorMessage error={this.state.dataOrError} history={this.props.history} />}
+                    subtitle={<ErrorMessage error={this.state.dataOrError} />}
                 />
             )
         }

--- a/client/web/src/settings/tokens/AccessTokenNode.tsx
+++ b/client/web/src/settings/tokens/AccessTokenNode.tsx
@@ -8,7 +8,6 @@ import { Timestamp } from '../../components/time/Timestamp'
 import { userURL } from '../../user'
 import { AccessTokenCreatedAlert } from './AccessTokenCreatedAlert'
 import { ErrorAlert } from '../../components/alerts'
-import * as H from 'history'
 import {
     AccessTokenFields,
     CreateAccessTokenResult,
@@ -60,7 +59,6 @@ export interface AccessTokenNodeProps {
     showSubject: boolean
 
     afterDelete: () => void
-    history: H.History
 }
 
 export const AccessTokenNode: React.FunctionComponent<AccessTokenNodeProps> = ({
@@ -68,7 +66,6 @@ export const AccessTokenNode: React.FunctionComponent<AccessTokenNodeProps> = ({
     showSubject,
     newToken,
     afterDelete,
-    history,
 }) => {
     const [isDeleting, setIsDeleting] = useState<boolean | Error>(false)
     const onDeleteAccessToken = useCallback(async () => {
@@ -136,7 +133,7 @@ export const AccessTokenNode: React.FunctionComponent<AccessTokenNodeProps> = ({
                     >
                         Delete
                     </button>
-                    {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} history={history} />}
+                    {isErrorLike(isDeleting) && <ErrorAlert className="mt-2" error={isDeleting} />}
                 </div>
             </div>
             {newToken && node.id === newToken.id && (

--- a/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
+++ b/client/web/src/site-admin/SiteAdminAllUsersPage.tsx
@@ -179,9 +179,7 @@ class UserNode extends React.PureComponent<UserNodeProps, UserNodeState> {
                         )}
                     </div>
                 </div>
-                {this.state.errorDescription && (
-                    <ErrorAlert className="mt-2" error={this.state.errorDescription} history={this.props.history} />
-                )}
+                {this.state.errorDescription && <ErrorAlert className="mt-2" error={this.state.errorDescription} />}
                 {this.state.resetPasswordURL && (
                     <div className="alert alert-success mt-2">
                         <p>

--- a/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
+++ b/client/web/src/site-admin/SiteAdminConfigurationPage.tsx
@@ -333,12 +333,7 @@ export class SiteAdminConfigurationPage extends React.Component<Props, State> {
         const alerts: JSX.Element[] = []
         if (this.state.error) {
             alerts.push(
-                <ErrorAlert
-                    key="error"
-                    className="site-admin-configuration-page__alert"
-                    error={this.state.error}
-                    history={this.props.history}
-                />
+                <ErrorAlert key="error" className="site-admin-configuration-page__alert" error={this.state.error} />
             )
         }
         if (this.state.reloadStartedAt) {

--- a/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
+++ b/client/web/src/site-admin/SiteAdminCreateUserPage.tsx
@@ -12,11 +12,6 @@ import { eventLogger } from '../tracking/eventLogger'
 import { createUser } from './backend'
 import { ErrorAlert } from '../components/alerts'
 import { asError } from '../../../shared/src/util/errors'
-import * as H from 'history'
-
-interface Props extends RouteComponentProps<{}> {
-    history: H.History
-}
 
 interface State {
     errorDescription?: string
@@ -35,7 +30,7 @@ interface State {
 /**
  * A page with a form to create a user account.
  */
-export class SiteAdminCreateUserPage extends React.Component<Props, State> {
+export class SiteAdminCreateUserPage extends React.Component<RouteComponentProps<{}>, State> {
     public state: State = {
         loading: false,
         username: '',
@@ -156,11 +151,7 @@ export class SiteAdminCreateUserPage extends React.Component<Props, State> {
                             </small>
                         </div>
                         {this.state.errorDescription && (
-                            <ErrorAlert
-                                className="my-2"
-                                error={this.state.errorDescription}
-                                history={this.props.history}
-                            />
+                            <ErrorAlert className="my-2" error={this.state.errorDescription} />
                         )}
                         <button className="btn btn-primary" disabled={this.state.loading} type="submit">
                             {window.context.resetPasswordEnabled

--- a/client/web/src/site-admin/SiteAdminOrgsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminOrgsPage.tsx
@@ -92,7 +92,7 @@ const OrgNode: React.FunctionComponent<OrgNodeProps> = ({ node, history, onDidUp
                     </button>
                 </div>
             </div>
-            {isErrorLike(loading) && <ErrorAlert className="mt-2" error={loading.message} history={history} />}
+            {isErrorLike(loading) && <ErrorAlert className="mt-2" error={loading.message} />}
         </li>
     )
 }

--- a/client/web/src/site-admin/SiteAdminTokensPage.tsx
+++ b/client/web/src/site-admin/SiteAdminTokensPage.tsx
@@ -60,7 +60,6 @@ export const SiteAdminTokensPage: React.FunctionComponent<Props> = ({
                 nodeComponentProps={{
                     showSubject: true,
                     afterDelete: onDidUpdateAccessToken,
-                    history,
                 }}
                 updates={accessTokenUpdates}
                 hideSearch={true}

--- a/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUpdatesPage.tsx
@@ -4,7 +4,6 @@ import formatDistance from 'date-fns/formatDistance'
 import CheckIcon from 'mdi-react/CheckIcon'
 import CloudDownloadIcon from 'mdi-react/CloudDownloadIcon'
 import React, { useMemo } from 'react'
-import { RouteComponentProps } from 'react-router'
 import { Link } from 'react-router-dom'
 import { PageTitle } from '../components/PageTitle'
 import { fetchSiteUpdateCheck } from './backend'
@@ -13,12 +12,12 @@ import { TelemetryProps } from '../../../shared/src/telemetry/telemetryService'
 import { useObservable } from '../../../shared/src/util/useObservable'
 import { isErrorLike } from '../../../shared/src/util/errors'
 
-interface Props extends Pick<RouteComponentProps<{}>, 'history'>, TelemetryProps {}
+interface Props extends TelemetryProps {}
 
 /**
  * A page displaying information about available updates for the server.
  */
-export const SiteAdminUpdatesPage: React.FunctionComponent<Props> = ({ history, telemetryService }) => {
+export const SiteAdminUpdatesPage: React.FunctionComponent<Props> = ({ telemetryService }) => {
     useMemo(() => {
         telemetryService.logViewEvent('SiteAdminUpdates')
     }, [telemetryService])
@@ -36,9 +35,7 @@ export const SiteAdminUpdatesPage: React.FunctionComponent<Props> = ({ history, 
         <div className="site-admin-updates-page">
             <PageTitle title="Updates - Admin" />
             <h2>Updates</h2>
-            {isErrorLike(state) && (
-                <ErrorAlert className="site-admin-updates-page__error" history={history} error={state} />
-            )}
+            {isErrorLike(state) && <ErrorAlert className="site-admin-updates-page__error" error={state} />}
             {updateCheck && (updateCheck.pending || updateCheck.checkedAt) && (
                 <div>
                     {updateCheck.pending && (
@@ -62,7 +59,6 @@ export const SiteAdminUpdatesPage: React.FunctionComponent<Props> = ({ history, 
                             className="site-admin-updates-page__alert"
                             prefix="Error checking for updates"
                             error={updateCheck.errorMessage}
-                            history={history}
                         />
                     )}
                 </div>

--- a/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
+++ b/client/web/src/site-admin/SiteAdminUsageStatisticsPage.tsx
@@ -243,9 +243,7 @@ export class SiteAdminUsageStatisticsPage extends React.Component<
             <div className="site-admin-usage-statistics-page">
                 <PageTitle title="Usage statistics - Admin" />
                 <h2>Usage statistics</h2>
-                {this.state.error && (
-                    <ErrorAlert className="mb-3" error={this.state.error} history={this.props.history} />
-                )}
+                {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
 
                 <a
                     href="/site-admin/usage-statistics/archive"

--- a/client/web/src/site-admin/init/SiteInitPage.test.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { SiteInitPage } from './SiteInitPage'
 import { MemoryRouter, Redirect } from 'react-router'
-import { createMemoryHistory } from 'history'
 
 describe('SiteInitPage', () => {
     const origContext = window.context
@@ -22,7 +21,6 @@ describe('SiteInitPage', () => {
                     isLightTheme={true}
                     needsSiteInit={false}
                     authenticatedUser={null}
-                    history={createMemoryHistory()}
                     context={{ authProviders: [], sourcegraphDotComMode: false }}
                 />
             </MemoryRouter>
@@ -40,7 +38,6 @@ describe('SiteInitPage', () => {
                         isLightTheme={true}
                         needsSiteInit={true}
                         authenticatedUser={{ username: 'alice' }}
-                        history={createMemoryHistory()}
                         context={{ authProviders: [], sourcegraphDotComMode: false }}
                     />
                 )
@@ -55,7 +52,6 @@ describe('SiteInitPage', () => {
                         isLightTheme={true}
                         needsSiteInit={true}
                         authenticatedUser={null}
-                        history={createMemoryHistory()}
                         context={{ authProviders: [], sourcegraphDotComMode: false }}
                     />
                 )

--- a/client/web/src/site-admin/init/SiteInitPage.tsx
+++ b/client/web/src/site-admin/init/SiteInitPage.tsx
@@ -4,7 +4,6 @@ import { SignUpArguments, SignUpForm } from '../../auth/SignUpForm'
 import { submitTrialRequest } from '../../marketing/backend'
 import { BrandLogo } from '../../components/branding/BrandLogo'
 import { ThemeProps } from '../../../../shared/src/theme'
-import * as H from 'history'
 import { AuthenticatedUser } from '../../auth'
 import { SourcegraphContext } from '../../jscontext'
 
@@ -47,7 +46,6 @@ interface Props extends ThemeProps {
      * `window.context.needsSiteInit` is used.
      */
     needsSiteInit?: typeof window.context.needsSiteInit
-    history: H.History
     context: Pick<SourcegraphContext, 'sourcegraphDotComMode' | 'authProviders'>
 }
 
@@ -59,7 +57,6 @@ export const SiteInitPage: React.FunctionComponent<Props> = ({
     authenticatedUser,
     isLightTheme,
     needsSiteInit = window.context.needsSiteInit,
-    history,
     context,
 }) => {
     if (!needsSiteInit) {
@@ -87,7 +84,6 @@ export const SiteInitPage: React.FunctionComponent<Props> = ({
                                 className="w-100"
                                 buttonLabel="Create admin account & continue"
                                 doSignUp={initSite}
-                                history={history}
                                 context={context}
                             />
                         </>

--- a/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
+++ b/client/web/src/site-admin/overview/SiteAdminOverviewPage.tsx
@@ -240,7 +240,7 @@ export const SiteAdminOverviewPage: React.FunctionComponent<Props> = ({
                         {info.users > 1 &&
                             stats !== undefined &&
                             (isErrorLike(stats) ? (
-                                <ErrorAlert className="mb-3" error={stats} history={history} />
+                                <ErrorAlert className="mb-3" error={stats} />
                             ) : (
                                 <Collapsible
                                     title={

--- a/client/web/src/tree/ChildTreeLayer.tsx
+++ b/client/web/src/tree/ChildTreeLayer.tsx
@@ -22,7 +22,6 @@ interface ChildTreeLayerProps extends Pick<TreeRootProps, Exclude<keyof TreeRoot
 export const ChildTreeLayer: React.FunctionComponent<ChildTreeLayerProps> = (props: ChildTreeLayerProps) => {
     const sharedProps = {
         location: props.location,
-        history: props.history,
         activePath: props.activePath,
         activeNode: props.activeNode,
         depth: props.depth + 1,

--- a/client/web/src/tree/Tree.tsx
+++ b/client/web/src/tree/Tree.tsx
@@ -304,7 +304,6 @@ export class Tree extends React.PureComponent<Props, State> {
                     activeNode={this.state.activeNode}
                     activePath={this.props.activePath}
                     depth={0}
-                    history={this.props.history}
                     location={this.props.location}
                     repoName={this.props.repoName}
                     revision={this.props.revision}

--- a/client/web/src/tree/TreeLayer.tsx
+++ b/client/web/src/tree/TreeLayer.tsx
@@ -37,7 +37,6 @@ import { ThemeProps } from '../../../shared/src/theme'
 import { FileDecorationsByPath } from '../../../shared/src/api/extension/flatExtensionApi'
 
 export interface TreeLayerProps extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps {
-    history: H.History
     location: H.Location
     activeNode: TreeNode
     activePath: string
@@ -312,7 +311,6 @@ export class TreeLayer extends React.Component<TreeLayerProps, TreeLayerState> {
                                                     style={treePadding(this.props.depth, true)}
                                                     error={treeOrError}
                                                     prefix="Error loading file tree"
-                                                    history={this.props.history}
                                                 />
                                             ) : (
                                                 treeOrError && (

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -33,7 +33,6 @@ const errorWidth = (width?: string): { width: string } => ({
 })
 
 export interface TreeRootProps extends AbsoluteRepo, ExtensionsControllerProps, ThemeProps {
-    history: H.History
     location: H.Location
     activeNode: TreeNode
     activePath: string
@@ -191,7 +190,6 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
                         className="tree__row tree__row-alert"
                         prefix="Error loading tree"
                         error={treeOrError}
-                        history={this.props.history}
                     />
                 ) : (
                     <table className="tree-layer" tabIndex={0}>

--- a/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsCreateAccessTokenPage.tsx
@@ -204,9 +204,7 @@ export const UserSettingsCreateAccessTokenPage: React.FunctionComponent<Props> =
                 </Link>
             </Form>
 
-            {isErrorLike(creationOrError) && (
-                <ErrorAlert className="invite-form__alert" error={creationOrError} history={history} />
-            )}
+            {isErrorLike(creationOrError) && <ErrorAlert className="invite-form__alert" error={creationOrError} />}
         </div>
     )
 }

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensPage.tsx
@@ -91,7 +91,6 @@ export const UserSettingsTokensPage: React.FunctionComponent<Props> = ({
                     afterDelete: onDeleteAccessToken,
                     showSubject: false,
                     newToken,
-                    history,
                 }}
                 updates={accessTokenUpdates}
                 hideSearch={true}

--- a/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsPasswordPage.tsx
@@ -10,14 +10,12 @@ import { PageTitle } from '../../../components/PageTitle'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { updatePassword } from '../backend'
 import { ErrorAlert } from '../../../components/alerts'
-import * as H from 'history'
 import { AuthenticatedUser } from '../../../auth'
 import { UserAreaUserFields } from '../../../graphql-operations'
 
 interface Props extends RouteComponentProps<{}> {
     user: UserAreaUserFields
     authenticatedUser: AuthenticatedUser
-    history: H.History
 }
 
 interface State {
@@ -102,9 +100,7 @@ export class UserSettingsPasswordPage extends React.Component<Props, State> {
                     </div>
                 ) : (
                     <>
-                        {this.state.error && (
-                            <ErrorAlert className="mb-3" error={this.state.error} history={this.props.history} />
-                        )}
+                        {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
                         {this.state.saved && <div className="alert alert-success mb-3">Password changed!</div>}
                         <Form onSubmit={this.handleSubmit}>
                             {/* Include a username field as a hint for password managers to update the saved password. */}

--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -1,6 +1,5 @@
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import * as React from 'react'
-import { RouteComponentProps } from 'react-router'
 import { Subject, Subscription } from 'rxjs'
 import { catchError, filter, mergeMap, tap } from 'rxjs/operators'
 import { PasswordInput } from '../../../auth/SignInSignUpCommon'
@@ -40,7 +39,7 @@ interface UserExternalAccountsResult {
     }
 }
 
-interface Props extends RouteComponentProps<{}> {
+interface Props {
     user: UserAreaUserFields
     authenticatedUser: AuthenticatedUser
     context: Pick<SourcegraphContext, 'authProviders'>
@@ -202,9 +201,7 @@ export class UserSettingsSecurityPage extends React.Component<Props, State> {
                     </div>
                 )}
 
-                {this.state.error && (
-                    <ErrorAlert className="mb-3" error={this.state.error} history={this.props.history} />
-                )}
+                {this.state.error && <ErrorAlert className="mb-3" error={this.state.error} />}
 
                 {this.state.saved && <div className="alert alert-success mb-3">Password changed!</div>}
 

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useState, useEffect } from 'react'
-import { RouteComponentProps } from 'react-router'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import * as H from 'history'
 
 import { CodeHostItem } from './CodeHostItem'
 import { PageTitle } from '../../../components/PageTitle'
@@ -15,10 +13,9 @@ import { asError, ErrorLike, isErrorLike } from '../../../../../shared/src/util/
 import { Scalars, ExternalServiceKind, ListExternalServiceFields } from '../../../graphql-operations'
 import { eventLogger } from '../../../tracking/eventLogger'
 
-export interface UserAddCodeHostsPageProps extends RouteComponentProps {
+export interface UserAddCodeHostsPageProps {
     userID: Scalars['ID']
     codeHostExternalServices: Record<string, AddExternalServiceOptions>
-    history: H.History
     routingPrefix: string
 }
 
@@ -31,7 +28,6 @@ const isServicesByKind = (status: Status): status is ServicesByKind =>
 export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageProps> = ({
     userID,
     codeHostExternalServices,
-    history,
     routingPrefix,
 }) => {
     const [statusOrError, setStatusOrError] = useState<Status>()
@@ -114,7 +110,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
 
             {/* display other errors */}
             {isErrorLike(statusOrError) && (
-                <ErrorAlert error={statusOrError} history={history} prefix="Code host action error" icon={false} />
+                <ErrorAlert error={statusOrError} prefix="Code host action error" icon={false} />
             )}
 
             {codeHostExternalServices && statusOrError !== 'loading' ? (

--- a/client/web/src/user/settings/emails/AddUserEmailForm.tsx
+++ b/client/web/src/user/settings/emails/AddUserEmailForm.tsx
@@ -1,6 +1,5 @@
 import React, { FunctionComponent, useMemo, useState } from 'react'
 import classNames from 'classnames'
-import * as H from 'history'
 
 import { AddUserEmailResult, AddUserEmailVariables } from '../../../graphql-operations'
 import { gql, dataOrThrowErrors } from '../../../../../shared/src/graphql/graphql'
@@ -16,14 +15,13 @@ import { LoaderInput } from '../../../../../branded/src/components/LoaderInput'
 interface Props {
     user: string
     onDidAdd: () => void
-    history: H.History
 
     className?: string
 }
 
 type Status = undefined | 'loading' | ErrorLike
 
-export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, onDidAdd, history }) => {
+export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, onDidAdd }) => {
     const [statusOrError, setStatusOrError] = useState<Status>()
 
     const [emailState, nextEmailFieldChange, emailInputReference, overrideEmailState] = useInputValidation(
@@ -118,7 +116,7 @@ export const AddUserEmailForm: FunctionComponent<Props> = ({ user, className, on
                     </small>
                 )}
             </form>
-            {isErrorLike(statusOrError) && <ErrorAlert className="mt-2" error={statusOrError} history={history} />}
+            {isErrorLike(statusOrError) && <ErrorAlert className="mt-2" error={statusOrError} />}
         </div>
     )
 }

--- a/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
+++ b/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
@@ -1,5 +1,4 @@
 import React, { useState, FunctionComponent, useCallback } from 'react'
-import * as H from 'history'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import { gql, dataOrThrowErrors } from '../../../../../shared/src/graphql/graphql'
@@ -17,7 +16,6 @@ interface Props {
     user: string
     emails: UserEmail[]
     onDidSet: () => void
-    history: H.History
 
     className?: string
 }
@@ -28,7 +26,7 @@ type Status = undefined | 'loading' | ErrorLike
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const findPrimaryEmail = (emails: UserEmail[]): string => emails.find(email => email.isPrimary)!.email
 
-export const SetUserPrimaryEmailForm: FunctionComponent<Props> = ({ user, emails, onDidSet, className, history }) => {
+export const SetUserPrimaryEmailForm: FunctionComponent<Props> = ({ user, emails, onDidSet, className }) => {
     const [primaryEmail, setPrimaryEmail] = useState<string>(findPrimaryEmail(emails))
     const [statusOrError, setStatusOrError] = useState<Status>()
 
@@ -99,7 +97,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<Props> = ({ user, emails
                     className="btn btn-primary"
                 />
             </Form>
-            {isErrorLike(statusOrError) && <ErrorAlert className="mt-2" error={statusOrError} history={history} />}
+            {isErrorLike(statusOrError) && <ErrorAlert className="mt-2" error={statusOrError} />}
         </div>
     )
 }

--- a/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
+++ b/client/web/src/user/settings/emails/UserSettingsEmailsPage.tsx
@@ -1,7 +1,5 @@
 import React, { FunctionComponent, useEffect, useState, useCallback } from 'react'
-import { RouteComponentProps } from 'react-router'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
-import * as H from 'history'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import { UserAreaUserFields, UserEmailsResult, UserEmailsVariables } from '../../../graphql-operations'
@@ -17,16 +15,15 @@ import { UserEmail } from './UserEmail'
 import { AddUserEmailForm } from './AddUserEmailForm'
 import { SetUserPrimaryEmailForm } from './SetUserPrimaryEmailForm'
 
-interface Props extends RouteComponentProps<{}> {
+interface Props {
     user: UserAreaUserFields
-    history: H.History
 }
 
 type UserEmail = NonNullable<UserEmailsResult['node']>['emails'][number]
 type Status = undefined | 'loading' | 'loaded' | ErrorLike
 type EmailActionError = undefined | ErrorLike
 
-export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user, history }) => {
+export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user }) => {
     const [emails, setEmails] = useState<UserEmail[]>([])
     const [statusOrError, setStatusOrError] = useState<Status>()
     const [emailActionError, setEmailActionError] = useState<EmailActionError>()
@@ -98,10 +95,8 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user, history
                 </div>
             )}
 
-            {isErrorLike(statusOrError) && <ErrorAlert className="mt-2" error={statusOrError} history={history} />}
-            {isErrorLike(emailActionError) && (
-                <ErrorAlert className="mt-2" error={emailActionError} history={history} />
-            )}
+            {isErrorLike(statusOrError) && <ErrorAlert className="mt-2" error={statusOrError} />}
+            {isErrorLike(emailActionError) && <ErrorAlert className="mt-2" error={emailActionError} />}
 
             <h2>Emails</h2>
 
@@ -129,10 +124,10 @@ export const UserSettingsEmailsPage: FunctionComponent<Props> = ({ user, history
             )}
 
             {/* re-fetch emails on onDidAdd to guarantee correct state */}
-            <AddUserEmailForm className="mt-4" user={user.id} onDidAdd={fetchEmails} history={history} />
+            <AddUserEmailForm className="mt-4" user={user.id} onDidAdd={fetchEmails} />
             <hr className="my-4" />
             {statusOrError === 'loaded' && (
-                <SetUserPrimaryEmailForm user={user.id} emails={emails} onDidSet={fetchEmails} history={history} />
+                <SetUserPrimaryEmailForm user={user.id} emails={emails} onDidSet={fetchEmails} />
             )}
         </div>
     )

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -609,7 +609,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                             selectionState.radio === 'selected' && (
                                 <div className="ml-4">
                                     {filterControls}
-                                    {repoState.error !== '' && <ErrorAlert error={repoState.error} history={history} />}
+                                    {repoState.error !== '' && <ErrorAlert error={repoState.error} />}
                                     <table role="grid" className="table">
                                         {
                                             // if we're selecting repos, and the repos are still loading, display the loading animation

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -197,7 +197,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                     repositories may not appear up-to-date in the list of repositories.
                 </div>
             )}
-            {isErrorLike(pendingOrError) && <ErrorAlert error={pendingOrError} icon={true} history={history} />}
+            {isErrorLike(pendingOrError) && <ErrorAlert error={pendingOrError} icon={true} />}
             <PageTitle title="Repositories" />
             <div className="d-flex justify-content-between align-items-center">
                 <h2 className="mb-2">Repositories</h2>

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -110,13 +110,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
     {
         path: '/code-hosts',
         render: props => (
-            <UserAddCodeHostsPageContainer
-                userID={props.user.id}
-                routingPrefix={props.user.url + '/settings'}
-                history={props.history}
-                match={props.match}
-                location={props.location}
-            />
+            <UserAddCodeHostsPageContainer userID={props.user.id} routingPrefix={props.user.url + '/settings'} />
         ),
         exact: true,
         condition: allowUserExternalServicePublic,


### PR DESCRIPTION
From https://github.com/sourcegraph/sourcegraph/pull/18804#discussion_r585968146

Refactors `ErrorAlert` and `ErrorMessage` to use `useHistory` hook instead of `history` prop. 

Apologies in advance for the huge diff, this seemingly simple refactor causes a huge cascading event where `history` no longer needs to be prop-drilled through the whole webapp just to render errors. 
