### PR TITLE
search: enable streaming search by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
+- Searches are streamed into Sourcegraph by default. [#19300](https://github.com/sourcegraph/sourcegraph/pull/19300)
+  - This gives a faster time to first result.
+  - Several heuristics around result limits have been improved. You should see more consistent result counts now.
+  - Can be disabled with the setting `experimentalFeatures.streamingSearch`.
 - Opsgenie API keys can now be added via an environment variable. [#18662](https://github.com/sourcegraph/sourcegraph/pull/18662)
 - It's now possible to control where code insights are displayed through the boolean settings `insights.displayLocation.homepage`, `insights.displayLocation.insightsPage` and `insights.displayLocation.directory`. [#18979](https://github.com/sourcegraph/sourcegraph/pull/18979)
 - Users can now create changesets in batch changes on repositories that are cloned using SSH. [#16888](https://github.com/sourcegraph/sourcegraph/issues/16888)


### PR DESCRIPTION
Lots of work went into making this a reality. Add the changelog entry
and flip the default.

We only read the user setting in the webapp, so we only need to update
what we return from the GraphQL resolver. This seems to be the first
time we have changed defaults via what the backend returns, which is why
this PR is bigger than one line.