### PR TITLE
Some low hanging fruit improvements for burndown chart

### DIFF
--- a/client/web/src/enterprise.scss
+++ b/client/web/src/enterprise.scss
@@ -25,9 +25,10 @@
 @import './enterprise/batches/detail/changesets/EmptyChangesetListElement';
 @import './enterprise/batches/detail/changesets/ExternalChangesetNode';
 @import './enterprise/batches/detail/changesets/HiddenExternalChangesetNode';
-@import './enterprise/batches/detail/BatchSpecTab';
+@import './enterprise/batches/detail/BatchChangeBurndownChart';
 @import './enterprise/batches/detail/BatchChangeTabs';
 @import './enterprise/batches/detail/BatchChangeStatsCard';
+@import './enterprise/batches/detail/BatchSpecTab';
 @import './enterprise/batches/list/BatchChangesListIntro';
 @import './enterprise/batches/list/BatchChangeListPage';
 @import './enterprise/batches/list/BatchChangeNode';

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.scss
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.scss
@@ -1,0 +1,9 @@
+.batch-change-burndown-chart {
+    &-legend {
+        &__color-box {
+            width: 1rem;
+            height: 1rem;
+            display: inline-block;
+        }
+    }
+}

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.scss
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.scss
@@ -6,4 +6,10 @@
             display: inline-block;
         }
     }
+    &__container {
+        @include media-breakpoint-down(xs) {
+            flex-direction: column-reverse;
+            align-items: flex-start !important;
+        }
+    }
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
@@ -11,28 +11,6 @@ const { add } = storiesOf('web/batches/BurndownChart', module).addDecorator(stor
     <div className="p-3 container web-content">{story()}</div>
 ))
 
