### PR TITLE
batches: update doc image and video assets

### DIFF
--- a/doc/batch_changes/explanations/introduction_to_batch_changes.md
+++ b/doc/batch_changes/explanations/introduction_to_batch_changes.md
@@ -18,12 +18,10 @@ A batch change tracks all of its changesets (a generic term for pull requests or
 - Checks: passed (green), failed (red), or pending (yellow)
 - Review status: approved, changes requested, pending, or other statuses (depending on your code host or code review tool)
 
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/campaign_tracking_sourcegraph_prs.png" class="screenshot">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/batch_tracking_sourcegraph_prs.png" class="screenshot">
 
 You can see the overall trend of a batch change in the burndown chart, which shows the proportion of changesets that have been merged over time since the batch change was created.
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/campaign_tracking_sourcegraph_prs_burndown.png" class="screenshot">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/batch_tracking_sourcegraph_prs_burndown.png" class="screenshot">
 
 ## Supported code hosts and changeset types
 

--- a/doc/batch_changes/how-tos/closing_or_deleting_a_batch_change.md
+++ b/doc/batch_changes/how-tos/closing_or_deleting_a_batch_change.md
@@ -8,17 +8,14 @@ Any person with [admin access to the batch change](../explanations/permissions_i
 
 1. Click the <img src="../batch_changes-icon.svg" alt="Batch Changes icon" /> Batch Changes icon in the top navigation bar.
 
-  <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/campaigns_icon_in_menu.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/batch_changes_icon_in_menu.png" class="screenshot">
 1. In the list of batch changes, click the batch change that you'd like to close or delete.
 1. In the top right, click the **Close** button.
 
-  <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/closing_campaigns_close_icon.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/closing_batch_change_close_icon.png" class="screenshot">
 1. Select whether you want to close all of the batch change's open changesets (e.g., closing all associated GitHub pull requests on the code host).
 
-  <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/closing_campaigns_close_changesets.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/closing_batch_change_close_changesets.png" class="screenshot">
 1. Click **Close batch change**.
 
 Once a batch change is closed it can't be updated or reopened anymore.
@@ -28,8 +25,7 @@ Once a batch change is closed it can't be updated or reopened anymore.
 1. First, close the batch change.
 1. Instead of a "Close batch change" button you'll now see a **Delete** button.
 
-  <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/closing_campaigns_deleting_campaign.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/closing_batch_change_deleting.png" class="screenshot">
 1. Click **Delete**.
 
 The batch change is now deleted from the Sourcegraph instance. The changesets it created (and possibly closed) will still exist on the code hosts, since most code hosts don't support deleting changesets.

--- a/doc/batch_changes/how-tos/configuring_user_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_user_credentials.md
@@ -18,16 +18,14 @@ Adding personal access tokens is done through the the Batch Changes section of y
 
 You should now see a list of the code hosts that are configured on Sourcegraph. Code hosts with tokens configured are indicated by a green tick, while code hosts without tokens have an empty red circle next to them.
 
-<!---TODO update link-->
 <video width="1920" height="1080" autoplay loop muted playsinline controls style="width: 100%; height: auto; max-width: 50rem">
-  <source src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.webm" type="video/webm">
-  <source src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.mp4" type="video/mp4">
+  <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/user-tokens.webm" type="video/webm">
+  <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/user-tokens.mp4" type="video/mp4">
 </video>
 
 To add a token for a code host, click on the **Add token** button next to its name. This will display an input modal like the following:
 
-<!---TODO update link-->
-<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-token-input-3.25.png" alt="An input dialog, titled &quot;Github Batch Changes token for https://github.com&quot;, with an input box to type or paste a token and a list of scopes that must be enabled on the token, which are repo, read:org, user:email, and read:discussion">
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/batch_changes/user-token-input.png" alt="An input dialog, titled &quot;Github Batch Changes token for https://github.com&quot;, with an input box to type or paste a token and a list of scopes that must be enabled on the token, which are repo, read:org, user:email, and read:discussion">
 
 To create a personal access token for a specific code host provider, please refer to the relevant section for "[GitHub](#github)", "[GitLab](#gitlab)", or "[Bitbucket Server](#bitbucket-server)". Once you have a token, you should paste it into the Sourcegraph input shown above, and click **Add token**.
 
@@ -35,7 +33,7 @@ To create a personal access token for a specific code host provider, please refe
 
 Once this is done, Sourcegraph should indicate that you have a token with a green tick:
 
-<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/batch-changes/how-tos/one-token.png" alt="A list of code hosts, with GitHub indicating that it has a token and the other hosts indicating that they do not">
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/batch_changes/one-token.png" alt="A list of code hosts, with GitHub indicating that it has a token and the other hosts indicating that they do not">
 
 ### GitHub
 
@@ -43,8 +41,7 @@ In addition to the below, you should refer to [GitHub's documentation on creatin
 
 Sourcegraph requires the `repo`, `read:org`, `user:email`, and `read:discussion` scopes to be enabled on the user token. This is done by selecting the relevant checkboxes when creating the token:
 
-<!---TODO update link-->
-<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/github-token.png" alt="The GitHub token creation page, with the repo scope selected">
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/batch_changes/github-token.png" alt="The GitHub token creation page, with the repo scope selected">
 
 ### GitLab
 
@@ -52,8 +49,7 @@ In addition to the below, you should refer to [GitLab's documentation on creatin
 
 Sourcegraph requires the `api`, `read_repository`, and `write_repository` scopes to be enabled on the user token. This is done by selecting the relevant checkboxes when creating the token:
 
-<!---TODO update link-->
-<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/gitlab-token.png" alt="The GitLab token creation page, with the api, read_repository, and write_repository scopes selected">
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/batch_changes/gitlab-token.png" alt="The GitLab token creation page, with the api, read_repository, and write_repository scopes selected">
 
 ### Bitbucket Server
 
@@ -61,8 +57,7 @@ In addition to the below, you should refer to [Bitbucket Server's documentation 
 
 Sourcegraph requires the access token to have the `write` permission on both projects and repositories. This is done by selecting the **Write** level in the **Projects** dropdown, and letting it be inherited by repositories:
 
-<!---TODO update link-->
-<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/bb-token.png" alt="The Bitbucket Server token creation page, with Write permissions selected on both the Project and Repository dropdowns">
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/batch_changes/bb-token.png" alt="The Bitbucket Server token creation page, with Write permissions selected on both the Project and Repository dropdowns">
 
 ## Removing a personal access token
 
@@ -75,13 +70,11 @@ Removing personal access tokens is done through the the Batch Changes section of
 
 You should now see a list of the code hosts that are configured on Sourcegraph. Code hosts with tokens configured are indicated by a green tick, while code hosts without tokens have an empty red circle next to them.
 
-<!---TODO update link-->
 <video width="1920" height="1080" autoplay loop muted playsinline controls style="width: 100%; height: auto; max-width: 50rem">
-  <source src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.webm" type="video/webm">
-  <sourec src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/user-tokens.mp4" type="video/mp4">
+  <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/removing-user-token.webm" type="video/webm">
+  <sourec src="https://sourcegraphstatic.com/docs/videos/batch_changes/removing-user-token.mp4" type="video/mp4">
 </video>
 
 To remove a personal access token for a code host, click **Remove** next to that code host. The code host's indicator will change to an empty red circle to indicate that no token is configured for that code host:
 
-<!---TODO update link-->
-<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/campaigns/how-tos/no-tokens.png" alt="A list of code hosts, with all code hosts indicating that they do not have a token">
+<img class="screenshot" src="https://sourcegraphstatic.com/docs/images/batch_changes/no-tokens.png" alt="A list of code hosts, with all code hosts indicating that they do not have a token">

--- a/doc/batch_changes/how-tos/creating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/creating_a_batch_change.md
@@ -49,7 +49,6 @@ After writing a batch spec you use the [Sourcegraph CLI (`src`)](https://github.
     > NOTE: Batch Changes's default behavior is to stop if computing changes in a repository errors. You can choose to ignore errors instead by adding the [`skip-errors`](../../cli/references/batch/preview.md) flag : `src batch preview -f spec.batch.yml -skip-errors`
 
 1. Wait for it to run and compute the changes for each repository (using the repositories and commands in the batch spec).
-    <!---TODO update link-->
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_waiting.png" class="screenshot">
 1. Open the preview URL that the command printed out.
     <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_link.png" class="screenshot">

--- a/doc/batch_changes/how-tos/creating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/creating_a_batch_change.md
@@ -50,11 +50,11 @@ After writing a batch spec you use the [Sourcegraph CLI (`src`)](https://github.
 
 1. Wait for it to run and compute the changes for each repository (using the repositories and commands in the batch spec).
     <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/src_campaign_preview_waiting.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_waiting.png" class="screenshot">
 1. Open the preview URL that the command printed out.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/src_campaign_preview_link.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_link.png" class="screenshot">
 1. Examine the preview. This is the result of executing the batch spec. Confirm that the changes are what you intended. If not, edit the batch spec and then rerun the command above.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/browser_campaign_preview.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_preview.png" class="screenshot">
 1. Click the **Apply spec** button to create the batch change.
 
 After you've applied a batch spec, you can [publish changesets](publishing_changesets.md) to the code host when you're ready. This will turn the patches into commits, branches, and changesets (such as GitHub pull requests) for others to review and merge.

--- a/doc/batch_changes/how-tos/handling_errored_changesets.md
+++ b/doc/batch_changes/how-tos/handling_errored_changesets.md
@@ -6,12 +6,11 @@ Sometimes the problem can be fixed by automatically retrying to publish the chan
 
 Errored changesets that are marked as **Retrying** are being automatically retried:
 
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/retrying_changeset.png" class="screenshot">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/retrying_changeset.png" class="screenshot">
 
 Changesets that are marked as **Failed** can be [retried manually](#manual-retrying-of-errored-changesets):
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/failed_changeset_retry.png" class="screenshot">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/failed_changeset_retry.png" class="screenshot">
 
 ## Types of errors
 

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -2,8 +2,7 @@
 
 After you've [created a batch change](creating_a_batch_change.md) with `published: false` in its batch spec, you can see a preview of the changesets (e.g., GitHub pull requests) that will be created on the code host once they're published:
 
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/publishing_changesets_preview_unpublished.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_created.png" class="screenshot center">
 
 In order to create these changesets on the code hosts, you need to publish them.
 
@@ -44,7 +43,7 @@ Publishing a changesets will:
 
 In the Sourcegraph web UI you'll see a progress indicator for the changesets that are being published and any possible errors:
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/publishing_changesets_viewing_progress_and_errors.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/publishing_changesets_viewing_progress_and_errors.png" class="screenshot center">
 
 If you run into any errors, you can retry publishing after you've resolved the problem by running `src batch apply` again.
 

--- a/doc/batch_changes/how-tos/tracking_existing_changesets.md
+++ b/doc/batch_changes/how-tos/tracking_existing_changesets.md
@@ -2,8 +2,7 @@
 
 Batch Changes allow you not only to [publish changesets](publishing_changesets.md) but also to **import and track changesets** that already exist on different code hosts. That allows you to get an overview of the status of multiple changesets, with the ability to filter and drill down into the details of a specific changeset.
 
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tracking_existing_changesets_overview.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/tracking_existing_changesets_overview.png" class="screenshot center">
 
 ## Importing changesets into a batch change
 
@@ -32,4 +31,4 @@ See "[Creating a batch change](creating_a_batch_change.md)" on how to create a b
 
 Once you've created the batch change you'll see the existing changeset show up in the list of changesets. The batch change will track the changeset's status and include it in the overall batch change progress (in the same way as if it had been created by the batch change):
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tracking_existing_changesets_burndown_chart.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/tracking_existing_changesets_burndown_chart.png" class="screenshot center">

--- a/doc/batch_changes/how-tos/viewing_batch_changes.md
+++ b/doc/batch_changes/how-tos/viewing_batch_changes.md
@@ -2,18 +2,16 @@
 
 You can view a list of all batch changes by clicking the <img src="../batch_changes-icon.svg" alt="Batch Changes icon" /> Batch Changes icon in the top navigation bar:
 
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/campaigns_icon_in_menu.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/batch_changes_icon_in_menu.png" class="screenshot center">
 
 ## Filtering batch changes
 
 Use the filters to switch between showing all batch changes, open batch changes, or closed batch changes.
 
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/viewing_batch_changes_filtering.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/viewing_batch_changes_filtering.png" class="screenshot center">
 
 ## Filtering changesets
 
-When looking at a batch change you can filter the list of changesets with the controls at the top of the list:
+When looking at a batch change you can search and filter the list of changesets with the controls at the top of the list:
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/viewing_batch_changes_filtering_changesets.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/viewing_batch_changes_filtering_changesets.png" class="screenshot center">

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -34,7 +34,7 @@ In order to create batch changes we need to [install the Sourcegraph CLI](../cli
     ```
     src login https://YOUR-SOURCEGRAPH-INSTANCE
     ```
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/src_login_success.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_login_success.png" class="screenshot">
 
 
 Once `src login` reports that you're authenticated, we're ready for the next step.
@@ -78,16 +78,16 @@ Let's see the changes that will be made. Don't worry---no commits, branches, or 
 
     <pre>src batch preview -f hello-world.batch.yaml</pre>
 1. Wait for it to run and compute the changes for each repository.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/src_campaign_preview_waiting.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_waiting.png" class="screenshot">
 1. When it's done, click the displayed link to see all of the changes that will be made.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/src_campaign_preview_link.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_batch_preview_link.png" class="screenshot">
 1. Make sure the changes look right.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/browser_campaign_preview.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_preview.png" class="screenshot">
 1. If you want to modify which changes are made, edit the `hello-world.batch.yaml` file, rerun the `src batch preview` command and open the newly generated preview URL.
 
     >NOTE: If you want to run the batch change on fewer repositories, change the `repositoriesMatchingQuery` in `hello-world.batch.yaml` to something like `file:README.md repo:myproject` (to only match repositories whose name contains `myproject`).
 1. Click the **Apply spec** button to create the batch change. You should see something like this:
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/browser_campaign_created.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_created.png" class="screenshot">
 
 You created your first batch change! The batch change's changesets are still unpublished, which means they exist only on Sourcegraph and haven't been pushed to your code host yet.
 
@@ -121,15 +121,15 @@ The red circle next to the code host will now change to a green tick. Sourcegrap
 Now that you have credentials set up, you can publish the changesets in the batch change. On a real batch change, you would do the following:
 
 1. Change the `published: false` in `hello-world.batch.yaml` to `published: true`.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/campaign_publish_true.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/batch_publish_true.png" class="screenshot">
 
     > NOTE: Change [`published` to an array](references/batch_spec_yaml_reference.md#publishing-only-specific-changesets) to publish only some of the changesets, or set [`'draft'` to create changesets as drafts on code hosts that support drafts](references/batch_spec_yaml_reference.md#changesettemplate-published).
 1. Run the `src batch preview` command again and open the URL.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/src_rerun_preview.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_rerun_preview.png" class="screenshot">
 1. On the preview page you can confirm that changesets will be published when the spec is applied.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/browser_campaign_preview_publish.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_preview_publish.png" class="screenshot">
 1. Click the **Apply spec** button and those changesets will be published on the code host.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/browser_campaign_async.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/browser_batch_async.png" class="screenshot">
 
     > NOTE: You can also create or update a batch change by running `src batch apply`. This skips the preview stage, and is especially useful when updating an existing batch change.
 

--- a/doc/batch_changes/tutorials/search_and_replace_specific_terms.md
+++ b/doc/batch_changes/tutorials/search_and_replace_specific_terms.md
@@ -16,7 +16,7 @@ This tutorial shows you how to create [a batch spec](../explanations/introductio
 
 The batch spec can be easily changed to search and replace other terms in other file types.
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_teaser.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/use_allowlist_denylist_wording_teaser.png" class="screenshot center">
 
 ### Prerequisites
 
@@ -62,12 +62,12 @@ changesetTemplate:
 1. In your terminal, run this command:
 
     <pre>src batch preview -f use-allowlist-denylist-wording.batch.yaml</pre>
-1. Wait for it to run and compute the changes for each repository. <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_wait_run.png" class="screenshot">
-1. Open the preview URL that the command printed out. <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_click_url.png" class="screenshot">
-1. Examine the preview. Confirm that the changes are what you intended. If not, edit your batch spec and then rerun the command above. <!---TODO update link-->
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/use_allowlist_denylist_wording_preview.png" class="screenshot">
+1. Wait for it to run and compute the changes for each repository.
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/use_allowlist_denylist_wording_wait_run.png" class="screenshot">
+1. Open the preview URL that the command printed out.
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/use_allowlist_denylist_wording_click_url.png" class="screenshot">
+1. Examine the preview. Confirm that the changes are what you intended. If not, edit your batch spec and then rerun the command above.
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/use_allowlist_denylist_wording_preview.png" class="screenshot">
 1. Click the **Apply spec** button to create the batch change.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the batch spec](../references/batch_spec_yaml_reference.md#changesettemplate-published) and re-running the `src batch preview` command.
 

--- a/doc/batch_changes/tutorials/update_base_images_in_dockerfiles.md
+++ b/doc/batch_changes/tutorials/update_base_images_in_dockerfiles.md
@@ -21,8 +21,7 @@ This tutorial shows you how to create [a batch spec](../explanations/introductio
 
 The batch spec and instructions here can [easily be adapted to update other base images](#updating-other-base-images).
 
-<!---TODO update link-->
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/update_base_images_in_dockerfiles_teaser.png" class="screenshot center">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/update_base_images_in_dockerfiles_teaser.png" class="screenshot center">
 
 ### Prerequisites
 
@@ -79,11 +78,11 @@ changesetTemplate:
 
     <pre>src batch preview -f update-dart-base-images-2-10.batch.yaml</pre>
 1. Wait for it to run and compute the changes for each repository.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/update_base_images_in_dockerfiles_wait_run.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/update_base_images_in_dockerfiles_wait_run.png" class="screenshot">
 1. Open the preview URL that the command printed out.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/update_base_images_in_dockerfiles_click_url.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/update_base_images_in_dockerfiles_click_url.png" class="screenshot">
 1. Examine the preview. Confirm that the changesets are the ones you intended to track. If not, edit the batch spec and then rerun the command above.
-    <img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/tutorials/update_base_images_in_dockerfiles_preview.png" class="screenshot">
+    <img src="https://sourcegraphstatic.com/docs/images/batch_changes/update_base_images_in_dockerfiles_preview.png" class="screenshot">
 1. Click the **Apply spec** button to create the batch change.
 1. Feel free to then publish the changesets (i.e. create pull requests and merge requests) by [modifying the `published` attribute in the batch spec](../references/batch_spec_yaml_reference.md#changesettemplate-published) and re-running the `src batch preview` command.
 

--- a/doc/cli/quickstart.md
+++ b/doc/cli/quickstart.md
@@ -43,7 +43,7 @@ For other options, please refer to [the Windows specific `src` documentation](ex
 
 `src` needs to be authenticated against your Sourcegraph instance. The quickest way to do this is to run `src login https://YOUR-SOURCEGRAPH-INSTANCE` and follow the instructions:
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/docs/images/campaigns/src_login_success.png" class="screenshot" alt="Output from src login showing success">
+<img src="https://sourcegraphstatic.com/docs/images/batch_changes/src_login_success.png" class="screenshot" alt="Output from src login showing success">
 
 Once complete, you should have two new environment variables set: `SRC_ENDPOINT` and `SRC_ACCESS_TOKEN`.
 


### PR DESCRIPTION
This PR updates all image and video assets in the ~campaigns~ batch changes documentation to use the new nomenclature.