### PR TITLE
gitserver: Trial remove repos that are on the wrong shard

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -51,6 +52,10 @@ var (
 		Name: "src_gitserver_repos_removed",
 		Help: "number of repos removed during cleanup",
 	})
+	reposRemovedWrongShard = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "src_gitserver_repos_removed_wrong_shard",
+		Help: "number of repos removed during cleanup because they are on the wrong shard",
+	})
 	reposRecloned = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "src_gitserver_repos_recloned",
 		Help: "number of repos removed and recloned due to age",
@@ -77,9 +82,9 @@ const reposStatsName = "repos-stats.json"
 // 2. Remove stale lock files.
 // 3. Remove repos based on disk pressure.
 // 4. Reclone repos after a while. (simulate git gc)
-func (s *Server) cleanupRepos() {
+// 5. Remove repos on disk that don't belong in this shard
+func (s *Server) cleanupRepos(addrs []string) {
 	janitorRunning.Set(1)
-
 	defer janitorRunning.Set(0)
 
 	bCtx, bCancel := s.serverContext()
@@ -224,6 +229,25 @@ func (s *Server) cleanupRepos() {
 		return false, gitGC(dir)
 	}
 
+	removeWrongShard := func(dir GitDir) (done bool, err error) {
+		if len(addrs) == 0 {
+			return false, nil
+		}
+		addr := gitserver.AddrForRepo(s.name(dir), addrs)
+		if s.hostnameMatch(addr) {
+			return false, nil
+		}
+		// TODO: Enable this once we've confirmed it's safe and remove  reposRemovedWrongShard counter.
+		//
+		//log15.Info("removing repo for wrong shard", "repo", dir)
+		//if err := s.removeRepoDirectory(dir); err != nil {
+		//	return true, err
+		//}
+		//reposRemoved.Inc()
+		reposRemovedWrongShard.Inc()
+		return false, nil
+	}
+
 	type cleanupFn struct {
 		Name string
 		Do   func(GitDir) (bool, error)
@@ -232,27 +256,28 @@ func (s *Server) cleanupRepos() {
 		{"compute statistics", computeStats},
 		// Do some sanity checks on the repository.
 		{"maybe remove corrupt", maybeRemoveCorrupt},
-		// If git is interrupted it can leave lock files lying around. It does
-		// not clean these up, and instead fails commands.
+		// If git is interrupted it can leave lock files lying around. It does not clean
+		// these up, and instead fails commands.
 		{"remove stale locks", removeStaleLocks},
-		// We always want to have the same git attributes file at
-		// info/attributes.
+		// We always want to have the same git attributes file at info/attributes.
 		{"ensure git attributes", ensureGitAttributes},
-		// 2021-03-01 (tomas,keegan) we used to store an authenticated remote
-		// URL on disk. We no longer need it so we can scrub it.
+		// 2021-03-01 (tomas,keegan) we used to store an authenticated remote URL on
+		// disk. We no longer need it so we can scrub it.
 		{"scrub remote URL", scrubRemoteURL},
-		// Old git clones accumulate loose git objects that waste space and
-		// slow down git operations. Periodically do a fresh clone to avoid
-		// these problems. git gc is slow and resource intensive. It is
-		// cheaper and faster to just reclone the repository.
+		// Old git clones accumulate loose git objects that waste space and slow down git
+		// operations. Periodically do a fresh clone to avoid these problems. git gc is
+		// slow and resource intensive. It is cheaper and faster to just reclone the
+		// repository.
 		{"maybe reclone", maybeReclone},
-		// Runs a number of housekeeping tasks within the current repository,
-		// such as compressing file revisions (to reduce disk space and increase
-		// performance), removing unreachable objects which may have been created
-		// from prior invocations of git add, packing refs, pruning reflog, rerere
-		// metadata or stale working trees. May also update ancillary indexes such
-		// as the commit-graph.
+		// Runs a number of housekeeping tasks within the current repository, such as
+		// compressing file revisions (to reduce disk space and increase performance),
+		// removing unreachable objects which may have been created from prior
+		// invocations of git add, packing refs, pruning reflog, rerere metadata or stale
+		// working trees. May also update ancillary indexes such as the commit-graph.
 		{"garbage collect", performGC},
+		// Repos are sharded across gitserver instances based on their name. Remove repos
+		// that no longer belong on this shard.
+		{"remove wrong shard", removeWrongShard},
 	}
 
 	err := bestEffortWalk(s.ReposDir, func(dir string, fi os.FileInfo) error {

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -61,7 +61,7 @@ func TestCleanup_computeStats(t *testing.T) {
 	// the correct file in the correct place.
 	s := &Server{ReposDir: root}
 	s.Handler() // Handler as a side-effect sets up Server
-	s.cleanupRepos()
+	s.cleanupRepos(nil)
 
 	// we hardcode the name here so the tests break if someone changes the
 	// value of reposStatsName. We don't want it to change without good reason
@@ -108,7 +108,7 @@ func TestCleanupInactive(t *testing.T) {
 
 	s := &Server{ReposDir: root}
 	s.Handler() // Handler as a side-effect sets up Server
-	s.cleanupRepos()
+	s.cleanupRepos(nil)
 
 	if _, err := os.Stat(repoA); os.IsNotExist(err) {
 		t.Error("expected repoA not to be removed")
@@ -165,7 +165,7 @@ func TestGitGCAuto(t *testing.T) {
 	// Handler must be invoked for Server side-effects.
 	s := &Server{ReposDir: root}
 	s.Handler()
-	s.cleanupRepos()
+	s.cleanupRepos(nil)
 
 	// Verify that there are no more GC-able objects in the repository.
 	if !strings.Contains(countObjects(), "count: 0") {
@@ -279,7 +279,7 @@ func TestCleanupExpired(t *testing.T) {
 		},
 	}
 	s.Handler() // Handler as a side-effect sets up Server
-	s.cleanupRepos()
+	s.cleanupRepos(nil)
 
 	// repos that shouldn't be recloned
 	if repoNewTime.Before(modTime(repoNew)) {
@@ -363,7 +363,7 @@ func TestCleanupOldLocks(t *testing.T) {
 
 	s := &Server{ReposDir: root}
 	s.Handler() // Handler as a side-effect sets up Server
-	s.cleanupRepos()
+	s.cleanupRepos(nil)
 
 	assertPaths(t, root,
 		"repos-stats.json",

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -279,7 +279,8 @@ func (s *Server) Handler() http.Handler {
 // background goroutine.
 func (s *Server) Janitor(interval time.Duration) {
 	for {
-		s.cleanupRepos()
+		addrs := conf.Get().ServiceConnections.GitServers
+		s.cleanupRepos(addrs)
 		time.Sleep(interval)
 	}
 }


### PR DESCRIPTION
Instead of actually removing the repos we'll just increment a counter
for now until we're more confident that this is safe.