### PR TITLE
app/ui: Add tests for serveRaw handler

### DIFF
--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -86,6 +86,19 @@ func repoShortName(name api.RepoName) string {
 	return strings.Join(split[1:], "/")
 }
 
+// serveErrorHandler is a function signature used in newCommon and
+// mockNewCommon. This is used as syntactic sugar to prevent programmer's
+// (fragile creatures from planet Earth) from crashing out.
+type serveErrorHandler func(w http.ResponseWriter, r *http.Request, err error, statusCode int)
+
+// mockNewCommon is used in tests to mock newCommon (duh!).
+//
+// Ensure that the mock is reset at the end of every test by adding a call like the following:
+//	defer func() {
+//		mockNewCommon = nil
+//	}()
+var mockNewCommon func(w http.ResponseWriter, r *http.Request, title string, serveError serveErrorHandler) (*Common, error)
+
 // newCommon builds a *Common data structure, returning an error if one occurs.
 //
 // In the event of the repository having been renamed, the request is handled
@@ -101,7 +114,11 @@ func repoShortName(name api.RepoName) string {
 //
 // In the case of a repository that is cloning, a Common data structure is
 // returned but it has an incomplete RevSpec.
-func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError func(w http.ResponseWriter, r *http.Request, err error, statusCode int)) (*Common, error) {
+func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError serveErrorHandler) (*Common, error) {
+	if mockNewCommon != nil {
+		return mockNewCommon(w, r, title, serveError)
+	}
+
 	common := &Common{
 		Injected: InjectedHTML{
 			HeadTop:    template.HTML(conf.Get().HtmlHeadTop),

--- a/cmd/frontend/internal/app/ui/raw.go
+++ b/cmd/frontend/internal/app/ui/raw.go
@@ -145,8 +145,8 @@ func serveRaw(w http.ResponseWriter, r *http.Request) (err error) {
 
 	switch contentType {
 	case applicationZip, applicationXTar:
-		// Set the proper filename field, so that downloading "/github.com/gorilla/mux/-/raw"
-		// gives us a "mux.zip" file (e.g. when downloading via a browser).
+		// Set the proper filename field, so that downloading "/github.com/gorilla/mux/-/raw" gives us a
+		// "mux.zip" file (e.g. when downloading via a browser) or a .tar file depending on the contentType.
 		ext := ".zip"
 		if contentType == applicationXTar {
 			ext = ".tar"
@@ -291,6 +291,7 @@ var metricRawDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Help:    "A histogram of latencies for the raw endpoint.",
 	Buckets: prometheus.ExponentialBuckets(.1, 5, 5), // 100ms -> 62s
 }, []string{"content", "type", "error"})
+
 var metricRawArchiveRunning = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "src_frontend_http_raw_archive_running",
 	Help: "The number of concurrent raw archives being fetched.",

--- a/cmd/frontend/internal/app/ui/raw_test.go
+++ b/cmd/frontend/internal/app/ui/raw_test.go
@@ -1,0 +1,367 @@
+package ui
+
+import (
+	"io"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/util"
+)
+
+// initHTTPTestGitServer instantiates an httptest.Server to make it return an HTTP response as set
+// by httpStatusCode and a body as set by resp. It also ensures that the server is closed during
+// test cleanup, thus ensuring that the caller does not have to remember to close the server.
+//
+// Finally, initHTTPTestGitServer patches the gitserver.DefaultClient.Addrs to the URL of the test
+// HTTP server, so that API calls to the gitserver are received by the test HTTP server.
+//
+// TL;DR: This function helps us to mock the gitserver without having to define mock functions for
+// each of the gitserver client methods.
+func initHTTPTestGitServer(t *testing.T, httpStatusCode int, resp string) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Trailer", "X-Exec-Error")
+		w.Header().Add("Trailer", "X-Exec-Exit-Status")
+		w.Header().Add("Trailer", "X-Exec-Stderr")
+		w.Header().Set("X-Exec-Error", "")
+		w.Header().Set("X-Exec-Exit-Status", "0")
+		w.Header().Set("X-Exec-Stderr", "")
+		w.WriteHeader(httpStatusCode)
+		_, err := w.Write([]byte(resp))
+		if err != nil {
+			t.Fatalf("Failed to write to httptest server: %v", err)
+		}
+	}))
+
+	t.Cleanup(func() { s.Close() })
+
+	// Strip the protocol from the URI while patching the gitserver client's addres, since the
+	// gitsever implementation does not want the protocol in the address.
+	gitserver.DefaultClient.Addrs = func() []string {
+		return []string{strings.TrimPrefix(s.URL, "http://")}
+	}
+}
+
+func Test_serveRawWithHTTPRequestMethodHEAD(t *testing.T) {
+	// mockNewCommon ensures that we do not need the repo-updater running for this unit test.
+	mockNewCommon = func(w http.ResponseWriter, r *http.Request, title string, serveError serveErrorHandler) (*Common, error) {
+		return &Common{
+			Repo: &types.Repo{
+				Name: "test",
+			},
+			CommitID: api.CommitID("12345"),
+		}, nil
+	}
+	defer func() {
+		mockNewCommon = nil
+	}()
+
+	t.Run("success response for HEAD request", func(t *testing.T) {
+		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return
+		// an error.
+		initHTTPTestGitServer(t, http.StatusOK, "{}")
+
+		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err != nil {
+			t.Fatalf("Failed to invoke serveRaw: %v", err)
+		}
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Want %d but got %d", http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("failure response for HEAD request", func(t *testing.T) {
+		// httptest server will return a 404 Not Found, so gitserver.DefaultClient.RepoInfo will
+		// return an error.
+		initHTTPTestGitServer(t, http.StatusNotFound, "{}")
+
+		req := httptest.NewRequest("HEAD", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err == nil {
+			t.Fatal("Want error but got nil")
+		}
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("Want %d but got %d", http.StatusNotFound, w.Code)
+		}
+	})
+}
+
+func Test_serveRawWithContentArchive(t *testing.T) {
+	mockNewCommon = func(w http.ResponseWriter, r *http.Request, title string, serveError serveErrorHandler) (*Common, error) {
+		return &Common{
+			Repo: &types.Repo{
+				Name: "test",
+			},
+			CommitID: api.CommitID("12345"),
+		}, nil
+	}
+	defer func() {
+		mockNewCommon = nil
+	}()
+
+	mockGitServerResponse := "this is a gitserver archive response"
+
+	t.Run("success response for format=zip", func(t *testing.T) {
+		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+
+		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
+
+		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=zip", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err != nil {
+			t.Fatalf("Failed to invoke serveRaw: %v", err)
+		}
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Want %d but got %d", http.StatusOK, w.Code)
+		}
+
+		expectedHeaders := map[string]string{
+			"X-Content-Type-Options": "nosniff",
+			"Content-Type":           "application/zip",
+			"Content-Disposition":    mime.FormatMediaType("Attachment", map[string]string{"filename": "test.zip"}),
+		}
+
+		if len(w.Header()) != len(expectedHeaders) {
+			t.Errorf("Want %d headers but got %d headers", len(w.Header()), len(expectedHeaders))
+		}
+
+		for k, v := range expectedHeaders {
+			if h := w.Header().Get(k); h != v {
+				t.Errorf("Expected header %q to have value %q but got %q", k, v, h)
+			}
+		}
+
+		body := string(w.Body.Bytes())
+		if body != mockGitServerResponse {
+			t.Errorf("Want %q in body, but got %q", mockGitServerResponse, body)
+		}
+	})
+
+	t.Run("success response for format=tar", func(t *testing.T) {
+		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+
+		initHTTPTestGitServer(t, http.StatusOK, mockGitServerResponse)
+
+		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=tar", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err != nil {
+			t.Fatalf("Failed to invoke serveRaw: %v", err)
+		}
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Want %d but got %d", http.StatusOK, w.Code)
+		}
+
+		expectedHeaders := map[string]string{
+			"X-Content-Type-Options": "nosniff",
+			"Content-Type":           "application/x-tar",
+			"Content-Disposition":    mime.FormatMediaType("Attachment", map[string]string{"filename": "test.tar"}),
+		}
+
+		if len(w.Header()) != len(expectedHeaders) {
+			t.Errorf("Want %d headers but got %d headers", len(w.Header()), len(expectedHeaders))
+		}
+
+		for k, v := range expectedHeaders {
+			if h := w.Header().Get(k); h != v {
+				t.Errorf("Expected header %q to have value %q but got %q", k, v, h)
+			}
+		}
+
+		body := string(w.Body.Bytes())
+		if body != mockGitServerResponse {
+			t.Errorf("Want %q in body, but got %q", mockGitServerResponse, body)
+		}
+	})
+
+}
+
+func Test_serveRawWithContentTypePlain(t *testing.T) {
+	mockNewCommon = func(w http.ResponseWriter, r *http.Request, title string, serveError serveErrorHandler) (*Common, error) {
+		return &Common{
+			Repo: &types.Repo{
+				Name: "test",
+			},
+			CommitID: api.CommitID("12345"),
+		}, nil
+	}
+	defer func() {
+		mockNewCommon = nil
+	}()
+
+	assertHeaders := func(w http.ResponseWriter) {
+		t.Helper()
+
+		expectedHeaders := map[string]string{
+			"X-Content-Type-Options": "nosniff",
+			"Content-Type":           "text/plain; charset=utf-8",
+		}
+
+		if len(w.Header()) != len(expectedHeaders) {
+			t.Errorf("Want %d headers but got %d headers", len(w.Header()), len(expectedHeaders))
+		}
+
+		for k, v := range expectedHeaders {
+			if h := w.Header().Get(k); h != v {
+				t.Errorf("Want header %q to have value %q but got %q", k, v, h)
+			}
+		}
+	}
+
+	t.Run("404 Not Found for non existent directory", func(t *testing.T) {
+		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		initHTTPTestGitServer(t, http.StatusOK, "{}")
+
+		git.Mocks.Stat = func(commit api.CommitID, name string) (os.FileInfo, error) {
+			return &util.FileInfo{}, os.ErrNotExist
+		}
+		defer git.ResetMocks()
+
+		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err != nil {
+			t.Fatalf("Failed to invoke serveRaw: %v", err)
+		}
+
+		if w.Code != http.StatusNotFound {
+			t.Fatalf("Want %d but got %d", http.StatusOK, w.Code)
+		}
+
+		assertHeaders(w)
+	})
+
+	t.Run("success response for existing directory", func(t *testing.T) {
+		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		initHTTPTestGitServer(t, http.StatusOK, "{}")
+
+		git.Mocks.Stat = func(commit api.CommitID, name string) (os.FileInfo, error) {
+			return &util.FileInfo{Mode_: os.ModeDir}, nil
+		}
+
+		git.Mocks.ReadDir = func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error) {
+			return []os.FileInfo{
+				&util.FileInfo{Name_: "test/a", Mode_: os.ModeDir},
+				&util.FileInfo{Name_: "test/b", Mode_: os.ModeDir},
+				&util.FileInfo{Name_: "c.go", Mode_: 0},
+			}, nil
+		}
+
+		defer git.ResetMocks()
+
+		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err != nil {
+			t.Fatalf("Failed to invoke serveRaw: %v", err)
+		}
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Want %d but got %d", http.StatusOK, w.Code)
+		}
+
+		assertHeaders(w)
+
+		want := `a/
+b/
+c.go`
+		body := string(w.Body.Bytes())
+		if body != want {
+			t.Errorf("Want %q in body, but got %q", want, body)
+		}
+	})
+
+	t.Run("success response for existing file", func(t *testing.T) {
+		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		initHTTPTestGitServer(t, http.StatusOK, "{}")
+
+		git.Mocks.Stat = func(commit api.CommitID, name string) (os.FileInfo, error) {
+			return &util.FileInfo{Mode_: 0}, nil
+		}
+
+		git.Mocks.NewFileReader = func(commit api.CommitID, name string) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader("this is a test file")), nil
+		}
+
+		defer git.ResetMocks()
+
+		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err != nil {
+			t.Fatalf("Failed to invoke serveRaw: %v", err)
+		}
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Want %d but got %d", http.StatusOK, w.Code)
+		}
+
+		assertHeaders(w)
+
+		want := "this is a test file"
+
+		body := string(w.Body.Bytes())
+		if body != want {
+			t.Errorf("Want %q in body, but got %q", want, body)
+		}
+	})
+
+	// Ensure that anything apart from tar/zip/text is still handled with a text/plain content type.
+	t.Run("success response for existing file with format=exe", func(t *testing.T) {
+		// httptest server will return a 200 OK, so gitserver.DefaultClient.RepoInfo will not return an error.
+		initHTTPTestGitServer(t, http.StatusOK, "{}")
+
+		git.Mocks.Stat = func(commit api.CommitID, name string) (os.FileInfo, error) {
+			return &util.FileInfo{Mode_: 0}, nil
+		}
+
+		git.Mocks.NewFileReader = func(commit api.CommitID, name string) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader("this is a test file")), nil
+		}
+
+		defer git.ResetMocks()
+
+		req := httptest.NewRequest("GET", "/github.com/sourcegraph/sourcegraph/-/raw?format=exe", nil)
+		w := httptest.NewRecorder()
+
+		err := serveRaw(w, req)
+		if err != nil {
+			t.Fatalf("Failed to invoke serveRaw: %v", err)
+		}
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Want %d but got %d", http.StatusOK, w.Code)
+		}
+
+		assertHeaders(w)
+
+		want := "this is a test file"
+
+		body := string(w.Body.Bytes())
+		if body != want {
+			t.Errorf("Want %q in body, but got %q", want, body)
+		}
+	})
+}


### PR DESCRIPTION
In this commit we make newCommon mockable by adding a mock. This is
used in the tests for the serveRaw handler.

Closes #11259 

Co-authored-by: Joe Chen <joe@sourcegraph.com>
Co-authored-by:  Thorsten Ball <mrnugget@gmail.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
