### PR TITLE
search: move logging from evaluateLeaf to Results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -624,7 +624,7 @@ func pathParentsByFrequency(paths []string) []string {
 // year 1. As a workaround, wrap instantiates start with time.now().
 // TODO(rvantonder): #10801.
 func (a searchAlert) wrap() *SearchResultsResolver {
-	return &SearchResultsResolver{db: a.db, alert: &a, start: time.Now()}
+	return &SearchResultsResolver{db: a.db, alert: &a}
 }
 
 // capFirst capitalizes the first rune in the given string. It can be safely

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -203,7 +203,6 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 
 	return &SearchResultsResolver{
 		db:            r.db,
-		start:         start,
 		Stats:         common,
 		SearchResults: results,
 		alert:         alert,

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -255,27 +255,6 @@ func TestSearchResults(t *testing.T) {
 			t.Error("calledSearchSymbols")
 		}
 	})
-
-	t.Run("test start time is not null when alert thrown", func(t *testing.T) {
-		mockDecodedViewerFinalSettings = &schema.Settings{}
-		defer func() { mockDecodedViewerFinalSettings = nil }()
-
-		for _, v := range searchVersions {
-			r, err := (&schemaResolver{db: db}).Search(context.Background(), &SearchArgs{Query: `repo:*`, Version: v})
-			if err != nil {
-				t.Fatal("Search:", err)
-			}
-
-			results, err := r.Results(context.Background())
-			if err != nil {
-				t.Fatal("Search: ", err)
-			}
-
-			if results.start.IsZero() {
-				t.Error("Start value is not set")
-			}
-		}
-	})
 }
 
 func TestOrderedFuzzyRegexp(t *testing.T) {
@@ -1049,7 +1028,6 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 				SearchResults: tt.fields.results,
 				Stats:         tt.fields.searchResultsCommon,
 				alert:         tt.fields.alert,
-				start:         tt.fields.start,
 			}
 			if got := sr.ApproximateResultCount(); got != tt.want {
 				t.Errorf("searchResultsResolver.ApproximateResultCount() = %v, want %v", got, tt.want)


### PR DESCRIPTION
This moves logging to Prometheus, Honeycomb, and the Ping DB from
`evaluateLeaf` up to `Results`.

Apart from just moving around code I also changed how we keep track of
the elapsed time. I replaced `SearchResultsResolver.start` with
`SearchResultsResolver.elapsed`. The data shouldn't change too much, if
at all, with this change.

I also split up the switch block so that it becomes (hopefully) more
obvious when we can expect `srr` not to be `nil`.
