### PR TITLE
client/web: when tracing a query, add a link to the trace

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -222,6 +222,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                                 state={results?.state || 'loading'}
                                 history={props.history}
                                 onSearchAgain={onSearchAgain}
+                                showTrace={!!trace}
                             />
                         }
                     />

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.story.tsx
@@ -38,6 +38,29 @@ add('0 results, in progress', () => {
     )
 })
 
+add('0 results, in progress, traced', () => {
+    const progress: Progress = {
+        durationMs: 0,
+        matchCount: 0,
+        skipped: [],
+        trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
+    }
+
+    return (
+        <WebStory>
+            {() => (
+                <StreamingProgress
+                    progress={progress}
+                    state="loading"
+                    onSearchAgain={onSearchAgain}
+                    history={history}
+                    showTrace={true}
+                />
+            )}
+        </WebStory>
+    )
+})
+
 add('1 result from 1 repository, in progress', () => {
     const progress: Progress = {
         durationMs: 500,
@@ -76,6 +99,30 @@ add('big numbers, done', () => {
                     state="complete"
                     onSearchAgain={onSearchAgain}
                     history={history}
+                />
+            )}
+        </WebStory>
+    )
+})
+
+add('big numbers, done, traced', () => {
+    const progress: Progress = {
+        durationMs: 52500,
+        matchCount: 1234567,
+        repositoriesCount: 8901,
+        skipped: [],
+        trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
+    }
+
+    return (
+        <WebStory>
+            {() => (
+                <StreamingProgress
+                    progress={progress}
+                    state="complete"
+                    onSearchAgain={onSearchAgain}
+                    history={history}
+                    showTrace={true}
                 />
             )}
         </WebStory>

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.tsx
@@ -8,6 +8,7 @@ export interface StreamingProgressProps {
     state: StreamingResultsState
     progress: Progress
     history: H.History
+    showTrace?: boolean
     onSearchAgain: (additionalFilters: string[]) => void
 }
 

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -75,4 +75,15 @@ describe('StreamingProgressCount', () => {
 
         expect(mount(<StreamingProgressCount state="complete" progress={progress} />)).toMatchSnapshot()
     })
+
+    it('should render correctly when a trace url is provided', () => {
+        const progress: Progress = {
+            durationMs: 0,
+            matchCount: 0,
+            skipped: [],
+            trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
+        }
+
+        expect(mount(<StreamingProgressCount state="loading" progress={progress} />)).toMatchSnapshot()
+    })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -84,6 +84,16 @@ describe('StreamingProgressCount', () => {
             trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
         }
 
+        expect(mount(<StreamingProgressCount state="loading" progress={progress} showTrace={true} />)).toMatchSnapshot()
+    })
+    it('should not render a trace link when not opted into with &trace=1', () => {
+        const progress: Progress = {
+            durationMs: 0,
+            matchCount: 0,
+            skipped: [],
+            trace: 'https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg',
+        }
+
         expect(mount(<StreamingProgressCount state="loading" progress={progress} />)).toMatchSnapshot()
     })
 })

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.test.tsx
@@ -86,6 +86,7 @@ describe('StreamingProgressCount', () => {
 
         expect(mount(<StreamingProgressCount state="loading" progress={progress} showTrace={true} />)).toMatchSnapshot()
     })
