### PR TITLE
extensions: link to registry page with host

### DIFF
--- a/client/web/src/extensions/ExtensionCard.tsx
+++ b/client/web/src/extensions/ExtensionCard.tsx
@@ -173,11 +173,7 @@ export const ExtensionCard = memo<Props>(function ExtensionCard({
                         <div className="d-flex align-items-center">
                             <span className="mb-0 mr-1 text-truncate flex-1">
                                 <Link
-                                    to={`/extensions/${
-                                        extension.registryExtension
-                                            ? extension.registryExtension.extensionIDWithoutRegistry
-                                            : extension.id
-                                    }`}
+                                    to={`/extensions/${extension.id}`}
                                     className={classNames('font-weight-bold', change === 'enabled' ? 'alert-link' : '')}
                                 >
                                     {name}


### PR DESCRIPTION
Fixes #13829

Link to extension details page _with_ host, to fix link to registry details page from extension card