### PR TITLE
search frontend: remove Quoted token

### DIFF
--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -301,7 +301,7 @@ export async function getCompletionItems(
                         // Set the current value as filterText, so that all dynamic suggestions
                         // returned by the server are displayed. otherwise, if the current filter value
                         // is a regex pattern, Monaco's filtering might hide some suggestions.
-                        filterText: value && (value?.type === 'literal' ? value.value : value.quotedValue),
+                        filterText: value?.value,
                         range: value ? toMonacoRange(value.range) : defaultRange,
                         command: COMPLETION_ITEM_SELECTED,
                     })),

--- a/client/shared/src/search/query/diagnostics.ts
+++ b/client/shared/src/search/query/diagnostics.ts
@@ -21,7 +21,7 @@ export function getDiagnostics(tokens: Token[], patternType: SearchPatternType):
                 message: validationResult.reason,
                 ...toMonacoRange(field.range),
             })
-        } else if (token.type === 'quoted') {
+        } else if (token.type === 'literal' && token.quoted) {
             if (patternType === SearchPatternType.literal) {
                 diagnostics.push({
                     severity: Monaco.MarkerSeverity.Warning,

--- a/client/shared/src/search/query/filters.test.ts
+++ b/client/shared/src/search/query/filters.test.ts
@@ -1,5 +1,5 @@
 import { escapeSpaces, validateFilter } from './filters'
-import { Literal, Quoted } from './token'
+import { Literal, createLiteral } from './token'
 
 expect.addSnapshotSerializer({
     serialize: value => value as string,
@@ -11,7 +11,7 @@ describe('validateFilter()', () => {
         description: string
         filterType: string
         expected: ReturnType<typeof validateFilter>
-        token: Literal | Quoted
+        token: Literal
     }
     const range = { start: 0, end: 1 }
     const TESTCASES: TestCase[] = [
@@ -19,49 +19,49 @@ describe('validateFilter()', () => {
             description: 'Valid repo filter',
             filterType: 'repo',
             expected: { valid: true },
-            token: { type: 'literal', value: 'a', range },
+            token: createLiteral('a', range),
         },
         {
             description: 'Valid repo filter - quoted value',
             filterType: 'repo',
             expected: { valid: true },
-            token: { type: 'quoted', quotedValue: 'a', range },
+            token: createLiteral('a', range, true),
         },
         {
             description: 'Valid repo filter - alias',
-            filterType: 'repo',
+            filterType: 'r',
             expected: { valid: true },
-            token: { type: 'quoted', quotedValue: 'a', range },
+            token: createLiteral('a', range, true),
         },
         {
             description: 'Invalid filter type',
             filterType: 'repoo',
             expected: { valid: false, reason: 'Invalid filter type.' },
-            token: { type: 'literal', value: 'a', range },
+            token: createLiteral('a', range),
         },
         {
             description: 'Valid case filter',
             filterType: 'case',
             expected: { valid: true },
-            token: { type: 'literal', value: 'yes', range },
+            token: createLiteral('yes', range),
         },
         {
             description: 'Valid quoted value for case filter',
             filterType: 'case',
             expected: { valid: true },
-            token: { type: 'quoted', quotedValue: 'yes', range },
+            token: createLiteral('yes', range, true),
         },
         {
             description: 'Invalid literal value for case filter',
             filterType: 'case',
             expected: { valid: false, reason: 'Invalid filter value, expected one of: yes, no.' },
-            token: { type: 'literal', value: 'yess', range },
+            token: createLiteral('yess', range, true),
         },
         {
             description: 'Valid case-insensitive repo filter',
             filterType: 'RePo',
             expected: { valid: true },
-            token: { type: 'literal', value: 'a', range },
+            token: createLiteral('a', range, true),
         },
     ]
 

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -1,4 +1,4 @@
-import { Filter, Quoted, Literal } from './token'
+import { Filter, Literal } from './token'
 import { SearchSuggestion } from '../suggestions'
 import { Omit } from 'utility-types'
 import { selectorCompletion } from './selectFilter'
@@ -109,7 +109,7 @@ export const resolveNegatedFilter = (filter: NegatedFilters): NegatableFilter =>
 interface BaseFilterDefinition {
     alias?: string
     description: string
-    discreteValues?: (value: Quoted | Literal | undefined) => string[]
+    discreteValues?: (value: Literal | undefined) => string[]
     suggestions?: SearchSuggestion['__typename'] | string[]
     default?: string
     /** Whether the filter may only be used 0 or 1 times in a query. */
@@ -332,7 +332,7 @@ export const resolveFilter = (
  */
 const isValidDiscreteValue = (
     definition: NegatableFilterDefinition | BaseFilterDefinition,
-    input: Literal | Quoted,
+    input: Literal,
     value: string
 ): boolean => {
     if (!definition.discreteValues || definition.discreteValues(input).includes(value)) {
@@ -363,13 +363,7 @@ export const validateFilter = (
         return { valid: false, reason: 'Invalid filter type.' }
     }
     const { definition } = typeAndDefinition
-    if (
-        definition.discreteValues &&
-        (!value ||
-            (value.type !== 'literal' && value.type !== 'quoted') ||
-            (value.type === 'literal' && !isValidDiscreteValue(definition, value, value.value)) ||
-            (value.type === 'quoted' && !isValidDiscreteValue(definition, value, value.quotedValue)))
-    ) {
+    if (definition.discreteValues && (!value || !isValidDiscreteValue(definition, value, value.value))) {
         return {
             valid: false,
             reason: `Invalid filter value, expected one of: ${definition.discreteValues(value).join(', ')}.`,

--- a/client/shared/src/search/query/parser.ts
+++ b/client/shared/src/search/query/parser.ts
@@ -68,11 +68,7 @@ const tokenToLeafNode = (token: Token): ParseResult => {
         return createPattern(token.value, token.kind, false, false)
     }
     if (token.type === 'filter') {
-        const filterValue = token.value
-            ? token.value.type === 'literal'
-                ? token.value.value
-                : token.value.quotedValue
-            : ''
+        const filterValue = token.value ? token.value.value : ''
         return createParameter(token.field.value, filterValue, token.negated)
     }
     return { type: 'error', expected: 'a convertable token to tree node' }

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -91,55 +91,55 @@ describe('scanSearchQuery() for literal search', () => {
 
     test('filter', () =>
         expect(scanSearchQuery('f:b')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"b","range":{"start":2,"end":3}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"b","range":{"start":2,"end":3},"quoted":false},"negated":false}]}'
         ))
 
     test('negated filter', () =>
         expect(scanSearchQuery('-f:b')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"-f","range":{"start":0,"end":2}},"value":{"type":"literal","value":"b","range":{"start":3,"end":4}},"negated":true}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"-f","range":{"start":0,"end":2}},"value":{"type":"literal","value":"b","range":{"start":3,"end":4},"quoted":false},"negated":true}]}'
         ))
 
     test('filter with quoted value', () => {
         expect(scanSearchQuery('f:"b"')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":5},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"quoted","quotedValue":"b","range":{"start":2,"end":5}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":5},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"b","range":{"start":2,"end":5},"quoted":true},"negated":false}]}'
         )
     })
 
     test('filter with a value ending with a colon', () => {
         expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a:","range":{"start":2,"end":4},"quoted":false},"negated":false}]}'
         )
     })
 
     test('filter where the value is a colon', () => {
         expect(scanSearchQuery('f:a:')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a:","range":{"start":2,"end":4}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":4},"field":{"type":"literal","value":"f","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a:","range":{"start":2,"end":4},"quoted":false},"negated":false}]}'
         )
     })
 
     test('quoted, double quotes', () =>
         expect(scanSearchQuery('"a:b"')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}]}'
