### PR TITLE
search frontend: add completion for symbol kinds

### DIFF
--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -309,7 +309,7 @@ export async function getCompletionItems(
         }
         if (resolvedFilter.definition.discreteValues) {
             return {
-                suggestions: resolvedFilter.definition.discreteValues.map(
+                suggestions: resolvedFilter.definition.discreteValues(token.value).map(
                     (label, index): Monaco.languages.CompletionItem => ({
                         label,
                         sortText: index.toString(), // suggestions sort by order in the list, not alphabetically.

--- a/client/shared/src/search/query/selectFilter.test.ts
+++ b/client/shared/src/search/query/selectFilter.test.ts
@@ -1,0 +1,57 @@
+import { selectorCompletion } from './selectFilter'
+import { Literal } from './token'
+
+expect.addSnapshotSerializer({
+    serialize: (value: string[]): string => value.join(',\n'),
+    test: () => true,
+})
+
+const create = (value: string): Literal => ({
+    type: 'literal',
+    value,
+    range: { start: 0, end: 0 },
+})
+
+describe('selectorCompletion', () => {
+    test('suggest depth 0 completions', () => {
+        expect(selectorCompletion(create('foo'))).toMatchInlineSnapshot(`
+            repo,
+            file,
+            content,
+            symbol,
+            commit
+        `)
+    })
+
+    test('suggest depth 1 symbol completions', () => {
+        expect(selectorCompletion(create('symbol.f'))).toMatchInlineSnapshot(`
+            symbol,
+            symbol.file,
+            symbol.module,
+            symbol.namespace,
+            symbol.package,
+            symbol.class,
+            symbol.method,
+            symbol.property,
+            symbol.field,
+            symbol.constructor,
+            symbol.enum,
+            symbol.interface,
+            symbol.function,
+            symbol.variable,
+            symbol.constant,
+            symbol.string,
+            symbol.number,
+            symbol.boolean,
+            symbol.array,
+            symbol.object,
+            symbol.key,
+            symbol.null,
+            symbol.enum-member,
+            symbol.struct,
+            symbol.event,
+            symbol.operator,
+            symbol.type-parameter
+        `)
+    })
+})

--- a/client/shared/src/search/query/selectFilter.ts
+++ b/client/shared/src/search/query/selectFilter.ts
@@ -1,0 +1,85 @@
+import { Quoted, Literal } from './token'
+
+interface Selector {
+    kind: string
+    fields?: Selector[]
+}
+
+export const SELECTORS: Selector[] = [
+    {
+        kind: 'repo',
+    },
+    {
+        kind: 'file',
+    },
+    {
+        kind: 'content',
+    },
+    {
+        kind: 'symbol',
+        fields: [
+            { kind: 'file' },
+            { kind: 'module' },
+            { kind: 'namespace' },
+            { kind: 'package' },
+            { kind: 'class' },
+            { kind: 'method' },
+            { kind: 'property' },
+            { kind: 'field' },
+            { kind: 'constructor' },
+            { kind: 'enum' },
+            { kind: 'interface' },
+            { kind: 'function' },
+            { kind: 'variable' },
+            { kind: 'constant' },
+            { kind: 'string' },
+            { kind: 'number' },
+            { kind: 'boolean' },
+            { kind: 'array' },
+            { kind: 'object' },
+            { kind: 'key' },
+            { kind: 'null' },
+            { kind: 'enum-member' },
+            { kind: 'struct' },
+            { kind: 'event' },
+            { kind: 'operator' },
+            { kind: 'type-parameter' },
+        ],
+    },
+    {
+        kind: 'commit',
+    },
+]
+
+/**
+ * Returns all paths rooted at a {@link selector} up to {@param depth}.
+ */
+export const selectDiscreteValues = (selectors: Selector[], depth: number): string[] => {
+    if (depth < 0) {
+        return []
+    }
+    const paths: string[] = []
+    for (const entry of selectors) {
+        paths.push(`${entry.kind}`)
+        if (entry.fields) {
+            paths.push(...selectDiscreteValues(entry.fields, depth - 1).map(value => `${entry.kind}.` + value))
+        }
+    }
+    return paths
+}
+
+export const selectorCompletion = (value: Quoted | Literal | undefined): string[] => {
+    if (!value || value.type === 'quoted') {
+        return selectDiscreteValues(SELECTORS, 0)
+    }
+
+    if (value.value.endsWith('.') || value.value.split('.').length > 1) {
+        // Resolve completions to greater depth for `foo.` if the value is `foo.` or `foo.bar`.
+        const kind = value.value.split('.')[0]
+        return selectDiscreteValues(
+            SELECTORS.filter(value => value.kind === kind),
+            1
+        )
+    }
+    return selectDiscreteValues(SELECTORS, 0)
+}


### PR DESCRIPTION
This adds `symbol.<kind>` completion suggestions:

https://user-images.githubusercontent.com/888624/110147612-22aa8180-7d99-11eb-9939-5979bb4cb65d.mp4

Couple of implementation notes:

- It's getting a bit awkward to deal with `discreteValues` associated with filters, see in line comment for change.

- To resolve at the next level, I inspect the current `select` value to resolve further completions. There seems to be some builtin Monaco way to help with this sort of thing in `resolveCompletionItem`, but I couldn't figure it out and would probably have to spend a lot more time familiarizing myself with this before being able to ship this. So I'm going to spend more time with Monaco since this is important for other planned changes too, but not right now.