### PR TITLE
database: Optimize listing user repos

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -505,6 +505,7 @@ Check constraints:
 Indexes:
     "external_service_repos_repo_id_external_service_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_service_id)
     "external_service_repos_external_service_id" btree (external_service_id)
+    "external_service_repos_idx" btree (external_service_id, repo_id)
 Foreign-key constraints:
     "external_service_repos_external_service_id_fkey" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE DEFERRABLE
     "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE

--- a/migrations/frontend/1528395800_add_external_service_repos_index.down.sql
+++ b/migrations/frontend/1528395800_add_external_service_repos_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS external_service_repos_idx;
+
+COMMIT;

--- a/migrations/frontend/1528395800_add_external_service_repos_index.up.sql
+++ b/migrations/frontend/1528395800_add_external_service_repos_index.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX external_service_repos_idx ON external_service_repos(external_service_id, repo_id);
+
+COMMIT;


### PR DESCRIPTION
This commit optimizes listing user repos by adding a covering index to
(external_service_id, repo_id) in the external_service_repos table and
using a CTE to pre-filter all user repo ids which simplifies the join
with the repo table.

Fixes #19223

```
Limit  (cost=31888.43..33201.64 rows=100 width=561) (actual time=5.305..5.333 rows=1 loops=1)
  ->  Merge Join  (cost=31888.43..854852.75 rows=62668 width=561) (actual time=5.304..5.331 rows=1 loops=1)
        Merge Cond: (repo.id = esr.repo_id)
        ->  Index Scan using repo_pkey on repo  (cost=0.43..485690.34 rows=4612146 width=529) (actual time=0.018..4.146 rows=1688 loops=1)
              Filter: (deleted_at IS NULL)
              Rows Removed by Filter: 5
        ->  Sort  (cost=31888.00..32044.72 rows=62691 width=4) (actual time=0.727..0.747 rows=1 loops=1)
              Sort Key: esr.repo_id
              Sort Method: quicksort  Memory: 25kB
              ->  HashAggregate  (cost=25638.97..26265.88 rows=62691 width=4) (actual time=0.463..0.738 rows=1 loops=1)
                    Group Key: esr.repo_id
                    ->  Append  (cost=0.57..25482.24 rows=62691 width=4) (actual time=0.100..0.118 rows=1 loops=1)
                          ->  Nested Loop  (cost=0.57..24535.35 rows=62685 width=4) (actual time=0.086..0.088 rows=0 loops=1)
                                ->  Index Scan using external_services_pkey on external_services es  (cost=0.14..9.02 rows=1 width=8) (actual time=0.065..0.066 rows=1 loops=1)
                                      Filter: ((deleted_at IS NULL) AND (namespace_user_id = 24621))
                                      Rows Removed by Filter: 73
                                ->  Index Only Scan using tmp_tomas_esr_covering_index on external_service_repos esr  (cost=0.43..16795.21 rows=773112 width=12) (actual time=0.018..0.018 rows=0 loops=1)
                                      Index Cond: (external_service_id = es.id)
                                      Heap Fetches: 0
                          ->  Bitmap Heap Scan on user_public_repos  (cost=1.30..6.52 rows=6 width=4) (actual time=0.012..0.027 rows=1 loops=1)
                                Recheck Cond: (user_id = 24621)
                                Heap Blocks: exact=1
                                ->  Bitmap Index Scan on user_public_repos_user_id_repo_id_key  (cost=0.00..1.30 rows=6 width=0) (actual time=0.005..0.006 rows=1 loops=1)
                                      Index Cond: (user_id = 24621)
        SubPlan 1
          ->  Aggregate  (cost=5.17..5.18 rows=1 width=32) (actual time=0.093..0.095 rows=1 loops=1)
                ->  Nested Loop  (cost=0.57..5.16 rows=1 width=99) (actual time=0.070..0.072 rows=1 loops=1)
                      ->  Index Scan using external_service_repos_repo_id_external_service_id_unique on external_service_repos esr_1  (cost=0.43..2.65 rows=1 width=92) (actual time=0.053..0.054 rows=1 loops=1)
                            Index Cond: (repo_id = repo.id)
                      ->  Index Scan using external_services_pkey on external_services svcs  (cost=0.14..2.36 rows=1 width=15) (actual time=0.013..0.013 rows=1 loops=1)
                            Index Cond: (id = esr_1.external_service_id)
                            Filter: (deleted_at IS NULL)
Planning Time: 1.165 ms
Execution Time: 6.073 ms
```

Final query looks like this:

```sql
WITH user_repos AS (
    SELECT repo_id as id
    FROM external_service_repos esr
    JOIN external_services es ON esr.external_service_id = es.id
    WHERE es.namespace_user_id = 24621 AND es.deleted_at IS NULL
    
    UNION
    
    SELECT repo_id as id FROM user_public_repos WHERE user_id = 24621  
)

SELECT repo.id,
       repo.name,
       repo.private,
       repo.external_id,
       repo.external_service_type,
       repo.external_service_id,
       repo.uri,
       repo.description,
       repo.fork,
       repo.archived,
       repo.created_at,
       repo.updated_at,
       repo.deleted_at,
       repo.metadata,
       (
           SELECT JSON_AGG(
                          JSON_BUILD_OBJECT(
                                  'CloneURL', esr.clone_url,
                                  'ID', esr.external_service_id,
                                  'Kind', LOWER(svcs.kind)
                              )
                      )
           FROM external_service_repos AS esr
                    JOIN external_services AS svcs ON esr.external_service_id = svcs.id
           WHERE esr.repo_id = repo.id
             AND svcs.deleted_at IS NULL
       )
FROM repo
JOIN user_repos ON user_repos.id = repo.id
WHERE deleted_at IS NULL
AND ((
            TRUE -- TRUE or FALSE to indicate whether to bypass the check
            OR (
                    NOT FALSE -- Disregard unrestricted state when permissions user mapping is enabled
                    AND (
                            NOT repo.private -- Happy path of non-private repositories
                            OR EXISTS( -- Each external service defines if repositories are unrestricted
                                    SELECT
                                    FROM external_services AS es
                                             JOIN external_service_repos AS esr ON (
                                            esr.external_service_id = es.id
                                            AND esr.repo_id = repo.id
                                            AND es.unrestricted = TRUE
                                            AND es.deleted_at IS NULL
                                        )
                                    LIMIT 1
                                )
                        )
                ) OR ( -- Restricted repositories require checking permissions
                SELECT object_ids_ints @> INTSET(repo.id)
                FROM user_permissions
                WHERE user_id = 24621
                  AND permission = 'read'
                  AND object_type = 'repos'
            )
        )
)
ORDER BY id ASC
LIMIT 100 OFFSET 0;
```

There's definitely still room for optimization (i.e. we're accessing the external_service_repos table three times), but this improves things for now.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