+            '{"type":"success","term":[{"type":"literal","value":"a:b","range":{"start":0,"end":5},"quoted":true}]}'
         ))
 
     test('quoted, single quotes', () =>
         expect(scanSearchQuery("'a:b'")).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"quoted","quotedValue":"a:b","range":{"start":0,"end":5}}]}'
+            '{"type":"success","term":[{"type":"literal","value":"a:b","range":{"start":0,"end":5},"quoted":true}]}'
         ))
 
     test('quoted (escaped quotes)', () =>
         expect(scanSearchQuery('"-\\"a\\":b"')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"quoted","quotedValue":"-\\\\\\"a\\\\\\":b","range":{"start":0,"end":10}}]}'
+            '{"type":"success","term":[{"type":"literal","value":"-\\\\\\"a\\\\\\":b","range":{"start":0,"end":10},"quoted":true}]}'
         ))
 
     test('complex query', () =>
         expect(scanSearchQuery('repo:^github\\.com/gorilla/mux$ lang:go -file:mux.go Router')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":30},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30}},"negated":false},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"field":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"value":{"type":"literal","value":"go","range":{"start":36,"end":38}},"negated":false},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"field":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"value":{"type":"literal","value":"mux.go","range":{"start":45,"end":51}},"negated":true},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":30},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"^github\\\\.com/gorilla/mux$","range":{"start":5,"end":30},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":30,"end":31}},{"type":"filter","range":{"start":31,"end":38},"field":{"type":"literal","value":"lang","range":{"start":31,"end":35}},"value":{"type":"literal","value":"go","range":{"start":36,"end":38},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":38,"end":39}},{"type":"filter","range":{"start":39,"end":51},"field":{"type":"literal","value":"-file","range":{"start":39,"end":44}},"value":{"type":"literal","value":"mux.go","range":{"start":45,"end":51},"quoted":false},"negated":true},{"type":"whitespace","range":{"start":51,"end":52}},{"type":"pattern","range":{"start":52,"end":58},"kind":1,"value":"Router"}]}'
         ))
 
     test('parenthesized parameters', () => {
         expect(scanSearchQuery('repo:a (file:b and c)')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":6},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"a","range":{"start":5,"end":6}},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"field":{"type":"literal","value":"file","range":{"start":8,"end":12}},"value":{"type":"literal","value":"b","range":{"start":13,"end":14}},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"keyword","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":6},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"a","range":{"start":5,"end":6},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":6,"end":7}},{"type":"openingParen","range":{"start":7,"end":8}},{"type":"filter","range":{"start":8,"end":14},"field":{"type":"literal","value":"file","range":{"start":8,"end":12}},"value":{"type":"literal","value":"b","range":{"start":13,"end":14},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":14,"end":15}},{"type":"keyword","value":"and","range":{"start":15,"end":18},"kind":"and"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"pattern","range":{"start":19,"end":20},"kind":1,"value":"c"},{"type":"closingParen","range":{"start":20,"end":21}}]}'
         )
     })
 
