### PR TITLE
insights: filter out null extension insights

### DIFF
--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -8,7 +8,7 @@ import {
     mergeMap,
     switchMap,
 } from 'rxjs/operators'
-import { isDefined, isExactly, isNot, property } from '../../util/types'
+import { allOf, isDefined, isExactly, isNot, property } from '../../util/types'
 import { FlatExtensionHostAPI } from '../contract'
 import { providerResultToObservable, ProxySubscribable, proxySubscribable } from './api/common'
 import { updateContext } from './extensionHost'
@@ -626,6 +626,7 @@ function callViewProviders<W extends ContributableViewContainer>(
                     concat(
                         [undefined],
                         providerResultToObservable(viewProvider.provideView(context)).pipe(
+                            defaultIfEmpty<sourcegraph.View | null | undefined>(null),
                             catchError((error): [ErrorLike] => {
                                 console.error('View provider errored:', error)
                                 return [asError(error)]
@@ -635,7 +636,7 @@ function callViewProviders<W extends ContributableViewContainer>(
                 ),
             ])
         ),
-        map(views => views.filter(isDefined))
+        map(views => views.filter(allOf(isDefined, property('view', isNot(isExactly(null))))))
     )
 }
 


### PR DESCRIPTION
Fixes #19157, introduced by #18898.

Filter out null extension insights. [`ViewGrid`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/repo/tree/ViewGrid.tsx#L84-102) will only check that the view isn't `undefined`, not that it isn't falsy.

The real issue is that `providerResultToObservable` isn't type-safe; it erases primitive members of `ProviderResult` (`undefined` + `null`)! However, I want to get this fix out as fast as possible to confirm that this is the problem.

`ErrorBoundaries` for `ViewGrid` + `ViewContent` would be nice too