### PR TITLE
doc: provide more detailed instructions for bouncing docsite

### DIFF
--- a/doc/dev/how-to/documentation_implementation.md
+++ b/doc/dev/how-to/documentation_implementation.md
@@ -62,24 +62,7 @@ The docs.sourcegraph.com site reloads content, templates, and assets every 5 min
 
 If you need to force a reload — either because your change can't wait 5 minutes, or because you've updated redirects — you can delete the `docs-sourcegraph-com-*` Kubernetes pod on the Sourcegraph.com Kubernetes cluster. (It will restart and come back online with the latest data.)
 
-To do this:
-
-1. Ensure you are [logged into our Google Cloud project](https://about.sourcegraph.com/handbook/engineering/deployments/kubernetes).
-1. List the active pods with `kubectl get pods`. This should produce a list that includes items like the following:
-
-    ```
-    NAME                                     READY   STATUS      RESTARTS   AGE
-    about-sourcegraph-com-74f96c659b-t6lqp   1/1     Running     0          7m49s
-    docs-sourcegraph-com-5f97dd5db-7wrxm     1/1     Running     0          7m49s 
-    ```
-
-    The exact names will differ, but the general format will be the same.
-1. Delete the pods, being careful to copy the exact names from the output in the previous step. For example, with that output, you would run:
-
-    ```sh
-    kubectl delete pod about-sourcegraph-com-74f96c659b-t6lqp docs-sourcegraph-com-5f97dd5db-7wrxm
-    ```
-1. Wait a moment, and check https://docs.sourcegraph.com/. Your changes should be live!
+To do this, follow the ["Restarting about.sourcegraph.com and docs.sourcegraph.com" playbook](https://about.sourcegraph.com/handbook/engineering/deployments/playbooks#restarting-about-sourcegraph-com-and-docs-sourcegraph-com).
 
 ## Other ways of previewing changes locally (very rare)
 

--- a/doc/dev/how-to/documentation_implementation.md
+++ b/doc/dev/how-to/documentation_implementation.md
@@ -60,7 +60,9 @@ See "[Updating documentation](#updating-documentation)" and "[Previewing changes
 
 The docs.sourcegraph.com site reloads content, templates, and assets every 5 minutes. After you push a [documentation update](#updating-documentation), just wait up to 5 minutes to see your changes reflected on docs.sourcegraph.com.
 
-If you need to force a reload — either because your change can't wait 5 minutes, or because you've updated redirects — you can delete the `docs-sourcegraph-com-*` Kubernetes pod on the Sourcegraph.com Kubernetes cluster. (It will restart and come back online with the latest data.)
+If you need to force a reload — either because your change is _extremely_ urgent and can't wait 5 minutes, or because you've updated redirects — you can delete the `docs-sourcegraph-com-*` Kubernetes pod on the Sourcegraph.com Kubernetes cluster. Once done, it will restart and come back online with the latest data.
+
+>WARNING: There may be a few seconds of downtime when restarting the docs cluster this way. This shouldn't be a routine part of your workflow!
 
 To do this, follow the ["Restarting about.sourcegraph.com and docs.sourcegraph.com" playbook](https://about.sourcegraph.com/handbook/engineering/deployments/playbooks#restarting-about-sourcegraph-com-and-docs-sourcegraph-com).
 

--- a/doc/dev/how-to/documentation_implementation.md
+++ b/doc/dev/how-to/documentation_implementation.md
@@ -48,6 +48,8 @@ To update documentation content, templates, or assets on https://docs.sourcegrap
 - The sidebar lives in `doc/sidebar.md`. Only important pages belong in the sidebar; use section index page links for other documents.
 - Assets and templates live in `doc/_resources/{templates,assets}`.
 
+Updates to the redirects in `doc/_resources/assets/redirects` require a full reload of the service, which involves deleting the relevant Kubernetes pods. See ["Forcing immediate reload of data"](#forcing-immediate-reload-of-data) for more details.
+
 ## Advanced documentation site
 
 Our documentation site (https://docs.sourcegraph.com) runs [docsite](https://github.com/sourcegraph/docsite).
@@ -58,7 +60,26 @@ See "[Updating documentation](#updating-documentation)" and "[Previewing changes
 
 The docs.sourcegraph.com site reloads content, templates, and assets every 5 minutes. After you push a [documentation update](#updating-documentation), just wait up to 5 minutes to see your changes reflected on docs.sourcegraph.com.
 
-If you can't wait 5 minutes and need to force a reload, you can kill the `docs-sourcegraph-com-*` Kubernetes pod on the Sourcegraph.com Kubernetes cluster. (It will restart and come back online with the latest data.)
+If you need to force a reload — either because your change can't wait 5 minutes, or because you've updated redirects — you can delete the `docs-sourcegraph-com-*` Kubernetes pod on the Sourcegraph.com Kubernetes cluster. (It will restart and come back online with the latest data.)
+
+To do this:
+
+1. Ensure you are [logged into our Google Cloud project](https://about.sourcegraph.com/handbook/engineering/deployments/kubernetes).
+1. List the active pods with `kubectl get pods`. This should produce a list that includes items like the following:
+
+    ```
+    NAME                                     READY   STATUS      RESTARTS   AGE
+    about-sourcegraph-com-74f96c659b-t6lqp   1/1     Running     0          7m49s
+    docs-sourcegraph-com-5f97dd5db-7wrxm     1/1     Running     0          7m49s 
+    ```
+
+    The exact names will differ, but the general format will be the same.
+1. Delete the pods, being careful to copy the exact names from the output in the previous step. For example, with that output, you would run:
+
+    ```sh
+    kubectl delete pod about-sourcegraph-com-74f96c659b-t6lqp docs-sourcegraph-com-5f97dd5db-7wrxm
+    ```
+1. Wait a moment, and check https://docs.sourcegraph.com/. Your changes should be live!
 
 ## Other ways of previewing changes locally (very rare)
 


### PR DESCRIPTION
This points to instructions being added in https://github.com/sourcegraph/about/pull/2747, so cannot be merged until that occurs.