### PR TITLE
search: Use labeled code fences and add CSS for highlighting

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -805,6 +805,18 @@ body.theme-light .markdown-body .chroma .vg { color: #dd7700 } /* Name.Variable.
 body.theme-light .markdown-body .chroma .vi { color: #3333bb } /* Name.Variable.Instance */
 body.theme-light .markdown-body .chroma .vm { color: #336699 } /* Name.Variable.Magic */
 body.theme-light .markdown-body .chroma .il { color: #0000DD; font-weight: bold } /* Literal.Number.Integer.Long */
+
+/* Light query colors */
+body.theme-light .markdown-body .chroma.sgquery .c { color: #d9480f } /* Comment */
+body.theme-light .markdown-body .chroma.sgquery .k { color: #ae3ec9; font-weight: bold } /* Keyword */
+body.theme-light .markdown-body .chroma.sgquery .nb { color: #268bd2 } /* Name.Builtin */
+body.theme-light .markdown-body .chroma.sgquery .nf { color: #ae3ec9; font-weight: bold } /* Name.Function */
+body.theme-light .markdown-body .chroma.sgquery .se { color: #af5200; background-color: transparent } /* Literal.String.Escape */
+body.theme-light .markdown-body .chroma.sgquery .sr { color: #c92a2a; background-color: transparent } /* Literal.String.Regex */
+body.theme-light .markdown-body .chroma.sgquery .dl { color: #d9480f; background-color: transparent } /* Literal.String.Delimiter */
+body.theme-light .markdown-body .chroma.sgquery .sa { color: #1098ad } /* Literal.String.Affix */
+body.theme-light .markdown-body .chroma.sgquery .ss { color: #c92a2a; background-color: transparent } /* Literal.String.Symbol */
+
 /* Dark theme */
 body.theme-dark .markdown-body .chroma .c { color: #75715e } /* Comment */
 body.theme-dark .markdown-body .chroma .err { color: #960050; background-color: #1e0010 } /* Error */
@@ -874,6 +886,18 @@ body.theme-dark .markdown-body .chroma .vg { color: #f8f8f2 } /* Name.Variable.G
 body.theme-dark .markdown-body .chroma .vi { color: #f8f8f2 } /* Name.Variable.Instance */
 body.theme-dark .markdown-body .chroma .vm { color: #f8f8f2 } /* Name.Variable.Magic */
 body.theme-dark .markdown-body .chroma .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+
+/* Dark query colors */
+body.theme-dark .markdown-body .chroma.sgquery .c { color: #ffa94d } /* Comment */
+body.theme-dark .markdown-body .chroma.sgquery .k { color: #da77f2; font-weight: bold } /* Keyword */
+body.theme-dark .markdown-body .chroma.sgquery .nb { color: #569cd6 } /* Name.Builtin */
+body.theme-dark .markdown-body .chroma.sgquery .nf { color: #da77f2; font-weight: bold } /* Name.Function */
+body.theme-dark .markdown-body .chroma.sgquery .se { color: #ffa8a8; background-color: transparent } /* Literal.String.Escape */
+body.theme-dark .markdown-body .chroma.sgquery .sr { color: #ff6b6b; background-color: transparent } /* Literal.String.Regex */
+body.theme-dark .markdown-body .chroma.sgquery .dl { color: #ffa94d; background-color: transparent } /* Literal.String.Delimiter */
+body.theme-dark .markdown-body .chroma.sgquery .sa { color: #3bc9db } /* Literal.String.Affix */
+body.theme-dark .markdown-body .chroma.sgquery .ss { color: #ff6b6b; background-color: transparent } /* Literal.String.Symbol */
+
 
 /* Getting started links */
 /* See campaign docs for examles */

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -51,6 +51,15 @@ body.theme-light {
   --table-row-bg-2: #f2f4f8; /* should be slightly different from var(--table-row-bg-1) */
   --text-muted: #888888;
   --search-result-path-color: green;
+
+  /*
+   * TODO (@camdencheek): These variables are also defined in colors.scss, and
+   * shouldn't be defined here, but we have no SCSS compilation process for the docsite,
+   * so we can't use them directly.
+   * https://github.com/sourcegraph/sourcegraph/issues/19234
+   */
+  --search-filter-keyword-color: #268bd2;
+  --search-keyword-color: #ae3ec9;
 }
 
 body.theme-dark {
@@ -70,6 +79,9 @@ body.theme-dark {
   --table-row-bg-2: #080820;
   --text-muted: #7c7c9f;
   --search-result-path-color: #e89fff;
+
+  --search-filter-keyword-color: #569cd6;
+  --search-keyword-color: #da77f2;
 }
 
 * {
@@ -808,8 +820,8 @@ body.theme-light .markdown-body .chroma .il { color: #0000DD; font-weight: bold 
 
 /* Light query colors */
 body.theme-light .markdown-body .chroma.sgquery .c { color: #d9480f } /* Comment */
-body.theme-light .markdown-body .chroma.sgquery .k { color: #ae3ec9; font-weight: bold } /* Keyword */
-body.theme-light .markdown-body .chroma.sgquery .nb { color: #268bd2 } /* Name.Builtin */
+body.theme-light .markdown-body .chroma.sgquery .k { color: var(--search-keyword-color); font-weight: bold } /* Keyword */
+body.theme-light .markdown-body .chroma.sgquery .nb { color: var(--search-filter-keyword-color) } /* Name.Builtin */
 body.theme-light .markdown-body .chroma.sgquery .nf { color: #ae3ec9; font-weight: bold } /* Name.Function */
 body.theme-light .markdown-body .chroma.sgquery .se { color: #af5200; background-color: transparent } /* Literal.String.Escape */
 body.theme-light .markdown-body .chroma.sgquery .sr { color: #c92a2a; background-color: transparent } /* Literal.String.Regex */
@@ -889,8 +901,8 @@ body.theme-dark .markdown-body .chroma .il { color: #ae81ff } /* Literal.Number.
 
 /* Dark query colors */
 body.theme-dark .markdown-body .chroma.sgquery .c { color: #ffa94d } /* Comment */
-body.theme-dark .markdown-body .chroma.sgquery .k { color: #da77f2; font-weight: bold } /* Keyword */
-body.theme-dark .markdown-body .chroma.sgquery .nb { color: #569cd6 } /* Name.Builtin */
+body.theme-dark .markdown-body .chroma.sgquery .k { color: var(--search-keyword-color); font-weight: bold } /* Keyword */
+body.theme-dark .markdown-body .chroma.sgquery .nb { color: var(--search-filter-keyword-color) } /* Name.Builtin */
 body.theme-dark .markdown-body .chroma.sgquery .nf { color: #da77f2; font-weight: bold } /* Name.Function */
 body.theme-dark .markdown-body .chroma.sgquery .se { color: #ffa8a8; background-color: transparent } /* Literal.String.Escape */
 body.theme-dark .markdown-body .chroma.sgquery .sr { color: #ff6b6b; background-color: transparent } /* Literal.String.Regex */

--- a/doc/code_search/tutorials/examples.md
+++ b/doc/code_search/tutorials/examples.md
@@ -4,37 +4,61 @@ Below are examples that search repositories on [Sourcegraph.com](https://sourceg
 
 > See [**search query syntax**](../reference/queries.md) reference.
 
-- [Recent security-related changes on all branches](https://sourcegraph.com/search?q=type:diff+repo:github%5C.com/kubernetes/kubernetes%24+repo:%40*refs/heads/+after:"5+days+ago"+%5Cb%28auth%5B%5Eo%5D%5B%5Er%5D%7Csecurity%5Cb%7Ccve%7Cpassword%7Csecure%7Cunsafe%7Cperms%7Cpermissions%29)<br/>
-`type:diff repo:@*refs/heads/ after:"5 days ago" \b(auth[^o][^r]|security\b|cve|password|secure|unsafe|perms|permissions)`
+[Recent security-related changes on all branches](https://sourcegraph.com/search?q=type:diff+repo:github%5C.com/kubernetes/kubernetes%24+repo:%40*refs/heads/+after:"5+days+ago"+%5Cb%28auth%5B%5Eo%5D%5B%5Er%5D%7Csecurity%5Cb%7Ccve%7Cpassword%7Csecure%7Cunsafe%7Cperms%7Cpermissions%29)<br/>
 
-- [Admitted hacks and TODOs in app code](https://sourcegraph.com/search?q=-file:%5C.%28json%7Cmd%7Ctxt%29%24+hack%7Ctodo%7Ckludge%7Cfixme)<br/>
-`-file:\.(json|md|txt)$ hack|todo|kludge|fixme`
+```sgquery
+type:diff repo:@*refs/heads/ after:"5 days ago" 
+\b(auth[^o][^r]|security\b|cve|password|secure|unsafe|perms|permissions)
+```
 
-- [New usages of a function](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+type:diff+after:%221+week+ago%22+%5C.subscribe%5C%28+lang:typescript)<br/>
-`type:diff after:"1 week ago" \.subscribe\( lang:typescript`
+[Admitted hacks and TODOs in app code](https://sourcegraph.com/search?q=-file:%5C.%28json%7Cmd%7Ctxt%29%24+hack%7Ctodo%7Ckludge%7Cfixme)<br/>
 
-- [Recent quality related changes on all branches (customize for your linters)](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+repo:%40*refs/heads/:%5Emaster+type:diff+after:"1+week+ago"+%28eslint-disable%29)<br/>
-`repo:@*refs/heads/:^master type:diff after:"1 week ago" (eslint-disable)`
+```sgquery
+-file:\.(json|md|txt)$ hack|todo|kludge|fixme
+```
 
-- [Recent dependency changes](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+file:package.json+type:diff+after:%221+week+ago%22)<br/>
-`file:package.json type:diff after:"1 week ago"`
+[New usages of a function](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+type:diff+after:%221+week+ago%22+%5C.subscribe%5C%28+lang:typescript)<br/>
+
+```sgquery
+type:diff after:"1 week ago" \.subscribe\( lang:typescript
+```
+
+[Recent quality related changes on all branches (customize for your linters)](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+repo:%40*refs/heads/:%5Emaster+type:diff+after:"1+week+ago"+%28eslint-disable%29)<br/>
+
+```sgquery
+repo:@*refs/heads/:^master type:diff after:"1 week ago" (eslint-disable)
+```
+
+[Recent dependency changes](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+file:package.json+type:diff+after:%221+week+ago%22)<br/>
+
+```sgquery
+file:package.json type:diff after:"1 week ago"
+```
 
 ## When to use regex search mode
 
 Sourcegraph's default literal search mode is line-based and will not match across lines, so regex can be useful when you wish to do so:
 
-- [Matching multiple text strings in a file](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/Parsely/pykafka%24+Not+leader+for+partition&patternType=regexp)<br/>
-`repo:^github\.com/Parsely/pykafka$ Not leader for partition`
+[Matching multiple text strings in a file](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/Parsely/pykafka%24+Not+leader+for+partition&patternType=regexp)<br/>
+
+```sgquery
+repo:^github\.com/Parsely/pykafka$ Not leader for partition
+```
 
 Regex searches are also useful when searching boundaries that are not delimited by code structures:
 
-- [Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%5Cbbtn-secondary%5Cb&patternType=regexp) <br /> 
-`repo:^github\.com/sourcegraph/sourcegraph$ \bbtn-secondary\b`
+[Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%5Cbbtn-secondary%5Cb&patternType=regexp) <br /> 
+```sgquery
+repo:^github\.com/sourcegraph/sourcegraph$ \bbtn-secondary\b
+```
 
 
 ## When to use structural search mode
 
 Use structural search when you want to match code boundaries such as () or {}:
 
-- [Finding try catch statements with varying content](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+try+%7B+:%5Bmatched_statements%5D+%7D+catch+%7B+:%5Bmatched_catch%5D+%7D&patternType=structural)<br/> 
-`repo:^github\.com/sourcegraph/sourcegraph$ try { :[matched_statements] } catch { :[matched_catch] }`
+[Finding try catch statements with varying content](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+try+%7B+:%5Bmatched_statements%5D+%7D+catch+%7B+:%5Bmatched_catch%5D+%7D&patternType=structural)<br/> 
+```sgquery
+repo:^github\.com/sourcegraph/sourcegraph$ 
+try { :[matched_statements] } catch { :[matched_catch] }
+```


### PR DESCRIPTION
This PR paves the way for enabling query syntax highlighting on our docs page. 

It does two things:
1) Adds CSS for highlighting `.chroma.sgquery` code blocks with colors that match the query editor
2) Converts our search examples page to use code blocks so that we can take advantage of the highlighting

# How it works
- `docsite` [PR #70](https://github.com/sourcegraph/docsite/pull/70) adds a lexer for our queries, and modifies the generated `<pre>` block surrounding code to include a class named the same as the code block language. For example, for the following code block, the tag would look like `<pre class="chroma sgquery">`

````md
```sgquery
repo:test (a or b)
```
````

- New CSS selectors are added that translate the syntax tags added by chroma to the colors we use in our query editor. These override the colors defined for all other languages. This is so our syntax highlighting for other languages is not affected by this change. 

I am a complete CSS noob, so please take a close look at the CSS and feel free to suggest any modifications. 

# What it looks like:
## Before
![before](https://user-images.githubusercontent.com/12631702/111348536-e8b56700-8645-11eb-99d2-813b5f572b06.png)

## After
![after](https://user-images.githubusercontent.com/12631702/111348548-ee12b180-8645-11eb-8d6f-8621c49e1006.png)
