### PR TITLE
insights: various critical bug fixes & improvements

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -226,27 +226,8 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, uniqueSeries map[s
 			to = to.Add(-24 * time.Hour)
 		}
 
-		// Build a function which tells if a given series has data in this timeframe for a specific
-		// repository.
-		seriesIDsWithData, err := h.insightsStore.DistinctSeriesWithData(ctx, from, to)
-		if err != nil {
-			return multierror.Append(multi, errors.Wrap(err, "DistinctSeriesWithData")) // DB error, no point in continuing.
-		}
-		haveData := map[string]struct{}{}
-		for _, id := range seriesIDsWithData {
-			haveData[id] = struct{}{}
-		}
-		haveDataForRepo := func(seriesID string, id api.RepoID, from, to time.Time) bool {
-			// TODO(slimsag): future: actually check if the insight is missing data for the given
-			// repo ID. In the meantime, if there is *any* datapoint in this timeframe we won't do
-			// backfilling. e.g., if a new repository is added to Sourcegraph after we built
-			// historical data for an insight, it will not be accounted for.
-			_, haveData := haveData[seriesID]
-			return haveData
-		}
-
 		// Build historical data for this timeframe.
-		softErr, hardErr := h.buildFrame(ctx, uniqueSeries, sortedSeriesIDs, from, to, haveDataForRepo)
+		softErr, hardErr := h.buildFrame(ctx, uniqueSeries, sortedSeriesIDs, from, to)
 		if softErr != nil {
 			multi = multierror.Append(multi, softErr)
 			continue
@@ -264,9 +245,6 @@ func (h *historicalEnqueuer) buildFrames(ctx context.Context, uniqueSeries map[s
 // It is expected to backfill data for all unique series that are missing data, across all repos
 // (using h.allReposIterator.)
 //
-// It should not backfill data for series that already have data recorded for a given repo, checked
-// via haveDataForRepo().
-//
 // It may return both hard errors (e.g. DB connection failure, future frames are unlikely to build)
 // and soft errors (e.g. user made a mistake or we did partial work, future frames will likely
 // succeed.)
@@ -276,7 +254,6 @@ func (h *historicalEnqueuer) buildFrame(
 	sortedSeriesIDs []string,
 	from time.Time,
 	to time.Time,
-	haveDataForRepo func(seriesID string, id api.RepoID, from, to time.Time) bool,
 ) (hardErr, softErr error) {
 	// We yield frequently for a small period of time for a few reasons:
 	//
@@ -323,7 +300,17 @@ func (h *historicalEnqueuer) buildFrame(
 			yield()
 
 			// If we already have data for this frame+repo+series, then there's nothing to do.
-			if haveDataForRepo(seriesID, repo.ID, from, to) {
+			var numDataPoints int
+			numDataPoints, hardErr = h.insightsStore.CountData(ctx, store.CountDataOpts{
+				From:     &from,
+				To:       &to,
+				SeriesID: &seriesID,
+				RepoID:   &repo.ID,
+			})
+			if err != nil {
+				return multierror.Append(softErr, hardErr)
+			}
+			if numDataPoints > 0 {
 				continue
 			}
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -277,7 +277,11 @@ func (h *historicalEnqueuer) buildFrame(
 		// Lookup the repository (we need its database ID)
 		repo, err := h.repoStore.GetByName(ctx, api.RepoName(repoName))
 		if err != nil {
-			return err // hard DB error
+			// Ignore RepoNotFoundErr because it could just be that the repository was actually
+			// deleted and allReposIterator had it cached.
+			if _, ok := err.(*database.RepoNotFoundErr); !ok {
+				return err // hard DB error
+			}
 		}
 
 		// Find the first commit made to the repository on the default branch.

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -56,25 +56,11 @@ func testHistoricalEnqueuer(t *testing.T, p *testParams) *testResults {
 	}
 
 	insightsStore := store.NewMockInterface()
-	insightsStore.DistinctSeriesWithDataFunc.SetDefaultHook(func(ctx context.Context, from time.Time, to time.Time) ([]string, error) {
+	insightsStore.CountDataFunc.SetDefaultHook(func(ctx context.Context, opts store.CountDataOpts) (int, error) {
 		if p.haveData {
-			insights, err := discovery.Discover(ctx, settingStore)
-			if err != nil {
-				panic(err)
-			}
-			var haveData []string
-			for _, insight := range insights {
-				for _, series := range insight.Series {
-					seriesID, err := discovery.EncodeSeriesID(series)
-					if err != nil {
-						panic(err)
-					}
-					haveData = append(haveData, seriesID)
-				}
-			}
-			return haveData, nil
+			return 100, nil
 		}
-		return []string{}, nil
+		return 0, nil
 	})
 	insightsStore.RecordSeriesPointFunc.SetDefaultHook(func(ctx context.Context, args store.RecordSeriesPointArgs) error {
 		r.operations = append(r.operations, fmt.Sprintf("recordSeriesPoint(point=%v, repoName=%v)", args.Point.String(), *args.RepoName))

--- a/enterprise/internal/insights/background/queryrunner/graphql.go
+++ b/enterprise/internal/insights/background/queryrunner/graphql.go
@@ -26,13 +26,42 @@ type graphQLQuery struct {
 const gqlSearchQuery = `query Search(
 	$query: String!,
 ) {
-	search(query: $query, ) {
+	search(query: $query, version: V2, patternType:literal) {
 		results {
 			limitHit
 			cloning { name }
 			missing { name }
 			timedout { name }
 			matchCount
+			results {
+				__typename
+				... on FileMatch {
+					repository {
+						id
+					}
+					lineMatches {
+						offsetAndLengths
+					}
+					symbols {
+						name
+					}
+				}
+				... on CommitSearchResult {
+					matches {
+						highlights {
+							line
+						}
+					}
+					commit {
+						repository {
+							id
+						}
+					}
+				}
+				... on Repository {
+					id
+				}
+			}
 			alert {
 				title
 				description
@@ -54,6 +83,7 @@ type gqlSearchResponse struct {
 				Missing    []*api.Repo
 				Timedout   []*api.Repo
 				MatchCount int
+				Results    []json.RawMessage
 				Alert      *struct {
 					Title       string
 					Description string

--- a/enterprise/internal/insights/background/queryrunner/graphql_results.go
+++ b/enterprise/internal/insights/background/queryrunner/graphql_results.go
@@ -71,6 +71,7 @@ import (
 // that so am I and this is some of the oldest "tech debt" in all of Sourcegraph :)
 
 type result interface {
+	repoID() string
 	matchCount() int
 }
 
@@ -128,6 +129,10 @@ func (r *fileMatch) matchCount() int {
 	return matches
 }
 
+func (r *fileMatch) repoID() string {
+	return r.Repository.ID
+}
+
 type commitSearchResult struct {
 	Matches struct {
 		Highlights []struct {
@@ -141,6 +146,10 @@ type commitSearchResult struct {
 	}
 }
 
+func (r *commitSearchResult) repoID() string {
+	return r.Commit.Repository.ID
+}
+
 func (r *commitSearchResult) matchCount() int {
 	matches := 1
 	if len(r.Matches.Highlights) > 0 {
@@ -151,6 +160,10 @@ func (r *commitSearchResult) matchCount() int {
 
 type repository struct {
 	ID string
+}
+
+func (r *repository) repoID() string {
+	return r.ID
 }
 
 func (r *repository) matchCount() int {

--- a/enterprise/internal/insights/background/queryrunner/graphql_results.go
+++ b/enterprise/internal/insights/background/queryrunner/graphql_results.go
@@ -1,0 +1,104 @@
+package queryrunner
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// TODO(slimsag): future: It's really nasty that our GraphQL search API is like this:
+//
+// 1. GraphQL makes it really annoying for us to extract the individual result values out
+//    due to the `... on Type` switches.
+// 2. More annoying, the GraphQL API has "results" which contain multiple matches. The web UI
+//    reported the aggregate "match" count, not the number of "results" (and misleadingly
+//    _calls these_ "results") - since we cannot use the global/aggregate count returned by the
+//    API (we need per-repository match counts) we have to calculate this information ourselves
+//    in the same way the search backend does (see the matchCount() methods) in order to get the
+//    correct value. Yuck.
+
+type result interface {
+	matchCount() int
+}
+
+func decodeResult(result json.RawMessage) (result, error) {
+	typeName := struct {
+		TypeName string `json:"__typeName"`
+	}{}
+	if err := json.Unmarshal(result, &typeName); err != nil {
+		return nil, err
+	}
+	switch typeName.TypeName {
+	case "FileMatch":
+		var v fileMatch
+		if err := json.Unmarshal(result, &v); err != nil {
+			return nil, err
+		}
+		return &v, nil
+	case "CommitSearchResult":
+		var v commitSearchResult
+		if err := json.Unmarshal(result, &v); err != nil {
+			return nil, err
+		}
+		return &v, nil
+	case "Repository":
+		var v repository
+		if err := json.Unmarshal(result, &v); err != nil {
+			return nil, err
+		}
+		return &v, nil
+	default:
+		return nil, fmt.Errorf("cannot decode search result: unexpected TypeName: %s", string(result))
+	}
+}
+
+type fileMatch struct {
+	Repository struct {
+		ID string
+	}
+	LineMatches []struct {
+		OffsetAndLengths [][]int
+	}
+	Symbols []struct {
+		Name string
+	}
+}
+
+func (r *fileMatch) matchCount() int {
+	matches := len(r.Symbols)
+	for _, lineMatch := range r.LineMatches {
+		matches += len(lineMatch.OffsetAndLengths)
+	}
+	if matches == 0 {
+		matches = 1 // 1 to count "empty" results like type:path results
+	}
+	return matches
+}
+
+type commitSearchResult struct {
+	Matches struct {
+		Highlights []struct {
+			Line int
+		}
+	}
+	Commit struct {
+		Repository struct {
+			ID string
+		}
+	}
+}
+
+func (r *commitSearchResult) matchCount() int {
+	matches := 1
+	if len(r.Matches.Highlights) > 0 {
+		matches = len(r.Matches.Highlights)
+	}
+	return matches
+}
+
+type repository struct {
+	ID string
+}
+
+func (r *repository) matchCount() int {
+	return 1
+}

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -107,16 +107,7 @@ func (r *workHandler) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf(`for query "%s"`, job.SearchQuery))
 		}
-		switch r := decoded.(type) {
-		case *fileMatch:
-			matchesPerRepo[r.Repository.ID] = matchesPerRepo[r.Repository.ID] + r.matchCount()
-		case *commitSearchResult:
-			matchesPerRepo[r.Commit.Repository.ID] = matchesPerRepo[r.Commit.Repository.ID] + r.matchCount()
-		case *repository:
-			matchesPerRepo[r.ID] = matchesPerRepo[r.ID] + r.matchCount()
-		default:
-			panic(fmt.Sprintf("never here %T", r))
-		}
+		matchesPerRepo[decoded.repoID()] = matchesPerRepo[decoded.repoID()] + r.matchCount()
 	}
 
 	// Record the number of results we got, one data point per-repository.

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -107,7 +107,7 @@ func (r *workHandler) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf(`for query "%s"`, job.SearchQuery))
 		}
-		matchesPerRepo[decoded.repoID()] = matchesPerRepo[decoded.repoID()] + r.matchCount()
+		matchesPerRepo[decoded.repoID()] = matchesPerRepo[decoded.repoID()] + decoded.matchCount()
 	}
 
 	// Record the number of results we got, one data point per-repository.

--- a/enterprise/internal/insights/background/queryrunner/work_handler.go
+++ b/enterprise/internal/insights/background/queryrunner/work_handler.go
@@ -101,7 +101,7 @@ func (r *workHandler) Handle(ctx context.Context, workerStore dbworkerstore.Stor
 
 	// Figure out how many matches we got for every unique repository returned in the search
 	// results.
-	matchesPerRepo := map[string]int{}
+	matchesPerRepo := make(map[string]int, len(results.Data.Search.Results.Results)*4)
 	for _, result := range results.Data.Search.Results.Results {
 		decoded, err := decodeResult(result)
 		if err != nil {

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -104,7 +104,7 @@ func TestResolver_InsightSeries(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			autogold.Want("insights[0][0].Points store opts", `{"SeriesID":"s:087855E6A24440837303FD8A252E9893E8ABDFECA55B61AC83DA1B521906626E","From":"2006-01-02T15:04:05Z","To":"2006-01-03T15:04:05Z","Limit":0}`).Equal(t, string(json))
+			autogold.Want("insights[0][0].Points store opts", `{"SeriesID":"s:087855E6A24440837303FD8A252E9893E8ABDFECA55B61AC83DA1B521906626E","RepoID":null,"From":"2006-01-02T15:04:05Z","To":"2006-01-03T15:04:05Z","Limit":0}`).Equal(t, string(json))
 			return []store.SeriesPoint{
 				{Time: args.From.Time, Value: 1},
 				{Time: args.From.Time, Value: 2},

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -80,7 +80,10 @@ type SeriesPointsOpts struct {
 	// SeriesID is the unique series ID to query, if non-nil.
 	SeriesID *string
 
-	// TODO(slimsag): Add ability to filter based on repo ID, name, original name.
+	// RepoID, if non-nil, indicates to filter results to only points recorded with this repo ID.
+	RepoID *api.RepoID
+
+	// TODO(slimsag): Add ability to filter based on repo name, original name.
 	// TODO(slimsag): Add ability to do limited filtering based on metadata.
 
 	// Time ranges to query from/to, if non-nil, in UTC.
@@ -168,6 +171,9 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 
 	if opts.SeriesID != nil {
 		preds = append(preds, sqlf.Sprintf("series_id = %s", *opts.SeriesID))
+	}
+	if opts.RepoID != nil {
+		preds = append(preds, sqlf.Sprintf("repo_id = %d", int32(*opts.RepoID)))
 	}
 	if opts.From != nil {
 		preds = append(preds, sqlf.Sprintf("time >= %s", *opts.From))

--- a/enterprise/internal/insights/store/store.go
+++ b/enterprise/internal/insights/store/store.go
@@ -21,7 +21,7 @@ import (
 type Interface interface {
 	SeriesPoints(ctx context.Context, opts SeriesPointsOpts) ([]SeriesPoint, error)
 	RecordSeriesPoint(ctx context.Context, v RecordSeriesPointArgs) error
-	DistinctSeriesWithData(ctx context.Context, from, to time.Time) ([]string, error)
+	CountData(ctx context.Context, opts CountDataOpts) (int, error)
 }
 
 var _ Interface = &Store{}
@@ -195,26 +195,55 @@ func seriesPointsQuery(opts SeriesPointsOpts) *sqlf.Query {
 	)
 }
 
-// DistinctSeriesWithData returns the distinct Series IDs that have at least one data point recorded
-// in the given time range.
-func (s *Store) DistinctSeriesWithData(ctx context.Context, from, to time.Time) ([]string, error) {
-	query := sqlf.Sprintf(distinctSeriesWithDataFmtstr, from, to)
-	var seriesIDs []string
-	err := s.query(ctx, query, func(sc scanner) error {
-		var seriesID string
-		err := sc.Scan(&seriesID)
-		if err != nil {
-			return err
-		}
-		seriesIDs = append(seriesIDs, seriesID)
-		return nil
-	})
-	return seriesIDs, err
+type CountDataOpts struct {
+	// The time range to look for data, if non-nil.
+	From, To *time.Time
+
+	// SeriesID, if non-nil, indicates to look for data with this series ID only.
+	SeriesID *string
+
+	// RepoID, if non-nil, indicates to look for data with this repo ID only.
+	RepoID *api.RepoID
 }
 
-const distinctSeriesWithDataFmtstr = `
-SELECT DISTINCT series_id FROM series_points WHERE time >= %s AND time <= %s;
+// CountData counts the amount of data points in a given time range.
+func (s *Store) CountData(ctx context.Context, opts CountDataOpts) (int, error) {
+	count, ok, err := basestore.ScanFirstInt(s.Store.Query(ctx, countDataQuery(opts)))
+	if err != nil {
+		return 0, errors.Wrap(err, "ScanFirstInt")
+	}
+	if !ok {
+		return 0, errors.Wrap(err, "count row not found (this should never happen)")
+	}
+	return count, nil
+}
+
+const countDataFmtstr = `
+SELECT COUNT(*) FROM series_points WHERE %s
 `
+
+func countDataQuery(opts CountDataOpts) *sqlf.Query {
+	preds := []*sqlf.Query{}
+	if opts.From != nil {
+		preds = append(preds, sqlf.Sprintf("time >= %s", *opts.From))
+	}
+	if opts.To != nil {
+		preds = append(preds, sqlf.Sprintf("time <= %s", *opts.To))
+	}
+	if opts.SeriesID != nil {
+		preds = append(preds, sqlf.Sprintf("series_id = %s", *opts.SeriesID))
+	}
+	if opts.RepoID != nil {
+		preds = append(preds, sqlf.Sprintf("repo_id = %d", int32(*opts.RepoID)))
+	}
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+	return sqlf.Sprintf(
+		countDataFmtstr,
+		sqlf.Join(preds, "\n AND "),
+	)
+}
 
 // RecordSeriesPointArgs describes arguments for the RecordSeriesPoint method.
 type RecordSeriesPointArgs struct {

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -243,6 +243,28 @@ func TestRecordSeriesPoints(t *testing.T) {
 	autogold.Want("points[1].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 2.2, Metadata: ["some", "data", "two"]}`).Equal(t, points[1].String())
 	autogold.Want("points[2].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 1.1, Metadata: {"some": "data"}}`).Equal(t, points[2].String())
 
-	// Confirm the data point with repository name got recorded correctly.
-	// TODO(slimsag): future: once we support querying by repo ID/names, add tests to ensure that information is inserted properly here.
+	// Confirm querying by repo ID works as expected.
+	forRepoIDPoints, err := store.SeriesPoints(ctx, SeriesPointsOpts{RepoID: optionalRepoID(3)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	autogold.Want("len(forRepoIDPoints)", int(1)).Equal(t, len(forRepoIDPoints))
+	autogold.Want("forRepoIDPoints[0].String()", `SeriesPoint{Time: "2020-02-17 00:00:00 +0000 UTC", Value: 1.1, Metadata: {"some": "data"}}`).Equal(t, forRepoIDPoints[0].String())
+
+	// TODO: future: once querying by RepoName and/or OriginalRepoName is possible, test that here:
+	// // Confirm querying by repo name works as expected.
+	// forRepoNamePoints, err := store.SeriesPoints(ctx, SeriesPointsOpts{RepoName: optionalString("repo1")})
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// autogold.Want("len(forRepoNamePoints)", nil).Equal(t, len(forRepoNamePoints))
+	// autogold.Want("forRepoNamePoints[0].String()", nil).Equal(t, forRepoNamePoints[0].String())
+	//
+	// // Confirm querying by original repo name works as expected.
+	// forOriginalRepoNamePoints, err := store.SeriesPoints(ctx, SeriesPointsOpts{OriginalRepoName: optionalString("repo1")})
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+	// autogold.Want("len(forOriginalRepoNamePoints)", nil).Equal(t, len(forOriginalRepoNamePoints))
+	// autogold.Want("forOriginalRepoNamePoints[0].String()", nil).Equal(t, forOriginalRepoNamePoints[0].String())
 }

--- a/enterprise/internal/insights/store/store_test.go
+++ b/enterprise/internal/insights/store/store_test.go
@@ -107,7 +107,7 @@ SELECT time,
 
 }
 
-func TestDistinctSeriesWithData(t *testing.T) {
+func TestCountData(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -119,12 +119,16 @@ func TestDistinctSeriesWithData(t *testing.T) {
 	defer cleanup()
 	store := NewWithClock(timescale, clock)
 
-	time := func(s string) time.Time {
+	timeValue := func(s string) time.Time {
 		v, err := time.Parse(time.RFC3339, s)
 		if err != nil {
 			t.Fatal(err)
 		}
 		return v
+	}
+	timePtr := func(s string) *time.Time {
+		t := timeValue(s)
+		return &t
 	}
 	optionalString := func(v string) *string { return &v }
 	optionalRepoID := func(v api.RepoID) *api.RepoID { return &v }
@@ -133,29 +137,29 @@ func TestDistinctSeriesWithData(t *testing.T) {
 	for _, record := range []RecordSeriesPointArgs{
 		{
 			SeriesID: "one",
-			Point:    SeriesPoint{Time: time("2020-03-01T00:00:00Z"), Value: 1.1},
+			Point:    SeriesPoint{Time: timeValue("2020-03-01T00:00:00Z"), Value: 1.1},
 			RepoName: optionalString("repo1"),
 			RepoID:   optionalRepoID(3),
 			Metadata: map[string]interface{}{"some": "data"},
 		},
 		{
 			SeriesID: "two",
-			Point:    SeriesPoint{Time: time("2020-03-02T00:00:00Z"), Value: 2.2},
+			Point:    SeriesPoint{Time: timeValue("2020-03-02T00:00:00Z"), Value: 2.2},
 			Metadata: []interface{}{"some", "data", "two"},
 		},
 		{
 			SeriesID: "two",
-			Point:    SeriesPoint{Time: time("2020-03-02T00:01:00Z"), Value: 2.2},
+			Point:    SeriesPoint{Time: timeValue("2020-03-02T00:01:00Z"), Value: 2.2},
 			Metadata: []interface{}{"some", "data", "two"},
 		},
 		{
 			SeriesID: "three",
-			Point:    SeriesPoint{Time: time("2020-03-03T00:00:00Z"), Value: 3.3},
+			Point:    SeriesPoint{Time: timeValue("2020-03-03T00:00:00Z"), Value: 3.3},
 			Metadata: nil,
 		},
 		{
 			SeriesID: "three",
-			Point:    SeriesPoint{Time: time("2020-03-03T00:01:00Z"), Value: 3.3},
+			Point:    SeriesPoint{Time: timeValue("2020-03-03T00:01:00Z"), Value: 3.3},
 			Metadata: nil,
 		},
 	} {
@@ -164,26 +168,35 @@ func TestDistinctSeriesWithData(t *testing.T) {
 		}
 	}
 
-	// Which series on 02-29 have data?
-	withData, err := store.DistinctSeriesWithData(ctx, time("2020-02-29T00:00:00Z"), time("2020-02-29T23:59:59Z"))
+	// How many data points on 02-29?
+	numDataPoints, err := store.CountData(ctx, CountDataOpts{
+		From: timePtr("2020-02-29T00:00:00Z"),
+		To:   timePtr("2020-02-29T23:59:59Z"),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	autogold.Want("first", []string{}).Equal(t, withData)
+	autogold.Want("first", int(0)).Equal(t, numDataPoints)
 
-	// Which series on 03-01 have data?
-	withData, err = store.DistinctSeriesWithData(ctx, time("2020-03-01T00:00:00Z"), time("2020-03-01T23:59:59Z"))
+	// How many data points on 03-01?
+	numDataPoints, err = store.CountData(ctx, CountDataOpts{
+		From: timePtr("2020-03-01T00:00:00Z"),
+		To:   timePtr("2020-03-01T23:59:59Z"),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	autogold.Want("second", []string{"one"}).Equal(t, withData)
+	autogold.Want("second", int(1)).Equal(t, numDataPoints)
 
-	// Which series from 03-01 to 03-04 have data?
-	withData, err = store.DistinctSeriesWithData(ctx, time("2020-03-01T00:00:00Z"), time("2020-03-04T23:59:59Z"))
+	// How many data points from 03-01 to 03-04?
+	numDataPoints, err = store.CountData(ctx, CountDataOpts{
+		From: timePtr("2020-03-01T00:00:00Z"),
+		To:   timePtr("2020-03-04T23:59:59Z"),
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	autogold.Want("third", []string{"one", "three", "two"}).Equal(t, withData)
+	autogold.Want("third", int(5)).Equal(t, numDataPoints)
 }
 
 func TestRecordSeriesPoints(t *testing.T) {


### PR DESCRIPTION
1. Make the backend store insights per-repository. The historical enqueuer does this today, but not the regular enqueuer because we needed to extract out match counts per repository and this is a bit annoying to do. Now implemented. Helps #18966 and makes it clear how we'd implement querying of per-repo datapoints this in the future.

2. When considering backfilling data for certain timeframe, check if _the specific repo we're backfilling data for has any_. This should hopefully fix the issue on Sourcegraph.com and k8s.sgdev.org where the graph is totally flat which is very incorrect. Suspicion is that it managed to generate one data point correctly, ran into an error, restarted, and now thinks "we have data for those timeframes" Helps #18961

3. Ignore cached repos that are not found, e.g. if someone actually removes a repo and we have it in our cache to iterate over ignore it. Fixes an issue Thorsten noticed https://sourcegraph.slack.com/archives/CHPC7UX16/p1615468766294800

