### PR TITLE
search: Remove db from languageResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search"
@@ -333,7 +332,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		resolvers := make([]SearchSuggestionResolver, 0, len(inventory.Languages))
 		for _, l := range inventory.Languages {
 			resolvers = append(resolvers, languageSuggestionResolver{
-				lang:  &languageResolver{db: r.db, name: strings.ToLower(l.Name)},
+				lang:  &languageResolver{name: strings.ToLower(l.Name)},
 				score: math.MaxInt32,
 			})
 		}
@@ -528,7 +527,6 @@ func allEmptyStrings(ss1, ss2 []string) bool {
 }
 
 type languageResolver struct {
-	db   dbutil.DB
 	name string
 }
 


### PR DESCRIPTION
The reference to the database is never used, so no need to keep it
available.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
