### PR TITLE
search: Simplify evaluateOr

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -749,22 +749,9 @@ func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query
 		wantCount = *count
 	}
 
-	result, err := r.evaluatePatternExpression(ctx, scopeParameters, operands[0])
-	if err != nil {
-		return nil, err
-	}
-	if result == nil {
-		return nil, nil
-	}
-	// Do not rely on result.Stats.resultCount because it may
-	// count non-content matches and there's no easy way to know.
-	if len(result.SearchResults) > wantCount {
-		result.SearchResults = result.SearchResults[:wantCount]
-		return result, nil
-	}
-	var new *SearchResultsResolver
-	for _, term := range operands[1:] {
-		new, err = r.evaluatePatternExpression(ctx, scopeParameters, term)
+	var result *SearchResultsResolver
+	for _, term := range operands {
+		new, err := r.evaluatePatternExpression(ctx, scopeParameters, term)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -749,7 +749,7 @@ func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query
 		wantCount = *count
 	}
 
-	var result *SearchResultsResolver
+	result := &SearchResultsResolver{}
 	for _, term := range operands {
 		new, err := r.evaluatePatternExpression(ctx, scopeParameters, term)
 		if err != nil {


### PR DESCRIPTION
The first term was special cased, ostensibly because result wouldn't
exist yet to be unioned, but union supports passing in nils gracefully,
so this isn't necessary.

Re-opened from #18840 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
