### PR TITLE
gqltest: add buildkite sections for docker logs

### DIFF
--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -18,7 +18,28 @@ fi
 
 echo "--- Running a daemonized $IMAGE as the test subject..."
 CONTAINER="$(docker container run -d -e GOTRACEBACK=all "$IMAGE")"
-trap 'kill $(jobs -p -r)'" ; docker logs --timestamps $CONTAINER ; docker container rm -f $CONTAINER ; docker image rm -f $IMAGE" EXIT
+function cleanup() {
+  exit_status=$?
+  if [ $exit_status -ne 0 ]; then
+    # Expand the output if our run failed.
+    echo "^^^ +++"
+  fi
+
+  jobs -p -r | xargs kill
+  echo "--- server logs"
+  docker logs --timestamps "$CONTAINER"
+  echo "--- docker cleanup"
+  docker container rm -f "$CONTAINER"
+  docker image rm -f "$IMAGE"
+
+  if [ $exit_status -ne 0 ]; then
+    # This command will fail, so our last step will be expanded. We don't want
+    # to expand "docker cleanup" so we add in a dummy section.
+    echo "--- gqltest failed"
+    echo "See go test section for test runner logs."
+  fi
+}
+trap cleanup EXIT
 
 docker exec "$CONTAINER" apk add --no-cache socat
 # Connect the server container's port 7080 to localhost:7080 so that integration tests


### PR DESCRIPTION
This is the same change I did for E2E tests. We add in buildkite log
markers when we do docker log output. This makes it possible to easily
see the test output for the sourcegraph server output.

To see the change I did for e2e look at #18477 and #18479.

I'm hoping after the decreasing of verbosity of logs and test output + this change the backend integration test output will be much more readable.