### PR TITLE
perforce: use ticket-based authentication

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -952,7 +952,7 @@ func (s *Server) handleP4Exec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Make sure credentials are valid before heavier operation
-	err := p4pingWithLogin(r.Context(), req.P4Port, req.P4User, req.P4Passwd)
+	err := p4pingWithTrust(r.Context(), req.P4Port, req.P4User, req.P4Passwd)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -1068,6 +1068,7 @@ func (s *Server) p4exec(w http.ResponseWriter, r *http.Request, req *protocol.P4
 	cmd.Env = append(os.Environ(),
 		"P4PORT="+req.P4Port,
 		"P4USER="+req.P4User,
+		"P4PASSWD="+req.P4Passwd,
 	)
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -39,6 +39,7 @@ Use the `depots` field to configure which depots are mirrored/synchronized as Gi
 
 - [`depots`](perforce.md#depots)<br>A list of depot paths that can be either a depot root or an arbitrary subdirectory.
 - [`p4.user`](perforce.md#p4-user)<br>The user to be authenticated for p4 CLI, and should be capable of performing `p4 ping`, `p4 login`, `p4 trust` and any p4 commands involved with `git p4 clone` and `git p4 sync` for listed `depots`. If repository permissions are mirrored, the user needs additional ability to perform the `p4 protects`, `p4 groups`, `p4 group`, `p4 users` commands (aka. "super" access level).
+- [`p4.passwd`](perforce.md#p4-passwd)<br>The ticket value to be used for authenticating the `p4.user`. It is recommended to create tickets that do not expire.
 
 ### Repository permissions
 

--- a/doc/admin/repo/perforce.md
+++ b/doc/admin/repo/perforce.md
@@ -43,7 +43,7 @@ Use the `depots` field to configure which depots are mirrored/synchronized as Gi
 
 ### Repository permissions
 
-> NOTE: Permissions syncing for Perforce depots is available in Sourcegraph 3.26.1+.
+> NOTE: Permissions syncing for Perforce depots is available in Sourcegraph 3.26+.
 
 To enable permissions syncing for Perforce depots by including the `authorization` field:
 

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -19,7 +19,7 @@
       "examples": ["admin"]
     },
     "p4.passwd": {
-      "description": "The plain password of the user (P4PASSWD).",
+      "description": "The ticket value for the user (P4PASSWD).",
       "type": "string"
     },
     "depots": {
@@ -38,8 +38,7 @@
       "title": "PerforceAuthorization",
       "description": "If non-null, enforces Perforce depot permissions.",
       "type": "object",
-      "properties": {},
-      "hide": true
+      "properties": {}
     },
     "repositoryPathPattern": {
       "description": "The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable \"{depot}\" is replaced with the Perforce depot's path.\n\nFor example, if your Perforce depot path is \"//Sourcegraph/\" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of \"perforce/{depot}\" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.",

--- a/schema/perforce_stringdata.go
+++ b/schema/perforce_stringdata.go
@@ -24,7 +24,7 @@ const PerforceSchemaJSON = `{
       "examples": ["admin"]
     },
     "p4.passwd": {
-      "description": "The plain password of the user (P4PASSWD).",
+      "description": "The ticket value for the user (P4PASSWD).",
       "type": "string"
     },
     "depots": {
@@ -43,8 +43,7 @@ const PerforceSchemaJSON = `{
       "title": "PerforceAuthorization",
       "description": "If non-null, enforces Perforce depot permissions.",
       "type": "object",
-      "properties": {},
-      "hide": true
+      "properties": {}
     },
     "repositoryPathPattern": {
       "description": "The pattern used to generate the corresponding Sourcegraph repository name for a Perforce depot. In the pattern, the variable \"{depot}\" is replaced with the Perforce depot's path.\n\nFor example, if your Perforce depot path is \"//Sourcegraph/\" and your Sourcegraph URL is https://src.example.com, then a repositoryPathPattern of \"perforce/{depot}\" would mean that the Perforce depot is available on Sourcegraph at https://src.example.com/perforce/Sourcegraph.\n\nIt is important that the Sourcegraph repository name generated with this pattern be unique to this Perforce Server. If different Perforce Servers generate repository names that collide, Sourcegraph's behavior is undefined.",

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1026,7 +1026,7 @@ type PerforceConnection struct {
 	Depots []string `json:"depots,omitempty"`
 	// MaxChanges description: Only import at most n changes when possible (git p4 clone --max-changes).
 	MaxChanges float64 `json:"maxChanges,omitempty"`
-	// P4Passwd description: The plain password of the user (P4PASSWD).
+	// P4Passwd description: The ticket value for the user (P4PASSWD).
 	P4Passwd string `json:"p4.passwd"`
 	// P4Port description: The Perforce Server address to be used for p4 CLI (P4PORT).
 	P4Port string `json:"p4.port"`


### PR DESCRIPTION
During a customer call, the Perforce admin mentioned they are and often to create tickets that never expire for service accounts, and would never provide plain password for a 3rd-party service.

I thought tickets have to expire for X hours, but turns out it [can be set to unlimited](https://www.perforce.com/perforce/doc.091/manuals/cmdref/login.html) and it's a common practice for service accounts.

This PR changes from using plain password to ticket values. The additional benefit of using tickets is that it's more like a PAT on GitLab/GitHub, and we no longer store it on disk (always specify via env vars). Plus, it makes our config field name `p4.passwd` align with what `P4PASSWD` is actually expecting (ticket not plain password).

Tested end-to-end.