### PR TITLE
search: don't set span to failed for context error

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1585,7 +1585,7 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {
 		a.error(ctx, err)
-		tr.SetError(err)
+		tr.SetErrorIfNotContext(err)
 		tr.Finish()
 	}()
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -372,7 +372,7 @@ func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextPara
 
 	tr, ctx := trace.New(ctx, "searchFilesInRepos", fmt.Sprintf("query: %s", args.PatternInfo.Pattern))
 	defer func() {
-		tr.SetError(err)
+		tr.SetErrorIfNotContext(err)
 		tr.Finish()
 	}()
 	tr.LogFields(

--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -60,7 +60,7 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 
 	tr, ctx := trace.New(ctx, "zoekt."+cat, queryString(q), tags...)
 	defer func() {
-		tr.SetError(err)
+		tr.SetErrorIfNotContext(err)
 		tr.Finish()
 	}()
 	if opts != nil {

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -135,6 +135,17 @@ func (t *Trace) SetError(err error) {
 	ext.Error.Set(t.span, true)
 }
 
+// SetErrorIfNotContext calls SetError unless err is context.Canceled or
+// context.DeadlineExceeded.
+func (t *Trace) SetErrorIfNotContext(err error) {
+	if err == context.Canceled || err == context.DeadlineExceeded {
+		t.trace.LazyPrintf("error: %v", err)
+		t.span.LogFields(log.Error(err))
+		return
+	}
+	t.SetError(err)
+}
+
 // Finish declares that this trace and span is complete.
 // The trace should not be used after calling this method.
 func (t *Trace) Finish() {

--- a/internal/trace/traceutil.go
+++ b/internal/trace/traceutil.go
@@ -2,6 +2,7 @@ package trace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -138,7 +139,7 @@ func (t *Trace) SetError(err error) {
 // SetErrorIfNotContext calls SetError unless err is context.Canceled or
 // context.DeadlineExceeded.
 func (t *Trace) SetErrorIfNotContext(err error) {
-	if err == context.Canceled || err == context.DeadlineExceeded {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		t.trace.LazyPrintf("error: %v", err)
 		t.span.LogFields(log.Error(err))
 		return


### PR DESCRIPTION
With this change we still log context errors, but we don't set the
corresponding span as failed.

By design, context errors are very common for streaming search. For
example, every time we hit a count limit, `limitStream` cancels the
context. As a result, a lot of spans are marked as failed although we
shouldn't consider them as such. This might be confusing for anyone
trying to troubleshoot issues by investigating traces.

<img width="600" alt="Screenshot 2021-03-17 at 09 43 45" src="https://user-images.githubusercontent.com/26413131/111449065-5a0d1c80-870f-11eb-9ccf-98148196e1ee.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
