### PR TITLE
Enable remaining gocritic lints

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -23,6 +23,7 @@ linters-settings:
     enabled-checks:
       - unlambda
       - wrapperFunc
+      - underef
 
 issues:
   exclude-rules:

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -22,12 +22,12 @@ linters-settings:
   gocritic:
     disabled-checks:
       - appendAssign      # Too many false positives
-      - ifElseChain       # Noisy for not much gain
-      - exitAfterDefer    # Only occurs in auxiliary tools
-      - singleCaseSwitch  # Noisy for not much gain
+      - assignOp          # Maybe worth adding, but likely not worth the noise
       - commentFormatting # No strong benefit
       - deprecatedComment # Unnecessary
-      - assignOp          # Maybe worth adding, but likely not worth the noise
+      - exitAfterDefer    # Only occurs in auxiliary tools
+      - ifElseChain       # Noisy for not much gain
+      - singleCaseSwitch  # Noisy for not much gain
 
 issues:
   exclude-rules:

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -28,7 +28,6 @@ linters-settings:
       - commentFormatting # No strong benefit
       - deprecatedComment # Unnecessary
       - assignOp          # Maybe worth adding, but likely not worth the noise
-      - captLocal
 
 issues:
   exclude-rules:

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -29,7 +29,6 @@ linters-settings:
       - deprecatedComment # Unnecessary
       - assignOp          # Maybe worth adding, but likely not worth the noise
       - captLocal
-      - elseif
 
 issues:
   exclude-rules:

--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -1,5 +1,5 @@
 # This file contains the configuration of the enforced linters for the project.
-# Eventually, the goal is to unify this with .golangci.yml. 
+# Eventually, the goal is to unify this with .golangci.yml.
 # https://github.com/sourcegraph/sourcegraph/issues/18720
 
 
@@ -20,10 +20,16 @@ linters:
 
 linters-settings:
   gocritic:
