### PR TITLE
repo-updater: Use NoNamespace instead of -1

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -149,7 +149,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		es, err := store.ExternalServiceStore.List(ctx, database.ExternalServicesListOptions{
 			// On Cloud we only want to fetch site level external services here where the
 			// cloud_default flag has been set.
-			NamespaceUserID:  -1,
+			NoNamespace:      true,
 			OnlyCloudDefault: true,
 			Kinds:            []string{extsvc.KindGitHub, extsvc.KindGitLab},
 		})

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -925,7 +925,8 @@ func (e *ExternalServiceStore) GetAffiliatedSyncErrors(ctx context.Context, u *t
 	if u == nil {
 		return nil, errors.New("nil user")
 	}
-	q := sqlf.Sprintf(`SELECT DISTINCT ON(external_service_id) external_service_id, failure_message
+	q := sqlf.Sprintf(`
+SELECT DISTINCT ON(external_service_id) external_service_id, failure_message
 FROM external_service_sync_jobs sj
 JOIN external_services es ON sj.external_service_id = es.id
 WHERE


### PR DESCRIPTION
-1 was left over from some older code and it's only been doing the
correct thing by chance since all our cloud_default repos are already
site admin owned.
