### PR TITLE
Enable gocritic unlambda and wrapperfunc lints

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -26,6 +26,11 @@ linters-settings:
 
 issues:
   exclude-rules:
+    # Excluded generated bindata.go from gocritic lints
+    - path: cmd/server/shared/assets/bindata.go
+      linters:
+        - gocritic
+
     # Exclude bodyclose lint from tests because leaking connections in tests
     # is a non-issue, and checking that adds unnecessary noise
     - path: _test\.go

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -16,6 +16,12 @@ linters:
     - varcheck
     - bodyclose
     - deadcode
+    - gocritic
+
+linters-settings:
+  gocritic:
+    enabled-checks:
+      - unlambda
 
 issues:
   exclude-rules:
@@ -25,7 +31,7 @@ issues:
       linters:
         - bodyclose
 
-    # TODO (camdencheek): This is only excluded because at the time of enabling 
+    # TODO (camdencheek): This is only excluded because at the time of enabling
     # the deadcode lint, there was active work in removing other dead code in this package
     - path: enterprise/internal/codeintel
       linters:

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -22,6 +22,7 @@ linters-settings:
   gocritic:
     enabled-checks:
       - unlambda
+      - wrapperFunc
 
 issues:
   exclude-rules:

--- a/cmd/frontend/graphqlbackend/externallink/repository.go
+++ b/cmd/frontend/graphqlbackend/externallink/repository.go
@@ -89,7 +89,7 @@ func Commit(ctx context.Context, db dbutil.DB, repo *types.Repo, commitID api.Co
 
 	if link != nil && link.Commit != "" {
 		links = append(links, NewResolver(
-			strings.Replace(link.Commit, "{commit}", commitStr, -1),
+			strings.ReplaceAll(link.Commit, "{commit}", commitStr),
 			serviceType,
 		))
 	}

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -59,5 +59,5 @@ func (r *gitRevisionRange) MergeBase() *gitObject { return r.mergeBase }
 // For niceness/readability, we do NOT escape slashes but we do escape other characters like '#'
 // that are necessary for correctness.
 func escapePathForURL(path string) string {
-	return strings.Replace(url.PathEscape(path), "%2F", "/", -1)
+	return strings.ReplaceAll(url.PathEscape(path), "%2F", "/")
 }

--- a/cmd/frontend/internal/routevar/util.go
+++ b/cmd/frontend/internal/routevar/util.go
@@ -4,5 +4,5 @@ import "strings"
 
 // pathUnescape is a limited version of url.QueryEscape that only unescapes '?'.
 func pathUnescape(p string) string {
-	return strings.Replace(p, "%3F", "?", -1)
+	return strings.ReplaceAll(p, "%3F", "?")
 }

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -667,7 +667,7 @@ func optimizeRepoPatternWithHeuristics(repoPattern string) string {
 	}
 	// Optimization: make the "." in "github.com" a literal dot
 	// so that the regexp can be optimized more effectively.
-	repoPattern = strings.Replace(repoPattern, "github.com", `github\.com`, -1)
+	repoPattern = strings.ReplaceAll(repoPattern, "github.com", `github\.com`)
 	return repoPattern
 }
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1425,7 +1425,7 @@ func newURLRedactor(parsedURL *url.URL) *urlRedactor {
 // Sensitive strings are replaced with "<redacted>".
 func (r *urlRedactor) redact(message string) string {
 	for _, s := range r.sensitive {
-		message = strings.Replace(message, s, "<redacted>", -1)
+		message = strings.ReplaceAll(message, s, "<redacted>")
 	}
 	return message
 }

--- a/cmd/repo-updater/shared/assets/bindata.go
+++ b/cmd/repo-updater/shared/assets/bindata.go
@@ -93,7 +93,7 @@ func stateHtmlTmpl() (*asset, error) {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func Asset(name string) ([]byte, error) {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -131,7 +131,7 @@ func MustAssetString(name string) string {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func AssetInfo(name string) (os.FileInfo, error) {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -145,7 +145,7 @@ func AssetInfo(name string) (os.FileInfo, error) {
 // AssetDigest returns the digest of the file with the given name. It returns an
 // error if the asset could not be found or the digest could not be loaded.
 func AssetDigest(name string) ([sha256.Size]byte, error) {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -202,7 +202,7 @@ const AssetDebug = false
 func AssetDir(name string) ([]string, error) {
 	node := _bintree
 	if len(name) != 0 {
-		canonicalName := strings.ReplaceAll(name, "\\", "/")
+		canonicalName := strings.Replace(name, "\\", "/", -1)
 		pathList := strings.Split(canonicalName, "/")
 		for _, p := range pathList {
 			node = node.Children[p]
@@ -269,6 +269,6 @@ func RestoreAssets(dir, name string) error {
 }
 
 func _filePath(dir, name string) string {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(canonicalName, "/")...)...)
 }

--- a/cmd/repo-updater/shared/assets/bindata.go
+++ b/cmd/repo-updater/shared/assets/bindata.go
@@ -93,7 +93,7 @@ func stateHtmlTmpl() (*asset, error) {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func Asset(name string) ([]byte, error) {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -131,7 +131,7 @@ func MustAssetString(name string) string {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func AssetInfo(name string) (os.FileInfo, error) {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -145,7 +145,7 @@ func AssetInfo(name string) (os.FileInfo, error) {
 // AssetDigest returns the digest of the file with the given name. It returns an
 // error if the asset could not be found or the digest could not be loaded.
 func AssetDigest(name string) ([sha256.Size]byte, error) {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -202,7 +202,7 @@ const AssetDebug = false
 func AssetDir(name string) ([]string, error) {
 	node := _bintree
 	if len(name) != 0 {
-		canonicalName := strings.Replace(name, "\\", "/", -1)
+		canonicalName := strings.ReplaceAll(name, "\\", "/")
 		pathList := strings.Split(canonicalName, "/")
 		for _, p := range pathList {
 			node = node.Children[p]
@@ -269,6 +269,6 @@ func RestoreAssets(dir, name string) error {
 }
 
 func _filePath(dir, name string) string {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	return filepath.Join(append([]string{dir}, strings.Split(canonicalName, "/")...)...)
 }

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -55,9 +55,7 @@ func main() {
 			FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
 				return gitserver.DefaultClient.Archive(ctx, repo, gitserver.ArchiveOptions{Treeish: string(commit), Format: "tar"})
 			},
-			FilterTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (store.FilterFunc, error) {
-				return search.NewFilter(ctx, repo, commit)
-			},
+			FilterTar:         search.NewFilter,
 			Path:              filepath.Join(cacheDir, "searcher-archives"),
 			MaxCacheSizeBytes: cacheSizeBytes,
 		},

--- a/cmd/server/shared/assets/bindata.go
+++ b/cmd/server/shared/assets/bindata.go
@@ -219,7 +219,7 @@ func nginxSourcegraph_serverConf() (*asset, error) {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func Asset(name string) ([]byte, error) {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -257,7 +257,7 @@ func MustAssetString(name string) string {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func AssetInfo(name string) (os.FileInfo, error) {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -271,7 +271,7 @@ func AssetInfo(name string) (os.FileInfo, error) {
 // AssetDigest returns the digest of the file with the given name. It returns an
 // error if the asset could not be found or the digest could not be loaded.
 func AssetDigest(name string) ([sha256.Size]byte, error) {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -334,7 +334,7 @@ const AssetDebug = false
 func AssetDir(name string) ([]string, error) {
 	node := _bintree
 	if len(name) != 0 {
-		canonicalName := strings.ReplaceAll(name, "\\", "/")
+		canonicalName := strings.Replace(name, "\\", "/", -1)
 		pathList := strings.Split(canonicalName, "/")
 		for _, p := range pathList {
 			node = node.Children[p]
@@ -409,6 +409,6 @@ func RestoreAssets(dir, name string) error {
 }
 
 func _filePath(dir, name string) string {
-	canonicalName := strings.ReplaceAll(name, "\\", "/")
+	canonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(canonicalName, "/")...)...)
 }

--- a/cmd/server/shared/assets/bindata.go
+++ b/cmd/server/shared/assets/bindata.go
@@ -219,7 +219,7 @@ func nginxSourcegraph_serverConf() (*asset, error) {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func Asset(name string) ([]byte, error) {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -257,7 +257,7 @@ func MustAssetString(name string) string {
 // It returns an error if the asset could not be found or
 // could not be loaded.
 func AssetInfo(name string) (os.FileInfo, error) {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -271,7 +271,7 @@ func AssetInfo(name string) (os.FileInfo, error) {
 // AssetDigest returns the digest of the file with the given name. It returns an
 // error if the asset could not be found or the digest could not be loaded.
 func AssetDigest(name string) ([sha256.Size]byte, error) {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	if f, ok := _bindata[canonicalName]; ok {
 		a, err := f()
 		if err != nil {
@@ -334,7 +334,7 @@ const AssetDebug = false
 func AssetDir(name string) ([]string, error) {
 	node := _bintree
 	if len(name) != 0 {
-		canonicalName := strings.Replace(name, "\\", "/", -1)
+		canonicalName := strings.ReplaceAll(name, "\\", "/")
 		pathList := strings.Split(canonicalName, "/")
 		for _, p := range pathList {
 			node = node.Children[p]
@@ -409,6 +409,6 @@ func RestoreAssets(dir, name string) error {
 }
 
 func _filePath(dir, name string) string {
-	canonicalName := strings.Replace(name, "\\", "/", -1)
+	canonicalName := strings.ReplaceAll(name, "\\", "/")
 	return filepath.Join(append([]string{dir}, strings.Split(canonicalName, "/")...)...)
 }

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -183,5 +183,5 @@ func union(a, b map[string]string) map[string]string {
 }
 
 func scriptNameFromJobStep(job executor.Job, i int) string {
-	return fmt.Sprintf("%d.%d_%s@%s.sh", job.ID, i, strings.Replace(job.RepositoryName, "/", "_", -1), job.Commit)
+	return fmt.Sprintf("%d.%d_%s@%s.sh", job.ID, i, strings.ReplaceAll(job.RepositoryName, "/", "_"), job.Commit)
 }

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/subscriptions_graphql.go
@@ -80,7 +80,7 @@ func (r *productSubscription) UUID() string {
 }
 
 func (r *productSubscription) Name() string {
-	return fmt.Sprintf("L-%s", strings.ToUpper(strings.Replace(r.v.ID, "-", "", -1)[:10]))
+	return fmt.Sprintf("L-%s", strings.ToUpper(strings.ReplaceAll(r.v.ID, "-", "")[:10]))
 }
 
 func (r *productSubscription) Account(ctx context.Context) (*graphqlbackend.UserResolver, error) {

--- a/enterprise/cmd/frontend/internal/registry/extensions_db.go
+++ b/enterprise/cmd/frontend/internal/registry/extensions_db.go
@@ -205,7 +205,7 @@ func (o dbExtensionsListOptions) sqlConditions() []*sqlf.Query {
 	}
 	if o.Query != "" {
 		likePattern := func(value string) string {
-			return "%" + strings.Replace(strings.ToLower(value), " ", "%", -1) + "%"
+			return "%" + strings.ReplaceAll(strings.ToLower(value), " ", "%") + "%"
 		}
 		queryConds := []*sqlf.Query{
 			sqlf.Sprintf(extensionIDExpr+" ILIKE %s", likePattern(o.Query)),

--- a/enterprise/internal/batches/resolvers/apitest/exec.go
+++ b/enterprise/internal/batches/resolvers/apitest/exec.go
@@ -40,7 +40,7 @@ func Exec(
 ) []*gqlerrors.QueryError {
 	t.Helper()
 
-	query = strings.Replace(query, "\t", "  ", -1)
+	query = strings.ReplaceAll(query, "\t", "  ")
 
 	b, err := json.Marshal(in)
 	if err != nil {

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -372,9 +372,7 @@ func (m MockSyncStore) Repos() *database.RepoStore {
 }
 
 func (m MockSyncStore) Clock() func() time.Time {
-	return func() time.Time {
-		return time.Now()
-	}
+	return time.Now
 }
 
 func (m MockSyncStore) ListCodeHosts(ctx context.Context, opts store.ListCodeHostsOpts) ([]*batches.CodeHost, error) {

--- a/enterprise/internal/insights/dbtesting/insights.go
+++ b/enterprise/internal/insights/dbtesting/insights.go
@@ -49,7 +49,7 @@ func TimescaleDB(t testing.TB) (db *sql.DB, cleanup func()) {
 	}
 
 	// Create database just for this test.
-	dbname := "insights_test_" + strings.ToLower(strings.Replace(t.Name(), "/", "_", -1))
+	dbname := "insights_test_" + strings.ToLower(strings.ReplaceAll(t.Name(), "/", "_"))
 	_, err = initConn.Exec(ctx, "DROP DATABASE IF EXISTS "+dbname+";")
 	if err != nil {
 		t.Fatal("dropping test database", err)

--- a/internal/conf/reposource/gitolite.go
+++ b/internal/conf/reposource/gitolite.go
@@ -33,7 +33,7 @@ func (c Gitolite) CloneURLToRepoName(cloneURL string) (repoName api.RepoName, er
 // the prefix concatenated with the Gitolite name. Gitolite permits the "@" character, but
 // Sourcegraph does not, so "@" characters are rewritten to be "-".
 func GitoliteRepoName(prefix, gitoliteName string) api.RepoName {
-	gitoliteNameWithNoIllegalChars := strings.Replace(gitoliteName, "@", "-", -1)
+	gitoliteNameWithNoIllegalChars := strings.ReplaceAll(gitoliteName, "@", "-")
 	return api.RepoName(strings.NewReplacer(
 		"{prefix}", prefix,
 		"{gitoliteName}", gitoliteNameWithNoIllegalChars,

--- a/internal/database/dbconn/dbconn.go
+++ b/internal/database/dbconn/dbconn.go
@@ -301,7 +301,7 @@ func registerPrometheusCollector(db *sql.DB, dbNameSuffix string) {
 	c := prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
 			Namespace: "src",
-			Subsystem: "pgsql" + strings.Replace(dbNameSuffix, "-", "_", -1),
+			Subsystem: "pgsql" + strings.ReplaceAll(dbNameSuffix, "-", "_"),
 			Name:      "open_connections",
 			Help:      "Number of open connections to pgsql DB, as reported by pgsql.DB.Stats()",
 		},

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -55,7 +55,7 @@ var (
 func findName() (string, string) {
 	// Environment variable names can't contain, for instance, hyphens.
 	origName := filepath.Base(os.Args[0])
-	name := strings.Replace(origName, "-", "_", -1)
+	name := strings.ReplaceAll(origName, "-", "_")
 	if name == "" {
 		name = "unknown"
 	}

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -395,7 +395,7 @@ func TestClient_LoadPullRequest(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			name := "PullRequests-" + strings.Replace(tc.name, " ", "-", -1)
+			name := "PullRequests-" + strings.ReplaceAll(tc.name, " ", "-")
 			cli, save := NewTestClient(t, name, *update)
 			defer save()
 
@@ -418,7 +418,7 @@ func TestClient_LoadPullRequest(t *testing.T) {
 				return
 			}
 
-			checkGolden(t, "LoadPullRequest-"+strings.Replace(tc.name, " ", "-", -1), pr)
+			checkGolden(t, "LoadPullRequest-"+strings.ReplaceAll(tc.name, " ", "-"), pr)
 		})
 	}
 }
@@ -537,7 +537,7 @@ func TestClient_CreatePullRequest(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			name := "CreatePullRequest-" + strings.Replace(tc.name, " ", "-", -1)
+			name := "CreatePullRequest-" + strings.ReplaceAll(tc.name, " ", "-")
 
 			cli, save := NewTestClient(t, name, *update)
 			defer save()
@@ -621,7 +621,7 @@ func TestClient_DeclinePullRequest(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			name := "DeclinePullRequest-" + strings.Replace(tc.name, " ", "-", -1)
+			name := "DeclinePullRequest-" + strings.ReplaceAll(tc.name, " ", "-")
 
 			cli, save := NewTestClient(t, name, *update)
 			defer save()
@@ -718,7 +718,7 @@ func TestClient_LoadPullRequestActivities(t *testing.T) {
 				return
 			}
 
-			checkGolden(t, "LoadPullRequestActivities-"+strings.Replace(tc.name, " ", "-", -1), pr)
+			checkGolden(t, "LoadPullRequestActivities-"+strings.ReplaceAll(tc.name, " ", "-"), pr)
 		})
 	}
 }

--- a/internal/extsvc/phabricator/client_test.go
+++ b/internal/extsvc/phabricator/client_test.go
@@ -235,7 +235,7 @@ func TestClient_GetDiffInfo(t *testing.T) {
 func newClient(t testing.TB, name string) (*phabricator.Client, func()) {
 	t.Helper()
 
-	cassete := filepath.Join("testdata/vcr/", strings.Replace(name, " ", "-", -1))
+	cassete := filepath.Join("testdata/vcr/", strings.ReplaceAll(name, " ", "-"))
 	rec, err := httptestutil.NewRecorder(cassete, *update, func(i *cassette.Interaction) error {
 		// Remove all tokens
 		i.Request.Body = ""

--- a/internal/gituri/uri_test.go
+++ b/internal/gituri/uri_test.go
@@ -9,7 +9,7 @@ import (
 func TestParse(t *testing.T) {
 	tests := map[string]url.URL{}
 	for uriStr, want := range tests {
-		t.Run(strings.Replace(uriStr, "/", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(uriStr, "/", "-"), func(t *testing.T) {
 			uri, err := Parse(uriStr)
 			if err != nil {
 				t.Fatal(err)
@@ -29,7 +29,7 @@ func TestParse_error(t *testing.T) {
 		"%":                    "invalid",
 	}
 	for uriStr, want := range tests {
-		t.Run(strings.Replace(uriStr, "/", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(uriStr, "/", "-"), func(t *testing.T) {
 			uri, err := Parse(uriStr)
 			if err == nil {
 				t.Fatalf("got nil error, want %q", want)
@@ -53,7 +53,7 @@ func TestURI_CloneURL(t *testing.T) {
 		"https://github.com/foo/bar#f",
 	}
 	for _, uriStr := range uriStrs {
-		t.Run(strings.Replace(uriStr, "/", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(uriStr, "/", "-"), func(t *testing.T) {
 			uri, err := Parse(uriStr)
 			if err != nil {
 				t.Fatal(err)
@@ -73,7 +73,7 @@ func TestURI_Rev(t *testing.T) {
 		"https://github.com/foo/bar?v#f": "v",
 	}
 	for uriStr, want := range tests {
-		t.Run(strings.Replace(uriStr, "/", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(uriStr, "/", "-"), func(t *testing.T) {
 			uri, err := Parse(uriStr)
 			if err != nil {
 				t.Fatal(err)
@@ -100,7 +100,7 @@ func TestURI_FilePath(t *testing.T) {
 		"https://github.com/foo/bar?v#d%2Ff":  "d/f",
 	}
 	for uriStr, want := range tests {
-		t.Run(strings.Replace(uriStr, "/", "-", -1), func(t *testing.T) {
+		t.Run(strings.ReplaceAll(uriStr, "/", "-"), func(t *testing.T) {
 			uri, err := Parse(uriStr)
 			if err != nil {
 				t.Fatal(err)

--- a/internal/httptestutil/recorder.go
+++ b/internal/httptestutil/recorder.go
@@ -63,7 +63,7 @@ func NewRecorderOpt(rec *recorder.Recorder) httpcli.Opt {
 func NewGitHubRecorderFactory(t testing.TB, update bool, name string) (*httpcli.Factory, func()) {
 	t.Helper()
 
-	cassete := filepath.Join("testdata/vcr/", strings.Replace(name, " ", "-", -1))
+	cassete := filepath.Join("testdata/vcr/", strings.ReplaceAll(name, " ", "-"))
 
 	rec, err := NewRecorder(cassete, update, func(i *cassette.Interaction) error {
 		return nil

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -381,7 +381,7 @@ func TestBitbucketServerSource_CloseChangeset(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		tc.name = "BitbucketServerSource_CloseChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+		tc.name = "BitbucketServerSource_CloseChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
 			cf, save := newClientFactory(t, tc.name)
@@ -450,7 +450,7 @@ func TestBitbucketServerSource_ReopenChangeset(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		tc.name = "BitbucketServerSource_ReopenChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+		tc.name = "BitbucketServerSource_ReopenChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
 			cf, save := newClientFactory(t, tc.name)
@@ -524,7 +524,7 @@ func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		tc.name = "BitbucketServerSource_UpdateChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+		tc.name = "BitbucketServerSource_UpdateChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
 			cf, save := newClientFactory(t, tc.name)

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -82,7 +82,7 @@ func TestGithubSource_CreateChangeset(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 
-		tc.name = "GithubSource_CreateChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+		tc.name = "GithubSource_CreateChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
 			// The GithubSource uses the github.Client under the hood, which
@@ -157,7 +157,7 @@ func TestGithubSource_CloseChangeset(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		tc.name = "GithubSource_CloseChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+		tc.name = "GithubSource_CloseChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
 			// The GithubSource uses the github.Client under the hood, which
@@ -225,7 +225,7 @@ func TestGithubSource_ReopenChangeset(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		tc.name = "GithubSource_ReopenChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+		tc.name = "GithubSource_ReopenChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
 			// The GithubSource uses the github.Client under the hood, which
@@ -295,7 +295,7 @@ func TestGithubSource_UpdateChangeset(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
-		tc.name = "GithubSource_UpdateChangeset_" + strings.Replace(tc.name, " ", "_", -1)
+		tc.name = "GithubSource_UpdateChangeset_" + strings.ReplaceAll(tc.name, " ", "_")
 
 		t.Run(tc.name, func(t *testing.T) {
 			// The GithubSource uses the github.Client under the hood, which

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -758,7 +758,7 @@ func TestSources_ListRepos(t *testing.T) {
 }
 
 func newClientFactory(t testing.TB, name string, mws ...httpcli.Middleware) (*httpcli.Factory, func(testing.TB)) {
-	cassete := filepath.Join("testdata", "sources", strings.Replace(name, " ", "-", -1))
+	cassete := filepath.Join("testdata", "sources", strings.ReplaceAll(name, " ", "-"))
 	rec := newRecorder(t, cassete, update(name))
 	mws = append(mws, httpcli.GitHubProxyRedirectMiddleware, gitserverRedirectMiddleware)
 	mw := httpcli.NewMiddleware(mws...)

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -189,7 +189,7 @@ func unredactField(old, new string, cfg interface{}, fields ...jsonStringField) 
 		}
 		if stringValue != RedactedSecret {
 			// using unicode zero width space might mean the user includes it when editing still, we strip that out here
-			new, err = jsonc.Edit(new, strings.Replace(stringValue, RedactedSecret, "", -1), field.path)
+			new, err = jsonc.Edit(new, strings.ReplaceAll(stringValue, RedactedSecret, ""), field.path)
 			if err != nil {
 				return new, err
 			}

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -103,7 +103,7 @@ func InitGitRepository(t testing.TB, cmds ...string) string {
 	if err := os.MkdirAll(remotes, 0700); err != nil {
 		t.Fatal(err)
 	}
-	dir, err := ioutil.TempDir(remotes, strings.Replace(t.Name(), "/", "__", -1))
+	dir, err := ioutil.TempDir(remotes, strings.ReplaceAll(t.Name(), "/", "__"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/monitoring/definitions/shared/container.go
+++ b/monitoring/definitions/shared/container.go
@@ -26,7 +26,7 @@ var (
 			NoAlert: true,
 			Panel:   monitoring.Panel().LegendFormat("{{name}}"),
 			Owner:   owner,
-			Interpretation: strings.Replace(`
+			Interpretation: strings.ReplaceAll(`
 				This value is the number of times a container has not been seen for more than one minute. If you observe this
 				value change independent of deployment events (such as an upgrade), it could indicate pods are being OOM killed or terminated for some other reasons.
 
@@ -36,7 +36,7 @@ var (
 				- **Docker Compose:**
 					- Determine if the pod was OOM killed using 'docker inspect -f \'{{json .State}}\' {{CONTAINER_NAME}}' (look for '"OOMKilled":true') and, if so, consider increasing the memory limit of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
 					- Check the logs before the container restarted to see if there are 'panic:' messages or similar using 'docker logs {{CONTAINER_NAME}}' (note this will include logs from the previous and currently running container).
-			`, "{{CONTAINER_NAME}}", containerName, -1),
+			`, "{{CONTAINER_NAME}}", containerName),
 		}
 	}
 
@@ -48,10 +48,10 @@ var (
 			Warning:     monitoring.Alert().GreaterOrEqual(99, nil),
 			Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Interval(100).Max(100).Min(0),
 			Owner:       owner,
-			PossibleSolutions: strings.Replace(`
+			PossibleSolutions: strings.ReplaceAll(`
 			- **Kubernetes:** Consider increasing memory limit in relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'memory:' of {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-		`, "{{CONTAINER_NAME}}", containerName, -1),
+		`, "{{CONTAINER_NAME}}", containerName),
 		}
 	}
 
@@ -63,10 +63,10 @@ var (
 			Warning:     monitoring.Alert().GreaterOrEqual(99, nil),
 			Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Interval(100).Max(100).Min(0),
 			Owner:       owner,
-			PossibleSolutions: strings.Replace(`
+			PossibleSolutions: strings.ReplaceAll(`
 			- **Kubernetes:** Consider increasing CPU limits in the the relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-		`, "{{CONTAINER_NAME}}", containerName, -1),
+		`, "{{CONTAINER_NAME}}", containerName),
 		}
 	}
 

--- a/monitoring/definitions/shared/frontend.go
+++ b/monitoring/definitions/shared/frontend.go
@@ -16,7 +16,7 @@ var FrontendInternalAPIErrorResponses sharedObservable = func(containerName stri
 		Warning:     monitoring.Alert().GreaterOrEqual(2, nil).For(5 * time.Minute),
 		Panel:       monitoring.Panel().LegendFormat("{{category}}").Unit(monitoring.Percentage),
 		Owner:       owner,
-		PossibleSolutions: strings.Replace(`
+		PossibleSolutions: strings.ReplaceAll(`
 			- **Single-container deployments:** Check 'docker logs $CONTAINER_ID' for logs starting with 'repo-updater' that indicate requests to the frontend service are failing.
 			- **Kubernetes:**
 				- Confirm that 'kubectl get pods' shows the 'frontend' pods are healthy.
@@ -24,6 +24,6 @@ var FrontendInternalAPIErrorResponses sharedObservable = func(containerName stri
 			- **Docker Compose:**
 				- Confirm that 'docker ps' shows the 'frontend-internal' container is healthy.
 				- Check 'docker logs {{CONTAINER_NAME}}' for logs indicating request failures to 'frontend' or 'frontend-internal'.
-		`, "{{CONTAINER_NAME}}", containerName, -1),
+		`, "{{CONTAINER_NAME}}", containerName),
 	}
 }

--- a/monitoring/definitions/shared/provisioning.go
+++ b/monitoring/definitions/shared/provisioning.go
@@ -25,10 +25,10 @@ var (
 			Warning:     monitoring.Alert().GreaterOrEqual(80, nil).For(14 * 24 * time.Hour),
 			Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Max(100).Min(0),
 			Owner:       owner,
-			PossibleSolutions: strings.Replace(`
+			PossibleSolutions: strings.ReplaceAll(`
 			- **Kubernetes:** Consider increasing CPU limits in the 'Deployment.yaml' for the {{CONTAINER_NAME}} service.
 			- **Docker Compose:** Consider increasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-		`, "{{CONTAINER_NAME}}", containerName, -1),
+		`, "{{CONTAINER_NAME}}", containerName),
 		}
 	}
 
@@ -40,10 +40,10 @@ var (
 			Warning:     monitoring.Alert().GreaterOrEqual(80, nil).For(14 * 24 * time.Hour),
 			Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Max(100).Min(0),
 			Owner:       owner,
-			PossibleSolutions: strings.Replace(`
+			PossibleSolutions: strings.ReplaceAll(`
 			- **Kubernetes:** Consider increasing memory limits in the 'Deployment.yaml' for the {{CONTAINER_NAME}} service.
 			- **Docker Compose:** Consider increasing 'memory:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-		`, "{{CONTAINER_NAME}}", containerName, -1),
+		`, "{{CONTAINER_NAME}}", containerName),
 		}
 	}
 
@@ -55,10 +55,10 @@ var (
 			Warning:     monitoring.Alert().GreaterOrEqual(90, nil).For(30 * time.Minute),
 			Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Interval(100).Max(100).Min(0),
 			Owner:       owner,
-			PossibleSolutions: strings.Replace(`
+			PossibleSolutions: strings.ReplaceAll(`
 			- **Kubernetes:** Consider increasing CPU limits in the the relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'cpus:' of the {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-		`, "{{CONTAINER_NAME}}", containerName, -1),
+		`, "{{CONTAINER_NAME}}", containerName),
 		}
 	}
 
@@ -70,10 +70,10 @@ var (
 			Warning:     monitoring.Alert().GreaterOrEqual(90, nil),
 			Panel:       monitoring.Panel().LegendFormat("{{name}}").Unit(monitoring.Percentage).Interval(100).Max(100).Min(0),
 			Owner:       owner,
-			PossibleSolutions: strings.Replace(`
+			PossibleSolutions: strings.ReplaceAll(`
 			- **Kubernetes:** Consider increasing memory limit in relevant 'Deployment.yaml'.
 			- **Docker Compose:** Consider increasing 'memory:' of {{CONTAINER_NAME}} container in 'docker-compose.yml'.
-		`, "{{CONTAINER_NAME}}", containerName, -1),
+		`, "{{CONTAINER_NAME}}", containerName),
 		}
 	}
 )

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -98,7 +98,7 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Containe
 				clog.Crit("Invalid rules", "err", err)
 				return err
 			}
-			fileName := strings.Replace(container.Name, "-", "_", -1) + alertRulesFileSuffix
+			fileName := strings.ReplaceAll(container.Name, "-", "_") + alertRulesFileSuffix
 			generatedAssets = append(generatedAssets, fileName)
 			err = ioutil.WriteFile(filepath.Join(opts.PrometheusDir, fileName), data, os.ModePerm)
 			if err != nil {

--- a/monitoring/monitoring/util.go
+++ b/monitoring/monitoring/util.go
@@ -34,9 +34,9 @@ func toMarkdown(m string, forceList bool) (string, error) {
 
 	// Replace single quotes with backticks.
 	// Replace escaped single quotes with single quotes.
-	m = strings.Replace(m, `\'`, `$ESCAPED_SINGLE_QUOTE`, -1)
-	m = strings.Replace(m, `'`, "`", -1)
-	m = strings.Replace(m, `$ESCAPED_SINGLE_QUOTE`, "'", -1)
+	m = strings.ReplaceAll(m, `\'`, `$ESCAPED_SINGLE_QUOTE`)
+	m = strings.ReplaceAll(m, `'`, "`")
+	m = strings.ReplaceAll(m, `$ESCAPED_SINGLE_QUOTE`, "'")
 
 	// Unindent based on the indention of the last line.
 	lines := strings.Split(m, "\n")

--- a/schema/stringdata.go
+++ b/schema/stringdata.go
@@ -49,7 +49,7 @@ func main() {
 }
 
 func backtickStringLiteral(data string) string {
-	return "`" + strings.Replace(data, "`", "` + \"`\" + `", -1) + "`"
+	return "`" + strings.ReplaceAll(data, "`", "` + \"`\" + `") + "`"
 }
 
 // writeFileIfDifferent is like ioutil.WriteFile, except it only writes if the


### PR DESCRIPTION
I'm planning to enable the `gocritic` lints in smaller PRs since there are many of them, and I'm not sure we want/need all of them. 

Progresses #18720 

Lints enabled:
- `unlambda` catches unnecessary wrapping of functions in anonymous functions
- `wrapperfunc` catches uses of stdlib functions with special args when there is a more specific function that does the same thing more explicitly. 

The only case `wrapperfunc` caught was `strings.Replace(..., -1) -> strings.ReplaceAll(...)`. Seemed worth changing since `ReplaceAll` is more explicit and readable than the magic -1, so I used comby (another great use case @rvantonder) to change it across the codebase with the following command:
```bash
comby -in-place 'strings.Replace(:[1],:[2],:[3], -1)' 'strings.ReplaceAll(:[1],:[2],:[3])' .go
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
