### PR TITLE
Fix nil-panic on sourcegraph.com in site alerts

### DIFF
--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -235,6 +235,7 @@ func deprecationAlert(args AlertFuncArgs) []*Alert {
 	cv, err := semver.NewVersion(version.Version())
 	if err != nil {
 		log15.Error("cannot determine version", "error", err)
+		return nil
 	}
 
 	if cv.Minor() == 26 && args.IsSiteAdmin {


### PR DESCRIPTION
This fixes the nil-panic introduced by https://github.com/sourcegraph/sourcegraph/commit/682ad7bc03d7d6a813d3a45ce594399ff42758e0 that only shows up on Sourcegraph.com where there's no proper "minor version" configured which is why the `semver` call fails.

Shows up in the browser console as this:

![image](https://user-images.githubusercontent.com/1185253/111597967-03ffae00-87cf-11eb-8115-96c526b2606c.png)

And has a stack trace in the logs: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22sourcegraph-dev%22%0Aresource.labels.location%3D%22us-central1-f%22%0Aresource.labels.cluster_name%3D%22cloud%22%0Aresource.labels.namespace_name%3D%22prod%22%0Alabels.k8s-pod%2Fapp%3D%22sourcegraph-frontend%22%20severity%3E%3DDEFAULT%0Atimestamp%3D%222021-03-18T08:41:28.669421831Z%22%0AinsertId%3D%221bqnyvyg3p2gj1s%22?project=sourcegraph-dev