### PR TITLE
search: use V2 search API in gqltests

### DIFF
--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -310,7 +310,7 @@ func parseURLQuery(q url.Values) (*args, error) {
 	a := args{
 		Query:          get("q", ""),
 		Version:        get("v", "V2"),
-		PatternType:    get("t", "literal"),
+		PatternType:    get("t", ""),
 		VersionContext: get("vc", ""),
 	}
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -667,9 +667,8 @@ func testSearchClient(t *testing.T, client searchClient) {
 				zeroResult: true,
 			},
 			{
-				name:       `Mixed regexp and literal`,
-				query:      `repo:^github\.com/sgtest/go-diff$ func(.*) or does_not_exist_3744 type:file`,
-				skipStream: true,
+				name:  `Mixed regexp and literal`,
+				query: `repo:^github\.com/sgtest/go-diff$ patternType:regexp func(.*) or does_not_exist_3744 type:file`,
 			},
 			{
 				name:  `Mixed regexp and literal heuristic`,
@@ -681,14 +680,12 @@ func testSearchClient(t *testing.T, client searchClient) {
 				zeroResult: true,
 			},
 			{
-				name:       `Escape sequences`,
-				query:      `repo:^github\.com/sgtest/go-diff$ \' and \" and \\ and /`,
-				skipStream: true,
+				name:  `Escape sequences`,
+				query: `repo:^github\.com/sgtest/go-diff$ patternType:regexp \' and \" and \\ and /`,
 			},
 			{
-				name:       `Escaped whitespace sequences with 'and'`,
-				query:      `repo:^github\.com/sgtest/go-diff$ \ and /`,
-				skipStream: true,
+				name:  `Escaped whitespace sequences with 'and'`,
+				query: `repo:^github\.com/sgtest/go-diff$ patternType:regexp \ and /`,
 			},
 			{
 				name:  `Concat converted to spaces for literal search`,

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -48,7 +48,7 @@ func (rs SearchRepositoryResults) String() string {
 func (c *Client) SearchRepositories(query string) (SearchRepositoryResults, error) {
 	const gqlQuery = `
 query Search($query: String!) {
-	search(query: $query) {
+	search(query: $query, version: V2) {
 		results {
 			results {
 				... on Repository {
@@ -114,7 +114,7 @@ type SearchAlert struct {
 func (c *Client) SearchFiles(query string) (*SearchFileResults, error) {
 	const gqlQuery = `
 query Search($query: String!) {
-	search(query: $query) {
+	search(query: $query, version: V2) {
 		results {
 			matchCount
 			alert {
@@ -183,7 +183,7 @@ type SearchCommitResults struct {
 func (c *Client) SearchCommits(query string) (*SearchCommitResults, error) {
 	const gqlQuery = `
 query Search($query: String!) {
-	search(query: $query) {
+	search(query: $query, version: V2) {
 		results {
 			matchCount
 			results {
@@ -277,7 +277,7 @@ type RepositoryResult struct {
 func (c *Client) SearchAll(query string) ([]*AnyResult, error) {
 	const gqlQuery = `
 query Search($query: String!) {
-	search(query: $query) {
+	search(query: $query, version: V2) {
 		results {
 			results {
 				__typename
@@ -337,7 +337,7 @@ type SearchStatsResult struct {
 func (c *Client) SearchStats(query string) (*SearchStatsResult, error) {
 	const gqlQuery = `
 query SearchResultsStats($query: String!) {
-	search(query: $query) {
+	search(query: $query, version: V2) {
 		stats {
 			languages {
 				name
@@ -449,7 +449,7 @@ type LanguageSuggestionResult struct {
 func (c *Client) SearchSuggestions(query string) ([]SearchSuggestionsResult, error) {
 	const gqlQuery = `
 query SearchSuggestions($query: String!) {
-	search(query: $query) {
+	search(query: $query, version: V2) {
 		suggestions {
 			__typename
 			... on Repository {

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -31,6 +31,19 @@ const (
 	SearchTypeStructural
 )
 
+func (s SearchType) String() string {
+	switch s {
+	case SearchTypeRegex:
+		return "regex"
+	case SearchTypeLiteral:
+		return "literal"
+	case SearchTypeStructural:
+		return "structural"
+	default:
+		return fmt.Sprintf("unknown{%d}", s)
+	}
+}
+
 // QueryInfo is an interface for accessing query values that drive our search logic.
 // It will be removed in favor of a cleaner query API to access values.
 type QueryInfo interface {


### PR DESCRIPTION
We were using the old version of the graphql API for search. This was
the reason some of the streaming search integration tests failed, since
the tests where written against the old version. The old version
defaulted to patternType regexp, while V2 defaults to patternType
literal.

We update the tests to explicitly specify the patternType when
needed. We also update streaming search to only specify patternType as
an argument, if the user specified it. This allows the
"detectPatternType" logic to work correctly if the version is V1 in
streaming.

Co-authored-by: @stefanhengl 