### PR TITLE
Prototype: loading debug assets from a custom URL

### DIFF
--- a/cmd/frontend/internal/app/assetsutil/debugAssets.go
+++ b/cmd/frontend/internal/app/assetsutil/debugAssets.go
@@ -1,0 +1,39 @@
+package assetsutil
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+)
+
+func GetDebugAssetsLocation(r *http.Request) (*url.URL, error) {
+	const debugAssetsQueryParam = "debugAssetsUrl"
+
+	q := r.URL.Query()
+	debugAssetsValue := q.Get(debugAssetsQueryParam)
+
+	if debugAssetsValue == "" {
+		return nil, errors.New("debugAssets query param not present")
+	}
+
+	a := actor.FromContext(r.Context())
+	if !a.IsAuthenticated() {
+		return nil, errors.New("user is not authenticated")
+	}
+
+	// The user may have a tag that opts them in
+	ok, _ := database.GlobalUsers.HasTag(r.Context(), a.UID, database.TagAllowDebugAssets)
+	if !ok {
+		return nil, errors.New(("user does not have AllowDebugAssets tag"))
+	}
+
+	debugAssetsURL, err := url.Parse(debugAssetsValue)
+	if (err != nil) {
+		return nil, err
+	}
+
+	return debugAssetsURL, nil
+}

--- a/cmd/frontend/internal/app/assetsutil/debugAssets.go
+++ b/cmd/frontend/internal/app/assetsutil/debugAssets.go
@@ -31,7 +31,7 @@ func GetDebugAssetsLocation(r *http.Request) (*url.URL, error) {
 	}
 
 	debugAssetsURL, err := url.Parse(debugAssetsValue)
-	if (err != nil) {
+	if err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -121,6 +121,12 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 		WebpackDevServer: webpackDevServer,
 	}
 
+	assetsURL, err := assetsutil.GetDebugAssetsLocation(r)
+	if err == nil {
+		common.AssetURL = assetsURL.String()
+		common.WebpackDevServer = true
+	}
+
 	if _, ok := mux.Vars(r)["Repo"]; ok {
 		// Common repo pages (blob, tree, etc).
 		var err error

--- a/internal/database/users.go
+++ b/internal/database/users.go
@@ -1071,6 +1071,8 @@ const (
 	TagAllowUserExternalServicePrivate = "AllowUserExternalServicePrivate"
 	// If the owner of an external service has this tag, the service is allowed to sync public code only
 	TagAllowUserExternalServicePublic = "AllowUserExternalServicePublic"
+	// If the user is allowed to load debug assets (eg. webpack dev server running locally)
+	TagAllowDebugAssets = "AllowDebugAssets"
 )
 
 // SetTag adds (present=true) or removes (present=false) a tag from the given user's set of tags. An


### PR DESCRIPTION
How this works:
- User must be signed in and have `AllowDebugAssets` tag
- Page must be loaded with `?debugAssetsUrl=<location>` URL, eg: `?debugAssetsUrl=http://localhost:3080/.assets`
- Webpack bundle is now loaded from that URL