### PR TITLE
Set HOSTNAME in server to what other services think gitserver is

### DIFF
--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -130,7 +130,7 @@ func Main() {
 	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter --log.level=%s`, dbutil.PostgresDSN("", "postgres", os.Getenv), convertLogLevel(os.Getenv("SRC_LOG_LEVEL")))
 
 	// Tell `gitserver` that its `hostname` is what the others think of as gitserver hostnames.
-	gitserverLine := fmt.Sprintf(`gitserver: env HOSTNAME=%q gitserver`, DefaultEnv["SRC_GIT_SERVERS"])
+	gitserverLine := fmt.Sprintf(`gitserver: env HOSTNAME=%q gitserver`, os.Getenv("SRC_GIT_SERVERS"))
 
 	procfile := []string{
 		nginx,

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -129,10 +129,13 @@ func Main() {
 
 	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter --log.level=%s`, dbutil.PostgresDSN("", "postgres", os.Getenv), convertLogLevel(os.Getenv("SRC_LOG_LEVEL")))
 
+	// Tell `gitserver` that its `hostname` is what the others think of as gitserver hostnames.
+	gitserverLine := fmt.Sprintf(`gitserver: env HOSTNAME=%q gitserver`, DefaultEnv["SRC_GIT_SERVERS"])
+
 	procfile := []string{
 		nginx,
 		`frontend: env CONFIGURATION_MODE=server frontend`,
-		`gitserver: gitserver`,
+		gitserverLine,
 		`query-runner: query-runner`,
 		`symbols: symbols`,
 		`searcher: searcher`,

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -129,6 +129,7 @@ func Main() {
 
 	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter --log.level=%s`, dbutil.PostgresDSN("", "postgres", os.Getenv), convertLogLevel(os.Getenv("SRC_LOG_LEVEL")))
 
+	// TODO: This should be fixed properly.
 	// Tell `gitserver` that its `hostname` is what the others think of as gitserver hostnames.
 	gitserverLine := fmt.Sprintf(`gitserver: env HOSTNAME=%q gitserver`, os.Getenv("SRC_GIT_SERVERS"))
 


### PR DESCRIPTION
This fixes integration tests that use the server image. These were flaky because gitserver kept deleting repositories since it didn't consider itself of the shard. See [slack message here](https://sourcegraph.slack.com/archives/CMBA8F926/p1615552217026800)