### PR TITLE
qa: Fix code intel e2e test

### DIFF
--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -177,7 +177,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "ef/fix-qa"
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main"
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.

--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -177,7 +177,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main"
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "ef/fix-qa"
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.


### PR DESCRIPTION
Remove check in code-intel-qa test for precision indicators, which were removed in https://github.com/sourcegraph/sourcegraph/pull/18843.