### PR TITLE
search contexts: Use external services repoCount field to toggle dropdown visibility

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -554,8 +554,8 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         this.extensionsController.services.workspace.versionContext.next(resolvedVersionContext)
     }
 
-    private onUserRepositoriesUpdate = (): void => {
-        this.userRepositoriesUpdates.next()
+    private onUserRepositoriesUpdate = (userRepoCount: number): void => {
+        this.setState({ hasUserAddedRepositories: userRepoCount > 0 })
     }
 
     private canShowSearchContext = (): boolean => this.state.showSearchContext && this.state.hasUserAddedRepositories

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -346,7 +346,8 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
 
                             // if the lastSyncAt has changed for all hosts then we're done
                             if (result.nodes.every(codeHost => codeHost.lastSyncAt !== syncTimes.get(codeHost.id))) {
-                                onUserRepositoriesUpdate()
+                                const repoCount = result.nodes.reduce((sum, codeHost) => sum + codeHost.repoCount, 0)
+                                onUserRepositoriesUpdate(repoCount)
                                 // push the user back to the repo list page
                                 history.push(routingPrefix + '/repositories')
                                 // cancel the repeatUntil

--- a/client/web/src/util/index.tsx
+++ b/client/web/src/util/index.tsx
@@ -44,5 +44,5 @@ export const isMacPlatform = window.navigator.platform.includes('Mac')
 export interface UserRepositoriesUpdateProps {
     // Callback triggered when a user successfuly updates their
     // synced repositories
-    onUserRepositoriesUpdate: () => void
+    onUserRepositoriesUpdate: (userRepoCount: number) => void
 }


### PR DESCRIPTION
A hard-to-reproduce issue was discovered during user testing where search contexts dropdown would not appear, even though the user just added new repositories. My guess is that there was a timing issue between syncing external services and us querying the API for user repositories. So instead of relying on the API for user repositories, we can get the number of repositories directly from external services once they are done syncing.

Fixes #18732