### PR TITLE
Enable varcheck lint

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -13,6 +13,7 @@ linters:
     - unconvert
     - goimports
     - gosimple
+    - varcheck
 
 run:
   timeout: 5m

--- a/docker-images/prometheus/cmd/prom-wrapper/status.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/status.go
@@ -17,8 +17,6 @@ import (
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
 )
 
-const statusReporterPathPrefix = "/prom-wrapper/alerts-status"
-
 // AlertsStatusReporter summarizes alert activity from Alertmanager
 type AlertsStatusReporter struct {
 	log          log15.Logger

--- a/enterprise/internal/codemonitors/action_emails.go
+++ b/enterprise/internal/codemonitors/action_emails.go
@@ -199,12 +199,6 @@ func deleteActionsEmailQuery(ctx context.Context, actionIDs []int64, monitorID i
 	), nil
 }
 
-const getAllEmailActionsForTriggerQueryIDInt64FmtStr = `
-SELECT e.id, e.monitor, e.enabled, e.priority, e.header, e.created_by, e.created_at, e.changed_by, e.changed_at
-FROM cm_emails e INNER JOIN cm_queries q ON e.monitor = q.monitor
-WHERE q.id = %s
-`
-
 var EmailsColumns = []*sqlf.Query{
 	sqlf.Sprintf("cm_emails.id"),
 	sqlf.Sprintf("cm_emails.monitor"),

--- a/internal/cmd/precise-code-intel-tester/main.go
+++ b/internal/cmd/precise-code-intel-tester/main.go
@@ -7,18 +7,11 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
 
-var client *gqltestutil.Client
-
 var (
-	endpoint    = env.Get("SOURCEGRAPH_BASE_URL", "http://127.0.0.1:3080", "Sourcegraph frontend endpoint")
-	token       = env.Get("SOURCEGRAPH_SUDO_TOKEN", "", "Access token")
-	githubToken = env.Get("GITHUB_TOKEN", "", "The GitHub personal access token that will be used to authenticate a GitHub external service")
-	email       = "test@sourcegraph.com"
-	username    = "admin"
-	password    = "supersecurepassword"
+	endpoint = env.Get("SOURCEGRAPH_BASE_URL", "http://127.0.0.1:3080", "Sourcegraph frontend endpoint")
+	token    = env.Get("SOURCEGRAPH_SUDO_TOKEN", "", "Access token")
 
 	// Flags
 	indexDir                    string

--- a/internal/trace/ot/ot.go
+++ b/internal/trace/ot/ot.go
@@ -84,7 +84,7 @@ func requestWantsTracing(r *http.Request) bool {
 	}
 	// PERF: Avoid parsing RawQuery if "trace=" is not present
 	if strings.Contains(r.URL.RawQuery, "trace=") {
-		v := r.URL.Query().Get("trace")
+		v := r.URL.Query().Get(traceQuery)
 		b, _ := strconv.ParseBool(v)
 		return b
 	}


### PR DESCRIPTION
Fixes the handful of lint warnings, and enables the `varcheck` lint as one of our enforced lints. 

Progresses #18720 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
