### PR TITLE
gitserver: Rename environment variable

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -42,7 +42,7 @@ var (
 	syncRepoStateInterval        = env.MustGetDuration("SRC_REPOS_SYNC_STATE_INTERVAL", 10*time.Minute, "Interval between state syncs")
 	syncRepoStateBatchSize       = env.MustGetInt("SRC_REPOS_SYNC_STATE_BATCH_SIZE", 500, "Number of upserts to perform per batch")
 	syncRepoStateUpsertPerSecond = env.MustGetInt("SRC_REPOS_SYNC_STATE_UPSERT_PER_SEC", 500, "The number of upserted rows allowed per second across all gitserver instances")
-	envHostname                  = env.Get("HOSTNAME", "", "Hostname override")
+	envShardID                   = env.Get("SRC_GIT_SERVER_SHARD_ID", "", "This gitserver instance's shard id")
 )
 
 func main() {
@@ -122,8 +122,8 @@ func main() {
 			}
 			return &server.GitRepoSyncer{}, nil
 		},
-		Hostname: hostnameBestEffort(),
-		DB:       db,
+		ShardID: shardIDBestEffort(),
+		DB:      db,
 	}
 	gitserver.RegisterMetrics()
 
@@ -179,9 +179,9 @@ func main() {
 	gitserver.Stop()
 }
 
-func hostnameBestEffort() string {
-	if envHostname != "" {
-		return envHostname
+func shardIDBestEffort() string {
+	if envShardID != "" {
+		return envShardID
 	}
 	h, _ := os.Hostname()
 	return h

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -230,7 +230,7 @@ func (s *Server) cleanupRepos(addrs []string) {
 			return false, nil
 		}
 		addr := gitserver.AddrForRepo(s.name(dir), addrs)
-		if s.hostnameMatch(addr) {
+		if s.shardIDMatch(addr) {
 			return false, nil
 		}
 		log15.Info("removing repo for wrong shard", "repo", dir)
@@ -500,7 +500,7 @@ func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status t
 	if err != nil {
 		return err
 	}
-	return database.NewGitserverReposWith(tx).SetCloneStatus(ctx, repo.ID, status, s.Hostname)
+	return database.NewGitserverReposWith(tx).SetCloneStatus(ctx, repo.ID, status, s.ShardID)
 }
 
 // setCloneStatusNonFatal is the same as setCloneStatus but only logs errors

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -136,7 +136,7 @@ func TestCleanupWrongShard(t *testing.T) {
 	repo1 := mkRepo("repo1")
 	repo2 := mkRepo("repo2")
 	s := &Server{
-		Hostname: "addr1",
+		ShardID:  "addr1",
 		ReposDir: root,
 	}
 	s.Handler() // Handler as a side-effect sets up Server

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -823,8 +823,8 @@ func TestHostnameMatch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			s := Server{Hostname: tc.hostname}
-			have := s.hostnameMatch(tc.addr)
+			s := Server{ShardID: tc.hostname}
+			have := s.shardIDMatch(tc.addr)
 			if have != tc.shouldMatch {
 				t.Fatalf("Want %v, got %v", tc.shouldMatch, have)
 			}
@@ -858,7 +858,7 @@ func TestSyncRepoState(t *testing.T) {
 		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
 			return &GitRepoSyncer{}, nil
 		},
-		Hostname:         hostname,
+		ShardID:          hostname,
 		DB:               db,
 		ctx:              ctx,
 		locker:           &RepositoryLocker{},

--- a/cmd/server/shared/shared.go
+++ b/cmd/server/shared/shared.go
@@ -129,9 +129,9 @@ func Main() {
 
 	postgresExporterLine := fmt.Sprintf(`postgres_exporter: env DATA_SOURCE_NAME="%s" postgres_exporter --log.level=%s`, dbutil.PostgresDSN("", "postgres", os.Getenv), convertLogLevel(os.Getenv("SRC_LOG_LEVEL")))
 
-	// TODO: This should be fixed properly.
-	// Tell `gitserver` that its `hostname` is what the others think of as gitserver hostnames.
-	gitserverLine := fmt.Sprintf(`gitserver: env HOSTNAME=%q gitserver`, os.Getenv("SRC_GIT_SERVERS"))
+	// Tell `gitserver` that its `shard id` is what the others think of as gitserver
+	// hostname so that our sharding logic on both frontend and gitserver match.
+	gitserverLine := fmt.Sprintf(`gitserver: env SRC_GIT_SERVER_SHARD_ID=%q gitserver`, os.Getenv("SRC_GIT_SERVERS"))
 
 	procfile := []string{
 		nginx,

--- a/dev/Procfile
+++ b/dev/Procfile
@@ -1,4 +1,4 @@
-gitserver: env HOSTNAME=$SRC_GIT_SERVER_1 gitserver
+gitserver: env SRC_GIT_SERVER_SHARD_ID=$SRC_GIT_SERVER_1 gitserver
 query-runner: query-runner
 repo-updater: repo-updater
 searcher: searcher


### PR DESCRIPTION
HOSTNAME is a really generic name for an env var (and also set/used by
other Unix programs) that's used to give a gitserver shard member a
unique identity. Instead, we use a more specific name.

Closes: https://github.com/sourcegraph/sourcegraph/issues/19098