@@ -151,7 +151,7 @@ describe('scanSearchQuery() for literal search', () => {
 
     test('do not treat links as filters', () => {
         expect(scanSearchQuery('http://example.com repo:a')).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"field":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"value":{"type":"literal","value":"a","range":{"start":24,"end":25}},"negated":false}]}'
+            '{"type":"success","term":[{"type":"pattern","range":{"start":0,"end":18},"kind":1,"value":"http://example.com"},{"type":"whitespace","range":{"start":18,"end":19}},{"type":"filter","range":{"start":19,"end":25},"field":{"type":"literal","value":"repo","range":{"start":19,"end":23}},"value":{"type":"literal","value":"a","range":{"start":24,"end":25},"quoted":false},"negated":false}]}'
         )
     })
 })
@@ -175,7 +175,7 @@ describe('scanSearchQuery() for regexp', () => {
 
     test('interpret regexp slash quotes', () => {
         expect(scanSearchQuery('r:a /a regexp \\ pattern/', false, SearchPatternType.regexp)).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"field":{"type":"literal","value":"r","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a","range":{"start":2,"end":3}},"negated":false},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"quoted","quotedValue":"a regexp \\\\ pattern","range":{"start":4,"end":24}}]}'
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":3},"field":{"type":"literal","value":"r","range":{"start":0,"end":1}},"value":{"type":"literal","value":"a","range":{"start":2,"end":3},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":3,"end":4}},{"type":"literal","value":"a regexp \\\\ pattern","range":{"start":4,"end":24},"quoted":true}]}'
         )
     })
 })
