### PR TITLE
perforce: pin p4 CLI deps to a specific commit

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4
 
 # This is a trick to include libraries required by p4,
 # please refer to https://blog.tilander.org/docker-perforce/
-ADD https://github.com/jtilander/p4d/raw/master/lib/lib-x64.tgz /
+ADD https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad613358/lib/lib-x64.tgz /
 RUN tar zxf /lib-x64.tgz --directory /
 
 RUN mkdir -p /data/repos && chown -R sourcegraph:sourcegraph /data/repos

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -101,7 +101,7 @@ COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4
 
 # This is a trick to include libraries required by p4,
 # please refer to https://blog.tilander.org/docker-perforce/
-ADD https://github.com/jtilander/p4d/raw/master/lib/lib-x64.tgz /
+ADD https://github.com/jtilander/p4d/raw/4600d741720f85d77852dcca7c182e96ad613358/lib/lib-x64.tgz /
 RUN tar zxf /lib-x64.tgz --directory /
 
 # hadolint ignore=DL3022


### PR DESCRIPTION
We're fetching tarball from an URL, and it's better to stick to a specific commit than always the latest.