### PR TITLE
search: Add comments about why Equal methods exist

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -44,6 +44,7 @@ type FileMatchResolver struct {
 	db           dbutil.DB
 }
 
+// Equal provides custom comparison which is used by go-cmp
 func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 	return reflect.DeepEqual(fm, other)
 }

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -75,6 +75,7 @@ type RepositoryRevisions struct {
 	ListRefs func(context.Context, api.RepoName) ([]git.Ref, error)
 }
 
+// Equal provides custom comparison which is used by go-cmp
 func (r *RepositoryRevisions) Equal(other *RepositoryRevisions) bool {
 	return reflect.DeepEqual(r.Repo, other.Repo) && reflect.DeepEqual(r.Revs, other.Revs)
 }

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -109,6 +109,7 @@ func (c *Stats) String() string {
 	return "Stats{" + strings.Join(parts, " ") + "}"
 }
 
+// Equal provides custom comparison which is used by go-cmp
 func (c *Stats) Equal(other *Stats) bool {
 	return reflect.DeepEqual(c, other)
 }


### PR DESCRIPTION
Find references doesn't return any results because Equal is used through
reflection by the go-cmp library. This just adds some breadcrumb
comments to point people in the right direction if they are confused
like me.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
