### PR TITLE
dev/gqltest: enable streaming integration tests

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -103,6 +103,11 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	}
 	tr.LazyPrintf("parsing done")
 
+	// We do not support stable for streaming
+	if args.Stream != nil && q.BoolValue(query.FieldStable) {
+		return alertForQuery(db, args.Query, errors.New("stable is not supported for the streaming API. Please remove from query")), nil
+	}
+
 	// If stable:truthy is specified, make the query return a stable result ordering.
 	if q.BoolValue(query.FieldStable) {
 		args, q, err = queryForStableResults(args, q)

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -328,6 +328,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			zeroResult    bool
 			minMatchCount int64
 			wantAlert     *gqltestutil.SearchAlert
+			skipStream    bool
 		}{
 			// Global search
 			{
@@ -381,6 +382,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:  "non-master branch, nonzero result",
 				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 type:file`,
+			},
+			{
+				name:       "non-master branch, nonzero result stable",
+				query:      `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 stable:yes type:file`,
+				skipStream: true,
 			},
 			{
 				name:  "indexed multiline search, nonzero result",
@@ -473,6 +479,10 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
+				if test.skipStream && isStreaming {
+					t.Skip("streaming not supported yet")
+				}
+
 				results, err := client.SearchFiles(test.query)
 				if err != nil {
 					t.Fatal(err)
@@ -600,6 +610,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:  `And operator, basic`,
 				query: `repo:^github\.com/sgtest/go-diff$ func and main count:1 type:file`,
+			},
+			{
+				name:       `And operator, basic with stable`,
+				query:      `repo:^github\.com/sgtest/go-diff$ func and main count:1 stable:yes type:file`,
+				skipStream: true,
 			},
 			{
 				name:  `Or operator, single and double quoted`,

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -74,7 +74,14 @@ func TestSearch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testSearchClient(t, client)
+	t.Run("graphql", func(t *testing.T) {
+		testSearchClient(t, client)
+	})
+	t.Run("stream", func(t *testing.T) {
+		testSearchClient(t, &gqltestutil.SearchStreamClient{
+			Client: client,
+		})
+	})
 
 	testSearchOther(t)
 }

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -270,6 +270,14 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query: "repohasfile:README",
 			},
 			{
+				name:  "repo search by name, nonzero result",
+				query: "repo:go-diff$",
+			},
+			{
+				name:  "true is an alias for yes when fork is set",
+				query: `repo:github\.com/sgtest/mux fork:true`,
+			},
+			{
 				name:  `exclude counts for fork and archive`,
 				query: `repo:mux|archived|go-diff`,
 				wantMissing: []string{
@@ -360,16 +368,8 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			// Repo search
 			{
-				name:  "repo search by name, nonzero result",
-				query: "repo:go-diff$",
-			},
-			{
 				name:  "repo search by name, case yes, nonzero result",
 				query: `repo:^github\.com/sgtest/go-diff$ String case:yes count:1 type:file`,
-			},
-			{
-				name:  "true is an alias for yes when fork is set",
-				query: `repo:github\.com/sgtest/mux fork:true`,
 			},
 			{
 				name:  "non-master branch, nonzero result",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -969,8 +969,8 @@ func testSearchClient(t *testing.T, client searchClient) {
 				}
 
 				count := countResults(results)
-				if !cmp.Equal(count, test.counts) {
-					t.Fatalf(cmp.Diff(test.counts, count))
+				if diff := cmp.Diff(test.counts, count); diff != "" {
+					t.Fatalf("mismatch (-want +got):\n%s", diff)
 				}
 			})
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -354,11 +354,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  "double-quoted pattern, nonzero result",
-				query: `"func main() {\n" patterntype:regexp count:1 type:file`,
+				query: `"func main() {\n" patterntype:regexp type:file`,
 			},
 			{
 				name:  "exclude repo, nonzero result",
-				query: `"func main() {\n" -repo:go-diff patterntype:regexp count:1 type:file`,
+				query: `"func main() {\n" -repo:go-diff patterntype:regexp type:file`,
 			},
 			{
 				name:       "fork:no",
@@ -377,11 +377,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			// Repo search
 			{
 				name:  "repo search by name, case yes, nonzero result",
-				query: `repo:^github\.com/sgtest/go-diff$ String case:yes count:1 type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ String case:yes type:file`,
 			},
 			{
 				name:  "non-master branch, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 type:file`,
+				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal type:file`,
 			},
 			{
 				name:       "non-master branch, nonzero result stable",
@@ -390,11 +390,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  "indexed multiline search, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:only patterntype:regexp count:1 type:file`,
+				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:only patterntype:regexp type:file`,
 			},
 			{
 				name:  "unindexed multiline search, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:no patterntype:regexp count:1 type:file`,
+				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:no patterntype:regexp type:file`,
 			},
 			{
 				name:       "random characters, zero result",
@@ -424,11 +424,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			// Commit search
 			{
 				name:  "commit search, nonzero result",
-				query: `repo:^github\.com/sgtest/go-diff$ type:commit count:1`,
+				query: `repo:^github\.com/sgtest/go-diff$ type:commit`,
 			},
 			{
 				name:       "commit search, non-existent ref",
-				query:      `repo:^github\.com/sgtest/go-diff$@ref/noexist type:commit count:1`,
+				query:      `repo:^github\.com/sgtest/go-diff$@ref/noexist type:commit`,
 				zeroResult: true,
 				wantAlert: &gqltestutil.SearchAlert{
 					Title:           "Some repositories could not be searched",
@@ -447,17 +447,17 @@ func testSearchClient(t *testing.T, client searchClient) {
 			// Diff search
 			{
 				name:  "diff search, nonzero result",
-				query: `repo:^github\.com/sgtest/go-diff$ type:diff main count:1`,
+				query: `repo:^github\.com/sgtest/go-diff$ type:diff main`,
 			},
 			// Repohascommitafter
 			{
 				name:  `Repohascommitafter, nonzero result`,
-				query: `repo:^github\.com/sgtest/go-diff$ repohascommitafter:"2019-01-01" test patterntype:literal count:1`,
+				query: `repo:^github\.com/sgtest/go-diff$ repohascommitafter:"2019-01-01" test patterntype:literal`,
 			},
 			// Regex text search
 			{
 				name:  `regex, unindexed, nonzero result`,
-				query: `^func.*$ patterntype:regexp index:only count:1 type:file`,
+				query: `^func.*$ patterntype:regexp index:only type:file`,
 			},
 			{
 				name:  `regex, fork only, nonzero result`,
@@ -465,7 +465,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  `regex, filter by language`,
-				query: `\bfunc\b lang:go count:1 type:file patterntype:regexp`,
+				query: `\bfunc\b lang:go type:file patterntype:regexp`,
 			},
 			{
 				name:       `regex, filename, zero results`,
@@ -474,7 +474,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  `regexp, filename, nonzero result`,
-				query: `file:doc.go patterntype:regexp count:1`,
+				query: `file:doc.go patterntype:regexp`,
 			},
 		}
 		for _, test := range tests {
@@ -609,36 +609,36 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}{
 			{
 				name:  `And operator, basic`,
-				query: `repo:^github\.com/sgtest/go-diff$ func and main count:1 type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ func and main type:file`,
 			},
 			{
 				name:       `And operator, basic with stable`,
-				query:      `repo:^github\.com/sgtest/go-diff$ func and main count:1 stable:yes type:file`,
+				query:      `repo:^github\.com/sgtest/go-diff$ func and main stable:yes type:file`,
 				skipStream: true,
 			},
 			{
 				name:  `Or operator, single and double quoted`,
-				query: `repo:^github\.com/sgtest/go-diff$ "func PrintMultiFileDiff" or 'func readLine(' type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ "func PrintMultiFileDiff" or 'func readLine(' type:file patterntype:regexp`,
 			},
 			{
 				name:  `Literals, grouped parens with parens-as-patterns heuristic`,
-				query: `repo:^github\.com/sgtest/go-diff$ (() or ()) type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ (() or ()) type:file patterntype:regexp`,
 			},
 			{
 				name:  `Literals, no grouped parens`,
-				query: `repo:^github\.com/sgtest/go-diff$ () or () type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ () or () type:file patterntype:regexp`,
 			},
 			{
 				name:  `Literals, escaped parens`,
-				query: `repo:^github\.com/sgtest/go-diff$ \(\) or \(\) type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ \(\) or \(\) type:file patterntype:regexp`,
 			},
 			{
 				name:  `Literals, escaped and unescaped parens, no group`,
-				query: `repo:^github\.com/sgtest/go-diff$ () or \(\) type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ () or \(\) type:file patterntype:regexp`,
 			},
 			{
 				name:  `Literals, escaped and unescaped parens, grouped`,
-				query: `repo:^github\.com/sgtest/go-diff$ (() or \(\)) type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ (() or \(\)) type:file patterntype:regexp`,
 			},
 			{
 				name:       `Literals, double paren`,
@@ -657,16 +657,16 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:       `Mixed regexp and literal`,
-				query:      `repo:^github\.com/sgtest/go-diff$ func(.*) or does_not_exist_3744 count:1 type:file`,
+				query:      `repo:^github\.com/sgtest/go-diff$ func(.*) or does_not_exist_3744 type:file`,
 				skipStream: true,
 			},
 			{
 				name:  `Mixed regexp and literal heuristic`,
-				query: `repo:^github\.com/sgtest/go-diff$ func( or func(.*) count:1 type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ func( or func(.*) type:file`,
 			},
 			{
 				name:       `Mixed regexp and quoted literal`,
-				query:      `repo:^github\.com/sgtest/go-diff$ "*" and cert.*Load count:1 type:file`,
+				query:      `repo:^github\.com/sgtest/go-diff$ "*" and cert.*Load type:file`,
 				zeroResult: true,
 			},
 			{

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -358,8 +358,12 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:       "fork:no",
-				query:      "fork:no FORK_SENTINEL",
+				query:      "fork:no FORK" + "_SENTINEL",
 				zeroResult: true,
+			},
+			{
+				name:  "fork:yes",
+				query: "fork:yes FORK" + "_SENTINEL",
 			},
 			{
 				name:       "random characters, zero results",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -266,6 +266,10 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query: `repo:^github\.com/sgtest/mux$`,
 			},
 			{
+				name:  "repohasfile returns results for global search",
+				query: "repohasfile:README",
+			},
+			{
 				name:  `exclude counts for fork and archive`,
 				query: `repo:mux|archived|go-diff`,
 				wantMissing: []string{
@@ -327,10 +331,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 				name:          "something with more than 1000 results and use count:1000",
 				query:         ". count:1000",
 				minMatchCount: 1000,
-			},
-			{
-				name:  "repohasfile returns results for global search",
-				query: "repohasfile:README",
 			},
 			{
 				name:  "regular expression without indexed search",

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -104,15 +104,15 @@ func testSearchClient(t *testing.T, client searchClient) {
 			wantMissing []string
 		}{
 			{
-				query:       "type:repo visibility:private",
+				query:       "type:repo visibility:private sgtest",
 				wantMissing: []string{},
 			},
 			{
-				query:       "type:repo visibility:public",
+				query:       "type:repo visibility:public sgtest",
 				wantMissing: []string{"github.com/sgtest/private"},
 			},
 			{
-				query:       "type:repo visibility:any",
+				query:       "type:repo visibility:any sgtest",
 				wantMissing: []string{},
 			},
 		}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -342,11 +342,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  "double-quoted pattern, nonzero result",
-				query: `"func main() {\n" patterntype:regexp count:1 stable:yes type:file`,
+				query: `"func main() {\n" patterntype:regexp count:1 type:file`,
 			},
 			{
 				name:  "exclude repo, nonzero result",
-				query: `"func main() {\n" -repo:go-diff patterntype:regexp count:1 stable:yes type:file`,
+				query: `"func main() {\n" -repo:go-diff patterntype:regexp count:1 type:file`,
 			},
 			{
 				name:       "fork:no",
@@ -365,7 +365,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  "repo search by name, case yes, nonzero result",
-				query: `repo:^github\.com/sgtest/go-diff$ String case:yes count:1 stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ String case:yes count:1 type:file`,
 			},
 			{
 				name:  "true is an alias for yes when fork is set",
@@ -373,15 +373,15 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  "non-master branch, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 type:file`,
 			},
 			{
 				name:  "indexed multiline search, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:only patterntype:regexp count:1 stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:only patterntype:regexp count:1 type:file`,
 			},
 			{
 				name:  "unindexed multiline search, nonzero result",
-				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:no patterntype:regexp count:1 stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/java-langserver$ \nimport index:no patterntype:regexp count:1 type:file`,
 			},
 			{
 				name:       "random characters, zero result",
@@ -444,7 +444,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			// Regex text search
 			{
 				name:  `regex, unindexed, nonzero result`,
-				query: `^func.*$ patterntype:regexp index:only count:1 stable:yes type:file`,
+				query: `^func.*$ patterntype:regexp index:only count:1 type:file`,
 			},
 			{
 				name:  `regex, fork only, nonzero result`,
@@ -452,7 +452,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  `regex, filter by language`,
-				query: `\bfunc\b lang:go count:1 stable:yes type:file patterntype:regexp`,
+				query: `\bfunc\b lang:go count:1 type:file patterntype:regexp`,
 			},
 			{
 				name:       `regex, filename, zero results`,
@@ -590,31 +590,31 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}{
 			{
 				name:  `And operator, basic`,
-				query: `repo:^github\.com/sgtest/go-diff$ func and main count:1 stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ func and main count:1 type:file`,
 			},
 			{
 				name:  `Or operator, single and double quoted`,
-				query: `repo:^github\.com/sgtest/go-diff$ "func PrintMultiFileDiff" or 'func readLine(' stable:yes type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ "func PrintMultiFileDiff" or 'func readLine(' type:file count:1 patterntype:regexp`,
 			},
 			{
 				name:  `Literals, grouped parens with parens-as-patterns heuristic`,
-				query: `repo:^github\.com/sgtest/go-diff$ (() or ()) stable:yes type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ (() or ()) type:file count:1 patterntype:regexp`,
 			},
 			{
 				name:  `Literals, no grouped parens`,
-				query: `repo:^github\.com/sgtest/go-diff$ () or () stable:yes type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ () or () type:file count:1 patterntype:regexp`,
 			},
 			{
 				name:  `Literals, escaped parens`,
-				query: `repo:^github\.com/sgtest/go-diff$ \(\) or \(\) stable:yes type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ \(\) or \(\) type:file count:1 patterntype:regexp`,
 			},
 			{
 				name:  `Literals, escaped and unescaped parens, no group`,
-				query: `repo:^github\.com/sgtest/go-diff$ () or \(\) stable:yes type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ () or \(\) type:file count:1 patterntype:regexp`,
 			},
 			{
 				name:  `Literals, escaped and unescaped parens, grouped`,
-				query: `repo:^github\.com/sgtest/go-diff$ (() or \(\)) stable:yes type:file count:1 patterntype:regexp`,
+				query: `repo:^github\.com/sgtest/go-diff$ (() or \(\)) type:file count:1 patterntype:regexp`,
 			},
 			{
 				name:       `Literals, double paren`,
@@ -633,15 +633,15 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  `Mixed regexp and literal`,
-				query: `repo:^github\.com/sgtest/go-diff$ func(.*) or does_not_exist_3744 count:1 stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ func(.*) or does_not_exist_3744 count:1 type:file`,
 			},
 			{
 				name:  `Mixed regexp and literal heuristic`,
-				query: `repo:^github\.com/sgtest/go-diff$ func( or func(.*) count:1 stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ func( or func(.*) count:1 type:file`,
 			},
 			{
 				name:       `Mixed regexp and quoted literal`,
-				query:      `repo:^github\.com/sgtest/go-diff$ "*" and cert.*Load count:1 stable:yes type:file`,
+				query:      `repo:^github\.com/sgtest/go-diff$ "*" and cert.*Load count:1 type:file`,
 				zeroResult: true,
 			},
 			{
@@ -728,7 +728,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:  `Concat converted to .* for regexp search`,
-				query: `repo:^github\.com/sgtest/go-diff$ file:^diff/print\.go t := or ts Time patterntype:regexp stable:yes type:file`,
+				query: `repo:^github\.com/sgtest/go-diff$ file:^diff/print\.go t := or ts Time patterntype:regexp type:file`,
 			},
 			{
 				name:  `Structural search uses literal search parser`,

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -326,7 +326,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:          "something with more than 1000 results and use count:1000",
 				query:         ". count:1000",
-				minMatchCount: 1001,
+				minMatchCount: 1000,
 			},
 			{
 				name:  "repohasfile returns results for global search",

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -534,15 +534,22 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 		},
 		OnMatches: func(matches []streamhttp.EventMatch) {
 			for _, m := range matches {
-				fm, ok := m.(*streamhttp.EventFileMatch)
-				if !ok {
-					continue
+				switch v := m.(type) {
+				case *streamhttp.EventFileMatch:
+					var r SearchFileResult
+					r.File.Name = v.Path
+					r.Repository.Name = v.Repository
+					r.RevSpec.Expr = v.Branches[0]
+					results.Results = append(results.Results, &r)
+
+				case *streamhttp.EventSymbolMatch:
+					var r SearchFileResult
+					r.File.Name = v.Path
+					r.Repository.Name = v.Repository
+					r.RevSpec.Expr = v.Branches[0]
+					results.Results = append(results.Results, &r)
+
 				}
-				var r SearchFileResult
-				r.File.Name = fm.Path
-				r.Repository.Name = fm.Repository
-				r.RevSpec.Expr = fm.Branches[0]
-				results.Results = append(results.Results, &r)
 			}
 		},
 		OnAlert: func(alert *streamhttp.EventAlert) {

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming/api"
@@ -32,6 +33,15 @@ func (rs SearchRepositoryResults) Exists(names ...string) []string {
 		missing = append(missing, name)
 	}
 	return missing
+}
+
+func (rs SearchRepositoryResults) String() string {
+	var names []string
+	for _, r := range rs {
+		names = append(names, r.Name)
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("%q", names)
 }
 
 // SearchRepositories search repositories with given query.

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -535,6 +535,9 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 		OnMatches: func(matches []streamhttp.EventMatch) {
 			for _, m := range matches {
 				switch v := m.(type) {
+				case *streamhttp.EventRepoMatch:
+					results.Results = append(results.Results, &SearchFileResult{})
+
 				case *streamhttp.EventFileMatch:
 					var r SearchFileResult
 					r.File.Name = v.Path

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -549,6 +549,11 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 					r.RevSpec.Expr = v.Branches[0]
 					results.Results = append(results.Results, &r)
 
+				case *streamhttp.EventCommitMatch:
+					// The tests don't actually look at the value. We need to
+					// update this client to be more generic, but this will do
+					// for now.
+					results.Results = append(results.Results, &SearchFileResult{})
 				}
 			}
 		},
@@ -586,9 +591,23 @@ func (s *SearchStreamClient) SearchAll(query string) ([]*AnyResult, error) {
 						lms[i].OffsetAndLengths = v.LineMatches[i].OffsetAndLengths
 					}
 					results = append(results, FileResult{
-						File:       struct{ Path string }{Path: v.Path},
-						Repository: RepositoryResult{Name: v.Repository},
+						File:        struct{ Path string }{Path: v.Path},
+						Repository:  RepositoryResult{Name: v.Repository},
+						LineMatches: lms,
 					})
+
+				case *streamhttp.EventSymbolMatch:
+					var r FileResult
+					r.File.Path = v.Path
+					r.Repository.Name = v.Repository
+					r.Symbols = make([]interface{}, len(v.Symbols))
+					results = append(results, &r)
+
+				case *streamhttp.EventCommitMatch:
+					// The tests don't actually look at the value. We need to
+					// update this client to be more generic, but this will do
+					// for now.
+					results = append(results, CommitResult{URL: v.URL})
 				}
 			}
 		},


### PR DESCRIPTION
This runs all search tests against both the GraphQL API as well as the streaming API. Some tests do not work yet against streaming, so they are individually skipped. Some other tests had subtle bugs in them that I fixed.

I would like to land this in so we get integration testing coverage going forward for streaming.