### PR TITLE
Don't show sync banner when external service was just added

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicePage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicePage.story.tsx
@@ -28,6 +28,8 @@ const fetchExternalService: typeof _fetchExternalService = () =>
         repoCount: 0,
         lastSyncAt: '0001-01-01T00:00:00Z',
         nextSyncAt: '0001-01-01T00:00:00Z',
+        updatedAt: '2021-03-15T19:39:11Z',
+        createdAt: '2021-03-15T19:39:11Z',
     })
 
 add('View external service config', () => (

--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -29,6 +29,8 @@ const queryExternalServices: typeof _queryExternalServices = () =>
                 repoCount: 0,
                 lastSyncAt: '0001-01-01T00:00:00Z',
                 nextSyncAt: '0001-01-01T00:00:00Z',
+                updatedAt: '2021-03-15T19:39:11Z',
+                createdAt: '2021-03-15T19:39:11Z',
             },
         ],
     })

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -35,6 +35,8 @@ export const externalServiceFragment = gql`
         webhookURL
         lastSyncAt
         nextSyncAt
+        updatedAt
+        createdAt
     }
 `
 
@@ -187,6 +189,8 @@ export const listExternalServiceFragment = gql`
         repoCount
         lastSyncAt
         nextSyncAt
+        updatedAt
+        createdAt
     }
 `
 

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -342,7 +342,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
             }
 
             if (!selectionState.radio) {
-                history.push(routingPrefix + '/repositories')
+                return history.push(routingPrefix + '/repositories')
             }
 
             const syncTimes = new Map<string, string>()

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -123,13 +123,21 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                         repeatUntil(
                             result => {
                                 let pending: Status
-                                const now = new Date().getTime()
+                                const now = new Date()
 
                                 setExternalServices(result.nodes)
 
                                 for (const node of result.nodes) {
-                                    // if the next sync time is not blank, or in the future we must not be syncing
-                                    if (node.nextSyncAt !== '' && now - new Date(node.nextSyncAt).getTime() > 0) {
+                                    const nextSyncAt = new Date(node.nextSyncAt)
+
+                                    // when the service was just added both
+                                    // createdAt and updatedAt will have the same timestamp
+                                    if (node.createdAt === node.updatedAt) {
+                                        continue
+                                    }
+
+                                    // if the next sync is in the future we must not be syncing
+                                    if (now > nextSyncAt) {
                                         pending = 'pending'
                                     }
                                 }

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struct {
@@ -59,6 +60,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 
 	// set to time.Zero to sync ASAP
 	es.NextSyncAt = time.Time{}
+	es.UpdatedAt = timeutil.Now()
 
 	err = database.GlobalExternalServices.Upsert(ctx, es)
 	if err != nil {


### PR DESCRIPTION
### Description

1. Update `updatedAt` timestamp when users successfully execute `setExternalServiceRepos` GraphQL query
2. don't display the `Some repositories are still being updated` banner when the external service was just added