### PR TITLE
search: Add method Archived() to query.Q

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -423,13 +423,15 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		fork = query.No
 	}
 
-	archivedStr, _ := r.Query.StringValue(query.FieldArchived)
-	archived := query.ParseYesNoOnly(archivedStr)
-	if archived == query.Invalid && !searchrepos.ExactlyOneRepo(repoFilters) && !settingArchived {
+	archived := query.No
+	if searchrepos.ExactlyOneRepo(repoFilters) || settingArchived {
 		// archived defaults to No unless either of:
 		// (1) exactly one repo is being searched, or
 		// (2) user/org/global setting includes archives in all searches
-		archived = query.No
+		archived = query.Yes
+	}
+	if setArchived := r.Query.Archived(); setArchived != nil {
+		archived = *setArchived
 	}
 
 	visibilityStr, _ := r.Query.StringValue(query.FieldVisibility)

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -135,8 +135,8 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 	fork, _ := r.Query.StringValue(query.FieldFork)
 	onlyForks, noForks := fork == "only", fork == "no"
 	forksNotSet := len(fork) == 0
-	archived, _ := r.Query.StringValue(query.FieldArchived)
-	archivedNotSet := len(archived) == 0
+	archived := r.Query.Archived()
+	archivedNotSet := archived == nil
 
 	// Handle repogroup-only scenarios.
 	if len(repoFilters) == 0 && len(repoGroupFilters) == 0 {

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -459,9 +459,7 @@ func computeExcludedRepositories(ctx context.Context, q query.Q, op database.Rep
 		}()
 	}
 
-	archivedStr, _ := q.StringValue(query.FieldArchived)
-	archived := query.ParseYesNoOnly(archivedStr)
-	if archived == query.Invalid && !ExactlyOneRepo(op.IncludePatterns) {
+	if q.Archived() == nil && !ExactlyOneRepo(op.IncludePatterns) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -34,6 +34,7 @@ const (
 // It will be removed in favor of a cleaner query API to access values.
 type QueryInfo interface {
 	Count() *int
+	Archived() *YesNoOnly
 	RegexpPatterns(field string) (values, negatedValues []string)
 	StringValues(field string) (values, negatedValues []string)
 	StringValue(field string) (value, negatedValue string)
@@ -126,6 +127,22 @@ func (q Q) Count() *int {
 		count = &c
 	})
 	return count
+}
+
+func (q Q) Archived() *YesNoOnly {
+	return q.yesNoOnlyValue(FieldArchived)
+}
+
+func (q Q) yesNoOnlyValue(field string) *YesNoOnly {
+	var res *YesNoOnly
+	VisitField(q, field, func(value string, _ bool, _ Annotation) {
+		yno := ParseYesNoOnly(value)
+		if yno == Invalid {
+			panic(fmt.Sprintf("Invalid value %q for field %q", value, field))
+		}
+		res = &yno
+	})
+	return res
 }
 
 func (q Q) IsCaseSensitive() bool {

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -245,10 +245,6 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		FieldFile:
 		return satisfies(isValidRegexp)
 	case
-		FieldFork,
-		FieldArchived:
-		return satisfies(isSingular, isNotNegated)
-	case
 		FieldLang:
 		return satisfies(isLanguage)
 	case
@@ -275,7 +271,9 @@ func validateField(field, value string, negated bool, seen map[string]struct{}) 
 		FieldMessage:
 		return satisfies(isValidRegexp)
 	case
-		FieldIndex:
+		FieldIndex,
+		FieldFork,
+		FieldArchived:
 		return satisfies(isSingular, isNotNegated, isYesNoOnly)
 	case
 		FieldCount:


### PR DESCRIPTION
Adds a well-typed `Archived()` method. Additionally, includes
FieldArchived and FieldFork on the list of fields validated with
isYesNoOnly.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
