### PR TITLE
Reset mocks on TestSetExternalServiceRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -69,6 +69,7 @@ func TestSetExternalServiceRepos(t *testing.T) {
 		UID:      1,
 	})
 
+	oldClient := repoupdater.DefaultClient.HTTPClient
 	repoupdater.DefaultClient.HTTPClient = &http.Client{
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
@@ -77,6 +78,11 @@ func TestSetExternalServiceRepos(t *testing.T) {
 			}, nil
 		}),
 	}
+
+	defer func() {
+		database.Mocks = database.MockStores{}
+		repoupdater.DefaultClient.HTTPClient = oldClient
+	}()
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{


### PR DESCRIPTION
I forgot to reset mocks, which is causing some build failures

https://sourcegraph.slack.com/archives/C07KZF47K/p1615802087064200

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
