### PR TITLE
Ensure we always use the newest external service

### DIFF
--- a/enterprise/internal/batches/syncer/util.go
+++ b/enterprise/internal/batches/syncer/util.go
@@ -24,8 +24,9 @@ func loadExternalService(ctx context.Context, esStore ExternalServiceStore, repo
 	}
 
 	// Sort the external services so user owned external service go last.
-	sort.Slice(es, func(i, j int) bool {
-		return es[i].NamespaceUserID == 0
+	// This also retains the initial ORDER BY ID DESC.
+	sort.SliceStable(es, func(i, j int) bool {
+		return es[i].NamespaceUserID == 0 && es[i].ID > es[j].ID
 	})
 
 	for _, e := range es {


### PR DESCRIPTION
I always thought we use the oldest, but the stores default ordering is `id DESC`, so maybe that never was the case.. Looking back git histories a bit, I didn't find evidence it was changed. Regardless, my recent attempt to deprioritize user external services removed that ordering and it was basically random, this fixes it to be stable again, at least. As this logic is going to disappear anyways, I'm not too concerned about it for now.