### PR TITLE
gitserver: Set repo as not_cloned when removed on disk

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -123,6 +123,7 @@ func main() {
 			return &server.GitRepoSyncer{}, nil
 		},
 		Hostname: hostnameBestEffort(),
+		DB:       db,
 	}
 	gitserver.RegisterMetrics()
 

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -39,7 +39,7 @@ var (
 	reposDir                     = env.Get("SRC_REPOS_DIR", "/data/repos", "Root dir containing repos.")
 	wantPctFree                  = env.MustGetInt("SRC_REPOS_DESIRED_PERCENT_FREE", 10, "Target percentage of free space on disk.")
 	janitorInterval              = env.MustGetDuration("SRC_REPOS_JANITOR_INTERVAL", 1*time.Minute, "Interval between cleanup runs")
-	syncRepoStateInterval        = env.MustGetDuration("SRC_REPOS_SYNC_STATE_INTERVAL", 1*time.Minute, "Interval between state syncs")
+	syncRepoStateInterval        = env.MustGetDuration("SRC_REPOS_SYNC_STATE_INTERVAL", 5*time.Minute, "Interval between state syncs")
 	syncRepoStateBatchSize       = env.MustGetInt("SRC_REPOS_SYNC_STATE_BATCH_SIZE", 500, "Number of upserts to perform per batch")
 	syncRepoStateUpsertPerSecond = env.MustGetInt("SRC_REPOS_SYNC_STATE_UPSERT_PER_SEC", 500, "The number of upserted rows allowed per second across all gitserver instances")
 	envHostname                  = env.Get("HOSTNAME", "", "Hostname override")

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -468,7 +468,7 @@ func dirSize(d string) int64 {
 	return size
 }
 
-func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName) (err error) {
+func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status types.CloneStatus) (err error) {
 	rs := database.Repos(s.DB)
 	tx, err := rs.Transact(ctx)
 	if err != nil {
@@ -481,7 +481,7 @@ func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName) (err err
 		return err
 	}
 	gs := database.NewGitserverReposWith(rs)
-	return gs.SetCloneStatus(ctx, repo.ID, types.CloneStatusNotCloned)
+	return gs.SetCloneStatus(ctx, repo.ID, status)
 }
 
 // removeRepoDirectory atomically removes a directory from s.ReposDir.
@@ -510,7 +510,7 @@ func (s *Server) removeRepoDirectory(gitDir GitDir) error {
 
 	// Set as not_cloned in the database
 	if s.DB != nil {
-		err := s.setCloneStatus(ctx, s.name(gitDir))
+		err := s.setCloneStatus(ctx, s.name(gitDir), types.CloneStatusNotCloned)
 		if err != nil {
 			log15.Error("Setting clone status", "error", err)
 		}

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -493,13 +493,15 @@ func (s *Server) removeRepoDirectory(gitDir GitDir) error {
 	// should not be returned, just logged.
 
 	// Set as not_cloned in the database
-	repo, err := database.Repos(s.DB).GetByName(ctx, s.name(gitDir))
-	if err != nil {
-		log15.Error("Getting repo from db", "error", err)
-	} else {
-		err = database.GitserverRepos(s.DB).SetCloneStatus(ctx, repo.ID, types.CloneStatusNotCloned)
+	if s.DB != nil {
+		repo, err := database.Repos(s.DB).GetByName(ctx, s.name(gitDir))
 		if err != nil {
-			log15.Error("Setting clone status", "error", err)
+			log15.Error("Getting repo from db", "error", err)
+		} else {
+			err = database.GitserverRepos(s.DB).SetCloneStatus(ctx, repo.ID, types.CloneStatusNotCloned)
+			if err != nil {
+				log15.Error("Setting clone status", "error", err)
+			}
 		}
 	}
 

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -469,19 +469,17 @@ func dirSize(d string) int64 {
 }
 
 func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status types.CloneStatus) (err error) {
-	rs := database.Repos(s.DB)
-	tx, err := rs.Transact(ctx)
+	tx, err := database.Repos(s.DB).Transact(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { err = tx.Done(err) }()
 
-	repo, err := rs.GetByName(ctx, name)
+	repo, err := tx.GetByName(ctx, name)
 	if err != nil {
 		return err
 	}
-	gs := database.NewGitserverReposWith(rs)
-	return gs.SetCloneStatus(ctx, repo.ID, status)
+	return database.NewGitserverReposWith(tx).SetCloneStatus(ctx, repo.ID, status)
 }
 
 // removeRepoDirectory atomically removes a directory from s.ReposDir.

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -143,6 +143,9 @@ type Server struct {
 	// skipCloneForTests is set by tests to avoid clones.
 	skipCloneForTests bool
 
+	// shared db handle
+	DB dbutil.DB
+
 	// ctx is the context we use for all background jobs. It is done when the
 	// server is stopped. Do not directly call this, rather call
 	// Server.context()

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -159,3 +159,25 @@ WHERE repo_id = %s
 
 	return &gr, nil
 }
+
+func (s *GitserverRepoStore) SetCloneStatus(ctx context.Context, id api.RepoID, status types.CloneStatus) error {
+	q := `
+UPDATE gitserver_repos 
+SET clone_status = %s
+WHERE repo_id = %s
+`
+
+	result, err := s.ExecResult(ctx, sqlf.Sprintf(q, status, id))
+	if err != nil {
+		return errors.Wrap(err, "setting clone status")
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "checking affected rows")
+	}
+	if affected < 1 {
+		return errors.New("no rows updated")
+	}
+
+	return nil
+}

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -162,7 +162,7 @@ WHERE repo_id = %s
 
 func (s *GitserverRepoStore) SetCloneStatus(ctx context.Context, id api.RepoID, status types.CloneStatus) error {
 	q := `
-UPDATE gitserver_repos 
+UPDATE gitserver_repos
 SET clone_status = %s
 WHERE repo_id = %s
 `


### PR DESCRIPTION
Whenever we delete a repo, mark it as `not_cloned'