@@ -187,7 +187,7 @@ repo:sourcegraph
 // search for thing
 thing`
         expect(scanSearchQuery(query, true)).toMatchInlineSnapshot(
-            '{"type":"success","term":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"field":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"value":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44}},"negated":false},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}]}'
+            '{"type":"success","term":[{"type":"comment","value":"// saucegraph is best graph","range":{"start":0,"end":27}},{"type":"whitespace","range":{"start":27,"end":28}},{"type":"filter","range":{"start":28,"end":44},"field":{"type":"literal","value":"repo","range":{"start":28,"end":32}},"value":{"type":"literal","value":"sourcegraph","range":{"start":33,"end":44},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":44,"end":45}},{"type":"comment","value":"// search for thing","range":{"start":45,"end":64}},{"type":"whitespace","range":{"start":64,"end":65}},{"type":"pattern","range":{"start":65,"end":70},"kind":1,"value":"thing"}]}'
         )
     })
 

--- a/client/shared/src/search/query/selectFilter.test.ts
+++ b/client/shared/src/search/query/selectFilter.test.ts
@@ -1,16 +1,12 @@
 import { selectorCompletion } from './selectFilter'
-import { Literal } from './token'
+import { Literal, createLiteral } from './token'
 
 expect.addSnapshotSerializer({
     serialize: (value: string[]): string => value.join(',\n'),
     test: () => true,
 })
 
-const create = (value: string): Literal => ({
-    type: 'literal',
-    value,
-    range: { start: 0, end: 0 },
-})
+const create = (value: string): Literal => createLiteral(value, { start: 0, end: 0 })
 
 describe('selectorCompletion', () => {
     test('suggest depth 0 completions', () => {

--- a/client/shared/src/search/query/selectFilter.ts
+++ b/client/shared/src/search/query/selectFilter.ts
@@ -1,4 +1,4 @@
-import { Quoted, Literal } from './token'
+import { Literal } from './token'
 
 interface Selector {
     kind: string
@@ -68,8 +68,8 @@ export const selectDiscreteValues = (selectors: Selector[], depth: number): stri
     return paths
 }
 
-export const selectorCompletion = (value: Quoted | Literal | undefined): string[] => {
-    if (!value || value.type === 'quoted') {
+export const selectorCompletion = (value: Literal | undefined): string[] => {
+    if (!value) {
         return selectDiscreteValues(SELECTORS, 0)
     }
 

--- a/client/shared/src/search/query/token.ts
+++ b/client/shared/src/search/query/token.ts
@@ -19,7 +19,7 @@ export interface BaseToken {
 /**
  * All recognized tokens.
  */
-export type Token = Whitespace | OpeningParen | ClosingParen | Keyword | Comment | Literal | Pattern | Filter | Quoted
+export type Token = Whitespace | OpeningParen | ClosingParen | Keyword | Comment | Literal | Pattern | Filter
 
 /**
  * A label associated with a pattern token. We don't use SearchPatternType because
@@ -42,13 +42,14 @@ export interface Pattern extends BaseToken {
 }
 
 /**
- * Represents a literal in a search query.
+ * Represents a value in a search query. E.g., either a quoted or unquoted pattern or field value.
  *
  * Example: `Conn`.
  */
 export interface Literal extends BaseToken {
     type: 'literal'
     value: string
+    quoted: boolean
 }
 
 /**
@@ -59,7 +60,7 @@ export interface Literal extends BaseToken {
 export interface Filter extends BaseToken {
     type: 'filter'
     field: Literal
-    value: Quoted | Literal | undefined
+    value: Literal | undefined
     negated: boolean
 }
 
@@ -78,16 +79,6 @@ export interface Keyword extends BaseToken {
     type: 'keyword'
     value: string
     kind: KeywordKind
-}
-
-/**
- * Represents a quoted string in a search query.
- *
- * Example: "Conn".
- */
-export interface Quoted extends BaseToken {
-    type: 'quoted'
-    quotedValue: string
 }
 
 /**
@@ -111,3 +102,10 @@ export interface OpeningParen extends BaseToken {
 export interface ClosingParen extends BaseToken {
     type: 'closingParen'
 }
+
+export const createLiteral = (value: string, range: CharacterRange, quoted = false): Literal => ({
+    type: 'literal',
+    value,
+    range,
+    quoted,
+})

--- a/client/shared/src/util/url.ts
+++ b/client/shared/src/util/url.ts
@@ -596,18 +596,14 @@ export function buildSearchURLQuery(
     const globalPatternType = findFilter(queryParameter, 'patterntype', FilterKind.Global)
     if (globalPatternType?.value) {
         const { start, end } = globalPatternType.range
-        patternTypeParameter =
-            globalPatternType.value.type === 'literal'
-                ? globalPatternType.value.value
-                : globalPatternType.value.quotedValue
+        patternTypeParameter = globalPatternType.value.value
         queryParameter = replaceRange(queryParameter, { start: Math.max(0, start - 1), end }).trim()
     }
 
     const globalCase = findFilter(queryParameter, 'case', FilterKind.Global)
     if (globalCase?.value) {
         // When case:value is explicit in the query, override any previous value of caseParameter.
-        const globalCaseParameterValue =
-            globalCase.value.type === 'literal' ? globalCase.value.value : globalCase.value.quotedValue
+        const globalCaseParameterValue = globalCase.value.value
         caseParameter = discreteValueAliases.yes.includes(globalCaseParameterValue) ? 'yes' : 'no'
         queryParameter = replaceRange(queryParameter, globalCase.range)
     }

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -175,11 +175,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
 
     useEffect(() => {
         const globalContextFilter = findFilter(query, FilterType.context, FilterKind.Global)
-        const searchContextSpec = globalContextFilter?.value
-            ? globalContextFilter.value.type === 'literal'
-                ? globalContextFilter.value.value
-                : globalContextFilter.value.quotedValue
-            : undefined
+        const searchContextSpec = globalContextFilter?.value ? globalContextFilter.value.value : undefined
 
         let finalQuery = query
         if (

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -44,12 +44,8 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                 filter =>
                                     filter.type === 'filter' &&
                                     resolveFilter(filter.field.value)?.type === FilterType.type &&
-                                    ((filter.value?.type === 'literal' &&
-                                        filter.value &&
-                                        isDiffOrCommit(filter.value.value)) ||
-                                        (filter.value?.type === 'quoted' &&
-                                            filter.value &&
-                                            isDiffOrCommit(filter.value.quotedValue)))
+                                    filter.value &&
+                                    isDiffOrCommit(filter.value.value)
                             )
                             if (!hasTypeDiffOrCommitFilter) {
                                 return 'Code monitors require queries to specify either `type:commit` or `type:diff`.'

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -133,11 +133,8 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
                     token.type === 'filter' &&
                     (token.field.value === FilterType.repo || token.field.value === FILTERS[FilterType.repo].alias)
                 ) {
-                    if (token.value?.type === 'literal' && !recentlySearchedRepos.includes(token.value.value)) {
+                    if (token.value && !recentlySearchedRepos.includes(token.value.value)) {
                         recentlySearchedRepos.push(token.value.value)
-                    }
-                    if (token.value?.type === 'quoted' && !recentlySearchedRepos.includes(token.value.quotedValue)) {
-                        recentlySearchedRepos.push(token.value.quotedValue)
                     }
                 }
             }

--- a/client/web/src/search/results/SearchResultTab.tsx
+++ b/client/web/src/search/results/SearchResultTab.tsx
@@ -53,10 +53,7 @@ export const SearchResultTabHeader: React.FunctionComponent<Props> = ({
         // we can check whether this tab should be active.
         for (const token of scannedQuery.term) {
             if (token.type === 'filter' && token.field.value === 'type' && token.value) {
-                typeInQuery =
-                    token.value.type === 'literal'
-                        ? (token.value.value as SearchType)
-                        : (token.value.quotedValue as SearchType)
+                typeInQuery = token.value.value as SearchType
             }
         }
     }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -74,12 +74,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
             return null
         }
         const globalTypeFilterInQuery = findFilter(props.query, 'type', FilterKind.Global)
-        const globalTypeFilterValue =
-            globalTypeFilterInQuery?.value?.type === 'literal'
-                ? globalTypeFilterInQuery.value.value
-                : globalTypeFilterInQuery?.value?.type === 'quoted'
-                ? globalTypeFilterInQuery.value.quotedValue
-                : undefined
+        const globalTypeFilterValue = globalTypeFilterInQuery?.value ? globalTypeFilterInQuery.value.value : undefined
         const canCreateMonitorFromQuery = globalTypeFilterValue === 'diff' || globalTypeFilterValue === 'commit'
         if (!canCreateMonitorFromQuery) {
             return null


### PR DESCRIPTION
Stacked on #18910.

We represent a quoted value as a separated `Token` in the frontend scanner. It creates more trouble than its worth--there are very few cases we actually care whether a value is quoted after scanning a query. The change adds `quoted` as a boolean value to indicate whether a value is quoted, and removes the `Quoted` token. The rest just propagates changes, and simplifies a lot of code where we don't need to care whether the scanned value was quoted or not.