### PR TITLE
Finish overhaul of batch changes GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -7824,11 +7824,13 @@ type CodeHostRepository {
 
 ############################################################################################
 #                                                                                          #
-#                               Begin campaigns schema                                     #
+#                               Begin batches schema                                       #
 #                                                                                          #
 ############################################################################################
+
+##################################### DEPRECATED API #######################################
 """
-The state of the campaign
+The state of the campaign.
 """
 enum CampaignState {
     OPEN
@@ -7991,6 +7993,486 @@ type Campaign implements Node {
 }
 
 """
+A list of campaigns.
+"""
+type CampaignConnection {
+    """
+    A list of campaigns.
+    """
+    nodes: [Campaign!]!
+
+    """
+    The total number of campaigns in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A connection of all code hosts usable with campaigns and accessible by the user
+this is requested on.
+"""
+type CampaignsCodeHostConnection {
+    """
+    A list of code hosts.
+    """
+    nodes: [CampaignsCodeHost!]!
+
+    """
+    The total number of configured external services in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
+}
+
+"""
+A code host usable with campaigns. This service is accessible by the user it belongs to.
+"""
+type CampaignsCodeHost {
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The configured credential, if any.
+    """
+    credential: CampaignsCredential
+
+    """
+    If true, some of the repositories on this code host require
+    an SSH key to be configured.
+    """
+    requiresSSH: Boolean!
+}
+
+"""
+A user token configured for campaigns use on the specified code host.
+"""
+type CampaignsCredential implements Node {
+    """
+    A globally unique identifier.
+    """
+    id: ID!
+
+    """
+    The kind of external service.
+    """
+    externalServiceKind: ExternalServiceKind!
+
+    """
+    The URL of the external service.
+    """
+    externalServiceURL: String!
+
+    """
+    The public key to use on the external service for SSH keypair authentication.
+    Not set if the credential doesn't support SSH access.
+    """
+    sshPublicKey: String
+
+    """
+    The date and time this token has been created at.
+    """
+    createdAt: DateTime!
+}
+
+"""
+A CampaignDescription describes a campaign.
+"""
+type CampaignDescription {
+    """
+    The name as parsed from the input.
+    """
+    name: String!
+
+    """
+    The description as parsed from the input.
+    """
+    description: String!
+}
+
+"""
+A campaign spec is an immutable description of the desired state of a campaign. To create a
+campaign spec, use the createCampaignSpec mutation.
+"""
+type CampaignSpec implements Node {
+    """
+    The unique ID for a campaign spec.
+
+    The ID is unguessable (i.e., long and randomly generated, not sequential).
+    Consider a campaign to fix a security vulnerability: the campaign author may prefer
+    to prepare the campaign, including the description in private so that the window
+    between revealing the problem and merging the fixes is as short as possible.
+    """
+    id: ID!
+
+    """
+    The original YAML or JSON input that was used to create this campaign spec.
+    """
+    originalInput: String!
+
+    """
+    The parsed JSON value of the original input. If the original input was YAML, the YAML is
+    converted to the equivalent JSON.
+    """
+    parsedInput: JSONValue!
+
+    """
+    The CampaignDescription that describes this campaign.
+    """
+    description: CampaignDescription!
+
+    """
+    Generates a preview what operations would be performed if the campaign spec would be applied.
+    This preview is not a guarantee, since the state of the changesets can change between the time
+    the preview is generated and when the campaign spec is applied.
+    """
+    applyPreview(
+        """
+        Returns the first n entries from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
+        """
+        search: String
+        """
+        Search for changesets that are currently in this state.
+        """
+        currentState: ChangesetState
+        """
+        Search for changesets that will have the given action performed.
+        """
+        action: ChangesetSpecOperation
+    ): ChangesetApplyPreviewConnection!
+
+    """
+    The specs for changesets associated with this campaign.
+    """
+    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
+
+    """
+    The user who created this campaign spec (or null if the user no longer exists).
+    """
+    creator: User
+
+    """
+    The date when this campaign spec was created.
+    """
+    createdAt: DateTime!
+
+    """
+    The namespace (either a user or organization) of the campaign spec.
+    """
+    namespace: Namespace!
+
+    """
+    The date, if any, when this campaign spec expires and is automatically purged. A campaign spec
+    never expires if it has been applied.
+    """
+    expiresAt: DateTime
+
+    """
+    The URL of a web page that allows applying this campaign spec and
+    displays a preview of which changesets will be created by applying it.
+    """
+    applyURL: String!
+
+    """
+    When true, the viewing user can apply this spec.
+    """
+    viewerCanAdminister: Boolean!
+
+    """
+    The diff stat for all the changeset specs in the campaign spec.
+    """
+    diffStat: DiffStat!
+
+    """
+    The campaign this spec will update when applied. If it's null, the
+    campaign doesn't yet exist.
+    """
+    appliesToCampaign: Campaign
+
+    """
+    The newest version of this campaign spec, as identified by its namespace
+    and name. If this is the newest version, this field will be null.
+    """
+    supersedingCampaignSpec: CampaignSpec
+
+    """
+    The code host connections required for applying this spec. Includes the credentials of the current user.
+    """
+    viewerCampaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only returns the code hosts for which the viewer doesn't have credentials.
+        """
+        onlyWithoutCredential: Boolean = false
+    ): CampaignsCodeHostConnection!
+}
+
+extend type Mutation {
+    """
+    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
+    campaign is returned.
+    If a campaign in the same namespace with the same name already exists, an error with the error code
+    ErrMatchingCampaignExists is returned.
+    """
+    createCampaign(
+        """
+        The campaign spec that describes the desired state of the campaign.
+        """
+        campaignSpec: ID!
+    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchChange instead.")
+
+    """
+    Create or update a campaign from a campaign spec and locally computed changeset specs. If no
+    campaign exists in the namespace with the name given in the campaign spec, a campaign will be
+    created. Otherwise, the existing campaign will be updated. The campaign is returned.
+    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
+    will be returned.
+    """
+    applyCampaign(
+        """
+        The campaign spec that describes the new desired state of the campaign.
+        """
+        campaignSpec: ID!
+
+        """
+        If set, return an error if the campaign identified using the namespace and campaignSpec
+        parameters does not match the campaign with this ID. This lets callers use a stable ID
+        that refers to a specific campaign during an edit session (and is not susceptible to
+        conflicts if the underlying campaign is moved to a different namespace, renamed, or
+        deleted). The returned error has the error code ErrEnsureCampaignFailed.
+        """
+        ensureCampaign: ID
+    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use applyBatchChange instead.")
+
+    """
+    Move a campaign to a different namespace, or rename it in the current namespace.
+    """
+    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use moveBatchChange instead.")
+
+    """
+    Close a campaign.
+    """
+    closeCampaign(
+        campaign: ID!
+        """
+        Whether to close the changesets associated with this campaign on their respective code
+        hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
+        GitHub and "declined" on Bitbucket Server).
+        """
+        closeChangesets: Boolean = false
+    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use closeBatchChange instead.")
+
+    """
+    Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
+    campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
+    """
+    deleteCampaign(campaign: ID!): EmptyResponse
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use deleteBatchChange instead.")
+
+    """
+    Create a campaign spec that will be used to create a campaign (with the createCampaign
+    mutation), or to update a campaign (with the applyCampaign mutation).
+
+    The returned CampaignSpec is immutable and expires after a certain period of time (if not used
+    in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
+
+    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
+    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
+    """
+    createCampaignSpec(
+        """
+        The namespace (either a user or organization). A campaign spec can only be applied to (or
+        used to create) campaigns in this namespace.
+        """
+        namespace: ID!
+
+        """
+        The campaign spec as YAML (or the equivalent JSON). See
+        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/campaign_spec.schema.json
+        for the JSON Schema that describes the structure of this input.
+        """
+        campaignSpec: String!
+
+        """
+        Changeset specs that were locally computed and then uploaded using createChangesetSpec.
+        """
+        changesetSpecs: [ID!]!
+    ): CampaignSpec! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchSpec instead.")
+
+    """
+    Create a new credential for the given user for the given code host.
+    If another token for that code host already exists, an error with the error code
+    ErrDuplicateCredential is returned.
+    """
+    createCampaignsCredential(
+        """
+        The user for which to create the credential.
+        """
+        user: ID!
+
+        """
+        The kind of external service being configured.
+        """
+        externalServiceKind: ExternalServiceKind!
+
+        """
+        The URL of the external service being configured.
+        """
+        externalServiceURL: String!
+
+        """
+        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
+        """
+        credential: String!
+    ): CampaignsCredential!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchChangesCredential instead.")
+
+    """
+    Hard-deletes a given campaigns credential.
+    """
+    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use deleteBatchChangesCredential instead.")
+}
+
+extend type Org {
+    """
+    A list of campaigns initially applied in this organization.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
+}
+
+extend type User {
+    """
+    A list of campaigns applied under this user's namespace.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
+
+    """
+    Returns a connection of configured external services accessible by this user, for usage with campaigns.
+    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
+    connected to CampaignCredential resources, if one has been created for the code host connection before.
+    """
+    campaignsCodeHosts(
+        """
+        Returns the first n code hosts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+    ): CampaignsCodeHostConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChangesCodeHosts instead.")
+}
+
+extend type Query {
+    """
+    A list of campaigns.
+    """
+    campaigns(
+        """
+        Returns the first n campaigns from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Only return campaigns in this state.
+        """
+        state: CampaignState
+        """
+        Only include campaigns that the viewer can administer.
+        """
+        viewerCanAdminister: Boolean
+    ): CampaignConnection!
+        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
+    """
+    Looks up a campaign by namespace and campaign name.
+    """
+    campaign(
+        """
+        The namespace where the campaign lives.
+        """
+        namespace: ID!
+        """
+        The campaigns name.
+        """
+        name: String!
+    ): Campaign @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChange instead.")
+}
+
+################################### END DEPRECATED API #####################################
+
+"""
 The counts of changesets in certain states at a specific point in time.
 """
 type ChangesetCounts {
@@ -8030,26 +8512,6 @@ type ChangesetCounts {
     The number of changesets that are both open and are pending review.
     """
     openPending: Int!
-}
-
-"""
-A list of campaigns.
-"""
-type CampaignConnection {
-    """
-    A list of campaigns.
-    """
-    nodes: [Campaign!]!
-
-    """
-    The total number of campaigns in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
 }
 
 """
@@ -8557,7 +9019,7 @@ type ExternalChangeset implements Node & Changeset {
 }
 
 """
-Used in the campaign page for the overview component.
+Used in the batch change page for the overview component.
 """
 type ChangesetsStats {
     """
@@ -8663,84 +9125,6 @@ type ChangesetEventConnection {
 }
 
 """
-A connection of all code hosts usable with campaigns and accessible by the user
-this is requested on.
-"""
-type CampaignsCodeHostConnection {
-    """
-    A list of code hosts.
-    """
-    nodes: [CampaignsCodeHost!]!
-
-    """
-    The total number of configured external services in the connection.
-    """
-    totalCount: Int!
-
-    """
-    Pagination information.
-    """
-    pageInfo: PageInfo!
-}
-
-"""
-A code host usable with campaigns. This service is accessible by the user it belongs to.
-"""
-type CampaignsCodeHost {
-    """
-    The kind of external service.
-    """
-    externalServiceKind: ExternalServiceKind!
-
-    """
-    The URL of the external service.
-    """
-    externalServiceURL: String!
-
-    """
-    The configured credential, if any.
-    """
-    credential: CampaignsCredential
-
-    """
-    If true, some of the repositories on this code host require
-    an SSH key to be configured.
-    """
-    requiresSSH: Boolean!
-}
-
-"""
-A user token configured for campaigns use on the specified code host.
-"""
-type CampaignsCredential implements Node {
-    """
-    A globally unique identifier.
-    """
-    id: ID!
-
-    """
-    The kind of external service.
-    """
-    externalServiceKind: ExternalServiceKind!
-
-    """
-    The URL of the external service.
-    """
-    externalServiceURL: String!
-
-    """
-    The public key to use on the external service for SSH keypair authentication.
-    Not set if the credential doesn't support SSH access.
-    """
-    sshPublicKey: String
-
-    """
-    The date and time this token has been created at.
-    """
-    createdAt: DateTime!
-}
-
-"""
 This enum declares all operations supported by the reconciler.
 """
 enum ChangesetSpecOperation {
@@ -8786,7 +9170,7 @@ enum ChangesetSpecOperation {
     """
     SLEEP
     """
-    The changeset is removed from some of the associated campaigns.
+    The changeset is removed from some of the associated batch changes.
     """
     DETACH
 }
@@ -8844,7 +9228,7 @@ enum ChangesetSpecType {
 }
 
 """
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+A changeset spec is an immutable description of the desired state of a changeset in a batch change. To
 create a changeset spec, use the createChangesetSpec mutation.
 """
 interface ChangesetSpec {
@@ -8854,8 +9238,8 @@ interface ChangesetSpec {
     The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
     even though repository permissions also apply to viewers of changeset specs, because being
     allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
+    changesets for that repository. Consider a batch change to fix a security vulnerability: the
+    batch change author may prefer to prepare all of the changesets in private so that the window
     between revealing the problem and merging the fixes is as short as possible.
     """
     id: ID!
@@ -8867,13 +9251,13 @@ interface ChangesetSpec {
 
     """
     The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
+    spec never expires (and this field is null) if its batch spec has been applied.
     """
     expiresAt: DateTime
 }
 
 """
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+A changeset spec is an immutable description of the desired state of a changeset in a batch change. To
 create a changeset spec, use the createChangesetSpec mutation.
 """
 type HiddenChangesetSpec implements ChangesetSpec & Node {
@@ -8883,8 +9267,8 @@ type HiddenChangesetSpec implements ChangesetSpec & Node {
     The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
     even though repository permissions also apply to viewers of changeset specs, because being
     allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
+    changesets for that repository. Consider a batch change to fix a security vulnerability: the
+    batch change author may prefer to prepare all of the changesets in private so that the window
     between revealing the problem and merging the fixes is as short as possible.
     """
     id: ID!
@@ -8896,13 +9280,13 @@ type HiddenChangesetSpec implements ChangesetSpec & Node {
 
     """
     The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
+    spec never expires (and this field is null) if its batch spec has been applied.
     """
     expiresAt: DateTime
 }
 
 """
-A changeset spec is an immutable description of the desired state of a changeset in a campaign. To
+A changeset spec is an immutable description of the desired state of a changeset in a batch change. To
 create a changeset spec, use the createChangesetSpec mutation.
 """
 type VisibleChangesetSpec implements ChangesetSpec & Node {
@@ -8912,8 +9296,8 @@ type VisibleChangesetSpec implements ChangesetSpec & Node {
     The ID is unguessable (i.e., long and randomly generated, not sequential). This is important
     even though repository permissions also apply to viewers of changeset specs, because being
     allowed to view a repository should not entitle a person to view all not-yet-published
-    changesets for that repository. Consider a campaign to fix a security vulnerability: the
-    campaign author may prefer to prepare all of the changesets in private so that the window
+    changesets for that repository. Consider a batch change to fix a security vulnerability: the
+    batch change author may prefer to prepare all of the changesets in private so that the window
     between revealing the problem and merging the fixes is as short as possible.
     """
     id: ID!
@@ -8930,7 +9314,7 @@ type VisibleChangesetSpec implements ChangesetSpec & Node {
 
     """
     The date, if any, when this changeset spec expires and is automatically purged. A changeset
-    spec never expires (and this field is null) if its campaign spec has been applied.
+    spec never expires (and this field is null) if its batch spec has been applied.
     """
     expiresAt: DateTime
 }
@@ -8942,7 +9326,7 @@ union ChangesetDescription = ExistingChangesetReference | GitBranchChangesetDesc
 
 """
 A reference to a changeset that already exists on a code host (and was not created by the
-campaign).
+batch change).
 """
 type ExistingChangesetReference {
     """
@@ -9101,7 +9485,7 @@ type ChangesetSpecConnection {
 }
 
 """
-A preview for which actions applyCampaign would result in when called at the point of time this preview was created at.
+A preview for which actions applyBatchChange would result in when called at the point of time this preview was created at.
 """
 union ChangesetApplyPreview = VisibleChangesetApplyPreview | HiddenChangesetApplyPreview
 
@@ -9139,7 +9523,7 @@ type VisibleApplyPreviewTargetsUpdate {
 
 """
 A preview entry where no changeset spec exists for the changeset currently in
-the target campaign.
+the target batch change.
 """
 type VisibleApplyPreviewTargetsDetach {
     """
@@ -9182,7 +9566,7 @@ type HiddenApplyPreviewTargetsUpdate {
 
 """
 A preview entry where no changeset spec exists for the changeset currently in
-the target campaign.
+the target batch change.
 """
 type HiddenApplyPreviewTargetsDetach {
     """
@@ -9192,7 +9576,7 @@ type HiddenApplyPreviewTargetsDetach {
 }
 
 """
-One preview entry in the list of all previews against a campaign spec. Each mapping
+One preview entry in the list of all previews against a batch spec. Each mapping
 between changeset specs and current changesets yields one of these. It describes
 which operations are taken against which changeset spec and changeset to ensure the
 desired state is met.
@@ -9216,7 +9600,7 @@ type HiddenChangesetApplyPreview {
 }
 
 """
-One preview entry in the list of all previews against a campaign spec. Each mapping
+One preview entry in the list of all previews against a batch spec. Each mapping
 between changeset specs and current changesets yields one of these. It describes
 which operations are taken against which changeset spec and changeset to ensure the
 desired state is met.
@@ -9285,20 +9669,20 @@ type ChangesetApplyPreviewConnectionStats {
     """
     sleep: Int!
     """
-    The changeset is removed from some of the associated campaigns.
+    The changeset is removed from some of the associated batch changes.
     """
     detach: Int!
 
     """
-    The amount of changesets that are added to the campaign in this operation.
+    The amount of changesets that are added to the batch change in this operation.
     """
     added: Int!
     """
-    The amount of changesets that are already attached to the campaign and modified in this operation.
+    The amount of changesets that are already attached to the batch change and modified in this operation.
     """
     modified: Int!
     """
-    The amount of changesets that are disassociated from the campaign in this operation.
+    The amount of changesets that are disassociated from the batch change in this operation.
     """
     removed: Int!
 }
@@ -9328,230 +9712,21 @@ type ChangesetApplyPreviewConnection {
     stats: ChangesetApplyPreviewConnectionStats!
 }
 
-"""
-A CampaignDescription describes a campaign.
-"""
-type CampaignDescription {
-    """
-    The name as parsed from the input.
-    """
-    name: String!
-
-    """
-    The description as parsed from the input.
-    """
-    description: String!
-}
-
-"""
-A campaign spec is an immutable description of the desired state of a campaign. To create a
-campaign spec, use the createCampaignSpec mutation.
-"""
-type CampaignSpec implements Node {
-    """
-    The unique ID for a campaign spec.
-
-    The ID is unguessable (i.e., long and randomly generated, not sequential).
-    Consider a campaign to fix a security vulnerability: the campaign author may prefer
-    to prepare the campaign, including the description in private so that the window
-    between revealing the problem and merging the fixes is as short as possible.
-    """
-    id: ID!
-
-    """
-    The original YAML or JSON input that was used to create this campaign spec.
-    """
-    originalInput: String!
-
-    """
-    The parsed JSON value of the original input. If the original input was YAML, the YAML is
-    converted to the equivalent JSON.
-    """
-    parsedInput: JSONValue!
-
-    """
-    The CampaignDescription that describes this campaign.
-    """
-    description: CampaignDescription!
-
-    """
-    Generates a preview what operations would be performed if the campaign spec would be applied.
-    This preview is not a guarantee, since the state of the changesets can change between the time
-    the preview is generated and when the campaign spec is applied.
-    """
-    applyPreview(
-        """
-        Returns the first n entries from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Search for changesets matching this query. Queries may include quoted substrings to match phrases, and words may be preceded by - to negate them.
-        """
-        search: String
-        """
-        Search for changesets that are currently in this state.
-        """
-        currentState: ChangesetState
-        """
-        Search for changesets that will have the given action performed.
-        """
-        action: ChangesetSpecOperation
-    ): ChangesetApplyPreviewConnection!
-
-    """
-    The specs for changesets associated with this campaign.
-    """
-    changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
-
-    """
-    The user who created this campaign spec (or null if the user no longer exists).
-    """
-    creator: User
-
-    """
-    The date when this campaign spec was created.
-    """
-    createdAt: DateTime!
-
-    """
-    The namespace (either a user or organization) of the campaign spec.
-    """
-    namespace: Namespace!
-
-    """
-    The date, if any, when this campaign spec expires and is automatically purged. A campaign spec
-    never expires if it has been applied.
-    """
-    expiresAt: DateTime
-
-    """
-    The URL of a web page that allows applying this campaign spec and
-    displays a preview of which changesets will be created by applying it.
-    """
-    applyURL: String!
-
-    """
-    When true, the viewing user can apply this spec.
-    """
-    viewerCanAdminister: Boolean!
-
-    """
-    The diff stat for all the changeset specs in the campaign spec.
-    """
-    diffStat: DiffStat!
-
-    """
-    The campaign this spec will update when applied. If it's null, the
-    campaign doesn't yet exist.
-    """
-    appliesToCampaign: Campaign
-
-    """
-    The newest version of this campaign spec, as identified by its namespace
-    and name. If this is the newest version, this field will be null.
-    """
-    supersedingCampaignSpec: CampaignSpec
-
-    """
-    The code host connections required for applying this spec. Includes the credentials of the current user.
-    """
-    viewerCampaignsCodeHosts(
-        """
-        Returns the first n code hosts from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only returns the code hosts for which the viewer doesn't have credentials.
-        """
-        onlyWithoutCredential: Boolean = false
-    ): CampaignsCodeHostConnection!
-}
-
 extend type Mutation {
     """
-    Create a campaign from a campaign spec and locally computed changeset specs. The newly created
-    campaign is returned.
-    If a campaign in the same namespace with the same name already exists, an error with the error code
-    ErrMatchingCampaignExists is returned.
-    """
-    createCampaign(
-        """
-        The campaign spec that describes the desired state of the campaign.
-        """
-        campaignSpec: ID!
-    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchChange instead.")
-
-    """
-    Create or update a campaign from a campaign spec and locally computed changeset specs. If no
-    campaign exists in the namespace with the name given in the campaign spec, a campaign will be
-    created. Otherwise, the existing campaign will be updated. The campaign is returned.
-    Closed campaigns cannot be applied to. In that case, an error with the error code ErrApplyClosedCampaign
-    will be returned.
-    """
-    applyCampaign(
-        """
-        The campaign spec that describes the new desired state of the campaign.
-        """
-        campaignSpec: ID!
-
-        """
-        If set, return an error if the campaign identified using the namespace and campaignSpec
-        parameters does not match the campaign with this ID. This lets callers use a stable ID
-        that refers to a specific campaign during an edit session (and is not susceptible to
-        conflicts if the underlying campaign is moved to a different namespace, renamed, or
-        deleted). The returned error has the error code ErrEnsureCampaignFailed.
-        """
-        ensureCampaign: ID
-    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use applyBatchChange instead.")
-
-    """
-    Move a campaign to a different namespace, or rename it in the current namespace.
-    """
-    moveCampaign(campaign: ID!, newName: String, newNamespace: ID): Campaign!
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use moveBatchChange instead.")
-
-    """
-    Close a campaign.
-    """
-    closeCampaign(
-        campaign: ID!
-        """
-        Whether to close the changesets associated with this campaign on their respective code
-        hosts. "Close" means the appropriate final state on the code host (e.g., "closed" on
-        GitHub and "declined" on Bitbucket Server).
-        """
-        closeChangesets: Boolean = false
-    ): Campaign! @deprecated(reason: "campaigns have been renamed to batch changes. Use closeBatchChange instead.")
-
-    """
-    Delete a campaign. A deleted campaign is completely removed and can't be un-deleted. The
-    campaign's changesets are kept as-is; to close them, use the closeCampaign mutation first.
-    """
-    deleteCampaign(campaign: ID!): EmptyResponse
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use deleteBatchChange instead.")
-
-    """
-    Upload a changeset spec that will be used in a future update to a campaign. The changeset spec
-    is stored and can be referenced by its ID in the applyCampaign mutation. Just uploading the
-    changeset spec does not result in changes to the campaign or any of its changesets; you need
-    to call applyCampaign to use it.
+    Upload a changeset spec that will be used in a future update to a batch change. The changeset spec
+    is stored and can be referenced by its ID in the applyBatchChange mutation. Just uploading the
+    changeset spec does not result in changes to the batch change or any of its changesets; you need
+    to call applyBatchChange to use it.
 
     You can use this mutation to upload large changeset specs (e.g., containing large diffs) in
-    individual HTTP requests. Then, in the eventual applyCampaign call, you just refer to the
-    changeset specs by their IDs. This lets you avoid problems when updating large campaigns where
+    individual HTTP requests. Then, in the eventual applyBatchChange call, you just refer to the
+    changeset specs by their IDs. This lets you avoid problems when updating large batch changes where
     a large HTTP request body (e.g., with many large diffs in the changeset specs) would be
     rejected by the web server/proxy or would be very slow.
 
     The returned ChangesetSpec is immutable and expires after a certain period of time (if not
-    used in a call to applyCampaign), which can be queried on ChangesetSpec.expiresAt.
+    used in a call to applyBatchChange), which can be queried on ChangesetSpec.expiresAt.
     """
     createChangesetSpec(
         """
@@ -9563,36 +9738,6 @@ extend type Mutation {
     ): ChangesetSpec!
 
     """
-    Create a campaign spec that will be used to create a campaign (with the createCampaign
-    mutation), or to update a campaign (with the applyCampaign mutation).
-
-    The returned CampaignSpec is immutable and expires after a certain period of time (if not used
-    in a call to applyCampaign), which can be queried on CampaignSpec.expiresAt.
-
-    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
-    the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
-    """
-    createCampaignSpec(
-        """
-        The namespace (either a user or organization). A campaign spec can only be applied to (or
-        used to create) campaigns in this namespace.
-        """
-        namespace: ID!
-
-        """
-        The campaign spec as YAML (or the equivalent JSON). See
-        https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/schema/campaign_spec.schema.json
-        for the JSON Schema that describes the structure of this input.
-        """
-        campaignSpec: String!
-
-        """
-        Changeset specs that were locally computed and then uploaded using createChangesetSpec.
-        """
-        changesetSpecs: [ID!]!
-    ): CampaignSpec! @deprecated(reason: "campaigns have been renamed to batch changes. Use createBatchSpec instead.")
-
-    """
     Enqueue the given changeset for high-priority syncing.
     """
     syncChangeset(changeset: ID!): EmptyResponse!
@@ -9601,152 +9746,7 @@ extend type Mutation {
     Re-enqueue the changeset for processing by the reconciler. The changeset must be in FAILED state.
     """
     reenqueueChangeset(changeset: ID!): Changeset!
-
-    """
-    Create a new credential for the given user for the given code host.
-    If another token for that code host already exists, an error with the error code
-    ErrDuplicateCredential is returned.
-    """
-    createCampaignsCredential(
-        """
-        The user for which to create the credential.
-        """
-        user: ID!
-
-        """
-        The kind of external service being configured.
-        """
-        externalServiceKind: ExternalServiceKind!
-
-        """
-        The URL of the external service being configured.
-        """
-        externalServiceURL: String!
-
-        """
-        The credential to be stored. This can never be retrieved through the API and will be stored encrypted.
-        """
-        credential: String!
-    ): CampaignsCredential!
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
-
-    """
-    Hard-deletes a given campaigns credential.
-    """
-    deleteCampaignsCredential(campaignsCredential: ID!): EmptyResponse!
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
 }
-
-extend type Org {
-    """
-    A list of campaigns initially applied in this organization.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
-}
-
-extend type User {
-    """
-    A list of campaigns applied under this user's namespace.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
-
-    """
-    Returns a connection of configured external services accessible by this user, for usage with campaigns.
-    These are all code hosts configured on the Sourcegraph instance that are supported by campaigns. They are
-    connected to CampaignCredential resources, if one has been created for the code host connection before.
-    """
-    campaignsCodeHosts(
-        """
-        Returns the first n code hosts from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-    ): CampaignsCodeHostConnection!
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
-}
-
-extend type Query {
-    """
-    A list of campaigns.
-    """
-    campaigns(
-        """
-        Returns the first n campaigns from the list.
-        """
-        first: Int = 50
-        """
-        Opaque pagination cursor.
-        """
-        after: String
-        """
-        Only return campaigns in this state.
-        """
-        state: CampaignState
-        """
-        Only include campaigns that the viewer can administer.
-        """
-        viewerCanAdminister: Boolean
-    ): CampaignConnection!
-        @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChanges instead.")
-    """
-    Looks up a campaign by namespace and campaign name.
-    """
-    campaign(
-        """
-        The namespace where the campaign lives.
-        """
-        namespace: ID!
-        """
-        The campaigns name.
-        """
-        name: String!
-    ): Campaign @deprecated(reason: "campaigns have been renamed to batch changes. Use batchChange instead.")
-}
-
-############################################################################################
-#                                                                                          #
-#                                 End campaigns schema                                     #
-#                                                                                          #
-############################################################################################
 
 extend type Mutation {
     """
@@ -9763,19 +9763,19 @@ extend type Mutation {
     ): BatchChange!
 
     """
-    Create a batch spec that will be used to create a campaign (with the createCampaign
-    mutation), or to update a campaign (with the applyCampaign mutation).
+    Create a batch spec that will be used to create a batch change (with the createBatchChange
+    mutation), or to update an existing batch change (with the applyBatchChange mutation).
 
     The returned BatchSpec is immutable and expires after a certain period of time (if not used
-    in a call to applyCampaign), which can be queried on BatchSpec.expiresAt.
+    in a call to applyBatchChange), which can be queried on BatchSpec.expiresAt.
 
-    If campaigns are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
+    If batch changes are unlicensed and the number of changesetSpecIDs is higher than what's allowed in
     the free tier, an error with the error code ErrCampaignsUnlicensed is returned.
     """
     createBatchSpec(
         """
         The namespace (either a user or organization). A batch spec can only be applied to (or
-        used to create) campaigns in this namespace.
+        used to create) batch changes in this namespace.
         """
         namespace: ID!
 
@@ -9895,7 +9895,7 @@ extend type Query {
         viewerCanAdminister: Boolean
     ): BatchChangeConnection!
     """
-    Looks up a batch change by namespace and campaign name.
+    Looks up a batch change by namespace and name.
     """
     batchChange(
         """
@@ -10073,7 +10073,7 @@ type BatchChange implements Node {
 }
 
 """
-A batch spec is an immutable description of the desired state of a campaign. To create a
+A batch spec is an immutable description of the desired state of a batch change. To create a
 batch spec, use the createBatchSpec mutation.
 """
 type BatchSpec implements Node {
@@ -10081,8 +10081,8 @@ type BatchSpec implements Node {
     The unique ID for a batch spec.
 
     The ID is unguessable (i.e., long and randomly generated, not sequential).
-    Consider a campaign to fix a security vulnerability: the campaign author may prefer
-    to prepare the campaign, including the description in private so that the window
+    Consider a batch change to fix a security vulnerability: the batch change author may prefer
+    to prepare the batch change, including the description in private so that the window
     between revealing the problem and merging the fixes is as short as possible.
     """
     id: ID!
@@ -10132,7 +10132,7 @@ type BatchSpec implements Node {
     ): ChangesetApplyPreviewConnection!
 
     """
-    The specs for changesets associated with this campaign.
+    The specs for changesets associated with this batch spec.
     """
     changesetSpecs(first: Int = 50, after: String): ChangesetSpecConnection!
 
@@ -10174,8 +10174,8 @@ type BatchSpec implements Node {
     diffStat: DiffStat!
 
     """
-    The campaign this spec will update when applied. If it's null, the
-    campaign doesn't yet exist.
+    The batch change this spec will update when applied. If it's null, the
+    batch change doesn't yet exist.
     """
     appliesToBatchChange: BatchChange
 
@@ -10380,3 +10380,9 @@ type BatchChangeDescription {
     """
     description: String!
 }
+
+############################################################################################
+#                                                                                          #
+#                                 End batches schema                                       #
+#                                                                                          #
+############################################################################################

--- a/enterprise/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/internal/batches/resolvers/permissions_test.go
@@ -293,7 +293,7 @@ func TestPermissionLevels(t *testing.T) {
 					input := map[string]interface{}{"user": graphqlID}
 					queryCodeHosts := `
 				  query($user: ID!) {
-				    node(id: $user) { ... on User { campaignsCodeHosts { totalCount } } }
+				    node(id: $user) { ... on User { batchChangesCodeHosts { totalCount } } }
 				  }
                 `
 
@@ -545,9 +545,9 @@ func TestPermissionLevels(t *testing.T) {
 				},
 			},
 			{
-				name: "deleteCampaign",
+				name: "deleteBatchChange",
 				mutationFunc: func(campaignID, changesetID, campaignSpecID string) string {
-					return fmt.Sprintf(`mutation { deleteCampaign(campaign: %q) { alwaysNil } } `, campaignID)
+					return fmt.Sprintf(`mutation { deleteBatchChange(batchChange: %q) { alwaysNil } } `, campaignID)
 				},
 			},
 			{
@@ -569,9 +569,9 @@ func TestPermissionLevels(t *testing.T) {
 				},
 			},
 			{
-				name: "moveCampaign",
+				name: "moveBatchChange",
 				mutationFunc: func(campaignID, changesetID, campaignSpecID string) string {
-					return fmt.Sprintf(`mutation { moveCampaign(campaign: %q, newName: "foobar") { id } }`, campaignID)
+					return fmt.Sprintf(`mutation { moveBatchChange(batchChange: %q, newName: "foobar") { id } }`, campaignID)
 				},
 			},
 		}
@@ -693,11 +693,11 @@ func TestPermissionLevels(t *testing.T) {
 				},
 			},
 			{
-				name: "createCampaignSpec",
+				name: "createBatchSpec",
 				mutationFunc: func(userID string) string {
 					return fmt.Sprintf(`
 					mutation {
-						createCampaignSpec(namespace: %q, campaignSpec: "{}", changesetSpecs: []) {
+						createBatchSpec(namespace: %q, batchSpec: "{}", changesetSpecs: []) {
 							id
 						}
 					}`, userID)


### PR DESCRIPTION
This moves all deprecated resolvers in one place, and updates all outdated doc strings.
Also, I commented the deprecated API out to test that we're not using it ourselves anywhere. Frontend, and resolver tests still work, I just had to update a few mentions of old mutation names.
