### PR TITLE
search: use RepoStore.Mock in repo resolver tests

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -420,7 +420,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 		Query:              r.Query,
 	}
 	repositoryResolver := &searchrepos.Resolver{
-		DB:               r.db,
+		RepoStore:        database.Repos(r.db),
 		Zoekt:            r.zoekt,
 		DefaultReposFunc: database.DefaultRepos(r.db).List,
 		NamespaceStore:   database.Namespaces(r.db),

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -122,7 +122,7 @@ func alertForStalePermissions(db dbutil.DB) *searchAlert {
 func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Options) bool {
 	options.UserSettings = r.UserSettings
 	repositoryResolver := &searchrepos.Resolver{
-		DB:               r.db,
+		RepoStore:        database.Repos(r.db),
 		Zoekt:            r.zoekt,
 		DefaultReposFunc: database.DefaultRepos(r.db).List,
 		NamespaceStore:   database.Namespaces(r.db),


### PR DESCRIPTION
We stop using global mocks. Additionally because we now directly pass in
a store, we don't need to pass in a DB. This avoid creating an unused
database for the unit test, which on my computer speeds the test up from
1.5s to 0.5s.
