### PR TITLE
web: add more error boundaries for repo pages

### DIFF
--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -1,5 +1,4 @@
 import * as sentry from '@sentry/browser'
-import classNames from 'classnames'
 import * as H from 'history'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import ReloadIcon from 'mdi-react/ReloadIcon'

--- a/client/web/src/components/ErrorBoundary.tsx
+++ b/client/web/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import * as sentry from '@sentry/browser'
+import classNames from 'classnames'
 import * as H from 'history'
 import ErrorIcon from 'mdi-react/ErrorIcon'
 import ReloadIcon from 'mdi-react/ReloadIcon'
@@ -12,6 +13,16 @@ interface Props {
      * react-router component).
      */
     location: H.Location | null
+
+    /**
+     * Extra context to aid with debugging
+     */
+    extraContext?: JSX.Element
+
+    /**
+     * Classname to pass to <HeroPage>
+     */
+    className?: string
 }
 
 interface State {
@@ -76,6 +87,7 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
                 <HeroPage
                     icon={ErrorIcon}
                     title="Error"
+                    className={this.props.className}
                     subtitle={
                         <div className="container">
                             <p>
@@ -85,6 +97,7 @@ export class ErrorBoundary extends React.PureComponent<Props, State> {
                             <p>
                                 <code className="text-wrap">{this.state.error.message}</code>
                             </p>
+                            {this.props.extraContext}
                         </div>
                     }
                 />

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Redirect, RouteComponentProps } from 'react-router'
 import { getModeFromPath } from '../../../shared/src/languages'
 import { isLegacyFragment, parseHash, toRepoURL } from '../../../shared/src/util/url'
+import { ErrorBoundary } from '../components/ErrorBoundary'
 import { lazyComponent } from '../util/lazyComponent'
 import { formatHash } from '../util/url'
 import { RepoContainerRoute } from './RepoContainer'
@@ -154,20 +155,22 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                     />
                     {!hideRepoRevisionContent && (
                         <div className="repo-revision-container__content">
-                            {objectType === 'blob' ? (
-                                <BlobPage
-                                    {...context}
-                                    {...repoRevisionProps}
-                                    repoID={repo.id}
-                                    repoName={repo.name}
-                                    mode={mode}
-                                    repoHeaderContributionsLifecycleProps={
-                                        context.repoHeaderContributionsLifecycleProps
-                                    }
-                                />
-                            ) : (
-                                <TreePage {...context} {...repoRevisionProps} repo={repo} />
-                            )}
+                            <ErrorBoundary location={context.location}>
+                                {objectType === 'blob' ? (
+                                    <BlobPage
+                                        {...context}
+                                        {...repoRevisionProps}
+                                        repoID={repo.id}
+                                        repoName={repo.name}
+                                        mode={mode}
+                                        repoHeaderContributionsLifecycleProps={
+                                            context.repoHeaderContributionsLifecycleProps
+                                        }
+                                    />
+                                ) : (
+                                    <TreePage {...context} {...repoRevisionProps} repo={repo} />
+                                )}
+                            </ErrorBoundary>
                         </div>
                     )}
                 </>

--- a/client/web/src/repo/tree/ViewGrid.tsx
+++ b/client/web/src/repo/tree/ViewGrid.tsx
@@ -7,6 +7,7 @@ import { ViewContent, ViewContentProps } from '../../views/ViewContent'
 import { WidthProvider, Responsive, Layout as ReactGridLayout, Layouts as ReactGridLayouts } from 'react-grid-layout'
 import { TelemetryProps } from '../../../../shared/src/telemetry/telemetryService'
 import { ViewProviderResult } from '../../../../shared/src/api/extension/extensionHostApi'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 
 // TODO use a method to get width that also triggers when file explorer is closed
 // (WidthProvider only listens to window resize events)
@@ -82,25 +83,36 @@ export const ViewGrid: React.FunctionComponent<ViewGridProps> = props => {
             >
                 {props.views.map(({ id, view }) => (
                     <div key={id} className={classNames('card view-grid__item')}>
-                        {view === undefined ? (
-                            <div className="flex-grow-1 d-flex flex-column align-items-center justify-content-center">
-                                <LoadingSpinner /> Loading code insight
-                            </div>
-                        ) : isErrorLike(view) ? (
-                            <ErrorAlert className="m-0" error={view} />
-                        ) : (
-                            <>
-                                <h3 className="view-grid__view-title">{view.title}</h3>
-                                {view.subtitle && <div className="view-grid__view-subtitle">{view.subtitle}</div>}
-                                <ViewContent
-                                    {...props}
-                                    settingsCascade={props.settingsCascade}
-                                    viewContent={view.content}
-                                    viewID={id}
-                                    containerClassName="view-grid__item"
-                                />
-                            </>
-                        )}
+                        <ErrorBoundary
+                            location={props.location}
+                            extraContext={
+                                <>
+                                    <p>ID: {id}</p>
+                                    <pre>View: {JSON.stringify(view, null, 2)}</pre>
+                                </>
+                            }
+                            className="pt-0"
+                        >
+                            {view === undefined ? (
+                                <div className="flex-grow-1 d-flex flex-column align-items-center justify-content-center">
+                                    <LoadingSpinner /> Loading code insight
+                                </div>
+                            ) : isErrorLike(view) ? (
+                                <ErrorAlert className="m-0" error={view} />
+                            ) : (
+                                <>
+                                    <h3 className="view-grid__view-title">{view.title}</h3>
+                                    {view.subtitle && <div className="view-grid__view-subtitle">{view.subtitle}</div>}
+                                    <ViewContent
+                                        {...props}
+                                        settingsCascade={props.settingsCascade}
+                                        viewContent={view.content}
+                                        viewID={id}
+                                        containerClassName="view-grid__item"
+                                    />
+                                </>
+                            )}
+                        </ErrorBoundary>
                     </div>
                 ))}
             </ResponsiveGridLayout>


### PR DESCRIPTION
(and code insights)

Prevent errors in directory viewers or code editors from making the repo header or file tree inaccessible.

Also modify `<ErrorBoundary>` to allow us to use it more granularly (with classnames to reduce padding) and add extra context to help with debugging. 

Fix #19280. I'm not sure which conditions led to an invalid view making it to `<ViewContent>`. I tried to reproduce by throwing an error in the Codecov extension, but `<ViewContent>` recognized the view as `ErrorLike`. This PR should hopefully prevent breaking repo pages for individual insight errors and provide us with the info necessary to debug extension insight errors.

### Result

#### Insight error

![Screenshot from 2021-03-18 18-41-55](https://user-images.githubusercontent.com/37420160/111707893-464edc80-881b-11eb-88f4-3154ace890ca.png)

#### Directory viewer error

![Screenshot from 2021-03-18 18-00-20](https://user-images.githubusercontent.com/37420160/111707916-4f3fae00-881b-11eb-8db7-ff30fc37e0a6.png)
