### PR TITLE
ci: remove verbose flag from backend integration tests

### DIFF
--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -42,5 +42,5 @@ fi
 set -e
 echo "Waiting for $URL... done"
 
-echo '--- go test ./dev/gqltest -long -v'
-go test ./dev/gqltest -long -v
+echo '--- go test ./dev/gqltest -long'
+go test ./dev/gqltest -long


### PR DESCRIPTION
When they fail there is too much output to find what went wrong. By
removing verbose we will only see output from failing tests.