### PR TITLE
search: delete parser options and parse

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -92,7 +92,10 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 
 	globbing := getBoolPtr(settings.SearchGlobbing, false)
 
-	q, err := query.Parse(args.Query, query.ParserOptions{SearchType: searchType, Globbing: globbing})
+	q, err := query.Pipeline(
+		query.Init(args.Query, searchType),
+		query.With(globbing, query.Globbing),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -358,7 +358,10 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			setMockResolveRepositories(test.repoRevs)
-			q, err := query.Parse(test.query, query.ParserOptions{SearchType: query.SearchType(0), Globbing: test.globbing})
+			q, err := query.Pipeline(
+				query.InitRegexp(test.query),
+				query.With(test.globbing, query.Globbing),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -426,8 +426,7 @@ func TestProcessSearchPatternAndOr(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			q, err := query.Parse(tt.pattern,
-				query.ParserOptions{SearchType: tt.searchType, Globbing: false})
+			q, err := query.ParseSearchType(tt.pattern, tt.searchType)
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
@@ -1103,7 +1102,7 @@ func TestGetExactFilePatterns(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			q, err := query.Parse(tt.in, query.ParserOptions{SearchType: query.SearchTypeLiteral, Globbing: true})
+			q, err := query.Pipeline(query.InitLiteral(tt.in), query.Globbing)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -72,6 +72,21 @@ func Init(in string, searchType SearchType) step {
 	return sequence(parser, For(searchType))
 }
 
+// InitLiteral is Init where SearchType is Literal.
+func InitLiteral(in string) step {
+	return Init(in, SearchTypeLiteral)
+}
+
+// InitRegexp is Init where SearchType is Regex.
+func InitRegexp(in string) step {
+	return Init(in, SearchTypeRegex)
+}
+
+// InitStructural is Init where SearchType is Structural.
+func InitStructural(in string) step {
+	return Init(in, SearchTypeStructural)
+}
+
 // Pipeline processes zero or more steps to produce a query. The first step must
 // be Init, otherwise this function is a no-op.
 func Pipeline(steps ...step) (Q, error) {

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -100,7 +100,7 @@ func TestSubstituteAliases(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run("substitute alises", func(t *testing.T) {
-			query, _ := Parse(c.input, ParserOptions{SearchType: c.searchType})
+			query, _ := ParseSearchType(c.input, c.searchType)
 			if diff := cmp.Diff(nodesToJSON(query), c.want); diff != "" {
 				t.Fatal(diff)
 			}
@@ -317,7 +317,7 @@ func TestEllipsesForHoles(t *testing.T) {
 	input := "if ... { ... }"
 	want := `"if :[_] { :[_] }"`
 	t.Run("Ellipses for holes", func(t *testing.T) {
-		query, _ := Parse(input, ParserOptions{SearchType: SearchTypeStructural})
+		query, _ := Pipeline(InitStructural(input))
 		got := toString(query)
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatal(diff)


### PR DESCRIPTION
Stacked on #19079.

This removes the `Parse` function and Parse Options in favor of using `Pipeline` as the underlying processing. I created helper functions for cases where we really do just care about the parse output.