### PR TITLE
gitserver: Store most recent clone or update error in the db

### DIFF
--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -510,6 +510,23 @@ func (s *Server) setCloneStatusNonFatal(ctx context.Context, name api.RepoName, 
 	}
 }
 
+func (s *Server) setLastError(ctx context.Context, name api.RepoName, error string) (err error) {
+	if s.DB == nil {
+		return nil
+	}
+	tx, err := database.Repos(s.DB).Transact(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { err = tx.Done(err) }()
+
+	repo, err := tx.GetByName(ctx, name)
+	if err != nil {
+		return err
+	}
+	return database.NewGitserverReposWith(tx).SetLastError(ctx, repo.ID, error, s.Hostname)
+}
+
 // removeRepoDirectory atomically removes a directory from s.ReposDir.
 //
 // It first moves the directory to a temporary location to avoid leaving

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -484,47 +483,6 @@ func dirSize(d string) int64 {
 		return nil
 	})
 	return size
-}
-
-func (s *Server) setCloneStatus(ctx context.Context, name api.RepoName, status types.CloneStatus) (err error) {
-	if s.DB == nil {
-		return nil
-	}
-	tx, err := database.Repos(s.DB).Transact(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	repo, err := tx.GetByName(ctx, name)
-	if err != nil {
-		return err
-	}
-	return database.NewGitserverReposWith(tx).SetCloneStatus(ctx, repo.ID, status, s.Hostname)
-}
-
-// setCloneStatusNonFatal is the same as setCloneStatus but only logs errors
-func (s *Server) setCloneStatusNonFatal(ctx context.Context, name api.RepoName, status types.CloneStatus) {
-	if err := s.setCloneStatus(ctx, name, status); err != nil {
-		log15.Warn("Setting clone status in DB", "error", err)
-	}
-}
-
-func (s *Server) setLastError(ctx context.Context, name api.RepoName, error string) (err error) {
-	if s.DB == nil {
-		return nil
-	}
-	tx, err := database.Repos(s.DB).Transact(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	repo, err := tx.GetByName(ctx, name)
-	if err != nil {
-		return err
-	}
-	return database.NewGitserverReposWith(tx).SetLastError(ctx, repo.ID, error, s.Hostname)
 }
 
 // removeRepoDirectory atomically removes a directory from s.ReposDir.

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1361,8 +1361,7 @@ func (s *Server) cloneRepo(ctx context.Context, repo api.RepoName, opts *cloneOp
 		if err != nil {
 			log15.Error("failed to clone repo", "repo", repo, "error", err)
 		}
-		// Use a background context to ensure we still update the DB even if we time out
-		s.setLastErrorNonFatal(context.Background(), repo, err)
+		s.setLastErrorNonFatal(ctx, repo, err)
 	}()
 
 	return "", nil

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1464,7 +1464,12 @@ func honeySampleRate(cmd string) uint {
 
 var headBranchPattern = lazyregexp.New(`HEAD branch: (.+?)\n`)
 
+var doRepoUpdateMock func(context.Context, api.RepoName) error
+
 func (s *Server) doRepoUpdate(ctx context.Context, repo api.RepoName) error {
+	if doRepoUpdateMock != nil {
+		return doRepoUpdateMock(ctx, repo)
+	}
 	span, ctx := ot.StartSpanFromContext(ctx, "Server.doRepoUpdate")
 	span.SetTag("repo", repo)
 	defer span.Finish()

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -656,6 +656,12 @@ func (s *Server) handleRepoUpdate(w http.ResponseWriter, r *http.Request) {
 			resp.Error = updateErr.Error()
 		}
 	}
+
+	if err := s.setLastError(context.Background(), req.Repo, resp.Error); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -17,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
@@ -24,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/mutablelimiter"
+	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 )
@@ -559,6 +563,108 @@ func TestCloneRepo(t *testing.T) {
 	gotCommit = cmd("git", "rev-parse", "HEAD")
 	if wantCommit != gotCommit {
 		t.Fatal("failed to clone:", gotCommit)
+	}
+}
+
+func TestHandleRepoUpdate(t *testing.T) {
+	ctx := context.Background()
+	remote := tmpDir(t)
+	repoName := api.RepoName("example.com/foo/bar")
+	db := dbtesting.GetDB(t)
+
+	dbRepo := &types.Repo{
+		Name:        repoName,
+		Description: "Test",
+	}
+	// Insert the repo into our database
+	if err := database.Repos(db).Create(ctx, dbRepo); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := remote
+	cmd := func(name string, arg ...string) string {
+		t.Helper()
+		return runCmd(t, repo, name, arg...)
+	}
+
+	// Setup a repo with a commit so we can see if we can clone it.
+	cmd("git", "init", ".")
+	cmd("sh", "-c", "echo hello world > hello.txt")
+	cmd("git", "add", "hello.txt")
+	cmd("git", "commit", "-m", "hello")
+	//wantCommit := cmd("git", "rev-parse", "HEAD")
+	// Add a bad tag
+	cmd("git", "tag", "HEAD")
+
+	reposDir := tmpDir(t)
+
+	s := &Server{
+		ReposDir:         reposDir,
+		GetRemoteURLFunc: staticGetRemoteURL(remote),
+		GetVCSSyncer: func(ctx context.Context, name api.RepoName) (VCSSyncer, error) {
+			return &GitRepoSyncer{}, nil
+		},
+		DB:               db,
+		ctx:              context.Background(),
+		locker:           &RepositoryLocker{},
+		cloneLimiter:     mutablelimiter.New(1),
+		cloneableLimiter: mutablelimiter.New(1),
+	}
+
+	rr := httptest.NewRecorder()
+
+	updateReq := protocol.RepoUpdateRequest{
+		Repo: repoName,
+	}
+	body, err := json.Marshal(updateReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This will perform an initial clone
+	req := httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))
+	s.handleRepoUpdate(rr, req)
+
+	want := &types.GitserverRepo{
+		RepoID:      dbRepo.ID,
+		ShardID:     "",
+		CloneStatus: types.CloneStatusCloned,
+	}
+	fromDB, err := database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We don't expect an error
+	if diff := cmp.Diff(want, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Now we'll call again and with an update that fails
+
+	doRepoUpdateMock = func(ctx context.Context, name api.RepoName) error {
+		return errors.New("fail")
+	}
+	t.Cleanup(func() { doRepoUpdateMock = nil })
+
+	// This will an update since the repo is already cloned
+	req = httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))
+	s.handleRepoUpdate(rr, req)
+
+	want = &types.GitserverRepo{
+		RepoID:      dbRepo.ID,
+		ShardID:     "",
+		CloneStatus: types.CloneStatusCloned,
+		LastError:   "fail",
+	}
+	fromDB, err = database.GitserverRepos(db).GetByID(ctx, dbRepo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We expect an error
+	if diff := cmp.Diff(want, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -610,6 +610,8 @@ func TestHandleRepoUpdate(t *testing.T) {
 		cloneLimiter:     mutablelimiter.New(1),
 		cloneableLimiter: mutablelimiter.New(1),
 	}
+	// We need some of the side effects here
+	_ = s.Handler()
 
 	rr := httptest.NewRecorder()
 
@@ -642,10 +644,10 @@ func TestHandleRepoUpdate(t *testing.T) {
 
 	// Now we'll call again and with an update that fails
 
-	doRepoUpdateMock = func(ctx context.Context, name api.RepoName) error {
+	doRepoUpdate2Mock = func(name api.RepoName) error {
 		return errors.New("fail")
 	}
-	t.Cleanup(func() { doRepoUpdateMock = nil })
+	t.Cleanup(func() { doRepoUpdate2Mock = nil })
 
 	// This will an update since the repo is already cloned
 	req = httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -189,7 +189,6 @@ SET (clone_status, shard_id, updated_at) =
 
 // SetLastError will attempt to update ONLY the last error of a GitServerRepo. If
 // a matching row does not yet exist a new one will be created.
-// TODO: Add a test
 func (s *GitserverRepoStore) SetLastError(ctx context.Context, id api.RepoID, error string, shardID string) error {
 	result, err := s.ExecResult(ctx, sqlf.Sprintf(`
 INSERT INTO gitserver_repos(repo_id, last_error, shard_id, updated_at)

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -164,51 +164,30 @@ WHERE repo_id = %s
 // SetCloneStatus will attempt to update ONLY the clone status of a
 // GitServerRepo. If a matching row does not yet exist a new one will be created.
 func (s *GitserverRepoStore) SetCloneStatus(ctx context.Context, id api.RepoID, status types.CloneStatus, shardID string) error {
-	result, err := s.ExecResult(ctx, sqlf.Sprintf(`
+	err := s.Exec(ctx, sqlf.Sprintf(`
 INSERT INTO gitserver_repos(repo_id, clone_status, shard_id, updated_at)
 VALUES (%s, %s, %s, now())
 ON CONFLICT (repo_id) DO UPDATE
 SET (clone_status, shard_id, updated_at) =
     (EXCLUDED.clone_status, EXCLUDED.shard_id, now())
+    WHERE gitserver_repos.clone_status IS DISTINCT FROM EXCLUDED.clone_status
 `, id, status, shardID))
 
-	if err != nil {
-		return errors.Wrap(err, "setting clone status")
-	}
-
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return errors.Wrap(err, "checking affected rows")
-	}
-	if affected < 1 {
-		return errors.New("no rows updated")
-	}
-
-	return nil
+	return errors.Wrap(err, "setting clone status")
 }
 
 // SetLastError will attempt to update ONLY the last error of a GitServerRepo. If
 // a matching row does not yet exist a new one will be created.
+// If the error value hasn't changed, the row will not be updated.
 func (s *GitserverRepoStore) SetLastError(ctx context.Context, id api.RepoID, error string, shardID string) error {
-	result, err := s.ExecResult(ctx, sqlf.Sprintf(`
+	err := s.Exec(ctx, sqlf.Sprintf(`
 INSERT INTO gitserver_repos(repo_id, last_error, shard_id, updated_at)
 VALUES (%s, %s, %s, now())
 ON CONFLICT (repo_id) DO UPDATE
 SET (last_error, shard_id, updated_at) =
     (EXCLUDED.last_error, EXCLUDED.shard_id, now())
+    WHERE gitserver_repos.last_error IS DISTINCT FROM EXCLUDED.last_error
 `, id, error, shardID))
 
-	if err != nil {
-		return errors.Wrap(err, "setting clone status")
-	}
-
-	affected, err := result.RowsAffected()
-	if err != nil {
-		return errors.Wrap(err, "checking affected rows")
-	}
-	if affected < 1 {
-		return errors.New("no rows updated")
-	}
-
-	return nil
+	return errors.Wrap(err, "setting last error")
 }

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -163,6 +163,7 @@ WHERE repo_id = %s
 
 // SetCloneStatus will attempt to update ONLY the clone status of a
 // GitServerRepo. If a matching row does not yet exist a new one will be created.
+// If the status value hasn't changed, the row will not be updated.
 func (s *GitserverRepoStore) SetCloneStatus(ctx context.Context, id api.RepoID, status types.CloneStatus, shardID string) error {
 	err := s.Exec(ctx, sqlf.Sprintf(`
 INSERT INTO gitserver_repos(repo_id, clone_status, shard_id, updated_at)

--- a/internal/database/gitserver_repos.go
+++ b/internal/database/gitserver_repos.go
@@ -181,6 +181,7 @@ SET (clone_status, shard_id, updated_at) =
 // a matching row does not yet exist a new one will be created.
 // If the error value hasn't changed, the row will not be updated.
 func (s *GitserverRepoStore) SetLastError(ctx context.Context, id api.RepoID, error string, shardID string) error {
+	ns := dbutil.NewNullString(error)
 	err := s.Exec(ctx, sqlf.Sprintf(`
 INSERT INTO gitserver_repos(repo_id, last_error, shard_id, updated_at)
 VALUES (%s, %s, %s, now())
@@ -188,7 +189,7 @@ ON CONFLICT (repo_id) DO UPDATE
 SET (last_error, shard_id, updated_at) =
     (EXCLUDED.last_error, EXCLUDED.shard_id, now())
     WHERE gitserver_repos.last_error IS DISTINCT FROM EXCLUDED.last_error
-`, id, error, shardID))
+`, id, ns, shardID))
 
 	return errors.Wrap(err, "setting last error")
 }

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -222,6 +222,18 @@ func TestSetCloneStatus(t *testing.T) {
 	if diff := cmp.Diff(gitserverRepo2, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
 		t.Fatal(diff)
 	}
+
+	// Setting the same status again should not touch the row
+	if err := GitserverRepos(db).SetCloneStatus(ctx, repo2.ID, types.CloneStatusCloned, shardID); err != nil {
+		t.Fatal(err)
+	}
+	after, err := GitserverRepos(db).GetByID(ctx, repo2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(fromDB, after); diff != "" {
+		t.Fatal(diff)
+	}
 }
 
 func TestSetLastError(t *testing.T) {
@@ -285,6 +297,22 @@ func TestSetLastError(t *testing.T) {
 
 	gitserverRepo.LastError = ""
 	if diff := cmp.Diff(gitserverRepo, fromDB, cmpopts.IgnoreFields(types.GitserverRepo{}, "UpdatedAt")); diff != "" {
+		t.Fatal(diff)
+	}
+
+	// Set again to same value, updated_at should not change
+	err = GitserverRepos(db).SetLastError(ctx, gitserverRepo.RepoID, "", shardID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := GitserverRepos(db).GetByID(ctx, gitserverRepo.RepoID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitserverRepo.LastError = ""
+	if diff := cmp.Diff(fromDB, after); diff != "" {
 		t.Fatal(diff)
 	}
 }

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -314,6 +315,16 @@ func TestSetLastError(t *testing.T) {
 	gitserverRepo.LastError = ""
 	if diff := cmp.Diff(fromDB, after); diff != "" {
 		t.Fatal(diff)
+	}
+
+	// Setting to empty error should set the column to null
+	count, _, err := basestore.ScanFirstInt(db.QueryContext(ctx, "SELECT COUNT(*) FROM gitserver_repos WHERE last_error IS NULL"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count != 1 {
+		t.Fatalf("Want %d, got %d", 1, count)
 	}
 }
 


### PR DESCRIPTION
This change causes us to store the most recent clone or update error
in the database in `gitserver_repos.last_error`. 

Setting the error to the empty string indicates that no error occurred.

Co-authored-by: Indradhanush Gupta <indradhanush.gupta@gmail.com>

Part of: https://github.com/sourcegraph/sourcegraph/issues/16670