### PR TITLE
Add typed Count() method to query interface

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -745,9 +745,9 @@ func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query
 	}
 
 	wantCount := defaultMaxSearchResults
-	query.VisitField(scopeParameters, query.FieldCount, func(value string, _ bool, _ query.Annotation) {
-		wantCount, _ = strconv.Atoi(value) // Invariant: count is validated.
-	})
+	if count := query.Q(scopeParameters).Count(); count != nil {
+		wantCount = *count
+	}
 
 	result, err := r.evaluatePatternExpression(ctx, scopeParameters, operands[0])
 	if err != nil {
@@ -869,9 +869,9 @@ func (r *searchResolver) Results(ctx context.Context) (srr *SearchResultsResolve
 	}()
 
 	wantCount := defaultMaxSearchResults
-	query.VisitField(r.Query, query.FieldCount, func(value string, _ bool, _ query.Annotation) {
-		wantCount, _ = strconv.Atoi(value)
-	})
+	if count := r.Query.Count(); count != nil {
+		wantCount = *count
+	}
 
 	if invalidateRepoCache(r.Query) {
 		r.invalidateRepoCache = true

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -3,6 +3,7 @@ package query
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 )
 
 type ExpectedOperand struct {
@@ -32,6 +33,7 @@ const (
 // QueryInfo is an interface for accessing query values that drive our search logic.
 // It will be removed in favor of a cleaner query API to access values.
 type QueryInfo interface {
+	Count() *int
 	RegexpPatterns(field string) (values, negatedValues []string)
 	StringValues(field string) (values, negatedValues []string)
 	StringValue(field string) (value, negatedValue string)
@@ -112,6 +114,18 @@ func (q Q) BoolValue(field string) bool {
 		result, _ = parseBool(value) // err was checked during parsing and validation.
 	})
 	return result
+}
+
+func (q Q) Count() *int {
+	var count *int
+	VisitField(q, FieldCount, func(value string, _ bool, _ Annotation) {
+		c, err := strconv.Atoi(value)
+		if err != nil {
+			panic(fmt.Sprintf("Value %q for count cannot be parsed as an int: %s", value, err))
+		}
+		count = &c
+	})
+	return count
 }
 
 func (q Q) IsCaseSensitive() bool {


### PR DESCRIPTION
This adds a `Count()` method to the QueryInfo interface. This makes it so
the caller does not need to validate and parse the returned string. The goal is 
to move toward providing well-typed accessor methods for all our fields.

Making a PR for this first change to validate the approach, but I don't plan to make
a single PR per field. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
