### PR TITLE
frontend: Avoid ratelimit panic

### DIFF
--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -335,8 +335,10 @@ func extractInt(i interface{}) (int, error) {
 		return int(v), nil
 	case string:
 		return strconv.Atoi(v)
+	case nil:
+		return 0, nil
 	default:
-		return 0, fmt.Errorf("unkown limit type: %T", i)
+		return 0, fmt.Errorf("unknown limit type: %T", i)
 	}
 }
 

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -72,8 +72,9 @@ func serveGraphQL(schema *graphql.Schema, rlw *graphqlbackend.RateLimitWatcher, 
 
 		var cost *graphqlbackend.QueryCost
 		var costErr error
+
+		// Don't attempt to estimate or rate limit a request that has failed validation
 		if len(validationErrs) == 0 {
-			// Don't attempt to estimate an invalid request
 			cost, costErr = graphqlbackend.EstimateQueryCost(params.Query, params.Variables)
 			if costErr != nil {
 				// We send errors to Honeycomb, no need to spam logs
@@ -81,16 +82,16 @@ func serveGraphQL(schema *graphql.Schema, rlw *graphqlbackend.RateLimitWatcher, 
 			}
 			traceData.costError = costErr
 			traceData.cost = cost
-		}
 
-		if rl, enabled := rlw.Get(); enabled && costErr == nil {
-			limited, result, err := rl.RateLimit(uid, isIP, cost.FieldCount)
-			if err != nil {
-				log15.Error("checking GraphQL rate limit", "error", err)
-				traceData.limitError = err
-			} else {
-				traceData.limited = limited
-				traceData.limitResult = result
+			if rl, enabled := rlw.Get(); enabled && cost != nil {
+				limited, result, err := rl.RateLimit(uid, isIP, cost.FieldCount)
+				if err != nil {
+					log15.Error("checking GraphQL rate limit", "error", err)
+					traceData.limitError = err
+				} else {
+					traceData.limited = limited
+					traceData.limitResult = result
+				}
 			}
 		}
 

--- a/cmd/frontend/internal/httpapi/graphql.go
+++ b/cmd/frontend/internal/httpapi/graphql.go
@@ -83,7 +83,7 @@ func serveGraphQL(schema *graphql.Schema, rlw *graphqlbackend.RateLimitWatcher, 
 			traceData.cost = cost
 		}
 
-		if rl, enabled := rlw.Get(); enabled {
+		if rl, enabled := rlw.Get(); enabled && costErr == nil {
 			limited, result, err := rl.RateLimit(uid, isIP, cost.FieldCount)
 			if err != nil {
 				log15.Error("checking GraphQL rate limit", "error", err)


### PR DESCRIPTION
We weren't checking whether there was a error calculating cost before
performing rate limiting. This led us to read cost.FieldCount on a nil
cost. Instead, we now only rate limit valid requests.

Also, fixed the source of the cost error in the case that triggered this
by treating nil limits as a limit of zero.
