### PR TITLE
gitlab: support use OAuth token for repo syncing

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/session.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/session.go
@@ -99,7 +99,8 @@ func (s *sessionIssuerHelper) CreateCodeHostConnection(ctx context.Context, toke
 {
   "url": "%s",
   "token": "%s",
-  "projectQuery": ["projects?visibility=public"]
+  "token.type": "oauth",
+  "projectQuery": ["projects?id_before=0"]
 }
 `, p.ServiceID, token.AccessToken),
 			NamespaceUserID: actor.UID,

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/session_test.go
@@ -61,7 +61,8 @@ func TestSessionIssuerHelper_CreateCodeHostConnection(t *testing.T) {
 {
   "url": "%s",
   "token": "%s",
-  "projectQuery": ["projects?visibility=public"]
+  "token.type": "oauth",
+  "projectQuery": ["projects?id_before=0"]
 }
 `, mockGitLabCom.ServiceID, tok.AccessToken),
 		NamespaceUserID: act.UID,

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -104,7 +104,13 @@ func newGitLabSource(svc *types.ExternalService, c *schema.GitLabConnection, cf 
 
 	provider := gitlab.NewClientProvider(baseURL, cli)
 
-	client := provider.GetPATClient(c.Token, "")
+	var client *gitlab.Client
+	switch c.TokenType {
+	case "oauth":
+		client = provider.GetOAuthClient(c.Token)
+	default:
+		client = provider.GetPATClient(c.Token, "")
+	}
 
 	if !envvar.SourcegraphDotComMode() || svc.CloudDefault {
 		client.RateLimitMonitor().SetCollector(&ratelimit.MetricsCollector{

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -20,9 +20,15 @@
       "examples": ["https://gitlab.com", "https://gitlab.example.com"]
     },
     "token": {
-      "description": "A GitLab access token with \"api\" scope. If you are enabling permissions with identity provider type \"external\", this token should also have \"sudo\" scope.",
+      "description": "A GitLab access token with \"api\" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type \"external\", this token should also have \"sudo\" scope.",
       "type": "string",
       "minLength": 1
+    },
+    "token.type": {
+      "description": "The type of the token",
+      "type": "string",
+      "enum": ["pat", "oauth"],
+      "default": "pat"
     },
     "rateLimit": {
       "description": "Rate limit applied when making background API requests to GitLab.",

--- a/schema/gitlab_stringdata.go
+++ b/schema/gitlab_stringdata.go
@@ -25,9 +25,15 @@ const GitLabSchemaJSON = `{
       "examples": ["https://gitlab.com", "https://gitlab.example.com"]
     },
     "token": {
-      "description": "A GitLab access token with \"api\" scope. If you are enabling permissions with identity provider type \"external\", this token should also have \"sudo\" scope.",
+      "description": "A GitLab access token with \"api\" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type \"external\", this token should also have \"sudo\" scope.",
       "type": "string",
       "minLength": 1
+    },
+    "token.type": {
+      "description": "The type of the token",
+      "type": "string",
+      "enum": ["pat", "oauth"],
+      "default": "pat"
     },
     "rateLimit": {
       "description": "Rate limit applied when making background API requests to GitLab.",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -697,8 +697,10 @@ type GitLabConnection struct {
 	//
 	// It is important that the Sourcegraph repository name generated with this pattern be unique to this code host. If different code hosts generate repository names that collide, Sourcegraph's behavior is undefined.
 	RepositoryPathPattern string `json:"repositoryPathPattern,omitempty"`
-	// Token description: A GitLab access token with "api" scope. If you are enabling permissions with identity provider type "external", this token should also have "sudo" scope.
+	// Token description: A GitLab access token with "api" scope. Can be a personal access token (PAT) or an OAuth token. If you are enabling permissions with identity provider type "external", this token should also have "sudo" scope.
 	Token string `json:"token"`
+	// TokenType description: The type of the token
+	TokenType string `json:"token.type,omitempty"`
 	// Url description: URL of a GitLab instance, such as https://gitlab.example.com or (for GitLab.com) https://gitlab.com.
 	Url string `json:"url"`
 	// Webhooks description: An array of webhook configurations


### PR DESCRIPTION
Add `"token.type"` field to the GitLab code host connection to indicate whether the token is a PAT or OAuth token.

User or site admin should not normally be aware of this field because OAuth token is almost always populated by a server application.

Fixes https://github.com/sourcegraph/sourcegraph/issues/19136