### PR TITLE
codeintel: More intelligently read from result chunks

### DIFF
--- a/enterprise/internal/codeintel/stores/lsifstore/locations.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/locations.go
@@ -96,11 +96,10 @@ func (s *Store) locations(ctx context.Context, bundleID int, ids []semantic.ID, 
 	}
 	traceLog(log.Int("totalCount", totalCount))
 
-	// Filter out all data in rangeIDsByResultID that falls outside of the current page
-	rangeIDsByResultID = limitResultMap(ids, rangeIDsByResultID, limit, offset)
-
-	// Gather the set of paths for documents we need to fetch from the limited map
-	paths := pathsFromResultMap(rangeIDsByResultID)
+	// Filter out all data in rangeIDsByResultID that falls outside of the current page. This
+	// also returns the set of paths for documents we will need to fetch to resolve the results
+	// of the current page.
+	rangeIDsByResultID, paths := limitResultMap(ids, rangeIDsByResultID, limit, offset)
 	traceLog(
 		log.Int("numPaths", len(paths)),
 		log.String("paths", strings.Join(paths, ", ")),
@@ -116,24 +115,21 @@ func (s *Store) locations(ctx context.Context, bundleID int, ids []semantic.ID, 
 	return locationsByResultID, totalCount, nil
 }
 
-// limitResultMap returns a map symmetric to the given rangeIDsByResultID including only the location results
-// the current page specified by limit and offset.
-//
-// TODO - more here
-func limitResultMap(ids []semantic.ID, rangeIDsByResultID map[semantic.ID]map[string][]semantic.ID, limit, offset int) map[semantic.ID]map[string][]semantic.ID {
-	pathMap := map[string]struct{}{}
-	for _, m := range rangeIDsByResultID {
-		for path := range m {
-			pathMap[path] = struct{}{}
-		}
-	}
-	paths := make([]string, 0, len(pathMap))
-	for path := range pathMap {
-		paths = append(paths, path)
-	}
-	sort.Strings(paths)
-
+// limitResultMap returns a map symmetric to the given rangeIDsByResultID that includes only the
+// location results on the current page specified by limit and offset, as well as a deduplicated
+// and sorted list of paths that exist in the second-level of the returned map.
+func limitResultMap(ids []semantic.ID, rangeIDsByResultID map[semantic.ID]map[string][]semantic.ID, limit, offset int) (limited map[semantic.ID]map[string][]semantic.ID, referencedPaths []string) {
 	limitedRangeIDsByResultID := make(map[semantic.ID]map[string][]semantic.ID, len(rangeIDsByResultID))
+
+	// Get a deduplicated and ordered set of paths that exist in the second-level of the given
+	// map. Iterating by sorted path names here tends to require fewer documents being opened
+	// per page. Alternatively, iterating by result identifier (which we had done previously)
+	// can make us open the same document on multiple disjoint pages in the result set.
+	paths := pathsFromResultMap(rangeIDsByResultID)
+
+	// We append paths to the following (re-used) slice whenever we add a previously unseen
+	// path to the second-level of the returned map.
+	filteredPaths := paths[:0]
 
 outer:
 	for _, path := range paths {
@@ -165,16 +161,24 @@ outer:
 				limit -= len(rangeIDs)
 			}
 
+			// Assign adjusted slice of ranges into map
 			rangeIDsByDocument[path] = rangeIDs
 
+			// If we haven't added this path added it to the filtered path set. Since
+			// our _outer_ iteration is paths, if it exists in the set it will be the
+			// most recent element (inserted when processing same path, previous id).
+			if len(filteredPaths) == 0 || filteredPaths[len(filteredPaths)-1] != path {
+				filteredPaths = append(filteredPaths, path)
+			}
+
 			if limit == 0 {
-				// Hit end of page
+				// Page cannot fit any more results
 				break outer
 			}
 		}
 	}
 
-	return limitedRangeIDsByResultID
+	return limitedRangeIDsByResultID, filteredPaths
 }
 
 // pathsFromResultMap returns a deduplicated and sorted set of document paths present in the given map.


### PR DESCRIPTION
We take the following steps to resolve locations from a set of result ids for a particular index:

1. For each id, find the result chunk index in which it's stored.
1. Deduplicate the set of indexes such that we keep the order of the _first_ occurrence of each index.
1. Open up all result chunks whose id is in this set; do this in batches and look up the ID in each result chunk; construct a mapping of result id -> document path -> range ids.
1. Iterate the map and remove the first `$offset` results and keep the next `$limit` results (_by some order_).
1. Gather and deduplicate the document paths from this map.
1. In batches, load a set of documents and resolve each range id to an actual extent within the document.

**Note**: (_by some order_) used to mean by result id _in the order they were given_, then by paths ordered lexicographically. This caused us on each page to return a random smattering of document ids to open.

This PR changes that order to be _by path lexicographically_, then by result id. This causes us to open fewer documents per page and open the same document fewer times in the same result set. Fixes https://github.com/sourcegraph/sourcegraph/issues/18620.