### PR TITLE
search: flush matches buffer based on marshalled size

### DIFF
--- a/internal/search/streaming/http/client.go
+++ b/internal/search/streaming/http/client.go
@@ -36,7 +36,9 @@ type Decoder struct {
 }
 
 func (rr Decoder) ReadAll(r io.Reader) error {
+	const maxPayloadSize = 10 * 1024 * 1024 // 10mb
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 4096), maxPayloadSize)
 	// bufio.ScanLines, except we look for two \n\n which separate events.
 	split := func(data []byte, atEOF bool) (int, []byte, error) {
 		if atEOF && len(data) == 0 {


### PR DESCRIPTION
Previously we flushed the buffer every 1000 items. However, this lead to
very large lines / payloads to parse. By splitting up our payload by
size we get more reasonable lines to parse.

Note: we don't gaurentee a line won't go over a certain size, but this
goes a long way to fixing that. This commit also increases the max
buffer size for the Go streaming client.