### PR TITLE
search: Reduce allocations in getRevsForMatchedRepo

### DIFF
--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -512,18 +512,15 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 	// if two repo specs match, and both provided non-empty rev lists,
 	// we want their intersection
 	allowedRevs := make(map[search.RevisionSpecifier]struct{}, len(revLists[0]))
-	allRevs := make(map[search.RevisionSpecifier]struct{}, len(revLists[0]))
 	// starting point: everything is "true" if it is currently allowed
 	for _, rev := range revLists[0] {
 		allowedRevs[rev] = struct{}{}
-		allRevs[rev] = struct{}{}
 	}
 	// in theory, "master-by-default" entries won't even be participating
 	// in this.
 	for _, revList := range revLists[1:] {
 		restrictedRevs := make(map[search.RevisionSpecifier]struct{}, len(revList))
 		for _, rev := range revList {
-			allRevs[rev] = struct{}{}
 			if _, ok := allowedRevs[rev]; ok {
 				restrictedRevs[rev] = struct{}{}
 			}
@@ -538,8 +535,15 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 		sort.Slice(matched, func(i, j int) bool { return matched[i].Less(matched[j]) })
 		return
 	}
+
 	// build a list of the revspecs which broke this, return it
 	// as the "clashing" list.
+	allRevs := make(map[search.RevisionSpecifier]struct{}, len(revLists[0]))
+	for _, revList := range revLists {
+		for _, rev := range revList {
+			allRevs[rev] = struct{}{}
+		}
+	}
 	clashing = make([]search.RevisionSpecifier, 0, len(allRevs))
 	for rev := range allRevs {
 		clashing = append(clashing, rev)

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -521,8 +521,8 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 		for _, rev := range revList {
 			if revCounts[rev] == i {
 				aliveCount += 1
-				revCounts[rev] += 1
 			}
+			revCounts[rev] += 1
 		}
 	}
 

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -519,10 +519,9 @@ func getRevsForMatchedRepo(repo api.RepoName, pats []patternRevspec) (matched []
 	for i, revList := range revLists {
 		aliveCount = 0
 		for _, rev := range revList {
-			seenCount := revCounts[rev]
-			if seenCount == i {
+			if revCounts[rev] == i {
 				aliveCount += 1
-				revCounts[rev] = seenCount + 1
+				revCounts[rev] += 1
 			}
 		}
 	}

--- a/cmd/frontend/internal/search/repos/repos_test.go
+++ b/cmd/frontend/internal/search/repos/repos_test.go
@@ -296,6 +296,23 @@ func TestSearchRevspecs(t *testing.T) {
 	}
 }
 
+func BenchmarkGetRevsForMatchedRepo(b *testing.B) {
+	b.Run("2 conflicting", func(b *testing.B) {
+		pats, _ := findPatternRevs([]string{".*o@123456", "foo@234567"})
+		for i := 0; i < b.N; i++ {
+			_, _ = getRevsForMatchedRepo("foo", pats)
+		}
+	})
+
+	b.Run("multiple overlapping", func(b *testing.B) {
+		pats, _ := findPatternRevs([]string{".*o@a:b:c:d", "foo@b:c:d:e", "foo@c:d:e:f"})
+		for i := 0; i < b.N; i++ {
+			_, _ = getRevsForMatchedRepo("foo", pats)
+		}
+	})
+}
+
+
 func TestDefaultRepositories(t *testing.T) {
 	tcs := []struct {
 		name             string

--- a/cmd/frontend/internal/search/repos/repos_test.go
+++ b/cmd/frontend/internal/search/repos/repos_test.go
@@ -312,7 +312,6 @@ func BenchmarkGetRevsForMatchedRepo(b *testing.B) {
 	})
 }
 
-
 func TestDefaultRepositories(t *testing.T) {
 	tcs := []struct {
 		name             string


### PR DESCRIPTION
~1.5% of our total [allocation count](https://console.cloud.google.com/profiler;timespan=1d/frontend;type=HEAP_ALLOC/alloc_objects;focus=github.com%2Fsourcegraph%2Fsourcegraph%2Fcmd%2Ffrontend%2Finternal%2Fsearch%2Frepos.getRevsForMatchedRepo?project=sourcegraph-dev) and 0.8% of our [allocated bytes](https://console.cloud.google.com/profiler;timespan=1d/frontend;type=HEAP_ALLOC/alloc_space;focus=github.com%2Fsourcegraph%2Fsourcegraph%2Fcmd%2Ffrontend%2Finternal%2Fsearch%2Frepos.getRevsForMatchedRepo?project=sourcegraph-dev) is coming from this function, and there were a couple of fairly easy changes that can reduce the amount of allocation this function does. 

Before:
```
❯ go test -bench GetRevs -run XXX ./cmd/frontend/internal/search/repos -benchmem
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkGetRevsForMatchedRepo/2_conflicting-16                  1522255               826.2 ns/op           314 B/op          6 allocs/op
BenchmarkGetRevsForMatchedRepo/multiple_overlapping-16            776492              1680 ns/op            1232 B/op          9 allocs/op
PASS
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos   3.796s
```

After:
```
❯ go test -bench GetRevs -run XXX ./cmd/frontend/internal/search/repos -benchmem
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkGetRevsForMatchedRepo/2_conflicting-16                  1303059               953.1 ns/op           265 B/op          5 allocs/op
BenchmarkGetRevsForMatchedRepo/multiple_overlapping-16            836583              1619 ns/op             298 B/op          5 allocs/op
PASS
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos   3.973s
```

After Stefan's suggestion:
```
❯ go test -bench GetRevs -run XXX ./cmd/frontend/internal/search/repos -benchmem
goos: darwin
goarch: amd64
pkg: github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkGetRevsForMatchedRepo/2_conflicting-16                  2432112               479.0 ns/op           120 B/op          3 allocs/op
BenchmarkGetRevsForMatchedRepo/multiple_overlapping-16            939200              1270 ns/op             395 B/op          5 allocs/op
PASS
ok      github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos   3.939s
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
