### PR TITLE
Fix UserSettingsRepositoriesPage to show user repos when only added via public code (no code host connections)

### DIFF
--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -499,10 +499,17 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                     type="radio"
                     value="selected"
                     checked={selectionState.radio === 'selected'}
+                    disabled={codeHosts.hosts.length === 0}
                     onChange={handleRadioSelect}
                 />
                 <div className="d-flex flex-column ml-2">
-                    <p className="mb-0">Sync selected public repositories</p>
+                    <p
+                        className={
+                            'mb-0 ' + ((codeHosts.hosts.length === 0 && 'user-settings-repos__text-coming-soon') || '')
+                        }
+                    >
+                        Sync selected public repositories
+                    </p>
                 </div>
             </label>
         </Form>
@@ -661,6 +668,14 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                                 Get updated when this feature launches
                             </Link>
                         </div>
+                        {codeHosts.hosts.length === 0 && (
+                            <div className="alert alert-warning">
+                                <Link to={`${routingPrefix}/code-hosts`} target="_blank" rel="noopener noreferrer">
+                                    Connect with a code host
+                                </Link>{' '}
+                                to add your own repositories to Sourcegraph.
+                            </div>
+                        )}
                         {
                             // display radio button for 'all' or 'selected' repos
                             modeSelect

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -60,26 +60,29 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
     routingPrefix,
     telemetryService,
 }) => {
-    const [hasRepos, setHasRepos] = useState(false)
+    const [hasRepos, setHasRepos] = useState<boolean | null>(null)
     const [externalServices, setExternalServices] = useState<ListExternalServiceFields[]>()
     const [pendingOrError, setPendingOrError] = useState<Status>()
 
+    const noReposState = (
+        <div className="border rounded p-3">
+            <h3>You have not added any repositories to Sourcegraph</h3>
+            <small>
+                <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
+                    Connect code hosts
+                </Link>{' '}
+                to start searching your own repositories, or{' '}
+                <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
+                    add public repositories
+                </Link>{' '}
+                from GitHub or GitLab.
+            </small>
+        </div>
+    )
     const showResults = (): JSX.Element => {
-        // no code hosts added
         const emptyState = (
             <div className="border rounded p-3">
-                <h3>No repositories found</h3>
-                <small>
-                    Try changing your search filter, or if you've not yet added any code, you can: <br />
-                    <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
-                        Connect code hosts
-                    </Link>{' '}
-                    to start searching your own repositories, or{' '}
-                    <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
-                        add public repositories
-                    </Link>{' '}
-                    from GitHub or GitLab.
-                </small>
+                <small>No repositories matched.</small>
             </div>
         )
         return (
@@ -215,6 +218,8 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
             const conn = value as Connection<SiteAdminRepositoryFields>
             if (conn.totalCount !== 0) {
                 setHasRepos(true)
+            } else {
+                setHasRepos(false)
             }
         }
     }, [])
