### PR TITLE
Fix and enforce gosimple linter

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -12,6 +12,7 @@ linters:
     - nolintlint
     - unconvert
     - goimports
+    - gosimple
 
 run:
   timeout: 5m

--- a/enterprise/cmd/executor/internal/command/logger.go
+++ b/enterprise/cmd/executor/internal/command/logger.go
@@ -34,10 +34,7 @@ func (l *Logger) Log(entry workerutil.ExecutionLogEntry) {
 
 // Entries returns a copy of the stored log entries.
 func (l *Logger) Entries() (entries []workerutil.ExecutionLogEntry) {
-	for _, entry := range l.entries {
-		entries = append(entries, entry)
-	}
-
+	entries = append(entries, l.entries...)
 	return entries
 }
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -63,7 +63,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 		metrics.WithCountHelp("Total number of insights historical enqueuer executions"),
 	)
 	operation := observationContext.Operation(observation.Op{
-		Name:    fmt.Sprintf("HistoricalEnqueuer.Run"),
+		Name:    "HistoricalEnqueuer.Run",
 		Metrics: metrics,
 	})
 

--- a/enterprise/internal/insights/background/insight_enqueuer.go
+++ b/enterprise/internal/insights/background/insight_enqueuer.go
@@ -2,7 +2,6 @@ package background
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -28,7 +27,7 @@ func newInsightEnqueuer(ctx context.Context, workerBaseStore *basestore.Store, s
 		metrics.WithCountHelp("Total number of insights enqueuer executions"),
 	)
 	operation := observationContext.Operation(observation.Op{
-		Name:    fmt.Sprintf("Enqueuer.Run"),
+		Name:    "Enqueuer.Run",
 		Metrics: metrics,
 	})
 

--- a/internal/batches/changeset.go
+++ b/internal/batches/changeset.go
@@ -457,7 +457,7 @@ func (c *Changeset) URL() (s string, err error) {
 
 // Events returns the deduplicated list of ChangesetEvents from the Changeset's metadata.
 func (c *Changeset) Events() (events []*ChangesetEvent) {
-	uniqueEvents := make(map[string]struct{}, 0)
+	uniqueEvents := make(map[string]struct{})
 
 	appendEvent := func(e *ChangesetEvent) {
 		k := string(e.Kind) + e.Key

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -843,7 +843,7 @@ func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.Code
 		)
 	}()
 	out := make([]types.CodeHostRepository, 0, len(repos))
-	for done == false {
+	for !done {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("context canceled")

--- a/internal/search/filter/select_symbol.go
+++ b/internal/search/filter/select_symbol.go
@@ -87,9 +87,6 @@ func pick(symbols []*result.SymbolMatch, satisfy func(*result.SymbolMatch) bool)
 
 func SelectSymbolKind(symbols []*result.SymbolMatch, field string) []*result.SymbolMatch {
 	return pick(symbols, func(s *result.SymbolMatch) bool {
-		if field == toSelectKind[strings.ToLower(s.Symbol.Kind)] {
-			return true
-		}
-		return false
+		return field == toSelectKind[strings.ToLower(s.Symbol.Kind)]
 	})
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -24,8 +24,7 @@ func SubstituteAliases(searchType SearchType) func(nodes []Node) []Node {
 		"msg":      FieldMessage,
 		"revision": FieldRev,
 	}
-	var mapper func(nodes []Node) []Node
-	mapper = func(nodes []Node) []Node {
+	mapper := func(nodes []Node) []Node {
 		return MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
 			if field == "content" {
 				if searchType == SearchTypeRegex {


### PR DESCRIPTION
Fixes the handful of `gosimple` warnings, and adds it to the list of enforced lints.

Progress #18720 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
