### PR TITLE
dev: remove schema.graphql special case from handle-change

### DIFF
--- a/dev/handle-change.sh
+++ b/dev/handle-change.sh
@@ -11,10 +11,6 @@ failed=false
 
 for i; do
   case $i in
-    "cmd/frontend/graphqlbackend/schema.graphql")
-      # We assume that frontend needs to be rebuilt when the schema changes, and add it to the list.
-      cmdlist+=("frontend")
-      ;;
     monitoring/*)
       generate_monitoring=true
       ;;


### PR DESCRIPTION
We handle files under cmd/ already in the script so we don't need to
special case schema.graphql.

Co-authored-by: @mrnugget 