### PR TITLE
Increase memory for storybook build in CI

### DIFF
--- a/.buildkite/pipeline.async.yml
+++ b/.buildkite/pipeline.async.yml
@@ -5,7 +5,7 @@ env:
 
 steps:
 - command:
-  - COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-storybook
+  - COVERAGE_INSTRUMENT=true NODE_OPTIONS="--max_old_space_size=4096" dev/ci/yarn-run.sh build-storybook
   - yarn run cover-storybook
   - yarn nyc report -r json
   - bash <(curl -s https://codecov.io/bash) -c -F typescript -F storybook


### PR DESCRIPTION
I saw some builds that ran out of memory, so I increased it to the amount of RAM we use for other prod builds, too.
