### PR TITLE
Fix and enforce deadcode linter

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -15,12 +15,24 @@ linters:
     - gosimple
     - varcheck
     - bodyclose
+    - deadcode
 
 issues:
   exclude-rules:
+    # Exclude bodyclose lint from tests because leaking connections in tests
+    # is a non-issue, and checking that adds unnecessary noise
     - path: _test\.go
       linters:
         - bodyclose
+
+    # TODO (camdencheek): This is only excluded because at the time of enabling 
+    # the deadcode lint, there was active work in removing other dead code in this package
+    - path: enterprise/internal/codeintel
+      linters:
+        - deadcode
+    - path: enterprise/cmd/frontend/internal/codeintel
+      linters:
+        - deadcode
 
 run:
   timeout: 5m

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -316,27 +316,6 @@ func repoNamesToStrings(repoNames []api.RepoName) []string {
 	return strings
 }
 
-func toRepositoryResolvers(db dbutil.DB, repos []*types.RepoName) []*RepositoryResolver {
-	if len(repos) == 0 {
-		return []*RepositoryResolver{}
-	}
-
-	resolvers := make([]*RepositoryResolver, len(repos))
-	for i := range repos {
-		resolvers[i] = NewRepositoryResolver(db, repos[i].ToRepo())
-	}
-
-	return resolvers
-}
-
-func toRepoNames(repos []*types.RepoName) []api.RepoName {
-	names := make([]api.RepoName, len(repos))
-	for i, repo := range repos {
-		names[i] = repo.Name
-	}
-	return names
-}
-
 func toDBRepoListColumn(ob string) database.RepoListColumn {
 	switch ob {
 	case "REPO_URI", "REPOSITORY_NAME":

--- a/cmd/frontend/internal/usagestatsdeprecated/usage_stats.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/usage_stats.go
@@ -336,6 +336,7 @@ func ListUsersThisMonth() (*ActiveUsers, error) {
 	return uniques(monthStartDate, &UsageDuration{Months: 1})
 }
 
+//nolint:deadcode // This package is deprecated and will likely be removed anyways, so no use getting rid of this now
 func usersSince(userList []string, dayStart time.Time, userField string) (map[string]bool, error) {
 	c := pool.Get()
 	defer c.Close()

--- a/cmd/searcher/search/zoekt_search.go
+++ b/cmd/searcher/search/zoekt_search.go
@@ -121,16 +121,6 @@ type zoektSearchStreamEvent struct {
 	err      error
 }
 
-func zoektSearchStream(ctx context.Context, args *search.TextPatternInfo, repoBranches map[string][]string, since func(t time.Time) time.Duration, endpoints []string, useFullDeadline bool) <-chan zoektSearchStreamEvent {
-	c := make(chan zoektSearchStreamEvent)
-	go func() {
-		defer close(c)
-		_, _, _, _ = zoektSearch(ctx, args, repoBranches, since, endpoints, useFullDeadline, c)
-	}()
-
-	return c
-}
-
 const defaultMaxSearchResults = 30
 
 // zoektSearch searches repositories using zoekt, returning file contents for

--- a/internal/authz/gitlab/common_test.go
+++ b/internal/authz/gitlab/common_test.go
@@ -2,7 +2,6 @@ package gitlab
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net/url"
 	"sort"
@@ -13,11 +12,9 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -416,31 +413,12 @@ func acct(t *testing.T, userID int32, serviceType, serviceID, accountID, oauthTo
 	}
 }
 
-func repo(uri, serviceType, serviceID, id string) *types.Repo {
-	return &types.Repo{
-		Name: api.RepoName(uri),
-		ExternalRepo: api.ExternalRepoSpec{
-			ID:          id,
-			ServiceType: serviceType,
-			ServiceID:   serviceID,
-		},
-	}
-}
-
 func mustURL(t *testing.T, u string) *url.URL {
 	parsed, err := url.Parse(u)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return parsed
-}
-
-func asJSON(t *testing.T, v interface{}) string {
-	b, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(b)
 }
 
 func getIntOrDefault(str string, def int) (int, error) {

--- a/internal/vcs/git/commits.go
+++ b/internal/vcs/git/commits.go
@@ -194,10 +194,6 @@ func isBadObjectErr(output, obj string) bool {
 	return output == "fatal: bad object "+obj
 }
 
-func isInvalidRevisionRangeError(output, obj string) bool {
-	return strings.HasPrefix(output, "fatal: Invalid revision range "+obj)
-}
-
 // commitLog returns a list of commits.
 //
 // The caller is responsible for doing checkSpecArgSafety on opt.Head and opt.Base.


### PR DESCRIPTION
Fixes a handful of deadcode lint warnings, and enforces the lint in CI. 

Purposefully excludes some `codeintel` code because there was quite a bit of dead code in there, and there were a few recent commits (37536bc) that appeared to be already making progress in removing it. Whenever that's completed, we can remove the lint exclusions in `.golangci.enforced.yml` (cc @efritz)

Progresses #18720 
 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
