### PR TITLE
gitserver: Set clone status after attempting to clone repo

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -140,7 +140,7 @@ func main() {
 
 	go debugserver.Start()
 	go gitserver.Janitor(janitorInterval)
-	go gitserver.SyncRepoState(db, syncRepoStateInterval, syncRepoStateBatchSize, syncRepoStateUpsertPerSecond)
+	go gitserver.SyncRepoState(syncRepoStateInterval, syncRepoStateBatchSize, syncRepoStateUpsertPerSecond)
 
 	port := "3178"
 	host := ""

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -39,7 +39,7 @@ var (
 	reposDir                     = env.Get("SRC_REPOS_DIR", "/data/repos", "Root dir containing repos.")
 	wantPctFree                  = env.MustGetInt("SRC_REPOS_DESIRED_PERCENT_FREE", 10, "Target percentage of free space on disk.")
 	janitorInterval              = env.MustGetDuration("SRC_REPOS_JANITOR_INTERVAL", 1*time.Minute, "Interval between cleanup runs")
-	syncRepoStateInterval        = env.MustGetDuration("SRC_REPOS_SYNC_STATE_INTERVAL", 5*time.Minute, "Interval between state syncs")
+	syncRepoStateInterval        = env.MustGetDuration("SRC_REPOS_SYNC_STATE_INTERVAL", 10*time.Minute, "Interval between state syncs")
 	syncRepoStateBatchSize       = env.MustGetInt("SRC_REPOS_SYNC_STATE_BATCH_SIZE", 500, "Number of upserts to perform per batch")
 	syncRepoStateUpsertPerSecond = env.MustGetInt("SRC_REPOS_SYNC_STATE_UPSERT_PER_SEC", 500, "The number of upserted rows allowed per second across all gitserver instances")
 	envHostname                  = env.Get("HOSTNAME", "", "Hostname override")

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -469,6 +469,9 @@ func dirSize(d string) int64 {
 }
 
 func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status types.CloneStatus) (err error) {
+	if s.DB == nil {
+		return nil
+	}
 	tx, err := database.Repos(s.DB).Transact(ctx)
 	if err != nil {
 		return err
@@ -507,11 +510,8 @@ func (s *Server) removeRepoDirectory(gitDir GitDir) error {
 	// should not be returned, just logged.
 
 	// Set as not_cloned in the database
-	if s.DB != nil {
-		err := s.setCloneStatus(ctx, s.name(gitDir), types.CloneStatusNotCloned)
-		if err != nil {
-			log15.Error("Setting clone status", "error", err)
-		}
+	if err := s.setCloneStatus(ctx, s.name(gitDir), types.CloneStatusNotCloned); err != nil {
+		log15.Error("Setting clone status", "error", err)
 	}
 
 	// Cleanup empty parent directories. We just attempt to remove and if we

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1227,7 +1227,8 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 			if !repoCloned(dir) {
 				status = types.CloneStatusNotCloned
 			}
-			if err := s.setCloneStatus(ctx, repo, status); err != nil {
+			// Use a different context to ensure we still update the DB
+			if err := s.setCloneStatus(context.Background(), repo, status); err != nil {
 				log15.Warn("Setting clone status in DB", "error", err)
 			}
 		}()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -140,11 +140,11 @@ type Server struct {
 	// actual hostname but can also be overridden by the HOSTNAME environment variable.
 	Hostname string
 
-	// skipCloneForTests is set by tests to avoid clones.
-	skipCloneForTests bool
-
 	// shared db handle
 	DB dbutil.DB
+
+	// skipCloneForTests is set by tests to avoid clones.
+	skipCloneForTests bool
 
 	// ctx is the context we use for all background jobs. It is done when the
 	// server is stopped. Do not directly call this, rather call
@@ -286,10 +286,10 @@ func (s *Server) Janitor(interval time.Duration) {
 
 // SyncRepoState syncs state on disk to the database for all repos and is expected to
 // run in a background goroutine.
-func (s *Server) SyncRepoState(db dbutil.DB, interval time.Duration, batchSize, perSecond int) {
+func (s *Server) SyncRepoState(interval time.Duration, batchSize, perSecond int) {
 	for {
 		addrs := conf.Get().ServiceConnections.GitServers
-		if err := s.syncRepoState(db, addrs, batchSize, perSecond); err != nil {
+		if err := s.syncRepoState(addrs, batchSize, perSecond); err != nil {
 			log15.Error("Syncing repo state", "error ", err)
 		}
 		time.Sleep(interval)
@@ -326,7 +326,7 @@ var (
 	}, []string{"success"})
 )
 
-func (s *Server) syncRepoState(db dbutil.DB, addrs []string, batchSize, perSecond int) error {
+func (s *Server) syncRepoState(addrs []string, batchSize, perSecond int) error {
 	// Sanity check our host exists in addrs before starting any work
 	var found bool
 	for _, a := range addrs {
@@ -340,7 +340,7 @@ func (s *Server) syncRepoState(db dbutil.DB, addrs []string, batchSize, perSecon
 	}
 
 	ctx := s.ctx
-	store := database.GitserverRepos(db)
+	store := database.GitserverRepos(s.DB)
 
 	// The rate limit should be enforced across all instances
 	perSecond = perSecond / len(addrs)
@@ -379,7 +379,7 @@ func (s *Server) syncRepoState(db dbutil.DB, addrs []string, batchSize, perSecon
 		repoStateUpsertCounter.WithLabelValues("true").Add(float64(len(batch)))
 	}
 
-	totalRepos, err := database.Repos(db).Count(ctx, database.ReposListOptions{})
+	totalRepos, err := database.Repos(s.DB).Count(ctx, database.ReposListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "counting repos")
 	}

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -824,6 +824,7 @@ func TestSyncRepoState(t *testing.T) {
 			return &GitRepoSyncer{}, nil
 		},
 		Hostname:         hostname,
+		DB:               db,
 		ctx:              ctx,
 		locker:           &RepositoryLocker{},
 		cloneLimiter:     mutablelimiter.New(1),
@@ -853,7 +854,7 @@ func TestSyncRepoState(t *testing.T) {
 		t.Fatal("Expected an error")
 	}
 
-	err = s.syncRepoState(db, []string{hostname}, 10, 10)
+	err = s.syncRepoState([]string{hostname}, 10, 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -449,7 +449,38 @@ func staticGetRemoteURL(remote string) func(context.Context, api.RepoName) (stri
 }
 
 func TestCloneRepo(t *testing.T) {
+	ctx := context.Background()
 	remote := tmpDir(t)
+	repoName := api.RepoName("example.com/foo/bar")
+	db := dbtesting.GetDB(t)
+
+	dbRepo := &types.Repo{
+		Name:        repoName,
+		Description: "Test",
+	}
+	// Insert the repo into our database
+	if err := database.Repos(db).Create(ctx, dbRepo); err != nil {
+		t.Fatal(err)
+	}
+	assertCloneStatus := func(status types.CloneStatus) {
+		t.Helper()
+		fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if fromDB.CloneStatus != status {
+			t.Fatalf("Want %q, got %q", status, fromDB.CloneStatus)
+		}
+	}
+
+	if err := database.GitserverRepos(db).Upsert(ctx, &types.GitserverRepo{
+		RepoID:      dbRepo.ID,
+		ShardID:     "test",
+		CloneStatus: types.CloneStatusNotCloned,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertCloneStatus(types.CloneStatusNotCloned)
 
 	repo := remote
 	cmd := func(name string, arg ...string) string {
@@ -474,12 +505,13 @@ func TestCloneRepo(t *testing.T) {
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
 			return &GitRepoSyncer{}, nil
 		},
+		DB:               db,
 		ctx:              context.Background(),
 		locker:           &RepositoryLocker{},
 		cloneLimiter:     mutablelimiter.New(1),
 		cloneableLimiter: mutablelimiter.New(1),
 	}
-	_, err := s.cloneRepo(context.Background(), "example.com/foo/bar", nil)
+	_, err := s.cloneRepo(ctx, repoName, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +519,7 @@ func TestCloneRepo(t *testing.T) {
 	// Wait until the clone is done. Please do not use this code snippet
 	// outside of a test. We only know this works since our test only starts
 	// one clone and will have nothing else attempt to lock.
-	dst := s.dir("example.com/foo/bar")
+	dst := s.dir(repoName)
 	for i := 0; i < 1000; i++ {
 		_, cloning := s.locker.Status(dst)
 		if !cloning {
@@ -495,6 +527,7 @@ func TestCloneRepo(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	assertCloneStatus(types.CloneStatusCloned)
 
 	repo = filepath.Dir(string(dst))
 	gotCommit := cmd("git", "rev-parse", "HEAD")
@@ -503,18 +536,20 @@ func TestCloneRepo(t *testing.T) {
 	}
 
 	// Test blocking with a failure (already exists since we didn't specify overwrite)
-	_, err = s.cloneRepo(context.Background(), "example.com/foo/bar", &cloneOptions{Block: true})
+	_, err = s.cloneRepo(context.Background(), repoName, &cloneOptions{Block: true})
 	if !os.IsExist(errors.Cause(err)) {
 		t.Fatalf("expected clone repo to fail with already exists: %s", err)
 	}
+	assertCloneStatus(types.CloneStatusCloned)
 
 	// Test blocking with overwrite. First add random file to GIT_DIR. If the
 	// file is missing after cloning we know the directory was replaced
 	mkFiles(t, string(dst), "HELLO")
-	_, err = s.cloneRepo(context.Background(), "example.com/foo/bar", &cloneOptions{Block: true, Overwrite: true})
+	_, err = s.cloneRepo(context.Background(), repoName, &cloneOptions{Block: true, Overwrite: true})
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertCloneStatus(types.CloneStatusCloned)
 
 	if _, err := os.Stat(dst.Path("HELLO")); !os.IsNotExist(err) {
 		t.Fatalf("expected clone to be overwritten: %s", err)


### PR DESCRIPTION
We now set the status of a repo to `cloning` when we begin cloning it, unless it
has already been cloned. Once we complete the cloning process we again set the
state in the db to either `cloned` or `not_cloned`.