### PR TITLE
search frontend: add hover delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Repositories and files containing spaces will now render with escaped spaces in the query bar rather than being
   quoted. [#18642](https://github.com/sourcegraph/sourcegraph/pull/18642)
 - Sourcegraph is now built with Go 1.16. [#18447](https://github.com/sourcegraph/sourcegraph/pull/18447)
+- Cursor hover information in the search query bar will now display after 150ms (previously 0ms). [#18916](https://github.com/sourcegraph/sourcegraph/pull/18916)
 
 ### Fixed
 

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -179,7 +179,6 @@ export class MonacoEditor extends React.PureComponent<Props, State> {
         }
         this.props.editorWillMount(monaco)
         const editor = monaco.editor.create(element, {
-            hover: { delay: 0 },
             value: this.props.value,
             language: this.props.language,
             theme: this.props.isLightTheme ? SOURCEGRAPH_LIGHT : SOURCEGRAPH_DARK,

--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -337,6 +337,7 @@ export const MonacoQueryInput: React.FunctionComponent<MonacoQueryInputProps> = 
             horizontal: 'hidden',
         },
         glyphMargin: false,
+        hover: { delay: 150 },
         lineDecorationsWidth: 0,
         lineNumbersMinChars: 0,
         overviewRulerBorder: false,


### PR DESCRIPTION
Stacked on #18914. Fixes  #17126.

https://user-images.githubusercontent.com/888624/110168167-0536e100-7db4-11eb-807c-33cff65e8d46.mp4

@quinnkeast I chose a 150ms delay, WDYT? The default on Monaco is 300ms, which I think is OK for a code editor which is a lot more "busy" and contains a lot of text, but IMO 300ms is too slow for surfacing query intel which feels like it's more beneficial if it's snappier, a la regexr.com (otherwise, people might not notice there's anything to reveal here at all).

TODO: changelog entry.