### PR TITLE
docs: search: clarify that two literal terms are matched _exactly_, not fuzzily

### DIFF
--- a/doc/code_search/reference/queries.md
+++ b/doc/code_search/reference/queries.md
@@ -44,7 +44,7 @@ Literal search interprets search patterns literally to simplify searching for wo
 
 | Search pattern syntax                                                             | Description                                                                                                                                                                                                                           |
 | ---                                                                               | ---                                                                                                                                                                                                                                   |
-| [`foo bar`](https://sourcegraph.com/search?q=foo+bar&patternType=literal)         | Match the string `foo bar`. Matching is ordered: match `foo` followed by `bar`. Matching is case-_insensitive_ (toggle the <span class="toggle-container"><img class="toggle" src=../img/case.png alt="case"></span> button to change). |
+| [`foo bar`](https://sourcegraph.com/search?q=foo+bar&patternType=literal)         | Match the string `foo bar`. Matching is ordered: match `foo` followed by `bar`, with exactly one space between the terms. Matching is case-_insensitive_ (toggle the <span class="toggle-container"><img class="toggle" src=../img/case.png alt="case"></span> button to change). |
 | [`"foo bar"`](https://sourcegraph.com/search?q=%22foo+bar%22&patternType=literal) | Match the string `"foo bar"`. The quotes are matched literally.                                                                                                                                                                       |
 
 ### Regular expression search


### PR DESCRIPTION
Multiple folks at https://app.hubspot.com/contacts/2762526/company/407948923/ were confused to find this implied the two terms `foo` and `bar` would be matched like a regex `foo.*bar` and thought this was a bug in Sourcegraph - so I try to clarify this here.
