### PR TITLE
frontend: handle go symbol paths without receiver or symbol name 

### DIFF
--- a/cmd/frontend/internal/app/go_symbol_url.go
+++ b/cmd/frontend/internal/app/go_symbol_url.go
@@ -116,7 +116,7 @@ func parseGoSymbolURLPath(path string) (*goSymbolSpec, error) {
 	if mode != "go" {
 		return nil, &errcode.HTTPErr{
 			Status: http.StatusNotFound,
-			Err:    errors.New("invalid mode (only \"go\" is supported"),
+			Err:    errors.New("invalid mode (only \"go\" is supported)"),
 		}
 	}
 

--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -29,9 +29,12 @@ func TestParseGoSymbolURLPath(t *testing.T) {
 	invalid := map[string]string{
 		"/ts/github.com/foo/bar/-/Bam": "invalid mode",
 		"/go":                          "invalid symbol URL path",
+		"/go/":                         "invalid symbol URL path",
+		"/go/google.golang.org/api/cloudresourcemanager/v1": "invalid symbol URL path",
 	}
 
 	for path, want := range valid {
+		t.Log(path)
 		got, err := parseGoSymbolURLPath(path)
 		if err != nil {
 			t.Errorf("parseGoSymbolURLPath(%q) got error: %v", path, err)
@@ -41,6 +44,7 @@ func TestParseGoSymbolURLPath(t *testing.T) {
 	}
 
 	for path, errSub := range invalid {
+		t.Log(path)
 		got, err := parseGoSymbolURLPath(path)
 		if err == nil {
 			t.Errorf("parseGoSymbolURLPath(%q) expected error got: %v", path, *got)

--- a/cmd/frontend/internal/app/go_symbol_url_test.go
+++ b/cmd/frontend/internal/app/go_symbol_url_test.go
@@ -107,7 +107,12 @@ func TestSymbolLocation(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		got, _ := symbolLocation(context.Background(), mapFS(test.args.vfs), test.args.commitID, test.args.importPath, test.args.path, test.args.receiver, test.args.symbol)
+		spec := &goSymbolSpec{
+			Pkg:      test.args.importPath,
+			Receiver: test.args.receiver,
+			Symbol:   test.args.symbol,
+		}
+		got, _ := symbolLocation(context.Background(), mapFS(test.args.vfs), test.args.commitID, spec, test.args.path)
 		if got != test.want && (got == nil || test.want == nil || *got != *test.want) {
 			t.Errorf("Test #%d:\ngot  %#v\nwant %#v", i, got, test.want)
 		}


### PR DESCRIPTION
Currently this is our most common panic on sourcegraph.com. If a URL
didn't include "/-/" in the path we would do an out of bounds access.

Noticed this on google cloud error reporter.

I refactored the function a bit and added tests so I could change it with confidence. Can review commit per commit.