### PR TITLE
search: Move CommitSearchResult to internal/search/result

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -29,43 +29,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
-type CommitSearchResult struct {
-	Commit         git.Commit
-	RepoName       types.RepoName
-	Refs           []string
-	SourceRefs     []string
-	MessagePreview *result.HighlightedString
-	DiffPreview    *result.HighlightedString
-	Body           result.HighlightedString
-}
-
-// ResultCount for CommitSearchResult returns the number of highlights if there
-// are highlights and 1 otherwise. We implemented this method because we want to
-// return a more meaningful result count for streaming while maintaining backward
-// compatibility for our GraphQL API. The GraphQL API calls ResultCount on the
-// resolver, while streaming calls ResultCount on CommitSearchResult.
-func (r *CommitSearchResult) ResultCount() int {
-	if n := len(r.Body.Highlights); n > 0 {
-		return n
-	}
-	// Queries such as type:commit after:"1 week ago" don't have highlights. We count
-	// those results as 1.
-	return 1
-}
-
-func (r *CommitSearchResult) Limit(limit int) int {
-	if len(r.Body.Highlights) == 0 {
-		return limit - 1 // just counting the commit
-	} else if len(r.Body.Highlights) > limit {
-		r.Body.Highlights = r.Body.Highlights[:limit]
-		return 0
-	}
-	return limit - len(r.Body.Highlights)
-}
-
 // CommitSearchResultResolver is a resolver for the GraphQL type `CommitSearchResult`
 type CommitSearchResultResolver struct {
-	CommitSearchResult
+	result.CommitSearchResult
 
 	db dbutil.DB
 
@@ -463,7 +429,7 @@ func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *se
 
 		results[i] = &CommitSearchResultResolver{
 			db: db,
-			CommitSearchResult: CommitSearchResult{
+			CommitSearchResult: result.CommitSearchResult{
 				Commit:         rawResult.Commit,
 				Refs:           rawResult.Refs,
 				SourceRefs:     rawResult.SourceRefs,

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -72,7 +72,7 @@ func TestSearchCommitsInRepo(t *testing.T) {
 
 	want := []*CommitSearchResultResolver{{
 		db: db,
-		CommitSearchResult: CommitSearchResult{
+		CommitSearchResult: result.CommitSearchResult{
 			Commit:      git.Commit{ID: "c1", Author: gitSignatureWithDate},
 			RepoName:    types.RepoName{ID: 1, Name: "repo"},
 			DiffPreview: &result.HighlightedString{Value: "x", Highlights: []result.HighlightedRange{}},
@@ -315,7 +315,7 @@ func searchCommitsInRepo(ctx context.Context, db dbutil.DB, op search.CommitPara
 
 func TestCommitSearchResult_Limit(t *testing.T) {
 	f := func(nHighlights []int, limitInput uint32) bool {
-		cr := &CommitSearchResult{
+		cr := &result.CommitSearchResult{
 			Body: result.HighlightedString{
 				Highlights: make([]result.HighlightedRange, len(nHighlights)),
 			},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1426,7 +1426,7 @@ func commitResult(urlKey string) *CommitSearchResultResolver {
 
 func diffResult(urlKey string) *CommitSearchResultResolver {
 	return &CommitSearchResultResolver{
-		CommitSearchResult: CommitSearchResult{
+		CommitSearchResult: result.CommitSearchResult{
 			DiffPreview: &result.HighlightedString{},
 		},
 		gitCommitResolver: &GitCommitResolver{

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -1,0 +1,40 @@
+package result
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+type CommitSearchResult struct {
+	Commit         git.Commit
+	RepoName       types.RepoName
+	Refs           []string
+	SourceRefs     []string
+	MessagePreview *HighlightedString
+	DiffPreview    *HighlightedString
+	Body           HighlightedString
+}
+
+// ResultCount for CommitSearchResult returns the number of highlights if there
+// are highlights and 1 otherwise. We implemented this method because we want to
+// return a more meaningful result count for streaming while maintaining backward
+// compatibility for our GraphQL API. The GraphQL API calls ResultCount on the
+// resolver, while streaming calls ResultCount on CommitSearchResult.
+func (r *CommitSearchResult) ResultCount() int {
+	if n := len(r.Body.Highlights); n > 0 {
+		return n
+	}
+	// Queries such as type:commit after:"1 week ago" don't have highlights. We count
+	// those results as 1.
+	return 1
+}
+
+func (r *CommitSearchResult) Limit(limit int) int {
+	if len(r.Body.Highlights) == 0 {
+		return limit - 1 // just counting the commit
+	} else if len(r.Body.Highlights) > limit {
+		r.Body.Highlights = r.Body.Highlights[:limit]
+		return 0
+	}
+	return limit - len(r.Body.Highlights)
+}


### PR DESCRIPTION
Progress #18348 
Depends on #18995 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
