### PR TITLE
batches: rename and update schemata

### DIFF
--- a/internal/batches/batch_spec.go
+++ b/internal/batches/batch_spec.go
@@ -41,7 +41,7 @@ func (cs *BatchSpec) Clone() *BatchSpec {
 // UnmarshalValidate unmarshals the RawSpec into Spec and validates it against
 // the BatchSpec schema and does additional semantic validation.
 func (cs *BatchSpec) UnmarshalValidate() error {
-	return yaml.UnmarshalValidate(schema.CampaignSpecSchemaJSON, []byte(cs.RawSpec), &cs.Spec)
+	return yaml.UnmarshalValidate(schema.BatchSpecSchemaJSON, []byte(cs.RawSpec), &cs.Spec)
 }
 
 // BatchSpecTTL specifies the TTL of BatchSpecs that haven't been applied

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -1,30 +1,30 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "CampaignSpec",
-  "description": "A campaign specification, which describes the campaign and what kinds of changes to make (or what existing changesets to track).",
+  "title": "BatchSpec",
+  "description": "A batch specification, which describes the batch change and what kinds of changes to make (or what existing changesets to track).",
   "type": "object",
   "additionalProperties": false,
   "required": ["name"],
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the campaign, which is unique among all campaigns in the namespace. A campaign's name is case-preserving.",
+      "description": "The name of the batch change, which is unique among all batch changes in the namespace. A batch change's name is case-preserving.",
       "pattern": "^[\\w.-]+$"
     },
     "description": {
       "type": "string",
-      "description": "The description of the campaign."
+      "description": "The description of the batch change."
     },
     "on": {
       "type": "array",
-      "description": "The set of repositories (and branches) to run the campaign on, specified as a list of search queries (that match repositories) and/or specific repositories.",
+      "description": "The set of repositories (and branches) to run the batch change on, specified as a list of search queries (that match repositories) and/or specific repositories.",
       "items": {
         "title": "OnQueryOrRepository",
         "oneOf": [
           {
             "title": "OnQuery",
             "type": "object",
-            "description": "A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the campaign will be run on.",
+            "description": "A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the batch change will be run on.",
             "additionalProperties": false,
             "required": ["repositoriesMatchingQuery"],
             "properties": {
@@ -38,7 +38,7 @@
           {
             "title": "OnRepository",
             "type": "object",
-            "description": "A specific repository (and branch) that is added to the list of repositories that the campaign will be run on.",
+            "description": "A specific repository (and branch) that is added to the list of repositories that the batch change will be run on.",
             "additionalProperties": false,
             "required": ["repository"],
             "properties": {
@@ -86,11 +86,11 @@
     },
     "steps": {
       "type": "array",
-      "description": "The sequence of commands to run (for each repository branch matched in the `on` property) to produce the campaign's changes.",
+      "description": "The sequence of commands to run (for each repository branch matched in the `on` property) to produce the workspace changes that will be included in the batch change.",
       "items": {
         "title": "Step",
         "type": "object",
-        "description": "A command to run (as part of a sequence) in a repository branch to produce the campaign's changes.",
+        "description": "A command to run (as part of a sequence) in a repository branch to produce the required changes.",
         "additionalProperties": false,
         "required": ["run", "container"],
         "properties": {
@@ -265,11 +265,11 @@
           }
         },
         "published": {
-          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
+          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
           "oneOf": [
             {
               "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
-              "description": "A single flag to control the publishing state for the entire campaign."
+              "description": "A single flag to control the publishing state for the entire batch change."
             },
             {
               "type": "array",

--- a/schema/batch_spec_stringdata.go
+++ b/schema/batch_spec_stringdata.go
@@ -2,34 +2,34 @@
 
 package schema
 
-// CampaignSpecSchemaJSON is the content of the file "campaign_spec.schema.json".
-const CampaignSpecSchemaJSON = `{
+// BatchSpecSchemaJSON is the content of the file "batch_spec.schema.json".
+const BatchSpecSchemaJSON = `{
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "CampaignSpec",
-  "description": "A campaign specification, which describes the campaign and what kinds of changes to make (or what existing changesets to track).",
+  "title": "BatchSpec",
+  "description": "A batch specification, which describes the batch change and what kinds of changes to make (or what existing changesets to track).",
   "type": "object",
   "additionalProperties": false,
   "required": ["name"],
   "properties": {
     "name": {
       "type": "string",
-      "description": "The name of the campaign, which is unique among all campaigns in the namespace. A campaign's name is case-preserving.",
+      "description": "The name of the batch change, which is unique among all batch changes in the namespace. A batch change's name is case-preserving.",
       "pattern": "^[\\w.-]+$"
     },
     "description": {
       "type": "string",
-      "description": "The description of the campaign."
+      "description": "The description of the batch change."
     },
     "on": {
       "type": "array",
-      "description": "The set of repositories (and branches) to run the campaign on, specified as a list of search queries (that match repositories) and/or specific repositories.",
+      "description": "The set of repositories (and branches) to run the batch change on, specified as a list of search queries (that match repositories) and/or specific repositories.",
       "items": {
         "title": "OnQueryOrRepository",
         "oneOf": [
           {
             "title": "OnQuery",
             "type": "object",
-            "description": "A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the campaign will be run on.",
+            "description": "A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the batch change will be run on.",
             "additionalProperties": false,
             "required": ["repositoriesMatchingQuery"],
             "properties": {
@@ -43,7 +43,7 @@ const CampaignSpecSchemaJSON = `{
           {
             "title": "OnRepository",
             "type": "object",
-            "description": "A specific repository (and branch) that is added to the list of repositories that the campaign will be run on.",
+            "description": "A specific repository (and branch) that is added to the list of repositories that the batch change will be run on.",
             "additionalProperties": false,
             "required": ["repository"],
             "properties": {
@@ -91,11 +91,11 @@ const CampaignSpecSchemaJSON = `{
     },
     "steps": {
       "type": "array",
-      "description": "The sequence of commands to run (for each repository branch matched in the ` + "`" + `on` + "`" + ` property) to produce the campaign's changes.",
+      "description": "The sequence of commands to run (for each repository branch matched in the ` + "`" + `on` + "`" + ` property) to produce the workspace changes that will be included in the batch change.",
       "items": {
         "title": "Step",
         "type": "object",
-        "description": "A command to run (as part of a sequence) in a repository branch to produce the campaign's changes.",
+        "description": "A command to run (as part of a sequence) in a repository branch to produce the required changes.",
         "additionalProperties": false,
         "required": ["run", "container"],
         "properties": {
@@ -270,11 +270,11 @@ const CampaignSpecSchemaJSON = `{
           }
         },
         "published": {
-          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
+          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
           "oneOf": [
             {
               "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
-              "description": "A single flag to control the publishing state for the entire campaign."
+              "description": "A single flag to control the publishing state for the entire batch change."
             },
             {
               "type": "array",

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -85,7 +85,7 @@
         },
         "published": {
           "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
-          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
+          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
         }
       },
       "required": [

--- a/schema/changeset_spec_stringdata.go
+++ b/schema/changeset_spec_stringdata.go
@@ -90,7 +90,7 @@ const ChangesetSpecSchemaJSON = `{
         },
         "published": {
           "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
-          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
+          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
         }
       },
       "required": [

--- a/schema/gen.sh
+++ b/schema/gen.sh
@@ -22,9 +22,9 @@ stringdata() {
 }
 
 stringdata aws_codecommit.schema.json AWSCodeCommitSchemaJSON
+stringdata batch_spec.schema.json BatchSpecSchemaJSON
 stringdata bitbucket_cloud.schema.json BitbucketCloudSchemaJSON
 stringdata bitbucket_server.schema.json BitbucketServerSchemaJSON
-stringdata campaign_spec.schema.json CampaignSpecSchemaJSON
 stringdata changeset_spec.schema.json ChangesetSpecSchemaJSON
 stringdata github.schema.json GitHubSchemaJSON
 stringdata gitlab.schema.json GitLabSchemaJSON

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -129,6 +129,26 @@ func (v *AuthProviders) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"builtin", "saml", "openidconnect", "http-header", "github", "gitlab"})
 }
 
+// BatchSpec description: A batch specification, which describes the batch change and what kinds of changes to make (or what existing changesets to track).
+type BatchSpec struct {
+	// ChangesetTemplate description: A template describing how to create (and update) changesets with the file changes produced by the command steps.
+	ChangesetTemplate *ChangesetTemplate `json:"changesetTemplate,omitempty"`
+	// Description description: The description of the batch change.
+	Description string `json:"description,omitempty"`
+	// ImportChangesets description: Import existing changesets on code hosts.
+	ImportChangesets []*ImportChangesets `json:"importChangesets,omitempty"`
+	// Name description: The name of the batch change, which is unique among all batch changes in the namespace. A batch change's name is case-preserving.
+	Name string `json:"name"`
+	// On description: The set of repositories (and branches) to run the batch change on, specified as a list of search queries (that match repositories) and/or specific repositories.
+	On []interface{} `json:"on,omitempty"`
+	// Steps description: The sequence of commands to run (for each repository branch matched in the `on` property) to produce the workspace changes that will be included in the batch change.
+	Steps []*Step `json:"steps,omitempty"`
+	// TransformChanges description: Optional transformations to apply to the changes produced in each repository.
+	TransformChanges *TransformChanges `json:"transformChanges,omitempty"`
+	// Workspaces description: Individual workspace configurations for one or more repositories that define which workspaces to use for the execution of steps in the repositories.
+	Workspaces []*WorkspaceConfiguration `json:"workspaces,omitempty"`
+}
+
 // BitbucketCloudConnection description: Configuration for a connection to Bitbucket Cloud.
 type BitbucketCloudConnection struct {
 	// ApiURL description: The API URL of Bitbucket Cloud, such as https://api.bitbucket.org. Generally, admin should not modify the value of this option because Bitbucket Cloud is a public hosting platform.
@@ -321,26 +341,6 @@ type BuiltinAuthProvider struct {
 	Type        string `json:"type"`
 }
 
-// CampaignSpec description: A campaign specification, which describes the campaign and what kinds of changes to make (or what existing changesets to track).
-type CampaignSpec struct {
-	// ChangesetTemplate description: A template describing how to create (and update) changesets with the file changes produced by the command steps.
-	ChangesetTemplate *ChangesetTemplate `json:"changesetTemplate,omitempty"`
-	// Description description: The description of the campaign.
-	Description string `json:"description,omitempty"`
-	// ImportChangesets description: Import existing changesets on code hosts.
-	ImportChangesets []*ImportChangesets `json:"importChangesets,omitempty"`
-	// Name description: The name of the campaign, which is unique among all campaigns in the namespace. A campaign's name is case-preserving.
-	Name string `json:"name"`
-	// On description: The set of repositories (and branches) to run the campaign on, specified as a list of search queries (that match repositories) and/or specific repositories.
-	On []interface{} `json:"on,omitempty"`
-	// Steps description: The sequence of commands to run (for each repository branch matched in the `on` property) to produce the campaign's changes.
-	Steps []*Step `json:"steps,omitempty"`
-	// TransformChanges description: Optional transformations to apply to the changes produced in each repository.
-	TransformChanges *TransformChanges `json:"transformChanges,omitempty"`
-	// Workspaces description: Individual workspace configurations for one or more repositories that define which workspaces to use for the execution of steps in the repositories.
-	Workspaces []*WorkspaceConfiguration `json:"workspaces,omitempty"`
-}
-
 // ChangesetTemplate description: A template describing how to create (and update) changesets with the file changes produced by the command steps.
 type ChangesetTemplate struct {
 	// Body description: The body (description) of the changeset.
@@ -349,7 +349,7 @@ type ChangesetTemplate struct {
 	Branch string `json:"branch"`
 	// Commit description: The Git commit to create with the changes.
 	Commit ExpandedGitCommitDescription `json:"commit"`
-	// Published description: Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the campaign, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.
+	// Published description: Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.
 	Published interface{} `json:"published"`
 	// Title description: The title of the changeset.
 	Title string `json:"title"`
@@ -955,13 +955,13 @@ type ObservabilityTracing struct {
 	Sampling string `json:"sampling,omitempty"`
 }
 
-// OnQuery description: A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the campaign will be run on.
+// OnQuery description: A Sourcegraph search query that matches a set of repositories (and branches). Each matched repository branch is added to the list of repositories that the batch change will be run on.
 type OnQuery struct {
 	// RepositoriesMatchingQuery description: A Sourcegraph search query that matches a set of repositories (and branches). If the query matches files, symbols, or some other object inside a repository, the object's repository is included.
 	RepositoriesMatchingQuery string `json:"repositoriesMatchingQuery"`
 }
 
-// OnRepository description: A specific repository (and branch) that is added to the list of repositories that the campaign will be run on.
+// OnRepository description: A specific repository (and branch) that is added to the list of repositories that the batch change will be run on.
 type OnRepository struct {
 	// Branch description: The branch on the repository to propose changes to. If unset, the repository's default branch is used.
 	Branch string `json:"branch,omitempty"`
@@ -1404,7 +1404,7 @@ type SiteConfiguration struct {
 	UserReposMaxPerUser int `json:"userRepos.maxPerUser,omitempty"`
 }
 
-// Step description: A command to run (as part of a sequence) in a repository branch to produce the campaign's changes.
+// Step description: A command to run (as part of a sequence) in a repository branch to produce the required changes.
 type Step struct {
 	// Container description: The Docker image used to launch the Docker container in which the shell command is run.
 	Container string `json:"container"`


### PR DESCRIPTION
This PR renames and updates the schemata for ~campaign~ batch and changeset specs to match https://github.com/sourcegraph/src-cli/pull/489. These changes are descriptive only and non-breaking.