### PR TITLE
search: introduce query pipeline processing

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -93,7 +93,10 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	var q query.Q
 	globbing := getBoolPtr(settings.SearchGlobbing, false)
 	tr.LogFields(otlog.Bool("globbing", globbing))
-	q, err = query.Parse(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
+	q, err = query.Pipeline(
+		query.Init(args.Query, searchType),
+		query.With(globbing, query.Globbing),
+	)
 	if err != nil {
 		return alertForQuery(db, args.Query, err), nil
 	}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1086,7 +1086,7 @@ func Parse(in string, options ParserOptions) (Q, error) {
 	}
 
 	if options.Globbing {
-		query, err = mapGlobToRegex(query)
+		query, err = Globbing(query)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -1,0 +1,90 @@
+package query
+
+/*
+Query processing involves multiple steps to produce a query to evaluate.
+
+To unify multiple concerns, query processing is abstracted to a sequence of
+steps that entail parsing, validity checking, transformation, and conditional
+processing logic driven by external options.
+*/
+
+// A step performs a transformation on nodes, which may fail.
+type step func(nodes []Node) ([]Node, error)
+
+// A pass is a step that never fails.
+type pass func(nodes []Node) []Node
+
+// sequence sequences zero or more steps to create a single step.
+func sequence(steps ...step) step {
+	return func(nodes []Node) ([]Node, error) {
+		var err error
+		for _, step := range steps {
+			nodes, err = step(nodes)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return nodes, nil
+	}
+}
+
+// succeeds converts a sequence of passes into a single step.
+func succeeds(passes ...pass) step {
+	return func(nodes []Node) ([]Node, error) {
+		for _, pass := range passes {
+			nodes = pass(nodes)
+		}
+		return nodes, nil
+	}
+}
+
+// With returns step if enabled is true. Use it to compose a pipeline that
+// conditionally run steps.
+func With(enabled bool, step step) step {
+	if !enabled {
+		return identity
+	}
+	return step
+}
+
+// For runs processing steps for a given search type. This includes
+// normalization, substitution for whitespace, and pattern labeling.
+func For(searchType SearchType) step {
+	var processType step
+	switch searchType {
+	case SearchTypeLiteral:
+		processType = succeeds(substituteConcat(space))
+	case SearchTypeRegex:
+		processType = succeeds(escapeParensHeuristic, substituteConcat(fuzzyRegexp))
+	case SearchTypeStructural:
+		processType = succeeds(labelStructural, ellipsesForHoles, substituteConcat(space))
+	}
+	normalize := succeeds(LowercaseFieldNames, SubstituteAliases(searchType))
+	return sequence(normalize, processType)
+}
+
+// Init creates a step from an input string and search type. It parses the
+// initial input string.
+func Init(in string, searchType SearchType) step {
+	parser := func([]Node) ([]Node, error) {
+		return ParseAndOr(in, searchType)
+	}
+	return sequence(parser, For(searchType))
+}
+
+// Pipeline processes zero or more steps to produce a query. The first step must
+// be Init, otherwise this function is a no-op.
+func Pipeline(steps ...step) (Q, error) {
+	nodes, err := sequence(steps...)(nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, disjunct := range Dnf(nodes) {
+		err = validate(disjunct)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nodes, nil
+}

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -250,8 +250,8 @@ func fuzzifyGlobPattern(value string) string {
 	return "**" + value + "**"
 }
 
-// mapGlobToRegex translates glob to regexp for fields repo, file, and repohasfile.
-func mapGlobToRegex(nodes []Node) ([]Node, error) {
+// Globbing translates glob to regexp for fields repo, file, and repohasfile.
+func Globbing(nodes []Node) ([]Node, error) {
 	var globErrors []globError
 
 	nodes = MapParameter(nodes, func(field, value string, negated bool, annotation Annotation) Node {
@@ -716,4 +716,8 @@ func AddRegexpField(q Q, field, pattern string) string {
 		q = newOperator(append(q, Parameter{Field: field, Value: pattern}), And)
 	}
 	return StringHuman(q)
+}
+
+func identity(nodes []Node) ([]Node, error) {
+	return nodes, nil
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -864,7 +864,7 @@ func TestMapGlobToRegex(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
 			query, _ := ParseAndOr(c.input, SearchTypeRegex)
-			regexQuery, _ := mapGlobToRegex(query)
+			regexQuery, _ := Globbing(query)
 			got := toString(regexQuery)
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)


### PR DESCRIPTION
Stacked on #19047.

This introduces an abstraction to make query processing easier to deal with. For example, streaming checks can incorporate directly into the processing. 

The main motivation for this though, is to encapsulate all query processing concerns in a separable pipeline, so that we can tie together processing that generates intermediate types inside a pipeline, and different output types of a pipeline too. This breaks the underlying assumption that a query string input maps to only to a parse tree that we have to interface with everywhere in the rest of the code.

This change makes `query.Parse` redundant (`ParseAndOr` will become `Parse`), but I will delete it after propagating this change everywhere in a separate PR. Integration tests should catch any issues here.