-// tzs := state.GenerateTimestamps(start, end)
-// 	wantCounts := make([]apitest.ChangesetCounts, 0, len(tzs))
-// 	idx := 0
-// 	for _, tz := range tzs {
-// 		currentWant := wantEntries[idx]
-// 		for len(wantEntries) > idx+1 && !tz.Before(wantEntries[idx+1].Time) {
-// 			idx++
-// 			currentWant = wantEntries[idx]
-// 		}
-// 		wantCounts = append(wantCounts, apitest.ChangesetCounts{
-// 			Date:                 marshalDateTime(t, tz),
-// 			Total:                currentWant.Total,
-// 			Merged:               currentWant.Merged,
-// 			Closed:               currentWant.Closed,
-// 			Open:                 currentWant.Open,
-// 			Draft:                currentWant.Draft,
-// 			OpenApproved:         currentWant.OpenApproved,
-// 			OpenChangesRequested: currentWant.OpenChangesRequested,
-// 			OpenPending:          currentWant.OpenPending,
-// 		})
-// 	}
-
 add('All states', () => {
     const changesetCounts = useMemo<ChangesetCountsOverTimeFields[]>(() => {
         const timeMarks = [
@@ -157,21 +135,24 @@ add('All states', () => {
                 open: 0,
             },
         ]
-        let index_ = 0
+        let timeMarkIndex = 0
         return new Array(150).fill(undefined).map((value, index) => {
-            let currentMark = timeMarks[index_]
-            const tz = addSeconds(
+            let currentMark = timeMarks[timeMarkIndex]
+            const currentDate = addSeconds(
                 new Date('2019-11-13T12:00:00Z'),
                 // 10 days of data
                 index * Math.round((10 * 24 * 60 * 60) / 150)
             )
-            while (timeMarks.length > index_ + 1 && !isBefore(tz, new Date(timeMarks[index_ + 1].date))) {
-                index_++
-                currentMark = timeMarks[index_]
+            while (
+                timeMarks.length > timeMarkIndex + 1 &&
+                !isBefore(currentDate, new Date(timeMarks[timeMarkIndex + 1].date))
+            ) {
+                timeMarkIndex++
+                currentMark = timeMarks[timeMarkIndex]
             }
             return {
                 __typename: 'ChangesetCounts',
-                date: tz.toISOString(),
+                date: currentDate.toISOString(),
                 closed: currentMark.closed,
                 draft: currentMark.draft,
                 merged: currentMark.merged,

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.story.tsx
@@ -1,155 +1,196 @@
 import { storiesOf } from '@storybook/react'
-import { select } from '@storybook/addon-knobs'
 import React from 'react'
 import { BatchChangeBurndownChart } from './BatchChangeBurndownChart'
 import { of } from 'rxjs'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import { ChangesetCountsOverTimeFields } from '../../../graphql-operations'
+import { addSeconds, isBefore } from 'date-fns'
+import { useMemo } from '@storybook/addons'
 
 const { add } = storiesOf('web/batches/BurndownChart', module).addDecorator(story => (
     <div className="p-3 container web-content">{story()}</div>
 ))
 
-add('All states', () => (
-    <EnterpriseWebStory>
-        {props => (
-            <BatchChangeBurndownChart
-                {...props}
-                batchChangeID="123"
-                queryChangesetCountsOverTime={() =>
-                    of(
-                        [
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-13T12:00:00Z',
-                                closed: 0,
-                                merged: 0,
-                                openApproved: 0,
-                                openChangesRequested: 0,
-                                openPending: 0,
-                                total: 10,
-                                draft: 10,
-                                open: 0,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-14T12:00:00Z',
-                                closed: 0,
-                                merged: 0,
-                                openApproved: 0,
-                                openChangesRequested: 0,
-                                openPending: 2,
-                                total: 10,
-                                draft: 5,
-                                open: 5,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-15T12:00:00Z',
-                                closed: 0,
-                                merged: 1,
-                                openApproved: 1,
-                                openChangesRequested: 0,
-                                openPending: 3,
-                                total: 10,
-                                draft: 0,
-                                open: 8,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-16T12:00:00Z',
-                                closed: 1,
-                                merged: 1,
-                                openApproved: 1,
-                                openChangesRequested: 0,
-                                openPending: 3,
-                                total: 10,
-                                draft: 0,
-                                open: 7,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-17T12:00:00Z',
-                                closed: 1,
-                                merged: 2,
-                                openApproved: 1,
-                                openChangesRequested: 0,
-                                openPending: 5,
-                                total: 10,
-                                draft: 0,
-                                open: 6,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-18T12:00:00Z',
-                                closed: 2,
-                                merged: 4,
-                                openApproved: 0,
-                                openChangesRequested: 2,
-                                openPending: 2,
-                                total: 10,
-                                draft: 0,
-                                open: 4,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-19T12:00:00Z',
-                                closed: 2,
-                                merged: 4,
-                                openApproved: 0,
-                                openChangesRequested: 2,
-                                openPending: 2,
-                                total: 10,
-                                draft: 0,
-                                open: 4,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-20T12:00:00Z',
-                                closed: 2,
-                                merged: 4,
-                                openApproved: 0,
-                                openChangesRequested: 2,
-                                openPending: 2,
-                                total: 10,
-                                draft: 0,
-                                open: 4,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-21T12:00:00Z',
-                                closed: 2,
-                                merged: 5,
-                                openApproved: 3,
-                                openChangesRequested: 0,
-                                openPending: 0,
-                                total: 10,
-                                draft: 0,
-                                open: 3,
-                            },
-                            {
-                                __typename: 'ChangesetCounts',
-                                date: '2019-11-22T12:00:00Z',
-                                closed: 2,
-                                merged: 8,
-                                openApproved: 0,
-                                openChangesRequested: 0,
-                                openPending: 0,
-                                total: 10,
-                                draft: 0,
-                                open: 0,
-                            },
-                        ].slice(0, select('Days of data', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 10))
-                    )
-                }
-            />
-        )}
-    </EnterpriseWebStory>
-))
+// tzs := state.GenerateTimestamps(start, end)
+// 	wantCounts := make([]apitest.ChangesetCounts, 0, len(tzs))
+// 	idx := 0
+// 	for _, tz := range tzs {
+// 		currentWant := wantEntries[idx]
+// 		for len(wantEntries) > idx+1 && !tz.Before(wantEntries[idx+1].Time) {
+// 			idx++
+// 			currentWant = wantEntries[idx]
+// 		}
+// 		wantCounts = append(wantCounts, apitest.ChangesetCounts{
+// 			Date:                 marshalDateTime(t, tz),
+// 			Total:                currentWant.Total,
+// 			Merged:               currentWant.Merged,
+// 			Closed:               currentWant.Closed,
+// 			Open:                 currentWant.Open,
+// 			Draft:                currentWant.Draft,
+// 			OpenApproved:         currentWant.OpenApproved,
+// 			OpenChangesRequested: currentWant.OpenChangesRequested,
+// 			OpenPending:          currentWant.OpenPending,
+// 		})
+// 	}
 
-add('No data', () => (
-    <EnterpriseWebStory>
-        {props => (
-            <BatchChangeBurndownChart {...props} batchChangeID="123" queryChangesetCountsOverTime={() => of([])} />
-        )}
-    </EnterpriseWebStory>
-))
+add('All states', () => {
+    const changesetCounts = useMemo<ChangesetCountsOverTimeFields[]>(() => {
+        const timeMarks = [
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-13T12:00:00Z',
+                closed: 0,
+                merged: 0,
+                openApproved: 0,
+                openChangesRequested: 0,
+                openPending: 0,
+                total: 10,
+                draft: 10,
+                open: 0,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-14T12:00:00Z',
+                closed: 0,
+                merged: 0,
+                openApproved: 0,
+                openChangesRequested: 0,
+                openPending: 2,
+                total: 10,
+                draft: 5,
+                open: 5,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-15T12:00:00Z',
+                closed: 0,
+                merged: 1,
+                openApproved: 1,
+                openChangesRequested: 0,
+                openPending: 3,
+                total: 10,
+                draft: 0,
+                open: 8,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-16T12:00:00Z',
+                closed: 1,
+                merged: 1,
+                openApproved: 1,
+                openChangesRequested: 0,
+                openPending: 3,
+                total: 10,
+                draft: 0,
+                open: 7,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-17T12:00:00Z',
+                closed: 1,
+                merged: 2,
+                openApproved: 1,
+                openChangesRequested: 0,
+                openPending: 5,
+                total: 10,
+                draft: 0,
+                open: 6,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-18T12:00:00Z',
+                closed: 2,
+                merged: 4,
+                openApproved: 0,
+                openChangesRequested: 2,
+                openPending: 2,
+                total: 10,
+                draft: 0,
+                open: 4,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-19T12:00:00Z',
+                closed: 2,
+                merged: 4,
+                openApproved: 0,
+                openChangesRequested: 2,
+                openPending: 2,
+                total: 10,
+                draft: 0,
+                open: 4,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-20T12:00:00Z',
+                closed: 2,
+                merged: 4,
+                openApproved: 0,
+                openChangesRequested: 2,
+                openPending: 2,
+                total: 10,
+                draft: 0,
+                open: 4,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-21T12:00:00Z',
+                closed: 2,
+                merged: 5,
+                openApproved: 3,
+                openChangesRequested: 0,
+                openPending: 0,
+                total: 10,
+                draft: 0,
+                open: 3,
+            },
+            {
+                __typename: 'ChangesetCounts',
+                date: '2019-11-22T12:00:00Z',
+                closed: 2,
+                merged: 8,
+                openApproved: 0,
+                openChangesRequested: 0,
+                openPending: 0,
+                total: 10,
+                draft: 0,
+                open: 0,
+            },
+        ]
+        let index_ = 0
+        return new Array(150).fill(undefined).map((value, index) => {
+            let currentMark = timeMarks[index_]
+            const tz = addSeconds(
+                new Date('2019-11-13T12:00:00Z'),
+                // 10 days of data
+                index * Math.round((10 * 24 * 60 * 60) / 150)
+            )
+            while (timeMarks.length > index_ + 1 && !isBefore(tz, new Date(timeMarks[index_ + 1].date))) {
+                index_++
+                currentMark = timeMarks[index_]
+            }
+            return {
+                __typename: 'ChangesetCounts',
+                date: tz.toISOString(),
+                closed: currentMark.closed,
+                draft: currentMark.draft,
+                merged: currentMark.merged,
+                openApproved: currentMark.openApproved,
+                openChangesRequested: currentMark.openChangesRequested,
+                openPending: currentMark.openPending,
+                total: currentMark.total,
+            }
+        })
+    }, [])
+    return (
+        <EnterpriseWebStory>
+            {props => (
+                <BatchChangeBurndownChart
+                    {...props}
+                    batchChangeID="123"
+                    queryChangesetCountsOverTime={() => of(changesetCounts)}
+                />
+            )}
+        </EnterpriseWebStory>
+    )
+})

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -110,7 +110,7 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
     }
 
     return (
-        <div className="d-flex align-items-center">
+        <div className="d-flex batch-change-burndown-chart__container align-items-center">
             <ResponsiveContainer width={width} height={300} className="test-batches-chart">
                 <ComposedChart
                     data={changesetCountsOverTime.map(snapshot => ({ ...snapshot, date: Date.parse(snapshot.date) }))}

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -85,7 +85,7 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
 
     const dateTickFormatter = useMemo(() => {
         let dateTickFormat = new Intl.DateTimeFormat(undefined, { month: 'long', day: 'numeric' })
-        if (changesetCountsOverTime?.length > 1) {
+        if (changesetCountsOverTime && changesetCountsOverTime?.length > 1) {
             const start = parseISO(changesetCountsOverTime[0].date)
             const end = parseISO(changesetCountsOverTime[changesetCountsOverTime.length - 1].date)
             // If the range spans multiple years, we want to display the year as well.

--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -218,6 +219,14 @@ func (r *batchChangeResolver) ChangesetCountsOverTime(
 		if err != nil {
 			return resolvers, err
 		}
+	}
+
+	// Sort all events once by their timestamps
+	events := state.ChangesetEvents(es)
+	sort.Sort(events)
+
+	if len(events) > 0 {
+		start = events[0].Timestamp().UTC()
 	}
 
 	counts, err := state.CalcCounts(start, end, cs, es...)

--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -182,8 +182,6 @@ func (r *batchChangeResolver) ChangesetCountsOverTime(
 	ctx context.Context,
 	args *graphqlbackend.ChangesetCountsArgs,
 ) ([]graphqlbackend.ChangesetCountsResolver, error) {
-	resolvers := []graphqlbackend.ChangesetCountsResolver{}
-
 	publishedState := batches.ChangesetPublicationStatePublished
 	opts := store.ListChangesetsOpts{
 		BatchChangeID: r.batchChange.ID,
@@ -192,23 +190,7 @@ func (r *batchChangeResolver) ChangesetCountsOverTime(
 	}
 	cs, _, err := r.store.ListChangesets(ctx, opts)
 	if err != nil {
-		return resolvers, err
-	}
-
-	now := r.store.Clock()()
-
-	weekAgo := now.Add(-7 * 24 * time.Hour)
-	start := r.batchChange.CreatedAt.UTC()
-	if start.After(weekAgo) {
-		start = weekAgo
-	}
-	if args.From != nil {
-		start = args.From.Time.UTC()
-	}
-
-	end := now.UTC()
-	if args.To != nil && args.To.Time.Before(end) {
-		end = args.To.Time.UTC()
+		return nil, err
 	}
 
 	var es []*batches.ChangesetEvent
@@ -217,23 +199,37 @@ func (r *batchChangeResolver) ChangesetCountsOverTime(
 		eventsOpts := store.ListChangesetEventsOpts{ChangesetIDs: changesetIDs, Kinds: state.RequiredEventTypesForHistory}
 		es, _, err = r.store.ListChangesetEvents(ctx, eventsOpts)
 		if err != nil {
-			return resolvers, err
+			return nil, err
 		}
 	}
-
-	// Sort all events once by their timestamps
+	// Sort all events once by their timestamps, CalcCounts depends on it.
 	events := state.ChangesetEvents(es)
 	sort.Sort(events)
 
-	if len(events) > 0 {
+	// Determine timeframe.
+	now := r.store.Clock()()
+	weekAgo := now.Add(-7 * 24 * time.Hour)
+	start := r.batchChange.CreatedAt.UTC()
+	// At least a week lookback, more if the batch change was created earlier.
+	if start.After(weekAgo) {
+		start = weekAgo
+	}
+	if args.From != nil {
+		start = args.From.Time.UTC()
+	} else if len(events) > 0 {
 		start = events[0].Timestamp().UTC()
+	}
+	end := now.UTC()
+	if args.To != nil && args.To.Time.Before(end) {
+		end = args.To.Time.UTC()
 	}
 
 	counts, err := state.CalcCounts(start, end, cs, es...)
 	if err != nil {
-		return resolvers, err
+		return nil, err
 	}
 
+	resolvers := make([]graphqlbackend.ChangesetCountsResolver, 0, len(counts))
 	for _, c := range counts {
 		resolvers = append(resolvers, &changesetCountsResolver{counts: c})
 	}

--- a/enterprise/internal/batches/state/counts.go
+++ b/enterprise/internal/batches/state/counts.go
@@ -108,10 +108,11 @@ func CalcCounts(start, end time.Time, cs []*batches.Changeset, es ...*batches.Ch
 }
 
 func generateTimestamps(start, end time.Time) []time.Time {
+	timeStep := end.Sub(start) / 150
 	// Walk backwards from `end` to >= `start` in 1 day intervals
 	// Backwards so we always end exactly on `end`
 	ts := []time.Time{}
-	for t := end; !t.Before(start); t = t.AddDate(0, 0, -1) {
+	for t := end; !t.Before(start); t = t.Add(-timeStep) {
 		ts = append(ts, t)
 	}
 

--- a/enterprise/internal/batches/state/counts.go
+++ b/enterprise/internal/batches/state/counts.go
@@ -2,11 +2,13 @@ package state
 
 import (
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/internal/batches"
 )
+
+// timestampCount defines how many timestamps we will return for a given dateframe.
+const timestampCount = 150
 
 // ChangesetCounts represents the states in which a given set of Changesets was
 // at a given point in time
@@ -38,23 +40,19 @@ func (cc *ChangesetCounts) String() string {
 
 // CalcCounts calculates ChangesetCounts for the given Changesets and their
 // ChangesetEvents in the timeframe specified by the start and end parameters.
-// The number of ChangesetCounts returned is the number of 1 day intervals
-// between start and end, with each ChangesetCounts representing a point in
-// time at the boundary of each 24h interval.
+// The number of ChangesetCounts returned is always `timestampCount`. Between
+// start and end, it generates `timestampCount` datapoints with each ChangesetCounts
+// representing a point in time. `es` are expected to be pre-sorted.
 func CalcCounts(start, end time.Time, cs []*batches.Changeset, es ...*batches.ChangesetEvent) ([]*ChangesetCounts, error) {
-	ts := generateTimestamps(start, end)
+	ts := GenerateTimestamps(start, end)
 	counts := make([]*ChangesetCounts, len(ts))
 	for i, t := range ts {
 		counts[i] = &ChangesetCounts{Time: t}
 	}
 
-	// Sort all events once by their timestamps
-	events := ChangesetEvents(es)
-	sort.Sort(events)
-
 	// Grouping Events by their Changeset ID
 	byChangesetID := make(map[int64]ChangesetEvents)
-	for _, e := range events {
+	for _, e := range es {
 		id := e.Changeset()
 		byChangesetID[id] = append(byChangesetID[id], e)
 	}
@@ -107,10 +105,10 @@ func CalcCounts(start, end time.Time, cs []*batches.Changeset, es ...*batches.Ch
 	return counts, nil
 }
 
-func generateTimestamps(start, end time.Time) []time.Time {
-	timeStep := end.Sub(start) / 150
-	// Walk backwards from `end` to >= `start` in 1 day intervals
-	// Backwards so we always end exactly on `end`
+func GenerateTimestamps(start, end time.Time) []time.Time {
+	timeStep := end.Sub(start) / timestampCount
+	// Walk backwards from `end` to >= `start` in equal intervals.
+	// Backwards so we always end exactly on `end`.
 	ts := []time.Time{}
 	for t := end; !t.Before(start); t = t.Add(-timeStep) {
 		ts = append(ts, t)


### PR DESCRIPTION
We now always return 150 datapoints and over the entire range where the batch change had any changesets. Also, the burndown chart allows to hide certain categories now.