### PR TITLE
Fix anchor alignment on firefox

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -533,12 +533,6 @@ body > #page > main > #content {
   z-index: 1;
   font-size: 16px;
 }
-/* Firefox fix for misaligned hash link. Prevents hash marks for links from being under the content on Firefox. */
-@-moz-document url-prefix() {
-    .markdown-body .anchor::before {
-        top: -26px;
-    }
-}
 .markdown-body .anchor:focus {
   outline: none;
 }


### PR DESCRIPTION
The removed section of code is causing misalignment of the anchor hash in the latest version of firefox. 

Firefox:
<img width="623" alt="Screen Shot 2021-03-17 at 17 50 28" src="https://user-images.githubusercontent.com/12631702/111553269-9cebe600-8749-11eb-9382-03c90feb8757.png">

Chrome:
<img width="500" alt="Screen Shot 2021-03-17 at 17 51 08" src="https://user-images.githubusercontent.com/12631702/111553276-a1180380-8749-11eb-8c71-85e4dbf113fa.png">

Firefox with this change:
<img width="432" alt="Screen Shot 2021-03-17 at 17 51 20" src="https://user-images.githubusercontent.com/12631702/111553291-ab3a0200-8749-11eb-8eac-3888bdf2e1ea.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
