### PR TITLE
ci: run go test in all modules

### DIFF
--- a/dev/ci/codecov.sh
+++ b/dev/ci/codecov.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Wrapper script for downloading codecov helper. Also includes buildkite log
+# output.
+
+echo "--- codecov"
+
+exec bash <(curl -s https://codecov.io/bash) "$@"

--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -15,31 +15,16 @@ echo "--- comby install"
 export CODEINSIGHTS_PGDATASOURCE=postgres://postgres:password@127.0.0.1:5435/postgres
 export DB_STARTUP_TIMEOUT=120s # codeinsights-db needs more time to start in some instances.
 
-# Separate out time for go mod from go test
-echo "--- go mod download"
-go mod download
+# We have multiple go.mod files and go list doesn't recurse into them.
+find . -name go.mod -exec dirname '{}' \; | while read -r d; do
+  pushd "$d" >/dev/null
 
-echo "--- go test"
-go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
+  # Separate out time for go mod from go test
+  echo "--- $d go mod download"
+  go mod download
 
-# Test lib submodule
-pushd lib >/dev/null
+  echo "--- $d go test"
+  go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
 
-echo "--- go mod download lib"
-go mod download
-
-echo "--- go test lib"
-go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
-
-popd >/dev/null
-
-# Test enterprise/lib submodule
-pushd enterprise/lib >/dev/null
-
-echo "--- go mod download enterprise/lib"
-go mod download
-
-echo "--- go test enterprise/lib"
-go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
-
-popd >/dev/null
+  popd >/dev/null
+done

--- a/dev/depgraph/summary.go
+++ b/dev/depgraph/summary.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
-	"github.com/sourcegraph/sourcegraph/dev/depgraph/graph"
+	"github.com/sourcegraph/sourcegraph/dev/depgraph/internal/graph"
 )
 
 var summaryFlagSet = flag.NewFlagSet("depgraph summary", flag.ExitOnError)

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -60,7 +60,7 @@ func addWebApp(pipeline *bk.Pipeline) {
 	// Webapp tests
 	pipeline.AddStep(":jest::globe_with_meridians: Test",
 		bk.Cmd("dev/ci/yarn-test.sh client/web"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
+		bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 }
 
 // Builds and tests the browser extension.
@@ -72,7 +72,7 @@ func addBrowserExt(pipeline *bk.Pipeline) {
 	// Browser extension tests
 	pipeline.AddStep(":jest::chrome: Test browser extension",
 		bk.Cmd("dev/ci/yarn-test.sh client/browser"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
+		bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 }
 
 // Adds the shared frontend tests (shared between the web app and browser extension).
@@ -86,7 +86,7 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			bk.Cmd("COVERAGE_INSTRUMENT=true dev/ci/yarn-run.sh build-web"),
 			bk.Cmd("yarn percy exec -- yarn run cover-integration"),
 			bk.Cmd("yarn nyc report -r json"),
-			bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F integration"),
+			bk.Cmd("dev/ci/codecov.sh -c -F typescript -F integration"),
 			bk.ArtifactPaths("./puppeteer/*.png"))
 
 		// Upload storybook to Chromatic
@@ -104,14 +104,14 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 		// Shared tests
 		pipeline.AddStep(":jest: Test shared client code",
 			bk.Cmd("dev/ci/yarn-test.sh client/shared"),
-			bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
+			bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 	}
 }
 
 func addBrandedTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":jest: Test branded client code",
 		bk.Cmd("dev/ci/yarn-test.sh client/branded"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F typescript -F unit"))
+		bk.Cmd("dev/ci/codecov.sh -c -F typescript -F unit"))
 }
 
 // Adds PostgreSQL backcompat tests.
@@ -123,7 +123,7 @@ func addPostgresBackcompat(pipeline *bk.Pipeline) {
 func addGoTests(pipeline *bk.Pipeline) {
 	pipeline.AddStep(":go: Test",
 		bk.Cmd("./dev/ci/go-test.sh"),
-		bk.Cmd("bash <(curl -s https://codecov.io/bash) -c -F go"))
+		bk.Cmd("dev/ci/codecov.sh -c -F go"))
 }
 
 // Builds the OSS and Enterprise Go commands.


### PR DESCRIPTION
We recently introduced more modules. I noticed we have a few more that
we aren't testing. This adds some code which discovers all go module
roots and runs the tests from them.

Note: we also have a CI step called go build which doesn't exercise all
our modules. However, the go build step is targetted at sourcegraph.com
service binaries so is not as generalizable.