### PR TITLE
Pin kubectl used for CI

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,4 @@ yarn 1.22.4
 fd 7.4.0
 shfmt 3.2.0
 shellcheck 0.7.1
+kubectl 1.17.3


### PR DESCRIPTION
Tests are brokend due to missing `kubectl`. While `kubectl` is installed through `asdf-vm` no version is set as default, which is correct, and we defer to `global`.
The problem is the system does not appear to have any global `kubectl`.

The odd thing is that this started failing in https://buildkite.com/sourcegraph/qa/builds/2243 but no changes have been made at this point in any related repo:/

- `/infrastructure`: Only added github-cli but was reverted
- `/deploy-sourcegraph`: No changes and we dont use its internal `.tool-versions`
- `/sourcegraph`: No changes related to `kubectl` or related scripts


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->