### PR TITLE
authz: enable PermsSyncer for Perforce provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- Experimental: Sync permissions of Perforce depots through the Sourcegraph UI. To enable, use the feature flag `"experimentalFeatures": { "perforce": "enabled" }`. For more information, see [how to enable permissions for your Perforce depots](https://docs.sourcegraph.com/admin/repo/perforce). [#16705](https://github.com/sourcegraph/sourcegraph/issues/16705)
 
 ### Changed
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -42,7 +42,16 @@ Use the `depots` field to configure which depots are mirrored/synchronized as Gi
 
 ### Repository permissions
 
-> WARNING: Permissions syncing for Perforce depots is not yet supported. All files that are synced from the Perforce Server will be readable by all Sourcegraph users. The following docs are based on prototypes and are subject to change.
+> NOTE: Permissions syncing for Perforce depots is available in Sourcegraph 3.26.1+.
+
+To enable permissions syncing for Perforce depots by including the `authorization` field:
+
+```json
+{
+  ...
+  "authorization": {}
+}
+```
 
 Sourcegraph only supports repository-level permissions and does not match the granularity of Perforce access control lists (which supports file-level permissions). The workaround is for site admins to sync arbitrary subdirectories of a depot, which can then enforce permissions in Sourcegraph. We suggest using the most concrete path of your permissions boundary.
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -249,7 +249,7 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		accts = append(accts, acct)
 	}
 
-	var repoSpecs []api.ExternalRepoSpec
+	var repoSpecs, includePrefixSpecs, excludePrefixSpecs []api.ExternalRepoSpec
 	for _, acct := range accts {
 		provider := providers[acct.ServiceID]
 		if provider == nil {
@@ -309,18 +309,58 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 				)
 			}
 		}
+		if len(extIDs.IncludePrefixes) > 0 {
+			for _, includePrefix := range extIDs.IncludePrefixes {
+				includePrefixSpecs = append(includePrefixSpecs,
+					api.ExternalRepoSpec{
+						ID:          string(includePrefix),
+						ServiceType: provider.ServiceType(),
+						ServiceID:   provider.ServiceID(),
+					},
+				)
+			}
+		}
+		if len(extIDs.ExcludePrefixes) > 0 {
+			for _, excludePrefix := range extIDs.ExcludePrefixes {
+				excludePrefixSpecs = append(excludePrefixSpecs,
+					api.ExternalRepoSpec{
+						ID:          string(excludePrefix),
+						ServiceType: provider.ServiceType(),
+						ServiceID:   provider.ServiceID(),
+					},
+				)
+			}
+		}
 	}
 
-	var rs []*types.Repo
+	// Get corresponding internal database IDs
+	var repoNames []*types.RepoName
 	if len(repoSpecs) > 0 {
-		// Get corresponding internal database IDs
-		rs, err = s.reposStore.RepoStore.List(ctx, database.ReposListOptions{
-			ExternalRepos: repoSpecs,
-			OnlyPrivate:   true,
-		})
+		rs, err := s.reposStore.RepoStore.ListRepoNames(ctx,
+			database.ReposListOptions{
+				ExternalRepos: repoSpecs,
+				OnlyPrivate:   true,
+			},
+		)
 		if err != nil {
-			return errors.Wrap(err, "list external repositories")
+			return errors.Wrap(err, "list external repositories by exact matching")
 		}
+		repoNames = append(repoNames, rs...)
+	}
+	// Exclusions are relative to inclusions, so if there is no inclusion, exclusion
+	// are meaningless and no need to trigger a DB query.
+	if len(includePrefixSpecs) > 0 {
+		rs, err := s.reposStore.RepoStore.ListRepoNames(ctx,
+			database.ReposListOptions{
+				ExternalRepoIncludePrefixes: includePrefixSpecs,
+				ExternalRepoExcludePrefixes: excludePrefixSpecs,
+				OnlyPrivate:                 true,
+			},
+		)
+		if err != nil {
+			return errors.Wrap(err, "list external repositories by prefix matching")
+		}
+		repoNames = append(repoNames, rs...)
 	}
 
 	// Save permissions to database
@@ -330,8 +370,8 @@ func (s *PermsSyncer) syncUserPerms(ctx context.Context, userID int32, noPerms b
 		Type:   authz.PermRepos,
 		IDs:    roaring.NewBitmap(),
 	}
