### PR TITLE
Adding LSIF entry

### DIFF
--- a/enterprise/docs/glossary.md
+++ b/enterprise/docs/glossary.md
@@ -62,7 +62,7 @@ Lattice is the service used to do review and goal tracking. These are done quart
 
 ### [LSIF](https://lsif.dev/)
 
-LSIF is a standard format for persisted code analyzer output. It allows a code viewing client (e.g., an editor or code browser) to provide features like autocomplete, go to definition, find references, and similar, without requiring a language analyzer to perform those computations in real-time. Today, several companies are working to support its growth, including Sourcegraph and GitHub/Microsoft, and the protocol is beginning to be used to power a rapidly growing list of language intelligence tools. See below for details on and links to current indexer implementations.
+LSIF is a standard format for persisted code analyzer output. It allows a code viewing client (e.g., an editor or code browser) to provide features like autocomplete, go to definition, find references, and similar, without requiring a language analyzer to perform those computations in real-time. Today, several companies are working to support its growth, including Sourcegraph and GitHub/Microsoft, and the protocol is beginning to be used to power a rapidly growing list of language intelligence tools. Sourcegraph uses LSIF to power it's code intelligence feature.
 
 ### [LSP](https://microsoft.github.io/language-server-protocol/)
 

--- a/enterprise/docs/glossary.md
+++ b/enterprise/docs/glossary.md
@@ -60,6 +60,10 @@ Container infrastructure, used to let us build images to run that have predictab
 
 Lattice is the service used to do review and goal tracking. These are done quarterly.
 
+### [LSIF](https://lsif.dev/)
+
+LSIF is a standard format for persisted code analyzer output. It allows a code viewing client (e.g., an editor or code browser) to provide features like autocomplete, go to definition, find references, and similar, without requiring a language analyzer to perform those computations in real-time. Today, several companies are working to support its growth, including Sourcegraph and GitHub/Microsoft, and the protocol is beginning to be used to power a rapidly growing list of language intelligence tools. See below for details on and links to current indexer implementations.
+
 ### [LSP](https://microsoft.github.io/language-server-protocol/)
 
 Language Server Protocol. A Microsoft spec intended to provide an easier interface for interactions between tools which need code intelligence (such as editors, IDEs, and code search tools) and tools which can provide it, such as language analyzers. Sourcegraph maintains resources for implementations and integrations at [langserver.org](https://langserver.org/).


### PR DESCRIPTION
During onboarding I'm seeing this around and it was confusing, I thought it should be in the glossary although, it might be redundant with LSP already having an entry



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
