### PR TITLE
gitserver: Setting clone status handles missing row

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -500,7 +500,7 @@ func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status t
 	if err != nil {
 		return err
 	}
-	return database.NewGitserverReposWith(tx).SetCloneStatus(ctx, repo.ID, status)
+	return database.NewGitserverReposWith(tx).SetCloneStatus(ctx, repo.ID, status, s.Hostname)
 }
 
 // setCloneStatusNonFatal is the same as setCloneStatus but only logs errors


### PR DESCRIPTION
Trying to set the clone status for a GitServerRepo that doesn't exist
yet is no longer an error and instead a new row will be created.
