### PR TITLE
search: Remove deprecated field 'max'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Removed
 
 - Removed the deprecated GraphQL fields `SearchResults.repositoriesSearched` and `SearchResults.indexedRepositoriesSearched`.
+- Removed the deprecated search field `max`
 
 ## 3.25.2
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"strconv"
 	"sync"
 
 	otlog "github.com/opentracing/opentracing-go/log"
@@ -310,8 +309,7 @@ func (r *searchResolver) rawQuery() string {
 
 func (r *searchResolver) countIsSet() bool {
 	count := r.Query.Count()
-	max, _ := r.Query.StringValues(query.FieldMax)
-	return count != nil || len(max) > 0
+	return count != nil
 }
 
 const defaultMaxSearchResults = 30
@@ -333,14 +331,6 @@ func (inputs SearchInputs) MaxResults() int {
 
 	if count := inputs.Query.Count(); count != nil {
 		return *count
-	}
-
-	max, _ := inputs.Query.StringValues(query.FieldMax)
-	if len(max) > 0 {
-		n, _ := strconv.Atoi(max[0])
-		if n > 0 {
-			return n
-		}
 	}
 
 	if inputs.DefaultLimit != 0 {

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -42,7 +42,6 @@ func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextPara
 		query.FieldDefault:            {},
 		query.FieldIndex:              {},
 		query.FieldCount:              {},
-		query.FieldMax:                {},
 		query.FieldTimeout:            {},
 		query.FieldFork:               {},
 		query.FieldArchived:           {},

--- a/internal/search/query/fields.go
+++ b/internal/search/query/fields.go
@@ -32,7 +32,6 @@ const (
 	FieldIndex     = "index"
 	FieldCount     = "count"  // Searches that specify `count:` will fetch at least that number of results, or the full result set
 	FieldStable    = "stable" // Forces search to return a stable result ordering (currently limited to file content matches).
-	FieldMax       = "max"    // Deprecated alias for count
 	FieldTimeout   = "timeout"
 	FieldCombyRule = "rule"
 	FieldSelect    = "select"
@@ -70,7 +69,6 @@ var allFields = map[string]struct{}{
 	FieldIndex:              empty,
 	FieldCount:              empty,
 	FieldStable:             empty,
-	FieldMax:                empty,
 	FieldTimeout:            empty,
 	FieldCombyRule:          empty,
 	FieldRev:                empty,

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -237,7 +237,6 @@ func (q Q) valueToTypedValue(field, value string, label labels) []*Value {
 	case
 		FieldIndex,
 		FieldCount,
-		FieldMax,
 		FieldTimeout,
 		FieldCombyRule:
 		return []*Value{{String: &value}}

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -291,7 +291,6 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		FieldStable:
 		return satisfies(isSingular, isBoolean, isNotNegated)
 	case
-		FieldMax,
 		FieldCombyRule:
 		return satisfies(isSingular, isNotNegated)
 	case


### PR DESCRIPTION
This field has been deprecated in favor of `count` since at least 2018, and is not documented. This PR removes the field from the codebase. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
