### PR TITLE
Rename URLs from campaigns to batch-changes in Go backend

### DIFF
--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -700,7 +700,7 @@ func campaignURL(ctx context.Context, ns *database.Namespace, c *batches.Campaig
 	// (Refactoring the resolver to use the same function is difficult due to
 	// the different querying and caching behaviour in GraphQL resolvers, so we
 	// simply replicate the logic here.)
-	u := extURL.ResolveReference(&url.URL{Path: namespaceURL(ns) + "/campaigns/" + c.Name})
+	u := extURL.ResolveReference(&url.URL{Path: namespaceURL(ns) + "/batch-changes/" + c.Name})
 
 	return u.String(), nil
 }

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -935,7 +935,7 @@ func TestDecorateChangesetBody(t *testing.T) {
 	if err := decorateChangesetBody(context.Background(), fs, database.Namespaces(new(dbtesting.MockDB)), rcs); err != nil {
 		t.Errorf("unexpected non-nil error: %v", err)
 	}
-	if want := body + "\n\n[_Created by Sourcegraph campaign `my-user/reconciler-test-campaign`._](https://sourcegraph.test/users/my-user/campaigns/reconciler-test-campaign)"; rcs.Body != want {
+	if want := body + "\n\n[_Created by Sourcegraph campaign `my-user/reconciler-test-campaign`._](https://sourcegraph.test/users/my-user/batch-changes/reconciler-test-campaign)"; rcs.Body != want {
 		t.Errorf("repos.Changeset body unexpectedly changed:\nhave=%q\nwant=%q", rcs.Body, want)
 	}
 }
@@ -971,7 +971,7 @@ func TestCampaignURL(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
-		if want := "https://sourcegraph.test/organizations/foo/campaigns/bar"; url != want {
+		if want := "https://sourcegraph.test/organizations/foo/batch-changes/bar"; url != want {
 			t.Errorf("unexpected URL: have=%q want=%q", url, want)
 		}
 	})

--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -105,7 +105,7 @@ func (r *batchChangeResolver) URL(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return campaignURL(n, r), nil
+	return batchChangeURL(n, r), nil
 }
 
 func (r *batchChangeResolver) Namespace(ctx context.Context) (graphqlbackend.NamespaceResolver, error) {

--- a/enterprise/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/internal/batches/resolvers/batch_change_test.go
@@ -74,7 +74,7 @@ func TestBatchChangeResolver(t *testing.T) {
 		LastApplier:    apiUser,
 		SpecCreator:    apiUser,
 		LastAppliedAt:  marshalDateTime(t, now),
-		URL:            fmt.Sprintf("/organizations/%s/campaigns/%s", orgName, campaign.Name),
+		URL:            fmt.Sprintf("/organizations/%s/batch-changes/%s", orgName, campaign.Name),
 		CreatedAt:      marshalDateTime(t, now),
 		UpdatedAt:      marshalDateTime(t, now),
 		// Not closed.

--- a/enterprise/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/internal/batches/resolvers/batch_spec.go
@@ -171,7 +171,7 @@ func (r *batchSpecResolver) ApplyURL(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return campaignsApplyURL(n, r), nil
+	return batchChangesApplyURL(n, r), nil
 }
 
 func (r *batchSpecResolver) CreatedAt() graphqlbackend.DateTime {

--- a/enterprise/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/internal/batches/resolvers/batch_spec_test.go
@@ -100,7 +100,7 @@ func TestBatchSpecResolver(t *testing.T) {
 		OriginalInput: spec.RawSpec,
 		ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
 
-		ApplyURL:            fmt.Sprintf("/organizations/%s/campaigns/apply/%s", orgname, apiID),
+		ApplyURL:            fmt.Sprintf("/organizations/%s/batch-changes/apply/%s", orgname, apiID),
 		Namespace:           apitest.UserOrg{ID: orgAPIID, Name: orgname},
 		Creator:             &apitest.User{ID: userAPIID, DatabaseID: userID},
 		ViewerCanAdminister: true,

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -209,7 +209,7 @@ func TestCreateBatchSpec(t *testing.T) {
 					ExpiresAt:     have.ExpiresAt,
 					OriginalInput: rawSpec,
 					ParsedInput:   graphqlbackend.JSONValue{Value: unmarshaled},
-					ApplyURL:      fmt.Sprintf("/users/%s/campaigns/apply/%s", user.Username, have.ID),
+					ApplyURL:      fmt.Sprintf("/users/%s/batch-changes/apply/%s", user.Username, have.ID),
 					Namespace:     apitest.UserOrg{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
 					Creator:       &apitest.User{ID: userAPIID, DatabaseID: userID, SiteAdmin: true},
 					ChangesetSpecs: apitest.ChangesetSpecConnection{
@@ -610,7 +610,7 @@ func TestMoveBatchChange(t *testing.T) {
 		t.Fatalf("unexpected name (-want +got):\n%s", diff)
 	}
 
-	wantURL := fmt.Sprintf("/users/%s/campaigns/%s", user.Username, newCampaignName)
+	wantURL := fmt.Sprintf("/users/%s/batch-changes/%s", user.Username, newCampaignName)
 	if diff := cmp.Diff(wantURL, haveCampaign.URL); diff != "" {
 		t.Fatalf("unexpected URL (-want +got):\n%s", diff)
 	}
@@ -628,7 +628,7 @@ func TestMoveBatchChange(t *testing.T) {
 	if diff := cmp.Diff(string(orgAPIID), haveCampaign.Namespace.ID); diff != "" {
 		t.Fatalf("unexpected namespace (-want +got):\n%s", diff)
 	}
-	wantURL = fmt.Sprintf("/organizations/%s/campaigns/%s", orgName, newCampaignName)
+	wantURL = fmt.Sprintf("/organizations/%s/batch-changes/%s", orgName, newCampaignName)
 	if diff := cmp.Diff(wantURL, haveCampaign.URL); diff != "" {
 		t.Fatalf("unexpected URL (-want +got):\n%s", diff)
 	}

--- a/enterprise/internal/batches/resolvers/urls.go
+++ b/enterprise/internal/batches/resolvers/urls.go
@@ -4,11 +4,11 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 )
 
-func campaignsApplyURL(n graphqlbackend.Namespace, c graphqlbackend.BatchSpecResolver) string {
-	return n.URL() + "/campaigns/apply/" + string(c.ID())
+func batchChangesApplyURL(n graphqlbackend.Namespace, c graphqlbackend.BatchSpecResolver) string {
+	return n.URL() + "/batch-changes/apply/" + string(c.ID())
 }
 
-func campaignURL(n graphqlbackend.Namespace, c graphqlbackend.BatchChangeResolver) string {
-	// This needs to be kept consistent with batches.campaignURL().
-	return n.URL() + "/campaigns/" + c.Name()
+func batchChangeURL(n graphqlbackend.Namespace, c graphqlbackend.BatchChangeResolver) string {
+	// This needs to be kept consistent with campaigns.campaignURL().
+	return n.URL() + "/batch-changes/" + c.Name()
 }


### PR DESCRIPTION
Separate PR so it's easier to review and we don't lose track of it.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
