### PR TITLE
Documentation fixes and improvements for local dev setup and architecture doc

### DIFF
--- a/doc/dev/background-information/architecture/index.md
+++ b/doc/dev/background-information/architecture/index.md
@@ -38,7 +38,7 @@ Code intelligence surfaces data (for example: doc comments for a symbol) and act
 
 By default, Sourcegraph provides imprecise [search-based code intelligence](../../../code_intelligence/explanations/search_based_code_intelligence.md). This reuses all the architecture that makes search fast, but it can result in false positives (for example: finding two definitions for a symbol, or references that aren't actually references), or false negatives (for example: not able to find the definition or all references). This is the default because it works with no extra configuration and is pretty good for many use cases and languages. We support a lot of languages this way because it only requires writing a few regular expressions.
 
-With some setup, customer can enable [precise code intelligence](../../../code_intelligence/explanations/precise_code_intelligence.md). Repositories add a step to their build pipeline that computes the index for that revision of code and uploads it to Sourcegraph. We have to write language specific indexers, so adding precise code intel support for new languages is a non-trivial task.
+With some setup, customers can enable [precise code intelligence](../../../code_intelligence/explanations/precise_code_intelligence.md). Repositories add a step to their build pipeline that computes the index for that revision of code and uploads it to Sourcegraph. We have to write language specific indexers, so adding precise code intel support for new languages is a non-trivial task.
 
 If you want to learn more about code intelligence:
 
@@ -205,7 +205,7 @@ You can click on each component to jump to its respective code repository or sub
 <object data="/dev/background-information/architecture/architecture.svg" type="image/svg+xml" style="width:100%; height: 100%">
 </object>
 
-Note that almost every service has a link back to the frontend, from which is gathers configuration updates.
+Note that almost every service has a link back to the frontend, from which it gathers configuration updates.
 These edges are omitted for clarity.
 
 ## Other resources

--- a/doc/dev/getting-started/quickstart_1_install_dependencies.md
+++ b/doc/dev/getting-started/quickstart_1_install_dependencies.md
@@ -176,7 +176,7 @@ The following are two recommendations for installing these dependencies:
     # $REDIS_DATA_DIR should be an absolute path to a folder where you intend to store Redis data
     ```
 
-    You need to have Redis running when you start the dev server later on. If you have issues running Docker, try [adding your user to the docker group][dockerGroup], and/or [updating the socket file persimissions][socketPermissions], or try running these commands under `sudo`.
+    You need to have Redis running when you start the dev server later on. If you have issues running Docker, try [adding your user to the docker group][dockerGroup], and/or [updating the socket file permissions][socketPermissions], or try running these commands under `sudo`.
 
     [dockerGroup]: https://stackoverflow.com/a/48957722
     [socketPermissions]: https://stackoverflow.com/a/51362528
@@ -191,7 +191,7 @@ We use asdf in buildkite to lock the versions of the tools that we use on a per-
 
 #### asdf binary
 
-See the [installation instructions on the official asdf documentation](https://asdf-vm.com/#/core-manage-asdf-vm?id=install-asdf-vm).
+See the [installation instructions on the official asdf documentation](https://asdf-vm.com/#/core-manage-asdf?id=install).
 
 #### Plugins
 

--- a/doc/dev/getting-started/quickstart_5_configure_https_reverse_proxy.md
+++ b/doc/dev/getting-started/quickstart_5_configure_https_reverse_proxy.md
@@ -36,6 +36,14 @@ its keys to your system's certificate store. You can get this out the way after 
 ./dev/caddy.sh trust
 ```
 
+Note: If you are using Firefox and have a master password set, the following prompt will come up first:
+
+```
+Enter Password or Pin for "NSS Certificate DB":
+```
+
+Enter your Firefox master password here and proceed. See [this issue on GitHub](https://github.com/FiloSottile/mkcert/issues/50) for more information.
+
 You might need to restart your web browsers in order for them to recognize the certificates.
 
 [< Previous](quickstart_4_clone_repository.md) | [Next >](quickstart_6_start_server.md)


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

This PR contains typo and grammatical fixes I encountered when I was setting up the local dev environment and reading the architecture doc. 

Additionally, it adds instructions to enter the Firefox master password (if it is configured) during caddy setup. This is something I ran into during the local dev setup.
