### PR TITLE
Quickstart: clarify check database connection

### DIFF
--- a/doc/dev/getting-started/quickstart_2_initialize_database.md
+++ b/doc/dev/getting-started/quickstart_2_initialize_database.md
@@ -73,7 +73,7 @@ You may also want to run Postgres within a docker container instead of as a syst
    -v $PGDATA_DIR:/var/lib/postgresql/data postgres
    ```
 
-3. Ensure you can connect to the database using `psql -U sourcegraph` and enter password `sourcegraph`.
+3. Ensure you can connect to the database in your container using `docker exec -it <container-id> psql -U sourcegraph` and enter password `sourcegraph`. You can use the command `docker ps` to view the container-id.
 
 4. Configure database settings in your environment:
 


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->

I had some confusion thinking that this check was supposed to be performed from outside the container. I chased my tail for awhile in junior dev mode going over unix environment stuff and wondering if I had some .zshrc configs wrong. If you are intended to access the database in the container from your local shell (not one opened inside the container, let me know!) 