### PR TITLE
refactor: Remove impossible ConnectionNodes conditions

### DIFF
--- a/client/web/src/components/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection.test.tsx
@@ -3,6 +3,7 @@ import { createLocation } from 'history'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { ConnectionNodesForTesting as ConnectionNodes } from './FilteredConnection'
+import sinon from 'sinon'
 
 function fakeConnection<N>({
     hasNextPage,
@@ -94,7 +95,7 @@ describe('ConnectionNodes', () => {
     })
 
     it('calls the onShowMore callback', async () => {
-        const showMoreCallback = jest.fn(() => {})
+        const showMoreCallback = sinon.spy(() => undefined)
         render(
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
@@ -104,7 +105,7 @@ describe('ConnectionNodes', () => {
             />
         )
         fireEvent.click(screen.getByRole('button')!)
-        await waitFor(() => expect(showMoreCallback).toHaveBeenCalledTimes(1))
+        await waitFor(() => sinon.assert.calledOnce(showMoreCallback))
     })
 
     it("doesn't show summary info if totalCount is null", () => {
@@ -177,7 +178,7 @@ describe('ConnectionNodes', () => {
                 {...defaultConnectionNodesProps}
                 connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
                 loading={true}
-                connectionQuery={'meow?'}
+                connectionQuery="meow?"
             />
         )
         // Summary should come _before_ the nodes.
@@ -192,7 +193,7 @@ describe('ConnectionNodes', () => {
                 {...defaultConnectionNodesProps}
                 connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
                 loading={true}
-                connectionQuery={'meow?'}
+                connectionQuery="meow?"
             />
         )
         // Summary should come _before_ the nodes.

--- a/client/web/src/components/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection.test.tsx
@@ -1,12 +1,20 @@
 import React from 'react'
 import { createLocation } from 'history'
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import { ConnectionNodesForTesting as ConnectionNodes } from './FilteredConnection'
 
-function fakeConnection({ hasNextPage, totalCount }: { hasNextPage: boolean; totalCount: number | null }) {
+function fakeConnection<N>({
+    hasNextPage,
+    totalCount,
+    nodes,
+}: {
+    hasNextPage: boolean
+    totalCount: number | null
+    nodes: N[]
+}) {
     return {
-        nodes: [{}],
+        nodes,
         pageInfo: {
             endCursor: '',
             hasNextPage,
@@ -15,9 +23,8 @@ function fakeConnection({ hasNextPage, totalCount }: { hasNextPage: boolean; tot
     }
 }
 
-/** A default set of props that are required by the ConnectionNodes component,
-    but that are not relevant to any of the things under test here. */
-const boringConnectionNodesProps = {
+/** A default set of props that are required by the ConnectionNodes component */
+const defaultConnectionNodesProps = {
     connectionQuery: '',
     first: 0,
     location: createLocation('/'),
@@ -33,12 +40,12 @@ const boringConnectionNodesProps = {
 describe('ConnectionNodes', () => {
     afterAll(cleanup)
 
-    it('should have a "Show more" button when *not* loading', () => {
+    it('has a "Show more" button when *not* loading', () => {
         render(
             <ConnectionNodes
-                connection={fakeConnection({ hasNextPage: true, totalCount: 2 })}
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
                 loading={false}
-                {...boringConnectionNodesProps}
             />
         )
         expect(screen.getByRole('button')).toHaveTextContent('Show more')
@@ -46,12 +53,12 @@ describe('ConnectionNodes', () => {
         expect(screen.getByText('(showing first 1)')).toBeVisible()
     })
 
-    it("should *not* have a 'Show more' button when loading", () => {
+    it("*doesn't* have a 'Show more' button when loading", () => {
         render(
             <ConnectionNodes
-                connection={fakeConnection({ hasNextPage: true, totalCount: 2 })}
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
                 loading={true}
-                {...boringConnectionNodesProps}
             />
         )
         expect(screen.queryByRole('button')).toBeNull()
@@ -60,15 +67,137 @@ describe('ConnectionNodes', () => {
         // NOTE: we also expect a LoadingSpinner, but that is not provided by ConnectionNodes.
     })
 
-    it("it doesn't show summary info if totalCount is null", () => {
+    it("doesn't have a 'Show more' button when noShowMore is true", () => {
         render(
             <ConnectionNodes
-                connection={fakeConnection({ hasNextPage: true, totalCount: null })}
-                loading={true}
-                {...boringConnectionNodesProps}
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
+                loading={false}
+                noShowMore={true}
             />
         )
-        expect(screen.queryByText('2 cats total')).toBeNull()
+        expect(screen.queryByRole('button')).toBeNull()
+        expect(screen.getByText('2 cats total')).toBeVisible()
+        expect(screen.getByText('(showing first 1)')).toBeVisible()
+    })
+
+    it("doesn't have a 'Show more' button or a summary if hasNextPage is false ", () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [{}] })}
+                loading={true}
+            />
+        )
+        expect(screen.queryByRole('button')).toBeNull()
+        expect(screen.queryByTestId('summary')).toBeNull()
+    })
+
+    it('calls the onShowMore callback', async () => {
+        const showMoreCallback = jest.fn(() => {})
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
+                loading={false}
+                onShowMore={showMoreCallback}
+            />
+        )
+        fireEvent.click(screen.getByRole('button')!)
+        await waitFor(() => expect(showMoreCallback).toHaveBeenCalledTimes(1))
+    })
+
+    it("doesn't show summary info if totalCount is null", () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: true, totalCount: null, nodes: [{}] })}
+                loading={true}
+            />
+        )
+        expect(screen.queryByTestId('summary')).toBeNull()
+    })
+
+    it('shows a summary if noSummaryIfAllNodesVisible is false', () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [{}] })}
+                loading={true}
+                noSummaryIfAllNodesVisible={false}
+            />
+        )
+        expect(screen.getByText('1 cat total')).toBeVisible()
         expect(screen.queryByText('(showing first 1)')).toBeNull()
+
+        // Summary should come after the nodes.
+        expect(screen.getByTestId('summary')!.compareDocumentPosition(screen.getByTestId('nodes'))).toEqual(
+            Node.DOCUMENT_POSITION_PRECEDING
+        )
+    })
+
+    it('shows a summary if nodes.length is 0', () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [] })}
+                loading={true}
+            />
+        )
+        expect(screen.getByText('1 cat total')).toBeVisible()
+        expect(screen.queryByText('(showing first 1)')).toBeNull()
+    })
+
+    it('shows a summary if nodes.length is 0', () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [] })}
+                loading={true}
+            />
+        )
+        expect(screen.getByText('1 cat total')).toBeVisible()
+        expect(screen.queryByText('(showing first 1)')).toBeNull()
+    })
+
+    it("shows 'No cats' if totalCount is 0", () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: false, totalCount: 0, nodes: [] })}
+                loading={true}
+            />
+        )
+        expect(screen.getByText('No cats')).toBeVisible()
+    })
+
+    it('shows the summary at the top if connectionQuery is specified', () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
+                loading={true}
+                connectionQuery={'meow?'}
+            />
+        )
+        // Summary should come _before_ the nodes.
+        expect(screen.getByTestId('summary')!.compareDocumentPosition(screen.getByTestId('nodes'))).toEqual(
+            Node.DOCUMENT_POSITION_FOLLOWING
+        )
+    })
+
+    it('shows the summary at the top if connectionQuery is specified', () => {
+        render(
+            <ConnectionNodes
+                {...defaultConnectionNodesProps}
+                connection={fakeConnection({ hasNextPage: true, totalCount: 2, nodes: [{}] })}
+                loading={true}
+                connectionQuery={'meow?'}
+            />
+        )
+        // Summary should come _before_ the nodes.
+        expect(screen.getByTestId('summary')!.compareDocumentPosition(screen.getByTestId('nodes'))).toEqual(
+            Node.DOCUMENT_POSITION_FOLLOWING
+        )
     })
 })

