### PR TITLE
search: process 'stable:' outside searchImplementer

### DIFF
--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -3,7 +3,6 @@ package graphqlbackend
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strings"
 	"sync"
@@ -354,49 +353,6 @@ func TestQuoteSuggestions(t *testing.T) {
 			t.Errorf("description is '%s', want it to contain 'regexp'", alert.description)
 		}
 	})
-}
-
-func TestQueryForStableResults(t *testing.T) {
-	cases := []struct {
-		query           string
-		wantStableCount int32
-		wantError       error
-	}{
-		{
-			query:           "foo stable:yes",
-			wantStableCount: 30,
-		},
-		{
-			query:           "foo stable:yes count:1000",
-			wantStableCount: 1000,
-		},
-		{
-			query:     "foo stable:yes count:5001",
-			wantError: fmt.Errorf("Stable searches are limited to at max count:%d results. Consider removing 'stable:', narrowing the search with 'repo:', or using the paginated search API.", maxSearchResultsPerPaginatedRequest),
-		},
-	}
-	for _, c := range cases {
-		t.Run("query for stable results", func(t *testing.T) {
-			queryInfo, _ := query.ParseLiteral(c.query)
-			args, queryInfo, err := queryForStableResults(&SearchArgs{}, queryInfo)
-			if err != nil {
-				if !reflect.DeepEqual(err, c.wantError) {
-					t.Errorf("Got error %v, want %v", err, c.wantError)
-				}
-				return
-			}
-			if diff := cmp.Diff(*args.First, c.wantStableCount); diff != "" {
-				t.Error(diff)
-			}
-			// Ensure type:file is set.
-			fileValue := "file"
-			wantTypeValue := query.Value{String: &fileValue}
-			gotTypeValues := queryInfo.Fields()["type"]
-			if len(gotTypeValues) != 1 && *gotTypeValues[0] != wantTypeValue {
-				t.Errorf("Query %s sets stable:yes but is not transformed with type:file.", c.query)
-			}
-		})
-	}
 }
 
 func TestVersionContext(t *testing.T) {

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -520,6 +520,17 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 	})
 
+	t.Run("stable search options", func(t *testing.T) {
+		results, err := client.SearchFiles(`router stable:yes count:5001`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if results.Alert == nil {
+			t.Fatal("Want search alert but got nil")
+		}
+	})
+
 	t.Run("structural search", func(t *testing.T) {
 		tests := []struct {
 			name       string


### PR DESCRIPTION
Moves the "if query contains `stable:` then perform pagination by populating `args.First`" logic into the pagination function, so that we only check whether `stable:` exists in `NewSearchImplementer` to take this execution path.

I need to move things out of `NewSearchImplementer` because the type/shape of query will change (from "query expression" to "query expression or basic query"), and cause messiness otherwise, because some of the code in `NewSearchImplementer` assumes that the query is not an expression (like this `stable` logic, and a couple other things).