### PR TITLE
web: support repos without default branch

### DIFF
--- a/client/web/src/repo/backend.ts
+++ b/client/web/src/repo/backend.ts
@@ -152,12 +152,15 @@ export const resolveRevision = memoizeObservable(
                 if (!data.repositoryRedirect.commit) {
                     throw new RevisionNotFoundError(revision)
                 }
-                if (!data.repositoryRedirect.defaultBranch || !data.repositoryRedirect.commit.tree) {
-                    throw new RevisionNotFoundError('HEAD')
+
+                const defaultBranch = data.repositoryRedirect.defaultBranch?.abbrevName || 'HEAD'
+
+                if (!data.repositoryRedirect.commit.tree) {
+                    throw new RevisionNotFoundError(defaultBranch)
                 }
                 return {
                     commitID: data.repositoryRedirect.commit.oid,
-                    defaultBranch: data.repositoryRedirect.defaultBranch.abbrevName,
+                    defaultBranch,
                     rootTreeURL: data.repositoryRedirect.commit.tree.url,
                 }
             })


### PR DESCRIPTION
Fix #9651.

We previously assumed that a repository must have a default branch. However, Phabricator [staging areas](https://secure.phabricator.com/book/phabricator/article/harbormaster/) do not require a default branch, which breaks "Go to definition" and "Find references" functionality for the Phabricator native integration/browser extension.

**Fix:** Don't throw `RevisionNotFoundError` when no default branch is found, rather only when no Git tree is found. Fallback to `'HEAD'` when default branch isn't found. I believe this isn't risky since we [already do this throughout the web app](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eclient/web/src/+HEAD+lang:ts&patternType=literal&case=yes)

### Before

![Screenshot from 2021-03-17 14-33-07](https://user-images.githubusercontent.com/37420160/111522056-40300180-8730-11eb-9b54-a05bdc7a5864.png)


### After

![Screenshot from 2021-03-17 14-51-46](https://user-images.githubusercontent.com/37420160/111522127-52aa3b00-8730-11eb-9430-e25333c4983b.png)

![Screenshot from 2021-03-17 14-36-27](https://user-images.githubusercontent.com/37420160/111522081-44f4b580-8730-11eb-972f-d4cabbc9f8c7.png)