### PR TITLE
dev: ensure we are using new bitbucket creds

### DIFF
--- a/enterprise/dev/start.sh
+++ b/enterprise/dev/start.sh
@@ -10,7 +10,7 @@ if [ ! -d "$DEV_PRIVATE_PATH" ]; then
 fi
 
 # Warn if dev-private needs to be updated.
-required_commit="eff6cce71f6b147f61567d19f16cbf03da0d7696"
+required_commit="d9962a66809bd1370ecc2847e3ed6b77e072cb7e"
 if ! git -C "$DEV_PRIVATE_PATH" merge-base --is-ancestor $required_commit HEAD; then
   echo "Error: You need to update dev-private to a commit that incorporates https://github.com/sourcegraph/dev-private/commit/$required_commit."
   echo


### PR DESCRIPTION
Bumping the required dev-private commit to ensure developers are using
the new bitbucket access token. We are running into captcha issues due
to failing to auth tokens. This may be the cause.