### PR TITLE
Please fix Renovate

### DIFF
--- a/.github/workflows/renovate-downstream.yml
+++ b/.github/workflows/renovate-downstream.yml
@@ -8,7 +8,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     # Run on commit status success on branch main, ignoring bot events
-    if: ${{ contains(github.event.branches.*.name, 'main') && github.event.state == 'success' && github.event.context == 'buildkite/sourcegraph' }}
+    if: ${{ contains(github.event.branches.*.name, 'main') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I've waited 4 hours and my commit isn't on k8s.sgdev.org or sourcegraph.com yet. This renovate downstream job is not firing, and is always being "skipped":

<img width="691" alt="image" src="https://user-images.githubusercontent.com/3173176/110044431-59838780-7d06-11eb-9c48-8b350b890592.png">

This happens even for jobs enqueued manually. I think this conditional is to blame, so I am relaxing it substantially. We may burn through more GitHub actions this way, but at least it will work.

I think it is happening because the GitHub commit status is "failed" due to LSIF uploads failing, even though buildkite passed (so it would not deploy the latest commit until someone makes a new commit and *every* status check passes:

<img width="874" alt="image" src="https://user-images.githubusercontent.com/3173176/110044544-8d5ead00-7d06-11eb-9c70-d2343ee6fbc7.png">
