### PR TITLE
Improve performance for batch changes with many changesets

### DIFF
--- a/enterprise/internal/batches/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_connection_test.go
@@ -146,13 +146,13 @@ func TestChangesetConnectionResolver(t *testing.T) {
 		wantOpen        int
 		wantNodes       []apitest.Changeset
 	}{
-		{firstParam: 1, wantHasNextPage: true, wantEndCursor: "1", wantTotalCount: 4, wantOpen: 2, wantNodes: nodes[:1]},
-		{firstParam: 2, wantHasNextPage: true, wantEndCursor: "2", wantTotalCount: 4, wantOpen: 2, wantNodes: nodes[:2]},
-		{firstParam: 3, wantHasNextPage: true, wantEndCursor: "3", wantTotalCount: 4, wantOpen: 2, wantNodes: nodes[:3]},
+		{firstParam: 1, wantHasNextPage: true, wantEndCursor: "2", wantTotalCount: 4, wantOpen: 2, wantNodes: nodes[:1]},
+		{firstParam: 2, wantHasNextPage: true, wantEndCursor: "3", wantTotalCount: 4, wantOpen: 2, wantNodes: nodes[:2]},
+		{firstParam: 3, wantHasNextPage: true, wantEndCursor: "4", wantTotalCount: 4, wantOpen: 2, wantNodes: nodes[:3]},
 		{firstParam: 4, wantHasNextPage: false, wantTotalCount: 4, wantOpen: 2, wantNodes: nodes[:4]},
 		// Expect only 3 changesets to be returned when an unsafe filter is applied.
-		{firstParam: 1, useUnsafeOpts: true, wantEndCursor: "1", wantHasNextPage: true, wantTotalCount: 3, wantOpen: 1, wantNodes: nodes[:1]},
-		{firstParam: 2, useUnsafeOpts: true, wantEndCursor: "2", wantHasNextPage: true, wantTotalCount: 3, wantOpen: 1, wantNodes: nodes[:2]},
+		{firstParam: 1, useUnsafeOpts: true, wantEndCursor: "2", wantHasNextPage: true, wantTotalCount: 3, wantOpen: 1, wantNodes: nodes[:1]},
+		{firstParam: 2, useUnsafeOpts: true, wantEndCursor: "3", wantHasNextPage: true, wantTotalCount: 3, wantOpen: 1, wantNodes: nodes[:2]},
 		{firstParam: 3, useUnsafeOpts: true, wantHasNextPage: false, wantTotalCount: 3, wantOpen: 1, wantNodes: nodes[:3]},
 	}
 

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -623,6 +623,11 @@ func unixMilliToTime(ms int64) time.Time {
 	return time.Unix(0, ms*int64(time.Millisecond))
 }
 
+var ComputeLabelsRequiredEventTypes = []batches.ChangesetEventKind{
+	batches.ChangesetEventKindGitHubLabeled,
+	batches.ChangesetEventKindGitHubUnlabeled,
+}
+
 // ComputeLabels returns a sorted list of current labels based the starting set
 // of labels found in the Changeset and looking at ChangesetEvents that have
 // occurred after the Changeset.UpdatedAt.

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -444,68 +444,6 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			}
 		}
 
