### PR TITLE
search: introduce basic query type

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -556,10 +556,10 @@ func intersect(left, right *SearchResultsResolver) *SearchResultsResolver {
 // evaluateAndStream is a wrapper around evaluateAnd which temporarily suspends
 // streaming and waits for evaluateAnd to return before streaming results back on
 // r.resultChannel.
-func (r *searchResolver) evaluateAndStream(ctx context.Context, scopeParameters []query.Node, operands []query.Node) (*SearchResultsResolver, error) {
+func (r *searchResolver) evaluateAndStream(ctx context.Context, q query.Basic) (*SearchResultsResolver, error) {
 	// Streaming disabled.
 	if r.stream == nil {
-		return r.evaluateAnd(ctx, scopeParameters, operands)
+		return r.evaluateAnd(ctx, q)
 	}
 	// For streaming search we rely on batch evaluation of
 	// results. Implementing true streaming on AND expressions will require
@@ -567,7 +567,7 @@ func (r *searchResolver) evaluateAndStream(ctx context.Context, scopeParameters 
 	r2 := *r
 	r2.stream = nil
 
-	result, err := r2.evaluateAnd(ctx, scopeParameters, operands)
+	result, err := r2.evaluateAnd(ctx, q)
 	if err != nil {
 		return nil, err
 	}
@@ -591,12 +591,13 @@ func (r *searchResolver) evaluateAndStream(ctx context.Context, scopeParameters 
 // and likely yields fewer than N results). If the intersection does not yield N
 // results, and is not exhaustive for every expression, we rerun the search by
 // doubling count again.
-func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []query.Node, operands []query.Node) (*SearchResultsResolver, error) {
+func (r *searchResolver) evaluateAnd(ctx context.Context, q query.Basic) (*SearchResultsResolver, error) {
 	start := time.Now()
 
-	if len(operands) == 0 {
-		return &SearchResultsResolver{}, nil
-	}
+	// Invariant: this function is only reachable from callers that
+	// guarantee a root node with one ore more operands.
+	operands := q.Pattern.(query.Operator).Operands
+	scopeParameters := query.ToNodes(q.Parameters)
 
 	var (
 		err        error
@@ -651,7 +652,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 			return query.Parameter{Field: field, Value: value, Negated: negated, Annotation: annotation}
 		})
 
-		result, err = r.evaluatePatternExpression(ctx, scopeParameters, operands[0])
+		result, err = r.evaluatePatternExpression(ctx, q.MapPattern(operands[0]))
 		if err != nil {
 			return nil, err
 		}
@@ -673,7 +674,7 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 			default:
 			}
 
-			termResult, err = r.evaluatePatternExpression(ctx, scopeParameters, term)
+			termResult, err = r.evaluatePatternExpression(ctx, q.MapPattern(term))
 			if err != nil {
 				return nil, err
 			}
@@ -709,19 +710,19 @@ func (r *searchResolver) evaluateAnd(ctx context.Context, scopeParameters []quer
 // expressions that are ORed together by searching for each subexpression. If
 // the maximum number of results are reached after evaluating a subexpression,
 // we shortcircuit and return results immediately.
-func (r *searchResolver) evaluateOr(ctx context.Context, scopeParameters []query.Node, operands []query.Node) (*SearchResultsResolver, error) {
-	if len(operands) == 0 {
-		return &SearchResultsResolver{}, nil
-	}
+func (r *searchResolver) evaluateOr(ctx context.Context, q query.Basic) (*SearchResultsResolver, error) {
+	// Invariant: this function is only reachable from callers that
+	// guarantee a root node with one ore more operands.
+	operands := q.Pattern.(query.Operator).Operands
 
 	wantCount := defaultMaxSearchResults
-	if count := query.Q(scopeParameters).Count(); count != nil {
+	if count := query.Q(query.ToNodes(q.Parameters)).Count(); count != nil {
 		wantCount = *count
 	}
 
 	result := &SearchResultsResolver{}
 	for _, term := range operands {
-		new, err := r.evaluatePatternExpression(ctx, scopeParameters, term)
+		new, err := r.evaluatePatternExpression(ctx, q.MapPattern(term))
 		if err != nil {
 			return nil, err
 		}
@@ -751,8 +752,8 @@ func (r *searchResolver) setQuery(q []query.Node) {
 }
 
 // evaluatePatternExpression evaluates a search pattern containing and/or expressions.
-func (r *searchResolver) evaluatePatternExpression(ctx context.Context, scopeParameters []query.Node, node query.Node) (*SearchResultsResolver, error) {
-	switch term := node.(type) {
+func (r *searchResolver) evaluatePatternExpression(ctx context.Context, q query.Basic) (*SearchResultsResolver, error) {
+	switch term := q.Pattern.(type) {
 	case query.Operator:
 		if len(term.Operands) == 0 {
 			return &SearchResultsResolver{}, nil
@@ -760,35 +761,31 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, scopePar
 
 		switch term.Kind {
 		case query.And:
-			return r.evaluateAndStream(ctx, scopeParameters, term.Operands)
+			return r.evaluateAndStream(ctx, q.MapPattern(query.Operator{Operands: term.Operands, Kind: query.And}))
 		case query.Or:
-			return r.evaluateOr(ctx, scopeParameters, term.Operands)
+			return r.evaluateOr(ctx, q.MapPattern(query.Operator{Operands: term.Operands, Kind: query.Or}))
 		case query.Concat:
-			r.setQuery(append(scopeParameters, term))
+			r.setQuery(q.ToParseTree())
 			return r.evaluateLeaf(ctx)
 		}
 	case query.Pattern:
-		r.setQuery(append(scopeParameters, term))
+		r.setQuery(q.ToParseTree())
 		return r.evaluateLeaf(ctx)
 	case query.Parameter:
 		// evaluatePatternExpression does not process Parameter nodes.
 		return &SearchResultsResolver{}, nil
 	}
 	// Unreachable.
-	return nil, fmt.Errorf("unrecognized type %T in evaluatePatternExpression", node)
+	return nil, fmt.Errorf("unrecognized type %T in evaluatePatternExpression", q.Pattern)
 }
 
 // evaluate evaluates all expressions of a search query.
-func (r *searchResolver) evaluate(ctx context.Context, q query.Q) (*SearchResultsResolver, error) {
-	scopeParameters, pattern, err := query.PartitionSearchPattern(q)
-	if err != nil {
-		return alertForQuery("", err).wrap(r.db), nil
-	}
-	if pattern == nil {
-		r.setQuery(query.ToNodes(scopeParameters))
+func (r *searchResolver) evaluate(ctx context.Context, q query.Basic) (*SearchResultsResolver, error) {
+	if q.Pattern == nil {
+		r.setQuery(query.ToNodes(q.Parameters))
 		return r.evaluateLeaf(ctx)
 	}
-	return r.evaluatePatternExpression(ctx, query.ToNodes(scopeParameters), pattern)
+	return r.evaluatePatternExpression(ctx, q)
 }
 
 // invalidateRepoCache returns whether resolved repos should be invalidated when
@@ -917,7 +914,11 @@ func (r *searchResolver) resultsRecursive(ctx context.Context, plan query.Plan) 
 			defer func() { r.stream = orig }()
 
 			r.invalidateRepoCache = true
-			return r.resultsRecursive(ctx, pred.Plan(q))
+			plan, err := pred.Plan(q)
+			if err != nil {
+				return nil, err
+			}
+			return r.resultsRecursive(ctx, plan)
 		})
 		if err != nil && errors.Is(err, ErrPredicateNoResults) {
 			continue
@@ -1006,10 +1007,10 @@ func (r *searchResolver) resultsWithTimeoutSuggestion(ctx context.Context) (*Sea
 
 // substitutePredicates replaces all the predicates in a query with their expanded form. The predicates
 // are expanded using the doExpand function.
-func substitutePredicates(q query.Q, evaluate func(query.Predicate) (*SearchResultsResolver, error)) (query.Plan, error) {
+func substitutePredicates(q query.Basic, evaluate func(query.Predicate) (*SearchResultsResolver, error)) (query.Plan, error) {
 	var topErr error
 	success := false
-	newQ := query.MapParameter(q, func(field, value string, neg bool, ann query.Annotation) query.Node {
+	newQ := query.MapParameter(q.ToParseTree(), func(field, value string, neg bool, ann query.Annotation) query.Node {
 		orig := query.Parameter{
 			Field:      field,
 			Value:      value,
@@ -1082,7 +1083,11 @@ func substitutePredicates(q query.Q, evaluate func(query.Predicate) (*SearchResu
 	if topErr != nil || !success {
 		return nil, topErr
 	}
-	return query.ToPlan(query.Dnf(newQ)), topErr
+	plan, err := query.ToPlan(query.Dnf(newQ))
+	if err != nil {
+		return nil, err
+	}
+	return plan, nil
 }
 
 var ErrPredicateNoResults = errors.New("no results returned for predicate")
@@ -2054,8 +2059,8 @@ func compareSearchResults(left, right SearchResultResolver, exactFilePatterns ma
 	return arepo < brepo
 }
 
-func selectResults(results []SearchResultResolver, q query.Q) []SearchResultResolver {
-	v, _ := q.StringValue(query.FieldSelect)
+func selectResults(results []SearchResultResolver, q query.Basic) []SearchResultResolver {
+	v, _ := q.ToParseTree().StringValue(query.FieldSelect)
 	if v == "" {
 		return results
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -745,9 +745,9 @@ func (r *searchResolver) evaluatePatternExpression(ctx context.Context, q query.
 
 		switch term.Kind {
 		case query.And:
-			return r.evaluateAndStream(ctx, q.MapPattern(query.Operator{Operands: term.Operands, Kind: query.And}))
+			return r.evaluateAndStream(ctx, q)
 		case query.Or:
-			return r.evaluateOr(ctx, q.MapPattern(query.Operator{Operands: term.Operands, Kind: query.Or}))
+			return r.evaluateOr(ctx, q)
 		case query.Concat:
 			r.setQuery(q.ToParseTree())
 			return r.evaluateLeaf(ctx)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -700,8 +700,8 @@ func (r *searchResolver) evaluateOr(ctx context.Context, q query.Basic) (*Search
 	operands := q.Pattern.(query.Operator).Operands
 
 	wantCount := defaultMaxSearchResults
-	if count := query.Q(query.ToNodes(q.Parameters)).Count(); count != nil {
-		wantCount = *count
+	if count := q.GetCount(); count != "" {
+		wantCount, _ = strconv.Atoi(count) // Invariant: count is already validated
 	}
 
 	result := &SearchResultsResolver{}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1036,27 +1036,6 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 	}
 }
 
-func TestSearchResolver_evaluateWarning(t *testing.T) {
-	db := new(dbtesting.MockDB)
-
-	q, _ := query.ParseRegexp("file:foo or file:bar")
-	wantPrefix := "I'm having trouble understanding that query."
-	got, _ := (&searchResolver{db: db}).evaluate(context.Background(), q)
-	t.Run("warn for unsupported and/or query", func(t *testing.T) {
-		if !strings.HasPrefix(got.alert.description, wantPrefix) {
-			t.Fatalf("got alert description %s, want %s", got.alert.description, wantPrefix)
-		}
-	})
-
-	_, err := query.ParseRegexp("file:foo or or or")
-	gotAlert := alertForQuery("", err)
-	t.Run("warn for unsupported ambiguous and/or query", func(t *testing.T) {
-		if !strings.HasPrefix(gotAlert.description, wantPrefix) {
-			t.Fatalf("got alert description %s, want %s", got.alert.description, wantPrefix)
-		}
-	})
-}
-
 func TestGetExactFilePatterns(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -22,7 +22,7 @@ type Predicate interface {
 
 	// Plan generates a plan of (possibly multiple) queries to execute the
 	// behavior of a predicate in a query Q.
-	Plan(parent Q) Plan
+	Plan(parent Q) (Plan, error)
 }
 
 var DefaultPredicateRegistry = predicateRegistry{
@@ -123,7 +123,7 @@ func (f *RepoContainsPredicate) ParseParams(params string) error {
 
 func (f *RepoContainsPredicate) Field() string { return FieldRepo }
 func (f *RepoContainsPredicate) Name() string  { return "contains" }
-func (f *RepoContainsPredicate) Plan(parent Q) Plan {
+func (f *RepoContainsPredicate) Plan(parent Q) (Plan, error) {
 	nodes := make([]Node, 0, 3)
 	nodes = append(nodes, Parameter{
 		Field: FieldSelect,

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -22,7 +22,7 @@ type Predicate interface {
 
 	// Plan generates a plan of (possibly multiple) queries to execute the
 	// behavior of a predicate in a query Q.
-	Plan(parent Q) (Plan, error)
+	Plan(parent Basic) (Plan, error)
 }
 
 var DefaultPredicateRegistry = predicateRegistry{
@@ -123,7 +123,7 @@ func (f *RepoContainsPredicate) ParseParams(params string) error {
 
 func (f *RepoContainsPredicate) Field() string { return FieldRepo }
 func (f *RepoContainsPredicate) Name() string  { return "contains" }
-func (f *RepoContainsPredicate) Plan(parent Q) (Plan, error) {
+func (f *RepoContainsPredicate) Plan(parent Basic) (Plan, error) {
 	nodes := make([]Node, 0, 3)
 	nodes = append(nodes, Parameter{
 		Field: FieldSelect,
@@ -151,9 +151,9 @@ func (f *RepoContainsPredicate) Plan(parent Q) (Plan, error) {
 }
 
 // nonPredicateRepos returns the repo nodes in a query that aren't predicates
-func nonPredicateRepos(q Q) []Node {
+func nonPredicateRepos(q Basic) []Node {
 	var res []Node
-	VisitField(q, FieldRepo, func(value string, negated bool, ann Annotation) {
+	VisitField(q.ToParseTree(), FieldRepo, func(value string, negated bool, ann Annotation) {
 		if _, _, err := ParseAsPredicate(value); err == nil {
 			// Skip predicates
 			return

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -94,6 +94,11 @@ func (b Basic) ToParseTree() Q {
 	return Q(append(nodes, b.Pattern))
 }
 
+// MapPattern returns a copy of a basic query with the pattern part replaced by pattern.
+func (b Basic) MapPattern(pattern Node) Basic {
+	return Basic{Parameters: b.Parameters, Pattern: pattern}
+}
+
 // A query is a tree of Nodes. We choose the type name Q so that external uses like query.Q do not stutter.
 type Q []Node
 

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -76,8 +76,11 @@ func (p Plan) ToParseTree() Q {
 }
 
 // Basic represents a leaf expression to evaluate in our search engine. A basic
-// query comprises (1) a single search pattern expression and (2) parameters
-// that scope the evaluation of search patterns (e.g., to repos, files, etc.).
+// query comprises:
+//   (1) a single search pattern expression, which may contain
+//       'and' or 'or' operators; and
+//   (2) parameters that scope the evaluation of search
+//       patterns (e.g., to repos, files, etc.).
 type Basic struct {
 	Pattern    Node
 	Parameters []Parameter


### PR DESCRIPTION
Introduces this type, which evaluate now operates on:

```go
// Basic represents a leaf expression to evaluate in our search engine. A basic
// query comprises (1) a single search pattern expression and (2) parameters
// that scope the evaluation of search patterns (e.g., to repos, files, etc.).
type Basic struct {
	Pattern    Node
	Parameters []Parameter
}
```

This lifts processing like query partitioning to Pipeline, which no longer happens in `evaluate*` functions. This generally reduces the amount of logic needed in `search_results.go`.


Note the above type is not the final form for expressing search queries--it's one step towards getting particular about the backend we use. For example, we will do more processing on `Basic` queries in pipeline to produce a query for just fetching repos, versus Zoekt text search, versus symbol search, etc. A `Basic` query represents a computable fallback, if we can't convert it to some backend-particular query.

- Commit 1:  Changes in `internal`: Introduce type and helper functions for converting to `[]Node` where needed, and to preserve functionality.
- Commit 2: Propagates change to `search_results.go`, simplifies it, removes irrelevant test.
- Commit 3: Propagate and simplify `evaluateAnd` logic that relies inspecting/updating query `count`