### PR TITLE
search: Create result.Type and result.Types

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	searchresult "github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -159,10 +160,10 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return nil, &badRequestError{err}
 	}
 
-	resultTypes := r.determineResultTypes(args, "")
+	resultTypes := r.determineResultTypes(args, 0)
 	tr.LazyPrintf("resultTypes: %v", resultTypes)
 
-	if len(resultTypes) != 1 || resultTypes[0] != "file" {
+	if resultTypes != searchresult.Types(searchresult.TypeFile) {
 		return nil, fmt.Errorf("experimental paginated search currently only supports 'file' (text match) result types. Found %q", resultTypes)
 	}
 

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -160,10 +160,10 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return nil, &badRequestError{err}
 	}
 
-	resultTypes := r.determineResultTypes(args, 0)
+	resultTypes := r.determineResultTypes(args, searchresult.TypeEmpty)
 	tr.LazyPrintf("resultTypes: %v", resultTypes)
 
-	if resultTypes != searchresult.Types(searchresult.TypeFile) {
+	if resultTypes != searchresult.TypeFile {
 		return nil, fmt.Errorf("experimental paginated search currently only supports 'file' (text match) result types. Found %q", resultTypes)
 	}
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -37,6 +37,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
@@ -964,7 +965,7 @@ func searchResultsToRepoNodes(srs []SearchResultResolver) ([]query.Node, error) 
 // query with a longer timeout.
 func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
-	rr, err := r.doResults(ctx, "")
+	rr, err := r.doResults(ctx, result.Types(0))
 
 	// If we encountered a context timeout, it indicates one of the many result
 	// type searchers (file, diff, symbol, etc) completely timed out and could not
@@ -1137,7 +1138,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		v, err = r.doResults(ctx, "")
+		v, err = r.doResults(ctx, result.Types(0))
 		if err != nil {
 			return nil, err // do not cache errors.
 		}
@@ -1414,24 +1415,31 @@ func (r *searchResolver) withTimeout(ctx context.Context) (context.Context, cont
 	return ctx, cancel, nil
 }
 
-func (r *searchResolver) determineResultTypes(args search.TextParameters, forceOnlyResultType string) (resultTypes []string) {
+func (r *searchResolver) determineResultTypes(args search.TextParameters, forceTypes result.Types) result.Types {
 	// Determine which types of results to return.
-	if forceOnlyResultType != "" {
-		resultTypes = []string{forceOnlyResultType}
+	var rts result.Types
+	if forceTypes != 0 {
+		rts = forceTypes
 	} else {
-		resultTypes, _ = r.Query.StringValues(query.FieldType)
-		if len(resultTypes) == 0 {
-			resultTypes = []string{"file", "path", "repo"}
+		stringTypes, _ := r.Query.StringValues(query.FieldType)
+		if len(stringTypes) == 0 {
+			rts = result.Types(result.TypeFile | result.TypePath | result.TypeRepo)
+		} else {
+			for _, stringType := range stringTypes {
+				rts = rts.With(result.TypeFromString[stringType])
+			}
 		}
 	}
-	for _, resultType := range resultTypes {
-		if resultType == "file" {
-			args.PatternInfo.PatternMatchesContent = true
-		} else if resultType == "path" {
-			args.PatternInfo.PatternMatchesPath = true
-		}
+
+	if rts.Has(result.TypeFile) {
+		args.PatternInfo.PatternMatchesContent = true
 	}
-	return resultTypes
+
+	if rts.Has(result.TypePath) {
+		args.PatternInfo.PatternMatchesPath = true
+	}
+
+	return rts
 }
 
 func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (resolved searchrepos.Resolved, res *SearchResultsResolver, err error) {
@@ -1694,7 +1702,7 @@ func (r *searchResolver) isGlobalSearch() bool {
 // regardless of what `type:` is specified in the query string.
 //
 // Partial results AND an error may be returned.
-func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType string) (_ *SearchResultsResolver, err error) {
+func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.Types) (_ *SearchResultsResolver, err error) {
 	tr, ctx := trace.New(ctx, "doResults", r.rawQuery())
 	defer func() {
 		tr.SetError(err)
@@ -1714,7 +1722,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	options.fileMatchLimit = int32(limit)
 	if r.PatternType == query.SearchTypeStructural {
 		options = &getPatternInfoOptions{performStructuralSearch: true}
-		forceOnlyResultType = "file"
+		forceResultTypes = result.Types(result.TypeFile)
 	}
 	if r.PatternType == query.SearchTypeLiteral {
 		options = &getPatternInfoOptions{performLiteralSearch: true}
@@ -1729,7 +1737,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	if r.PatternType == query.SearchTypeStructural && p.Pattern == "" {
 		r.PatternType = query.SearchTypeLiteral
 		p.IsStructuralPat = false
-		forceOnlyResultType = ""
+		forceResultTypes = result.Types(0)
 	}
 
 	args := search.TextParameters{
@@ -1747,12 +1755,11 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		return nil, &badRequestError{err}
 	}
 
-	resultTypes := r.determineResultTypes(args, forceOnlyResultType)
-	tr.LazyPrintf("resultTypes: %v", resultTypes)
+	resultTypes := r.determineResultTypes(args, forceResultTypes)
+	tr.LazyPrintf("resultTypes: %s", resultTypes)
 	var (
-		requiredWg      sync.WaitGroup
-		optionalWg      sync.WaitGroup
-		seenResultTypes = make(map[string]struct{})
+		requiredWg sync.WaitGroup
+		optionalWg sync.WaitGroup
 	)
 
 	waitGroup := func(required bool) *sync.WaitGroup {
@@ -1791,20 +1798,12 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 		_, _, _, _ = agg.get()
 	}()
 
-	isFileOrPath := func() bool {
-		for _, rt := range resultTypes {
-			if rt == "file" || rt == "path" {
-				return true
-			}
-		}
-		return false
-	}
-
+	isFileOrPath := resultTypes.Has(result.TypeFile) || resultTypes.Has(result.TypePath)
 	isIndexedSearch := args.PatternInfo.Index != query.No
 
 	// performance optimization: call zoekt early, resolve repos concurrently, filter
 	// search results with resolved repos.
-	if r.isGlobalSearch() && isIndexedSearch && isFileOrPath() {
+	if r.isGlobalSearch() && isIndexedSearch && isFileOrPath {
 		argsIndexed := args
 		argsIndexed.Mode = search.ZoektGlobalSearch
 		wg := waitGroup(true)
@@ -1855,55 +1854,53 @@ func (r *searchResolver) doResults(ctx context.Context, forceOnlyResultType stri
 	// results before the above reporting.
 	args.RepoPromise.Resolve(resolved.RepoRevs)
 
-	searchedFileContentsOrPaths := false
-	for _, resultType := range resultTypes {
-		resultType := resultType // shadow so it doesn't change in the goroutine
-		if _, seen := seenResultTypes[resultType]; seen {
-			continue
-		}
-		seenResultTypes[resultType] = struct{}{}
-		switch resultType {
-		case "repo":
-			wg := waitGroup(true)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-				_ = agg.doRepoSearch(ctx, &args, int32(limit))
-			})
-		case "symbol":
-			wg := waitGroup(len(resultTypes) == 1)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-				_ = agg.doSymbolSearch(ctx, &args, limit)
-			})
-		case "file", "path":
-			if searchedFileContentsOrPaths || args.Mode == search.NoFilePath {
-				// type:file and type:path use same searchFilesInRepos, so don't call 2x.
-				continue
-			}
-			searchedFileContentsOrPaths = true
+	if resultTypes.Has(result.TypeRepo) {
+		wg := waitGroup(true)
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+			_ = agg.doRepoSearch(ctx, &args, int32(limit))
+		})
+
+	}
+
+	if resultTypes.Has(result.TypeSymbol) {
+		wg := waitGroup(resultTypes.Without(result.TypeSymbol) == 0)
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+			_ = agg.doSymbolSearch(ctx, &args, limit)
+		})
+	}
+
+	if resultTypes.Has(result.TypeFile) || resultTypes.Has(result.TypePath) {
+		if args.Mode != search.NoFilePath {
 			wg := waitGroup(true)
 			wg.Add(1)
 			goroutine.Go(func() {
 				defer wg.Done()
 				_ = agg.doFilePathSearch(ctx, &args)
 			})
-		case "diff":
-			wg := waitGroup(len(resultTypes) == 1)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-				_ = agg.doDiffSearch(ctx, &args)
-			})
-		case "commit":
-			wg := waitGroup(len(resultTypes) == 1)
-			wg.Add(1)
-			goroutine.Go(func() {
-				defer wg.Done()
-				_ = agg.doCommitSearch(ctx, &args)
-			})
 		}
+	}
+
+	if resultTypes.Has(result.TypeDiff) {
+		wg := waitGroup(resultTypes.Without(result.TypeDiff) == 0)
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+			_ = agg.doDiffSearch(ctx, &args)
+		})
+	}
+
+	if resultTypes.Has(result.TypeCommit) {
+		wg := waitGroup(resultTypes.Without(result.TypeCommit) == 0)
+		wg.Add(1)
+		goroutine.Go(func() {
+			defer wg.Done()
+			_ = agg.doCommitSearch(ctx, &args)
+		})
+
 	}
 
 	hasStartedAllBackends = true

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1873,7 +1873,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 		})
 	}
 