-		{
-			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{WithoutDeleted: true})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if len(have) != len(changesets) {
-				t.Fatalf("have 0 changesets. want %d", len(changesets))
-			}
-
-			for _, c := range changesets {
-				c.SetDeleted()
-				c.UpdatedAt = clock.Now()
-
-				if err := s.UpdateChangeset(ctx, c); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			have, _, err = s.ListChangesets(ctx, ListChangesetsOpts{WithoutDeleted: true})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if len(have) != 0 {
-				t.Fatalf("have %d changesets. want 0", len(changesets))
-			}
-		}
-
-		{
-			gitlabMR := &gitlab.MergeRequest{
-				ID:        gitlab.ID(1),
-				Title:     "Fix a bunch of bugs",
-				CreatedAt: gitlab.Time{Time: clock.Now()},
-				UpdatedAt: gitlab.Time{Time: clock.Now()},
-			}
-			gitlabChangeset := &batches.Changeset{
-				Metadata:            gitlabMR,
-				RepoID:              gitlabRepo.ID,
-				ExternalServiceType: extsvc.TypeGitLab,
-			}
-			if err := s.CreateChangeset(ctx, gitlabChangeset); err != nil {
-				t.Fatal(err)
-			}
-			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{ExternalServiceID: "https://gitlab.com/"})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			want := 1
-			if len(have) != want {
-				t.Fatalf("have %d changesets; want %d", len(have), want)
-			}
-
-			if have[0].ID != gitlabChangeset.ID {
-				t.Fatalf("unexpected changeset: have %+v; want %+v", have[0], gitlabChangeset)
-			}
-			if err := s.DeleteChangeset(ctx, gitlabChangeset.ID); err != nil {
-				t.Fatal(err)
-			}
-		}
-
 		// No Limit should return all Changesets
 		{
 			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{})

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
+	user := ct.CreateTestUser(t, s.DB(), false)
 	githubActor := github.Actor{
 		AvatarURL: "https://avatars2.githubusercontent.com/u/1185253",
 		Login:     "mrnugget",
@@ -350,6 +351,61 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			}
 		})
 