--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -208,42 +208,35 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
         const FootComponent = this.props.footComponent
         const TotalCountSummaryComponent = this.props.totalCountSummaryComponent
 
-        const hasNextPage = this.props.connection
-            ? this.props.connection.pageInfo
-                ? this.props.connection.pageInfo.hasNextPage
-                : typeof this.props.connection.totalCount === 'number' &&
-                  this.props.connection.nodes.length < this.props.connection.totalCount
-            : false
+        const hasNextPage = this.props.connection.pageInfo
+            ? this.props.connection.pageInfo.hasNextPage
+            : typeof this.props.connection.totalCount === 'number' &&
+              this.props.connection.nodes.length < this.props.connection.totalCount
 
         let totalCount: number | null = null
-        if (this.props.connection) {
-            if (typeof this.props.connection.totalCount === 'number') {
-                totalCount = this.props.connection.totalCount
-            } else if (
-                // TODO(sqs): this line below is wrong because this.props.first might've just been changed and
-                // this.props.connection.nodes is still the data fetched from before this.props.first was changed.
-                // this causes the UI to incorrectly show "N items total" even when the count is indeterminate right
-                // after the user clicks "Show more" but before the new data is loaded.
-                this.props.connection.nodes.length < this.props.first ||
-                (this.props.connection.nodes.length === this.props.first &&
-                    this.props.connection.pageInfo &&
-                    typeof this.props.connection.pageInfo.hasNextPage === 'boolean' &&
-                    !this.props.connection.pageInfo.hasNextPage)
-            ) {
-                totalCount = this.props.connection.nodes.length
-            }
+        if (typeof this.props.connection.totalCount === 'number') {
+            totalCount = this.props.connection.totalCount
+        } else if (
+            // TODO(sqs): this line below is wrong because this.props.first might've just been changed and
+            // this.props.connection.nodes is still the data fetched from before this.props.first was changed.
+            // this causes the UI to incorrectly show "N items total" even when the count is indeterminate right
+            // after the user clicks "Show more" but before the new data is loaded.
+            this.props.connection.nodes.length < this.props.first ||
+            (this.props.connection.nodes.length === this.props.first &&
+                this.props.connection.pageInfo &&
+                typeof this.props.connection.pageInfo.hasNextPage === 'boolean' &&
+                !this.props.connection.pageInfo.hasNextPage)
+        ) {
+            totalCount = this.props.connection.nodes.length
         }
 
         let summary: React.ReactFragment | undefined
-        if (
-            this.props.connection &&
-            (!this.props.noSummaryIfAllNodesVisible || this.props.connection.nodes.length === 0 || hasNextPage)
-        ) {
+        if (!this.props.noSummaryIfAllNodesVisible || this.props.connection.nodes.length === 0 || hasNextPage) {
             if (totalCount !== null && totalCount > 0) {
                 summary = TotalCountSummaryComponent ? (
                     <TotalCountSummaryComponent totalCount={totalCount} />
                 ) : (
-                    <p className="filtered-connection__summary">
+                    <p className="filtered-connection__summary" data-testid="summary">
                         <small>
                             <span>
                                 {totalCount} {pluralize(this.props.noun, totalCount, this.props.pluralNoun)}{' '}
@@ -265,7 +258,7 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
                 // No total count to show, but it will show a 'Show more' button.
             } else if (totalCount === 0) {
                 summary = this.props.emptyElement || (
-                    <p className="filtered-connection__summary">
+                    <p className="filtered-connection__summary" data-testid="summary">
                         <small>
                             No {this.props.pluralNoun}{' '}
                             {this.props.connectionQuery && (
@@ -286,8 +279,11 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
         return (
             <>
                 {this.props.connectionQuery && summary}
-                {this.props.connection && this.props.connection.nodes.length > 0 && (
-                    <ListComponent className={classNames('filtered-connection__nodes', this.props.listClassName)}>
+                {this.props.connection.nodes.length > 0 && (
+                    <ListComponent
+                        className={classNames('filtered-connection__nodes', this.props.listClassName)}
+                        data-testid="nodes"
+                    >
                         {HeadComponent && (
                             <HeadComponent
                                 nodes={this.props.connection.nodes}
@@ -299,7 +295,7 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
                     </ListComponent>
                 )}
                 {!this.props.connectionQuery && summary}
-                {!this.props.loading && !this.props.noShowMore && this.props.connection && hasNextPage && (
+                {!this.props.loading && !this.props.noShowMore && hasNextPage && (
                     <button
                         type="button"
                         className={classNames(

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -549,6 +549,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
               >
                 <ul
                   className="filtered-connection__nodes"
+                  data-testid="nodes"
                 >
                   <CodeMonitorNode
                     authentictedUser={
@@ -2049,6 +2050,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
               >
                 <ul
                   className="filtered-connection__nodes"
+                  data-testid="nodes"
                 >
                   <CodeMonitorNode
                     authentictedUser={
@@ -3006,6 +3008,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
               >
                 <ul
                   className="filtered-connection__nodes"
+                  data-testid="nodes"
                 >
                   <CodeMonitorNode
                     authentictedUser={
@@ -4342,6 +4345,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                 </ul>
                 <p
                   className="filtered-connection__summary"
+                  data-testid="summary"
                 >
                   <small>
                     <span>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
@@ -176,6 +176,7 @@ exports[`SiteAdminProductSubscriptionPage renders 1`] = `
       
       <ul
         className="filtered-connection__nodes"
+        data-testid="nodes"
       >
         <SiteAdminProductLicenseNode
           node={


### PR DESCRIPTION
- Add more tests to ensure nearly complete coverage of ConnectionNodes
- Remove tests for `this.props.connection` because it can never be null.
