### PR TITLE
streaming progress: fix low hanging fruit a11y issues

### DIFF
--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -40,8 +40,6 @@
 
 .streaming-skipped-item {
     &__button {
-        background: transparent !important;
-        border: none !important;
         &:disabled {
             opacity: 1;
         }
@@ -79,6 +77,8 @@
 
     &__bottom-border-spacer {
         border-bottom: 1px solid var(--border-color-2);
+        margin-left: 0.75rem;
+        margin-right: 0.75rem;
     }
 
     &--warn {

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -39,11 +39,12 @@
 }
 
 .streaming-skipped-item {
-    background: transparent !important;
-    border: none !important;
-
-    &:disabled {
-        opacity: 1;
+    &__button {
+        background: transparent !important;
+        border: none !important;
+        &:disabled {
+            opacity: 1;
+        }
     }
 
     &__icon {
@@ -57,9 +58,11 @@
 
         // Border should appear directly under the width of the icon
         // Halfway past the icon, minus half the border size
-        margin-left: calc(#{$icon-inline-size} / 2 - #{$border-size} / 2);
+        margin-left: calc(#{$icon-inline-size} / 2 - #{$border-size} / 2 + 0.75rem);
         // Halfway past the icon, minus half the border size, plus the icon's right margin
         padding-left: calc(#{$icon-inline-size} / 2 - #{$border-size} / 2 + 0.5rem);
+
+        margin-right: 0.75rem;
 
         &.markdown {
             code {

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -39,7 +39,6 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
     const [isOpen, setIsOpen] = useState(startOpen)
 
     const toggleIsOpen = useCallback(() => setIsOpen(oldValue => !oldValue), [])
-    const cancelOpen = useCallback((event: React.MouseEvent) => event.stopPropagation(), [])
 
     // Reactstrap is preventing default behavior on all non-DropdownItem elements inside a Dropdown,
     // so we need to stop propagation to allow normal behavior (e.g. enter and space to activate buttons)
@@ -79,7 +78,7 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
                 </h4>
             </Button>
             {skipped.message && (
-                <Collapse isOpen={isOpen} onClick={cancelOpen}>
+                <Collapse isOpen={isOpen}>
                     <Markdown
                         className="streaming-skipped-item__message text-left"
                         dangerousInnerHTML={renderMarkdown(skipped.message)}

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -51,12 +51,12 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
 
     return (
         <div
-            className={classNames('streaming-skipped-item pt-2 pb-0 w-100', {
+            className={classNames('streaming-skipped-item pt-2 w-100', {
                 'streaming-skipped-item--warn': skipped.severity !== 'info',
             })}
         >
             <Button
-                className="streaming-skipped-item__button py-2 w-100"
+                className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0"
                 onClick={toggleIsOpen}
                 onKeyDown={onKeyDown}
                 disabled={!skipped.message}
@@ -80,13 +80,13 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
             {skipped.message && (
                 <Collapse isOpen={isOpen}>
                     <Markdown
-                        className="streaming-skipped-item__message text-left"
+                        className="streaming-skipped-item__message text-left mb-1"
                         dangerousInnerHTML={renderMarkdown(skipped.message)}
                         history={history}
                     />
                 </Collapse>
             )}
-            <div className="streaming-skipped-item__bottom-border-spacer mt-3" />
+            <div className="streaming-skipped-item__bottom-border-spacer mt-2" />
         </div>
     )
 }

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -39,41 +39,56 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
     const [isOpen, setIsOpen] = useState(startOpen)
 
     const toggleIsOpen = useCallback(() => setIsOpen(oldValue => !oldValue), [])
+    const cancelOpen = useCallback((event: React.MouseEvent) => event.stopPropagation(), [])
+
+    // Reactstrap is preventing default behavior on all non-DropdownItem elements inside a Dropdown,
+    // so we need to stop propagation to allow normal behavior (e.g. enter and space to activate buttons)
+    // See Reactstrap bug: https://github.com/reactstrap/reactstrap/issues/2099
+    const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLButtonElement>): void => {
+        if (event.key === ' ' || event.key === 'Enter') {
+            event.stopPropagation()
+        }
+    }, [])
 
     return (
-        <Button
-            className={classNames('streaming-skipped-item pt-3 pb-0 w-100', {
+        <div
+            className={classNames('streaming-skipped-item pt-2 pb-0 w-100', {
                 'streaming-skipped-item--warn': skipped.severity !== 'info',
             })}
-            onClick={toggleIsOpen}
-            disabled={!skipped.message}
         >
-            <h4 className="d-flex align-items-center mb-0 w-100">
-                {skipped.severity === 'info' ? (
-                    <InformationOutlineIcon className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0" />
-                ) : (
-                    <AlertCircleIcon className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0" />
-                )}
-                <span className="flex-grow-1 text-left">{skipped.title}</span>
-
-                {skipped.message &&
-                    (isOpen ? (
-                        <ChevronDownIcon className="icon-inline flex-shrink-0" />
+            <Button
+                className="streaming-skipped-item__button py-2 w-100"
+                onClick={toggleIsOpen}
+                onKeyDown={onKeyDown}
+                disabled={!skipped.message}
+            >
+                <h4 className="d-flex align-items-center mb-0 w-100">
+                    {skipped.severity === 'info' ? (
+                        <InformationOutlineIcon className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0" />
                     ) : (
-                        <ChevronLeftIcon className="icon-inline flex-shrink-0" />
-                    ))}
-            </h4>
+                        <AlertCircleIcon className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0" />
+                    )}
+                    <span className="flex-grow-1 text-left">{skipped.title}</span>
+
+                    {skipped.message &&
+                        (isOpen ? (
+                            <ChevronDownIcon className="icon-inline flex-shrink-0" />
+                        ) : (
+                            <ChevronLeftIcon className="icon-inline flex-shrink-0" />
+                        ))}
+                </h4>
+            </Button>
             {skipped.message && (
-                <Collapse isOpen={isOpen}>
+                <Collapse isOpen={isOpen} onClick={cancelOpen}>
                     <Markdown
-                        className="streaming-skipped-item__message mt-2 text-left"
+                        className="streaming-skipped-item__message text-left"
                         dangerousInnerHTML={renderMarkdown(skipped.message)}
                         history={history}
                     />
                 </Collapse>
             )}
             <div className="streaming-skipped-item__bottom-border-spacer mt-3" />
-        </Button>
+        </div>
     )
 }
 

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -80,7 +80,7 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
             {skipped.message && (
                 <Collapse isOpen={isOpen}>
                     <Markdown
-                        className="streaming-skipped-item__message text-left mb-1"
+                        className="streaming-skipped-item__message text-left py-1"
                         dangerousInnerHTML={renderMarkdown(skipped.message)}
                         history={history}
                     />

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -73,41 +73,64 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
     }
     startOpen={true}
   >
-    <Button
-      className="streaming-skipped-item pt-3 pb-0 w-100 streaming-skipped-item--warn"
-      color="secondary"
-      disabled={false}
-      onClick={[Function]}
-      tag="button"
+    <div
+      className="streaming-skipped-item pt-2 w-100 streaming-skipped-item--warn"
     >
-      <button
-        aria-label={null}
-        className="streaming-skipped-item pt-3 pb-0 w-100 streaming-skipped-item--warn btn btn-secondary"
+      <Button
+        className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0"
+        color="secondary"
         disabled={false}
         onClick={[Function]}
-        type="button"
+        onKeyDown={[Function]}
+        tag="button"
       >
-        <h4
-          className="d-flex align-items-center mb-0 w-100"
+        <button
+          aria-label={null}
+          className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0 btn btn-secondary"
+          disabled={false}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
         >
-          <Memo(AlertCircleIcon)
-            className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
-          />
-          <span
-            className="flex-grow-1 text-left"
+          <h4
+            className="d-flex align-items-center mb-0 w-100"
           >
-            Error loading results
-          </span>
-          <Memo(ChevronDownIcon)
-            className="icon-inline flex-shrink-0"
-          />
-        </h4>
-        <Collapse
+            <Memo(AlertCircleIcon)
+              className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
+            />
+            <span
+              className="flex-grow-1 text-left"
+            >
+              Error loading results
+            </span>
+            <Memo(ChevronDownIcon)
+              className="icon-inline flex-shrink-0"
+            />
+          </h4>
+        </button>
+      </Button>
+      <Collapse
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
+        isOpen={true}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        tag="div"
+        timeout={350}
+        unmountOnExit={false}
+      >
+        <Transition
           appear={false}
           enter={true}
           exit={true}
-          in={false}
-          isOpen={true}
+          in={true}
           mountOnEnter={false}
           onEnter={[Function]}
           onEntered={[Function]}
@@ -115,54 +138,37 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           onExit={[Function]}
           onExited={[Function]}
           onExiting={[Function]}
-          tag="div"
           timeout={350}
           unmountOnExit={false}
         >
-          <Transition
-            appear={false}
-            enter={true}
-            exit={true}
-            in={true}
-            mountOnEnter={false}
-            onEnter={[Function]}
-            onEntered={[Function]}
-            onEntering={[Function]}
-            onExit={[Function]}
-            onExited={[Function]}
-            onExiting={[Function]}
-            timeout={350}
-            unmountOnExit={false}
+          <div
+            className="collapse show"
+            style={Object {}}
           >
-            <div
-              className="collapse show"
-              style={Object {}}
-            >
-              <Markdown
-                className="streaming-skipped-item__message mt-2 text-left"
-                dangerousInnerHTML="<p>There was a network error retrieving search results. Check your Internet connection and try again.</p>
+            <Markdown
+              className="streaming-skipped-item__message text-left py-1"
+              dangerousInnerHTML="<p>There was a network error retrieving search results. Check your Internet connection and try again.</p>
 "
-                history="[History]"
-              >
-                <div
-                  className="streaming-skipped-item__message mt-2 text-left markdown"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>There was a network error retrieving search results. Check your Internet connection and try again.</p>
+              history="[History]"
+            >
+              <div
+                className="streaming-skipped-item__message text-left py-1 markdown"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>There was a network error retrieving search results. Check your Internet connection and try again.</p>
 ",
-                    }
                   }
-                  onClick={[Function]}
-                />
-              </Markdown>
-            </div>
-          </Transition>
-        </Collapse>
-        <div
-          className="streaming-skipped-item__bottom-border-spacer mt-3"
-        />
-      </button>
-    </Button>
+                }
+                onClick={[Function]}
+              />
+            </Markdown>
+          </div>
+        </Transition>
+      </Collapse>
+      <div
+        className="streaming-skipped-item__bottom-border-spacer mt-2"
+      />
+    </div>
   </SkippedMessage>
   <SkippedMessage
     history="[History]"
@@ -181,41 +187,64 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
     }
     startOpen={false}
   >
-    <Button
-      className="streaming-skipped-item pt-3 pb-0 w-100 streaming-skipped-item--warn"
-      color="secondary"
-      disabled={false}
-      onClick={[Function]}
-      tag="button"
+    <div
+      className="streaming-skipped-item pt-2 w-100 streaming-skipped-item--warn"
     >
-      <button
-        aria-label={null}
-        className="streaming-skipped-item pt-3 pb-0 w-100 streaming-skipped-item--warn btn btn-secondary"
+      <Button
+        className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0"
+        color="secondary"
         disabled={false}
         onClick={[Function]}
-        type="button"
+        onKeyDown={[Function]}
+        tag="button"
       >
-        <h4
-          className="d-flex align-items-center mb-0 w-100"
+        <button
+          aria-label={null}
+          className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0 btn btn-secondary"
+          disabled={false}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
         >
-          <Memo(AlertCircleIcon)
-            className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
-          />
-          <span
-            className="flex-grow-1 text-left"
+          <h4
+            className="d-flex align-items-center mb-0 w-100"
           >
-            Search timed out
-          </span>
-          <Memo(ChevronLeftIcon)
-            className="icon-inline flex-shrink-0"
-          />
-        </h4>
-        <Collapse
+            <Memo(AlertCircleIcon)
+              className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
+            />
+            <span
+              className="flex-grow-1 text-left"
+            >
+              Search timed out
+            </span>
+            <Memo(ChevronLeftIcon)
+              className="icon-inline flex-shrink-0"
+            />
+          </h4>
+        </button>
+      </Button>
+      <Collapse
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
+        isOpen={false}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        tag="div"
+        timeout={350}
+        unmountOnExit={false}
+      >
+        <Transition
           appear={false}
           enter={true}
           exit={true}
           in={false}
-          isOpen={false}
           mountOnEnter={false}
           onEnter={[Function]}
           onEntered={[Function]}
@@ -223,54 +252,37 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           onExit={[Function]}
           onExited={[Function]}
           onExiting={[Function]}
-          tag="div"
           timeout={350}
           unmountOnExit={false}
         >
-          <Transition
-            appear={false}
-            enter={true}
-            exit={true}
-            in={false}
-            mountOnEnter={false}
-            onEnter={[Function]}
-            onEntered={[Function]}
-            onEntering={[Function]}
-            onExit={[Function]}
-            onExited={[Function]}
-            onExiting={[Function]}
-            timeout={350}
-            unmountOnExit={false}
+          <div
+            className="collapse"
+            style={Object {}}
           >
-            <div
-              className="collapse"
-              style={Object {}}
-            >
-              <Markdown
-                className="streaming-skipped-item__message mt-2 text-left"
-                dangerousInnerHTML="<p>Search timed out</p>
+            <Markdown
+              className="streaming-skipped-item__message text-left py-1"
+              dangerousInnerHTML="<p>Search timed out</p>
 "
-                history="[History]"
-              >
-                <div
-                  className="streaming-skipped-item__message mt-2 text-left markdown"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>Search timed out</p>
+              history="[History]"
+            >
+              <div
+                className="streaming-skipped-item__message text-left py-1 markdown"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>Search timed out</p>
 ",
-                    }
                   }
-                  onClick={[Function]}
-                />
-              </Markdown>
-            </div>
-          </Transition>
-        </Collapse>
-        <div
-          className="streaming-skipped-item__bottom-border-spacer mt-3"
-        />
-      </button>
-    </Button>
+                }
+                onClick={[Function]}
+              />
+            </Markdown>
+          </div>
+        </Transition>
+      </Collapse>
+      <div
+        className="streaming-skipped-item__bottom-border-spacer mt-2"
+      />
+    </div>
   </SkippedMessage>
   <SkippedMessage
     history="[History]"
@@ -289,41 +301,64 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
     }
     startOpen={false}
   >
-    <Button
-      className="streaming-skipped-item pt-3 pb-0 w-100"
-      color="secondary"
-      disabled={false}
-      onClick={[Function]}
-      tag="button"
+    <div
+      className="streaming-skipped-item pt-2 w-100"
     >
-      <button
-        aria-label={null}
-        className="streaming-skipped-item pt-3 pb-0 w-100 btn btn-secondary"
+      <Button
+        className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0"
+        color="secondary"
         disabled={false}
         onClick={[Function]}
-        type="button"
+        onKeyDown={[Function]}
+        tag="button"
       >
-        <h4
-          className="d-flex align-items-center mb-0 w-100"
+        <button
+          aria-label={null}
+          className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0 btn btn-secondary"
+          disabled={false}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
         >
-          <Memo(InformationOutlineIcon)
-            className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
-          />
-          <span
-            className="flex-grow-1 text-left"
+          <h4
+            className="d-flex align-items-center mb-0 w-100"
           >
-            10k forked repositories excluded
-          </span>
-          <Memo(ChevronLeftIcon)
-            className="icon-inline flex-shrink-0"
-          />
-        </h4>
-        <Collapse
+            <Memo(InformationOutlineIcon)
+              className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
+            />
+            <span
+              className="flex-grow-1 text-left"
+            >
+              10k forked repositories excluded
+            </span>
+            <Memo(ChevronLeftIcon)
+              className="icon-inline flex-shrink-0"
+            />
+          </h4>
+        </button>
+      </Button>
+      <Collapse
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
+        isOpen={false}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        tag="div"
+        timeout={350}
+        unmountOnExit={false}
+      >
+        <Transition
           appear={false}
           enter={true}
           exit={true}
           in={false}
-          isOpen={false}
           mountOnEnter={false}
           onEnter={[Function]}
           onEntered={[Function]}
@@ -331,54 +366,37 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           onExit={[Function]}
           onExited={[Function]}
           onExiting={[Function]}
-          tag="div"
           timeout={350}
           unmountOnExit={false}
         >
-          <Transition
-            appear={false}
-            enter={true}
-            exit={true}
-            in={false}
-            mountOnEnter={false}
-            onEnter={[Function]}
-            onEntered={[Function]}
-            onEntering={[Function]}
-            onExit={[Function]}
-            onExited={[Function]}
-            onExiting={[Function]}
-            timeout={350}
-            unmountOnExit={false}
+          <div
+            className="collapse"
+            style={Object {}}
           >
-            <div
-              className="collapse"
-              style={Object {}}
-            >
-              <Markdown
-                className="streaming-skipped-item__message mt-2 text-left"
-                dangerousInnerHTML="<p>10k forked repositories excluded</p>
+            <Markdown
+              className="streaming-skipped-item__message text-left py-1"
+              dangerousInnerHTML="<p>10k forked repositories excluded</p>
 "
-                history="[History]"
-              >
-                <div
-                  className="streaming-skipped-item__message mt-2 text-left markdown"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>10k forked repositories excluded</p>
+              history="[History]"
+            >
+              <div
+                className="streaming-skipped-item__message text-left py-1 markdown"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>10k forked repositories excluded</p>
 ",
-                    }
                   }
-                  onClick={[Function]}
-                />
-              </Markdown>
-            </div>
-          </Transition>
-        </Collapse>
-        <div
-          className="streaming-skipped-item__bottom-border-spacer mt-3"
-        />
-      </button>
-    </Button>
+                }
+                onClick={[Function]}
+              />
+            </Markdown>
+          </div>
+        </Transition>
+      </Collapse>
+      <div
+        className="streaming-skipped-item__bottom-border-spacer mt-2"
+      />
+    </div>
   </SkippedMessage>
   <SkippedMessage
     history="[History]"
@@ -397,41 +415,64 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
     }
     startOpen={false}
   >
-    <Button
-      className="streaming-skipped-item pt-3 pb-0 w-100"
-      color="secondary"
-      disabled={false}
-      onClick={[Function]}
-      tag="button"
+    <div
+      className="streaming-skipped-item pt-2 w-100"
     >
-      <button
-        aria-label={null}
-        className="streaming-skipped-item pt-3 pb-0 w-100 btn btn-secondary"
+      <Button
+        className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0"
+        color="secondary"
         disabled={false}
         onClick={[Function]}
-        type="button"
+        onKeyDown={[Function]}
+        tag="button"
       >
-        <h4
-          className="d-flex align-items-center mb-0 w-100"
+        <button
+          aria-label={null}
+          className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0 btn btn-secondary"
+          disabled={false}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
         >
-          <Memo(InformationOutlineIcon)
-            className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
-          />
-          <span
-            className="flex-grow-1 text-left"
+          <h4
+            className="d-flex align-items-center mb-0 w-100"
           >
-            60k archived repositories excluded
-          </span>
-          <Memo(ChevronLeftIcon)
-            className="icon-inline flex-shrink-0"
-          />
-        </h4>
-        <Collapse
+            <Memo(InformationOutlineIcon)
+              className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
+            />
+            <span
+              className="flex-grow-1 text-left"
+            >
+              60k archived repositories excluded
+            </span>
+            <Memo(ChevronLeftIcon)
+              className="icon-inline flex-shrink-0"
+            />
+          </h4>
+        </button>
+      </Button>
+      <Collapse
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
+        isOpen={false}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        tag="div"
+        timeout={350}
+        unmountOnExit={false}
+      >
+        <Transition
           appear={false}
           enter={true}
           exit={true}
           in={false}
-          isOpen={false}
           mountOnEnter={false}
           onEnter={[Function]}
           onEntered={[Function]}
@@ -439,54 +480,37 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           onExit={[Function]}
           onExited={[Function]}
           onExiting={[Function]}
-          tag="div"
           timeout={350}
           unmountOnExit={false}
         >
-          <Transition
-            appear={false}
-            enter={true}
-            exit={true}
-            in={false}
-            mountOnEnter={false}
-            onEnter={[Function]}
-            onEntered={[Function]}
-            onEntering={[Function]}
-            onExit={[Function]}
-            onExited={[Function]}
-            onExiting={[Function]}
-            timeout={350}
-            unmountOnExit={false}
+          <div
+            className="collapse"
+            style={Object {}}
           >
-            <div
-              className="collapse"
-              style={Object {}}
-            >
-              <Markdown
-                className="streaming-skipped-item__message mt-2 text-left"
-                dangerousInnerHTML="<p>60k archived repositories excluded</p>
+            <Markdown
+              className="streaming-skipped-item__message text-left py-1"
+              dangerousInnerHTML="<p>60k archived repositories excluded</p>
 "
-                history="[History]"
-              >
-                <div
-                  className="streaming-skipped-item__message mt-2 text-left markdown"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>60k archived repositories excluded</p>
+              history="[History]"
+            >
+              <div
+                className="streaming-skipped-item__message text-left py-1 markdown"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>60k archived repositories excluded</p>
 ",
-                    }
                   }
-                  onClick={[Function]}
-                />
-              </Markdown>
-            </div>
-          </Transition>
-        </Collapse>
-        <div
-          className="streaming-skipped-item__bottom-border-spacer mt-3"
-        />
-      </button>
-    </Button>
+                }
+                onClick={[Function]}
+              />
+            </Markdown>
+          </div>
+        </Transition>
+      </Collapse>
+      <div
+        className="streaming-skipped-item__bottom-border-spacer mt-2"
+      />
+    </div>
   </SkippedMessage>
   <SkippedMessage
     history="[History]"
