### PR TITLE
gqltest: add SearchStreamClient

### DIFF
--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -292,8 +292,12 @@ func (c *Client) Get(url string) (*http.Response, error) {
 		return nil, err
 	}
 
-	req.AddCookie(c.csrfCookie)
-	req.AddCookie(c.sessionCookie)
+	c.addCookies(req)
 
 	return http.DefaultClient.Do(req)
+}
+
+func (c *Client) addCookies(req *http.Request) {
+	req.AddCookie(c.csrfCookie)
+	req.AddCookie(c.sessionCookie)
 }


### PR DESCRIPTION
This introduces SearchStreamClient which implements most of the search
interfaces of gqltest.Client. It does this by taking the nice clean
streaming search API and translating it into the awkward GraphQL
response types :)