### PR TITLE
doc/dev: Add note about outdated dev-private keys in getting started

### DIFF
--- a/doc/dev/getting-started/quickstart_6_start_server.md
+++ b/doc/dev/getting-started/quickstart_6_start_server.md
@@ -24,6 +24,14 @@ You'll need to clone [`sourcegraph/dev-private`](https://github.com/sourcegraph/
  +-- sourcegraph
 ```
 
+Note: Ensure that you have the latest changes from [`sourcegraph/dev-private`](https://github.com/sourcegraph/dev-private) as the secrets are updated from time to time. For example the following error is an indicator that there are new updated secrets in the repo that you might not have available locally:
+
+```
+14:43:03              repo-updater | ERROR source.list-repos, error: 1 error occurred:
+14:43:03              repo-updater | 	* UnrecognizedClientException: The security token included in the request is invalid.
+14:43:03              repo-updater | 	status code: 400, request id: 1aa331d7-42ff-4d21-9465-2483409f86b7
+```
+
 After the initial setup you can `cd` into `sourcegraph` and run `enterprise/dev/start.sh` instead of `dev/start.sh`.
 
 The environment variables `SITE_CONFIG_FILE`, `EXTSVC_CONFIG_FILE` and `GLOBAL_SETTINGS_FILE` are paths that are read at startup. The content of the files will overwrite the respective setting. `start.sh` will set these files to point into `dev-private`. To avoid overwriting configuration changes done in Sourcegraph, you can set the environment variable `DEV_NO_CONFIG=1`.


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
