### PR TITLE
streaming: add callback OnDone to decoder

### DIFF
--- a/internal/search/streaming/http/client.go
+++ b/internal/search/streaming/http/client.go
@@ -33,6 +33,7 @@ type Decoder struct {
 	OnAlert    func(*EventAlert)
 	OnError    func(*EventError)
 	OnUnknown  func(event, data []byte)
+	OnDone     func()
 }
 
 func (rr Decoder) ReadAll(r io.Reader) error {
@@ -127,6 +128,9 @@ func (rr Decoder) ReadAll(r io.Reader) error {
 			rr.OnError(&d)
 		} else if bytes.Equal(event, []byte("done")) {
 			// Always the last event
+			if rr.OnDone != nil {
+				rr.OnDone()
+			}
 			break
 		} else {
 			if rr.OnUnknown == nil {

--- a/internal/search/streaming/http/client_test.go
+++ b/internal/search/streaming/http/client_test.go
@@ -107,6 +107,11 @@ func TestDecoder(t *testing.T) {
 		OnUnknown: func(event, data []byte) {
 			t.Fatalf("got unexpected event: %s %s", event, data)
 		},
+		OnDone: func() {
+			if len(got) != len(want) {
+				t.Fatalf("OnDone was called before the last event was processed.")
+			}
+		},
 	}.ReadAll(resp.Body)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
It's convenient to know when all events have been processed and the
decoder is just about to return.

For example, the src-cli has to output a valid JSON from a stream.
Besides the results, the final JSON should also contain top-level
metadata like alerts or progress data. A callback `OnDone` gives us a
natural hook to add metadata and close the JSON object.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
