### PR TITLE
search: don't return nil, nil

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -155,6 +155,9 @@ func (sr *SearchResultsResolver) ApproximateResultCount() string {
 func (sr *SearchResultsResolver) Alert() *searchAlert { return sr.alert }
 
 func (sr *SearchResultsResolver) ElapsedMilliseconds() int32 {
+	if sr.start.IsZero() {
+		return 0
+	}
 	return int32(time.Since(sr.start).Milliseconds())
 }
 

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1743,3 +1743,10 @@ func TestIsGlobalSearch(t *testing.T) {
 	}
 
 }
+
+func TestZeroElapsedMilliseconds(t *testing.T) {
+	r := &SearchResultsResolver{}
+	if got := r.ElapsedMilliseconds(); got != 0 {
+		t.Fatalf("got %d, want %d", got, 0)
+	}
+}


### PR DESCRIPTION
We have a couple of places in the code where we return `resolver, err = nil, nil`.
Because of this we have to add guards against nil results everywhere.
I would prefer we always assume that `err=nil` implies a non-nil result.

For starters, I went through "search_results.go" and made sure that we don't return `nil, nil`
anywhere. I going to check more downstream code before we can remove the guards
against nil results that I left behind.