### PR TITLE
Fix names in deprecation message of old config properties

### DIFF
--- a/internal/batches/config.go
+++ b/internal/batches/config.go
@@ -7,11 +7,11 @@ import (
 func init() {
 	conf.ContributeValidator(func(c conf.Unified) (problems conf.Problems) {
 		if c.CampaignsEnabled != nil {
-			problems = append(problems, conf.NewSiteProblem("The `automation.readAccess.enabled` property is deprecated and will be removed in a future release. Use `campaigns.enabled` to enable or disable the campaigns feature instead."))
+			problems = append(problems, conf.NewSiteProblem("The `campaigns.enabled` property is deprecated and will be removed in a future release. Use `batchChanges.enabled` to enable or disable the batch changes feature instead."))
 		}
 
 		if c.CampaignsRestrictToAdmins != nil {
-			problems = append(problems, conf.NewSiteProblem("The `campaigns.readAccess.enabled` property is deprecated and will be removed in a future release. Use `campaigns.enabled` to enable or disable the campaigns feature instead."))
+			problems = append(problems, conf.NewSiteProblem("The `campaigns.restrictToAdmins` property is deprecated and will be removed in a future release. Use `campaigns.enabled` to enable or disable the campaigns feature instead."))
 		}
 
 		return


### PR DESCRIPTION
Just stumbled on this.