### PR TITLE
search: introduce query plan type

### DIFF
--- a/cmd/frontend/graphqlbackend/parse_search_query.go
+++ b/cmd/frontend/graphqlbackend/parse_search_query.go
@@ -92,7 +92,7 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 
 	globbing := getBoolPtr(settings.SearchGlobbing, false)
 
-	q, err := query.Pipeline(
+	plan, err := query.Pipeline(
 		query.Init(args.Query, searchType),
 		query.With(globbing, query.Globbing),
 	)
@@ -101,7 +101,7 @@ func (r *schemaResolver) ParseSearchQuery(ctx context.Context, args *struct {
 	}
 
 	var jsons []interface{}
-	for _, node := range q {
+	for _, node := range plan.ToParseTree() {
 		jsons = append(jsons, toJSON(node))
 	}
 	json, err := json.Marshal(jsons)

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -90,10 +90,10 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 		return nil, errors.New("Structural search is disabled in the site configuration.")
 	}
 
-	var q query.Q
+	var plan query.Plan
 	globbing := getBoolPtr(settings.SearchGlobbing, false)
 	tr.LogFields(otlog.Bool("globbing", globbing))
-	q, err = query.Pipeline(
+	plan, err = query.Pipeline(
 		query.Init(args.Query, searchType),
 		query.With(globbing, query.Globbing),
 	)
@@ -105,7 +105,7 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	// If the request is a paginated one, decode those arguments now.
 	var pagination *searchPaginationInfo
 	if args.First != nil {
-		pagination, err = processPaginationRequest(args, q)
+		pagination, err = processPaginationRequest(args, plan.ToParseTree())
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 		defaultLimit = defaultMaxSearchResults
 	}
 
-	if sp, _ := q.StringValue(query.FieldSelect); sp != "" && args.Stream != nil {
+	if sp, _ := plan.ToParseTree().StringValue(query.FieldSelect); sp != "" && args.Stream != nil {
 		// Invariant: error already checked
 		selectPath, _ := filter.SelectPathFromString(sp)
 		args.Stream = WithSelect(args.Stream, selectPath)
@@ -129,7 +129,8 @@ func NewSearchImplementer(ctx context.Context, db dbutil.DB, args *SearchArgs) (
 	return &searchResolver{
 		db: db,
 		SearchInputs: &SearchInputs{
-			Query:          q,
+			Plan:           plan,
+			Query:          plan.ToParseTree(),
 			OriginalQuery:  args.Query,
 			VersionContext: args.VersionContext,
 			UserSettings:   settings,
@@ -232,7 +233,8 @@ func getBoolPtr(b *bool, def bool) bool {
 
 // SearchInputs contains fields we set before kicking off search.
 type SearchInputs struct {
-	Query          query.Q               // the query
+	Plan           query.Plan            // the comprehensive query plan
+	Query          query.Q               // the current basic query being evaluated, one part of query.Plan
 	OriginalQuery  string                // the raw string of the original search query
 	Pagination     *searchPaginationInfo // pagination information, or nil if the request is not paginated.
 	PatternType    query.SearchType

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -358,7 +358,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			setMockResolveRepositories(test.repoRevs)
-			q, err := query.Pipeline(
+			plan, err := query.Pipeline(
 				query.InitRegexp(test.query),
 				query.With(test.globbing, query.Globbing),
 			)
@@ -369,7 +369,8 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 				db: db,
 				SearchInputs: &SearchInputs{
 					OriginalQuery: test.query,
-					Query:         q,
+					Plan:          plan,
+					Query:         plan.ToParseTree(),
 					UserSettings: &schema.Settings{
 						SearchGlobbing: &test.globbing,
 					}},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1102,11 +1102,17 @@ func TestGetExactFilePatterns(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			q, err := query.Pipeline(query.InitLiteral(tt.in), query.Globbing)
+			plan, err := query.Pipeline(query.InitLiteral(tt.in), query.Globbing)
 			if err != nil {
 				t.Fatal(err)
 			}
-			r := searchResolver{SearchInputs: &SearchInputs{Query: q, OriginalQuery: tt.in}}
+			r := searchResolver{
+				SearchInputs: &SearchInputs{
+					Plan:          plan,
+					Query:         plan.ToParseTree(),
+					OriginalQuery: tt.in,
+				},
+			}
 			if got := r.getExactFilePatterns(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getExactFilePatterns() = %v, want %v", got, tt.want)
 			}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -344,7 +344,7 @@ func TestQuoteSuggestions(t *testing.T) {
 
 	t.Run("regex error", func(t *testing.T) {
 		raw := "*"
-		_, err := query.ParseRegexp(raw)
+		_, err := query.Pipeline(query.InitRegexp(raw))
 		if err == nil {
 			t.Fatalf("error returned from query.ParseRegexp(%q) is nil", raw)
 		}
@@ -465,7 +465,7 @@ func TestVersionContext(t *testing.T) {
 	}}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			q, err := query.ParseLiteral(tc.searchQuery)
+			plan, err := query.Pipeline(query.InitLiteral(tc.searchQuery))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -473,7 +473,8 @@ func TestVersionContext(t *testing.T) {
 			resolver := searchResolver{
 				db: db,
 				SearchInputs: &SearchInputs{
-					Query:          q,
+					Plan:           plan,
+					Query:          plan.ToParseTree(),
 					VersionContext: &tc.versionContext,
 					UserSettings:   &schema.Settings{},
 				},

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -1058,14 +1058,14 @@ func Parse(in string, searchType SearchType) ([]Node, error) {
 	return newOperator(nodes, And), nil
 }
 
+func ParseSearchType(in string, searchType SearchType) (Q, error) {
+	return Run(Init(in, searchType))
+}
+
 func ParseLiteral(in string) (Q, error) {
-	return Pipeline(Init(in, SearchTypeLiteral))
+	return Run(Init(in, SearchTypeLiteral))
 }
 
 func ParseRegexp(in string) (Q, error) {
-	return Pipeline(Init(in, SearchTypeRegex))
-}
-
-func ParseSearchType(in string, searchType SearchType) (Q, error) {
-	return Pipeline(Init(in, searchType))
+	return Run(Init(in, SearchTypeRegex))
 }

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -87,19 +87,25 @@ func InitStructural(in string) step {
 	return Init(in, SearchTypeStructural)
 }
 
+func Run(step step) ([]Node, error) {
+	return step(nil)
+}
+
 // Pipeline processes zero or more steps to produce a query. The first step must
 // be Init, otherwise this function is a no-op.
-func Pipeline(steps ...step) (Q, error) {
+func Pipeline(steps ...step) (Plan, error) {
 	nodes, err := sequence(steps...)(nil)
 	if err != nil {
 		return nil, err
 	}
 
+	var plan Plan
 	for _, disjunct := range Dnf(nodes) {
 		err = validate(disjunct)
 		if err != nil {
 			return nil, err
 		}
+		plan = append(plan, Q(disjunct))
 	}
-	return nodes, nil
+	return plan, nil
 }

--- a/internal/search/query/query.go
+++ b/internal/search/query/query.go
@@ -99,7 +99,7 @@ func Pipeline(steps ...step) (Plan, error) {
 		return nil, err
 	}
 
-	var plan Plan
+	plan := make([]Q, 0, len(nodes))
 	for _, disjunct := range Dnf(nodes) {
 		err = validate(disjunct)
 		if err != nil {

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -1,0 +1,39 @@
+package query
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hexops/autogold"
+)
+
+func TestPipeline(t *testing.T) {
+	planToString := func(nodes [][]Node) string {
+		var plan Plan
+		for _, node := range nodes {
+			plan = append(plan, Q(node))
+		}
+
+		var result []string
+		for _, q := range plan {
+			result = append(result, toString(q))
+		}
+		return strings.Join(result, " ")
+	}
+
+	// The Pipeline must produce a value that is equivalent under DNF to parsing the query and processing it with DNF.
+	test := func(input string) string {
+		pipelinePlan, _ := Pipeline(InitLiteral(input))
+		nodes, _ := Run(InitLiteral(input))
+		if diff := cmp.Diff(
+			planToString(Dnf(pipelinePlan.ToParseTree())),
+			planToString(Dnf(nodes)),
+		); diff != "" {
+			return diff
+		}
+		return "equivalent"
+	}
+
+	autogold.Want("equivalent or-expression", "equivalent").Equal(t, test("(repo:bob or repo:jim) ((rev:olga or rev:ham) demo123232)"))
+}

--- a/internal/search/query/transformer_test.go
+++ b/internal/search/query/transformer_test.go
@@ -317,7 +317,7 @@ func TestEllipsesForHoles(t *testing.T) {
 	input := "if ... { ... }"
 	want := `"if :[_] { :[_] }"`
 	t.Run("Ellipses for holes", func(t *testing.T) {
-		query, _ := Pipeline(InitStructural(input))
+		query, _ := Run(InitStructural(input))
 		got := toString(query)
 		if diff := cmp.Diff(want, got); diff != "" {
 			t.Fatal(diff)

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -61,6 +61,19 @@ type QueryInfo interface {
 	IsCaseSensitive() bool
 }
 
+// A query plan represents a set of disjoint queries for the search engine to
+// execute. The result of executing a plan is the union of individual query results.
+type Plan []Q
+
+// ToParseTree models a plan as a parse tree of an Or-expression on plan queries.
+func (p Plan) ToParseTree() Q {
+	var nodes []Node
+	for _, q := range p {
+		nodes = append(nodes, Operator{Kind: And, Operands: q})
+	}
+	return Q(newOperator(nodes, Or))
+}
+
 // A query is a tree of Nodes. We choose the type name Q so that external uses like query.Q do not stutter.
 type Q []Node
 

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -67,7 +67,7 @@ type Plan []Q
 
 // ToParseTree models a plan as a parse tree of an Or-expression on plan queries.
 func (p Plan) ToParseTree() Q {
-	var nodes []Node
+	nodes := make([]Node, 0, len(p))
 	for _, q := range p {
 		nodes = append(nodes, Operator{Kind: And, Operands: q})
 	}

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -98,7 +98,7 @@ func TestAndOrQuery_Validation(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {
-			_, err := ParseSearchType(c.input, c.searchType)
+			_, err := Pipeline(Init(c.input, c.searchType))
 			if err == nil {
 				t.Fatal(fmt.Sprintf("expected test for %s to fail", c.input))
 			}
@@ -332,10 +332,10 @@ func TestContainsRefGlobs(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.input, func(t *testing.T) {
-			query, err := Pipeline(
+			query, err := Run(sequence(
 				Init(c.input, SearchTypeLiteral),
 				Globbing,
-			)
+			))
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
This introduces a new type `query.Plan` which will capture all the internal, processed values for queries. It is currently a set of queries of type `Q` which currently represents a parse tree. By breaking the definition between a parse tree `Q` and a query `Plan`, we will start to rely less and less on the parse tree definition `Q` which happens earlier in the pipeline, and instead turn the members of `Plan` into the kinds of queries we care about in the backend (e.g., populated with the processed textx parameter values, parameterized specifically for Zoekt backends, etc.)

Visually:

Previously:

```
Parse 
-> Q (parse tree) 
-> access Q values in various ways to get values to conduct searches. 
   Q is still global in resolver (bad)
```

Now:

```
Parse 
-> Q (parse tree) 
-> Plan 
-> Convert Plan to Q to remain compatible. 
   Access Q in various ways to get values to conduct searches. 
   Q is still global in resolver (bad)
```

Final state:

```
Parse 
-> Q (parse Tree) 
-> convert Q to Backend queries in plan (e.g., bound for Zoekt, Searcher, etc.) 
-> Plan 
-> Case out on backend query kinds in Plan to drive control flow for conducting searches. 
   Pass values down as needed (removes Q from global resolver).
```