+
     it('should not render a trace link when not opted into with &trace=1', () => {
         const progress: Progress = {
             durationMs: 0,

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -1,5 +1,6 @@
 import classNames from 'classnames'
 import CalculatorIcon from 'mdi-react/CalculatorIcon'
+import ClipboardPulseOutlineIcon from 'mdi-react/ClipboardPulseOutlineIcon'
 import * as React from 'react'
 import { pluralize } from '../../../../../../shared/src/util/strings'
 import { Progress } from '../../../stream'
@@ -23,21 +24,31 @@ const limitHit = (progress: Progress): boolean => progress.skipped.some(skipped 
 export const StreamingProgressCount: React.FunctionComponent<
     Pick<StreamingProgressProps, 'progress' | 'state'> & { className?: string }
 > = ({ progress, state, className = '' }) => (
-    <div
-        className={classNames(className, 'streaming-progress__count d-flex align-items-center', {
-            'streaming-progress__count--in-progress': state === 'loading',
-        })}
-    >
-        <CalculatorIcon className="mr-2 icon-inline" />
-        {abbreviateNumber(progress.matchCount)}
-        {limitHit(progress) ? '+' : ''} {pluralize('result', progress.matchCount)} in{' '}
-        {(progress.durationMs / 1000).toFixed(2)}s
-        {progress.repositoriesCount !== undefined && (
-            <>
-                {' '}
-                from {abbreviateNumber(progress.repositoriesCount)}{' '}
-                {pluralize('repository', progress.repositoriesCount, 'repositories')}
-            </>
+    <>
+        <div
+            className={classNames(className, 'streaming-progress__count d-flex align-items-center', {
+                'streaming-progress__count--in-progress': state === 'loading',
+            })}
+        >
+            <CalculatorIcon className="mr-2 icon-inline" />
+            {abbreviateNumber(progress.matchCount)}
+            {limitHit(progress) ? '+' : ''} {pluralize('result', progress.matchCount)} in{' '}
+            {(progress.durationMs / 1000).toFixed(2)}s
+            {progress.repositoriesCount !== undefined && (
+                <>
+                    {' '}
+                    from {abbreviateNumber(progress.repositoriesCount)}{' '}
+                    {pluralize('repository', progress.repositoriesCount, 'repositories')}
+                </>
+            )}
+        </div>
+        {progress.trace && (
+            <div className="d-flex">
+                <a href={progress.trace}>
+                    <ClipboardPulseOutlineIcon className="mr-2 icon-inline" />
+                    View trace
+                </a>
+            </div>
         )}
-    </div>
+    </>
 )

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -22,8 +22,8 @@ const abbreviateNumber = (number: number): string => {
 const limitHit = (progress: Progress): boolean => progress.skipped.some(skipped => skipped.reason.indexOf('-limit') > 0)
 
 export const StreamingProgressCount: React.FunctionComponent<
-    Pick<StreamingProgressProps, 'progress' | 'state'> & { className?: string }
-> = ({ progress, state, className = '' }) => (
+    Pick<StreamingProgressProps, 'progress' | 'state' | 'showTrace'> & { className?: string }
+> = ({ progress, state, showTrace, className = '' }) => (
     <>
         <div
             className={classNames(className, 'streaming-progress__count d-flex align-items-center', {
@@ -42,7 +42,7 @@ export const StreamingProgressCount: React.FunctionComponent<
                 </>
             )}
         </div>
-        {progress.trace && (
+        {showTrace && progress.trace && (
             <div className="d-flex">
                 <a href={progress.trace}>
                     <ClipboardPulseOutlineIcon className="mr-2 icon-inline" />

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -205,3 +205,44 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
   </div>
 </StreamingProgressCount>
 `;
+
+exports[`StreamingProgressCount should render correctly when a trace url is provided 1`] = `
+<StreamingProgressCount
+  progress={
+    Object {
+      "durationMs": 0,
+      "matchCount": 0,
+      "skipped": Array [],
+      "trace": "https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg",
+    }
+  }
+  state="loading"
+>
+  <div
+    className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
+  >
+    <Memo(CalculatorIcon)
+      className="mr-2 icon-inline"
+    />
+    0
+     
+    results
+     in
+     
+    0.00
+    s
+  </div>
+  <div
+    className="d-flex"
+  >
+    <a
+      href="https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg"
+    >
+      <Memo(ClipboardPulseOutlineIcon)
+        className="mr-2 icon-inline"
+      />
+      View trace
+    </a>
+  </div>
+</StreamingProgressCount>
+`;

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StreamingProgressCount should not render a trace link when not opted into with &trace=1 1`] = `
+<StreamingProgressCount
+  progress={
+    Object {
+      "durationMs": 0,
+      "matchCount": 0,
+      "skipped": Array [],
+      "trace": "https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg",
+    }
+  }
+  state="loading"
+>
+  <div
+    className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
+  >
+    <Memo(CalculatorIcon)
+      className="mr-2 icon-inline"
+    />
+    0
+     
+    results
+     in
+     
+    0.00
+    s
+  </div>
+</StreamingProgressCount>
+`;
+
 exports[`StreamingProgressCount should render correctly for 0 items in progress 1`] = `
 <StreamingProgressCount
   progress={
@@ -216,6 +245,7 @@ exports[`StreamingProgressCount should render correctly when a trace url is prov
       "trace": "https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg",
     }
   }
+  showTrace={true}
   state="loading"
 >
   <div

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -103,6 +103,9 @@ export interface Progress {
      * may appear anywhere in the list.
      */
     skipped: Skipped[]
+
+    // The URL of the trace for this query, if it exists.
+    trace?: string
 }
 
 export interface Skipped {

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -16,6 +16,7 @@ type progressAggregator struct {
 	MatchCount int
 	Stats      streaming.Stats
 	Limit      int
+	Trace      string // may be enmpty
 
 	// Dirty is true if p has changed since the last call to Current.
 	Dirty bool
@@ -58,6 +59,7 @@ func (p *progressAggregator) currentStats() api.ProgressStats {
 		Cloning:             getNames(p.Stats, searchshared.RepoStatusCloning),
 		LimitHit:            p.Stats.IsLimitHit,
 		SuggestedLimit:      suggestedLimit,
+		Trace:               p.Trace,
 	}
 }
 

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -21,6 +21,7 @@ func BuildProgressEvent(stats ProgressStats) Progress {
 		MatchCount:        stats.MatchCount,
 		DurationMs:        stats.ElapsedMilliseconds,
 		Skipped:           skipped,
+		Trace:             stats.Trace,
 	}
 }
 
@@ -43,6 +44,8 @@ type ProgressStats struct {
 
 	// SuggestedLimit is what to suggest to the user for count if needed.
 	SuggestedLimit int
+
+	Trace string // only filled if requested
 }
 
 func skippedReposHandler(repos []Namer, titleVerb, messageReason string, base Skipped) (Skipped, bool) {

--- a/internal/search/streaming/api/progress_test.go
+++ b/internal/search/streaming/api/progress_test.go
@@ -44,6 +44,9 @@ func TestSearchProgress(t *testing.T) {
 			LimitHit:            true,
 			SuggestedLimit:      1000,
 		},
+		"traced": {
+			Trace: "abcd",
+		},
 	}
 
 	for name, c := range cases {

--- a/internal/search/streaming/api/testdata/golden/TestSearchProgress/traced.json
+++ b/internal/search/streaming/api/testdata/golden/TestSearchProgress/traced.json
@@ -1,0 +1,7 @@
+{
+  "done": false,
+  "matchCount": 0,
+  "durationMs": 0,
+  "skipped": [],
+  "trace": "abcd"
+ }

--- a/internal/search/streaming/api/types.go
+++ b/internal/search/streaming/api/types.go
@@ -22,6 +22,9 @@ type Progress struct {
 	// same.  However, within a search stream when a new skipped reason is
 	// found, it may appear anywhere in the list.
 	Skipped []Skipped `json:"skipped"`
+
+	// Trace is the URL of an associated trace if the query is logging one.
+	Trace string `json:"trace,omitempty"`
 }
 
 // Skipped is a description of shards or documents that were skipped.


### PR DESCRIPTION
This only works for streaming queries. The trace URL is passed along in
the streaming query's progress event because the DOM EventSource API
doesn't support reading response headers for the X-Trace option. As a
benefit, being part of the normal data pipeline results in cleaner code.

The new "View Trace" link is just to the right of the query progress summary:
![image](https://user-images.githubusercontent.com/211868/110572860-7b6e7700-8117-11eb-8c25-73bcb23e59b8.png)
