### PR TITLE
gqltest: detect graphql query name to remove log spam

### DIFF
--- a/internal/gqltestutil/access_token.go
+++ b/internal/gqltestutil/access_token.go
@@ -26,7 +26,7 @@ mutation CreateAccessToken($user: ID!, $scopes: [String!]!, $note: String!) {
 			} `json:"createAccessToken"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, variables, &resp)
+	err := c.GraphQL("", query, variables, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
@@ -45,7 +45,7 @@ mutation DeleteAccessToken($token: String!) {
 	variables := map[string]interface{}{
 		"token": token,
 	}
-	err := c.GraphQL("", "", query, variables, nil)
+	err := c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
 // NeedsSiteInit returns true if the instance hasn't done "Site admin init" step.
@@ -203,7 +204,7 @@ func (c *Client) CurrentUserID(token string) (string, error) {
 			} `json:"currentUser"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", token, query, nil, &resp)
+	err := c.GraphQL(token, query, nil, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
@@ -216,16 +217,23 @@ func (c *Client) AuthenticatedUserID() string {
 	return c.userID
 }
 
+var graphqlQueryNameRe = lazyregexp.New(`query +(\w)+`)
+
 // GraphQL makes a GraphQL request to the server on behalf of the user authenticated by the client.
 // An optional token can be passed to impersonate other users. A nil target will skip unmarshalling
 // the returned JSON response.
-func (c *Client) GraphQL(name, token, query string, variables map[string]interface{}, target interface{}) error {
+func (c *Client) GraphQL(token, query string, variables map[string]interface{}, target interface{}) error {
 	body, err := jsoniter.Marshal(map[string]interface{}{
 		"query":     query,
 		"variables": variables,
 	})
 	if err != nil {
 		return err
+	}
+
+	var name string
+	if matches := graphqlQueryNameRe.FindStringSubmatch(query); len(matches) >= 1 {
+		name = matches[1]
 	}
 
 	req, err := http.NewRequest("POST", fmt.Sprintf("%s/.api/graphql?%s", c.baseURL, name), bytes.NewReader(body))

--- a/internal/gqltestutil/external_service.go
+++ b/internal/gqltestutil/external_service.go
@@ -34,7 +34,7 @@ mutation AddExternalService($input: AddExternalServiceInput!) {
 			} `json:"addExternalService"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, variables, &resp)
+	err := c.GraphQL("", query, variables, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
@@ -60,7 +60,7 @@ mutation DeleteExternalService($externalService: ID!) {
 	variables := map[string]interface{}{
 		"externalService": id,
 	}
-	err := c.GraphQL("", "", query, variables, nil)
+	err := c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/git_blob.go
+++ b/internal/gqltestutil/git_blob.go
@@ -33,7 +33,7 @@ query Blob($repoName: String!, $revision: String!, $filePath: String!) {
 			} `json:"repository"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", gqlQuery, variables, &resp)
+	err := c.GraphQL("", gqlQuery, variables, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/organization.go
+++ b/internal/gqltestutil/organization.go
@@ -25,7 +25,7 @@ mutation CreateOrganization($name: String!, $displayName: String) {
 			} `json:"createOrganization"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, variables, &resp)
+	err := c.GraphQL("", query, variables, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
@@ -46,7 +46,7 @@ mutation DeleteOrganization($organization: ID!) {
 	variables := map[string]interface{}{
 		"organization": id,
 	}
-	err := c.GraphQL("", "", query, variables, nil)
+	err := c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}
@@ -66,7 +66,7 @@ mutation RemoveUserFromOrganization($user: ID!, $organization: ID!) {
 		"user":         userID,
 		"organization": orgID,
 	}
-	err := c.GraphQL("", "", query, variables, nil)
+	err := c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -71,7 +71,7 @@ query Search($query: String!) {
 			} `json:"search"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", gqlQuery, variables, &resp)
+	err := c.GraphQL("", gqlQuery, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
@@ -163,7 +163,7 @@ query Search($query: String!) {
 			} `json:"search"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", gqlQuery, variables, &resp)
+	err := c.GraphQL("", gqlQuery, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
@@ -207,7 +207,7 @@ query Search($query: String!) {
 			} `json:"search"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", gqlQuery, variables, &resp)
+	err := c.GraphQL("", gqlQuery, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
@@ -318,7 +318,7 @@ query Search($query: String!) {
 			} `json:"search"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", gqlQuery, variables, &resp)
+	err := c.GraphQL("", gqlQuery, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
@@ -357,7 +357,7 @@ query SearchResultsStats($query: String!) {
 			} `json:"search"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", gqlQuery, variables, &resp)
+	err := c.GraphQL("", gqlQuery, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
@@ -496,7 +496,7 @@ query SearchSuggestions($query: String!) {
 			} `json:"search"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", gqlQuery, variables, &resp)
+	err := c.GraphQL("", gqlQuery, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/settings.go
+++ b/internal/gqltestutil/settings.go
@@ -31,7 +31,7 @@ mutation OverwriteSettings($subject: ID!, $lastID: Int, $contents: String!) {
 		"lastID":   lastID,
 		"contents": contents,
 	}
-	err = c.GraphQL("", "", query, variables, nil)
+	err = c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}
@@ -65,7 +65,7 @@ query ViewerSettings {
 			} `json:"viewerSettings"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, nil, &resp)
+	err := c.GraphQL("", query, nil, &resp)
 	if err != nil {
 		return 0, errors.Wrap(err, "request GraphQL")
 	}
@@ -101,7 +101,7 @@ query ViewerSettings {
 			} `json:"viewerSettings"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, nil, &resp)
+	err := c.GraphQL("", query, nil, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
@@ -131,7 +131,7 @@ query Site {
 			} `json:"site"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, nil, &resp)
+	err := c.GraphQL("", query, nil, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}
@@ -161,7 +161,7 @@ mutation UpdateSiteConfiguration($input: String!) {
 	variables := map[string]interface{}{
 		"input": string(input),
 	}
-	err = c.GraphQL("", "", query, variables, nil)
+	err = c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}

--- a/internal/gqltestutil/user.go
+++ b/internal/gqltestutil/user.go
@@ -31,7 +31,7 @@ mutation CreateUser($username: String!, $email: String) {
 			} `json:"createUser"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, variables, &resp)
+	err := c.GraphQL("", query, variables, &resp)
 	if err != nil {
 		return "", errors.Wrap(err, "request GraphQL")
 	}
@@ -54,7 +54,7 @@ mutation DeleteUser($user: ID!, $hard: Boolean) {
 		"user": id,
 		"hard": hard,
 	}
-	err := c.GraphQL("", "", query, variables, nil)
+	err := c.GraphQL("", query, variables, nil)
 	if err != nil {
 		return errors.Wrap(err, "request GraphQL")
 	}
@@ -88,7 +88,7 @@ query User($username: String) {
 			} `json:"user"`
 		} `json:"data"`
 	}
-	err := c.GraphQL("", "", query, variables, &resp)
+	err := c.GraphQL("", query, variables, &resp)
 	if err != nil {
 		return nil, errors.Wrap(err, "request GraphQL")
 	}


### PR DESCRIPTION
If the name isn't set, the query is logged by Sourcegraph. Given we only
set the name once for a repo and indexed repo query, it resulted in a
lot of log spam. We now extract the name out of the query.

Additionally we remove the intentional logging of the first
WaitForReposToBeCloned and WaitForReposToBeIndex call. This seems low
value and leads to a more complicated API.

The bulk of this commit is removing the first empty string to GraphQL
function calls. See the change to the GraphQL function where we use a
regex to extract the name.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
