### PR TITLE
batches: add and parse site configuration for rollout windows

### DIFF
--- a/enterprise/internal/batches/frontend.go
+++ b/enterprise/internal/batches/frontend.go
@@ -6,8 +6,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/enterprise"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/background"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/scheduler/window"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/webhooks"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -16,6 +18,15 @@ import (
 // resolvers for batch changes and sets up webhook handlers for changeset
 // events.
 func InitFrontend(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services) error {
+	// Validate site configuration.
+	conf.ContributeValidator(func(c conf.Unified) (problems conf.Problems) {
+		if _, err := window.NewConfiguration(c.BatchChangesRolloutWindows); err != nil {
+			problems = append(problems, conf.NewSiteProblem(err.Error()))
+		}
+
+		return
+	})
+
 	cstore := store.New(db)
 
 	enterpriseServices.BatchChangesResolver = resolvers.New(cstore)

--- a/enterprise/internal/batches/scheduler/window/config.go
+++ b/enterprise/internal/batches/scheduler/window/config.go
@@ -1,0 +1,247 @@
+package window
+
+import (
+	"math"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// Configuration represents the rollout windows configured on the site.
+type Configuration struct {
+	windows []Window
+}
+
+// NewConfiguration constructs a Configuration based on the given site
+// configuration.
+func NewConfiguration(raw *[]*schema.BatchChangeRolloutWindow) (*Configuration, error) {
+	windows, err := parseConfiguration(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Configuration{windows: windows}, nil
+}
+
+// Estimate attempts to estimate when the given entry in a queue of changesets
+// to be reconciled would be reconciled. nil indicates that there is no
+// reasonable estimate, either because all windows are zero or the estimate is
+// too far in the future to be reliable.
+func (cfg *Configuration) Estimate(now time.Time, n int) *time.Time {
+	if !cfg.HasRolloutWindows() {
+		return &now
+	}
+
+	// Roughly speaking, we iterate over schedules until we reach the one that
+	// would include the given entry. If we hit a week in the future, we'll
+	// bail, because a lot can happen in a week.
+	rem := n
+	at := now
+	until := at.Add(7 * 24 * time.Hour)
+	for at.Before(until) {
+		schedule := cfg.scheduleAt(at)
+
+		// An unlimited schedule means that the reconciliation will happen
+		// immediately at that point the window opens.
+		if schedule.total() == -1 {
+			return &at
+		}
+
+		total := schedule.total()
+		if total == 0 {
+			at = schedule.ValidUntil()
+			continue
+		}
+
+		rem -= total
+		if rem < 0 {
+			// We know how many extra reconciliations will occur within this
+			// schedule, so we can use that calculate what percentage of the way
+			// into the window our target will be reconciled, then we can
+			// multiple the schedule duration by that to get the approximate
+			// time.
+			perc := 1.0 - math.Abs(float64(rem))/float64(total)
+			duration := time.Duration(float64(schedule.ValidUntil().Sub(at)) * perc)
+			at = at.Add(duration)
+			return &at
+		} else if rem == 0 {
+			// Special case: this will be the very last entry to be reconciled.
+			at = schedule.ValidUntil()
+			return &at
+		}
+
+		at = schedule.ValidUntil()
+	}
+
+	return nil
+}
+
+// HasRolloutWindows returns true if one or more windows have been defined.
+func (cfg *Configuration) HasRolloutWindows() bool {
+	return len(cfg.windows) != 0
+}
+
+// Schedule returns the currently active schedule.
+func (cfg *Configuration) Schedule() *Schedule {
+	// If there are no rollout windows, then we return an unlimited schedule and
+	// have the scheduler check back in periodically in case the configuration
+	// updated. Ten minutes is probably safe enough.
+	if !cfg.HasRolloutWindows() {
+		return newSchedule(time.Now(), 10*time.Minute, rate{n: -1})
+	}
+
+	return cfg.scheduleAt(time.Now())
+}
+
+// currentFor returns the current rollout window, if any, and the duration for
+// which that window applies from now. The duration will be nil if the current
+// window applies indefinitely.
+func (cfg *Configuration) currentFor(now time.Time) (*Window, *time.Duration) {
+	// If there are no rollout windows, there's no current window. This should
+	// be checked before entry, but let's at least not panic here.
+	if len(cfg.windows) == 0 {
+		return nil, nil
+	}
+
+	// Find the last matching window that is currently active.
+	index := -1
+	for i := range cfg.windows {
+		if cfg.windows[i].IsOpen(now) {
+			index = i
+		}
+	}
+	if index == -1 {
+		// No matching window, so let's figure out when the next window would
+		// open and return a nil window.
+		var next *time.Time
+		for i := range cfg.windows {
+			at := cfg.windows[i].NextOpenAfter(now)
+			if next == nil || at.Before(*next) {
+				next = &at
+			}
+		}
+
+		// If we never saw a time, that's weird, since this scenario shouldn't
+		// occur if there are windows defined, but let's just say nothing can
+		// happen forever for now.
+		if next == nil {
+			return nil, nil
+		}
+
+		duration := next.Sub(now)
+		return nil, &duration
+	}
+	window := &cfg.windows[index]
+
+	// Calculate when this window closes. This may not be the end time on the
+	// window: if there's a later window that starts before the end time of this
+	// window, that will end up taking precedence.
+	var end *time.Time
+
+	if window.end == nil {
+		// There may still be a weekday restriction, so we should figure that out.
+		if !window.days.all() {
+			start := now.Truncate(24 * time.Hour)
+			for {
+				start = start.Add(24 * time.Hour)
+				if !window.days.includes(start.Weekday()) {
+					start.Add(-1 * time.Second)
+					end = &start
+					break
+				} else if start.After(now.Add(7 * 24 * time.Hour)) {
+					panic("could not find end of a day-limited window in the next week")
+				}
+			}
+		}
+	} else {
+		// We have a concrete end time for this window, so we can set end to
+		// that.
+		windowEnd := time.Date(now.Year(), now.Month(), now.Day(), int(window.end.hour), int(window.end.minute), 0, 0, time.UTC)
+		end = &windowEnd
+	}
+
+	// Now we iterate over the subsequent windows in the configuration and see
+	// if any of them would start before the existing end time, which would make
+	// them active (since they're subsequent). Note that we're using a C style
+	// for loop here instead of slicing: we'd have to check the bounds of the
+	// cfg.windows slice before being able to subslice, and this feels more
+	// readable.
+	for i := index + 1; i < len(cfg.windows); i++ {
+		nextActive := cfg.windows[i].NextOpenAfter(now)
+		if end != nil {
+			if nextActive.Before(*end) {
+				end = &nextActive
+			}
+		} else {
+			end = &nextActive
+		}
+	}
+
+	// If we still don't have an end time, then this window remains open forever
+	// and cannot be overridden. Cool.
+	if end == nil {
+		return window, nil
+	}
+
+	// Otherwise, let's calculate how long we have until this window closes, and
+	// return that.
+	d := end.Sub(now)
+	return window, &d
+}
+
+// scheduleAt constructs a schedule that is valid at the given time. Note that
+// scheduleAt does _not_ check if there are rollout windows configured at all:
+// the caller must do this.
+func (cfg *Configuration) scheduleAt(at time.Time) *Schedule {
+	// Get the window in effect at this time, along with how long it's valid
+	// for.
+	window, validity := cfg.currentFor(at)
+
+	// No window means a zero schedule should be returned until the next window
+	// change.
+	if window == nil {
+		if validity != nil {
+			return newSchedule(at, *validity, rate{n: 0})
+		}
+		// We should always have a validity in this case, but let's be defensive
+		// if we don't for some reason. The scheduler can check back in a
+		// minute.
+		return newSchedule(at, 1*time.Minute, rate{n: 0})
+	}
+
+	// OK, so we have a rollout window. It may or may not have an expiry. If it
+	// doesn't, then let's hand back a day of schedule.
+	if validity == nil {
+		return newSchedule(at, 24*time.Hour, window.rate)
+	}
+
+	// Otherwise, we can provide a schedule that goes right up to the end of the
+	// window, at which point the scheduler can check back in and get the new
+	// schedule.
+	return newSchedule(at, *validity, window.rate)
+}
+
+func parseConfiguration(raw *[]*schema.BatchChangeRolloutWindow) ([]Window, error) {
+	// Ensure we always start with an empty window slice.
+	windows := []Window{}
+
+	// If there's no window configuration, there are no windows, and we can just
+	// return here.
+	if raw == nil {
+		return windows, nil
+	}
+
+	var errs *multierror.Error
+	for i, rawWindow := range *raw {
+		if window, err := parseWindow(rawWindow); err != nil {
+			errs = multierror.Append(errs, errors.Wrapf(err, "window %d", i))
+		} else {
+			windows = append(windows, window)
+		}
+	}
+
+	return windows, errs.ErrorOrNil()
+}

--- a/enterprise/internal/batches/scheduler/window/config_test.go
+++ b/enterprise/internal/batches/scheduler/window/config_test.go
@@ -1,0 +1,422 @@
+package window
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// We have a bunch of tests in here that rely on unexported fields in the window
+// structs. Since we control all of this, we're going to provide a common set of
+// options that will allow that.
+var (
+	cmpAllowUnexported = cmp.AllowUnexported(Window{}, rate{})
+	cmpOptions         = cmp.Options{cmpAllowUnexported}
+)
+
+func timeOfDayPtr(hour, minute int8) *timeOfDay {
+	t := timeOfDayFromParts(hour, minute)
+	return &t
+}
+
+func TestConfiguration_Estimate(t *testing.T) {
+	t.Run("no windows", func(t *testing.T) {
+		cfg := &Configuration{}
+		now := time.Now()
+
+		if have := cfg.Estimate(now, 1000); have == nil {
+			t.Error("unexpected nil estimate")
+		} else if *have != now {
+			t.Errorf("unexpected estimate: have=%v want=%v", *have, now)
+		}
+	})
+
+	t.Run("multiple windows", func(t *testing.T) {
+		// Let's set up a configuration that looks roughly like this:
+		//
+		// |  Mon  |  Tue  |  Wed  |  Thu  |  Fri  |  Sat  |  Sun  |
+		// |-------|-------|-------|-------|-------|-------|-------|
+		// | 10/hr | 20/hr | 10/hr | 0     | 10/hr | 0     | ∞     |
+		makeWindow := func(day time.Weekday, n int) Window {
+			return Window{
+				days: newWeekdaySet(day),
+				rate: rate{n: n, unit: ratePerHour},
+			}
+		}
+		cfg := &Configuration{
+			windows: []Window{
+				makeWindow(time.Monday, 10),
+				makeWindow(time.Tuesday, 20),
+				makeWindow(time.Wednesday, 10),
+				makeWindow(time.Thursday, 0),
+				makeWindow(time.Friday, 10),
+				// Saturday intentionally omitted.
+				makeWindow(time.Sunday, -1),
+			},
+		}
+
+		// For convenience, let's also set up a time at 12:00 each day.
+		var (
+			monday    = time.Date(2021, 4, 5, 12, 0, 0, 0, time.UTC)
+			tuesday   = time.Date(2021, 4, 6, 12, 0, 0, 0, time.UTC)
+			wednesday = time.Date(2021, 4, 7, 12, 0, 0, 0, time.UTC)
+			thursday  = time.Date(2021, 4, 8, 12, 0, 0, 0, time.UTC)
+			friday    = time.Date(2021, 4, 9, 12, 0, 0, 0, time.UTC)
+			saturday  = time.Date(2021, 4, 10, 12, 0, 0, 0, time.UTC)
+			sunday    = time.Date(2021, 4, 11, 12, 0, 0, 0, time.UTC)
+		)
+
+		for name, tc := range map[string]struct {
+			now  time.Time
+			n    int
+			want time.Time
+		}{
+			"right now because the window is unlimited": {
+				now:  sunday,
+				n:    1000,
+				want: sunday,
+			},
+			"right now because n is 0 and a window is open": {
+				now:  monday,
+				n:    0,
+				want: monday,
+			},
+			"not right now, even though n is 0, because nothing is done until tomorrow": {
+				now:  saturday,
+				n:    0,
+				want: sunday.Truncate(24 * time.Hour),
+			},
+			"in an hour": {
+				now:  tuesday,
+				n:    20,
+				want: tuesday.Add(1 * time.Hour),
+			},
+			"at the very end of the day's schedule": {
+				now:  wednesday,
+				n:    120,
+				want: thursday.Truncate(24 * time.Hour),
+			},
+			"the next time we schedule anything, plus an hour": {
+				now:  thursday,
+				n:    10,
+				want: friday.Truncate(24 * time.Hour).Add(1 * time.Hour),
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				have := cfg.Estimate(tc.now, tc.n)
+				if have == nil {
+					t.Error("unexpected nil estimate")
+				} else if diff := time.Duration(math.Abs(float64(have.Sub(tc.want)))); diff > 1*time.Millisecond {
+					// There's some floating point maths involved in the
+					// estimation process, so we'll be happy if this is within a
+					// millisecond (which is still _wildly_ more accurate than
+					// any reasonable expectation).
+					t.Errorf("unexpected estimate: have=%v want=%v", *have, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("nil estimates", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			cfg *Configuration
+			now time.Time
+			n   int
+		}{
+			"all zeroes": {
+				cfg: &Configuration{
+					windows: []Window{
+						{days: newWeekdaySet(), rate: rate{n: 0}},
+					},
+				},
+				now: time.Now(),
+				n:   0,
+			},
+			"more than a week in the future": {
+				cfg: &Configuration{
+					windows: []Window{
+						{days: newWeekdaySet(), rate: rate{n: 1, unit: ratePerHour}},
+					},
+				},
+				now: time.Now(),
+				n:   24*7 + 1,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				if have := tc.cfg.Estimate(tc.now, tc.n); have != nil {
+					t.Errorf("unexpected non-nil estimate: %v", *have)
+				}
+			})
+		}
+	})
+}
+
+func TestConfiguration_Schedule(t *testing.T) {
+	// We have other tests to test the actual implementation of scheduleAt();
+	// this is purely to ensure that we do the special case handling of not
+	// having rollout windows correctly.
+	//
+	// Since we do _not_ control the current time here, any configurations below
+	// must have the same windows across the entire week.
+	for name, tc := range map[string]struct {
+		cfg          *Configuration
+		wantDuration time.Duration
+		wantRate     rate
+	}{
+		"no rollout windows": {
+			cfg: &Configuration{
+				windows: []Window{},
+			},
+			wantDuration: 10 * time.Minute,
+			wantRate:     rate{n: -1},
+		},
+		"rollout windows": {
+			cfg: &Configuration{
+				windows: []Window{
+					{days: newWeekdaySet(), rate: rate{n: 40, unit: ratePerHour}},
+				},
+			},
+			wantDuration: 24 * time.Hour,
+			wantRate:     rate{n: 40, unit: ratePerHour},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			have := tc.cfg.Schedule()
+			if have.duration != tc.wantDuration {
+				t.Errorf("unexpected schedule duration: have=%v want=%v", have.duration, tc.wantDuration)
+			}
+			if have.rate != tc.wantRate {
+				t.Errorf("unexpected schedule rate: have=%v want=%v", have.rate, tc.wantRate)
+			}
+		})
+	}
+}
+
+func TestConfiguration_currentFor(t *testing.T) {
+	// Let's set up some common windows to simplify defining the test cases.
+
+	// The window is always unlimited at zombo.com.
+	zombo := Window{
+		days: newWeekdaySet(),
+		rate: makeUnlimitedRate(),
+	}
+
+	// Restrict to a crawl on Friday afternoons because the ops team is drunk.
+	friday := Window{
+		days:  newWeekdaySet(time.Friday),
+		start: timeOfDayPtr(15, 0),
+		end:   timeOfDayPtr(23, 0),
+		rate:  rate{n: 1, unit: ratePerHour},
+	}
+
+	// Every day we shut down for breakfast. It's the most important meal of the
+	// day!
+	breakfast := Window{
+		days:  newWeekdaySet(),
+		start: timeOfDayPtr(8, 0),
+		end:   timeOfDayPtr(9, 0),
+		rate:  rate{n: 0},
+	}
+
+	// But we might also use coffee to go super fast.
+	coffee := Window{
+		days:  newWeekdaySet(),
+		start: timeOfDayPtr(8, 30),
+		end:   timeOfDayPtr(9, 0),
+		rate:  rate{n: 100, unit: ratePerSecond},
+	}
+
+	// Finally, we have a day of rest, where we have no start or end times, but
+	// a weekday restriction.
+	sunday := Window{
+		days: newWeekdaySet(time.Sunday),
+		rate: rate{n: 0},
+	}
+
+	// And some useful times.
+	thursday0815 := time.Date(2021, 4, 1, 8, 15, 0, 0, time.UTC)
+	friday1900 := time.Date(2021, 4, 2, 19, 0, 0, 0, time.UTC)
+	sunday0600 := time.Date(2021, 4, 4, 6, 0, 0, 0, time.UTC)
+
+	newDuration := func(d time.Duration) *time.Duration { return &d }
+
+	for name, tc := range map[string]struct {
+		cfg          *Configuration
+		when         time.Time
+		wantWindow   *Window
+		wantDuration *time.Duration
+	}{
+		"no windows": {
+			cfg:          &Configuration{},
+			when:         time.Now(),
+			wantWindow:   nil,
+			wantDuration: nil,
+		},
+		"single, unlimited window": {
+			cfg: &Configuration{
+				windows: []Window{zombo},
+			},
+			when:         time.Now(),
+			wantWindow:   &zombo,
+			wantDuration: nil,
+		},
+		"multiple windows, but zombo always wins": {
+			cfg: &Configuration{
+				windows: []Window{friday, zombo},
+			},
+			when:         friday1900,
+			wantWindow:   &zombo,
+			wantDuration: nil,
+		},
+		"multiple windows, but Friday wins": {
+			cfg: &Configuration{
+				windows: []Window{zombo, friday},
+			},
+			when:         friday1900,
+			wantWindow:   &friday,
+			wantDuration: newDuration(4 * time.Hour),
+		},
+		"multiple overlapping windows causing the current window to end early": {
+			cfg: &Configuration{
+				windows: []Window{zombo, breakfast, coffee},
+			},
+			when:         thursday0815,
+			wantWindow:   &breakfast,
+			wantDuration: newDuration(15 * time.Minute),
+		},
+		"duration calculated without an end time in the window": {
+			cfg: &Configuration{
+				windows: []Window{sunday},
+			},
+			when:         sunday0600,
+			wantWindow:   &sunday,
+			wantDuration: newDuration(18 * time.Hour),
+		},
+		"duration calculated without an end time in the window, but with an overlap": {
+			cfg: &Configuration{
+				windows: []Window{zombo, breakfast},
+			},
+			when:         sunday0600,
+			wantWindow:   &zombo,
+			wantDuration: newDuration(2 * time.Hour),
+		},
+		"no current window": {
+			cfg: &Configuration{
+				windows: []Window{breakfast, coffee},
+			},
+			when:       friday1900,
+			wantWindow: nil,
+			// 13 hours because it's 19:00, and the next window is at 08:00 the
+			// next day.
+			wantDuration: newDuration(13 * time.Hour),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			haveWindow, haveDuration := tc.cfg.currentFor(tc.when)
+
+			if tc.wantWindow == nil {
+				if haveWindow != nil {
+					t.Errorf("unexpected non-nil window: have=%v", *haveWindow)
+				}
+			} else if haveWindow == nil {
+				t.Errorf("unexpected nil window: want=%v", *tc.wantWindow)
+			} else if diff := cmp.Diff(*haveWindow, *tc.wantWindow, cmpOptions); diff != "" {
+				t.Errorf("unexpected window (-have +want):\n%s", diff)
+			}
+
+			if tc.wantDuration == nil {
+				if haveDuration != nil {
+					t.Errorf("unexpected non-nil duration: have=%v", *haveDuration)
+				}
+			} else if haveDuration == nil {
+				t.Errorf("unexpected nil duration: want=%v", *tc.wantDuration)
+			} else if *haveDuration != *tc.wantDuration {
+				t.Errorf("unexpected duration: have=%v want=%v", *haveDuration, *tc.wantDuration)
+			}
+		})
+	}
+}
+
+func TestParseConfiguration(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   *[]*schema.BatchChangeRolloutWindow
+			want int
+		}{
+			"one bad window": {
+				in: &[]*schema.BatchChangeRolloutWindow{
+					{Rate: "xx"},
+					{Rate: 0},
+				},
+				want: 1,
+			},
+			"two bad windows, ha ha ha": {
+				in: &[]*schema.BatchChangeRolloutWindow{
+					{Rate: "xx"},
+					{Rate: "yy"},
+				},
+				want: 2,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				if _, err := parseConfiguration(tc.in); err == nil {
+					t.Error("unexpected nil error")
+				} else if have := len(err.(*multierror.Error).Errors); have != tc.want {
+					t.Errorf("unexpected number of errors: have=%d want=%d", have, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   *[]*schema.BatchChangeRolloutWindow
+			want *Configuration
+		}{
+			"nil": {
+				in:   nil,
+				want: &Configuration{windows: []Window{}},
+			},
+			"valid windows": {
+				in: &[]*schema.BatchChangeRolloutWindow{
+					{
+						Rate:  "20/hr",
+						Days:  []string{"monday"},
+						Start: "01:15",
+						End:   "02:30",
+					},
+					{
+						Rate: "2/hr",
+					},
+				},
+				want: &Configuration{
+					windows: []Window{
+						{
+							rate:  rate{n: 20, unit: ratePerHour},
+							days:  newWeekdaySet(time.Monday),
+							start: timeOfDayPtr(1, 15),
+							end:   timeOfDayPtr(2, 30),
+						},
+						{
+							rate: rate{n: 2, unit: ratePerHour},
+							days: newWeekdaySet(),
+						},
+					},
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				if have, err := parseConfiguration(tc.in); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else if diff := cmp.Diff(have, tc.want.windows, cmpOptions); diff != "" {
+					t.Errorf("unexpected configuration (-have +want):\n%s", diff)
+				}
+			})
+		}
+	})
+}

--- a/enterprise/internal/batches/scheduler/window/rate.go
+++ b/enterprise/internal/batches/scheduler/window/rate.go
@@ -1,0 +1,105 @@
+package window
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type rate struct {
+	n    int
+	unit rateUnit
+}
+
+func makeUnlimitedRate() rate {
+	return rate{n: -1}
+}
+
+func (r rate) IsUnlimited() bool {
+	return r.n == -1
+}
+
+type rateUnit int
+
+const (
+	ratePerSecond = iota
+	ratePerMinute
+	ratePerHour
+)
+
+func (ru rateUnit) AsDuration() time.Duration {
+	switch ru {
+	case ratePerSecond:
+		return time.Second
+	case ratePerMinute:
+		return time.Minute
+	case ratePerHour:
+		return time.Hour
+	default:
+		panic(fmt.Sprintf("invalid rateUnit value: %v", ru))
+	}
+}
+
+func parseRateUnit(raw string) (rateUnit, error) {
+	// We're not going to replicate the full schema validation regex here; we'll
+	// assume that the conf package did that satisfactorily and just parse what
+	// we need to, ensuring we can't panic.
+	if raw == "" {
+		return ratePerSecond, errors.Errorf("malformed unit: %q", raw)
+	}
+
+	switch raw[0] {
+	case 's', 'S':
+		return ratePerSecond, nil
+	case 'm', 'M':
+		return ratePerMinute, nil
+	case 'h', 'H':
+		return ratePerHour, nil
+	default:
+		return ratePerSecond, errors.Errorf("malformed unit: %q", raw)
+	}
+}
+
+// parseRate parses a rate given either as a raw integer (which will be
+// interpreted as a rate per second), a string "unlimited" (which will be
+// interpreted, surprisingly, as unlimited), or a string in the form "N/UNIT".
+func parseRate(raw interface{}) (rate, error) {
+	switch v := raw.(type) {
+	case int:
+		if v == 0 {
+			return rate{n: 0}, nil
+		}
+		return rate{}, errors.Errorf("malformed rate (numeric values can only be 0): %d", v)
+
+	case string:
+		s := strings.ToLower(v)
+		if s == "unlimited" {
+			return rate{n: -1}, nil
+		}
+
+		wr := rate{}
+		parts := strings.SplitN(s, "/", 2)
+		if len(parts) != 2 {
+			return rate{}, errors.Errorf("malformed rate: %q", raw)
+		}
+
+		var err error
+		wr.n, err = strconv.Atoi(parts[0])
+		if err != nil || wr.n < 0 {
+			return wr, errors.Errorf("malformed rate: %q", raw)
+		}
+
+		wr.unit, err = parseRateUnit(parts[1])
+		if err != nil {
+			return wr, errors.Errorf("malformed rate: %q", raw)
+		}
+
+		return wr, nil
+
+	default:
+		return rate{}, errors.Errorf("malformed rate: unknown type %T", raw)
+	}
+}

--- a/enterprise/internal/batches/scheduler/window/rate_test.go
+++ b/enterprise/internal/batches/scheduler/window/rate_test.go
@@ -1,0 +1,127 @@
+package window
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRateUnit(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		for _, in := range []string{"", " ", "a"} {
+			t.Run(in, func(t *testing.T) {
+				if _, err := parseRateUnit(in); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for _, tc := range []struct {
+			inputs []string
+			want   rateUnit
+		}{
+			{
+				inputs: []string{"s", "S", "sec", "SEC", "secs", "SECS", "second", "SECOND", "seconds", "SECONDS"},
+				want:   ratePerSecond,
+			},
+			{
+				inputs: []string{"m", "M", "min", "MIN", "mins", "MINS", "minute", "MINUTE", "minutes", "MINUTES"},
+				want:   ratePerMinute,
+			},
+			{
+				inputs: []string{"h", "H", "hr", "HR", "hrs", "HRS", "hour", "HOUR", "hours", "HOURS"},
+				want:   ratePerHour,
+			},
+		} {
+			for _, in := range tc.inputs {
+				t.Run(in, func(t *testing.T) {
+					if have, err := parseRateUnit(in); err != nil {
+						t.Errorf("unexpected error: %v", err)
+					} else if have != tc.want {
+						t.Errorf("unexpected rate: have=%v want=%v", have, tc.want)
+					}
+				})
+			}
+		}
+	})
+}
+
+func TestParseRate(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		for name, in := range map[string]interface{}{
+			"nil":                                nil,
+			"non-zero int":                       1,
+			"empty string":                       "",
+			"string without slash":               "20",
+			"string without a rate number":       "/min",
+			"string with an invalid rate number": "n/min",
+			"string with a negative rate number": "-1/min",
+			"string with an invalid rate unit":   "20/year",
+			"bool":                               true,
+			"slice":                              []string{},
+			"map":                                map[string]string{},
+		} {
+			t.Run(name, func(t *testing.T) {
+				if _, err := parseRate(in); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   interface{}
+			want rate
+		}{
+			"zero": {
+				in:   0,
+				want: rate{n: 0},
+			},
+			"unlimited": {
+				in:   "unlimited",
+				want: rate{n: -1},
+			},
+			"also unlimited": {
+				in:   "UNLIMITED",
+				want: rate{n: -1},
+			},
+			"valid rate": {
+				in:   "20/min",
+				want: rate{n: 20, unit: ratePerMinute},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				if have, err := parseRate(tc.in); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else if diff := cmp.Diff(have, tc.want, cmpOptions); diff != "" {
+					t.Errorf("unexpected rate (-have +want):\n%s", diff)
+				}
+			})
+		}
+	})
+}
+
+func TestRateUnit_AsDuration(t *testing.T) {
+	for in, want := range map[rateUnit]time.Duration{
+		ratePerSecond: time.Second,
+		ratePerMinute: time.Minute,
+		ratePerHour:   time.Hour,
+	} {
+		t.Run(strconv.Itoa(int(in)), func(t *testing.T) {
+			if have := in.AsDuration(); have != want {
+				t.Errorf("unexpected duration: have=%v want=%v", have, want)
+			}
+		})
+	}
+
+	assert.Panics(t, func() {
+		ru := rateUnit(4)
+		ru.AsDuration()
+	})
+}

--- a/enterprise/internal/batches/scheduler/window/schedule.go
+++ b/enterprise/internal/batches/scheduler/window/schedule.go
@@ -1,0 +1,87 @@
+package window
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+	"go.uber.org/ratelimit"
+)
+
+// ErrZeroSchedule indicates a Schedule that has a zero rate limit, and for
+// which Take() will never succeed.
+var ErrZeroSchedule = errors.New("schedule will never yield")
+
+// Schedule represents a single Schedule in time: for a certain amount of time,
+// this particular window will be in force.
+type Schedule struct {
+	limiter ratelimit.Limiter
+
+	// until really needs to contain a monotonic time, which means that care
+	// must be taken to construct the baseSchedule without a time zone in
+	// production use. (Testing doesn't really matter.) time.Now() is OK.
+	until time.Time
+
+	// Fields we need to keep around for total calculation.
+	duration time.Duration
+	rate     rate
+}
+
+func newSchedule(base time.Time, d time.Duration, rate rate) *Schedule {
+	var limiter ratelimit.Limiter
+	if rate.IsUnlimited() {
+		limiter = ratelimit.NewUnlimited()
+	} else if rate.n > 0 {
+		limiter = ratelimit.New(rate.n, ratelimit.Per(rate.unit.AsDuration()))
+	}
+
+	return &Schedule{
+		duration: d,
+		limiter:  limiter,
+		rate:     rate,
+		until:    base.Add(d),
+	}
+}
+
+// Take blocks until a scheduling event can occur, and returns the time the
+// event occurred.
+func (s *Schedule) Take() (time.Time, error) {
+	if s.limiter == nil {
+		return time.Time{}, ErrZeroSchedule
+	}
+	return s.limiter.Take(), nil
+}
+
+// ValidUntil returns the time the schedule is valid until. After that time, a
+// new Schedule must be created and used.
+func (s *Schedule) ValidUntil() time.Time {
+	return s.until
+}
+
+// total returns the total number of events the schedule expects to be able to
+// handle while valid. If the schedule does not apply any rate limiting, then
+// this will be -1.
+func (s *Schedule) total() int {
+	if s.limiter == nil {
+		return 0
+	}
+	if s.rate.IsUnlimited() {
+		return -1
+	}
+
+	// How many events would occur in an hour?
+	//
+	// We use an hour here because that's the maximum unit value a rate can
+	// have, and therefore we can always calculate an exact integer value out of
+	// this.
+	perHour := s.rate.n * int(time.Hour/s.rate.unit.AsDuration())
+
+	// What fraction of an hour is this schedule valid for?
+	inAnHour := float64(s.duration) / float64(time.Hour)
+
+	// Technically, this will truncate the floating point value, but since we're
+	// only ever using this to estimate times for the user, this should be fine:
+	// if it's plus or minus a single notch in the rate limit, nobody is likely
+	// to notice, and our estimates can't be perfect anyway given code host rate
+	// limits.
+	return int(inAnHour * float64(perHour))
+}

--- a/enterprise/internal/batches/scheduler/window/schedule_test.go
+++ b/enterprise/internal/batches/scheduler/window/schedule_test.go
@@ -1,0 +1,128 @@
+package window
+
+import (
+	"testing"
+	"time"
+)
+
+func TestScheduleLimited(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	rate := rate{n: 100, unit: ratePerSecond}
+	schedule := newSchedule(base, 1*time.Minute, rate)
+
+	t.Run("Take", func(t *testing.T) {
+		// We don't want to block the tests for any real length of time, but we
+		// do want to validate that some sort of rate limiting is occurring.
+		// Given the rate we set up, it _should_ take at least 10 ms to take two
+		// slots out of the schedule (since the first Take() will be more or
+		// less instant, and then the second should be 1/100 seconds later).
+		if testing.Short() {
+			t.Skip("Take tests blocking behaviour, and is therefore not necessarily fast")
+		}
+
+		start := time.Now()
+		first, err := schedule.Take()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		second, err := schedule.Take()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		end := time.Now()
+
+		if !end.After(start) {
+			t.Fatalf("something funky is happening with the clock, as the end time is not after the start time: start=%v end=%v", start, end)
+		}
+
+		if !first.Before(second) {
+			t.Errorf("Take return values are not sequential: first=%v second=%v", first, second)
+		}
+
+		if duration := end.Sub(start); duration < 10*time.Millisecond {
+			t.Errorf("duration was less than the expected 10ms: %v", duration)
+		}
+	})
+
+	t.Run("ValidUntil", func(t *testing.T) {
+		have := schedule.ValidUntil()
+		want := base.Add(1 * time.Minute)
+		if have != want {
+			t.Errorf("unexpected validity: have=%v want=%v", have, want)
+		}
+	})
+
+	t.Run("total", func(t *testing.T) {
+		have := schedule.total()
+		want := 100 * 60
+		if have != want {
+			t.Errorf("unexpected total: have=%v want=%v", have, want)
+		}
+	})
+}
+
+func TestScheduleUnlimited(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	schedule := newSchedule(base, 1*time.Minute, makeUnlimitedRate())
+
+	t.Run("Take", func(t *testing.T) {
+		// There isn't really a sensible way to validate that no blocking occurs
+		// here, so we'll just validate that the return value seems sensible.
+		have, err := schedule.Take()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		} else if have.Before(base) {
+			t.Errorf("unexpected take time before base: %v", have)
+		}
+	})
+
+	t.Run("ValidUntil", func(t *testing.T) {
+		have := schedule.ValidUntil()
+		want := base.Add(1 * time.Minute)
+		if have != want {
+			t.Errorf("unexpected validity: have=%v want=%v", have, want)
+		}
+	})
+
+	t.Run("total", func(t *testing.T) {
+		have := schedule.total()
+		want := -1
+		if have != want {
+			t.Errorf("unexpected total: have=%v want=%v", have, want)
+		}
+	})
+}
+
+func TestScheduleZero(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	schedule := newSchedule(base, 1*time.Minute, rate{n: 0})
+
+	t.Run("Take", func(t *testing.T) {
+		_, err := schedule.Take()
+		if err != ErrZeroSchedule {
+			t.Errorf("unexpected error: have=%v want=%v", err, ErrZeroSchedule)
+		}
+	})
+
+	t.Run("ValidUntil", func(t *testing.T) {
+		have := schedule.ValidUntil()
+		want := base.Add(1 * time.Minute)
+		if have != want {
+			t.Errorf("unexpected validity: have=%v want=%v", have, want)
+		}
+	})
+
+	t.Run("total", func(t *testing.T) {
+		have := schedule.total()
+		want := 0
+		if have != want {
+			t.Errorf("unexpected total: have=%v want=%v", have, want)
+		}
+	})
+}

--- a/enterprise/internal/batches/scheduler/window/time.go
+++ b/enterprise/internal/batches/scheduler/window/time.go
@@ -1,0 +1,30 @@
+package window
+
+import "time"
+
+type timeOfDay struct {
+	hour   int8
+	minute int8
+
+	cmp int
+}
+
+func timeOfDayFromParts(hour, minute int8) timeOfDay {
+	return timeOfDay{
+		hour:   hour,
+		minute: minute,
+		cmp:    int(hour)*60 + int(minute),
+	}
+}
+
+func timeOfDayFromTime(t time.Time) timeOfDay {
+	return timeOfDayFromParts(int8(t.Hour()), int8(t.Minute()))
+}
+
+func (t timeOfDay) after(other timeOfDay) bool {
+	return t.cmp > other.cmp
+}
+
+func (t timeOfDay) before(other timeOfDay) bool {
+	return t.cmp < other.cmp
+}

--- a/enterprise/internal/batches/scheduler/window/time_test.go
+++ b/enterprise/internal/batches/scheduler/window/time_test.go
@@ -1,0 +1,25 @@
+package window
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (t timeOfDay) Equal(other timeOfDay) bool {
+	return t.cmp == other.cmp
+}
+
+func TestTimeOfDay(t *testing.T) {
+	early := timeOfDayFromParts(2, 0)
+	late := timeOfDayFromTime(time.Date(2021, 4, 7, 19, 37, 0, 0, time.UTC))
+	alsoLate := late
+
+	assert.True(t, early.before(late))
+	assert.False(t, early.after(late))
+	assert.True(t, late.after(early))
+	assert.False(t, late.before(early))
+	assert.True(t, alsoLate.Equal(late))
+	assert.False(t, alsoLate.Equal(early))
+}

--- a/enterprise/internal/batches/scheduler/window/weekday.go
+++ b/enterprise/internal/batches/scheduler/window/weekday.go
@@ -1,0 +1,50 @@
+package window
+
+import "time"
+
+// weekdaySet represents a set of weekdays. If no weekdays are set, then _all_
+// weekdays are considered to be set.
+type weekdaySet struct {
+	// d is used to encode the set of weekdays: since there are only seven
+	// possible weekdays, we can store them as bits in an int8.
+	d int8
+}
+
+// newWeekdaySet instantiates a new weekdaySet and returns it. If one or more
+// days are provided, they will be added to the initial state of the set.
+func newWeekdaySet(days ...time.Weekday) *weekdaySet {
+	ws := &weekdaySet{}
+	for _, day := range days {
+		ws.add(day)
+	}
+
+	return ws
+}
+
+// add adds a day to the weekdaySet.
+func (ws *weekdaySet) add(day time.Weekday) {
+	ws.d |= weekdayToBit(day)
+}
+
+// all returns true if the weekdaySet matches all days.
+func (ws *weekdaySet) all() bool {
+	return ws.d == 0 || ws.d == 127
+}
+
+// includes returns true if the given day is included in the weekdaySet.
+func (ws *weekdaySet) includes(day time.Weekday) bool {
+	if ws.all() {
+		return true
+	}
+
+	return (ws.d & weekdayToBit(day)) != 0
+}
+
+func weekdayToBit(day time.Weekday) int8 {
+	// We're relying on the internal representation of Go's time.Weekday type
+	// here: values are in the range [0, 6], per the Go documentation. This
+	// should be stable, since it's documented, but we're obviously in trouble
+	// should that ever change! (There is a sanity check for this in the unit
+	// tests.)
+	return int8(1) << int(day)
+}

--- a/enterprise/internal/batches/scheduler/window/weekday_test.go
+++ b/enterprise/internal/batches/scheduler/window/weekday_test.go
@@ -1,0 +1,86 @@
+package window
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+var allWeekdays = []time.Weekday{
+	time.Sunday,
+	time.Monday,
+	time.Tuesday,
+	time.Wednesday,
+	time.Thursday,
+	time.Friday,
+	time.Saturday,
+}
+
+// Equal is needed for test purposes, but not in normal use.
+func (ws *weekdaySet) Equal(other *weekdaySet) bool {
+	if ws != nil && other != nil {
+		return ws.d == other.d
+	}
+	return false
+}
+
+func TestWeekday_All(t *testing.T) {
+	for name, ws := range map[string]*weekdaySet{
+		"zero": newWeekdaySet(),
+		"all":  newWeekdaySet(allWeekdays...),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !ws.all() {
+				t.Error("unexpected false return from all")
+			}
+
+			for _, day := range allWeekdays {
+				if !ws.includes(day) {
+					t.Errorf("day not included: %v", day)
+				}
+			}
+		})
+	}
+
+	for i := 1; i < len(allWeekdays); i++ {
+		t.Run(fmt.Sprintf("%d weekday(s)", i), func(t *testing.T) {
+			ws := newWeekdaySet(allWeekdays[0:i]...)
+
+			if ws.all() {
+				t.Error("unexpected true return from all")
+			}
+		})
+	}
+}
+
+func TestWeekday_Includes(t *testing.T) {
+	for _, day := range allWeekdays {
+		t.Run(day.String(), func(t *testing.T) {
+			ws := newWeekdaySet(day)
+
+			for _, check := range allWeekdays {
+				if check == day {
+					if !ws.includes(check) {
+						t.Errorf("expected %v to be in set; it was not", check)
+					}
+				} else {
+					if ws.includes(check) {
+						t.Errorf("did not expect %v to be in set; it was", check)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestWeekdayBitSanity(t *testing.T) {
+	// This test exists solely as a safeguard in case Go ever changes the
+	// internal representation of time.Weekday: it _should_ be covered by
+	// semver, since it's documented, but there's no harm in being paranoid,
+	// right?
+	for _, day := range allWeekdays {
+		if int(day) < 0 || int(day) > 6 {
+			t.Errorf("unexpected Weekday value: %v", day)
+		}
+	}
+}

--- a/enterprise/internal/batches/scheduler/window/window.go
+++ b/enterprise/internal/batches/scheduler/window/window.go
@@ -1,0 +1,163 @@
+package window
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// Window represents a single rollout window configured on a site.
+type Window struct {
+	days  *weekdaySet
+	start *timeOfDay
+	end   *timeOfDay
+	rate  rate
+}
+
+func (w *Window) isTimeWithin(when timeOfDay) bool {
+	if w.start == nil || w.end == nil {
+		return true
+	}
+
+	return !(when.before(*w.start) || when.after(*w.end))
+}
+
+// IsOpen checks if this window is currently open.
+func (w *Window) IsOpen(at time.Time) bool {
+	return w.days.includes(at.Weekday()) && w.isTimeWithin(timeOfDayFromTime(at))
+}
+
+// NextOpenAfter returns the time that this window will next be open.
+func (w *Window) NextOpenAfter(after time.Time) time.Time {
+	// If the window is currently open, then the next time it will be open is...
+	// well, now.
+	if w.IsOpen(after) {
+		return after
+	}
+
+	// From here, the simplest way to find the next active time is to take the
+	// start time for this window (which is 00:00 if w.start is nil), then walk
+	// forward until we find a weekday where this window is open.
+	var t timeOfDay
+	if w.start != nil {
+		t = *w.start
+	}
+
+	when := time.Date(after.Year(), after.Month(), after.Day(), int(t.hour), int(t.minute), 0, 0, time.UTC)
+	for {
+		if w.days.includes(when.Weekday()) && when.After(after) {
+			return when
+		} else if when.Sub(after) > 7*24*time.Hour {
+			// This should never happen!
+			panic("cannot find the next time this window is active after searching the next week")
+		}
+		when = when.Add(24 * time.Hour)
+	}
+}
+
+func parseWindowTime(raw string) (*timeOfDay, error) {
+	// An empty time is valid.
+	if raw == "" {
+		return nil, nil
+	}
+
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) != 2 {
+		return nil, errors.Errorf("malformed time: %q", raw)
+	}
+
+	hour, err := parseTimePart(parts[0])
+	if err != nil || hour < 0 || hour > 23 {
+		return nil, errors.Errorf("malformed time: %q", raw)
+	}
+
+	minute, err := parseTimePart(parts[1])
+	if err != nil || minute < 0 || minute > 59 {
+		return nil, errors.Errorf("malformed time: %q", raw)
+	}
+
+	wt := timeOfDayFromParts(hour, minute)
+	return &wt, nil
+}
+
+func parseTimePart(s string) (int8, error) {
+	part, err := strconv.ParseInt(s, 10, 8)
+	if err != nil {
+		return 0, err
+	}
+
+	return int8(part), nil
+}
+
+func parseWeekday(raw string) (time.Weekday, error) {
+	// We're not going to replicate the full schema validation regex here; we'll
+	// assume that the conf package did that satisfactorily and just parse what
+	// we need to, ensuring we can't panic.
+	if len(raw) < 3 {
+		return time.Sunday, errors.Errorf("unknown weekday: %q", raw)
+	}
+
+	switch strings.ToLower(raw[0:3]) {
+	case "sun":
+		return time.Sunday, nil
+	case "mon":
+		return time.Monday, nil
+	case "tue":
+		return time.Tuesday, nil
+	case "wed":
+		return time.Wednesday, nil
+	case "thu":
+		return time.Thursday, nil
+	case "fri":
+		return time.Friday, nil
+	case "sat":
+		return time.Saturday, nil
+	default:
+		return time.Sunday, errors.Errorf("unknown weekday: %q", raw)
+	}
+}
+
+func parseWindow(raw *schema.BatchChangeRolloutWindow) (Window, error) {
+	w := Window{}
+	var errs *multierror.Error
+
+	if raw == nil {
+		return w, errors.New("raw window cannot be nil")
+	}
+
+	w.days = newWeekdaySet()
+	for i := range raw.Days {
+		if day, err := parseWeekday(raw.Days[i]); err != nil {
+			errs = multierror.Append(errs, err)
+		} else {
+			w.days.add(day)
+		}
+	}
+
+	var err error
+	w.start, err = parseWindowTime(raw.Start)
+	if err != nil {
+		errs = multierror.Append(errs, errors.Wrap(err, "start time"))
+	}
+	w.end, err = parseWindowTime(raw.End)
+	if err != nil {
+		errs = multierror.Append(errs, errors.Wrap(err, "end time"))
+	}
+	if (w.start != nil && w.end == nil) || (w.start == nil && w.end != nil) {
+		errs = multierror.Append(errs, errors.New("both start and end times must be provided"))
+	} else if w.start != nil && w.end != nil && !w.start.before(*w.end) {
+		errs = multierror.Append(errs, errors.New("end time must be after the start time"))
+	}
+
+	w.rate, err = parseRate(raw.Rate)
+	if err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	return w, errs.ErrorOrNil()
+}

--- a/enterprise/internal/batches/scheduler/window/window_test.go
+++ b/enterprise/internal/batches/scheduler/window/window_test.go
@@ -1,0 +1,377 @@
+package window
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestWindow_IsOpen(t *testing.T) {
+	// A time that corresponds rather closely to when this was getting written.
+	// Note that this is a Wednesday.
+	//
+	// We should be commended for not calling this variable whensday.
+	when := time.Date(2021, 3, 24, 1, 39, 44, 0, time.UTC)
+
+	for name, tc := range map[string]struct {
+		want   bool
+		at     time.Time
+		window *Window
+	}{
+		"always open": {
+			want: true,
+			at:   when,
+			window: &Window{
+				days: newWeekdaySet(),
+			},
+		},
+		"open on certain days; correct day": {
+			want: true,
+			at:   when,
+			window: &Window{
+				days: newWeekdaySet(time.Wednesday),
+			},
+		},
+		"open on certain days; incorrect day": {
+			want: false,
+			at:   when,
+			window: &Window{
+				days: newWeekdaySet(time.Thursday),
+			},
+		},
+		"open at certain times; correct time": {
+			want: true,
+			at:   when,
+			window: &Window{
+				days:  newWeekdaySet(),
+				start: timeOfDayPtr(int8(1), 0),
+				end:   timeOfDayPtr(int8(3), 0),
+			},
+		},
+		"open at certain times; incorrect time": {
+			want: false,
+			at:   when,
+			window: &Window{
+				days:  newWeekdaySet(),
+				start: timeOfDayPtr(int8(11), 0),
+				end:   timeOfDayPtr(int8(13), 0),
+			},
+		},
+		"open at certain days and times; correct day and time": {
+			want: true,
+			at:   when,
+			window: &Window{
+				days:  newWeekdaySet(time.Wednesday),
+				start: timeOfDayPtr(int8(1), 0),
+				end:   timeOfDayPtr(int8(3), 0),
+			},
+		},
+		"open at certain days and times; correct day only": {
+			want: false,
+			at:   when,
+			window: &Window{
+				days:  newWeekdaySet(time.Wednesday),
+				start: timeOfDayPtr(int8(11), 0),
+				end:   timeOfDayPtr(int8(13), 0),
+			},
+		},
+		"open at certain days and times; correct time only": {
+			want: false,
+			at:   when,
+			window: &Window{
+				days:  newWeekdaySet(time.Tuesday),
+				start: timeOfDayPtr(int8(1), 0),
+				end:   timeOfDayPtr(int8(3), 0),
+			},
+		},
+		"open at certain days and times; everything is terrible": {
+			want: false,
+			at:   when,
+			window: &Window{
+				days:  newWeekdaySet(time.Sunday),
+				start: timeOfDayPtr(int8(11), 0),
+				end:   timeOfDayPtr(int8(13), 0),
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if have := tc.window.IsOpen(tc.at); have != tc.want {
+				t.Errorf("unexpected open state: have=%v want=%v", have, tc.want)
+			}
+		})
+	}
+}
+
+func TestWindow_NextOpenAfter(t *testing.T) {
+	// Please see TestWindow_IsOpen for the derivation of this pseudo-constant,
+	// and a terrible pun.
+	when := time.Date(2021, 3, 24, 1, 39, 44, 0, time.UTC)
+
+	for name, tc := range map[string]struct {
+		want   time.Time
+		after  time.Time
+		window *Window
+	}{
+		"currently open": {
+			want:  when,
+			after: when,
+			window: &Window{
+				days: newWeekdaySet(),
+			},
+		},
+		"days only": {
+			// Truncate back to the start of Wednesday, then add two days to get
+			// to the start of Friday.
+			want:  when.Truncate(24 * time.Hour).Add(2 * 24 * time.Hour),
+			after: when,
+			window: &Window{
+				days: newWeekdaySet(time.Friday),
+			},
+		},
+		"every day except Wednesday": {
+			// Truncate back to the start of Wednesday, then add one day to get
+			// to the start of Thursday.
+			want:  when.Truncate(24 * time.Hour).Add(24 * time.Hour),
+			after: when,
+			window: &Window{
+				days: newWeekdaySet(
+					time.Sunday,
+					time.Monday,
+					time.Tuesday,
+					time.Thursday,
+					time.Friday,
+					time.Saturday,
+				),
+			},
+		},
+		"times only": {
+			// Truncate back to 00:00, then add 2 hours.
+			want:  when.Truncate(24 * time.Hour).Add(2 * time.Hour),
+			after: when,
+			window: &Window{
+				days:  newWeekdaySet(),
+				start: timeOfDayPtr(int8(2), 0),
+				end:   timeOfDayPtr(int8(4), 0),
+			},
+		},
+		"time in the mysterious past": {
+			// Truncate to 00:00, then add exactly one day and 30 minutes.
+			want:  when.Truncate(24 * time.Hour).Add(24 * time.Hour).Add(30 * time.Minute),
+			after: when,
+			window: &Window{
+				days:  newWeekdaySet(),
+				start: timeOfDayPtr(int8(0), int8(30)),
+				end:   timeOfDayPtr(int8(1), 0),
+			},
+		},
+		"times and days": {
+			// Truncate back to the start of Wednesday, then add five days to
+			// get to the start of Monday (which also means we've wrapped around
+			// Go's Weekday representation), then add another two hours to get
+			// to 02:00.
+			want:  when.Truncate(24 * time.Hour).Add(5 * 24 * time.Hour).Add(2 * time.Hour),
+			after: when,
+			window: &Window{
+				days:  newWeekdaySet(time.Monday),
+				start: timeOfDayPtr(int8(2), 0),
+				end:   timeOfDayPtr(int8(4), 0),
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if have := tc.window.NextOpenAfter(tc.after); have != tc.want {
+				t.Errorf("unexpected next open time: have=%v want=%v", have, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseWindowTime(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		for _, in := range []string{
+			"XX",
+			"XX:XX",
+			"24",
+			"24:00",
+			"23:60",
+			"-1:00",
+			"0:-1",
+			"0:X",
+			"X:0",
+		} {
+			t.Run(in, func(t *testing.T) {
+				if _, err := parseWindowTime(in); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for _, tc := range []struct {
+			in   string
+			want *timeOfDay
+		}{
+			{
+				in:   "",
+				want: nil,
+			},
+			{
+				in:   "0:0",
+				want: timeOfDayPtr(0, 0),
+			},
+			{
+				in:   "0:00",
+				want: timeOfDayPtr(0, 0),
+			},
+			{
+				in:   "00:00",
+				want: timeOfDayPtr(0, 0),
+			},
+			{
+				in:   "20:20",
+				want: timeOfDayPtr(20, 20),
+			},
+			{
+				in:   "1:1",
+				want: timeOfDayPtr(1, 1),
+			},
+		} {
+			t.Run(tc.in, func(t *testing.T) {
+				if have, err := parseWindowTime(tc.in); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else if diff := cmp.Diff(have, tc.want, cmpOptions); diff != "" {
+					t.Errorf("unexpected window time (-have +want)\n:%s", diff)
+				}
+			})
+		}
+	})
+}
+
+func TestParseWeekday(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		for _, in := range []string{
+			"",
+			"su",
+			"lunedi",
+		} {
+			t.Run(in, func(t *testing.T) {
+				if _, err := parseWeekday(in); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for _, tc := range []struct {
+			inputs []string
+			want   time.Weekday
+		}{
+			{
+				inputs: []string{"sun", "Sun", "sunday", "Sunday"},
+				want:   time.Sunday,
+			},
+			{
+				inputs: []string{"mon", "Mon", "monday", "Monday"},
+				want:   time.Monday,
+			},
+			{
+				inputs: []string{"tue", "Tues", "tuesday", "Tuesday"},
+				want:   time.Tuesday,
+			},
+			{
+				inputs: []string{"wed", "Wed", "wednesday", "Wednesday"},
+				want:   time.Wednesday,
+			},
+			{
+				inputs: []string{"thu", "Thurs", "thursday", "Thursday"},
+				want:   time.Thursday,
+			},
+			{
+				inputs: []string{"fri", "Fri", "friday", "Friday"},
+				want:   time.Friday,
+			},
+			{
+				inputs: []string{"sat", "Sat", "saturday", "Saturday"},
+				want:   time.Saturday,
+			},
+		} {
+			for _, in := range tc.inputs {
+				t.Run(in, func(t *testing.T) {
+					if have, err := parseWeekday(in); err != nil {
+						t.Errorf("unexpected error: %v", err)
+					} else if have != tc.want {
+						t.Errorf("unexpected weekday: have=%v want=%v", have, tc.want)
+					}
+				})
+			}
+		}
+	})
+}
+
+func TestParseWindow(t *testing.T) {
+	t.Run("errors", func(t *testing.T) {
+		// We've just painstakingly tested all the other parsers above, so this
+		// is just making sure each one is properly propagated when it returns
+		// an error, rather than trying to be exhaustive.
+		for name, in := range map[string]*schema.BatchChangeRolloutWindow{
+			"nil window":         nil,
+			"no rate":            {},
+			"invalid weekday":    {Days: []string{"martedi"}},
+			"invalid start time": {Start: "24:60"},
+			"invalid end time":   {End: "24:60"},
+			"invalid rate":       {Rate: "x/y"},
+			"only start time":    {Start: "00:00"},
+			"only end time":      {End: "00:00"},
+			"start after end":    {Start: "01:00", End: "00:00"},
+			"start equal to end": {Start: "01:00", End: "01:00"},
+		} {
+			t.Run(name, func(t *testing.T) {
+				if _, err := parseWindow(in); err == nil {
+					t.Error("unexpected nil error")
+				}
+			})
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			in   *schema.BatchChangeRolloutWindow
+			want Window
+		}{
+			"rate only": {
+				in: &schema.BatchChangeRolloutWindow{Rate: "unlimited"},
+				want: Window{
+					days: newWeekdaySet(),
+					rate: rate{n: -1},
+				},
+			},
+			"all fields": {
+				in: &schema.BatchChangeRolloutWindow{
+					Days:  []string{"monday", "tuesday"},
+					Rate:  "20/min",
+					Start: "01:15",
+					End:   "02:30",
+				},
+				want: Window{
+					days:  newWeekdaySet(time.Monday, time.Tuesday),
+					rate:  rate{n: 20, unit: ratePerMinute},
+					start: timeOfDayPtr(1, 15),
+					end:   timeOfDayPtr(2, 30),
+				},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				if have, err := parseWindow(tc.in); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				} else if diff := cmp.Diff(have, tc.want, cmpOptions); diff != "" {
+					t.Errorf("unexpected window (-have +want):\n%s", diff)
+				}
+			})
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -162,7 +162,7 @@ require (
 	github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/stripe/stripe-go v70.15.0+incompatible
 	github.com/temoto/robotstxt v1.1.1
 	github.com/throttled/throttled/v2 v2.7.1
@@ -182,6 +182,7 @@ require (
 	go.opencensus.io v0.22.6 // indirect
 	go.uber.org/atomic v1.7.0
 	go.uber.org/automaxprocs v1.3.0
+	go.uber.org/ratelimit v0.2.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	golang.org/x/oauth2 v0.0.0-20210210192628-66670185b0cd
@@ -193,7 +194,7 @@ require (
 	google.golang.org/genproto v0.0.0-20210211221406-4ccc9a5e4183
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxB
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ClickHouse/clickhouse-go v1.3.12/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
@@ -103,6 +104,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15 h1:AUNCr9CiJuwrRYS3XieqF+Z9B9gNxo/eANAJCF2eiN4=
 github.com/alecthomas/units v0.0.0-20210208195552-ff826a37aa15/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/andygrunwald/go-gerrit v0.0.0-20191101112536-3f5e365ccf57/go.mod h1:0iuRQp6WJ44ts+iihy5E/WlPqfg5RNeQxOmzRkxCdtk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -734,7 +737,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -935,7 +937,6 @@ github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkB
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1113,7 +1114,6 @@ github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtb
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
-github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1292,19 +1292,15 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.1.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
-github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1317,7 +1313,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
-github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
@@ -1334,7 +1329,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -1342,7 +1336,6 @@ github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPr
 github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
-github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -1464,6 +1457,8 @@ go.uber.org/automaxprocs v1.3.0/go.mod h1:9CWT6lKIep8U41DDaPiH6eFscnTyjfTANNQNx6
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
@@ -1925,7 +1920,6 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -129,6 +129,17 @@ func (v *AuthProviders) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"builtin", "saml", "openidconnect", "http-header", "github", "gitlab"})
 }
 
+type BatchChangeRolloutWindow struct {
+	// Days description: Day(s) the window applies to. If omitted, this rule applies to all days of the week.
+	Days []string `json:"days,omitempty"`
+	// End description: Window end time. If omitted, no time window is applied to the day(s) that match this rule.
+	End string `json:"end,omitempty"`
+	// Rate description: The rate changesets will be published at.
+	Rate interface{} `json:"rate"`
+	// Start description: Window start time. If omitted, no time window is applied to the day(s) that match this rule.
+	Start string `json:"start,omitempty"`
+}
+
 // BatchSpec description: A batch specification, which describes the batch change and what kinds of changes to make (or what existing changesets to track).
 type BatchSpec struct {
 	// ChangesetTemplate description: A template describing how to create (and update) changesets with the file changes produced by the command steps.
@@ -1331,6 +1342,8 @@ type SiteConfiguration struct {
 	BatchChangesEnabled *bool `json:"batchChanges.enabled,omitempty"`
 	// BatchChangesRestrictToAdmins description: When enabled, only site admins can create and apply batch changes.
 	BatchChangesRestrictToAdmins *bool `json:"batchChanges.restrictToAdmins,omitempty"`
+	// BatchChangesRolloutWindows description: Specifies specific windows, which can have associated rate limits, to be used when publishing changesets. All days and times are handled in UTC.
+	BatchChangesRolloutWindows *[]*BatchChangeRolloutWindow `json:"batchChanges.rolloutWindows,omitempty"`
 	// Branding description: Customize Sourcegraph homepage logo and search icon.
 	//
 	// Only available in Sourcegraph Enterprise.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -281,6 +281,51 @@
       "group": "BatchChanges",
       "default": false
     },
+    "batchChanges.rolloutWindows": {
+      "description": "Specifies specific windows, which can have associated rate limits, to be used when publishing changesets. All days and times are handled in UTC.",
+      "type": "array",
+      "!go": { "pointer": true },
+      "group": "BatchChanges",
+      "items": {
+        "title": "BatchChangeRolloutWindow",
+        "type": "object",
+        "required": ["rate"],
+        "additionalProperties": false,
+        "properties": {
+          "rate": {
+            "description": "The rate changesets will be published at.",
+            "oneOf": [
+              { "type": "number", "minimum": 0, "maximum": 0 },
+              {
+                "type": "string",
+                "pattern": "^(?i)(unlimited|[0-9]+/(sec|secs|second|seconds|min|mins|minute|minutes|hr|hrs|hour|hours))$"
+              }
+            ]
+          },
+          "start": {
+            "description": "Window start time. If omitted, no time window is applied to the day(s) that match this rule.",
+            "type": "string",
+            "pattern": "^[0-9]?[0-9]:[0-9]{2}$"
+          },
+          "end": {
+            "description": "Window end time. If omitted, no time window is applied to the day(s) that match this rule.",
+            "type": "string",
+            "pattern": "^[0-9]?[0-9]:[0-9]{2}$"
+          },
+          "days": {
+            "description": "Day(s) the window applies to. If omitted, this rule applies to all days of the week.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^(?i)(mon(day)?|tue(s|sday)?|wed(nesday)?|thu(r|rs|rsday)?|fri(day)?|sat(urday)?|sun(day)?)$"
+            }
+          }
+        },
+        "dependencies": {
+          "start": ["end"]
+        }
+      }
+    },
     "codeIntelAutoIndexing.enabled": {
       "description": "Enables/disables the code intel auto indexing feature.",
       "type": "boolean",


### PR DESCRIPTION
Part of #18921.

This PR just adds the bits we need to parse and validate the rollout window configuration. Using that configuration to construct a scheduler (and, you know, writing a scheduler) is coming in future PRs.