+		t.Run("PublicationState", func(t *testing.T) {
+			published := batches.ChangesetPublicationStatePublished
+			countPublished, err := s.CountChangesets(ctx, CountChangesetsOpts{PublicationState: &published})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := countPublished, 1; have != want {
+				t.Fatalf("have countPublished: %d, want: %d", have, want)
+			}
+
+			unpublished := batches.ChangesetPublicationStateUnpublished
+			countUnpublished, err := s.CountChangesets(ctx, CountChangesetsOpts{PublicationState: &unpublished})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := countUnpublished, len(changesets)-1; have != want {
+				t.Fatalf("have countUnpublished: %d, want: %d", have, want)
+			}
+		})
+
+		t.Run("TextSearch", func(t *testing.T) {
+			countMatchingString, err := s.CountChangesets(ctx, CountChangesetsOpts{TextSearch: []search.TextSearchTerm{{Term: "Fix a bunch"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := countMatchingString, len(changesets); have != want {
+				t.Fatalf("have countMatchingString: %d, want: %d", have, want)
+			}
+
+			countNotMatchingString, err := s.CountChangesets(ctx, CountChangesetsOpts{TextSearch: []search.TextSearchTerm{{Term: "Very not in the title"}}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := countNotMatchingString, 0; have != want {
+				t.Fatalf("have countNotMatchingString: %d, want: %d", have, want)
+			}
+		})
+
+		t.Run("EnforceAuthz", func(t *testing.T) {
+			// No access to repos.
+			ct.MockRepoPermissions(t, s.DB(), user.ID)
+			countAccessible, err := s.CountChangesets(ctx, CountChangesetsOpts{EnforceAuthz: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have, want := countAccessible, 0; have != want {
+				t.Fatalf("have countAccessible: %d, want: %d", have, want)
+			}
+		})
+
 		t.Run("OwnedByBatchChangeID", func(t *testing.T) {
 			count, err := s.CountChangesets(ctx, CountChangesetsOpts{OwnedByBatchChangeID: int64(1)})
 			if err != nil {
@@ -363,58 +419,62 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 	})
 
 	t.Run("List", func(t *testing.T) {
-		for i := 1; i <= len(changesets); i++ {
-			opts := ListChangesetsOpts{BatchChangeID: int64(i)}
+		t.Run("BatchChangeID", func(t *testing.T) {
+			for i := 1; i <= len(changesets); i++ {
+				opts := ListChangesetsOpts{BatchChangeID: int64(i)}
 
-			ts, next, err := s.ListChangesets(ctx, opts)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if have, want := next, int64(0); have != want {
-				t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
-			}
-
-			have, want := ts, changesets[i-1:i]
-			if len(have) != len(want) {
-				t.Fatalf("listed %d changesets, want: %d", len(have), len(want))
-			}
-
-			if diff := cmp.Diff(have, want); diff != "" {
-				t.Fatalf("opts: %+v, diff: %s", opts, diff)
-			}
-		}
-
-		for i := 1; i <= len(changesets); i++ {
-			ts, next, err := s.ListChangesets(ctx, ListChangesetsOpts{LimitOpts: LimitOpts{Limit: i}})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			{
-				have, want := next, int64(0)
-				if i < len(changesets) {
-					want = changesets[i].ID
+				ts, next, err := s.ListChangesets(ctx, opts)
+				if err != nil {
+					t.Fatal(err)
 				}
 
-				if have != want {
-					t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
+				if have, want := next, int64(0); have != want {
+					t.Fatalf("opts: %+v: have next %v, want %v", opts, have, want)
 				}
-			}
 
-			{
-				have, want := ts, changesets[:i]
+				have, want := ts, changesets[i-1:i]
 				if len(have) != len(want) {
 					t.Fatalf("listed %d changesets, want: %d", len(have), len(want))
 				}
 
 				if diff := cmp.Diff(have, want); diff != "" {
-					t.Fatal(diff)
+					t.Fatalf("opts: %+v, diff: %s", opts, diff)
 				}
 			}
-		}
+		})
 
-		{
+		t.Run("Limit", func(t *testing.T) {
+			for i := 1; i <= len(changesets); i++ {
+				ts, next, err := s.ListChangesets(ctx, ListChangesetsOpts{LimitOpts: LimitOpts{Limit: i}})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				{
+					have, want := next, int64(0)
+					if i < len(changesets) {
+						want = changesets[i].ID
+					}
+
+					if have != want {
+						t.Fatalf("limit: %v: have next %v, want %v", i, have, want)
+					}
+				}
+
+				{
+					have, want := ts, changesets[:i]
+					if len(have) != len(want) {
+						t.Fatalf("listed %d changesets, want: %d", len(have), len(want))
+					}
+
+					if diff := cmp.Diff(have, want); diff != "" {
+						t.Fatal(diff)
+					}
+				}
+			}
+		})
+
+		t.Run("IDs", func(t *testing.T) {
 			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{IDs: changesets.IDs()})
 			if err != nil {
 				t.Fatal(err)
@@ -424,9 +484,9 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			if diff := cmp.Diff(have, want); diff != "" {
 				t.Fatal(diff)
 			}
-		}
+		})
 
-		{
+		t.Run("Cursor pagination", func(t *testing.T) {
 			var cursor int64
 			for i := 1; i <= len(changesets); i++ {
 				opts := ListChangesetsOpts{Cursor: cursor, LimitOpts: LimitOpts{Limit: 1}}
@@ -442,10 +502,10 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 
 				cursor = next
 			}
-		}
+		})
 
 		// No Limit should return all Changesets
-		{
+		t.Run("No limit", func(t *testing.T) {
 			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{})
 			if err != nil {
 				t.Fatal(err)
@@ -454,7 +514,20 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 			if len(have) != 3 {
 				t.Fatalf("have %d changesets. want 3", len(have))
 			}
-		}
+		})
+
+		t.Run("EnforceAuthz", func(t *testing.T) {
+			// No access to repos.
+			ct.MockRepoPermissions(t, s.DB(), user.ID)
+			have, _, err := s.ListChangesets(ctx, ListChangesetsOpts{EnforceAuthz: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(have) != 0 {
+				t.Fatalf("have %d changesets. want 0", len(have))
+			}
+		})
 
 		statePublished := batches.ChangesetPublicationStatePublished
 		stateUnpublished := batches.ChangesetPublicationStateUnpublished
@@ -554,7 +627,7 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		}
 
 		for i, tc := range filterCases {
-			t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Run("States_"+strconv.Itoa(i), func(t *testing.T) {
 				have, _, err := s.ListChangesets(ctx, tc.opts)
 				if err != nil {
 					t.Fatal(err)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -181,6 +181,7 @@ Referenced by:
 Indexes:
     "changesets_pkey" PRIMARY KEY, btree (id)
     "changesets_repo_external_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_id)
+    "changesets_batch_change_ids" gin (batch_change_ids)
     "changesets_external_state_idx" btree (external_state)
     "changesets_publication_state_idx" btree (publication_state)
     "changesets_reconciler_state_idx" btree (reconciler_state)

--- a/migrations/frontend/1528395797_faster_changeset_lookups.down.sql
+++ b/migrations/frontend/1528395797_faster_changeset_lookups.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS changesets_batch_change_ids;

--- a/migrations/frontend/1528395797_faster_changeset_lookups.up.sql
+++ b/migrations/frontend/1528395797_faster_changeset_lookups.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS changesets_batch_change_ids ON changesets USING GIN (batch_change_ids jsonb_ops);

--- a/migrations/frontend/bindata.go
+++ b/migrations/frontend/bindata.go
@@ -128,6 +128,8 @@
 // 1528395795_add_clone_status_index_to_gitserver_repos.up.sql (112B)
 // 1528395796_alter_cloud_default_constraint.down.sql (186B)
 // 1528395796_alter_cloud_default_constraint.up.sql (209B)
+// 1528395797_faster_changeset_lookups.down.sql (50B)
+// 1528395797_faster_changeset_lookups.up.sql (122B)
 
 package migrations
 
@@ -2756,6 +2758,46 @@ func _1528395796_alter_cloud_default_constraintUpSql() (*asset, error) {
 	return a, nil
 }
 
+var __1528395797_faster_changeset_lookupsDownSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x09\xf2\x0f\x50\xf0\xf4\x73\x71\x8d\x50\xf0\x74\x53\x70\x8d\xf0\x0c\x0e\x09\x56\x48\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x29\x8e\x4f\x4a\x2c\x49\xce\x88\x87\x08\xc4\x67\xa6\x14\x5b\x73\x01\x02\x00\x00\xff\xff\x6e\x26\xb0\xa2\x32\x00\x00\x00")
+
+func _1528395797_faster_changeset_lookupsDownSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395797_faster_changeset_lookupsDownSql,
+		"1528395797_faster_changeset_lookups.down.sql",
+	)
+}
+
+func _1528395797_faster_changeset_lookupsDownSql() (*asset, error) {
+	bytes, err := _1528395797_faster_changeset_lookupsDownSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395797_faster_changeset_lookups.down.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x77, 0xe4, 0x35, 0xb7, 0x4a, 0x87, 0xe8, 0xfa, 0x97, 0xf3, 0x40, 0x98, 0x2, 0xda, 0x0, 0xd8, 0xe1, 0x53, 0x51, 0x17, 0xf2, 0x79, 0x98, 0x23, 0x99, 0x4f, 0xdf, 0xd0, 0x4a, 0xfc, 0xf6, 0x6c}}
+	return a, nil
+}
+
+var __1528395797_faster_changeset_lookupsUpSql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x72\x0e\x72\x75\x0c\x71\x55\xf0\xf4\x73\x71\x8d\x50\x70\xf6\xf7\x73\x0e\x0d\x0a\x72\xf5\x0b\xf1\x89\x54\xf0\x74\x53\xf0\xf3\x0f\x51\x70\x8d\xf0\x0c\x0e\x09\x56\x48\xce\x48\xcc\x4b\x4f\x2d\x4e\x2d\x29\x8e\x4f\x4a\x2c\x49\xce\x88\x87\x08\xc4\x67\xa6\x14\x2b\xf8\xfb\x21\x49\x2b\x84\x06\x7b\xfa\xb9\x2b\xb8\x7b\xfa\x29\x68\x60\xa8\xcc\x2a\xce\xcf\x4b\x8a\xcf\x2f\x28\xd6\xb4\xe6\x02\x04\x00\x00\xff\xff\x81\x66\x57\x59\x7a\x00\x00\x00")
+
+func _1528395797_faster_changeset_lookupsUpSqlBytes() ([]byte, error) {
+	return bindataRead(
+		__1528395797_faster_changeset_lookupsUpSql,
+		"1528395797_faster_changeset_lookups.up.sql",
+	)
+}
+
+func _1528395797_faster_changeset_lookupsUpSql() (*asset, error) {
+	bytes, err := _1528395797_faster_changeset_lookupsUpSqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "1528395797_faster_changeset_lookups.up.sql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info, digest: [32]uint8{0x4, 0x16, 0x32, 0xba, 0x62, 0x3, 0x2f, 0x6e, 0x89, 0xf3, 0x83, 0x5a, 0x7f, 0x84, 0xbd, 0xa4, 0x28, 0x7f, 0xff, 0x85, 0xf4, 0xef, 0x50, 0x31, 0xfc, 0x5b, 0x81, 0x50, 0x7d, 0xe, 0x94, 0x10}}
+	return a, nil
+}
+
 // Asset loads and returns the asset for the given name.
 // It returns an error if the asset could not be found or
 // could not be loaded.
@@ -2975,6 +3017,8 @@ var _bindata = map[string]func() (*asset, error){
 	"1528395795_add_clone_status_index_to_gitserver_repos.up.sql":                            _1528395795_add_clone_status_index_to_gitserver_reposUpSql,
 	"1528395796_alter_cloud_default_constraint.down.sql":                                     _1528395796_alter_cloud_default_constraintDownSql,
 	"1528395796_alter_cloud_default_constraint.up.sql":                                       _1528395796_alter_cloud_default_constraintUpSql,
+	"1528395797_faster_changeset_lookups.down.sql":                                           _1528395797_faster_changeset_lookupsDownSql,
+	"1528395797_faster_changeset_lookups.up.sql":                                             _1528395797_faster_changeset_lookupsUpSql,
 }
 
 // AssetDebug is true if the assets were built with the debug flag enabled.
@@ -3149,6 +3193,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 	"1528395795_add_clone_status_index_to_gitserver_repos.up.sql":                            {_1528395795_add_clone_status_index_to_gitserver_reposUpSql, map[string]*bintree{}},
 	"1528395796_alter_cloud_default_constraint.down.sql":                                     {_1528395796_alter_cloud_default_constraintDownSql, map[string]*bintree{}},
 	"1528395796_alter_cloud_default_constraint.up.sql":                                       {_1528395796_alter_cloud_default_constraintUpSql, map[string]*bintree{}},
+	"1528395797_faster_changeset_lookups.down.sql":                                           {_1528395797_faster_changeset_lookupsDownSql, map[string]*bintree{}},
+	"1528395797_faster_changeset_lookups.up.sql":                                             {_1528395797_faster_changeset_lookupsUpSql, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.


### PR DESCRIPTION
I have a local batch change that includes a bit over 10000 changesets and I was always annoyed by how slow it is, so I finally took a look into the trace and found that we're still fetching all changesets in the connection, just to filter by repo permissions then. Also, I found some general DB performance things. Commit-wise review is encouraged :) Hint: Tests come at the end of the git history.

List of changes:
- Add index on JSON "join" column
A GIN index of type jsonb_ops makes the `?` operator way faster, this got down the duration of some queries like GetChangesetsStats and GetBatchChangeDiffStat (probably also ListChangesets, CountChangesets, GetRewirerMappings and ListChangesetSyncData, as they also use this operator, but I didn't test them explicitly) for my local database with around 20000 changesets. This makes querying changesets by batch change a lot faster, namely around 100ms.
- Just fetch required events for labels resolver
We always fetched all events when computing labels, which for larger changesets meant some bandwidth usage because the metadata can be quite big, also lots of parsing overhead unmarshalling the JSON. This fixes it by only loading what's required.
- Use DB-based authz in changeset connection
Now that we can query repo permissions directly in the database, we no longer need to fetch all changesets first to then check how many are accessible and then do the page slicing manually. This also makes the code incredibly simpler.
Now that we use the count method again, I needed to catch up on option parity between count and list.
This change brought down getting a 30 element slice of a batch change with 10k changesets from the API from ~11s to ~160ms.