### PR TITLE
search: Use highlightedString for CommitSearchResult.Body

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -75,8 +75,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 			Commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
 			RepoName:    types.RepoName{ID: 1, Name: "repo"},
 			DiffPreview: &highlightedString{value: "x", highlights: []*highlightedRange{}},
-			Body:        "```diff\nx```",
-			Highlights:  []*highlightedRange{},
+			Body:        highlightedString{value: "```diff\nx```", highlights: []*highlightedRange{}},
 		},
 	}}
 
@@ -316,7 +315,9 @@ func searchCommitsInRepo(ctx context.Context, db dbutil.DB, op search.CommitPara
 func TestCommitSearchResult_Limit(t *testing.T) {
 	f := func(nHighlights []int, limitInput uint32) bool {
 		cr := &CommitSearchResult{
-			Highlights: make([]*highlightedRange, len(nHighlights)),
+			Body: highlightedString{
+				highlights: make([]*highlightedRange, len(nHighlights)),
+			},
 		}
 
 		// It isn't interesting to test limit > ResultCount, so we bound it to


### PR DESCRIPTION
The type `highlightedString` is used elsewhere in CommitSearchResult,
but not for Body and Highlights. This helps to simplify the interface
for CommitSearchResult.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
