### PR TITLE
Introduce licensing.BatchChanges (alias Campaigns to it)

### DIFF
--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -40,8 +40,9 @@ const (
 	// FeatureBranding is whether custom branding of this Sourcegraph instance has been purchased.
 	FeatureBranding Feature = "branding"
 
-	// DEPRECATED: See FeatureBatchChanges.
 	// FeatureCampaigns is whether campaigns (now: batch changes) on this Sourcegraph instance has been purchased.
+	//
+	// DEPRECATED: See FeatureBatchChanges.
 	FeatureCampaigns Feature = "campaigns"
 
 	// FeatureBatchChanges is whether Batch Changes on this Sourcegraph instance has been purchased.

--- a/enterprise/internal/licensing/data.go
+++ b/enterprise/internal/licensing/data.go
@@ -40,8 +40,12 @@ const (
 	// FeatureBranding is whether custom branding of this Sourcegraph instance has been purchased.
 	FeatureBranding Feature = "branding"
 
-	// FeatureCampaigns is whether campaigns on this Sourcegraph instance has been purchased.
+	// DEPRECATED: See FeatureBatchChanges.
+	// FeatureCampaigns is whether campaigns (now: batch changes) on this Sourcegraph instance has been purchased.
 	FeatureCampaigns Feature = "campaigns"
+
+	// FeatureBatchChanges is whether Batch Changes on this Sourcegraph instance has been purchased.
+	FeatureBatchChanges Feature = "batch-changes"
 
 	// FeatureMonitoring is whether monitoring on this Sourcegraph instance has been purchased.
 	FeatureMonitoring Feature = "monitoring"
@@ -60,6 +64,7 @@ var planFeatures = map[Plan][]Feature{
 		FeatureRemoteExtensionsAllowDisallow,
 		FeatureBranding,
 		FeatureCampaigns,
+		FeatureBatchChanges,
 		FeatureMonitoring,
 		FeatureBackupAndRestore,
 	},

--- a/enterprise/internal/licensing/features_test.go
+++ b/enterprise/internal/licensing/features_test.go
@@ -73,18 +73,23 @@ func TestCheckFeature(t *testing.T) {
 		check(t, FeatureBranding, license(plan(enterprise), string(FeatureBranding)), true)
 	})
 
-	t.Run(string(FeatureCampaigns), func(t *testing.T) {
-		check(t, FeatureCampaigns, nil, false)
+	testBatchChanges := func(feature Feature) func(*testing.T) {
+		return func(t *testing.T) {
+			check(t, feature, nil, false)
 
-		check(t, FeatureCampaigns, license("starter"), false)
-		check(t, FeatureCampaigns, license(plan(oldEnterpriseStarter)), false)
-		check(t, FeatureCampaigns, license(plan(oldEnterprise)), true)
-		check(t, FeatureCampaigns, license(), true)
+			check(t, feature, license("starter"), false)
+			check(t, feature, license(plan(oldEnterpriseStarter)), false)
+			check(t, feature, license(plan(oldEnterprise)), true)
+			check(t, feature, license(), true)
 
-		check(t, FeatureCampaigns, license(plan(team)), false)
-		check(t, FeatureCampaigns, license(plan(enterprise)), false)
-		check(t, FeatureCampaigns, license(plan(enterprise), string(FeatureCampaigns)), true)
-	})
+			check(t, feature, license(plan(team)), false)
+			check(t, feature, license(plan(enterprise)), false)
+			check(t, feature, license(plan(enterprise), string(feature)), true)
+		}
+	}
+	// FeatureCampaigns is deprecated but should behave like BatchChanges.
+	t.Run(string(FeatureCampaigns), testBatchChanges(FeatureCampaigns))
+	t.Run(string(FeatureBatchChanges), testBatchChanges(FeatureBatchChanges))
 
 	t.Run(string(FeatureMonitoring), func(t *testing.T) {
 		check(t, FeatureMonitoring, nil, false)

--- a/enterprise/internal/licensing/resolvers/resolvers_test.go
+++ b/enterprise/internal/licensing/resolvers/resolvers_test.go
@@ -39,14 +39,14 @@ func TestEnterpriseLicenseHasFeature(t *testing.T) {
 		wantErr bool
 	}{
 		"real feature, enabled": {
-			feature: string(licensing.FeatureCampaigns),
-			mock:    buildMock(licensing.FeatureCampaigns),
+			feature: string(licensing.FeatureBatchChanges),
+			mock:    buildMock(licensing.FeatureBatchChanges),
 			want:    true,
 			wantErr: false,
 		},
 		"real feature, disabled": {
 			feature: string(licensing.FeatureMonitoring),
-			mock:    buildMock(licensing.FeatureCampaigns),
+			mock:    buildMock(licensing.FeatureBatchChanges),
 			want:    false,
 			wantErr: false,
 		},


### PR DESCRIPTION
This introduces licensing.BatchChanges as a new licensing feature tag.

Since we're only deprecating the old tag, we'll fall back to check licensing.Campaigns.
