### PR TITLE
search: remove undocumented uppercase logic until further notice

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -97,9 +97,6 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	if err != nil {
 		return alertForQuery(db, args.Query, err), nil
 	}
-	if getBoolPtr(settings.SearchUppercase, false) {
-		q = query.SearchUppercase(q)
-	}
 	tr.LazyPrintf("parsing done")
 
 	// If the request is a paginated one, decode those arguments now.

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"unicode"
 
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
@@ -339,30 +338,6 @@ func Hoist(nodes []Node) ([]Node, error) {
 		return Pattern{Value: value, Negated: negated, Annotation: annotation}
 	})
 	return append(scopeParameters, newOperator(pattern, expression.Kind)...), nil
-}
-
-// SearchUppercase adds case:yes to queries if any pattern is mixed-case.
-func SearchUppercase(nodes []Node) []Node {
-	var foundMixedCase bool
-	VisitPattern(nodes, func(value string, _ bool, _ Annotation) {
-		if match := containsUppercase(value); match {
-			foundMixedCase = true
-		}
-	})
-	if foundMixedCase {
-		nodes = append(nodes, Parameter{Field: "case", Value: "yes"})
-		return newOperator(nodes, And)
-	}
-	return nodes
-}
-
-func containsUppercase(s string) bool {
-	for _, r := range s {
-		if unicode.IsUpper(r) && unicode.IsLetter(r) {
-			return true
-		}
-	}
-	return false
 }
 
 // partition partitions nodes into left and right groups. A node is put in the

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -210,63 +210,6 @@ func TestHoist(t *testing.T) {
 	}
 }
 
-func TestSearchUppercase(t *testing.T) {
-	cases := []struct {
-		input string
-		want  string
-	}{
-		{
-			input: `TeSt`,
-			want:  `(and "TeSt" "case:yes")`,
-		},
-		{
-			input: `test`,
-			want:  `"test"`,
-		},
-		{
-			input: `content:TeSt`,
-			want:  `(and "TeSt" "case:yes")`,
-		},
-		{
-			input: `content:test`,
-			want:  `"test"`,
-		},
-		{
-			input: `repo:foo TeSt`,
-			want:  `(and "repo:foo" "TeSt" "case:yes")`,
-		},
-		{
-			input: `repo:foo test`,
-			want:  `(and "repo:foo" "test")`,
-		},
-		{
-			input: `repo:foo content:TeSt`,
-			want:  `(and "repo:foo" "TeSt" "case:yes")`,
-		},
-		{
-			input: `repo:foo content:test`,
-			want:  `(and "repo:foo" "test")`,
-		},
-		{
-			input: `TeSt1 TesT2`,
-			want:  `(and (concat "TeSt1" "TesT2") "case:yes")`,
-		},
-		{
-			input: `TeSt1 test2`,
-			want:  `(and (concat "TeSt1" "test2") "case:yes")`,
-		},
-	}
-	for _, c := range cases {
-		t.Run("searchUppercase", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			got := toString(SearchUppercase(SubstituteAliases(SearchTypeRegex)(query)))
-			if diff := cmp.Diff(c.want, got); diff != "" {
-				t.Fatal(diff)
-			}
-		})
-	}
-}
-
 func TestSubstituteOrForRegexp(t *testing.T) {
 	cases := []struct {
 		input string

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1227,7 +1227,7 @@ type Settings struct {
 	SearchSavedQueries []*SearchSavedQueries `json:"search.savedQueries,omitempty"`
 	// SearchScopes description: Predefined search scopes
 	SearchScopes []*SearchScope `json:"search.scopes,omitempty"`
-	// SearchUppercase description: When active, any uppercase characters in the pattern will make the entire query case-sensitive.
+	// SearchUppercase description: REMOVED. Previously, when active, any uppercase characters in the pattern will make the entire query case-sensitive.
 	SearchUppercase *bool `json:"search.uppercase,omitempty"`
 }
 

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -307,7 +307,7 @@
       "default": false
     },
     "search.uppercase": {
-      "description": "When active, any uppercase characters in the pattern will make the entire query case-sensitive.",
+      "description": "REMOVED. Previously, when active, any uppercase characters in the pattern will make the entire query case-sensitive.",
       "type": "boolean",
       "default": false,
       "!go": {

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -312,7 +312,7 @@ const SettingsSchemaJSON = `{
       "default": false
     },
     "search.uppercase": {
-      "description": "When active, any uppercase characters in the pattern will make the entire query case-sensitive.",
+      "description": "REMOVED. Previously, when active, any uppercase characters in the pattern will make the entire query case-sensitive.",
       "type": "boolean",
       "default": false,
       "!go": {


### PR DESCRIPTION
Stacked on #19042.

I introduced this setting in the past. We never advertised it, and I'd like to disable it because it complicates query types. If it does turn out to be something we want to keep around, the logic works out better if we put it in the frontend, which is why I'm in favor of removing it entirely from the backend instead of refactoring. The potential issue with this setting is that it can cause confusion (one user sees results, another doesn't) depending on whether it's activated for the same query. This same issue is why I didn't really go ahead with advertising the option, but wanted to experiment with it. If it lives in the frontend, we can actually control the case setting/toggle and query shape, which would not lead to the "one user sees results, another doesn't" issue. The setting can stick around if we want to reintroduce it there.

Before my time, this functionality previously existed as "smart case" and activated by default in [`3.1.0`](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#changed-39). Interestingly, there isn't a corresponding changelog entry for when the decision back in `3.1.0` was reversed :-) 