### PR TITLE
Add examples for BackgroundRoutines

### DIFF
--- a/doc/dev/background-information/backgroundroutine.md
+++ b/doc/dev/background-information/backgroundroutine.md
@@ -11,6 +11,8 @@ Examples:
 - [out-of-band migrations](oobmigrations.md) are implemented as background routines.
 - [`HardDeleter`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@b946a20362ee7dfedb3b1fbc7f8bb002135d7283/-/blob/enterprise/cmd/frontend/internal/codeintel/background/janitor/hard_delete.go?subtree=true#L33) is a periodic background routine that periodically hard-deletes soft-deleted upload records.
 
+See also the [godocs.io examples for the `goroutine` package](https://godocs.io/github.com/sourcegraph/sourcegraph/internal/goroutine).
+
 ## Adding a background routine
 
 ### Step 1: Implement the `goroutine.BackgroundRoutine` interface

--- a/internal/goroutine/example_test.go
+++ b/internal/goroutine/example_test.go
@@ -1,0 +1,60 @@
+package goroutine
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+type exampleRoutine struct {
+	done chan struct{}
+}
+
+func (m *exampleRoutine) Start() {
+	for {
+		select {
+		case <-m.done:
+			fmt.Println("done!")
+			return
+		default:
+		}
+
+		fmt.Println("Hello there!")
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func (m *exampleRoutine) Stop() {
+	m.done <- struct{}{}
+}
+
+func ExampleBackgroundRoutine() {
+	r := &exampleRoutine{
+		done: make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go MonitorBackgroundRoutines(ctx, r)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	time.Sleep(200 * time.Millisecond)
+}
+
+func ExamplePeriodicGoroutine() {
+	h := NewHandlerWithErrorMessage("example background routine", func(ctx context.Context) error {
+		fmt.Println("Hello from the background!")
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	r := NewPeriodicGoroutine(ctx, 200*time.Millisecond, h)
+
+	go MonitorBackgroundRoutines(ctx, r)
+
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	time.Sleep(200 * time.Millisecond)
+}


### PR DESCRIPTION
Decided to add these because I realised I'm an idiot that thought these would always run with tests. Alas, they don't.

But I don't know how to view them online, since [https://pkg.go.dev/github.com/sourcegraph/sourcegraph/internal/goroutine] doesn't display them due to license restrictions.