@@ -505,41 +529,64 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
     }
     startOpen={false}
   >
-    <Button
-      className="streaming-skipped-item pt-3 pb-0 w-100"
-      color="secondary"
-      disabled={false}
-      onClick={[Function]}
-      tag="button"
+    <div
+      className="streaming-skipped-item pt-2 w-100"
     >
-      <button
-        aria-label={null}
-        className="streaming-skipped-item pt-3 pb-0 w-100 btn btn-secondary"
+      <Button
+        className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0"
+        color="secondary"
         disabled={false}
         onClick={[Function]}
-        type="button"
+        onKeyDown={[Function]}
+        tag="button"
       >
-        <h4
-          className="d-flex align-items-center mb-0 w-100"
+        <button
+          aria-label={null}
+          className="streaming-skipped-item__button py-2 w-100 bg-transparent border-0 btn btn-secondary"
+          disabled={false}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          type="button"
         >
-          <Memo(InformationOutlineIcon)
-            className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
-          />
-          <span
-            className="flex-grow-1 text-left"
+          <h4
+            className="d-flex align-items-center mb-0 w-100"
           >
-            1 archived
-          </span>
-          <Memo(ChevronLeftIcon)
-            className="icon-inline flex-shrink-0"
-          />
-        </h4>
-        <Collapse
+            <Memo(InformationOutlineIcon)
+              className="icon-inline mr-2 streaming-skipped-item__icon flex-shrink-0"
+            />
+            <span
+              className="flex-grow-1 text-left"
+            >
+              1 archived
+            </span>
+            <Memo(ChevronLeftIcon)
+              className="icon-inline flex-shrink-0"
+            />
+          </h4>
+        </button>
+      </Button>
+      <Collapse
+        appear={false}
+        enter={true}
+        exit={true}
+        in={false}
+        isOpen={false}
+        mountOnEnter={false}
+        onEnter={[Function]}
+        onEntered={[Function]}
+        onEntering={[Function]}
+        onExit={[Function]}
+        onExited={[Function]}
+        onExiting={[Function]}
+        tag="div"
+        timeout={350}
+        unmountOnExit={false}
+      >
+        <Transition
           appear={false}
           enter={true}
           exit={true}
           in={false}
