### PR TITLE
search: share symbol result type

### DIFF
--- a/cmd/frontend/backend/symbols.go
+++ b/cmd/frontend/backend/symbols.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	symbolsclient "github.com/sourcegraph/sourcegraph/internal/symbols"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 )
 
 // Symbols backend.
@@ -14,7 +14,7 @@ var Symbols = &symbols{}
 type symbols struct{}
 
 // ListTags returns symbols in a repository from ctags.
-func (symbols) ListTags(ctx context.Context, args search.SymbolsParameters) ([]protocol.Symbol, error) {
+func (symbols) ListTags(ctx context.Context, args search.SymbolsParameters) ([]result.Symbol, error) {
 	result, err := symbolsclient.DefaultClient.Search(ctx, args)
 	if result == nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
@@ -1616,16 +1615,16 @@ func TestUnionMerge(t *testing.T) {
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
 					fileResult(db, "a", nil, []*result.SearchSymbolResult{
-						{Symbol: protocol.Symbol{Name: "a"}},
-						{Symbol: protocol.Symbol{Name: "b"}},
+						{Symbol: result.Symbol{Name: "a"}},
+						{Symbol: result.Symbol{Name: "b"}},
 					}),
 				},
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
 					fileResult(db, "a", nil, []*result.SearchSymbolResult{
-						{Symbol: protocol.Symbol{Name: "c"}},
-						{Symbol: protocol.Symbol{Name: "d"}},
+						{Symbol: result.Symbol{Name: "c"}},
+						{Symbol: result.Symbol{Name: "d"}},
 					}),
 				},
 			},

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -21,7 +21,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -263,7 +262,7 @@ func unescapePattern(pattern string) string {
 // data member that currently exposes line content: the symbols Pattern member,
 // which has the form /^ ... $/. We find the offset of the symbol name in this
 // line, after escaping the Pattern.
-func computeSymbolOffset(s protocol.Symbol) int {
+func computeSymbolOffset(s result.Symbol) int {
 	if s.Pattern == "" {
 		return 0
 	}
@@ -274,7 +273,7 @@ func computeSymbolOffset(s protocol.Symbol) int {
 	return 0
 }
 
-func symbolRange(s protocol.Symbol) lsp.Range {
+func symbolRange(s result.Symbol) lsp.Range {
 	offset := computeSymbolOffset(s)
 	return lsp.Range{
 		Start: lsp.Position{Line: s.Line - 1, Character: offset},

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func TestMakeFileMatchURIFromSymbol(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	symbol := protocol.Symbol{
+	symbol := result.Symbol{
 		Name:    "test",
 		Path:    "foo/bar",
 		Line:    0,
@@ -68,7 +67,7 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("one file match, one symbol", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{{
-			Symbol: protocol.Symbol{
+			Symbol: result.Symbol{
 				Name: "symbol-name-1",
 			},
 		}})
@@ -97,11 +96,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("two file matches, one symbol per file", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{{
-			Symbol: protocol.Symbol{
+			Symbol: result.Symbol{
 				Name: "symbol-name-1",
 			},
 		}}, []*result.SearchSymbolResult{{
-			Symbol: protocol.Symbol{
+			Symbol: result.Symbol{
 				Name: "symbol-name-2",
 			},
 		}})
@@ -138,11 +137,11 @@ func TestLimitingSymbolResults(t *testing.T) {
 
 	t.Run("two file matches, multiple symbols per file", func(t *testing.T) {
 		res := mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
-			{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
-			{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
+			{Symbol: result.Symbol{Name: "symbol-name-1"}},
+			{Symbol: result.Symbol{Name: "symbol-name-2"}},
 		}, []*result.SearchSymbolResult{
-			{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
-			{Symbol: protocol.Symbol{Name: "symbol-name-4"}},
+			{Symbol: result.Symbol{Name: "symbol-name-3"}},
+			{Symbol: result.Symbol{Name: "symbol-name-4"}},
 		})
 
 		t.Run("symbol count is 4", func(t *testing.T) {
@@ -165,36 +164,36 @@ func TestLimitingSymbolResults(t *testing.T) {
 				name:  "limit 1 => one file match with one symbol",
 				limit: 1,
 				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
-					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
+					{Symbol: result.Symbol{Name: "symbol-name-1"}},
 				}),
 			},
 			{
 				name:  "limit 2 => one file match with all symbols",
 				limit: 2,
 				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
-					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{Symbol: result.Symbol{Name: "symbol-name-1"}},
+					{Symbol: result.Symbol{Name: "symbol-name-2"}},
 				}),
 			},
 			{
 				name:  "limit 3 => two file matches with three symbols",
 				limit: 3,
 				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
-					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{Symbol: result.Symbol{Name: "symbol-name-1"}},
+					{Symbol: result.Symbol{Name: "symbol-name-2"}},
 				}, []*result.SearchSymbolResult{
-					{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
+					{Symbol: result.Symbol{Name: "symbol-name-3"}},
 				}),
 			},
 			{
 				name:  "limit 4 => two file matches with all symbols",
 				limit: 4,
 				want: mkSymbolFileMatchResolvers(db, []*result.SearchSymbolResult{
-					{Symbol: protocol.Symbol{Name: "symbol-name-1"}},
-					{Symbol: protocol.Symbol{Name: "symbol-name-2"}},
+					{Symbol: result.Symbol{Name: "symbol-name-1"}},
+					{Symbol: result.Symbol{Name: "symbol-name-2"}},
 				}, []*result.SearchSymbolResult{
-					{Symbol: protocol.Symbol{Name: "symbol-name-3"}},
-					{Symbol: protocol.Symbol{Name: "symbol-name-4"}},
+					{Symbol: result.Symbol{Name: "symbol-name-3"}},
+					{Symbol: result.Symbol{Name: "symbol-name-4"}},
 				}),
 			},
 		}
@@ -220,7 +219,7 @@ func TestSymbolRange(t *testing.T) {
 			Start: lsp.Position{Line: 0, Character: 37},
 			End:   lsp.Position{Line: 0, Character: 40},
 		}
-		got := symbolRange(protocol.Symbol{Line: 1, Name: "baz", Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`})
+		got := symbolRange(result.Symbol{Line: 1, Name: "baz", Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`})
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatal(diff)
 		}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -18,7 +18,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
@@ -155,7 +154,7 @@ func searchZoektSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitReso
 					db,
 					commit,
 					&result.SearchSymbolResult{
-						Symbol: protocol.Symbol{
+						Symbol: result.Symbol{
 							Name:       m.SymbolInfo.Sym,
 							Kind:       m.SymbolInfo.Kind,
 							Parent:     m.SymbolInfo.Parent,

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/searcher"
-	symbolprotocol "github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -481,9 +480,9 @@ func TestSelect(t *testing.T) {
 	data := FileMatchResolver{
 		FileMatch: result.FileMatch{
 			Symbols: []*result.SearchSymbolResult{
-				{Symbol: symbolprotocol.Symbol{Name: "a()", Kind: "func"}},
-				{Symbol: symbolprotocol.Symbol{Name: "b()", Kind: "function"}},
-				{Symbol: symbolprotocol.Symbol{Name: "var c", Kind: "variable"}},
+				{Symbol: result.Symbol{Name: "a()", Kind: "func"}},
+				{Symbol: result.Symbol{Name: "b()", Kind: "function"}},
+				{Symbol: result.Symbol{Name: "var c", Kind: "variable"}},
 			},
 		},
 	}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -584,7 +583,7 @@ func zoektFileMatchToSymbolResults(repo *RepositoryResolver, inputRev string, fi
 			}
 
 			symbols = append(symbols, &result.SearchSymbolResult{
-				Symbol: protocol.Symbol{
+				Symbol: result.Symbol{
 					Name:       m.SymbolInfo.Sym,
 					Kind:       m.SymbolInfo.Kind,
 					Parent:     m.SymbolInfo.Parent,

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	zoektutil "github.com/sourcegraph/sourcegraph/internal/search/zoekt"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -1019,7 +1019,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 	repo := NewRepositoryResolver(db, &types.Repo{Name: "foo"})
 
 	results := zoektFileMatchToSymbolResults(repo, "master", file)
-	var symbols []protocol.Symbol
+	var symbols []result.Symbol
 	for _, res := range results {
 		// Check the fields which are not specific to the symbol
 		if got, want := res.Lang, "go"; got != want {
@@ -1032,7 +1032,7 @@ func TestZoektFileMatchToSymbolResults(t *testing.T) {
 		symbols = append(symbols, res.Symbol)
 	}
 
-	want := []protocol.Symbol{{
+	want := []result.Symbol{{
 		Name:    "a",
 		Line:    10,
 		Pattern: "/^symbol a symbol b$/",

--- a/cmd/symbols/internal/symbols/parse.go
+++ b/cmd/symbols/internal/symbols/parse.go
@@ -16,7 +16,7 @@ import (
 	nettrace "golang.org/x/net/trace"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
@@ -38,7 +38,7 @@ func (s *Service) startParsers() error {
 	return nil
 }
 
-func (s *Service) parseUncached(ctx context.Context, repo api.RepoName, commitID api.CommitID, callback func(symbol protocol.Symbol) error) (err error) {
+func (s *Service) parseUncached(ctx context.Context, repo api.RepoName, commitID api.CommitID, callback func(symbol result.Symbol) error) (err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "parseUncached")
 	defer func() {
 		if err != nil {
@@ -176,8 +176,8 @@ func (s *Service) parse(ctx context.Context, req parseRequest) (entries []*ctags
 	}
 }
 
-func entryToSymbol(e *ctags.Entry) protocol.Symbol {
-	return protocol.Symbol{
+func entryToSymbol(e *ctags.Entry) result.Symbol {
+	return result.Symbol{
 		Name:        e.Name,
 		Path:        e.Path,
 		Line:        e.Line,

--- a/cmd/symbols/internal/symbols/search.go
+++ b/cmd/symbols/internal/symbols/search.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // maxFileSize is the limit on file size in bytes. Only files smaller than this are processed.
@@ -134,7 +136,7 @@ func isLiteralEquality(expr string) (ok bool, lit string, err error) {
 	return true, string(r.Sub[1].Rune), nil
 }
 
-func filterSymbols(ctx context.Context, db *sqlx.DB, args protocol.SearchArgs) (res []protocol.Symbol, err error) {
+func filterSymbols(ctx context.Context, db *sqlx.DB, args protocol.SearchArgs) (res []result.Symbol, err error) {
 	span, _ := ot.StartSpanFromContext(ctx, "filterSymbols")
 	defer func() {
 		if err != nil {
@@ -237,7 +239,7 @@ type symbolInDB struct {
 	FileLimited bool
 }
 
-func symbolToSymbolInDB(symbol protocol.Symbol) symbolInDB {
+func symbolToSymbolInDB(symbol result.Symbol) symbolInDB {
 	return symbolInDB{
 		Name:          symbol.Name,
 		NameLowercase: strings.ToLower(symbol.Name),
@@ -255,8 +257,8 @@ func symbolToSymbolInDB(symbol protocol.Symbol) symbolInDB {
 	}
 }
 
-func symbolInDBToSymbol(symbolInDB symbolInDB) protocol.Symbol {
-	return protocol.Symbol{
+func symbolInDBToSymbol(symbolInDB symbolInDB) result.Symbol {
+	return result.Symbol{
 		Name:       symbolInDB.Name,
 		Path:       symbolInDB.Path,
 		Line:       symbolInDB.Line,
@@ -338,7 +340,7 @@ func (s *Service) writeAllSymbolsToNewDB(ctx context.Context, dbFile string, rep
 		return err
 	}
 
-	err = s.parseUncached(ctx, repoName, commitID, func(symbol protocol.Symbol) error {
+	err = s.parseUncached(ctx, repoName, commitID, func(symbol result.Symbol) error {
 		symbolInDBValue := symbolToSymbolInDB(symbol)
 		_, err := insertStatement.Exec(&symbolInDBValue)
 		return err

--- a/cmd/symbols/internal/symbols/service_test.go
+++ b/cmd/symbols/internal/symbols/service_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/sqliteutil"
 	symbolsclient "github.com/sourcegraph/sourcegraph/internal/symbols"
 	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
@@ -82,8 +83,8 @@ func TestService(t *testing.T) {
 	server := httptest.NewServer(service.Handler())
 	defer server.Close()
 	client := symbolsclient.Client{URL: server.URL}
-	x := protocol.Symbol{Name: "x", Path: "a.js"}
-	y := protocol.Symbol{Name: "y", Path: "a.js"}
+	x := result.Symbol{Name: "x", Path: "a.js"}
+	y := result.Symbol{Name: "y", Path: "a.js"}
 
 	tests := map[string]struct {
 		args search.SymbolsParameters
@@ -91,11 +92,11 @@ func TestService(t *testing.T) {
 	}{
 		"simple": {
 			args: search.SymbolsParameters{First: 10},
-			want: protocol.SearchResult{Symbols: []protocol.Symbol{x, y}},
+			want: protocol.SearchResult{Symbols: []result.Symbol{x, y}},
 		},
 		"onematch": {
 			args: search.SymbolsParameters{Query: "x", First: 10},
-			want: protocol.SearchResult{Symbols: []protocol.Symbol{x}},
+			want: protocol.SearchResult{Symbols: []result.Symbol{x}},
 		},
 		"nomatches": {
 			args: search.SymbolsParameters{Query: "foo", First: 10},
@@ -103,11 +104,11 @@ func TestService(t *testing.T) {
 		},
 		"caseinsensitiveexactmatch": {
 			args: search.SymbolsParameters{Query: "^X$", First: 10},
-			want: protocol.SearchResult{Symbols: []protocol.Symbol{x}},
+			want: protocol.SearchResult{Symbols: []result.Symbol{x}},
 		},
 		"casesensitiveexactmatch": {
 			args: search.SymbolsParameters{Query: "^x$", IsCaseSensitive: true, First: 10},
-			want: protocol.SearchResult{Symbols: []protocol.Symbol{x}},
+			want: protocol.SearchResult{Symbols: []result.Symbol{x}},
 		},
 		"casesensitivenoexactmatch": {
 			args: search.SymbolsParameters{Query: "^X$", IsCaseSensitive: true, First: 10},
@@ -115,11 +116,11 @@ func TestService(t *testing.T) {
 		},
 		"caseinsensitiveexactpathmatch": {
 			args: search.SymbolsParameters{IncludePatterns: []string{"^A.js$"}, First: 10},
-			want: protocol.SearchResult{Symbols: []protocol.Symbol{x, y}},
+			want: protocol.SearchResult{Symbols: []result.Symbol{x, y}},
 		},
 		"casesensitiveexactpathmatch": {
 			args: search.SymbolsParameters{IncludePatterns: []string{"^a.js$"}, IsCaseSensitive: true, First: 10},
-			want: protocol.SearchResult{Symbols: []protocol.Symbol{x, y}},
+			want: protocol.SearchResult{Symbols: []result.Symbol{x, y}},
 		},
 		"casesensitivenoexactpathmatch": {
 			args: search.SymbolsParameters{IncludePatterns: []string{"^A.js$"}, IsCaseSensitive: true, First: 10},

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -2,12 +2,26 @@ package result
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
 )
+
+// Symbol is a code symbol.
+type Symbol struct {
+	Name       string
+	Path       string
+	Line       int
+	Kind       string
+	Language   string
+	Parent     string
+	ParentKind string
+	Signature  string
+	Pattern    string
+
+	FileLimited bool
+}
 
 // SearchSymbolResult is a result from symbol search.
 type SearchSymbolResult struct {
-	Symbol  protocol.Symbol
+	Symbol  Symbol
 	BaseURI *gituri.URI
 	Lang    string
 }

--- a/internal/symbols/protocol/symbols.go
+++ b/internal/symbols/protocol/symbols.go
@@ -1,6 +1,9 @@
 package protocol
 
-import "github.com/sourcegraph/sourcegraph/internal/api"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+)
 
 // SearchArgs are the arguments to perform a search on the symbols service.
 type SearchArgs struct {
@@ -39,20 +42,5 @@ type SearchArgs struct {
 
 // SearchResult is the result of a search on the symbols service.
 type SearchResult struct {
-	Symbols []Symbol // code symbols
-}
-
-// Symbol is a code symbol.
-type Symbol struct {
-	Name       string
-	Path       string
-	Line       int
-	Kind       string
-	Language   string
-	Parent     string
-	ParentKind string
-	Signature  string
-	Pattern    string
-
-	FileLimited bool
+	Symbols []result.Symbol // code symbols
 }


### PR DESCRIPTION
This lived in `internal/symbols/protocol/symbols.go`, it now lives in `internal/search/result/symbol.go`

```
// Symbol is a code symbol.
type Symbol struct {
	Name       string
	Path       string
	Line       int
	Kind       string
	Language   string
	Parent     string
	ParentKind string
	Signature  string
	Pattern    string

	FileLimited bool
}
```

Even though the type is useful as the "protocol" response of the symbol service, we keep on using this result type as-is in the frontend symbol result (it is shared across the symbol service and frontend results), so we should use it from the shared location `internal/search/result`. The same applies to our searcher "protocol" match result type, which we haven't refactored to use a shared location yet. Making these moves as I come across them.