### PR TITLE
Check props for deep equality in ActionsNavItems

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -90,6 +90,9 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
             </li>
         )
     }, [props.enableCodeMonitoring, props.query, props.patternType, props.location.search])
+
+    const extraContext = useMemo(() => ({ searchQuery: props.query || null }), [props.query])
+
     return (
         <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
             <small className="search-results-info-bar__row">
@@ -99,7 +102,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 <ul className="nav align-items-center justify-content-end">
                     <ActionsNavItems
                         {...props}
-                        extraContext={{ searchQuery: props.query || null }}
+                        extraContext={extraContext}
                         menu={ContributableMenu.SearchResultsToolbar}
                         wrapInList={false}
                         showLoadingSpinnerDuringExecution={true}


### PR DESCRIPTION
Fix #19230, #19243

Regression from #18898, which refactored `<ActionsNavItems>` to a function component. It now requires `extraContext` to be memoized, or else it will refetch actions on every render.

Fix: memoize `extraContext`  in `<SearchResultsInfoBar>`

<details>
<summary>After GIF</summary>
<img src="https://user-images.githubusercontent.com/37420160/111562037-dafa0180-876b-11eb-9041-462a934ba280.gif" />
</details>

Update: prevent this issue from happening in the future by checking for deep equality of `scope` and `extraContext` in `<ActionsNavItems>`. It would be hard to memoize Panel `scope`, but the object is so small and deep equality check is so fast that it shouldn't matter that it runs on each keystroke.

<details>
<summary>Panel GIF</summary>
<img src="https://user-images.githubusercontent.com/37420160/111563870-2661df00-876f-11eb-9e4e-47e2294a1c83.gif" />
</details>
