### PR TITLE
Fix wrong field key: s/organizations/orgs

### DIFF
--- a/client/web/src/components/externalServices/externalServices.tsx
+++ b/client/web/src/components/externalServices/externalServices.tsx
@@ -134,7 +134,7 @@ const githubInstructions = (isEnterprise: boolean): JSX.Element => (
                 Specify which repositories Sourcegraph should index using one of the following fields:
                 <ul>
                     <li>
-                        <Field>organizations</Field>: a list of GitHub organizations.
+                        <Field>orgs</Field>: a list of GitHub organizations.
                     </li>
                     <li>
                         <Field>repositoryQuery</Field>: a list of GitHub search queries.


### PR DESCRIPTION
For reference, here's where this appears:

<img width="961" alt="Screenshot 2021-03-11 at 8 01 37 PM" src="https://user-images.githubusercontent.com/3893573/110802880-a0442500-82a4-11eb-91fa-960d648cd569.png">
