### PR TITLE
authz: make Provider.FetchUserPerms return AccessibleRepoIDs

### DIFF
--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -67,7 +67,7 @@ type mockProvider struct {
 	serviceType string
 	serviceID   string
 
-	fetchUserPerms func(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error)
+	fetchUserPerms func(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error)
 	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error)
 }
 
@@ -80,7 +80,7 @@ func (p *mockProvider) ServiceID() string   { return p.serviceID }
 func (p *mockProvider) URN() string         { return extsvc.URN(p.serviceType, p.id) }
 func (*mockProvider) Validate() []string    { return nil }
 
-func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
 	return p.fetchUserPerms(ctx, acct)
 }
 
@@ -156,8 +156,10 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p.fetchUserPerms = func(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
-				return []extsvc.RepoID{"1"}, extsvc.RepoIDExact, test.fetchErr
+			p.fetchUserPerms = func(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+				return &authz.AccessibleRepoIDs{
+					Exacts: []extsvc.RepoID{"1"},
+				}, test.fetchErr
 			}
 
 			err := s.syncUserPerms(context.Background(), 1, test.noPerms)
@@ -215,8 +217,8 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 			return nil
 		}
 
-		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
-			return nil, extsvc.RepoIDExact, &github.APIError{Code: http.StatusUnauthorized}
+		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+			return nil, &github.APIError{Code: http.StatusUnauthorized}
 		}
 
 		err := s.syncUserPerms(context.Background(), 1, false)
@@ -236,8 +238,8 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 			return nil
 		}
 
