### PR TITLE
search: refactor result.symbols

### DIFF
--- a/cmd/frontend/backend/symbols.go
+++ b/cmd/frontend/backend/symbols.go
@@ -14,10 +14,10 @@ var Symbols = &symbols{}
 type symbols struct{}
 
 // ListTags returns symbols in a repository from ctags.
-func (symbols) ListTags(ctx context.Context, args search.SymbolsParameters) ([]result.Symbol, error) {
+func (symbols) ListTags(ctx context.Context, args search.SymbolsParameters) (result.Symbols, error) {
 	result, err := symbolsclient.DefaultClient.Search(ctx, args)
 	if result == nil {
 		return nil, err
 	}
-	return result.Symbols, err
+	return *result, err
 }

--- a/cmd/symbols/internal/symbols/search.go
+++ b/cmd/symbols/internal/symbols/search.go
@@ -50,7 +50,8 @@ func (s *Service) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Service) search(ctx context.Context, args protocol.SearchArgs) (result *protocol.SearchResult, err error) {
+func (s *Service) search(ctx context.Context, args protocol.SearchArgs) (*result.Symbols, error) {
+	var err error
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 	defer cancel()
 
@@ -87,13 +88,11 @@ func (s *Service) search(ctx context.Context, args protocol.SearchArgs) (result 
 	}
 	defer db.Close()
 
-	result = &protocol.SearchResult{}
-	res, err := filterSymbols(ctx, db, args)
+	result, err := filterSymbols(ctx, db, args)
 	if err != nil {
 		return nil, err
 	}
-	result.Symbols = res
-	return result, nil
+	return &result, nil
 }
 
 // getDBFile returns the path to the sqlite3 database for the repo@commit

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -19,6 +19,9 @@ type Symbol struct {
 	FileLimited bool
 }
 
+// Symbols is the result of a search on the symbols service.
+type Symbols = []Symbol
+
 // SearchSymbolResult is a result from symbol search.
 type SearchSymbolResult struct {
 	Symbol  Symbol

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/endpoint"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	"github.com/sourcegraph/sourcegraph/internal/symbols/protocol"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
@@ -75,7 +75,7 @@ func (c *Client) url(key key) (string, error) {
 }
 
 // Search performs a symbol search on the symbols service.
-func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (result *protocol.SearchResult, err error) {
+func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (result *result.Symbols, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "symbols.Client.Search")
 	defer func() {
 		if err != nil {

--- a/internal/symbols/protocol/symbols.go
+++ b/internal/symbols/protocol/symbols.go
@@ -2,7 +2,6 @@ package protocol
 
 import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 // SearchArgs are the arguments to perform a search on the symbols service.
@@ -38,9 +37,4 @@ type SearchArgs struct {
 
 	// First indicates that only the first n symbols should be returned.
 	First int
-}
-
-// SearchResult is the result of a search on the symbols service.
-type SearchResult struct {
-	Symbols []result.Symbol // code symbols
 }


### PR DESCRIPTION
Stacked on #18842

Motivation move the below to `internal/search/result` 

```
// SearchResult is the result of a search on the symbols service.
type SearchResult struct {
	Symbols []result.Symbol // code symbols
}
```

and also simplify the type: we can just use `result.Symbols` to alias to the underlying slice and remove the need for `symbol.SearchResult`.