### PR TITLE
zoekt: enforce that repoid is up to date

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -209,7 +209,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210302122048-1e934d0e2521
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210309123010-cafbecb72244
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1289,6 +1289,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20210302122048-1e934d0e2521 h1:YDT/cYQvg+VSEkekDmpv3boxpJffRiKi/MVBOst0J3E=
 github.com/sourcegraph/zoekt v0.0.0-20210302122048-1e934d0e2521/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
+github.com/sourcegraph/zoekt v0.0.0-20210309123010-cafbecb72244 h1:q8oblDQDroGPmjVbXBRJEatM7jtT+8ehGFFWejDle4s=
+github.com/sourcegraph/zoekt v0.0.0-20210309123010-cafbecb72244/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
We want to enforce this in our next release of Sourcegraph to ensure all
indexes have the Sourcegraph repository ID set. Several releases ago we
would only have the repoid set if we re-indexed. This would only occur
if the repository was updated.

This bumps the zoekt version to include one more commit:
- https://github.com/sourcegraph/zoekt/commit/cafbecb build: enforce that repoid is up to date