### PR TITLE
search frontend: add setting to toggle case sensitivity on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ All notable changes to Sourcegraph are documented in this file.
 - `*.pyst` and `*.pyst-include` are now highlighted as Python files. Thanks to @jjwon0 [#19282](https://github.com/sourcegraph/sourcegraph/pull/19282)
 - The code monitoring feature flag is now enabled by default. [#19295](https://github.com/sourcegraph/sourcegraph/pull/19295)
 - New query field `select` enables returning only results of the desired type. See [documentation](https://docs.sourcegraph.com/code_search/reference/language#select) for details. [#19236](https://github.com/sourcegraph/sourcegraph/pull/19236)
+- Syntax highlighting for Elixer, Elm, REG, Julia, Move, Nix, Puppet, VimL thanks to @rvantonder
+- `BUILD.in` files are now highlighted as Bazel/Starlark build files. Thanks to @jjwon0
+- `*.pyst` and `*.pyst-include` are now highlighted as Python files. Thanks to @jjwon0
+- Added a `search.defaultCaseSensitive` setting to configure whether query patterns should be treated case sensitivitely by default.
 
 ### Changed
 

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -62,6 +62,7 @@ import { globbingEnabledFromSettings } from './util/globbing'
 import {
     SITE_SUBJECT_NO_ADMIN,
     viewerSubjectFromSettings,
+    defaultCaseSensitiveFromSettings,
     defaultPatternTypeFromSettings,
     experimentalFeaturesFromSettings,
 } from './util/settings'
@@ -311,6 +312,8 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                         authenticatedUser,
                         ...experimentalFeaturesFromSettings(settingsCascade),
                         globbing: globbingEnabledFromSettings(settingsCascade),
+                        searchCaseSensitivity:
+                            defaultCaseSensitiveFromSettings(settingsCascade) || state.searchCaseSensitivity,
                         searchPatternType: defaultPatternTypeFromSettings(settingsCascade) || state.searchPatternType,
                         viewerSubject: viewerSubjectFromSettings(settingsCascade, authenticatedUser),
                     }))

--- a/client/web/src/util/settings.ts
+++ b/client/web/src/util/settings.ts
@@ -44,6 +44,18 @@ export function defaultPatternTypeFromSettings(settingsCascade: SettingsCascadeO
     return
 }
 
+export function defaultCaseSensitiveFromSettings(settingsCascade: SettingsCascadeOrError): boolean {
+    // Analogous to defaultPatternTypeFromSettings, but for case sensitivity.
+    if (!parseSearchURLPatternType(window.location.search)) {
+        const defaultCaseSensitive =
+            settingsCascade.final &&
+            !isErrorLike(settingsCascade.final) &&
+            (settingsCascade.final['search.defaultCaseSensitive'] as boolean)
+        return defaultCaseSensitive || false
+    }
+    return false
+}
+
 export function experimentalFeaturesFromSettings(
     settingsCascade: SettingsCascadeOrError
 ): {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1211,6 +1211,8 @@ type Settings struct {
 	Quicklinks []*QuickLink `json:"quicklinks,omitempty"`
 	// SearchContextLines description: The default number of lines to show as context below and above search results. Default is 1.
 	SearchContextLines int `json:"search.contextLines,omitempty"`
+	// SearchDefaultCaseSensitive description: Whether query patterns are treated case sensitively. Patterns are case insensitive by default.
+	SearchDefaultCaseSensitive bool `json:"search.defaultCaseSensitive,omitempty"`
 	// SearchDefaultPatternType description: The default pattern type (literal or regexp) that search queries will be intepreted as.
 	SearchDefaultPatternType string `json:"search.defaultPatternType,omitempty"`
 	// SearchGlobbing description: Enables globbing for supported field values

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -206,6 +206,11 @@
       "type": "string",
       "pattern": "literal|regexp"
     },
+    "search.defaultCaseSensitive": {
+      "description": "Whether query patterns are treated case sensitively. Patterns are case insensitive by default.",
+      "type": "boolean",
+      "default": false
+    },
     "search.includeForks": {
       "description": "Whether searches should include searching forked repositories.",
       "type": "boolean",

--- a/schema/settings_stringdata.go
+++ b/schema/settings_stringdata.go
@@ -211,6 +211,11 @@ const SettingsSchemaJSON = `{
       "type": "string",
       "pattern": "literal|regexp"
     },
+    "search.defaultCaseSensitive": {
+      "description": "Whether query patterns are treated case sensitively. Patterns are case insensitive by default.",
+      "type": "boolean",
+      "default": false
+    },
     "search.includeForks": {
       "description": "Whether searches should include searching forked repositories.",
       "type": "boolean",


### PR DESCRIPTION
Closes #19232.

@limitedmage I almost got this working exactly right. There's just one issue. When settings are saved, turning on case sensitivity, the toggle triggers as desired. But if, after adding the setting, I then delete it or set it to false, the toggle does not immediately update until I hard refresh. For `search.defaultPatternType`, deleting the setting takes effect immediately. Wondering what small thing I'm missing? Some how the updated [caseSensitive toggle state](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/search/input/toggles/Toggles.tsx#L102-106) isn't propagated forward on-setting-save.

https://user-images.githubusercontent.com/888624/111557319-ab3a0200-8749-11eb-890b-ead2a8d9fd00.mp4

