### PR TITLE
zoekt: fix shard count

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -87,7 +87,7 @@ func (r *repositoryTextSearchIndexStatus) IndexByteSize() int32 {
 }
 
 func (r *repositoryTextSearchIndexStatus) IndexShardsCount() int32 {
-	return int32(r.entry.Stats.Shards + 1)
+	return int32(r.entry.Stats.Shards)
 }
 
 func (r *repositoryTextSearchIndexStatus) NewLinesCount() int32 {

--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210309123010-cafbecb72244
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210318102129-9cd98bfcf6c0
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1287,6 +1287,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20210309123010-cafbecb72244 h1:q8oblDQDroGPmjVbXBRJEatM7jtT+8ehGFFWejDle4s=
 github.com/sourcegraph/zoekt v0.0.0-20210309123010-cafbecb72244/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
+github.com/sourcegraph/zoekt v0.0.0-20210318102129-9cd98bfcf6c0 h1:LQlLk+MGQmVYgGtgHRPUS+to+WQhagOnhSKznwujwYw=
+github.com/sourcegraph/zoekt v0.0.0-20210318102129-9cd98bfcf6c0/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
fixes #19163.

Zoekt didn't report shards correctly. This change updates zoekt and
fixes an off-by-one error in the resolver method `IndexShardsCount`.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
