### PR TITLE
database: Ignore order and limit in RepoStore.Count

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -221,6 +221,9 @@ func (s *RepoStore) Count(ctx context.Context, opt ReposListOptions) (ct int, er
 	}()
 
 	opt.Select = []string{"COUNT(*)"}
+	opt.OrderBy = nil
+	opt.LimitOffset = nil
+
 	err = s.list(ctx, tr, opt, func(rows *sql.Rows) error {
 		return rows.Scan(&ct)
 	})

--- a/internal/database/repos_test.go
+++ b/internal/database/repos_test.go
@@ -141,6 +141,18 @@ func TestRepos_Count(t *testing.T) {
 		t.Errorf("got %d, want %d", count, want)
 	}
 
+	t.Run("order and limit options are ignored", func(t *testing.T) {
+		opts := ReposListOptions{
+			OrderBy:     []RepoListSort{{Field: RepoListID}},
+			LimitOffset: &LimitOffset{Limit: 1},
+		}
+		if count, err := Repos(db).Count(ctx, opts); err != nil {
+			t.Fatal(err)
+		} else if want := 1; count != want {
+			t.Errorf("got %d, want %d", count, want)
+		}
+	})
+
 	repos, err := Repos(db).List(ctx, ReposListOptions{})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR brings back #19303 after it's been reverted and fixes the issue that caused the revert, which was that the Count method of the RepoStore wasn't ignoring order and limit options as it should have been (since those don't make sense in counting).