### PR TITLE
Ensure that deprecated campaigns.* site-config settings still work

### DIFF
--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -220,6 +220,12 @@ func SearchIndexEnabled() bool {
 }
 
 func BatchChangesEnabled() bool {
+	// TODO(campaigns-deprecation): This check can be removed once we remove
+	// the deprecated site-config settings.
+	if deprecated := Get().CampaignsEnabled; deprecated != nil {
+		return *deprecated
+	}
+
 	if enabled := Get().BatchChangesEnabled; enabled != nil {
 		return *enabled
 	}
@@ -227,6 +233,12 @@ func BatchChangesEnabled() bool {
 }
 
 func BatchChangesRestrictedToAdmins() bool {
+	// TODO(campaigns-deprecation): This check can be removed once we remove
+	// the deprecated site-config settings.
+	if deprecated := Get().CampaignsRestrictToAdmins; deprecated != nil {
+		return *deprecated
+	}
+
 	if restricted := Get().BatchChangesRestrictToAdmins; restricted != nil {
 		return *restricted
 	}


### PR DESCRIPTION
Follow-up to the last PR in which I deprecated the `campaigns.*` site-settings. This makes sure that they still have an effect.