-    enabled-checks:
-      - unlambda
-      - wrapperFunc
-      - underef
+    disabled-checks:
+      - appendAssign      # Too many false positives
+      - ifElseChain       # Noisy for not much gain
+      - exitAfterDefer    # Only occurs in auxiliary tools
+      - singleCaseSwitch  # Noisy for not much gain
+      - commentFormatting # No strong benefit
+      - deprecatedComment # Unnecessary
+      - assignOp          # Maybe worth adding, but likely not worth the noise
+      - captLocal
+      - elseif
 
 issues:
   exclude-rules:

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -2009,7 +2009,7 @@ func compareDates(left, right *time.Time) bool {
 	if left == nil || right == nil {
 		return left != nil // Place the value that is defined first.
 	}
-	return (*left).After(*right)
+	return left.After(*right)
 }
 
 // compareSearchResults sorts repository matches, file matches, and commits.

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1088,9 +1088,9 @@ func substitutePredicates(q query.Q, evaluate func(query.Predicate) (*SearchResu
 var ErrPredicateNoResults = errors.New("no results returned for predicate")
 
 // longer returns a suggested longer time to wait if the given duration wasn't long enough.
-func longer(N int, dt time.Duration) time.Duration {
+func longer(n int, dt time.Duration) time.Duration {
 	dt2 := func() time.Duration {
-		Ndt := time.Duration(N) * dt
+		Ndt := time.Duration(n) * dt
 		dceil := func(x float64) time.Duration {
 			return time.Duration(math.Ceil(x))
 		}

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -328,13 +328,11 @@ func logPing(r *http.Request, pr *pingRequest, hasUpdate bool) {
 	if err != nil {
 		errorCounter.Inc()
 		log15.Warn("logPing.Marshal: failed to Marshal payload", "error", err)
-	} else {
-		if pubsub.Enabled() {
-			err := pubsub.Publish(pubSubPingsTopicID, string(message))
-			if err != nil {
-				errorCounter.Inc()
-				log15.Warn("pubsub.Publish: failed to Publish", "message", message, "error", err)
-			}
+	} else if pubsub.Enabled() {
+		err := pubsub.Publish(pubSubPingsTopicID, string(message))
+		if err != nil {
+			errorCounter.Inc()
+			log15.Warn("pubsub.Publish: failed to Publish", "message", message, "error", err)
 		}
 	}
 

--- a/cmd/frontend/internal/usagestatsdeprecated/usage_stats_test.go
+++ b/cmd/frontend/internal/usagestatsdeprecated/usage_stats_test.go
@@ -1,3 +1,4 @@
+//nolint
 package usagestatsdeprecated
 
 import (

--- a/cmd/frontend/registry/api/extensions.go
+++ b/cmd/frontend/registry/api/extensions.go
@@ -62,12 +62,9 @@ func ParseExtensionID(extensionID string) (prefix, extensionIDWithoutPrefix stri
 			return "", "", false, fmt.Errorf("remote extension lookup is forbidden (extension ID prefix %q, allowed prefixes are \"\" (default) and %q (local))", prefix, *configuredPrefix)
 		}
 		isLocal = true
-	} else {
-		// Extension ID is publisher/name.
-		if configuredPrefix == nil {
-			// Local extension on Sourcegraph.com instance.
-			isLocal = true
-		}
+	} else if configuredPrefix == nil { // Extension ID is publisher/name.
+		// Local extension on Sourcegraph.com instance.
+		isLocal = true
 	}
 
 	extensionIDWithoutPrefix = publisher + "/" + name

--- a/enterprise/cmd/frontend/internal/auth/saml/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/provider.go
@@ -152,11 +152,9 @@ func getServiceProvider(ctx context.Context, pc *schema.SAMLAuthProvider) (*saml
 	if c.keyPair != nil {
 		sp.SPKeyStore = dsig.TLSCertKeyStore(*c.keyPair)
 		sp.SignAuthnRequests = pc.SignRequests == nil || *pc.SignRequests
-	} else {
+	} else if pc.SignRequests != nil && *pc.SignRequests {
 		// If the SP private key isn't specified, then the IdP must not care to validate.
-		if pc.SignRequests != nil && *pc.SignRequests {
-			return nil, errors.New("signRequests is true for SAML Service Provider but no private key and cert are given")
-		}
+		return nil, errors.New("signRequests is true for SAML Service Provider but no private key and cert are given")
 	}
 
 	// pc.Issuer's default of ${externalURL}/.auth/saml/metadata already applied (in withConfigDefaults).

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_test.go
@@ -354,10 +354,8 @@ func TestHandleEnqueueMultipartFinalize(t *testing.T) {
 
 	if len(mockDBStore.MarkQueuedFunc.History()) != 1 {
 		t.Errorf("unexpected number of MarkQueued calls. want=%d have=%d", 1, len(mockDBStore.MarkQueuedFunc.History()))
-	} else {
-		if call := mockDBStore.MarkQueuedFunc.History()[0]; call.Arg1 != 42 {
-			t.Errorf("unexpected upload id. want=%d have=%d", 42, call.Arg1)
-		}
+	} else if call := mockDBStore.MarkQueuedFunc.History()[0]; call.Arg1 != 42 {
+		t.Errorf("unexpected upload id. want=%d have=%d", 42, call.Arg1)
 	}
 
 	if len(mockUploadStore.ComposeFunc.History()) != 1 {

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
@@ -153,10 +153,8 @@ func TestGCSUpload(t *testing.T) {
 
 	if calls := objectHandle.NewWriterFunc.History(); len(calls) != 1 {
 		t.Fatalf("unexpected number of NewWriter calls. want=%d have=%d", 1, len(calls))
-	} else {
-		if value := buf.String(); value != "TEST PAYLOAD" {
-			t.Errorf("unexpected payload. want=%s have=%s", "TEST PAYLOAD", value)
-		}
+	} else if value := buf.String(); value != "TEST PAYLOAD" {
+		t.Errorf("unexpected payload. want=%s have=%s", "TEST PAYLOAD", value)
 	}
 }
 

--- a/enterprise/internal/codemonitors/background/workers.go
+++ b/enterprise/internal/codemonitors/background/workers.go
@@ -256,7 +256,7 @@ func newQueryWithAfterFilter(q *cm.MonitorQuery) string {
 	// result. This means there is non-zero chance that we miss results whenever
 	// commits have a timestamp equal to the value of :after but arrive after this
 	// job has run.
-	afterTime := (*q.LatestResult).UTC().Add(time.Second).Format(time.RFC3339)
+	afterTime := q.LatestResult.UTC().Add(time.Second).Format(time.RFC3339)
 	return strings.Join([]string{q.QueryString, fmt.Sprintf(`after:"%s"`, afterTime)}, " ")
 }
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -68,13 +68,13 @@ func (r *Resolver) Monitors(ctx context.Context, userID int32, args *graphqlback
 	return &monitorConnection{Resolver: r, monitors: mrs, totalCount: totalCount, hasNextPage: hasNextPage}, nil
 }
 
-func (r *Resolver) MonitorByID(ctx context.Context, ID graphql.ID) (m graphqlbackend.MonitorResolver, err error) {
-	err = r.isAllowedToEdit(ctx, ID)
+func (r *Resolver) MonitorByID(ctx context.Context, id graphql.ID) (m graphqlbackend.MonitorResolver, err error) {
+	err = r.isAllowedToEdit(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	var monitorID int64
-	err = relay.UnmarshalSpec(ID, &monitorID)
+	err = relay.UnmarshalSpec(id, &monitorID)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +260,7 @@ func (r *Resolver) actionIDsForMonitorIDInt64(ctx context.Context, monitorID int
 	return ids, nil
 }
 
-func (r *Resolver) actionIDsForMonitorIDINT64SinglePage(ctx context.Context, q *sqlf.Query, limit int) (IDs []graphql.ID, cursor *string, err error) {
+func (r *Resolver) actionIDsForMonitorIDINT64SinglePage(ctx context.Context, q *sqlf.Query, limit int) (ids []graphql.ID, cursor *string, err error) {
 	var rows *sql.Rows
 	rows, err = r.store.Query(ctx, q)
 	if err != nil {
@@ -273,17 +273,17 @@ func (r *Resolver) actionIDsForMonitorIDINT64SinglePage(ctx context.Context, q *
 	if err != nil {
 		return nil, nil, err
 	}
-	IDs = make([]graphql.ID, 0, len(es))
+	ids = make([]graphql.ID, 0, len(es))
 	for _, e := range es {
-		IDs = append(IDs, (&monitorEmail{MonitorEmail: e}).ID())
+		ids = append(ids, (&monitorEmail{MonitorEmail: e}).ID())
 	}
 
 	// Set the cursor if the result size equals limit.
-	if len(IDs) == limit {
-		stringID := string(IDs[len(IDs)-1])
+	if len(ids) == limit {
+		stringID := string(ids[len(ids)-1])
 		cursor = &stringID
 	}
-	return IDs, cursor, nil
+	return ids, cursor, nil
 }
 
 // splitActionIDs splits actions into three buckets: create, delete and update.

--- a/internal/usagestats/usage_stats_test.go
+++ b/internal/usagestats/usage_stats_test.go
@@ -135,7 +135,7 @@ func TestUserUsageStatistics_LogPageView(t *testing.T) {
 	if wantViews := int32(1); a.PageViews != wantViews {
 		t.Errorf("got %d, want %d", a.PageViews, wantViews)
 	}
-	diff := (*a.LastActiveTime).Unix() - time.Now().Unix()
+	diff := a.LastActiveTime.Unix() - time.Now().Unix()
 	if wantMaxDiff := 10; diff > int64(wantMaxDiff) || diff < -int64(wantMaxDiff) {
 		t.Errorf("got %d seconds apart, wanted less than %d seconds apart", diff, wantMaxDiff)
 	}
@@ -202,7 +202,7 @@ func TestUserUsageStatistics_LogCodeHostIntegrationUsage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	diff := (*a.LastCodeHostIntegrationTime).Unix() - time.Now().Unix()
+	diff := a.LastCodeHostIntegrationTime.Unix() - time.Now().Unix()
 	if wantMaxDiff := 10; diff > int64(wantMaxDiff) || diff < -int64(wantMaxDiff) {
 		t.Errorf("got %d seconds apart, wanted less than %d seconds apart", diff, wantMaxDiff)
 	}


### PR DESCRIPTION
Enables the `underef`, `elseif`, and `captLocal` gocritic lints, which are the last of the gocritic lints that I think are worth enabling at this point. 

Progresses #18720 
Stacked on #19333 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
