### PR TITLE
Fix alignment of diffstat in changesets list

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -115,7 +115,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
             </span>
             <div
                 className={classNames(
-                    'align-self-stretch d-none d-md-flex justify-content-center',
+                    'align-self-center d-none d-md-flex justify-content-center',
                     node.diffStat && 'p-2'
                 )}
             >


### PR DESCRIPTION
The diffstat provides it's own container so the stretch didn't actually make it centered. This fixes it.