### PR TITLE
search: Add check to avoid OOB panic

### DIFF
--- a/internal/gqltestutil/search.go
+++ b/internal/gqltestutil/search.go
@@ -542,14 +542,18 @@ func (s *SearchStreamClient) SearchFiles(query string) (*SearchFileResults, erro
 					var r SearchFileResult
 					r.File.Name = v.Path
 					r.Repository.Name = v.Repository
-					r.RevSpec.Expr = v.Branches[0]
+					if len(v.Branches) > 0 {
+						r.RevSpec.Expr = v.Branches[0]
+					}
 					results.Results = append(results.Results, &r)
 
 				case *streamhttp.EventSymbolMatch:
 					var r SearchFileResult
 					r.File.Name = v.Path
 					r.Repository.Name = v.Repository
-					r.RevSpec.Expr = v.Branches[0]
+					if len(v.Branches) > 0 {
+						r.RevSpec.Expr = v.Branches[0]
+					}
 					results.Results = append(results.Results, &r)
 
 				case *streamhttp.EventCommitMatch:


### PR DESCRIPTION
We were seeing an out of bounds panic in Buildkite on this test. I was
unable to reproduce locally without putting a lot of effort into it, but
it was pretty clear from the stacktrace where this was coming from. This
just adds a simple check to avoid accessing into a nil slice.


Failing build:
https://buildkite.com/sourcegraph/sourcegraph/builds/90442#f2782ca9-d3cc-47c8-8f59-2ed1418b8b5d


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
