### PR TITLE
RFC database: mocks as a field on RepoStore

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -59,6 +59,8 @@ type RepoStore struct {
 	*basestore.Store
 
 	once sync.Once
+
+	Mock MockRepos
 }
 
 // Repos instantiates and returns a new RepoStore with prepared statements.
@@ -98,6 +100,9 @@ func (s *RepoStore) ensureStore() {
 // stale, the caller is responsible for fetching data from any
 // external services.
 func (s *RepoStore) Get(ctx context.Context, id api.RepoID) (*types.Repo, error) {
+	if s.Mock.Get != nil {
+		return s.Mock.Get(ctx, id)
+	}
 	if Mocks.Repos.Get != nil {
 		return Mocks.Repos.Get(ctx, id)
 	}
@@ -122,6 +127,9 @@ func (s *RepoStore) Get(ctx context.Context, id api.RepoID) (*types.Repo, error)
 // the same as URI, unless the user configures a non-default
 // repositoryPathPattern.
 func (s *RepoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (*types.Repo, error) {
+	if s.Mock.GetByName != nil {
+		return s.Mock.GetByName(ctx, nameOrURI)
+	}
 	if Mocks.Repos.GetByName != nil {
 		return Mocks.Repos.GetByName(ctx, nameOrURI)
 	}
@@ -154,6 +162,9 @@ func (s *RepoStore) GetByName(ctx context.Context, nameOrURI api.RepoName) (*typ
 // GetByIDs returns a list of repositories by given IDs. The number of results list could be less
 // than the candidate list due to no repository is associated with some IDs.
 func (s *RepoStore) GetByIDs(ctx context.Context, ids ...api.RepoID) ([]*types.Repo, error) {
+	if s.Mock.GetByIDs != nil {
+		return s.Mock.GetByIDs(ctx, ids...)
+	}
 	if Mocks.Repos.GetByIDs != nil {
 		return Mocks.Repos.GetByIDs(ctx, ids...)
 	}
@@ -202,6 +213,9 @@ func (s *RepoStore) GetReposSetByIDs(ctx context.Context, ids ...api.RepoID) (ma
 }
 
 func (s *RepoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, err error) {
+	if s.Mock.Count != nil {
+		return s.Mock.Count(ctx, opt)
+	}
 	if Mocks.Repos.Count != nil {
 		return Mocks.Repos.Count(ctx, opt)
 	}
@@ -593,6 +607,9 @@ func (s *RepoStore) List(ctx context.Context, opt ReposListOptions) (results []*
 		tr.Finish()
 	}()
 
+	if s.Mock.List != nil {
+		return s.Mock.List(ctx, opt)
+	}
 	if Mocks.Repos.List != nil {
 		return Mocks.Repos.List(ctx, opt)
 	}
@@ -622,6 +639,9 @@ func (s *RepoStore) ListRepoNames(ctx context.Context, opt ReposListOptions) (re
 		tr.SetError(err)
 		tr.Finish()
 	}()
+	if s.Mock.ListRepoNames != nil {
+		return s.Mock.ListRepoNames(ctx, opt)
+	}
 	if Mocks.Repos.ListRepoNames != nil {
 		return Mocks.Repos.ListRepoNames(ctx, opt)
 	}


### PR DESCRIPTION
This is a mergeable idea/pattern. Posting as pull request to gather feedback.

This is a step towards removing global mocks. In a test instead of
mocking the global "database.Mocks.Repos.List", you will pass in a
"RepoStore" with "rs.Mock.List" set.

I quite like this pattern, since it avoids interfaces but gives you the
benefit of mocking. As we move to passing around RepoStore more it will
start to bare fruit (right now we seem to pass around db a lot, instead
of the stores).

My preference of mocking this way is if a service uses a RepoStore, it
can directly store a "*RepoStore" in its struct rather than an
interface. This allows static analysis tools (find references, rename,
etc) to continue to function.

To see an example of it being used, see this PR https://github.com/sourcegraph/sourcegraph/pull/19173