### PR TITLE
extensibility: show better error messages on marketplace

### DIFF
--- a/client/web/src/extensions/ExtensionCard.test.tsx
+++ b/client/web/src/extensions/ExtensionCard.test.tsx
@@ -34,6 +34,7 @@ describe('ExtensionCard', () => {
                             platformContext={NOOP_PLATFORM_CONTEXT}
                             enabled={false}
                             isLightTheme={false}
+                            settingsURL="/settings/foobar"
                         />
                     </MemoryRouter>
                 )

--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -29,7 +29,7 @@ interface Props extends SettingsCascadeProps, PlatformContextProps<'updateSettin
     >
     subject: Pick<GQL.SettingsSubject, 'id' | 'viewerCanAdminister'>
     enabled: boolean
-    settingsURL: string | undefined
+    settingsURL: string | null | undefined
 }
 
 const stopPropagation: React.MouseEventHandler<HTMLElement> = event => {

--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -256,8 +256,7 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
                 {/* Visual feedback: alert when optimistic update fails */}
                 {optimisticFailure && (
                     <div className="alert alert-danger px-2 py-1 extension-card__disabled-feedback">
-                        <span className="font-weight-semibold">Network Error:</span> {name} is{' '}
-                        {optimisticFailure.previousValue ? 'enabled' : 'disabled'} again
+                        <span className="font-weight-semibold">Network Error:</span> {optimisticFailure.error.message}
                     </div>
                 )}
             </div>

--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -77,16 +77,22 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
         [extension]
     )
 
-    const actionableErrorMessage = (error: Error) => {
-        let errorMessage;
+    const actionableErrorMessage = (error: Error): JSX.Element => {
+        let errorMessage
 
         if (error.message.startsWith('invalid settings') && settingsURL) {
-            errorMessage = <>Could not enable / disable {name}. Edit your <a href={settingsURL}>user settings</a> to fix this error.</>
+            errorMessage = (
+                <>
+                    Could not enable / disable {name}. Edit your <Link to={settingsURL}>user settings</Link> to fix this
+                    error. <br />
+                    <br /> ({error.message})
+                </>
+            )
         } else {
-            errorMessage = <>{error.message}</>;
+            errorMessage = <>{error.message}</>
         }
 
-        return errorMessage;
+        return errorMessage
     }
 
     /**
@@ -270,7 +276,8 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
                 {/* Visual feedback: alert when optimistic update fails */}
                 {optimisticFailure && (
                     <div className="alert alert-danger px-2 py-1 extension-card__disabled-feedback">
-                        <span className="font-weight-semibold">Error:</span> {actionableErrorMessage(optimisticFailure.error)}
+                        <span className="font-weight-semibold">Error:</span>{' '}
+                        {actionableErrorMessage(optimisticFailure.error)}
                     </div>
                 )}
             </div>

--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -29,7 +29,7 @@ interface Props extends SettingsCascadeProps, PlatformContextProps<'updateSettin
     >
     subject: Pick<GQL.SettingsSubject, 'id' | 'viewerCanAdminister'>
     enabled: boolean
-    settingsURL: string
+    settingsURL: string | undefined
 }
 
 const stopPropagation: React.MouseEventHandler<HTMLElement> = event => {
@@ -80,7 +80,7 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
     const actionableErrorMessage = (error: Error) => {
         let errorMessage;
 
-        if (error.message.startsWith('invalid settings')) {
+        if (error.message.startsWith('invalid settings') && settingsURL) {
             errorMessage = <>Could not enable / disable {name}. Edit your <a href={settingsURL}>user settings</a> to fix this error.</>
         } else {
             errorMessage = <>{error.message}</>;

--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -29,6 +29,7 @@ interface Props extends SettingsCascadeProps, PlatformContextProps<'updateSettin
     >
     subject: Pick<GQL.SettingsSubject, 'id' | 'viewerCanAdminister'>
     enabled: boolean
+    settingsURL: string
 }
 
 const stopPropagation: React.MouseEventHandler<HTMLElement> = event => {
@@ -45,6 +46,7 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
     platformContext,
     subject,
     enabled,
+    settingsURL,
     isLightTheme,
 }) {
     const manifest: ExtensionManifest | undefined =
@@ -74,6 +76,18 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
             ),
         [extension]
     )
+
+    const actionableErrorMessage = (error: Error) => {
+        let errorMessage;
+
+        if (error.message.startsWith('invalid settings')) {
+            errorMessage = <>Could not enable / disable {name}. Edit your <a href={settingsURL}>user settings</a> to fix this error.</>
+        } else {
+            errorMessage = <>{error.message}</>;
+        }
+
+        return errorMessage;
+    }
 
     /**
      * When extension enablement state changes, display visual feedback for $delay seconds.
@@ -256,7 +270,7 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
                 {/* Visual feedback: alert when optimistic update fails */}
                 {optimisticFailure && (
                     <div className="alert alert-danger px-2 py-1 extension-card__disabled-feedback">
-                        <span className="font-weight-semibold">Network Error:</span> {optimisticFailure.error.message}
+                        <span className="font-weight-semibold">Error:</span> {actionableErrorMessage(optimisticFailure.error)}
                     </div>
                 )}
             </div>

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -42,6 +42,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
     enablementFilter,
     query,
     showMoreExtensions,
+    authenticatedUser,
     ...props
 }) => {
     /** Categories, but with 'Programming Languages' at the end */
@@ -112,6 +113,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
                             platformContext={platformContext}
                             enabled={isExtensionEnabled(settingsCascade.final, extensionId)}
                             isLightTheme={props.isLightTheme}
+                            settingsURL={authenticatedUser?.settingsURL}
                         />
                     ))}
                 </div>

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -113,7 +113,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
                             platformContext={platformContext}
                             enabled={isExtensionEnabled(settingsCascade.final, extensionId)}
                             isLightTheme={props.isLightTheme}
-                            settingsURL={authenticatedUser.settingsURL!}
+                            settingsURL={authenticatedUser?.settingsURL}
                         />
                     ))}
                 </div>

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -113,7 +113,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
                             platformContext={platformContext}
                             enabled={isExtensionEnabled(settingsCascade.final, extensionId)}
                             isLightTheme={props.isLightTheme}
-                            settingsURL={authenticatedUser?.settingsURL!}
+                            settingsURL={authenticatedUser.settingsURL!}
                         />
                     ))}
                 </div>

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -113,7 +113,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
                             platformContext={platformContext}
                             enabled={isExtensionEnabled(settingsCascade.final, extensionId)}
                             isLightTheme={props.isLightTheme}
-                            settingsURL={authenticatedUser?.settingsURL}
+                            settingsURL={authenticatedUser?.settingsURL!}
                         />
                     ))}
                 </div>


### PR DESCRIPTION
Currently if we run into issues when enabling/disabling extensions, we
dont display informative error messages. This change shows the internal
message we get. Closes #18676

![image](https://user-images.githubusercontent.com/1308560/110173503-8c378980-7db3-11eb-95ec-361e85726da0.png)

