### PR TITLE
streaming: support stable:yes

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -102,11 +102,6 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	}
 	tr.LazyPrintf("parsing done")
 
-	// We do not support stable for streaming
-	if args.Stream != nil && q.BoolValue(query.FieldStable) {
-		return alertForQuery(db, args.Query, errors.New("stable is not supported for the streaming API. Please remove from query")), nil
-	}
-
 	// If the request is a paginated one, decode those arguments now.
 	var pagination *searchPaginationInfo
 	if args.First != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -465,6 +465,9 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 			// there is a next cursor, and more results may exist.
 			result.Stats.IsLimitHit = true
 		}
+		if r.stream != nil {
+			r.stream.Send(SearchEvent{result.SearchResults, result.Stats})
+		}
 		return result, err
 	}
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -384,9 +384,8 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal type:file`,
 			},
 			{
-				name:       "non-master branch, nonzero result stable",
-				query:      `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 stable:yes type:file`,
-				skipStream: true,
+				name:  "non-master branch, nonzero result stable",
+				query: `repo:^github\.com/sgtest/java-langserver$@v1 void sendPartialResult(Object requestId, JsonPatch jsonPatch); patterntype:literal count:1 stable:yes type:file`,
 			},
 			{
 				name:  "indexed multiline search, nonzero result",
@@ -623,9 +622,8 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query: `repo:^github\.com/sgtest/go-diff$ func and main type:file`,
 			},
 			{
-				name:       `And operator, basic with stable`,
-				query:      `repo:^github\.com/sgtest/go-diff$ func and main stable:yes type:file`,
-				skipStream: true,
+				name:  `And operator, basic with stable`,
+				query: `repo:^github\.com/sgtest/go-diff$ func and main stable:yes type:file`,
 			},
 			{
 				name:  `Or operator, single and double quoted`,

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -328,7 +328,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 			zeroResult    bool
 			minMatchCount int64
 			wantAlert     *gqltestutil.SearchAlert
-			skipStream    bool
 		}{
 			// Global search
 			{
@@ -478,10 +477,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				if test.skipStream && isStreaming {
-					t.Skip("streaming not supported yet")
-				}
-
 				results, err := client.SearchFiles(test.query)
 				if err != nil {
 					t.Fatal(err)
@@ -614,8 +609,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 			query      string
 			zeroResult bool
 			wantAlert  *gqltestutil.SearchAlert
-
-			skipStream bool
 		}{
 			{
 				name:  `And operator, basic`,
@@ -799,10 +792,6 @@ func testSearchClient(t *testing.T, client searchClient) {
 		}
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				if test.skipStream && isStreaming {
-					t.Skip("streaming not supported yet")
-				}
-
 				results, err := client.SearchFiles(test.query)
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
This adds support for `stable:yes` to streaming search. Effectively we
trade "fast time to first result" against a stable result order.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
