### PR TITLE
Re-enable the 'public code' box in the Manage Repositories page, & hook up to graphql APIs

### DIFF
--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -47,6 +47,8 @@ import {
     UserPublicRepositoriesResult,
     UserPublicRepositoriesVariables,
     UserPublicRepositoriesFields,
+    SetUserPublicRepositoriesResult,
+    SetUserPublicRepositoriesVariables,
 } from '../graphql-operations'
 
 /**
@@ -827,8 +829,11 @@ export function queryUserPublicRepositories(
     )
 }
 
-export function setUserPublicRepositories(userId: Scalars['ID'], repos: string[]): Promise<void> {
-    return requestGraphQL<SetUserPublicReposResult, SetUserPublicReposVariables>(
+export function setUserPublicRepositories(
+    userId: Scalars['ID'],
+    repos: string[]
+): Observable<SetUserPublicRepositoriesResult> {
+    return requestGraphQL<SetUserPublicRepositoriesResult, SetUserPublicRepositoriesVariables>(
         gql`
             mutation SetUserPublicRepositories($userId: ID!, $repos: [String!]!) {
                 SetUserPublicRepos(userID: $userId, repoURIs: $repos) {
@@ -837,7 +842,5 @@ export function setUserPublicRepositories(userId: Scalars['ID'], repos: string[]
             }
         `,
         { userId, repos }
-    )
-        .pipe(map(dataOrThrowErrors))
-        .toPromise<void>()
+    ).pipe(map(dataOrThrowErrors))
 }

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -330,9 +330,16 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
             if (!publicRepoState.enabled) {
                 publicRepos = []
             }
-            await setUserPublicRepositories(userID, publicRepos).catch(error => {
-                setRepoState({ ...repoState, error: String(error) })
-            })
+            let didError = false
+            await setUserPublicRepositories(userID, publicRepos)
+                .toPromise()
+                .catch(error => {
+                    setRepoState({ ...repoState, error: String(error) })
+                    didError = true
+                })
+            if (didError) {
+                return
+            }
 
             if (!selectionState.radio) {
                 history.push(routingPrefix + '/repositories')
@@ -663,7 +670,6 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                             selectionState.radio === 'selected' && (
                                 <div className="ml-4">
                                     {filterControls}
-                                    {repoState.error !== '' && <ErrorAlert error={repoState.error} />}
                                     <table role="grid" className="table">
                                         {
                                             // if we're selecting repos, and the repos are still loading, display the loading animation
@@ -690,8 +696,8 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                 </li>
                 {window.context.sourcegraphDotComMode && (
                     <li className="list-group-item p-0 user-settings-repos__container" key="add-textarea">
-                        <div className="p-4 text-muted">
-                            <h3 className="text-muted">Other public repositories</h3>
+                        <div className="p-4">
+                            <h3>Other public repositories</h3>
                             <p className="text-muted">Public repositories on GitHub and GitLab</p>
                             <input
                                 id="add-public-repos"
@@ -720,6 +726,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                     </li>
                 )}
             </ul>
+            {repoState.error !== '' && <ErrorAlert className="mt-4" error={repoState.error} />}
             <Form className="mt-4 d-flex" onSubmit={submit}>
                 <LoaderButton
                     loading={isLoading(fetchingRepos)}

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -18,6 +18,7 @@ import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import { repeatUntil } from '../../../../../shared/src/util/rxjs/repeatUntil'
 import { LoaderButton } from '../../../components/LoaderButton'
 import { UserRepositoriesUpdateProps } from '../../../util'
+import { queryUserPublicRepositories, setUserPublicRepositories } from '../../../site-admin/backend'
 
 interface Props extends RouteComponentProps, TelemetryProps, UserRepositoriesUpdateProps {
     userID: string
@@ -62,6 +63,11 @@ const initialCodeHostState = {
     loaded: false,
     configuredRepos: emptyRepoNames,
 }
+const initialPublicRepoState = {
+    repos: '',
+    enabled: false,
+    loaded: false,
+}
 
 type initialFetchingReposState = undefined | 'loading' | 'slow' | 'slower'
 const isLoading = (status: initialFetchingReposState): boolean => {
@@ -88,15 +94,18 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
 
     // set up state hooks
     const [repoState, setRepoState] = useState(initialRepoState)
+    const [publicRepoState, setPublicRepoState] = useState(initialPublicRepoState)
     const [selectionState, setSelectionState] = useState({ repos: selectionMap, loaded: false, radio: '' })
     const [currentPage, setPage] = useState(1)
     const [query, setQuery] = useState('')
     const [codeHostFilter, setCodeHostFilter] = useState('')
     const [codeHosts, setCodeHosts] = useState(initialCodeHostState)
-    const [showTextArea, setShowTextArea] = useState(false)
     const [fetchingRepos, setFetchingRepos] = useState<initialFetchingReposState>()
 
-    const toggleTextArea = useCallback(() => setShowTextArea(!showTextArea), [showTextArea])
+    const toggleTextArea = useCallback(
+        () => setPublicRepoState({ ...publicRepoState, enabled: !publicRepoState.enabled }),
+        [publicRepoState]
+    )
 
     useCallback(() => {
         // first we should load code hosts
@@ -145,6 +154,27 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
             })
         }
     }, [codeHosts, selectionState.loaded, selectionState.repos, userID])()
+
+    useCallback(() => {
+        if (publicRepoState.loaded) {
+            return
+        }
+        const userPublicReposSubscription = queryUserPublicRepositories(userID).subscribe(result => {
+            if (!result) {
+                setPublicRepoState({ ...publicRepoState, loaded: true })
+                userPublicReposSubscription.unsubscribe()
+                return
+            }
+
+            let publicRepos = ''
+            for (const repo of result) {
+                publicRepos = `${publicRepos}${repo.name}\n`
+            }
+            setPublicRepoState({ repos: publicRepos, loaded: true, enabled: result.length > 0 })
+
+            userPublicReposSubscription.unsubscribe()
+        })
+    }, [publicRepoState, userID])()
 
     // once we've loaded code hosts and the 'selected' panel is visible, load repos and set the loading state
     useCallback(() => {
@@ -197,6 +227,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
         if (selectionState.radio === 'all' && selectedRepos.size > 0) {
             radioState = 'selected'
         }
+
         setSelectionState({
             repos: selectedRepos,
             loaded: true,
@@ -294,6 +325,19 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
     const submit = useCallback(
         async (event: FormEvent<HTMLFormElement>): Promise<void> => {
             event.preventDefault()
+
+            let publicRepos = publicRepoState.repos.split('\n').filter((row): boolean => row !== '')
+            if (!publicRepoState.enabled) {
+                publicRepos = []
+            }
+            await setUserPublicRepositories(userID, publicRepos).catch(error => {
+                setRepoState({ ...repoState, error: String(error) })
+            })
+
+            if (!selectionState.radio) {
+                history.push(routingPrefix + '/repositories')
+            }
+
             const syncTimes = new Map<string, string>()
             const codeHostRepoPromises = []
 
@@ -373,14 +417,16 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                 )
         },
         [
+            publicRepoState.repos,
+            publicRepoState.enabled,
+            userID,
             codeHosts.hosts,
-            history,
-            repoState,
-            routingPrefix,
             selectionState.radio,
             selectionState.repos,
-            userID,
+            repoState,
             onUserRepositoriesUpdate,
+            history,
+            routingPrefix,
         ]
     )
 
@@ -564,6 +610,10 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
         </tbody>
     )
 
+    const handlePublicReposChanged = (event: React.ChangeEvent<HTMLTextAreaElement>): void => {
+        setPublicRepoState({ ...publicRepoState, repos: event.target.value })
+    }
+
     const loadingAnimation: JSX.Element = (
         <tbody className="container">
             <tr className="mt-2 align-items-baseline row">
@@ -638,29 +688,37 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                         }
                     </div>
                 </li>
-                <li className="list-group-item p-0 user-settings-repos__container" key="add-textarea">
-                    <div className="p-4 text-muted">
-                        <h3 className="text-muted">Other public repositories (coming soon)</h3>
-                        <p className="text-muted">Public repositories on GitHub and GitLab</p>
-                        <input
-                            disabled={true}
-                            id="add-public-repos"
-                            className="mr-2 mt-2"
-                            type="checkbox"
-                            onChange={toggleTextArea}
-                            checked={showTextArea}
-                        />
-                        <label htmlFor="add-public-repos">Sync specific public repositories by URL</label>
+                {window.context.sourcegraphDotComMode && (
+                    <li className="list-group-item p-0 user-settings-repos__container" key="add-textarea">
+                        <div className="p-4 text-muted">
+                            <h3 className="text-muted">Other public repositories</h3>
+                            <p className="text-muted">Public repositories on GitHub and GitLab</p>
+                            <input
+                                id="add-public-repos"
+                                className="mr-2 mt-2"
+                                type="checkbox"
+                                onChange={toggleTextArea}
+                                checked={publicRepoState.enabled}
+                            />
+                            <label htmlFor="add-public-repos">Sync specific public repositories by URL</label>
 
-                        {showTextArea && (
-                            <div className="form-group ml-4 mt-3">
-                                <p className="mb-2">Repositories to sync</p>
-                                <textarea className="form-control" rows={5} />
-                                <p className="text-muted mt-2">Specify with complete URLs. One repository per line.</p>
-                            </div>
-                        )}
-                    </div>
-                </li>
+                            {publicRepoState.enabled && (
+                                <div className="form-group ml-4 mt-3">
+                                    <p className="mb-2">Repositories to sync</p>
+                                    <textarea
+                                        className="form-control"
+                                        rows={5}
+                                        value={publicRepoState.repos}
+                                        onChange={handlePublicReposChanged}
+                                    />
+                                    <p className="text-muted mt-2">
+                                        Specify with complete URLs. One repository per line.
+                                    </p>
+                                </div>
+                            )}
+                        </div>
+                    </li>
+                )}
             </ul>
             <Form className="mt-4 d-flex" onSubmit={submit}>
                 <LoaderButton
@@ -674,7 +732,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                         (fetchingRepos === 'slow' && 'Still working...') ||
                         "That's a lot of code..."
                     }
-                    disabled={!selectionState.radio || isLoading(fetchingRepos)}
+                    disabled={isLoading(fetchingRepos)}
                 />
 
                 <Link

--- a/cmd/frontend/graphqlbackend/set_user_public_repos.go
+++ b/cmd/frontend/graphqlbackend/set_user_public_repos.go
@@ -47,7 +47,7 @@ func (r *schemaResolver) SetUserPublicRepos(ctx context.Context, args struct {
 		eg.Go(func() error {
 			repo, err := getRepo(ctx, repoStore, repoURI)
 			if err != nil {
-				return errors.Wrapf(err, "getting ID for repo %s", repoURI)
+				return errors.Wrapf(err, "Adding repo %s", repoURI)
 			}
 			repos[i] = database.UserPublicRepo{
 				UserID:  userID,

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -402,22 +402,10 @@ func (r *UserResolver) Repositories(ctx context.Context, args *ListUserRepositor
 			Descending: args.Descending,
 		}}
 	}
-	extSvcs, err := database.GlobalExternalServices.List(ctx, database.ExternalServicesListOptions{
-		NamespaceUserID: r.user.ID,
-	})
-	if err != nil {
-		return nil, err
-	}
 
 	if args.ExternalServiceID == nil {
-		ids := make([]int64, 0, len(extSvcs))
-		for _, svc := range extSvcs {
-			ids = append(ids, svc.ID)
-		}
-		if len(ids) == 0 {
-			ids = []int64{-1}
-		}
-		opt.ExternalServiceIDs = ids
+		opt.UserID = r.user.ID
+		opt.IncludeUserPublicRepos = true
 	} else {
 		id, err := unmarshalExternalServiceID(*args.ExternalServiceID)
 		if err != nil {

--- a/internal/database/user_public_repos.go
+++ b/internal/database/user_public_repos.go
@@ -51,6 +51,9 @@ func (s *UserPublicRepoStore) SetUserRepos(ctx context.Context, userID int32, re
 			userID, repo.RepoURI, repo.RepoID,
 		))
 	}
+	if len(values) == 0 {
+		return nil
+	}
 	return tx.Exec(ctx, sqlf.Sprintf(
 		"INSERT INTO user_public_repos(user_id, repo_uri, repo_id) VALUES %s",
 		sqlf.Join(values, ","),

--- a/internal/database/user_public_repos.go
+++ b/internal/database/user_public_repos.go
@@ -44,15 +44,15 @@ func (s *UserPublicRepoStore) SetUserRepos(ctx context.Context, userID int32, re
 	if err != nil {
 		return err
 	}
+	if len(repos) == 0 {
+		return nil
+	}
 	values := make([]*sqlf.Query, 0, len(repos))
 	for _, repo := range repos {
 		values = append(values, sqlf.Sprintf(
 			"(%s, %s, %s)",
 			userID, repo.RepoURI, repo.RepoID,
 		))
-	}
-	if len(values) == 0 {
-		return nil
 	}
 	return tx.Exec(ctx, sqlf.Sprintf(
 		"INSERT INTO user_public_repos(user_id, repo_uri, repo_id) VALUES %s",


### PR DESCRIPTION
This PR hooks up the SetUserPublicRepos graphql API to the manage repositories page, allowing users to list public repos they're interested in searching, and have those repos appear in their searches.

We probably want to make a few further changes:
* enable search contexts if the user doesn't have any code hosts or directly added repos
* show public repos from this box on the previous page

https://user-images.githubusercontent.com/5236823/110816841-9bbb4480-8283-11eb-9242-d878f9dc1abd.mov


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