-	for i := range rs {
-		p.IDs.Add(uint32(rs[i].ID))
+	for i := range repoNames {
+		p.IDs.Add(uint32(repoNames[i].ID))
 	}
 
 	err = s.permsStore.SetUserPermissions(ctx, p)

--- a/enterprise/internal/authz/authz.go
+++ b/enterprise/internal/authz/authz.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/authz/github"
 	"github.com/sourcegraph/sourcegraph/internal/authz/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/authz/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -51,6 +52,7 @@ func ProvidersFromConfig(
 			extsvc.KindGitHub,
 			extsvc.KindGitLab,
 			extsvc.KindBitbucketServer,
+			extsvc.KindPerforce,
 		},
 		LimitOffset: &database.LimitOffset{
 			Limit: 500, // The number is randomly chosen
@@ -61,6 +63,7 @@ func ProvidersFromConfig(
 		gitHubConns          []*types.GitHubConnection
 		gitLabConns          []*types.GitLabConnection
 		bitbucketServerConns []*types.BitbucketServerConnection
+		perforceConns        []*types.PerforceConnection
 	)
 	for {
 		svcs, err := store.List(ctx, opt)
@@ -96,6 +99,11 @@ func ProvidersFromConfig(
 					URN:                       svc.URN(),
 					BitbucketServerConnection: c,
 				})
+			case *schema.PerforceConnection:
+				perforceConns = append(perforceConns, &types.PerforceConnection{
+					URN:                svc.URN(),
+					PerforceConnection: c,
+				})
 			default:
 				log15.Error("ProvidersFromConfig", "error", errors.Errorf("unexpected connection type: %T", cfg))
 				continue
@@ -127,6 +135,13 @@ func ProvidersFromConfig(
 		providers = append(providers, bbsProviders...)
 		seriousProblems = append(seriousProblems, bbsProblems...)
 		warnings = append(warnings, bbsWarnings...)
+	}
+
+	if len(perforceConns) > 0 {
+		pfProviders, pfProblems, pfWarnings := perforce.NewAuthzProviders(perforceConns)
+		providers = append(providers, pfProviders...)
+		seriousProblems = append(seriousProblems, pfProblems...)
+		warnings = append(warnings, pfWarnings...)
 	}
 
 	// 🚨 SECURITY: Warn the admin when both code host authz provider and the permissions user mapping are configured.

--- a/enterprise/internal/authz/authz_test.go
+++ b/enterprise/internal/authz/authz_test.go
@@ -501,6 +501,7 @@ type fakeStore struct {
 	gitlabs          []*schema.GitLabConnection
 	githubs          []*schema.GitHubConnection
 	bitbucketServers []*schema.BitbucketServerConnection
+	perforces        []*schema.PerforceConnection
 }
 
 func (s fakeStore) List(ctx context.Context, opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
@@ -534,6 +535,13 @@ func (s fakeStore) List(ctx context.Context, opt database.ExternalServicesListOp
 				svcs = append(svcs, &types.ExternalService{
 					Kind:   kind,
 					Config: mustMarshalJSONString(bbs),
+				})
+			}
+		case extsvc.KindPerforce:
+			for _, p := range s.perforces {
+				svcs = append(svcs, &types.ExternalService{
+					Kind:   kind,
+					Config: mustMarshalJSONString(p),
 				})
 			}
 		default:

--- a/enterprise/internal/database/external_services.go
+++ b/enterprise/internal/database/external_services.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/authz/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/authz/github"
 	"github.com/sourcegraph/sourcegraph/internal/authz/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/authz/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -21,6 +22,9 @@ func NewExternalServicesStore(d dbutil.DB) *database.ExternalServiceStore {
 	}
 	es.BitbucketServerValidators = []func(*schema.BitbucketServerConnection) error{
 		bitbucketserver.ValidateAuthz,
+	}
+	es.PerforceValidators = []func(connection *schema.PerforceConnection) error{
+		perforce.ValidateAuthz,
 	}
 
 	return es


### PR DESCRIPTION
This PR finally allows site admins to enable permissions syncing for Perforce depots!

Subset of #17881 and extracted here for easier review, and fixes #16705.