-		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
-			return nil, extsvc.RepoIDExact, &github.APIError{
+		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+			return nil, &github.APIError{
 				URL:     "https://api.github.com/user/repos",
 				Code:    http.StatusForbidden,
 				Message: "Sorry. Your account was suspended",

--- a/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
+++ b/enterprise/cmd/repo-updater/authz/perms_syncer_test.go
@@ -67,7 +67,7 @@ type mockProvider struct {
 	serviceType string
 	serviceID   string
 
-	fetchUserPerms func(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error)
+	fetchUserPerms func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error)
 	fetchRepoPerms func(ctx context.Context, repo *extsvc.Repository) ([]extsvc.AccountID, error)
 }
 
@@ -80,7 +80,7 @@ func (p *mockProvider) ServiceID() string   { return p.serviceID }
 func (p *mockProvider) URN() string         { return extsvc.URN(p.serviceType, p.id) }
 func (*mockProvider) Validate() []string    { return nil }
 
-func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+func (p *mockProvider) FetchUserPerms(ctx context.Context, acct *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 	return p.fetchUserPerms(ctx, acct)
 }
 
@@ -156,8 +156,8 @@ func TestPermsSyncer_syncUserPerms(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p.fetchUserPerms = func(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
-				return &authz.AccessibleRepoIDs{
+			p.fetchUserPerms = func(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error) {
+				return &authz.ExternalUserPermissions{
 					Exacts: []extsvc.RepoID{"1"},
 				}, test.fetchErr
 			}
@@ -217,7 +217,7 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 			return nil
 		}
 
-		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 			return nil, &github.APIError{Code: http.StatusUnauthorized}
 		}
 
@@ -238,7 +238,7 @@ func TestPermsSyncer_syncUserPerms_tokenExpire(t *testing.T) {
 			return nil
 		}
 
-		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+		p.fetchUserPerms = func(ctx context.Context, account *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 			return nil, &github.APIError{
 				URL:     "https://api.github.com/user/repos",
 				Code:    http.StatusForbidden,

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -48,7 +48,7 @@ func (m gitlabAuthzProviderParams) URN() string {
 
 func (m gitlabAuthzProviderParams) Validate() []string { return nil }
 
-func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
 	panic("should never be called")
 }
 

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -48,7 +48,7 @@ func (m gitlabAuthzProviderParams) URN() string {
 
 func (m gitlabAuthzProviderParams) Validate() []string { return nil }
 
-func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+func (m gitlabAuthzProviderParams) FetchUserPerms(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 	panic("should never be called")
 }
 

--- a/internal/authz/bitbucketserver/provider.go
+++ b/internal/authz/bitbucketserver/provider.go
@@ -128,7 +128,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 // callers to decide whether to discard.
 //
 // API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8296923984
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 	switch {
 	case account == nil:
 		return nil, errors.New("no account provided")
@@ -151,7 +151,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		extIDs = append(extIDs, extsvc.RepoID(strconv.FormatUint(uint64(id), 10)))
 	}
 
-	return &authz.AccessibleRepoIDs{
+	return &authz.ExternalUserPermissions{
 		Exacts: extIDs,
 	}, err
 }

--- a/internal/authz/bitbucketserver/provider.go
+++ b/internal/authz/bitbucketserver/provider.go
@@ -128,20 +128,20 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 // callers to decide whether to discard.
 //
 // API docs: https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8296923984
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
 	switch {
 	case account == nil:
-		return nil, extsvc.RepoIDExact, errors.New("no account provided")
+		return nil, errors.New("no account provided")
 	case account.Data == nil:
-		return nil, extsvc.RepoIDExact, errors.New("no account data provided")
+		return nil, errors.New("no account data provided")
 	case !extsvc.IsHostOfAccount(p.codeHost, account):
-		return nil, extsvc.RepoIDExact, fmt.Errorf("not a code host of the account: want %q but have %q",
+		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
 			p.codeHost.ServiceID, account.AccountSpec.ServiceID)
 	}
 
 	var user bitbucketserver.User
 	if err := json.Unmarshal(*account.Data, &user); err != nil {
-		return nil, extsvc.RepoIDExact, errors.Wrap(err, "unmarshaling account data")
+		return nil, errors.Wrap(err, "unmarshaling account data")
 	}
 
 	ids, err := p.repoIDs(ctx, user.Name, false)
@@ -151,7 +151,9 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		extIDs = append(extIDs, extsvc.RepoID(strconv.FormatUint(uint64(id), 10)))
 	}
 
-	return extIDs, extsvc.RepoIDExact, err
+	return &authz.AccessibleRepoIDs{
+		Exacts: extIDs,
+	}, err
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/internal/authz/bitbucketserver/provider_test.go
+++ b/internal/authz/bitbucketserver/provider_test.go
@@ -206,10 +206,10 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 					sort.Slice(got.Exacts, func(i, j int) bool { return got.Exacts[i] < got.Exacts[j] })
 				}
 
-				var want *authz.AccessibleRepoIDs
+				var want *authz.ExternalUserPermissions
 				if len(tc.ids) > 0 {
 					sort.Slice(tc.ids, func(i, j int) bool { return tc.ids[i] < tc.ids[j] })
-					want = &authz.AccessibleRepoIDs{
+					want = &authz.ExternalUserPermissions{
 						Exacts: tc.ids,
 					}
 				}

--- a/internal/authz/bitbucketserver/provider_test.go
+++ b/internal/authz/bitbucketserver/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -197,17 +198,23 @@ func testProviderFetchUserPerms(f *fixtures, cli *bitbucketserver.Client) func(*
 
 				tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", cli.URL.String())
 
-				ids, _, err := p.FetchUserPerms(tc.ctx, tc.acct)
-
+				got, err := p.FetchUserPerms(tc.ctx, tc.acct)
 				if have, want := fmt.Sprint(err), tc.err; have != want {
 					t.Errorf("error:\nhave: %q\nwant: %q", have, want)
 				}
+				if got != nil {
+					sort.Slice(got.Exacts, func(i, j int) bool { return got.Exacts[i] < got.Exacts[j] })
+				}
 
-				sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-				sort.Slice(tc.ids, func(i, j int) bool { return tc.ids[i] < tc.ids[j] })
-
-				if have, want := ids, tc.ids; !reflect.DeepEqual(have, want) {
-					t.Error(cmp.Diff(have, want))
+				var want *authz.AccessibleRepoIDs
+				if len(tc.ids) > 0 {
+					sort.Slice(tc.ids, func(i, j int) bool { return tc.ids[i] < tc.ids[j] })
+					want = &authz.AccessibleRepoIDs{
+						Exacts: tc.ids,
+					}
+				}
+				if diff := cmp.Diff(want, got); diff != "" {
+					t.Fatalf("Mismatch (-want +got):\n%s", diff)
 				}
 			})
 		}

--- a/internal/authz/github/github.go
+++ b/internal/authz/github/github.go
@@ -68,19 +68,19 @@ func (p *Provider) Validate() (problems []string) {
 // callers to decide whether to discard.
 //
 // API docs: https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-user
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
 	if account == nil {
-		return nil, extsvc.RepoIDExact, errors.New("no account provided")
+		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
-		return nil, extsvc.RepoIDExact, fmt.Errorf("not a code host of the account: want %q but have %q",
+		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := github.GetExternalAccountData(&account.AccountData)
 	if err != nil {
-		return nil, extsvc.RepoIDExact, errors.Wrap(err, "get external account data")
+		return nil, errors.Wrap(err, "get external account data")
 	} else if tok == nil {
-		return nil, extsvc.RepoIDExact, errors.New("no token found in the external account data")
+		return nil, errors.New("no token found in the external account data")
 	}
 
 	// 🚨 SECURITY: Use user token is required to only list repositories the user has access to.
@@ -94,7 +94,9 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		var repos []*github.Repository
 		repos, hasNextPage, _, err = client.ListAffiliatedRepositories(ctx, github.VisibilityPrivate, page)
 		if err != nil {
-			return repoIDs, extsvc.RepoIDExact, err
+			return &authz.AccessibleRepoIDs{
+				Exacts: repoIDs,
+			}, err
 		}
 
 		for _, r := range repos {
@@ -102,7 +104,9 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		}
 	}
 
-	return repoIDs, extsvc.RepoIDExact, nil
+	return &authz.AccessibleRepoIDs{
+		Exacts: repoIDs,
+	}, nil
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/internal/authz/github/github.go
+++ b/internal/authz/github/github.go
@@ -68,7 +68,7 @@ func (p *Provider) Validate() (problems []string) {
 // callers to decide whether to discard.
 //
 // API docs: https://developer.github.com/v3/repos/#list-repositories-for-the-authenticated-user
-func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -94,7 +94,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		var repos []*github.Repository
 		repos, hasNextPage, _, err = client.ListAffiliatedRepositories(ctx, github.VisibilityPrivate, page)
 		if err != nil {
-			return &authz.AccessibleRepoIDs{
+			return &authz.ExternalUserPermissions{
 				Exacts: repoIDs,
 			}, err
 		}
@@ -104,7 +104,7 @@ func (p *Provider) FetchUserPerms(ctx context.Context, account *extsvc.Account) 
 		}
 	}
 
-	return &authz.AccessibleRepoIDs{
+	return &authz.ExternalUserPermissions{
 		Exacts: repoIDs,
 	}, nil
 }

--- a/internal/authz/github/github_test.go
+++ b/internal/authz/github/github_test.go
@@ -25,7 +25,7 @@ func mustURL(t *testing.T, u string) *url.URL {
 func TestProvider_FetchUserPerms(t *testing.T) {
 	t.Run("nil account", func(t *testing.T) {
 		p := NewProvider("", mustURL(t, "https://github.com"), "admin_token", nil)
-		_, _, err := p.FetchUserPerms(context.Background(), nil)
+		_, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -35,7 +35,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("not the code host of the account", func(t *testing.T) {
 		p := NewProvider("", mustURL(t, "https://github.com"), "admin_token", nil)
-		_, _, err := p.FetchUserPerms(context.Background(),
+		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "gitlab",
@@ -52,7 +52,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 
 	t.Run("no token found in account data", func(t *testing.T) {
 		p := NewProvider("", mustURL(t, "https://github.com"), "admin_token", nil)
-		_, _, err := p.FetchUserPerms(context.Background(),
+		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: "github",
@@ -95,7 +95,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 	p.client = mockClient
 
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
-	repoIDs, _, err := p.FetchUserPerms(context.Background(),
+	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
 			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "github",
@@ -119,7 +119,7 @@ func TestProvider_FetchUserPerms(t *testing.T) {
 		"MDEwOlJlcG9zaXRvcnkyNDQ1MTc1MzY=",
 		"MDEwOlJlcG9zaXRvcnkyNDI2NTEwMDA=",
 	}
-	if diff := cmp.Diff(wantRepoIDs, repoIDs); diff != "" {
+	if diff := cmp.Diff(wantRepoIDs, repoIDs.Exacts); diff != "" {
 		t.Fatalf("RpoeIDs mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/authz/gitlab/oauth.go
+++ b/internal/authz/gitlab/oauth.go
@@ -79,7 +79,7 @@ func (p *OAuthProvider) FetchAccount(ctx context.Context, user *types.User, curr
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {

--- a/internal/authz/gitlab/oauth.go
+++ b/internal/authz/gitlab/oauth.go
@@ -79,19 +79,19 @@ func (p *OAuthProvider) FetchAccount(ctx context.Context, user *types.User, curr
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+func (p *OAuthProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
 	if account == nil {
-		return nil, extsvc.RepoIDExact, errors.New("no account provided")
+		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
-		return nil, extsvc.RepoIDExact, fmt.Errorf("not a code host of the account: want %q but have %q",
+		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	_, tok, err := gitlab.GetExternalAccountData(&account.AccountData)
 	if err != nil {
-		return nil, extsvc.RepoIDExact, errors.Wrap(err, "get external account data")
+		return nil, errors.Wrap(err, "get external account data")
 	} else if tok == nil {
-		return nil, extsvc.RepoIDExact, errors.New("no token found in the external account data")
+		return nil, errors.New("no token found in the external account data")
 	}
 
 	client := p.clientProvider.GetOAuthClient(tok.AccessToken)

--- a/internal/authz/gitlab/oauth_test.go
+++ b/internal/authz/gitlab/oauth_test.go
@@ -29,7 +29,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, _, err := p.FetchUserPerms(context.Background(), nil)
+		_, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -41,7 +41,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 		p := newOAuthProvider(OAuthProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, _, err := p.FetchUserPerms(context.Background(),
+		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: extsvc.TypeGitHub,
@@ -90,7 +90,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	)
 
 	authData := json.RawMessage(`{"access_token": "my_access_token"}`)
-	repoIDs, _, err := p.FetchUserPerms(context.Background(),
+	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
 			AccountSpec: extsvc.AccountSpec{
 				ServiceType: extsvc.TypeGitLab,
@@ -106,7 +106,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 	}
 
 	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
-	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
+	if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
 		t.Fatal(diff)
 	}
 }

--- a/internal/authz/gitlab/sudo.go
+++ b/internal/authz/gitlab/sudo.go
@@ -195,17 +195,17 @@ func (p *SudoProvider) fetchAccountByUsername(ctx context.Context, username stri
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
 	if account == nil {
-		return nil, extsvc.RepoIDExact, errors.New("no account provided")
+		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
-		return nil, extsvc.RepoIDExact, fmt.Errorf("not a code host of the account: want %q but have %q",
+		return nil, fmt.Errorf("not a code host of the account: want %q but have %q",
 			account.AccountSpec.ServiceID, p.codeHost.ServiceID)
 	}
 
 	user, _, err := gitlab.GetExternalAccountData(&account.AccountData)
 	if err != nil {
-		return nil, extsvc.RepoIDExact, errors.Wrap(err, "get external account data")
+		return nil, errors.Wrap(err, "get external account data")
 	}
 
 	client := p.clientProvider.GetPATClient(p.sudoToken, strconv.Itoa(int(user.ID)))
@@ -216,7 +216,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 // (access level: 20 => Reporter access) by the authenticated or impersonated user in the client.
 // It may return partial but valid results in case of error, and it is up to callers to decide
 // whether to discard.
-func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
+func listProjects(ctx context.Context, client *gitlab.Client) (*authz.AccessibleRepoIDs, error) {
 	q := make(url.Values)
 	q.Add("visibility", "private")  // This method is meant to return only private projects
 	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
@@ -231,7 +231,9 @@ func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.RepoID, 
 	for {
 		projects, next, err := client.ListProjects(ctx, nextURL)
 		if err != nil {
-			return projectIDs, extsvc.RepoIDExact, err
+			return &authz.AccessibleRepoIDs{
+				Exacts: projectIDs,
+			}, err
 		}
 
 		for _, p := range projects {
@@ -244,7 +246,9 @@ func listProjects(ctx context.Context, client *gitlab.Client) ([]extsvc.RepoID, 
 		nextURL = *next
 	}
 
-	return projectIDs, extsvc.RepoIDExact, nil
+	return &authz.AccessibleRepoIDs{
+		Exacts: projectIDs,
+	}, nil
 }
 
 // FetchRepoPerms returns a list of user IDs (on code host) who have read access to

--- a/internal/authz/gitlab/sudo.go
+++ b/internal/authz/gitlab/sudo.go
@@ -195,7 +195,7 @@ func (p *SudoProvider) fetchAccountByUsername(ctx context.Context, username stri
 // callers to decide whether to discard.
 //
 // API docs: https://docs.gitlab.com/ee/api/projects.html#list-all-projects
-func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 	if account == nil {
 		return nil, errors.New("no account provided")
 	} else if !extsvc.IsHostOfAccount(p.codeHost, account) {
@@ -216,7 +216,7 @@ func (p *SudoProvider) FetchUserPerms(ctx context.Context, account *extsvc.Accou
 // (access level: 20 => Reporter access) by the authenticated or impersonated user in the client.
 // It may return partial but valid results in case of error, and it is up to callers to decide
 // whether to discard.
-func listProjects(ctx context.Context, client *gitlab.Client) (*authz.AccessibleRepoIDs, error) {
+func listProjects(ctx context.Context, client *gitlab.Client) (*authz.ExternalUserPermissions, error) {
 	q := make(url.Values)
 	q.Add("visibility", "private")  // This method is meant to return only private projects
 	q.Add("min_access_level", "20") // 20 => Reporter access (i.e. have access to project code)
@@ -231,7 +231,7 @@ func listProjects(ctx context.Context, client *gitlab.Client) (*authz.Accessible
 	for {
 		projects, next, err := client.ListProjects(ctx, nextURL)
 		if err != nil {
-			return &authz.AccessibleRepoIDs{
+			return &authz.ExternalUserPermissions{
 				Exacts: projectIDs,
 			}, err
 		}
@@ -246,7 +246,7 @@ func listProjects(ctx context.Context, client *gitlab.Client) (*authz.Accessible
 		nextURL = *next
 	}
 
-	return &authz.AccessibleRepoIDs{
+	return &authz.ExternalUserPermissions{
 		Exacts: projectIDs,
 	}, nil
 }

--- a/internal/authz/gitlab/sudo_test.go
+++ b/internal/authz/gitlab/sudo_test.go
@@ -228,7 +228,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, _, err := p.FetchUserPerms(context.Background(), nil)
+		_, err := p.FetchUserPerms(context.Background(), nil)
 		want := "no account provided"
 		got := fmt.Sprintf("%v", err)
 		if got != want {
@@ -240,7 +240,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 		p := newSudoProvider(SudoProviderOp{
 			BaseURL: mustURL(t, "https://gitlab.com"),
 		}, nil)
-		_, _, err := p.FetchUserPerms(context.Background(),
+		_, err := p.FetchUserPerms(context.Background(),
 			&extsvc.Account{
 				AccountSpec: extsvc.AccountSpec{
 					ServiceType: extsvc.TypeGitHub,
@@ -295,7 +295,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	)
 
 	accountData := json.RawMessage(`{"id": 999}`)
-	repoIDs, _, err := p.FetchUserPerms(context.Background(),
+	repoIDs, err := p.FetchUserPerms(context.Background(),
 		&extsvc.Account{
 			AccountSpec: extsvc.AccountSpec{
 				ServiceType: "gitlab",
@@ -311,7 +311,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 	}
 
 	expRepoIDs := []extsvc.RepoID{"1", "2", "3"}
-	if diff := cmp.Diff(expRepoIDs, repoIDs); diff != "" {
+	if diff := cmp.Diff(expRepoIDs, repoIDs.Exacts); diff != "" {
 		t.Fatal(diff)
 	}
 }

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -9,10 +9,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// AccessibleRepoIDs is a collection of accessible repository/project IDs (on
-// code host). It contains exact IDs, as well as prefixes to both include and
-// exclude IDs.
-type AccessibleRepoIDs struct {
+// ExternalUserPermissions is a collection of accessible repository/project IDs
+// (on code host). It contains exact IDs, as well as prefixes to both include
+// and exclude IDs.
+//
+// 🚨 SECURITY: Every call site should evaluate all fields of this struct to
+// have a complete set of IDs.
+type ExternalUserPermissions struct {
 	Exacts          []extsvc.RepoID
 	IncludePrefixes []extsvc.RepoID
 	ExcludePrefixes []extsvc.RepoID
@@ -51,7 +54,7 @@ type Provider interface {
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchUserPerms(ctx context.Context, account *extsvc.Account) (*AccessibleRepoIDs, error)
+	FetchUserPerms(ctx context.Context, account *extsvc.Account) (*ExternalUserPermissions, error)
 
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 	// the given repository/project on the code host. The user ID should be the same value

--- a/internal/authz/iface.go
+++ b/internal/authz/iface.go
@@ -9,6 +9,15 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
+// AccessibleRepoIDs is a collection of accessible repository/project IDs (on
+// code host). It contains exact IDs, as well as prefixes to both include and
+// exclude IDs.
+type AccessibleRepoIDs struct {
+	Exacts          []extsvc.RepoID
+	IncludePrefixes []extsvc.RepoID
+	ExcludePrefixes []extsvc.RepoID
+}
+
 // Provider defines a source of truth of which repositories a user is authorized to view. The
 // user is identified by an extsvc.Account instance. Examples of authz providers include the
 // following:
@@ -33,19 +42,16 @@ type Provider interface {
 	// provided user, implementations should return nil, nil.
 	FetchAccount(ctx context.Context, user *types.User, current []*extsvc.Account) (mine *extsvc.Account, err error)
 
-	// FetchUserPerms returns a list of repository/project IDs (on code host) that
-	// the given account has read access on the code host. The repository/project ID
-	// should be the same value as it would be used as or prefix of
-	// api.ExternalRepoSpec.ID. The returned list should only include private
-	// repositories/project IDs.
-	//
-	// The second return value (extsvc.RepoIDType) should indicate whether the
-	// returned list of extsvc.RepoID contain exact matches or prefix matches.
+	// FetchUserPerms returns a collection of accessible repository/project IDs (on
+	// code host) that the given account has read access on the code host. The
+	// repository/project ID should be the same value as it would be used as or
+	// prefix of api.ExternalRepoSpec.ID. The returned set should only include
+	// private repositories/project IDs.
 	//
 	// Because permissions fetching APIs are often expensive, the implementation should
 	// try to return partial but valid results in case of error, and it is up to callers
 	// to decide whether to discard.
-	FetchUserPerms(ctx context.Context, account *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error)
+	FetchUserPerms(ctx context.Context, account *extsvc.Account) (*AccessibleRepoIDs, error)
 
 	// FetchRepoPerms returns a list of user IDs (on code host) who have read access to
 	// the given repository/project on the code host. The user ID should be the same value

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -38,8 +38,8 @@ func (p *fakeProvider) ServiceID() string             { return p.codeHost.Servic
 func (p *fakeProvider) URN() string                   { return extsvc.URN(p.codeHost.ServiceType, 0) }
 func (p *fakeProvider) Validate() (problems []string) { return nil }
 
-func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) ([]extsvc.RepoID, extsvc.RepoIDType, error) {
-	return nil, extsvc.RepoIDExact, nil
+func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+	return nil, nil
 }
 
 func (p *fakeProvider) FetchRepoPerms(context.Context, *extsvc.Repository) ([]extsvc.AccountID, error) {

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -38,7 +38,7 @@ func (p *fakeProvider) ServiceID() string             { return p.codeHost.Servic
 func (p *fakeProvider) URN() string                   { return extsvc.URN(p.codeHost.ServiceType, 0) }
 func (p *fakeProvider) Validate() (problems []string) { return nil }
 
-func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) (*authz.AccessibleRepoIDs, error) {
+func (p *fakeProvider) FetchUserPerms(context.Context, *extsvc.Account) (*authz.ExternalUserPermissions, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This PR changes the signature of `authz.Provider.FetchUserPerms` to return newly defined `AccessibleRepoIDs` as a collection of repo IDs that a user have access to. This is still not perfect, but it is more clear than the current version about what call sites should do with the `AccessibleRepoIDs` (i.e. should take use of all fields).

Subset of #17881 and extracted here for easier review, and part of #16705.