### PR TITLE
Fix and enforce bodyclose lint

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -14,6 +14,13 @@ linters:
     - goimports
     - gosimple
     - varcheck
+    - bodyclose
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - bodyclose
 
 run:
   timeout: 5m

--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -86,6 +86,8 @@ func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err er
 		if err != nil {
 			return 0, err
 		}
+		defer response.Body.Close()
+
 		var result struct {
 			Results []struct {
 				Path string

--- a/cmd/frontend/internal/gosrc/import_path.go
+++ b/cmd/frontend/internal/gosrc/import_path.go
@@ -179,6 +179,7 @@ func fetchMeta(client httpcli.Doer, importPath string) (scheme string, im *impor
 			resp.Body.Close()
 		}
 		scheme = "http"
+		//nolint:bodyclose // False positive: https://github.com/timakin/bodyclose/issues/29
 		resp, err = get()
 		if err != nil {
 			return scheme, nil, nil, err

--- a/cmd/loadtest/main.go
+++ b/cmd/loadtest/main.go
@@ -76,6 +76,7 @@ func search(v GQLSearchVars) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("response error: %s", err)
 	}
+	defer resp.Body.Close()
 	var res GraphQLResponseSearch
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
 		return 0, fmt.Errorf("could not decode response body: %s", err)

--- a/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
+++ b/cmd/query-runner/queryrunnerapi/queryrunnerapi.go
@@ -105,6 +105,7 @@ func (c *client) post(path string, data interface{}) error {
 	if err != nil {
 		return errors.Wrap(err, "Post "+u.String())
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
 		return nil
 	}

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1,3 +1,4 @@
+//nolint:bodyclose // Body is closed in Client.Do, but the response is still returned to provide access to the headers
 package bitbucketserver
 
 import (

--- a/internal/httptestutil/client.go
+++ b/internal/httptestutil/client.go
@@ -122,6 +122,7 @@ func (c *Client) DoJSON(method, url string, in, out interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if ct := resp.Header.Get("content-type"); !strings.HasPrefix(ct, "application/json") {
 		return fmt.Errorf("content type %q is not JSON", ct)
 	}

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -155,6 +155,7 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
This commit enables the bodyclose lint as an enforced lint, and fixes
all warnings.

There were a number of lint warnings for test files, but for this
particular lint, it's not very valuable in tests since connection leaks
just don't matter that much, and it would likely just add noise. For
this reason, the lint has been disabled for `_test\.go` files.

There were a few false positives, but it also caught a few cases that
appear to be actual connection leaks, so I think it's still worth enabling
even if it does add a small amount of noise.


Progresses #18720 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
