### PR TITLE
endpoint: handle error from client.Watch

### DIFF
--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -180,6 +180,9 @@ func inform(client v1.EndpointsInterface, m *Map, u *k8sURL) error {
 	watcher, err := client.Watch(metav1.ListOptions{
 		FieldSelector: "metadata.name=" + u.Service,
 	})
+	if err != nil {
+		return errors.Wrap(err, "could not create watcher")
+	}
 
 	defer watcher.Stop()
 


### PR DESCRIPTION
This is the likely source of the panics we have been seeing in
production occasionally. Was accidently introduced in our switch to
client-go.
