### PR TITLE
search: Add Timeout method to query.Q

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1266,20 +1266,16 @@ var (
 )
 
 func (r *searchResolver) searchTimeoutFieldSet() bool {
-	timeout, _ := r.Query.StringValue(query.FieldTimeout)
-	return timeout != "" || r.countIsSet()
+	timeout := r.Query.Timeout()
+	return timeout != nil || r.countIsSet()
 }
 
 func (r *searchResolver) withTimeout(ctx context.Context) (context.Context, context.CancelFunc, error) {
 	d := defaultTimeout
 	maxTimeout := time.Duration(searchrepos.SearchLimits().MaxTimeoutSeconds) * time.Second
-	timeout, _ := r.Query.StringValue(query.FieldTimeout)
-	if timeout != "" {
-		var err error
-		d, err = time.ParseDuration(timeout)
-		if err != nil {
-			return nil, nil, errors.WithMessage(err, `invalid "timeout:" value (examples: "timeout:2s", "timeout:200ms")`)
-		}
+	timeout := r.Query.Timeout()
+	if timeout != nil {
+		d = *timeout
 	} else if r.countIsSet() {
 		// If `count:` is set but `timeout:` is not explicitly set, use the max timeout
 		d = maxTimeout

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"time"
 )
 
 type ExpectedOperand struct {
@@ -35,6 +36,7 @@ const (
 type QueryInfo interface {
 	Count() *int
 	Archived() *YesNoOnly
+	Timeout() *time.Duration
 	RegexpPatterns(field string) (values, negatedValues []string)
 	StringValues(field string) (values, negatedValues []string)
 	StringValue(field string) (value, negatedValue string)
@@ -143,6 +145,18 @@ func (q Q) yesNoOnlyValue(field string) *YesNoOnly {
 		res = &yno
 	})
 	return res
+}
+
+func (q Q) Timeout() *time.Duration {
+	var timeout *time.Duration
+	VisitField(q, FieldTimeout, func(value string, _ bool, _ Annotation) {
+		t, err := time.ParseDuration(value)
+		if err != nil {
+			panic(fmt.Sprintf("Value %q for timeout cannot be parsed as an duration: %s", value, err))
+		}
+		timeout = &t
+	})
+	return timeout
 }
 
 func (q Q) IsCaseSensitive() bool {

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-enry/go-enry/v2"
 	"github.com/pkg/errors"
@@ -193,6 +194,14 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		return nil
 	}
 
+	isDuration := func() error {
+		_, err := time.ParseDuration(value)
+		if err != nil {
+			return errors.New(`invalid value for field 'timeout' (examples: "timeout:2s", "timeout:200ms")`)
+		}
+		return nil
+	}
+
 	isLanguage := func() error {
 		_, ok := enry.GetLanguageByAlias(value)
 		if !ok {
@@ -283,9 +292,11 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		return satisfies(isSingular, isBoolean, isNotNegated)
 	case
 		FieldMax,
-		FieldTimeout,
 		FieldCombyRule:
 		return satisfies(isSingular, isNotNegated)
+	case
+		FieldTimeout:
+		return satisfies(isSingular, isNotNegated, isDuration)
 	case
 		FieldRev:
 		return satisfies(isSingular, isNotNegated)


### PR DESCRIPTION
Adds the field `Timeout()` to query.Q so we can get a well-typed result.

Additionally, adds validation for the timeout field in
`internal/search/query/validate.go`.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
