### PR TITLE
search: rename ParseAndOr -> Parse

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -203,7 +203,7 @@ func detectSearchType(version string, patternType *string) (query.SearchType, er
 }
 
 func overrideSearchType(input string, searchType query.SearchType) query.SearchType {
-	q, err := query.ParseAndOr(input, query.SearchTypeLiteral)
+	q, err := query.Parse(input, query.SearchTypeLiteral)
 	q = query.LowercaseFieldNames(q)
 	if err != nil {
 		// If parsing fails, return the default search type. Any actual

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1010,8 +1010,8 @@ func (p *parser) tryFallbackParser(in string) ([]Node, error) {
 	return newOperator(nodes, And), nil
 }
 
-// ParseAndOr a raw input string into a parse tree comprising Nodes.
-func ParseAndOr(in string, searchType SearchType) ([]Node, error) {
+// Parse parses a raw input string into a parse tree comprising Nodes.
+func Parse(in string, searchType SearchType) ([]Node, error) {
 	if strings.TrimSpace(in) == "" {
 		return nil, nil
 	}

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -243,7 +243,7 @@ func TestParse(t *testing.T) {
 			resultGrammar = toString(queryGrammar)
 		}
 
-		queryHeuristic, err = ParseAndOr(input, SearchTypeRegex)
+		queryHeuristic, err = Parse(input, SearchTypeRegex)
 		if err != nil {
 			resultHeuristic = err.Error()
 		} else {
@@ -540,7 +540,7 @@ func TestMatchUnaryKeyword(t *testing.T) {
 
 func TestParseAndOrLiteral(t *testing.T) {
 	test := func(input string) string {
-		result, err := ParseAndOr(input, SearchTypeLiteral)
+		result, err := Parse(input, SearchTypeLiteral)
 		if err != nil {
 			return fmt.Sprintf("ERROR: %s", err.Error())
 		}

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -67,7 +67,7 @@ func For(searchType SearchType) step {
 // initial input string.
 func Init(in string, searchType SearchType) step {
 	parser := func([]Node) ([]Node, error) {
-		return ParseAndOr(in, searchType)
+		return Parse(in, searchType)
 	}
 	return sequence(parser, For(searchType))
 }

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -111,7 +111,7 @@ func TestSubstituteAliases(t *testing.T) {
 func TestLowercaseFieldNames(t *testing.T) {
 	input := "rEpO:foo PATTERN"
 	want := `(and "repo:foo" "PATTERN")`
-	query, _ := ParseAndOr(input, SearchTypeRegex)
+	query, _ := Parse(input, SearchTypeRegex)
 	got := toString(LowercaseFieldNames(query))
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Fatal(diff)
@@ -246,7 +246,7 @@ func TestSubstituteOrForRegexp(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			got := toString(substituteOrForRegexp(query))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -304,7 +304,7 @@ func TestSubstituteConcat(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			got := toString(Map(query, substituteConcat(c.concat)))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -379,7 +379,7 @@ func TestConvertEmptyGroupsToLiteral(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			got := escapeParensHeuristic(query)[0].(Pattern)
 			if diff := cmp.Diff(c.want, toString([]Node{got})); diff != "" {
 				t.Error(diff)
@@ -431,7 +431,7 @@ func TestExpandOr(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			queries := Dnf(query)
 			var queriesStr []string
 			for _, q := range queries {
@@ -464,7 +464,7 @@ func TestMap(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("Map query", func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			got := toString(Map(query, c.fns...))
 			if diff := cmp.Diff(c.want, got); diff != "" {
 				t.Fatal(diff)
@@ -720,7 +720,7 @@ func TestFuzzifyRegexPatterns(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			query, _ := ParseAndOr(tt.in, SearchTypeRegex)
+			query, _ := Parse(tt.in, SearchTypeRegex)
 			got := toString(FuzzifyRegexPatterns(query))
 			if got != tt.want {
 				t.Fatalf("got = %v, want %v", got, tt.want)
@@ -863,7 +863,7 @@ func TestMapGlobToRegex(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			regexQuery, _ := Globbing(query)
 			got := toString(regexQuery)
 			if diff := cmp.Diff(c.want, got); diff != "" {
@@ -905,7 +905,7 @@ func TestConcatRevFilters(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			queries := Dnf(query)
 
 			var queriesStr []string
@@ -941,7 +941,7 @@ func TestConcatRevFiltersTopLevelAnd(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			query, _ := ParseAndOr(c.input, SearchTypeRegex)
+			query, _ := Parse(c.input, SearchTypeRegex)
 			qConcat := ConcatRevFilters(query)
 			if diff := cmp.Diff(c.want, toString(qConcat)); diff != "" {
 				t.Error(diff)

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -251,7 +251,7 @@ func TestPartitionSearchPattern(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run("partition search pattern", func(t *testing.T) {
-			q, _ := ParseAndOr(tt.input, SearchTypeRegex)
+			q, _ := Parse(tt.input, SearchTypeRegex)
 			scopeParameters, pattern, err := PartitionSearchPattern(q)
 			if err != nil {
 				if diff := cmp.Diff(tt.want, err.Error()); diff != "" {


### PR DESCRIPTION
Stacked on #19080.

As per title. `Parse` is now the raw parse function, without any additional pipeline processing.