### PR TITLE
gitserver: Rename doRepoupdate2 to doBackgroundRepoUpdate

### DIFF
--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -644,10 +644,10 @@ func TestHandleRepoUpdate(t *testing.T) {
 
 	// Now we'll call again and with an update that fails
 
-	doRepoUpdate2Mock = func(name api.RepoName) error {
+	doBackgroundRepoUpdateMock = func(name api.RepoName) error {
 		return errors.New("fail")
 	}
-	t.Cleanup(func() { doRepoUpdate2Mock = nil })
+	t.Cleanup(func() { doBackgroundRepoUpdateMock = nil })
 
 	// This will an update since the repo is already cloned
 	req = httptest.NewRequest("GET", "/repo-update", bytes.NewReader(body))

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -264,7 +264,7 @@ var repoLastFetched = func(dir GitDir) (time.Time, error) {
 //
 // This breaks on file systems that do not record mtime. This is a Sourcegraph
 // extension to track last time a repo changed. The file is updated by
-// setLastChanged via doRepoUpdate2.
+// setLastChanged via doBackgroundRepoUpdate.
 //
 // As a special case, tries both the directory given, and the .git subdirectory,
 // because we're a bit inconsistent about which name to use.


### PR DESCRIPTION
Also move it closer to where it's actually used.

As mentioned in: https://github.com/sourcegraph/sourcegraph/pull/19172