### PR TITLE
dev/start.sh: don't use yarn --silent; it hides errors

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -167,7 +167,7 @@ export PATH="$PWD/.bin:$PWD/node_modules/.bin:$PATH"
 tmp_install_procfile=$(mktemp -t procfile_install_XXXXXXX)
 
 cat >"${tmp_install_procfile}" <<EOF
-yarn: cd $(pwd) && yarn --silent --no-progress
+yarn: cd $(pwd) && yarn --no-progress
 go-install: cd $(pwd) && ./dev/go-install.sh
 ctags-image: cd $(pwd) && ./cmd/symbols/build-ctags.sh
 EOF

--- a/enterprise/dev/ci/ci/pipeline.go
+++ b/enterprise/dev/ci/ci/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	bk "github.com/sourcegraph/sourcegraph/internal/buildkite"
@@ -28,10 +29,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		"DATE":                             c.now.Format(time.RFC3339),
 		"VERSION":                          c.version,
 		// For Bundlesize
-		"CI_REPO_OWNER":     "sourcegraph",
-		"CI_REPO_NAME":      "sourcegraph",
-		"CI_COMMIT_SHA":     os.Getenv("BUILDKITE_COMMIT"),
-		"CI_COMMIT_MESSAGE": os.Getenv("BUILDKITE_MESSAGE"),
+		"CI_REPO_OWNER": "sourcegraph",
+		"CI_REPO_NAME":  "sourcegraph",
+		"CI_COMMIT_SHA": os.Getenv("BUILDKITE_COMMIT"),
+		// $ in commit messages must be escaped to not attempt interpolation which will fail.
+		"CI_COMMIT_MESSAGE": strings.ReplaceAll(os.Getenv("BUILDKITE_MESSAGE"), "$", "$$"),
 
 		// Add debug flags for scripts to consume
 		"CI_DEBUG_PROFILE": strconv.FormatBool(c.profilingEnabled),


### PR DESCRIPTION
With yarn --silent, packages that fail to install will not provide any
hints, and the resulting goreman output lacks any obvious errors apart
from the exit status 1.

--silent doesn't suppress much, so this adds little noise:

fresh:
```
$ rm -r node_modules/ && yarn --no-progress |& wc
     28     250    2334
$ rm -r node_modules/ && yarn --silent --no-progress |& wc
     17     180    1770
```

rebuild:
```
$ yarn --no-progress |& wc
      7      35     319
$ yarn --silent --no-progress |& wc
      2      20     194
```
