### PR TITLE
Fix Badge casing for extensions list

### DIFF
--- a/client/web/src/extensions/extension/ExtensionStatusBadge.tsx
+++ b/client/web/src/extensions/extension/ExtensionStatusBadge.tsx
@@ -14,5 +14,6 @@ export const ExtensionStatusBadge: React.FunctionComponent<{ viewerCanAdminister
                 ? 'Remove "WIP" from the title when this extension is ready for use.'
                 : 'Work in progress (not ready for use)'
         }
+        className="text-uppercase"
     />
 )


### PR DESCRIPTION
This is a recent regression as the Badges were changed to default to `capitalized` instead of `uppercase`. This just fixes the badge casing for this variant.

Before:
![image](https://user-images.githubusercontent.com/9516420/110604888-7bef2800-8180-11eb-8bb5-a1123c0cda56.png)

After:
![image](https://user-images.githubusercontent.com/9516420/110604973-8f01f800-8180-11eb-8cb2-2b24ca7da25d.png)
