### PR TITLE
search: always copy stats.Repos

### DIFF
--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -45,16 +45,11 @@ func (c *Stats) Update(other *Stats) {
 	c.IsLimitHit = c.IsLimitHit || other.IsLimitHit
 	c.IsIndexUnavailable = c.IsIndexUnavailable || other.IsIndexUnavailable
 
-	if c.Repos == nil {
-		// PERF: use other's map assuming it will never be concurrently
-		// written/read to in the future. This is the sort of assumption that
-		// will break, but we are doing it for now since this map is very
-		// large.
-		c.Repos = other.Repos
-	} else {
-		for id, r := range other.Repos {
-			c.Repos[id] = r
-		}
+	if c.Repos == nil && len(other.Repos) > 0 {
+		c.Repos = make(map[api.RepoID]*types.RepoName, len(other.Repos))
+	}
+	for id, r := range other.Repos {
+		c.Repos[id] = r
 	}
 
 	c.Status.Union(&other.Status)


### PR DESCRIPTION
This removes a performance optimization we had around sharing the
underlying map for stats.Repos. We will follow-up with a way to avoid
the extra allocations this change introduces.

The optimization assumed we only created the c.Repos map once. However,
with and/or queries we call doResults per term. Each call to doResults
creates a new c.Repos. This is then aggregated, leading to writes to a
shared c.Repos. Concurrent writes to a map cause a panic.