### PR TITLE
search: rename ProcessAndOr -> Parse

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -92,7 +92,7 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 
 	globbing := getBoolPtr(settings.SearchGlobbing, false)
 
-	q, err := query.ProcessAndOr(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
+	q, err := query.Parse(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -94,7 +94,7 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	var q query.Q
 	globbing := getBoolPtr(settings.SearchGlobbing, false)
 	tr.LogFields(otlog.Bool("globbing", globbing))
-	q, err = query.ProcessAndOr(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
+	q, err = query.Parse(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
 	if err != nil {
 		return alertForQuery(db, args.Query, err), nil
 	}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -358,7 +358,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			setMockResolveRepositories(test.repoRevs)
-			q, err := query.ProcessAndOr(test.query, query.ParserOptions{SearchType: query.SearchType(0), Globbing: test.globbing})
+			q, err := query.Parse(test.query, query.ParserOptions{SearchType: query.SearchType(0), Globbing: test.globbing})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -287,20 +287,19 @@ func BenchmarkSearchRepositories(b *testing.B) {
 		repo := &types.RepoName{Name: api.RepoName("github.com/org/repo" + strconv.Itoa(i))}
 		repos[i] = &search.RepositoryRevisions{Repo: repo, Revs: []search.RevisionSpecifier{{}}}
 	}
-	q := "context.WithValue"
-	queryInfo, err := query.ProcessAndOr(q, query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: false})
+	q, err := query.ParseLiteral("context.WithValue")
 	if err != nil {
 		b.Fatal(err)
 	}
 	options := &getPatternInfoOptions{}
-	textPatternInfo, err := getPatternInfo(queryInfo, options)
+	textPatternInfo, err := getPatternInfo(q, options)
 	if err != nil {
 		b.Fatal(err)
 	}
 	tp := search.TextParameters{
 		PatternInfo: textPatternInfo,
 		RepoPromise: (&search.Promise{}).Resolve(repos),
-		Query:       queryInfo,
+		Query:       q,
 	}
 	for i := 0; i < b.N; i++ {
 		_, _, err = searchRepositoriesBatch(context.Background(), db, &tp, options.fileMatchLimit)

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -379,8 +379,7 @@ func TestIsPatternNegated(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			q, err := query.ProcessAndOr(tt.pattern,
-				query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: false})
+			q, err := query.ParseLiteral(tt.pattern)
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -426,7 +425,7 @@ func TestProcessSearchPatternAndOr(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			q, err := query.ProcessAndOr(tt.pattern,
+			q, err := query.Parse(tt.pattern,
 				query.ParserOptions{SearchType: tt.searchType, Globbing: false})
 			if err != nil {
 				t.Fatalf(err.Error())
@@ -1061,7 +1060,7 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 func TestSearchResolver_evaluateWarning(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	q, _ := query.ProcessAndOr("file:foo or file:bar", query.ParserOptions{SearchType: query.SearchTypeRegex, Globbing: false})
+	q, _ := query.ParseRegexp("file:foo or file:bar")
 	wantPrefix := "I'm having trouble understanding that query."
 	got, _ := (&searchResolver{db: db}).evaluate(context.Background(), q)
 	t.Run("warn for unsupported and/or query", func(t *testing.T) {
@@ -1070,7 +1069,7 @@ func TestSearchResolver_evaluateWarning(t *testing.T) {
 		}
 	})
 
-	_, err := query.ProcessAndOr("file:foo or or or", query.ParserOptions{SearchType: query.SearchTypeRegex, Globbing: false})
+	_, err := query.ParseRegexp("file:foo or or or")
 	gotAlert := alertForQuery(db, "", err)
 	t.Run("warn for unsupported ambiguous and/or query", func(t *testing.T) {
 		if !strings.HasPrefix(gotAlert.description, wantPrefix) {
@@ -1103,7 +1102,7 @@ func TestGetExactFilePatterns(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			q, err := query.ProcessAndOr(tt.in, query.ParserOptions{Globbing: true, SearchType: query.SearchTypeLiteral})
+			q, err := query.Parse(tt.in, query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: true})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1307,7 +1306,7 @@ func TestEvaluateAnd(t *testing.T) {
 			}
 			defer func() { database.Mocks = database.MockStores{} }()
 
-			q, err := query.ProcessAndOr(tt.query, query.ParserOptions{SearchType: query.SearchTypeLiteral})
+			q, err := query.ParseLiteral(tt.query)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -709,7 +709,7 @@ func BenchmarkSearchResults(b *testing.B) {
 	b.ReportAllocs()
 
 	for n := 0; n < b.N; n++ {
-		q, err := query.ProcessAndOr(`print index:only count:350`, query.ParserOptions{SearchType: query.SearchTypeLiteral})
+		q, err := query.ParseLiteral(`print index:only count:350`)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1059,8 +1059,8 @@ type ParserOptions struct {
 	Globbing bool
 }
 
-// ProcessAndOr query parses and validates an and/or query for a given search type.
-func ProcessAndOr(in string, options ParserOptions) (Q, error) {
+// Parse parses and validates an and/or query for a given search type.
+func Parse(in string, options ParserOptions) (Q, error) {
 	var query []Node
 	var err error
 
@@ -1096,9 +1096,9 @@ func ProcessAndOr(in string, options ParserOptions) (Q, error) {
 }
 
 func ParseLiteral(in string) (Q, error) {
-	return ProcessAndOr(in, ParserOptions{SearchType: SearchTypeLiteral})
+	return Parse(in, ParserOptions{SearchType: SearchTypeLiteral})
 }
 
 func ParseRegexp(in string) (Q, error) {
-	return ProcessAndOr(in, ParserOptions{SearchType: SearchTypeRegex})
+	return Parse(in, ParserOptions{SearchType: SearchTypeRegex})
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -100,7 +100,7 @@ func TestSubstituteAliases(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("substitute alises", func(t *testing.T) {
-			query, _ := ProcessAndOr(c.input, ParserOptions{SearchType: c.searchType})
+			query, _ := Parse(c.input, ParserOptions{SearchType: c.searchType})
 			if diff := cmp.Diff(nodesToJSON(query), c.want); diff != "" {
 				t.Fatal(diff)
 			}
@@ -374,7 +374,7 @@ func TestEllipsesForHoles(t *testing.T) {
 	input := "if ... { ... }"
 	want := `"if :[_] { :[_] }"`
 	t.Run("Ellipses for holes", func(t *testing.T) {
-		query, _ := ProcessAndOr(input, ParserOptions{SearchType: SearchTypeStructural})
+		query, _ := Parse(input, ParserOptions{SearchType: SearchTypeStructural})
 		got := toString(query)
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatal(diff)

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -98,7 +98,7 @@ func TestAndOrQuery_Validation(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {
-			_, err := ProcessAndOr(c.input, ParserOptions{c.searchType, false})
+			_, err := Parse(c.input, ParserOptions{c.searchType, false})
 			if err == nil {
 				t.Fatal(fmt.Sprintf("expected test for %s to fail", c.input))
 			}
@@ -135,7 +135,7 @@ func TestAndOrQuery_IsCaseSensitive(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			query, err := ProcessAndOr(c.input, ParserOptions{SearchTypeRegex, false})
+			query, err := ParseRegexp(c.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -165,7 +165,7 @@ func TestAndOrQuery_RegexpPatterns(t *testing.T) {
 		},
 	}
 	t.Run("for regexp field", func(t *testing.T) {
-		query, err := ProcessAndOr(c.query, ParserOptions{SearchTypeRegex, false})
+		query, err := ParseRegexp(c.query)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -332,7 +332,7 @@ func TestContainsRefGlobs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			qInfo, err := ProcessAndOr(tt.query, ParserOptions{SearchType: SearchTypeLiteral, Globbing: tt.globbing})
+			qInfo, err := Parse(tt.query, ParserOptions{SearchType: SearchTypeLiteral, Globbing: tt.globbing})
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
Now that there are no longer conflicts, we can use the `Parse` name for this function.