### PR TITLE
Fix yield func in historical enqueuer, also a bug report for infinite looping frames

### DIFF
--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -288,7 +288,7 @@ func (h *historicalEnqueuer) buildFrame(
 	lastIteration := h.now()
 	yield := func() {
 		if diff := h.timeSince(lastIteration); diff < 100*time.Millisecond {
-			h.sleep(diff)
+			h.sleep(100*time.Millisecond - diff)
 			lastIteration = h.now()
 		}
 	}

--- a/enterprise/internal/insights/background/historical_enqueuer_test.go
+++ b/enterprise/internal/insights/background/historical_enqueuer_test.go
@@ -166,7 +166,8 @@ func Test_historicalEnqueuer(t *testing.T) {
 	t.Run("no_work", func(t *testing.T) {
 		want := autogold.Want("no_work", &testResults{
 			allReposIteratorCalls: 2, sleeps: 20,
-			reposGetByName: 4,
+			reposGetByName:   4,
+			totalSleepTimeMS: 2000,
 			operations: []string{
 				"sleep()",
 				"sleep()",
@@ -209,7 +210,8 @@ func Test_historicalEnqueuer(t *testing.T) {
 	t.Run("no_data", func(t *testing.T) {
 		want := autogold.Want("no_data", &testResults{
 			allReposIteratorCalls: 2, sleeps: 20,
-			reposGetByName: 4,
+			reposGetByName:   4,
+			totalSleepTimeMS: 2000,
 			operations: []string{
 				"sleep()",
 				"sleep()",


### PR DESCRIPTION
@mrnugget and i were debugging some gitserver CPU usage issues and noticed a small bug in the yield func meaning it wouldn't yield as much as expected,  eg:

```
we want to run at most every 100ms
do something, it takes 5ms
sleep for 5ms // the bug is here
reset interval
iterate
```

instead: 
```
we want to run at most every 100ms
do something, it takes 5ms
sleep for 100ms - 5ms
reset interval
iterate
```

**However i still think there is an unresolved bug here** it seems like the enqueuer never stops re-enqueueing all frames, eg once a full 52 weeks are processed, it loops back to the beginning and starts again. 

you can see this below where 2020 loops back to 2021 and we start processing frames again.

![Screenshot 2021-03-12 at 09 08 41](https://user-images.githubusercontent.com/5236823/110919032-b76e2b80-8313-11eb-89b6-88dae8a53bb2.png)

right now this is manifesting as gitserver spawning git log & git rev-list commands in a tight loop permanently, eating a CPU core and spending a lot of time doing GC. I'll also raise this in a separate issue & ref here.

https://user-images.githubusercontent.com/5236823/110919270-f7351300-8313-11eb-8cba-db6d067534ba.mov


