### PR TITLE
search: Parse predicate params as part of the full value

### DIFF
--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -322,6 +322,16 @@ func ScanBalancedPattern(buf []byte) (scanned string, count int, ok bool) {
 
 	// looks ahead to see if there are any recognized fields or operators.
 	keepScanning := func() bool {
+		// TODO (@camdencheek): The intent here is to continue scanning if
+		// what we're parsing looks like a predicate. This is probably not the best
+		// way to do it, but we need to avoid breaking early if the things in the
+		// parens look like a subquery because predicate filters often look very
+		// much like a subquery. This obviously only works right now for `repo:contains`,
+		// and this will need to be expanded or re-thought when we add more predicates.
+		if string(result) == "contains" {
+			return true
+		}
+
 		if field, _, _ := ScanField(buf); field != "" {
 			// This "pattern" contains a recognized field, reject it.
 			return false

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -322,12 +322,8 @@ func ScanBalancedPattern(buf []byte) (scanned string, count int, ok bool) {
 
 	// looks ahead to see if there are any recognized fields or operators.
 	keepScanning := func() bool {
-		// TODO (@camdencheek): The intent here is to continue scanning if
-		// what we're parsing looks like a predicate. This is probably not the best
-		// way to do it, but we need to avoid breaking early if the things in the
-		// parens look like a subquery because predicate filters often look very
-		// much like a subquery. This obviously only works right now for `repo:contains`,
-		// and this will need to be expanded or re-thought when we add more predicates.
+		// Keep scanning in case we see a reserved predicate keyword, which may
+		// contain subsequent parantheses. TODO (@camdencheek) See #19075 for more info
 		if string(result) == "contains" {
 			return true
 		}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -174,6 +174,10 @@ func TestParseParameterList(t *testing.T) {
 		Result:      `{"field":"repo","value":"contains(file:test)","negated":false}`,
 		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":24}}`,
 	}).Equal(t, test(`repo:contains(file:test)`))
+
+	autogold.Want("Pattern looks like predicate", value{
+		Result: `{"Kind":2,"Operands":[{"value":"abc","negated":false},{"value":"contains(file:test)","negated":false}],"Annotation":{"labels":0,"range":{"start":{"line":0,"column":0},"end":{"line":0,"column":0}}}}`,
+	}).Equal(t, test(`abc contains(file:test)`))
 }
 
 func TestScanField(t *testing.T) {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -169,6 +169,11 @@ func TestParseParameterList(t *testing.T) {
 		ResultLabels: "HeuristicDanglingParens,Regexp",
 		ResultRange:  `{"start":{"line":0,"column":0},"end":{"line":0,"column":14}}`,
 	}).Equal(t, test(`Search(xxx)\\(`))
+
+	autogold.Want("Repo contains predicate", value{
+		Result:      `{"field":"repo","value":"contains(file:test)","negated":false}`,
+		ResultRange: `{"start":{"line":0,"column":0},"end":{"line":0,"column":24}}`,
+	}).Equal(t, test(`repo:contains(file:test)`))
 }
 
 func TestScanField(t *testing.T) {


### PR DESCRIPTION
When parsing predicates like `repo:contains(file:test)`, this would be
parsed like `repo:contains "(file:test)"`. This is done to avoid parsing
subqueries as part of the literal, but for predicate filters, the params
often look a lot like subqueries. This is the minimum change I could
make to make this non-blocking, but it should be revisited quickly for a
less hacky solution.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
