### PR TITLE
database: Properly populate repo_id in IterateRepoGitserverStatus

### DIFF
--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -108,6 +108,7 @@ FROM repo
 		// gitserver_repos
 		if cloneStatus != "" {
 			gr.CloneStatus = types.ParseCloneStatus(cloneStatus)
+			gr.RepoID = rgs.ID
 			rgs.GitserverRepo = &gr
 		}
 

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -65,6 +65,9 @@ func TestIterateRepoGitserverStatus(t *testing.T) {
 		repoCount++
 		if repo.GitserverRepo != nil {
 			statusCount++
+			if repo.GitserverRepo.RepoID == 0 {
+				t.Fatal("GitServerRepo has zero id")
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
We were not properly setting the ID of the embedded GitserverRepo in
cases where a row already exists in the gitservr_repos table. This was
leading to failed batches when updating clone status in gitserver
because multiple rows were being inserted with an ID of 0.
