### PR TITLE
streaming search: fix failing e2e tests

### DIFF
--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -1095,11 +1095,6 @@ describe('e2e test suite', () => {
     })
 
     describe('Search component', () => {
-        test('redirects to a URL with &patternType=regexp if no patternType in URL', async () => {
-            await driver.page.goto(sourcegraphBaseUrl + '/search?q=test')
-            await driver.assertWindowLocation('/search?q=test&patternType=regexp')
-        })
-
         test('regexp toggle appears and updates patternType query parameter when clicked', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/search?q=test&patternType=literal')
             // Wait for monaco query input to load to avoid race condition with the intermediate input
@@ -1142,14 +1137,14 @@ describe('e2e test suite', () => {
     })
 
     describe('Saved searches', () => {
-        test('Save search from search results page', async () => {
+        test.only('Save search from search results page', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/search?q=test')
             await driver.page.waitForSelector('.test-save-search-link', { visible: true })
             await driver.page.click('.test-save-search-link')
             await driver.page.waitForSelector('.test-saved-search-modal')
             await driver.page.waitForSelector('.test-saved-search-modal-save-button')
             await driver.page.click('.test-saved-search-modal-save-button')
-            await driver.assertWindowLocation('/users/test/searches/add?query=test&patternType=regexp')
+            await driver.assertWindowLocation('/users/test/searches/add?query=test&patternType=literal')
 
             await driver.page.waitForSelector('.test-saved-search-form-input-description', { visible: true })
             await driver.page.click('.test-saved-search-form-input-description')

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -1137,7 +1137,7 @@ describe('e2e test suite', () => {
     })
 
     describe('Saved searches', () => {
-        test.only('Save search from search results page', async () => {
+        test('Save search from search results page', async () => {
             await driver.page.goto(sourcegraphBaseUrl + '/search?q=test')
             await driver.page.waitForSelector('.test-save-search-link', { visible: true })
             await driver.page.click('.test-save-search-link')

--- a/client/web/src/search/stream.test.ts
+++ b/client/web/src/search/stream.test.ts
@@ -13,7 +13,7 @@ export const REPO_MATCH_CONTAINING_SPACES: RepositoryMatch = {
 describe('escapeSpaces', () => {
     test('escapes spaces in value', () => {
         expect(toGQLRepositoryMatch(REPO_MATCH_CONTAINING_SPACES).label).toMatchInlineSnapshot(
-            '{"__typename":"Markdown","text":"[github.com/save/the andimals](github.com/save/the%20andimals)"}'
+            '{"__typename":"Markdown","text":"[github.com/save/the andimals](/github.com/save/the%20andimals)"}'
         )
     })
 })

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -253,14 +253,14 @@ export function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
     const branch = repo?.branches?.[0]
     const revision = branch ? `@${branch}` : ''
     const label = repo.repository + revision
-    const url = encodeURI(label)
+    const url = '/' + encodeURI(label)
 
     // We only need to return the subset defined in IGenericSearchResultInterface
     const gqlRepo: unknown = {
         __typename: 'Repository',
         icon: repoIcon,
         label: toMarkdown(`[${label}](${url})`),
-        url: '/' + url,
+        url,
         detail: toMarkdown('Repository match'),
         matches: [],
         name: repo.repository,

--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -177,7 +177,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || strings.HasPrefix(c.branch, "master-dry-run/")
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || c.isMasterDryRun
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.

--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -177,7 +177,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main"
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || strings.HasPrefix(c.branch, "master-dry-run/")
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.


### PR DESCRIPTION
- streaming repo results now add leading slash to match old gql results
- updated tests to reflect that streaming search doesn't update URLs to add patternType:regex if pattern type is omitted
- allows e2e tests to be run when branch name starts with `master-dry-run/`