### PR TITLE
gitserver: Clean up repos that are on the wrong shard

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -52,10 +52,6 @@ var (
 		Name: "src_gitserver_repos_removed",
 		Help: "number of repos removed during cleanup",
 	})
-	reposRemovedWrongShard = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "src_gitserver_repos_removed_wrong_shard",
-		Help: "number of repos removed during cleanup because they are on the wrong shard",
-	})
 	reposRecloned = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "src_gitserver_repos_recloned",
 		Help: "number of repos removed and recloned due to age",
@@ -229,10 +225,6 @@ func (s *Server) cleanupRepos(addrs []string) {
 		return false, gitGC(dir)
 	}
 
-	var wrongshardCount int
-	defer func() {
-		reposRemovedWrongShard.Set(float64(wrongshardCount))
-	}()
 	removeWrongShard := func(dir GitDir) (done bool, err error) {
 		if len(addrs) == 0 {
 			return false, nil
@@ -241,14 +233,11 @@ func (s *Server) cleanupRepos(addrs []string) {
 		if s.hostnameMatch(addr) {
 			return false, nil
 		}
-		// TODO: Enable this once we've confirmed it's safe and remove reposRemovedWrongShard gauge.
-		//
-		//log15.Info("removing repo for wrong shard", "repo", dir)
-		//if err := s.removeRepoDirectory(dir); err != nil {
-		//	return true, err
-		//}
-		//reposRemoved.Inc()
-		wrongshardCount++
+		log15.Info("removing repo for wrong shard", "repo", dir)
+		if err := s.removeRepoDirectory(dir); err != nil {
+			return true, err
+		}
+		reposRemoved.Inc()
 		return false, nil
 	}
 

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -118,6 +118,42 @@ func TestCleanupInactive(t *testing.T) {
 	}
 }
 
+func TestCleanupWrongShard(t *testing.T) {
+	root, err := ioutil.TempDir("", "gitserver-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	mkRepo := func(name string) string {
+		repo := path.Join(root, name, ".git")
+		cmd := exec.Command("git", "--bare", "init", repo)
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+		return repo
+	}
+	repo1 := mkRepo("repo1")
+	repo2 := mkRepo("repo2")
+	s := &Server{
+		Hostname: "addr1",
+		ReposDir: root,
+	}
+	s.Handler() // Handler as a side-effect sets up Server
+	s.cleanupRepos([]string{"addr1", "addr2"})
+
+	// repo1 maps to addr1
+	// repo2 maps to addr2
+
+	// We therefore expect repo1 to be retained and repo2 should be removed
+	if _, err := os.Stat(repo1); os.IsNotExist(err) {
+		t.Error("expected repo1 not to be removed")
+	}
+	if _, err := os.Stat(repo2); err == nil {
+		t.Error("expected repo2 to be removed during clean up")
+	}
+}
+
 // Note that the exact values (e.g. 50 commits) below are related to git's
 // internal heuristics regarding whether or not to invoke `git gc --auto`.
 //


### PR DESCRIPTION
This code has been trialled in prod and we didn't see any unexpected
behaviour so it's safe to roll out.

In fact, we didn't see any repos cleaned up which indicates our sharding
from the client is working well.