### PR TITLE
extensibility: load global css files only on known code-hosts

### DIFF
--- a/client/browser/src/native-integration/integration.main.ts
+++ b/client/browser/src/native-integration/integration.main.ts
@@ -38,7 +38,9 @@ function init(): void {
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL
     // TODO handle subscription
-    injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION)
+    injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION).catch((error) => {
+        console.error('Error injecting Sourcegraph code intelligence: ', error)
+    })
 }
 
 init()

--- a/client/browser/src/native-integration/integration.main.ts
+++ b/client/browser/src/native-integration/integration.main.ts
@@ -38,8 +38,8 @@ function init(): void {
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     window.SOURCEGRAPH_URL = sourcegraphURL
     // TODO handle subscription
-    injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION).catch((error) => {
-        console.error('Error injecting Sourcegraph code intelligence: ', error)
+    injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION).catch(error => {
+        console.error('Error injecting Sourcegraph code intelligence:', error)
     })
 }
 

--- a/client/browser/src/native-integration/phabricator/integration.main.ts
+++ b/client/browser/src/native-integration/phabricator/integration.main.ts
@@ -39,7 +39,7 @@ async function init(): Promise<void> {
     // so we do not need to do this here.
     if (!window.SOURCEGRAPH_BUNDLE_URL && !window.localStorage.getItem('SOURCEGRAPH_BUNDLE_URL')) {
         injectExtensionMarker()
-        injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION)
+        await injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION)
         metaClickOverride()
         return
     }

--- a/client/browser/src/native-integration/phabricator/integration.main.ts
+++ b/client/browser/src/native-integration/phabricator/integration.main.ts
@@ -54,7 +54,7 @@ async function init(): Promise<void> {
     window.localStorage.setItem('SOURCEGRAPH_URL', sourcegraphURL)
     metaClickOverride()
     injectExtensionMarker()
-    injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION)
+    await injectCodeIntelligence({ sourcegraphURL, assetsURL }, IS_EXTENSION)
 }
 
 init().catch(error => console.error('Error initializing Phabricator integration', error))

--- a/client/browser/src/shared/code-hosts/shared/inject.ts
+++ b/client/browser/src/shared/code-hosts/shared/inject.ts
@@ -2,7 +2,7 @@ import { Observable, Subscription } from 'rxjs'
 import { startWith } from 'rxjs/operators'
 import { MutationRecordLike, observeMutations as defaultObserveMutations } from '../../util/dom'
 
-import { determineCodeHost, injectCodeIntelligenceToCodeHost, ObserveMutations } from './codeHost'
+import { determineCodeHost, CodeHost, injectCodeIntelligenceToCodeHost, ObserveMutations } from './codeHost'
 import { SourcegraphIntegrationURLs } from '../../platform/context'
 
 /**
@@ -10,12 +10,19 @@ import { SourcegraphIntegrationURLs } from '../../platform/context'
  * injects features for the lifetime of the script in reaction to DOM mutations.
  *
  * @param isExtension `true` when executing in the browser extension.
+ * @param onCodeHostFound setup logic to run when a code host is found (e.g. loading stylesheet) to avoid doing
+ * such work on unsupported websites
  */
-export function injectCodeIntelligence(urls: SourcegraphIntegrationURLs, isExtension: boolean): Subscription {
+export async function injectCodeIntelligence(urls: SourcegraphIntegrationURLs, isExtension: boolean, onCodeHostFound?: (codeHost: CodeHost) =>Promise<void> ): Promise<Subscription> {
     const subscriptions = new Subscription()
     const codeHost = determineCodeHost()
     if (codeHost) {
         console.log('Sourcegraph: Detected code host:', codeHost.type)
+
+        if (onCodeHostFound) {
+        await onCodeHostFound(codeHost)
+        }
+
         const observeMutations: ObserveMutations = codeHost.observeMutations || defaultObserveMutations
         const mutations: Observable<MutationRecordLike[]> = observeMutations(document.body, {
             childList: true,

--- a/client/browser/src/shared/code-hosts/shared/inject.ts
+++ b/client/browser/src/shared/code-hosts/shared/inject.ts
@@ -13,14 +13,18 @@ import { SourcegraphIntegrationURLs } from '../../platform/context'
  * @param onCodeHostFound setup logic to run when a code host is found (e.g. loading stylesheet) to avoid doing
  * such work on unsupported websites
  */
-export async function injectCodeIntelligence(urls: SourcegraphIntegrationURLs, isExtension: boolean, onCodeHostFound?: (codeHost: CodeHost) =>Promise<void> ): Promise<Subscription> {
+export async function injectCodeIntelligence(
+    urls: SourcegraphIntegrationURLs,
+    isExtension: boolean,
+    onCodeHostFound?: (codeHost: CodeHost) => Promise<void>
+): Promise<Subscription> {
     const subscriptions = new Subscription()
     const codeHost = determineCodeHost()
     if (codeHost) {
         console.log('Sourcegraph: Detected code host:', codeHost.type)
 
         if (onCodeHostFound) {
-        await onCodeHostFound(codeHost)
+            await onCodeHostFound(codeHost)
         }
 
         const observeMutations: ObserveMutations = codeHost.observeMutations || defaultObserveMutations


### PR DESCRIPTION
We currently load top level css on every page, which breaks non-code-host pages.
By making a check we prevent this issue from happening.
Fixes #10595