@@ -253,7 +258,10 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 </Link>
             </p>
             {externalServices ? (
-                showResults()
+                <>
+                    {hasRepos === false && noReposState}
+                    {(hasRepos || hasRepos === null) && showResults()}
+                </>
             ) : (
                 <div className="d-flex justify-content-center mt-4">
                     <LoadingSpinner className="icon-inline" />

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -50,13 +50,6 @@ const Row: React.FunctionComponent<RowProps> = props => (
 type Status = undefined | 'pending' | ErrorLike
 const emptyFilters: FilteredConnectionFilter[] = []
 
-const getHelpfulBanner = (MessageLink: JSX.Element): JSX.Element => (
-    <div className="border rounded p-3">
-        <h3>You have not added any repositories to Sourcegraph</h3>
-        <small>{MessageLink} to start searching your code with Sourcegraph.</small>
-    </div>
-)
-
 /**
  * A page displaying the repositories for this user.
  */
@@ -71,28 +64,24 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
     const [externalServices, setExternalServices] = useState<ListExternalServiceFields[]>()
     const [pendingOrError, setPendingOrError] = useState<Status>()
 
-    const showResults = (services: ListExternalServiceFields[] | undefined): JSX.Element => {
+    const showResults = (): JSX.Element => {
         // no code hosts added
-        if (!services || services.length === 0) {
-            const ConnectCodeHostsLink = (
-                <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
-                    Connect code hosts
-                </Link>
-            )
-            return getHelpfulBanner(ConnectCodeHostsLink)
-        }
-
-        // code hosts added but don't have any repos
-        if (services.every(({ repoCount }) => repoCount === 0)) {
-            const AddReposLink = (
-                <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
-                    Add repositories
-                </Link>
-            )
-            return getHelpfulBanner(AddReposLink)
-        }
-
-        // otherwise, if we have connected code hosts and they have repos - list repositories
+        const emptyState = (
+            <div className="border rounded p-3">
+                <h3>No repositories found</h3>
+                <small>
+                    Try changing your search filter, or if you've not yet added any code, you can: <br />
+                    <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
+                        Connect code hosts
+                    </Link>{' '}
+                    to start searching your own repositories, or{' '}
+                    <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
+                        add public repositories
+                    </Link>{' '}
+                    from GitHub or GitLab.
+                </small>
+            </div>
+        )
         return (
             <FilteredConnection<SiteAdminRepositoryFields, Omit<UserRepositoriesResult, 'node'>>
                 className="table mt-3"
@@ -108,6 +97,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 filters={filters}
                 history={history}
                 location={location}
+                emptyElement={emptyState}
                 totalCountSummaryComponent={TotalCountSummary}
                 hideControlsWhenEmpty={true}
                 inputClassName="user-settings-repos__filter-input"
@@ -245,18 +235,16 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
             <PageTitle title="Repositories" />
             <div className="d-flex justify-content-between align-items-center">
                 <h2 className="mb-2">Repositories</h2>
-                {filters[1] && filters[1].values.length !== 1 && (
-                    <Link
-                        className="btn btn-primary test-goto-add-external-service-page"
-                        to={`${routingPrefix}/repositories/manage`}
-                    >
-                        {(hasRepos && <>Manage Repositories</>) || (
-                            <>
-                                <AddIcon className="icon-inline" /> Add repositories
-                            </>
-                        )}
-                    </Link>
-                )}
+                <Link
+                    className="btn btn-primary test-goto-add-external-service-page"
+                    to={`${routingPrefix}/repositories/manage`}
+                >
+                    {(hasRepos && <>Manage Repositories</>) || (
+                        <>
+                            <AddIcon className="icon-inline" /> Add repositories
+                        </>
+                    )}
+                </Link>
             </div>
             <p className="text-muted pb-2">
                 All repositories synced with Sourcegraph from{' '}
@@ -265,7 +253,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 </Link>
             </p>
             {externalServices ? (
-                showResults(externalServices)
+                showResults()
             ) : (
                 <div className="d-flex justify-content-center mt-4">
                     <LoadingSpinner className="icon-inline" />

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -230,7 +230,12 @@ func (s *RepoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 		joins = append(joins, sqlf.Sprintf("JOIN external_service_repos e ON (repo.id = e.repo_id AND e.external_service_id IN (%s))", sqlf.Join(serviceIDQuery, ",")))
 	} else if opt.UserID != 0 {
 		joins = append(joins, sqlf.Sprintf(`JOIN external_service_repos e ON (repo.id = e.repo_id)
-												   JOIN external_services es on es.id = e.external_service_id AND es.namespace_user_id = %s`, opt.UserID))
+												   JOIN external_services es on es.id = e.external_service_id`))
+		if opt.IncludeUserPublicRepos {
+			conds = append(conds, sqlf.Sprintf("(es.namespace_user_id = %d OR EXISTS (SELECT 1 FROM user_public_repos WHERE user_id = %d AND repo_id = repo.id)) AND es.deleted_at IS NULL", opt.UserID, opt.UserID))
+		} else {
+			conds = append(conds, sqlf.Sprintf("es.namespace_user_id = %d AND es.deleted_at IS NULL", opt.UserID))
+		}
 	}
 
 	predQ := sqlf.Sprintf("TRUE")


### PR DESCRIPTION
closes #19161 
closes #19162

I spotted this morning that if you added code via public repos without any code host connections, nothing would appear. this is because we were testing for the existence of code hosts to show the FilteredConnection element. It also meant that there was no entrypoint to add public code without a code host connection, i've fixed that as well with updated copy & different logic for showing the add/manage repos button.

There's some slightly janky state in here, as we need to present the filtered connection in order to populate the hasRepos state, and then hide it if there's nothing. If there's a better way for me to directly call queryRepositories without creating too many extra network requests please let me know, but i wasn't sure how i could do that.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
