### PR TITLE
Rename "default repos" to "indexable repos"

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -150,7 +150,7 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 	return database.GlobalRepos.List(ctx, opt)
 }
 
-// ListDefault calls database.DefaultRepos.List, with tracing.
+// ListDefault calls database.IndexableRepos.List, with tracing.
 func (s *repos) ListDefault(ctx context.Context) (repos []*types.RepoName, err error) {
 	ctx, done := trace(ctx, "Repos", "ListDefault", nil, &err)
 	defer func() {
@@ -160,7 +160,7 @@ func (s *repos) ListDefault(ctx context.Context) (repos []*types.RepoName, err e
 		}
 		done()
 	}()
-	return database.GlobalDefaultRepos.List(ctx)
+	return database.GlobalIndexableRepos.List(ctx)
 }
 
 func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api.CommitID, forceEnhancedLanguageDetection bool) (res *inventory.Inventory, err error) {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -425,10 +425,10 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		Query:              r.Query,
 	}
 	repositoryResolver := &searchrepos.Resolver{
-		DB:               r.db,
-		Zoekt:            r.zoekt,
-		DefaultReposFunc: database.DefaultRepos(r.db).List,
-		NamespaceStore:   database.Namespaces(r.db),
+		DB:                 r.db,
+		Zoekt:              r.zoekt,
+		IndexableReposFunc: database.IndexableRepos(r.db).List,
+		NamespaceStore:     database.Namespaces(r.db),
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	tr.LazyPrintf("resolveRepositories - done")

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -122,10 +122,10 @@ func alertForStalePermissions(db dbutil.DB) *searchAlert {
 func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Options) bool {
 	options.UserSettings = r.UserSettings
 	repositoryResolver := &searchrepos.Resolver{
-		DB:               r.db,
-		Zoekt:            r.zoekt,
-		DefaultReposFunc: database.DefaultRepos(r.db).List,
-		NamespaceStore:   database.Namespaces(r.db),
+		DB:                 r.db,
+		Zoekt:              r.zoekt,
+		IndexableReposFunc: database.IndexableRepos(r.db).List,
+		NamespaceStore:     database.Namespaces(r.db),
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -60,8 +60,8 @@ func (mockAddrForRepo) AddrForRepo(name api.RepoName) string {
 }
 
 func TestReposIndex(t *testing.T) {
-	defaultRepos := []string{"github.com/popular/foo", "github.com/popular/bar"}
-	allRepos := append(defaultRepos, "github.com/alice/foo", "github.com/alice/bar")
+	indexableRepos := []string{"github.com/popular/foo", "github.com/popular/bar"}
+	allRepos := append(indexableRepos, "github.com/alice/foo", "github.com/alice/bar")
 
 	cases := []struct {
 		name string
@@ -72,8 +72,8 @@ func TestReposIndex(t *testing.T) {
 		name: "indexers",
 		srv: &reposListServer{
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -83,8 +83,8 @@ func TestReposIndex(t *testing.T) {
 		name: "indexers",
 		srv: &reposListServer{
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -95,8 +95,8 @@ func TestReposIndex(t *testing.T) {
 		srv: &reposListServer{
 			SourcegraphDotComMode: true,
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -106,8 +106,8 @@ func TestReposIndex(t *testing.T) {
 		name: "none",
 		srv: &reposListServer{
 			Repos: &mockRepos{
-				defaultRepos: defaultRepos,
-				repos:        allRepos,
+				indexableRepos: indexableRepos,
+				repos:          allRepos,
 			},
 			Indexers: suffixIndexers(true),
 		},
@@ -145,13 +145,13 @@ func TestReposIndex(t *testing.T) {
 }
 
 type mockRepos struct {
-	defaultRepos []string
-	repos        []string
+	indexableRepos []string
+	repos          []string
 }
 
 func (r *mockRepos) ListDefault(context.Context) ([]*types.RepoName, error) {
 	var repos []*types.RepoName
-	for _, name := range r.defaultRepos {
+	for _, name := range r.indexableRepos {
 		repos = append(repos, &types.RepoName{
 			Name: api.RepoName(name),
 		})

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -415,11 +415,11 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 			return
 		}
 
-		// Fetch all default repos that are NOT cloned so that we can add them to the
+		// Fetch all indexable repos that are NOT cloned so that we can add them to the
 		// scheduler
-		repos, err := baseRepoStore.ListDefaultRepos(ctx, database.ListDefaultReposOptions{OnlyUncloned: true})
+		repos, err := baseRepoStore.ListIndexableRepos(ctx, database.ListIndexableReposOptions{OnlyUncloned: true})
 		if err != nil {
-			log15.Error("Listing default repos", "error", err)
+			log15.Error("Listing indexable repos", "error", err)
 			return
 		}
 

--- a/docker-images/prometheus/cmd/prom-wrapper/mocks/prometheus_mock.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/mocks/prometheus_mock.go
@@ -4,11 +4,10 @@ package mocks
 
 import (
 	"context"
-	"sync"
-	"time"
-
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	model "github.com/prometheus/common/model"
+	"sync"
+	"time"
 )
 
 // MockAPI is a mock implementation of the API interface (from the package

--- a/enterprise/cmd/executor/internal/worker/mock_command_runner_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_command_runner_test.go
@@ -4,9 +4,8 @@ package worker
 
 import (
 	"context"
-	"sync"
-
 	command "github.com/sourcegraph/sourcegraph/enterprise/cmd/executor/internal/command"
+	"sync"
 )
 
 // MockRunner is a mock implementation of the Runner interface (from the

--- a/enterprise/cmd/executor/internal/worker/mock_store_test.go
+++ b/enterprise/cmd/executor/internal/worker/mock_store_test.go
@@ -4,9 +4,8 @@ package worker
 
 import (
 	"context"
-	"sync"
-
 	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"sync"
 )
 
 // MockStore is a mock implementation of the Store interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/autoindex/enqueuer/mock_iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/autoindex/enqueuer/mock_iface.go
@@ -4,12 +4,11 @@ package enqueuer
 
 import (
 	"context"
+	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"regexp"
 	"sync"
 	"time"
-
-	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
-	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/commitgraph/mock_iface_test.go
@@ -4,11 +4,10 @@ package commitgraph
 
 import (
 	"context"
-	"sync"
-	"time"
-
 	gitserver "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"sync"
+	"time"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/mock_iface_test.go
@@ -4,11 +4,10 @@ package indexing
 
 import (
 	"context"
+	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"regexp"
 	"sync"
 	"time"
-
-	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/mock_iface_test.go
@@ -4,9 +4,8 @@ package httpapi
 
 import (
 	"context"
-	"sync"
-
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"sync"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -4,14 +4,13 @@ package resolvers
 
 import (
 	"context"
-	"sync"
-	"time"
-
 	config "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
 	gitserver "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	semantic "github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/semantic"
+	"sync"
+	"time"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_position_adjuster_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_position_adjuster_test.go
@@ -4,9 +4,8 @@ package resolvers
 
 import (
 	"context"
-	"sync"
-
 	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"sync"
 )
 
 // MockPositionAdjuster is a mock implementation of the PositionAdjuster

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_query.go
@@ -4,10 +4,9 @@ package mocks
 
 import (
 	"context"
-	"sync"
-
 	resolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	lsifstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"sync"
 )
 
 // MockQueryResolver is a mock implementation of the QueryResolver interface

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks/mock_resolver.go
@@ -4,11 +4,10 @@ package mocks
 
 import (
 	"context"
-	"sync"
-
 	graphqlbackend "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	resolvers "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	dbstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"sync"
 )
 
 // MockResolver is a mock implementation of the Resolver interface (from the

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_iface_test.go
@@ -4,10 +4,9 @@ package worker
 
 import (
 	"context"
-	"sync"
-
 	semantic "github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/semantic"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"sync"
 )
 
 // MockDBStore is a mock implementation of the DBStore interface (from the

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/mock_worker_store_test.go
@@ -4,13 +4,12 @@ package worker
 
 import (
 	"context"
-	"sync"
-	"time"
-
 	sqlf "github.com/keegancsmith/sqlf"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 	store "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	"sync"
+	"time"
 )
 
 // MockWorkerStore is a mock implementation of the Store interface (from the

--- a/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
@@ -3,11 +3,10 @@
 package uploadstore
 
 import (
+	storage "cloud.google.com/go/storage"
 	"context"
 	"io"
 	"sync"
-
-	storage "cloud.google.com/go/storage"
 )
 
 // MockGcsAPI is a mock implementation of the gcsAPI interface (from the

--- a/enterprise/internal/codeintel/stores/uploadstore/mock_s3_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mock_s3_api_test.go
@@ -4,10 +4,9 @@ package uploadstore
 
 import (
 	"context"
-	"sync"
-
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	s3manager "github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"sync"
 )
 
 // MockS3API is a mock implementation of the s3API interface (from the

--- a/enterprise/internal/codeintel/stores/uploadstore/mocks/mock_store.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mocks/mock_store.go
@@ -4,10 +4,9 @@ package mocks
 
 import (
 	"context"
+	uploadstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 	"io"
 	"sync"
-
-	uploadstore "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/uploadstore"
 )
 
 // MockStore is a mock implementation of the Store interface (from the

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -86,7 +86,7 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 		frameLength:      7 * 24 * time.Hour,
 
 		allReposIterator: (&discovery.AllReposIterator{
-			DefaultRepoStore:      database.DefaultRepos(workerBaseStore.Handle().DB()),
+			IndexableRepoStore:    database.IndexableRepos(workerBaseStore.Handle().DB()),
 			RepoStore:             database.Repos(workerBaseStore.Handle().DB()),
 			Clock:                 time.Now,
 			SourcegraphDotComMode: envvar.SourcegraphDotComMode(),

--- a/enterprise/internal/insights/background/mock_repo_store.go
+++ b/enterprise/internal/insights/background/mock_repo_store.go
@@ -4,10 +4,9 @@ package background
 
 import (
 	"context"
-	"sync"
-
 	api "github.com/sourcegraph/sourcegraph/internal/api"
 	types "github.com/sourcegraph/sourcegraph/internal/types"
+	"sync"
 )
 
 // MockRepoStore is a mock implementation of the RepoStore interface (from

--- a/enterprise/internal/insights/discovery/all_repos_iterator.go
+++ b/enterprise/internal/insights/discovery/all_repos_iterator.go
@@ -10,8 +10,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-// DefaultRepoStore is a subset of the API exposed by the database.DefaultRepos() store.
-type DefaultRepoStore interface {
+// IndexableRepoStore is a subset of the API exposed by the database.IndexableRepos() store.
+type IndexableRepoStore interface {
 	List(ctx context.Context) ([]*types.RepoName, error)
 }
 
@@ -26,7 +26,7 @@ type RepoStore interface {
 // It caches multiple consecutive uses in order to ensure repository lists (which can be quite
 // large, e.g. 500,000+ repositories) are only fetched as frequently as needed.
 type AllReposIterator struct {
-	DefaultRepoStore      DefaultRepoStore
+	IndexableRepoStore    IndexableRepoStore
 	RepoStore             RepoStore
 	Clock                 func() time.Time
 	SourcegraphDotComMode bool // result of envvar.SourcegraphDotComMode()
@@ -61,11 +61,11 @@ func (a *AllReposIterator) ForEach(ctx context.Context, forEach func(repoName st
 			a.cachedRepoNames = a.cachedRepoNames[:0]
 
 			// We shouldn't try to fill historical data for ALL repos on Sourcegraph.com, it would take
-			// forever. Instead, we use the same list of default repositories used when you do a global
+			// forever. Instead, we use the same list of indexable repositories used when you do a global
 			// search on Sourcegraph.com.
-			res, err := a.DefaultRepoStore.List(ctx)
+			res, err := a.IndexableRepoStore.List(ctx)
 			if err != nil {
-				return errors.Wrap(err, "DefaultRepoStore.List")
+				return errors.Wrap(err, "IndexableRepoStore.List")
 			}
 			for _, r := range res {
 				a.cachedRepoNames = append(a.cachedRepoNames, string(r.Name))

--- a/enterprise/internal/insights/discovery/gen.go
+++ b/enterprise/internal/insights/discovery/gen.go
@@ -2,5 +2,5 @@ package discovery
 
 //go:generate env GOBIN=$PWD/.bin GO111MODULE=on go install github.com/efritz/go-mockgen
 //go:generate $PWD/.bin/go-mockgen -f github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i SettingStore -o mock_setting_store.go
-//go:generate $PWD/.bin/go-mockgen -f github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i DefaultRepoStore -o mock_default_repo_store.go
+//go:generate $PWD/.bin/go-mockgen -f github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i IndexableRepoStore -o mock_indexable_repo_store.go
 //go:generate $PWD/.bin/go-mockgen -f github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery -i RepoStore -o mock_repo_store.go

--- a/enterprise/internal/insights/discovery/mock_indexable_repo_store.go
+++ b/enterprise/internal/insights/discovery/mock_indexable_repo_store.go
@@ -4,27 +4,26 @@ package discovery
 
 import (
 	"context"
-	"sync"
-
 	types "github.com/sourcegraph/sourcegraph/internal/types"
+	"sync"
 )
 
-// MockDefaultRepoStore is a mock implementation of the DefaultRepoStore
+// MockIndexableRepoStore is a mock implementation of the IndexableRepoStore
 // interface (from the package
 // github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery)
 // used for unit testing.
-type MockDefaultRepoStore struct {
+type MockIndexableRepoStore struct {
 	// ListFunc is an instance of a mock function object controlling the
 	// behavior of the method List.
-	ListFunc *DefaultRepoStoreListFunc
+	ListFunc *IndexableRepoStoreListFunc
 }
 
-// NewMockDefaultRepoStore creates a new mock of the DefaultRepoStore
+// NewMockIndexableRepoStore creates a new mock of the IndexableRepoStore
 // interface. All methods return zero values for all results, unless
 // overwritten.
-func NewMockDefaultRepoStore() *MockDefaultRepoStore {
-	return &MockDefaultRepoStore{
-		ListFunc: &DefaultRepoStoreListFunc{
+func NewMockIndexableRepoStore() *MockIndexableRepoStore {
+	return &MockIndexableRepoStore{
+		ListFunc: &IndexableRepoStoreListFunc{
 			defaultHook: func(context.Context) ([]*types.RepoName, error) {
 				return nil, nil
 			},
@@ -32,46 +31,46 @@ func NewMockDefaultRepoStore() *MockDefaultRepoStore {
 	}
 }
 
-// NewMockDefaultRepoStoreFrom creates a new mock of the
-// MockDefaultRepoStore interface. All methods delegate to the given
+// NewMockIndexableRepoStoreFrom creates a new mock of the
+// MockIndexableRepoStore interface. All methods delegate to the given
 // implementation, unless overwritten.
-func NewMockDefaultRepoStoreFrom(i DefaultRepoStore) *MockDefaultRepoStore {
-	return &MockDefaultRepoStore{
-		ListFunc: &DefaultRepoStoreListFunc{
+func NewMockIndexableRepoStoreFrom(i IndexableRepoStore) *MockIndexableRepoStore {
+	return &MockIndexableRepoStore{
+		ListFunc: &IndexableRepoStoreListFunc{
 			defaultHook: i.List,
 		},
 	}
 }
 
-// DefaultRepoStoreListFunc describes the behavior when the List method of
-// the parent MockDefaultRepoStore instance is invoked.
-type DefaultRepoStoreListFunc struct {
+// IndexableRepoStoreListFunc describes the behavior when the List method of
+// the parent MockIndexableRepoStore instance is invoked.
+type IndexableRepoStoreListFunc struct {
 	defaultHook func(context.Context) ([]*types.RepoName, error)
 	hooks       []func(context.Context) ([]*types.RepoName, error)
-	history     []DefaultRepoStoreListFuncCall
+	history     []IndexableRepoStoreListFuncCall
 	mutex       sync.Mutex
 }
 
 // List delegates to the next hook function in the queue and stores the
 // parameter and result values of this invocation.
-func (m *MockDefaultRepoStore) List(v0 context.Context) ([]*types.RepoName, error) {
+func (m *MockIndexableRepoStore) List(v0 context.Context) ([]*types.RepoName, error) {
 	r0, r1 := m.ListFunc.nextHook()(v0)
-	m.ListFunc.appendCall(DefaultRepoStoreListFuncCall{v0, r0, r1})
+	m.ListFunc.appendCall(IndexableRepoStoreListFuncCall{v0, r0, r1})
 	return r0, r1
 }
 
 // SetDefaultHook sets function that is called when the List method of the
-// parent MockDefaultRepoStore instance is invoked and the hook queue is
+// parent MockIndexableRepoStore instance is invoked and the hook queue is
 // empty.
-func (f *DefaultRepoStoreListFunc) SetDefaultHook(hook func(context.Context) ([]*types.RepoName, error)) {
+func (f *IndexableRepoStoreListFunc) SetDefaultHook(hook func(context.Context) ([]*types.RepoName, error)) {
 	f.defaultHook = hook
 }
 
 // PushHook adds a function to the end of hook queue. Each invocation of the
-// List method of the parent MockDefaultRepoStore instance invokes the hook
-// at the front of the queue and discards it. After the queue is empty, the
-// default hook function is invoked for any future action.
-func (f *DefaultRepoStoreListFunc) PushHook(hook func(context.Context) ([]*types.RepoName, error)) {
+// List method of the parent MockIndexableRepoStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *IndexableRepoStoreListFunc) PushHook(hook func(context.Context) ([]*types.RepoName, error)) {
 	f.mutex.Lock()
 	f.hooks = append(f.hooks, hook)
 	f.mutex.Unlock()
@@ -79,7 +78,7 @@ func (f *DefaultRepoStoreListFunc) PushHook(hook func(context.Context) ([]*types
 
 // SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
 // the given values.
-func (f *DefaultRepoStoreListFunc) SetDefaultReturn(r0 []*types.RepoName, r1 error) {
+func (f *IndexableRepoStoreListFunc) SetDefaultReturn(r0 []*types.RepoName, r1 error) {
 	f.SetDefaultHook(func(context.Context) ([]*types.RepoName, error) {
 		return r0, r1
 	})
@@ -87,13 +86,13 @@ func (f *DefaultRepoStoreListFunc) SetDefaultReturn(r0 []*types.RepoName, r1 err
 
 // PushReturn calls PushDefaultHook with a function that returns the given
 // values.
-func (f *DefaultRepoStoreListFunc) PushReturn(r0 []*types.RepoName, r1 error) {
+func (f *IndexableRepoStoreListFunc) PushReturn(r0 []*types.RepoName, r1 error) {
 	f.PushHook(func(context.Context) ([]*types.RepoName, error) {
 		return r0, r1
 	})
 }
 
-func (f *DefaultRepoStoreListFunc) nextHook() func(context.Context) ([]*types.RepoName, error) {
+func (f *IndexableRepoStoreListFunc) nextHook() func(context.Context) ([]*types.RepoName, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -106,26 +105,26 @@ func (f *DefaultRepoStoreListFunc) nextHook() func(context.Context) ([]*types.Re
 	return hook
 }
 
-func (f *DefaultRepoStoreListFunc) appendCall(r0 DefaultRepoStoreListFuncCall) {
+func (f *IndexableRepoStoreListFunc) appendCall(r0 IndexableRepoStoreListFuncCall) {
 	f.mutex.Lock()
 	f.history = append(f.history, r0)
 	f.mutex.Unlock()
 }
 
-// History returns a sequence of DefaultRepoStoreListFuncCall objects
+// History returns a sequence of IndexableRepoStoreListFuncCall objects
 // describing the invocations of this function.
-func (f *DefaultRepoStoreListFunc) History() []DefaultRepoStoreListFuncCall {
+func (f *IndexableRepoStoreListFunc) History() []IndexableRepoStoreListFuncCall {
 	f.mutex.Lock()
-	history := make([]DefaultRepoStoreListFuncCall, len(f.history))
+	history := make([]IndexableRepoStoreListFuncCall, len(f.history))
 	copy(history, f.history)
 	f.mutex.Unlock()
 
 	return history
 }
 
-// DefaultRepoStoreListFuncCall is an object that describes an invocation of
-// method List on an instance of MockDefaultRepoStore.
-type DefaultRepoStoreListFuncCall struct {
+// IndexableRepoStoreListFuncCall is an object that describes an invocation
+// of method List on an instance of MockIndexableRepoStore.
+type IndexableRepoStoreListFuncCall struct {
 	// Arg0 is the value of the 1st argument passed to this method
 	// invocation.
 	Arg0 context.Context
@@ -139,12 +138,12 @@ type DefaultRepoStoreListFuncCall struct {
 
 // Args returns an interface slice containing the arguments of this
 // invocation.
-func (c DefaultRepoStoreListFuncCall) Args() []interface{} {
+func (c IndexableRepoStoreListFuncCall) Args() []interface{} {
 	return []interface{}{c.Arg0}
 }
 
 // Results returns an interface slice containing the results of this
 // invocation.
-func (c DefaultRepoStoreListFuncCall) Results() []interface{} {
+func (c IndexableRepoStoreListFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1}
 }

--- a/enterprise/internal/insights/discovery/mock_repo_store.go
+++ b/enterprise/internal/insights/discovery/mock_repo_store.go
@@ -4,10 +4,9 @@ package discovery
 
 import (
 	"context"
-	"sync"
-
 	database "github.com/sourcegraph/sourcegraph/internal/database"
 	types "github.com/sourcegraph/sourcegraph/internal/types"
+	"sync"
 )
 
 // MockRepoStore is a mock implementation of the RepoStore interface (from

--- a/enterprise/internal/insights/discovery/mock_setting_store.go
+++ b/enterprise/internal/insights/discovery/mock_setting_store.go
@@ -4,9 +4,8 @@ package discovery
 
 import (
 	"context"
-	"sync"
-
 	api "github.com/sourcegraph/sourcegraph/internal/api"
+	"sync"
 )
 
 // MockSettingStore is a mock implementation of the SettingStore interface

--- a/go.sum
+++ b/go.sum
@@ -733,6 +733,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -935,6 +936,7 @@ github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkB
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1112,6 +1114,7 @@ github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtb
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1292,15 +1295,19 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.1.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1313,6 +1320,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
+github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
@@ -1335,6 +1343,7 @@ github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPr
 github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -1916,6 +1925,7 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=

--- a/internal/database/default_repos_test.go
+++ b/internal/database/default_repos_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func TestListDefaultRepos(t *testing.T) {
+func TestListIndexableRepos(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -87,9 +87,9 @@ func TestListDefaultRepos(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			DefaultRepos(db).resetCache()
+			IndexableRepos(db).resetCache()
 
-			repos, err := DefaultRepos(db).List(ctx)
+			repos, err := IndexableRepos(db).List(ctx)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -138,9 +138,9 @@ func TestListDefaultRepos(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		DefaultRepos(db).resetCache()
+		IndexableRepos(db).resetCache()
 
-		repos, err := DefaultRepos(db).List(ctx)
+		repos, err := IndexableRepos(db).List(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -159,14 +159,14 @@ func TestListDefaultRepos(t *testing.T) {
 				Name: "github.com/foo/bar14",
 			},
 		}
-		// expect 2 repos, the user added repo and the one that is referenced in the default repos table
+		// expect 2 repos, the user added repo and the one that is referenced in the indexable repos table
 		if diff := cmp.Diff(want, repos, cmpopts.EquateEmpty()); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
 	})
 }
 
-func TestListDefaultReposUncloned(t *testing.T) {
+func TestListIndexableReposUncloned(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
@@ -206,7 +206,7 @@ func TestListDefaultReposUncloned(t *testing.T) {
 		}
 	}
 
-	repos, err := Repos(db).ListDefaultRepos(ctx, ListDefaultReposOptions{
+	repos, err := Repos(db).ListIndexableRepos(ctx, ListIndexableReposOptions{
 		OnlyUncloned: true,
 	})
 	if err != nil {
@@ -220,7 +220,7 @@ func TestListDefaultReposUncloned(t *testing.T) {
 	}
 }
 
-func BenchmarkDefaultRepos_List_Empty(b *testing.B) {
+func BenchmarkIndexableRepos_List_Empty(b *testing.B) {
 	db := dbtest.NewDB(b, "")
 
 	ctx := context.Background()
@@ -231,7 +231,7 @@ func BenchmarkDefaultRepos_List_Empty(b *testing.B) {
 	}
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err := DefaultRepos(db).List(ctx)
+		_, err := IndexableRepos(db).List(ctx)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/database/stores.go
+++ b/internal/database/stores.go
@@ -4,7 +4,7 @@ package database
 // Deprecated: Use store constructors instead.
 var (
 	GlobalExternalServices            = &ExternalServiceStore{}
-	GlobalDefaultRepos                = &DefaultRepoStore{}
+	GlobalIndexableRepos              = &IndexableRepoStore{}
 	GlobalRepos                       = &RepoStore{}
 	GlobalOrgs                        = &OrgStore{}
 	GlobalSettings                    = &SettingStore{}

--- a/internal/workerutil/dbworker/store/mocks/mock_store.go
+++ b/internal/workerutil/dbworker/store/mocks/mock_store.go
@@ -4,13 +4,12 @@ package mocks
 
 import (
 	"context"
-	"sync"
-	"time"
-
 	sqlf "github.com/keegancsmith/sqlf"
 	basestore "github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	workerutil "github.com/sourcegraph/sourcegraph/internal/workerutil"
 	store "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+	"sync"
+	"time"
 )
 
 // MockStore is a mock implementation of the Store interface (from the


### PR DESCRIPTION
Default repos doesn't really convey the intent anymore. It was
originally just listing repos from the default_repos table on
sourcegraph.com so that they would be indexed. We are now pulling in
repos from more places so calling it "default repos" is confusing. The
intent is still that any repo included should be indexed.
