### PR TITLE
extensibility: fix GitLab doc not found error for deleted files

### DIFF
--- a/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/domFunctions.ts
@@ -7,7 +7,7 @@ const getSingleFileCodeElementFromLineNumber = (
     part?: DiffPart
 ): HTMLElement | null => codeView.querySelector<HTMLElement>(`#LC${line}`)
 export const singleFileDOMFunctions: DOMFunctions = {
-    getCodeElementFromTarget: target => target.closest('span.line') as HTMLElement | null,
+    getCodeElementFromTarget: target => target.closest('span.line'),
     getLineNumberFromCodeElement: codeElement => {
         const line = codeElement.id.replace(/^LC/, '')
         return parseInt(line, 10)
@@ -60,7 +60,9 @@ export const diffDOMFunctions: DOMFunctions = {
         let cell: HTMLElement | null = codeElement.closest('.diff-td,td')
         while (
             cell &&
-            !cell.matches(`.diff-line-num.${part === 'base' ? 'old_line' : 'new_line'}`) &&
+            // It's possible for a line number container to not contain an <a> tag with the line
+            // number, e.g. right side 'old_line' for a deleted file
+            !(cell.matches(`.diff-line-num.${part === 'base' ? 'old_line' : 'new_line'}`) && cell.querySelector('a')) &&
             cell.previousElementSibling
         ) {
             cell = cell.previousElementSibling as HTMLElement | null

--- a/client/browser/src/shared/code-hosts/gitlab/scrape.ts
+++ b/client/browser/src/shared/code-hosts/gitlab/scrape.ts
@@ -116,6 +116,11 @@ const getFilePathFromElement = (element: HTMLElement): string => {
         throw new Error('Unable to get file paths from code view: no file title')
     }
 
+    // Deleted files in MRs include " deleted" after the filepath of deleted files
+    if (filePath.endsWith(' deleted')) {
+        return filePath.slice(0, -8)
+    }
+
     return filePath
 }
 


### PR DESCRIPTION
Fixes #17103.

No longer throw `DocumentNotFoundError`

![Screenshot from 2021-03-16 17-53-50](https://user-images.githubusercontent.com/37420160/111385056-9e051080-8680-11eb-9b28-d3268618e15e.png)
