### PR TITLE
test: Add a basic tests for ConnectionNodes component

### DIFF
--- a/client/web/src/components/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import '@testing-library/jest-dom/extend-expect'
+import * as H from 'history'
 import { cleanup, render, screen } from '@testing-library/react'
 
 import { ConnectionNodesForTesting as ConnectionNodes } from './FilteredConnection'
 
-const emptyLocation = {
+const emptyLocation: H.Location<{}> = {
     pathname: '',
     search: '',
     hash: '',

--- a/client/web/src/components/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection.test.tsx
@@ -12,14 +12,14 @@ const emptyLocation = {
     key: '',
 }
 
-function fakeConnection(pageInfoProps: { hasNextPage: boolean }) {
+function fakeConnection({ hasNextPage, totalCount }: { hasNextPage: boolean; totalCount: number | null }) {
     return {
-        nodes: [],
+        nodes: [{}],
         pageInfo: {
             endCursor: '',
-            ...pageInfoProps,
+            hasNextPage,
         },
-        totalCount: 1,
+        totalCount,
     }
 }
 
@@ -41,30 +41,42 @@ const boringConnectionNodesProps = {
 describe('ConnectionNodes', () => {
     afterAll(cleanup)
 
-    it('pdubroy it should have a "Show more" button when not loading', () => {
+    it('should have a "Show more" button when *not* loading', () => {
         render(
             <ConnectionNodes
-                connection={fakeConnection({ hasNextPage: true })}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2 })}
                 loading={false}
                 {...boringConnectionNodesProps}
             />
         )
         expect(screen.getByRole('button')).toHaveTextContent('Show more')
-        expect(screen.queryByText('1 cat total')).toBeNull()
-        expect(screen.queryByText('(showing first 0)')).toBeNull()
+        expect(screen.getByText('2 cats total')).toBeVisible()
+        expect(screen.getByText('(showing first 1)')).toBeVisible()
     })
 
-    it('pdubroy it should have no button text when loading', () => {
+    it("should *not* have a 'Show more' button when loading", () => {
         render(
             <ConnectionNodes
-                connection={fakeConnection({ hasNextPage: true })}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2 })}
                 loading={true}
                 {...boringConnectionNodesProps}
             />
         )
         expect(screen.queryByRole('button')).toBeNull()
-        expect(screen.getByText('1 cat total')).toBeVisible()
-        expect(screen.getByText('(showing first 0)')).toBeVisible()
+        expect(screen.getByText('2 cats total')).toBeVisible()
+        expect(screen.getByText('(showing first 1)')).toBeVisible()
         // NOTE: we also expect a LoadingSpinner, but that is not provided by ConnectionNodes.
+    })
+
+    it("it doesn't show summary info if totalCount is null", () => {
+        render(
+            <ConnectionNodes
+                connection={fakeConnection({ hasNextPage: true, totalCount: null })}
+                loading={true}
+                {...boringConnectionNodesProps}
+            />
+        )
+        expect(screen.queryByText('2 cats total')).toBeNull()
+        expect(screen.queryByText('(showing first 1)')).toBeNull()
     })
 })

--- a/client/web/src/components/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { ConnectionNodesForTesting as ConnectionNodes } from './FilteredConnection'
+
+const emptyLocation = {
+    pathname: '',
+    search: '',
+    hash: '',
+    state: {},
+    key: '',
+}
+
+function fakeConnection(pageInfoProps: { hasNextPage: boolean }) {
+    return {
+        nodes: [],
+        pageInfo: {
+            endCursor: '',
+            ...pageInfoProps,
+        },
+        totalCount: 1,
+    }
+}
+
+/** A default set of props that are required by the ConnectionNodes component,
+    but that are not relevant to any of the things under test here. */
+const boringConnectionNodesProps = {
+    connectionQuery: '',
+    first: 0,
+    location: emptyLocation,
+    noSummaryIfAllNodesVisible: true,
+    nodeComponent: () => null,
+    nodeComponentProps: {},
+    noun: 'cat',
+    onShowMore: () => {},
+    pluralNoun: 'cats',
+    query: '',
+}
+
+describe('ConnectionNodes', () => {
+    afterAll(cleanup)
+
+    it('pdubroy it should have a "Show more" button when not loading', () => {
+        render(
+            <ConnectionNodes
+                connection={fakeConnection({ hasNextPage: true })}
+                loading={false}
+                {...boringConnectionNodesProps}
+            />
+        )
+        expect(screen.getByRole('button')).toHaveTextContent('Show more')
+        expect(screen.queryByText('1 cat total')).toBeNull()
+        expect(screen.queryByText('(showing first 0)')).toBeNull()
+    })
+
+    it('pdubroy it should have no button text when loading', () => {
+        render(
+            <ConnectionNodes
+                connection={fakeConnection({ hasNextPage: true })}
+                loading={true}
+                {...boringConnectionNodesProps}
+            />
+        )
+        expect(screen.queryByRole('button')).toBeNull()
+        expect(screen.getByText('1 cat total')).toBeVisible()
+        expect(screen.getByText('(showing first 0)')).toBeVisible()
+        // NOTE: we also expect a LoadingSpinner, but that is not provided by ConnectionNodes.
+    })
+})

--- a/client/web/src/components/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection.test.tsx
@@ -1,16 +1,8 @@
 import React from 'react'
-import * as H from 'history'
+import { createLocation } from 'history'
 import { cleanup, render, screen } from '@testing-library/react'
 
 import { ConnectionNodesForTesting as ConnectionNodes } from './FilteredConnection'
-
-const emptyLocation: H.Location<{}> = {
-    pathname: '',
-    search: '',
-    hash: '',
-    state: {},
-    key: '',
-}
 
 function fakeConnection({ hasNextPage, totalCount }: { hasNextPage: boolean; totalCount: number | null }) {
     return {
@@ -28,7 +20,7 @@ function fakeConnection({ hasNextPage, totalCount }: { hasNextPage: boolean; tot
 const boringConnectionNodesProps = {
     connectionQuery: '',
     first: 0,
-    location: emptyLocation,
+    location: createLocation('/'),
     noSummaryIfAllNodesVisible: true,
     nodeComponent: () => null,
     nodeComponentProps: {},

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -318,6 +318,8 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
     private onClickShowMore = (): void => this.props.onShowMore()
 }
 
+export const ConnectionNodesForTesting = ConnectionNodes
+
 /**
  * Fields that belong in FilteredConnectionProps and that don't depend on the type parameters. These are the fields
  * that are most likely to be needed by callers, and it's simpler for them if they are in a parameter-less type.

--- a/package.json
+++ b/package.json
@@ -166,6 +166,7 @@
     "@types/sinon": "9.0.4",
     "@types/socket.io": "2.1.10",
     "@types/socket.io-client": "1.4.33",
+    "@types/testing-library__jest-dom": "^5.9.5",
     "@types/textarea-caret": "3.0.0",
     "@types/uuid": "8.0.1",
     "@types/webpack": "4.41.25",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4142,7 +4142,7 @@
   resolved "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
 
-"@types/testing-library__jest-dom@^5.9.1":
+"@types/testing-library__jest-dom@^5.9.1", "@types/testing-library__jest-dom@^5.9.5":
   version "5.9.5"
   resolved "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
   integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==


### PR DESCRIPTION
- Prepare for a small refactoring for #18904 by introducing some tests for the `ConnectionNodes` component. This is a private component that is an implementation detail of `FilteredConnection`, but is exported in order to have the smallest possible characterization test for this bug.