### PR TITLE
changed from localhost to docs.sourcegraph.com

### DIFF
--- a/doc/dev/background-information/codeintel/extensions.md
+++ b/doc/dev/background-information/codeintel/extensions.md
@@ -1,10 +1,10 @@
 # How code intelligence extensions resolve hovers
 
-Definition, reference, and hover providers are invoked from the extension host when the user hovers over a symbol in a code view. See the documentation for [authoring extensions](http://localhost:5080/extensions/authoring) for more details about the general extension architecture.
+Definition, reference, and hover providers are invoked from the extension host when the user hovers over a symbol in a code view. See the documentation for [authoring extensions](https://docs.sourcegraph.com/extensions/authoring) for more details about the general extension architecture.
 
 These providers receive the current text document (denoting a repository, commit, and path) and the position the user is hovering (a line and column offset within the file). The providers return results as an asynchronous iterator, which allows additional results to be streamed into the UI as they are received from the backend.
 
-Code intelligence queries are resolved favoring [precise](http://localhost:5080/code_intelligence/explanations/precise_code_intelligence) code intelligence, if available, then falling back to [search-based](http://localhost:5080/code_intelligence/explanations/search_based_code_intelligence).
+Code intelligence queries are resolved favoring [precise](https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence) code intelligence, if available, then falling back to [search-based](https://docs.sourcegraph.com/code_intelligence/explanations/search_based_code_intelligence).
 
 ## Definitions
 


### PR DESCRIPTION
changed some links in dev/background-information/codeintel/extensions.md to point to the actual documentation