-          isOpen={false}
           mountOnEnter={false}
           onEnter={[Function]}
           onEntered={[Function]}
@@ -547,54 +594,37 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
           onExit={[Function]}
           onExited={[Function]}
           onExiting={[Function]}
-          tag="div"
           timeout={350}
           unmountOnExit={false}
         >
-          <Transition
-            appear={false}
-            enter={true}
-            exit={true}
-            in={false}
-            mountOnEnter={false}
-            onEnter={[Function]}
-            onEntered={[Function]}
-            onEntering={[Function]}
-            onExit={[Function]}
-            onExited={[Function]}
-            onExiting={[Function]}
-            timeout={350}
-            unmountOnExit={false}
+          <div
+            className="collapse"
+            style={Object {}}
           >
-            <div
-              className="collapse"
-              style={Object {}}
-            >
-              <Markdown
-                className="streaming-skipped-item__message mt-2 text-left"
-                dangerousInnerHTML="<p>By default we exclude archived repositories. Include them with <code>archived:yes</code> in your query.</p>
+            <Markdown
+              className="streaming-skipped-item__message text-left py-1"
+              dangerousInnerHTML="<p>By default we exclude archived repositories. Include them with <code>archived:yes</code> in your query.</p>
 "
-                history="[History]"
-              >
-                <div
-                  className="streaming-skipped-item__message mt-2 text-left markdown"
-                  dangerouslySetInnerHTML={
-                    Object {
-                      "__html": "<p>By default we exclude archived repositories. Include them with <code>archived:yes</code> in your query.</p>
+              history="[History]"
+            >
+              <div
+                className="streaming-skipped-item__message text-left py-1 markdown"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<p>By default we exclude archived repositories. Include them with <code>archived:yes</code> in your query.</p>
 ",
-                    }
                   }
-                  onClick={[Function]}
-                />
-              </Markdown>
-            </div>
-          </Transition>
-        </Collapse>
-        <div
-          className="streaming-skipped-item__bottom-border-spacer mt-3"
-        />
-      </button>
-    </Button>
+                }
+                onClick={[Function]}
+              />
+            </Markdown>
+          </div>
+        </Transition>
+      </Collapse>
+      <div
+        className="streaming-skipped-item__bottom-border-spacer mt-2"
+      />
+    </div>
   </SkippedMessage>
   <Form
     className="pb-3 px-3"


### PR DESCRIPTION
- Fixes #18041 Text in the streaming search alerts dropdown is not selectable
- Fixes #18195 Can't expand/collapse streaming search alerts with keyboard

FYI @rrhyne  this is what the new focus ring around the search alert looks like:

![image](https://user-images.githubusercontent.com/206864/110181168-0ec64600-7dc0-11eb-8ad7-a2eeb328c72f.png)