-	if resultTypes.Has(result.TypeFile) || resultTypes.Has(result.TypePath) {
+	if resultTypes.Has(result.TypeFile | result.TypePath) {
 		if args.Mode != search.NoFilePath {
 			wg := waitGroup(true)
 			wg.Add(1)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -965,7 +965,7 @@ func searchResultsToRepoNodes(srs []SearchResultResolver) ([]query.Node, error) 
 // query with a longer timeout.
 func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*SearchResultsResolver, error) {
 	start := time.Now()
-	rr, err := r.doResults(ctx, result.Types(0))
+	rr, err := r.doResults(ctx, result.TypeEmpty)
 
 	// If we encountered a context timeout, it indicates one of the many result
 	// type searchers (file, diff, symbol, etc) completely timed out and could not
@@ -1138,7 +1138,7 @@ func (r *searchResolver) Stats(ctx context.Context) (stats *searchResultsStats, 
 	for {
 		// Query search results.
 		var err error
-		v, err = r.doResults(ctx, result.Types(0))
+		v, err = r.doResults(ctx, result.TypeEmpty)
 		if err != nil {
 			return nil, err // do not cache errors.
 		}
@@ -1423,7 +1423,7 @@ func (r *searchResolver) determineResultTypes(args search.TextParameters, forceT
 	} else {
 		stringTypes, _ := r.Query.StringValues(query.FieldType)
 		if len(stringTypes) == 0 {
-			rts = result.Types(result.TypeFile | result.TypePath | result.TypeRepo)
+			rts = result.TypeFile | result.TypePath | result.TypeRepo
 		} else {
 			for _, stringType := range stringTypes {
 				rts = rts.With(result.TypeFromString[stringType])
@@ -1722,7 +1722,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 	options.fileMatchLimit = int32(limit)
 	if r.PatternType == query.SearchTypeStructural {
 		options = &getPatternInfoOptions{performStructuralSearch: true}
-		forceResultTypes = result.Types(result.TypeFile)
+		forceResultTypes = result.TypeFile
 	}
 	if r.PatternType == query.SearchTypeLiteral {
 		options = &getPatternInfoOptions{performLiteralSearch: true}

--- a/cmd/frontend/graphqlbackend/search_results_stats.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats.go
@@ -2,11 +2,13 @@ package graphqlbackend
 
 import (
 	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		srs.srs, srs.srsErr = srs.sr.doResults(ctx, "")
+		srs.srs, srs.srsErr = srs.sr.doResults(ctx, result.Types(0))
 	})
 	return srs.srs, srs.srsErr
 }

--- a/cmd/frontend/graphqlbackend/search_results_stats.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats.go
@@ -8,7 +8,7 @@ import (
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		srs.srs, srs.srsErr = srs.sr.doResults(ctx, result.Types(0))
+		srs.srs, srs.srsErr = srs.sr.doResults(ctx, result.TypeEmpty)
 	})
 	return srs.srs, srs.srsErr
 }

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -428,7 +428,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
 		if len(r.Query.Values(query.FieldDefault)) > 0 {
-			results, err := r.doResults(ctx, result.Types(result.TypeFile)) // only "file" result type
+			results, err := r.doResults(ctx, result.TypeFile) // only "file" result type
 			if err == context.DeadlineExceeded {
 				err = nil // don't log as error below
 			}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gituri"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 )
 
 const maxSearchSuggestions = 100
@@ -427,7 +428,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 		defer cancel()
 		if len(r.Query.Values(query.FieldDefault)) > 0 {
-			results, err := r.doResults(ctx, "file") // only "file" result type
+			results, err := r.doResults(ctx, result.Types(result.TypeFile)) // only "file" result type
 			if err == context.DeadlineExceeded {
 				err = nil // don't log as error below
 			}

--- a/internal/search/result/result_type.go
+++ b/internal/search/result/result_type.go
@@ -3,7 +3,7 @@ package result
 import "strings"
 
 // Type represents a single, named result type.
-type Type uint32
+type Type uint8
 
 const (
 	TypeRepo Type = 1 << iota

--- a/internal/search/result/result_type.go
+++ b/internal/search/result/result_type.go
@@ -2,11 +2,16 @@ package result
 
 import "strings"
 
-// Type represents a single, named result type.
-type Type uint8
+// Types represents a set of result types.
+// It's a bitset corresponding to the disjunction of types it represents.
+//
+// For example, the set of file and repo results
+// is represented as Types(TypeFile|TypeRepo)
+type Types uint8
 
 const (
-	TypeRepo Type = 1 << iota
+	TypeEmpty Types = 0
+	TypeRepo  Types = 1 << (iota - 1)
 	TypeSymbol
 	TypeFile
 	TypePath
@@ -14,25 +19,7 @@ const (
 	TypeCommit
 )
 
-func (r Type) String() string {
-	switch r {
-	case TypeRepo:
-		return "repo"
-	case TypeSymbol:
-		return "symbol"
-	case TypeFile:
-		return "file"
-	case TypePath:
-		return "path"
-	case TypeDiff:
-		return "diff"
-	case TypeCommit:
-		return "commit"
-	}
-	return ""
-}
-
-var TypeFromString = map[string]Type{
+var TypeFromString = map[string]Types{
 	"repo":   TypeRepo,
 	"symbol": TypeSymbol,
 	"file":   TypeFile,
@@ -41,29 +28,22 @@ var TypeFromString = map[string]Type{
 	"commit": TypeCommit,
 }
 
-// Types represents a set of result types.
-// It's a bitset corresponding to the disjunction of types it represents.
-//
-// For example, the set of file and repo results
-// is represented as Types(TypeFile|TypeRepo)
-type Types uint32
-
-func (r Types) Has(t Type) bool {
-	return r&Types(t) != 0
+func (r Types) Has(t Types) bool {
+	return r&t != 0
 }
 
-func (r Types) With(t Type) Types {
-	return r | Types(t)
+func (r Types) With(t Types) Types {
+	return r | t
 }
 
-func (r Types) Without(t Type) Types {
-	return r &^ Types(t)
+func (r Types) Without(t Types) Types {
+	return r &^ t
 }
 
 func (r Types) String() string {
 	var s strings.Builder
 	first := true
-	for _, t := range []Type{TypeRepo, TypeSymbol, TypePath, TypeDiff, TypeCommit} {
+	for name, t := range TypeFromString {
 		if !r.Has(t) {
 			continue
 		}
@@ -71,7 +51,7 @@ func (r Types) String() string {
 			s.WriteByte('|')
 			first = false
 		}
-		s.WriteString(t.String())
+		s.WriteString(name)
 	}
 	return s.String()
 }

--- a/internal/search/result/result_type.go
+++ b/internal/search/result/result_type.go
@@ -1,0 +1,77 @@
+package result
+
+import "strings"
+
+// Type represents a single, named result type.
+type Type uint32
+
+const (
+	TypeRepo Type = 1 << iota
+	TypeSymbol
+	TypeFile
+	TypePath
+	TypeDiff
+	TypeCommit
+)
+
+func (r Type) String() string {
+	switch r {
+	case TypeRepo:
+		return "repo"
+	case TypeSymbol:
+		return "symbol"
+	case TypeFile:
+		return "file"
+	case TypePath:
+		return "path"
+	case TypeDiff:
+		return "diff"
+	case TypeCommit:
+		return "commit"
+	}
+	return ""
+}
+
+var TypeFromString = map[string]Type{
+	"repo":   TypeRepo,
+	"symbol": TypeSymbol,
+	"file":   TypeFile,
+	"path":   TypePath,
+	"diff":   TypeDiff,
+	"commit": TypeCommit,
+}
+
+// Types represents a set of result types.
+// It's a bitset corresponding to the disjunction of types it represents.
+//
+// For example, the set of file and repo results
+// is represented as Types(TypeFile|TypeRepo)
+type Types uint32
+
+func (r Types) Has(t Type) bool {
+	return r&Types(t) != 0
+}
+
+func (r Types) With(t Type) Types {
+	return r | Types(t)
+}
+
+func (r Types) Without(t Type) Types {
+	return r &^ Types(t)
+}
+
+func (r Types) String() string {
+	var s strings.Builder
+	first := true
+	for _, t := range []Type{TypeRepo, TypeSymbol, TypePath, TypeDiff, TypeCommit} {
+		if !r.Has(t) {
+			continue
+		}
+		if !first {
+			s.WriteByte('|')
+			first = false
+		}
+		s.WriteString(t.String())
+	}
+	return s.String()
+}


### PR DESCRIPTION
In many places, we are using `[]string` to represent the set of result
types to be returned. This is a poor representation because it is
difficult to test membership, does not guarantee uniqueness of the
members, and uses way more memory than necessary. Instead, we can use a
bitset, which makes our code more simple and more type-safe.

There are more places where we use string literals, but this was the
place where it caused the most complexity. I'll continue to work on those
in followup PRs. Once we have a well-defined base query, we should have 
the result types be a member on that rather than being generated from strings.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
