### PR TITLE
Add repos from user_public_repos to the user's search context.

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -464,7 +464,12 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		CommitAfter:        commitAfter,
 		Query:              r.Query,
 	}
-	repositoryResolver := &searchrepos.Resolver{Zoekt: r.zoekt, DefaultReposFunc: database.GlobalDefaultRepos.List, NamespaceStore: database.Namespaces(r.db)}
+	repositoryResolver := &searchrepos.Resolver{
+		DB:               r.db,
+		Zoekt:            r.zoekt,
+		DefaultReposFunc: database.DefaultRepos(r.db).List,
+		NamespaceStore:   database.Namespaces(r.db),
+	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	tr.LazyPrintf("resolveRepositories - done")
 	if effectiveRepoFieldValues == nil {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -121,7 +121,12 @@ func alertForStalePermissions(db dbutil.DB) *searchAlert {
 // query does not contain any repos to search.
 func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Options) bool {
 	options.UserSettings = r.UserSettings
-	repositoryResolver := &searchrepos.Resolver{Zoekt: r.zoekt, DefaultReposFunc: database.GlobalDefaultRepos.List, NamespaceStore: database.Namespaces(r.db)}
+	repositoryResolver := &searchrepos.Resolver{
+		DB:               r.db,
+		Zoekt:            r.zoekt,
+		DefaultReposFunc: database.DefaultRepos(r.db).List,
+		NamespaceStore:   database.Namespaces(r.db),
+	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 	"github.com/hexops/autogold"
@@ -21,6 +19,7 @@ import (
 	searchrepos "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 	"github.com/hexops/autogold"
@@ -1349,6 +1351,8 @@ func TestSearchContext(t *testing.T) {
 	envvar.MockSourcegraphDotComMode(true)
 	defer envvar.MockSourcegraphDotComMode(orig)
 
+	db := dbtest.NewDB(t, "")
+
 	tts := []struct {
 		name        string
 		searchQuery string
@@ -1383,6 +1387,7 @@ func TestSearchContext(t *testing.T) {
 				reposMu:  &sync.Mutex{},
 				resolved: &searchrepos.Resolved{},
 				zoekt:    mockZoekt,
+				db:       db,
 			}
 
 			numGetByNameCalls := 0

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -179,7 +179,8 @@ func (r *Resolver) Resolve(ctx context.Context, op Options) (Resolved, error) {
 			}
 			for _, repo := range userRepos {
 				name := types.RepoName{
-					ID:   repo.RepoID,
+					ID: repo.RepoID,
+					// this is safe as the SetUserPublicRepo graphql endpoint normalises the repo URI before saving
 					Name: api.RepoName(repo.RepoURI),
 				}
 				out = append(out, &name)

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -12,8 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-
 	"github.com/inconshreveable/log15"
 	"github.com/neelance/parallel"
 	"github.com/pkg/errors"
@@ -23,6 +21,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/search"

--- a/cmd/frontend/internal/search/repos/repos_test.go
+++ b/cmd/frontend/internal/search/repos/repos_test.go
@@ -477,6 +477,18 @@ func TestResolveRepositoriesWithUserSearchContext(t *testing.T) {
 				ID:   3,
 				Name: "example.com/c",
 			},
+			{
+				ID:   4,
+				Name: "external.com/a",
+			},
+			{
+				ID:   5,
+				Name: "external.com/b",
+			},
+			{
+				ID:   6,
+				Name: "external.com/c",
+			},
 		}, nil
 	}
 	database.Mocks.Repos.Count = func(ctx context.Context, op database.ReposListOptions) (int, error) { return 3, nil }
@@ -484,22 +496,6 @@ func TestResolveRepositoriesWithUserSearchContext(t *testing.T) {
 		database.Mocks.Repos.ListRepoNames = nil
 		database.Mocks.Repos.Count = nil
 	}()
-	database.Mocks.UserPublicRepos.ListByUser = func(ctx context.Context, userID int32) ([]database.UserPublicRepo, error) {
-		return []database.UserPublicRepo{
-			{
-				RepoID:  4,
-				RepoURI: "external.com/a",
-			},
-			{
-				RepoID:  5,
-				RepoURI: "external.com/b",
-			},
-			{
-				RepoID:  6,
-				RepoURI: "external.com/c",
-			},
-		}, nil
-	}
 
 	getNamespaceByName := func(ctx context.Context, name string) (*database.Namespace, error) {
 		if name != wantName {

--- a/cmd/frontend/internal/search/repos/repos_test.go
+++ b/cmd/frontend/internal/search/repos/repos_test.go
@@ -8,14 +8,13 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/zoekt"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	searchbackend "github.com/sourcegraph/sourcegraph/internal/search/backend"

--- a/internal/database/default_repos_test.go
+++ b/internal/database/default_repos_test.go
@@ -128,6 +128,11 @@ func TestListDefaultRepos(t *testing.T) {
 			INSERT INTO repo(id, name) VALUES (13, 'github.com/foo/bar13');
 			INSERT INTO external_services(id, kind, display_name, config, cloud_default) VALUES (101, 'github', 'github', '{}', true);
 			INSERT INTO external_service_repos VALUES (101, 13, 'https://github.com/foo/bar13');
+
+			-- insert a repo only referenced by a cloud_default external service, but also in user_public_repos
+			INSERT INTO repo(id, name) VALUES (14, 'github.com/foo/bar14');
+			INSERT INTO external_service_repos VALUES (101, 14, 'https://github.com/foo/bar14');
+			INSERT INTO user_public_repos(user_id, repo_id, repo_uri) VALUES (1, 14, 'github.com/foo/bar/14')
 		`)
 		if err != nil {
 			t.Fatal(err)
@@ -148,6 +153,10 @@ func TestListDefaultRepos(t *testing.T) {
 			{
 				ID:   api.RepoID(11),
 				Name: "github.com/foo/bar11",
+			},
+			{
+				ID:   api.RepoID(14),
+				Name: "github.com/foo/bar14",
 			},
 		}
 		// expect 2 repos, the user added repo and the one that is referenced in the default repos table

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -27,4 +27,6 @@ type MockStores struct {
 	Authz MockAuthz
 
 	EventLogs MockEventLogs
+
+	UserPublicRepos MockUserPublicRepos
 }

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -15,6 +15,7 @@ type MockStores struct {
 	Users           MockUsers
 	UserCredentials MockUserCredentials
 	UserEmails      MockUserEmails
+	UserPublicRepos MockUserPublicRepos
 
 	Phabricator MockPhabricator
 
@@ -27,6 +28,4 @@ type MockStores struct {
 	Authz MockAuthz
 
 	EventLogs MockEventLogs
-
-	UserPublicRepos MockUserPublicRepos
 }

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -540,7 +540,7 @@ type ReposListOptions struct {
 	UseOr bool
 
 	// IncludeUserPublicRepos will include repos from the user_public_repos table if this field is true, and the user_id
-	// is non-zero. note that these are not repos owned by this user, just ones they are interested in🔐.
+	// is non-zero. Note that these are not repos owned by this user, just ones they are interested in.
 	IncludeUserPublicRepos bool
 
 	*LimitOffset

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -673,8 +673,7 @@ func (s *RepoStore) list(ctx context.Context, tr *trace.Trace, minimal bool, opt
 		if opt.IncludeUserPublicRepos {
 			conds = append(conds, sqlf.Sprintf("(es.namespace_user_id = %d OR repo.id IN (SELECT repo_id FROM user_public_repos WHERE user_id = %d)) AND es.deleted_at IS NULL", opt.UserID, opt.UserID))
 		} else {
-			conds = append(conds, sqlf.Sprintf("es.namespace_user_id = %d AND es.deleted_at IS NULL", opt.UserID, opt.UserID))
-
+			conds = append(conds, sqlf.Sprintf("es.namespace_user_id = %d AND es.deleted_at IS NULL", opt.UserID))
 		}
 	}
 

--- a/internal/database/repos_db_test.go
+++ b/internal/database/repos_db_test.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/rand"
-
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"

--- a/internal/database/user_public_repos.go
+++ b/internal/database/user_public_repos.go
@@ -72,6 +72,9 @@ func (s *UserPublicRepoStore) SetUserRepo(ctx context.Context, upr UserPublicRep
 }
 
 func (s *UserPublicRepoStore) ListByUser(ctx context.Context, userID int32) ([]UserPublicRepo, error) {
+	if mock := Mocks.UserPublicRepos.ListByUser; mock != nil {
+		return mock(ctx, userID)
+	}
 	rows, err := s.store.Query(ctx, sqlf.Sprintf(
 		"SELECT user_id, repo_uri, repo_id FROM user_public_repos WHERE user_id = %v",
 		userID,

--- a/internal/database/user_public_repos_mock.go
+++ b/internal/database/user_public_repos_mock.go
@@ -1,0 +1,7 @@
+package database
+
+import "context"
+
+type MockUserPublicRepos struct {
+	ListByUser func(ctx context.Context, userID int32) ([]UserPublicRepo, error)
+}


### PR DESCRIPTION
This PR hooks up the user_public_repos table to the user's search context, doing a concurrent ListByUser when fetching repos to resolve for the search context. I also slightly expanded the testing on user search contexts to assert that we're getting back the repos we expect from the resolver, and i also replaced a few usages of database.GlobalSomething with an injected dbutil.DB

![Screenshot 2021-03-08 at 10 26 50](https://user-images.githubusercontent.com/5236823/110311689-0f4b2080-7ffc-11eb-9609-d99dbc9b210e.png)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
