### PR TITLE
Add graphql endpoint to read user public repos

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -720,7 +720,7 @@ type Mutation {
     SetUserPublicRepos sets the list of public repos for a user's search context, ensuring those repos
     exist and are cloned
     """
-    SetUserPublicRepos(userId: ID!, repoURIs: [String!]!): EmptyResponse!
+    SetUserPublicRepos(userID: ID!, repoURIs: [String!]!): EmptyResponse!
 }
 
 """
@@ -5285,6 +5285,11 @@ type User implements Node & SettingsSubject & Namespace {
         """
         externalServiceID: ID
     ): RepositoryConnection!
+
+    """
+    publicRepositories returns the repos listed in user_public_repos for this user
+    """
+    publicRepositories: [Repository!]!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/set_user_public_repos.go
+++ b/cmd/frontend/graphqlbackend/set_user_public_repos.go
@@ -45,7 +45,7 @@ func (r *schemaResolver) SetUserPublicRepos(ctx context.Context, args struct {
 	for i, repoURI := range args.RepoURIs {
 		i, repoURI := i, repoURI
 		eg.Go(func() error {
-			repo, err := getRepoID(ctx, repoStore, repoURI)
+			repo, err := getRepo(ctx, repoStore, repoURI)
 			if err != nil {
 				return errors.Wrapf(err, "getting ID for repo %s", repoURI)
 			}
@@ -68,10 +68,10 @@ func (r *schemaResolver) SetUserPublicRepos(ctx context.Context, args struct {
 	return &EmptyResponse{}, nil
 }
 
-// getRepoID attempts to find a repo in the database by URI, returning the ID if it's found. If it's not found
+// getRepo attempts to find a repo in the database by URI, returning the ID if it's found. If it's not found
 // it will use RepoLookup on repo-updater to fetch the repo info from a code host, store it in the repos table,
 // enqueue a clone for that repo, and return the repo ID
-func getRepoID(ctx context.Context, repoStore *database.RepoStore, repoURI string) (repo *types.Repo, err error) {
+func getRepo(ctx context.Context, repoStore *database.RepoStore, repoURI string) (repo *types.Repo, err error) {
 	u, err := url.Parse(repoURI)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to parse repository URL "+repoURI)


### PR DESCRIPTION
This PR adds a new publicRepos connection to the User graphql object, this will be used in the manage repositories page to pre-populate the public repos box.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
