### PR TITLE
ci: push new set of tags for internal dev images

### DIFF
--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -115,6 +115,15 @@ func ComputeConfig() Config {
 	}
 }
 
+func (c Config) shortCommit() string {
+	// http://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#Short-SHA-1
+	if len(c.commit) < 12 {
+		return c.commit
+	}
+
+	return c.commit[:12]
+}
+
 func (c Config) ensureCommit() error {
 	if len(c.mustIncludeCommit) == 0 {
 		return nil

--- a/enterprise/dev/ci/ci/helpers.go
+++ b/enterprise/dev/ci/ci/helpers.go
@@ -17,10 +17,11 @@ import (
 // Config is the set of configuration parameters that determine the structure of the CI build. These
 // parameters are extracted from the build environment (branch name, commit hash, timestamp, etc.)
 type Config struct {
-	now     time.Time
-	branch  string
-	version string
-	commit  string
+	now         time.Time
+	branch      string
+	version     string
+	commit      string
+	buildNumber int
 
 	// mustIncludeCommit, if non-empty, is a list of commits at least one of which must be present
 	// in the branch. If empty, then no check is enforced.
@@ -53,6 +54,7 @@ func ComputeConfig() Config {
 	if commit == "" {
 		commit = "1234567890123456789012345678901234567890" // for testing
 	}
+	buildNumber, _ := strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))
 
 	taggedRelease := true // true if this is a tagged release
 	switch {
@@ -61,8 +63,7 @@ func ComputeConfig() Config {
 		version = strings.TrimPrefix(version, "v")
 	default:
 		taggedRelease = false
-		buildNum, _ := strconv.Atoi(os.Getenv("BUILDKITE_BUILD_NUMBER"))
-		version = fmt.Sprintf("%05d_%s_%.7s", buildNum, now.Format("2006-01-02"), commit)
+		version = fmt.Sprintf("%05d_%s_%.7s", buildNumber, now.Format("2006-01-02"), commit)
 	}
 
 	patchNoTest := strings.HasPrefix(branch, "docker-images-patch-notest/")
@@ -99,6 +100,7 @@ func ComputeConfig() Config {
 		commit:            commit,
 		mustIncludeCommit: mustIncludeCommits,
 		changedFiles:      changedFiles,
+		buildNumber:       buildNumber,
 
 		taggedRelease:       taggedRelease,
 		releaseBranch:       lazyregexp.New(`^[0-9]+\.[0-9]+$`).MatchString(branch),

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -433,7 +433,10 @@ func addFinalDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline)
 		for _, tag := range []string{
 			c.version,
 			c.commit,
-			fmt.Sprintf("%s_%s", c.commit, strconv.Itoa(c.buildNumber)),
+			c.shortCommit(),
+			fmt.Sprintf("%s_%s_%d", c.shortCommit(), c.now.Format("2006-01-02"), c.buildNumber),
+			fmt.Sprintf("%s_%d", c.shortCommit(), c.buildNumber),
+			fmt.Sprintf("%s_%d", c.commit, c.buildNumber),
 			strconv.Itoa(c.buildNumber),
 		} {
 			internalImage := fmt.Sprintf("%s:%s", devImage, tag)

--- a/enterprise/dev/ci/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/ci/pipeline-steps.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/dev/ci/images"
@@ -425,6 +426,18 @@ func addFinalDockerImage(c Config, app string, insiders bool) func(*bk.Pipeline)
 			if insiders {
 				images = append(images, fmt.Sprintf("%s:insiders", image))
 			}
+		}
+
+		// these tags are pushed to our dev registry, and are only
+		// used internally
+		for _, tag := range []string{
+			c.version,
+			c.commit,
+			fmt.Sprintf("%s_%s", c.commit, strconv.Itoa(c.buildNumber)),
+			strconv.Itoa(c.buildNumber),
+		} {
+			internalImage := fmt.Sprintf("%s:%s", devImage, tag)
+			images = append(images, internalImage)
 		}
 
 		candidateImage := fmt.Sprintf("%s:%s", devImage, c.candidateImageTag())


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/18585

After this change, the following additional image tags should be pushed to `us.gcr.io`:

- `${SHORT_SHA}_${DATE}_${BUILD_NUMBER}` (this is what `c.version` is comprised of)
- `${FULL_SHA}_${BUILD_NUMBER}`
- `${BUILD_NUMBER}`

...

- `${FULL_SHA}` - **Note**: this tag can get overwritten since the same commit can be built multiple times via different buildkite agents)

Note that all tags besides `${FULL_SHA}` should will only get pushed to once (since the buildktie build number serves as a unique identifier). 