### PR TITLE
search: Simplify alert construction

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -655,29 +655,29 @@ func alertForError(err error, inputs *SearchInputs) *searchAlert {
 			prometheusType: "structural_search_needs_more_memory",
 			title:          "Structural search needs more memory",
 			description:    "Running your structural search may require more memory. If you are running the query on many repositories, try reducing the number of repositories with the `repo:` filter.",
+			priority:       5,
 		}
-		alert.priority = 5
 	} else if strings.Contains(err.Error(), "Out of memory") {
 		a := searchAlert{
 			prometheusType: "structural_search_needs_more_memory__give_searcher_more_memory",
 			title:          "Structural search needs more memory",
 			description:    `Running your structural search requires more memory. You could try reducing the number of repositories with the "repo:" filter. If you are an administrator, try double the memory allocated for the "searcher" service. If you're unsure, reach out to us at support@sourcegraph.com.`,
+			priority:       4,
 		}
-		a.priority = 4
 	} else if errors.As(err, &rErr) {
 		alert = &searchAlert{
 			prometheusType: "exceeded_diff_commit_search_limit",
 			title:          fmt.Sprintf("Too many matching repositories for %s search to handle", rErr.ResultType),
 			description:    fmt.Sprintf(`%s search can currently only handle searching across %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search, or using 'after:"1 week ago"'.`, strings.Title(rErr.ResultType), rErr.Max),
+			priority:       2,
 		}
-		alert.priority = 2
 	} else if errors.As(err, &tErr) {
 		alert = &searchAlert{
 			prometheusType: "exceeded_diff_commit_with_time_search_limit",
 			title:          fmt.Sprintf("Too many matching repositories for %s search to handle", tErr.ResultType),
 			description:    fmt.Sprintf(`%s search can currently only handle searching across %d repositories at a time. Try using the "repo:" filter to narrow down which repositories to search.`, strings.Title(tErr.ResultType), tErr.Max),
+			priority:       1,
 		}
-		alert.priority = 1
 	}
 	return alert
 }

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -658,7 +658,7 @@ func alertForError(err error, inputs *SearchInputs) *searchAlert {
 			priority:       5,
 		}
 	} else if strings.Contains(err.Error(), "Out of memory") {
-		a := searchAlert{
+		alert = &searchAlert{
 			prometheusType: "structural_search_needs_more_memory__give_searcher_more_memory",
 			title:          "Structural search needs more memory",
 			description:    `Running your structural search requires more memory. You could try reducing the number of repositories with the "repo:" filter. If you are an administrator, try double the memory allocated for the "searcher" service. If you're unsure, reach out to us at support@sourcegraph.com.`,


### PR DESCRIPTION
Just a couple of small changes to `alertForError`

1) Moves priority into the alert construction rather than setting it afterwards
2) Fix an issue where one of the alerts was not being set correctly, so woudl be swallowed

Depends on #19309 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
