### PR TITLE
streaming: track time to first result

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -513,6 +513,11 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 			act = *a
 		}
 
+		var streamLatency int64
+		if ts, ok := r.stream.(TimerSender); ok {
+			streamLatency = ts.Latency().Milliseconds()
+		}
+
 		ev := honey.Event("search")
 		ev.AddField("query", r.rawQuery())
 		ev.AddField("actor_uid", act.UID)
@@ -522,6 +527,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 		ev.AddField("status", status)
 		ev.AddField("alert_type", alertType)
 		ev.AddField("duration_ms", time.Since(start).Milliseconds())
+		ev.AddField("stream_latency_ms", streamLatency)
 		if rr != nil {
 			ev.AddField("result_size", len(rr.SearchResults))
 		}

--- a/cmd/frontend/graphqlbackend/search_stream_test.go
+++ b/cmd/frontend/graphqlbackend/search_stream_test.go
@@ -1,0 +1,36 @@
+package graphqlbackend
+
+import (
+	"testing"
+	"time"
+)
+
+// Compare BenchmarkWithoutTimer and BenchmarkWithTimer to see how much overhead
+// is added by keeping track of "time to first event".
+func BenchmarkWithoutTimer(b *testing.B) {
+	s := StreamFunc(func(event SearchEvent) {})
+	se := SearchEvent{Results: make([]SearchResultResolver, 10)}
+	for i := 0; i < b.N; i++ {
+		s.Send(se)
+	}
+}
+
+func BenchmarkWithTimer(b *testing.B) {
+	s := WithTimer(StreamFunc(func(event SearchEvent) {}), time.Now())
+	se := SearchEvent{Results: make([]SearchResultResolver, 10)}
+	for i := 0; i < b.N; i++ {
+		s.Send(se)
+	}
+}
+
+func TestWithTimer(t *testing.T) {
+	s := WithTimer(StreamFunc(func(event SearchEvent) {}), time.Now())
+	time.Sleep(1 * time.Millisecond)
+	if got := s.Latency(); got != 0 {
+		t.Fatalf("want 0, got %d ", got)
+	}
+	s.Send(SearchEvent{Results: make([]SearchResultResolver, 1)})
+	if got := s.Latency().Milliseconds(); got < 1 {
+		t.Fatalf("want >=1, got %d ", got)
+	}
+}


### PR DESCRIPTION
This adds func `WithTimer` which takes a `Sender` and keeps track of "time to
first result".

Benchmarks show that the overhead is negligble compared to the overal latency of
a search request which is in the order of miliseconds.

```
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkWithoutTimer-16        1000000000               0.2281 ns/op
BenchmarkWithTimer-16           153142389                7.901 ns/op
```

We log the new metric to honeycomb.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
