### PR TITLE
search: change query partition to return parameter types

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -785,10 +785,10 @@ func (r *searchResolver) evaluate(ctx context.Context, q query.Q) (*SearchResult
 		return alertForQuery("", err).wrap(r.db), nil
 	}
 	if pattern == nil {
-		r.setQuery(scopeParameters)
+		r.setQuery(query.ToNodes(scopeParameters))
 		return r.evaluateLeaf(ctx)
 	}
-	return r.evaluatePatternExpression(ctx, scopeParameters, pattern)
+	return r.evaluatePatternExpression(ctx, query.ToNodes(scopeParameters), pattern)
 }
 
 // invalidateRepoCache returns whether resolved repos should be invalidated when

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -37,19 +37,17 @@ func stringHumanPattern(nodes []Node) string {
 	return strings.Join(result, "")
 }
 
-func stringHumanParameters(nodes []Node) string {
+func stringHumanParameters(parameters []Parameter) string {
 	var result []string
-	for _, node := range nodes {
-		if n, ok := node.(Parameter); ok {
-			v := n.Value
-			if n.Annotation.Labels.isSet(Quoted) {
-				v = strconv.Quote(v)
-			}
-			if n.Negated {
-				return fmt.Sprintf("-%s:%s", n.Field, v)
-			}
-			result = append(result, fmt.Sprintf("%s:%s", n.Field, v))
+	for _, p := range parameters {
+		v := p.Value
+		if p.Annotation.Labels.isSet(Quoted) {
+			v = strconv.Quote(v)
 		}
+		if p.Negated {
+			return fmt.Sprintf("-%s:%s", p.Field, v)
+		}
+		result = append(result, fmt.Sprintf("%s:%s", p.Field, v))
 	}
 	return strings.Join(result, " ")
 }

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -287,6 +287,14 @@ func Globbing(nodes []Node) ([]Node, error) {
 	return nodes, nil
 }
 
+func ToNodes(parameters []Parameter) []Node {
+	nodes := make([]Node, 0, len(parameters))
+	for _, p := range parameters {
+		nodes = append(nodes, p)
+	}
+	return nodes
+}
+
 // Hoist is a heuristic that rewrites simple but possibly ambiguous queries. It
 // changes certain expressions in a way that some consider to be more natural.
 // For example, the following query without parentheses is interpreted as
@@ -317,7 +325,7 @@ func Hoist(nodes []Node) ([]Node, error) {
 
 	n := len(expression.Operands)
 	var pattern []Node
-	var scopeParameters []Node
+	var scopeParameters []Parameter
 	for i, node := range expression.Operands {
 		if i == 0 || i == n-1 {
 			scopePart, patternPart, err := PartitionSearchPattern([]Node{node})
@@ -337,7 +345,7 @@ func Hoist(nodes []Node) ([]Node, error) {
 		annotation.Labels |= HeuristicHoisted
 		return Pattern{Value: value, Negated: negated, Annotation: annotation}
 	})
-	return append(scopeParameters, newOperator(pattern, expression.Kind)...), nil
+	return append(ToNodes(scopeParameters), newOperator(pattern, expression.Kind)...), nil
 }
 
 // partition partitions nodes into left and right groups. A node is put in the

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -107,7 +107,7 @@ func processTopLevel(nodes []Node) ([]Node, error) {
 // search patterns (e.g., to repos, files, etc.). It validates that a query
 // contains at most one search pattern expression and that scope parameters do
 // not contain nested expressions.
-func PartitionSearchPattern(nodes []Node) (parameters []Node, pattern Node, err error) {
+func PartitionSearchPattern(nodes []Node) (parameters []Parameter, pattern Node, err error) {
 	if len(nodes) == 1 {
 		nodes, err = processTopLevel(nodes)
 		if err != nil {

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -259,9 +259,9 @@ func TestPartitionSearchPattern(t *testing.T) {
 				}
 				return
 			}
-			result := scopeParameters
+			result := ToNodes(scopeParameters)
 			if pattern != nil {
-				result = append(scopeParameters, pattern)
+				result = append(result, pattern)
 			}
 			got := toString(result)
 			if diff := cmp.Diff(tt.want, got); diff != "" {


### PR DESCRIPTION
There is an important function `PartitionSearchParameters` that ensures we get a simple, basic query to process. As a prep for defining basic query, I need to change its return signature because this will become the "create" method for a basic query. 


```patch
- func PartitionSearchPattern(nodes []Node) (parameters []Node, pattern Node, err error) {
+ func PartitionSearchPattern(nodes []Node) (parameters []Parameter, pattern Node, err error) 
```

I avoided having this function return a `[]Parameter` type directly because I wanted to avoid the silly conversions to `[]Node` that Go forces me to do. But now, I don't have a choice, because we want to actually distinguish this type going forward. to preserve existing uses that rely on `[]Node` and not `[]Parameter`, I have to introduce a convert--if I try make the change directly right now it will cause far too many issues to update to compile.