### PR TITLE
Add settings for code insight display locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Opsgenie API keys can now be added via an environment variable. [#18662](https://github.com/sourcegraph/sourcegraph/pull/18662)
-- It's now possible to control where code insights are displayed through the boolean settings `insights.displayLocation.homepage`, `insights.displayLocation.insightsPage` and `insights.displayLocation.directory`.
+- It's now possible to control where code insights are displayed through the boolean settings `insights.displayLocation.homepage`, `insights.displayLocation.insightsPage` and `insights.displayLocation.directory`. [#18979](https://github.com/sourcegraph/sourcegraph/pull/18979)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Opsgenie API keys can now be added via an environment variable. [#18662](https://github.com/sourcegraph/sourcegraph/pull/18662)
+- It's now possible to control where code insights are displayed through the boolean settings `insights.displayLocation.homepage`, `insights.displayLocation.insightsPage` and `insights.displayLocation.directory`.
 
 ### Changed
 

--- a/client/web/src/nav/NavLinks.tsx
+++ b/client/web/src/nav/NavLinks.tsx
@@ -87,7 +87,9 @@ const getMinimizableNavItems = (props: Props): JSX.Element[] => {
     const { showBatchChanges, settingsCascade } = props
 
     const settings = !isErrorLike(settingsCascade.final) ? settingsCascade.final : null
-    const { codeInsights, codeMonitoring } = settings?.experimentalFeatures || {}
+    const { codeMonitoring } = settings?.experimentalFeatures || {}
+    const codeInsights =
+        settings?.experimentalFeatures?.codeInsights && settings?.['insights.displayLocation.insightsPage'] !== false
 
     return getReactElements([
         codeInsights && <InsightsNavItem />,

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -213,13 +213,15 @@ export const TreePage: React.FunctionComponent<Props> = ({
 
     const { services } = props.extensionsController
 
-    const codeInsightsEnabled =
-        !isErrorLike(settingsCascade.final) && !!settingsCascade.final?.experimentalFeatures?.codeInsights
+    const showCodeInsights =
+        !isErrorLike(settingsCascade.final) &&
+        !!settingsCascade.final?.experimentalFeatures?.codeInsights &&
+        settingsCascade.final['insights.displayLocation.directory'] !== false
 
     // Add DirectoryViewer
     const uri = toURIWithPath({ repoName: repo.name, commitID, filePath })
     useEffect(() => {
-        if (!codeInsightsEnabled) {
+        if (!showCodeInsights) {
             return
         }
         const viewerId = services.viewer.addViewer({
@@ -228,14 +230,14 @@ export const TreePage: React.FunctionComponent<Props> = ({
             resource: uri,
         })
         return () => services.viewer.removeViewer(viewerId)
-    }, [services.viewer, services.model, uri, codeInsightsEnabled])
+    }, [services.viewer, services.model, uri, showCodeInsights])
 
     // Observe directory views
     const workspaceUri = services.workspace.roots.value[0]?.uri
     const views = useObservable(
         useMemo(
             () =>
-                codeInsightsEnabled && workspaceUri
+                showCodeInsights && workspaceUri
                     ? getCombinedViews(
                           ContributableViewContainer.Directory,
                           {
@@ -252,7 +254,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                           services.view
                       )
                     : EMPTY,
-            [codeInsightsEnabled, workspaceUri, uri, services.view]
+            [showCodeInsights, workspaceUri, uri, services.view]
         )
     )
 

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -194,7 +194,8 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         render: lazyComponent(() => import('./insights/InsightsPage'), 'InsightsPage'),
         condition: props =>
             !isErrorLike(props.settingsCascade.final) &&
-            !!props.settingsCascade.final?.experimentalFeatures?.codeInsights,
+            !!props.settingsCascade.final?.experimentalFeatures?.codeInsights &&
+            props.settingsCascade.final['insights.displayLocation.insightsPage'] !== false,
     },
     {
         path: '/views',

--- a/client/web/src/search/input/SearchPage.tsx
+++ b/client/web/src/search/input/SearchPage.tsx
@@ -88,20 +88,22 @@ export const SearchPage: React.FunctionComponent<SearchPageProps> = props => {
 
     useEffect(() => props.telemetryService.logViewEvent('Home'), [props.telemetryService])
 
-    const codeInsightsEnabled =
-        !isErrorLike(props.settingsCascade.final) && !!props.settingsCascade.final?.experimentalFeatures?.codeInsights
+    const showCodeInsights =
+        !isErrorLike(props.settingsCascade.final) &&
+        !!props.settingsCascade.final?.experimentalFeatures?.codeInsights &&
+        props.settingsCascade.final['insights.displayLocation.homepage'] !== false
 
     const views = useObservable(
         useMemo(
             () =>
-                codeInsightsEnabled
+                showCodeInsights
                     ? getCombinedViews(
                           ContributableViewContainer.Homepage,
                           {},
                           props.extensionsController.services.view
                       )
                     : EMPTY,
-            [codeInsightsEnabled, props.extensionsController.services.view]
+            [showCodeInsights, props.extensionsController.services.view]
         )
     )
     return (

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1189,7 +1189,10 @@ type Settings struct {
 	// Extensions description: The Sourcegraph extensions to use. Enable an extension by adding a property `"my/extension": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.
 	Extensions map[string]bool `json:"extensions,omitempty"`
 	// Insights description: EXPERIMENTAL: Code Insights
-	Insights []*Insight `json:"insights,omitempty"`
+	Insights                            []*Insight `json:"insights,omitempty"`
+	InsightsDisplayLocationDirectory    *bool      `json:"insights.displayLocation.directory,omitempty"`
+	InsightsDisplayLocationHomepage     *bool      `json:"insights.displayLocation.homepage,omitempty"`
+	InsightsDisplayLocationInsightsPage *bool      `json:"insights.displayLocation.insightsPage,omitempty"`
 	// Motd description: DEPRECATED: Use `notices` instead.
 	//
 	// An array (often with just one element) of messages to display at the top of all pages, including for unauthenticated users. Users may dismiss a message (and any message with the same string value will remain dismissed for the user).

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -330,6 +330,27 @@
         "pointer": true
       }
     },
+    "insights.displayLocation.insightsPage": {
+      "type": "boolean",
+      "default": true,
+      "!go": {
+        "pointer": true
+      }
+    },
+    "insights.displayLocation.directory": {
+      "type": "boolean",
+      "default": true,
+      "!go": {
+        "pointer": true
+      }
+    },
+    "insights.displayLocation.homepage": {
+      "type": "boolean",
+      "default": true,
+      "!go": {
+        "pointer": true
+      }
+    },
     "insights": {
       "description": "EXPERIMENTAL: Code Insights",
       "type": "array",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -335,6 +335,27 @@ const SettingsSchemaJSON = `{
         "pointer": true
       }
     },
+    "insights.displayLocation.insightsPage": {
+      "type": "boolean",
+      "default": true,
+      "!go": {
+        "pointer": true
+      }
+    },
+    "insights.displayLocation.directory": {
+      "type": "boolean",
+      "default": true,
+      "!go": {
+        "pointer": true
+      }
+    },
+    "insights.displayLocation.homepage": {
+      "type": "boolean",
+      "default": true,
+      "!go": {
+        "pointer": true
+      }
+    },
     "insights": {
       "description": "EXPERIMENTAL: Code Insights",
       "type": "array",


### PR DESCRIPTION
Closes #18710

Adds three boolean settings in addition to the feature flag:
- `insights.displayLocation.homepage`
- `insights.displayLocation.insightsPage`
- `insights.displayLocation.directory`

All default to `true` (maintaining current behavior). The feature flag also always needs to be on.