### PR TITLE
Make authenticator marshalling for DB reusable

### DIFF
--- a/enterprise/internal/batches/background/ssh_migrator.go
+++ b/enterprise/internal/batches/background/ssh_migrator.go
@@ -32,8 +32,8 @@ var _ oobmigration.Migrator = &sshMigrator{}
 // credential type that ends on WithSSH is considered migrated.
 func (m *sshMigrator) Progress(ctx context.Context) (float64, error) {
 	unmigratedMigratorTypes := []*sqlf.Query{
-		sqlf.Sprintf("%s", strconv.Quote(string(database.UserCredentialTypeBasicAuth))),
-		sqlf.Sprintf("%s", strconv.Quote(string(database.UserCredentialTypeOAuthBearerToken))),
+		sqlf.Sprintf("%s", strconv.Quote(string(database.AuthenticatorTypeBasicAuth))),
+		sqlf.Sprintf("%s", strconv.Quote(string(database.AuthenticatorTypeOAuthBearerToken))),
 	}
 	progress, _, err := basestore.ScanFirstFloat(
 		m.store.Query(ctx, sqlf.Sprintf(
@@ -72,7 +72,7 @@ func (m *sshMigrator) Up(ctx context.Context) error {
 		LimitOffset: &database.LimitOffset{
 			Limit: sshMigrationCountPerRun,
 		},
-		AuthenticatorType: []database.UserCredentialType{database.UserCredentialTypeBasicAuth, database.UserCredentialTypeOAuthBearerToken},
+		AuthenticatorType: []database.AuthenticatorType{database.AuthenticatorTypeBasicAuth, database.AuthenticatorTypeOAuthBearerToken},
 		ForUpdate:         true,
 	})
 	if err != nil {
@@ -128,7 +128,7 @@ func (m *sshMigrator) Down(ctx context.Context) error {
 		LimitOffset: &database.LimitOffset{
 			Limit: sshMigrationCountPerRun,
 		},
-		AuthenticatorType: []database.UserCredentialType{database.UserCredentialTypeBasicAuthWithSSH, database.UserCredentialTypeOAuthBearerTokenWithSSH},
+		AuthenticatorType: []database.AuthenticatorType{database.AuthenticatorTypeBasicAuthWithSSH, database.AuthenticatorTypeOAuthBearerTokenWithSSH},
 		ForUpdate:         true,
 	})
 	for _, cred := range credentials {

--- a/internal/database/authenticator.go
+++ b/internal/database/authenticator.go
@@ -1,0 +1,129 @@
+package database
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+)
+
+// AuthenticatorType defines all possible types of authenticators stored in the database.
+type AuthenticatorType string
+
+// Define credential type strings that we'll use when encoding credentials.
+const (
+	AuthenticatorTypeOAuthClient                        AuthenticatorType = "OAuthClient"
+	AuthenticatorTypeBasicAuth                          AuthenticatorType = "BasicAuth"
+	AuthenticatorTypeBasicAuthWithSSH                   AuthenticatorType = "BasicAuthWithSSH"
+	AuthenticatorTypeOAuthBearerToken                   AuthenticatorType = "OAuthBearerToken"
+	AuthenticatorTypeOAuthBearerTokenWithSSH            AuthenticatorType = "OAuthBearerTokenWithSSH"
+	AuthenticatorTypeBitbucketServerSudoableOAuthClient AuthenticatorType = "BitbucketSudoableOAuthClient"
+	AuthenticatorTypeGitLabSudoableToken                AuthenticatorType = "GitLabSudoableToken"
+)
+
+// NullAuthenticator represents an authenticator that may be null. It implements
+// the sql.Scanner interface so it can be used as a scan destination, similar to
+// sql.NullString. When the scanned value is null, the authenticator will be nil.
+// It handles marshalling and unmarshalling the authenticator from and to JSON.
+type NullAuthenticator struct{ A *auth.Authenticator }
+
+// Scan implements the Scanner interface.
+func (n *NullAuthenticator) Scan(value interface{}) (err error) {
+	switch value := value.(type) {
+	case string:
+		*n.A, err = unmarshalAuthenticator(value)
+		return err
+	case nil:
+		return nil
+	default:
+		return fmt.Errorf("value is not string: %T", value)
+	}
+}
+
+// Value implements the driver Valuer interface.
+func (n NullAuthenticator) Value() (driver.Value, error) {
+	if *n.A == nil {
+		return nil, nil
+	}
+	return marshalAuthenticator(*n.A)
+}
+
+// marshalAuthenticator encodes an Authenticator into a JSON string.
+func marshalAuthenticator(a auth.Authenticator) (string, error) {
+	var t AuthenticatorType
+	switch a.(type) {
+	case *auth.OAuthClient:
+		t = AuthenticatorTypeOAuthClient
+	case *auth.BasicAuth:
+		t = AuthenticatorTypeBasicAuth
+	case *auth.BasicAuthWithSSH:
+		t = AuthenticatorTypeBasicAuthWithSSH
+	case *auth.OAuthBearerToken:
+		t = AuthenticatorTypeOAuthBearerToken
+	case *auth.OAuthBearerTokenWithSSH:
+		t = AuthenticatorTypeOAuthBearerTokenWithSSH
+	case *bitbucketserver.SudoableOAuthClient:
+		t = AuthenticatorTypeBitbucketServerSudoableOAuthClient
+	case *gitlab.SudoableToken:
+		t = AuthenticatorTypeGitLabSudoableToken
+	default:
+		return "", errors.Errorf("unknown Authenticator implementation type: %T", a)
+	}
+
+	raw, err := json.Marshal(struct {
+		Type AuthenticatorType
+		Auth auth.Authenticator
+	}{
+		Type: t,
+		Auth: a,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return string(raw), nil
+}
+
+// unmarshalAuthenticator decodes a JSON string into an Authenticator.
+func unmarshalAuthenticator(raw string) (auth.Authenticator, error) {
+	// We do two unmarshals: the first just to get the type, and then the second
+	// to actually unmarshal the authenticator itself.
+	var partial struct {
+		Type AuthenticatorType
+		Auth json.RawMessage
+	}
+	if err := json.Unmarshal([]byte(raw), &partial); err != nil {
+		return nil, err
+	}
+
+	var a interface{}
+	switch partial.Type {
+	case AuthenticatorTypeOAuthClient:
+		a = &auth.OAuthClient{}
+	case AuthenticatorTypeBasicAuth:
+		a = &auth.BasicAuth{}
+	case AuthenticatorTypeBasicAuthWithSSH:
+		a = &auth.BasicAuthWithSSH{}
+	case AuthenticatorTypeOAuthBearerToken:
+		a = &auth.OAuthBearerToken{}
+	case AuthenticatorTypeOAuthBearerTokenWithSSH:
+		a = &auth.OAuthBearerTokenWithSSH{}
+	case AuthenticatorTypeBitbucketServerSudoableOAuthClient:
+		a = &bitbucketserver.SudoableOAuthClient{}
+	case AuthenticatorTypeGitLabSudoableToken:
+		a = &gitlab.SudoableToken{}
+	default:
+		return nil, errors.Errorf("unknown credential type: %s", partial.Type)
+	}
+
+	if err := json.Unmarshal(partial.Auth, &a); err != nil {
+		return nil, err
+	}
+
+	return a.(auth.Authenticator), nil
+}

--- a/internal/database/user_credentials_test.go
+++ b/internal/database/user_credentials_test.go
@@ -336,7 +336,7 @@ func TestUserCredentials_List(t *testing.T) {
 				UserID: user.ID,
 			},
 		},
-		"authenticator type": {AuthenticatorType: []UserCredentialType{UserCredentialTypeOAuthBearerToken}},
+		"authenticator type": {AuthenticatorType: []AuthenticatorType{AuthenticatorTypeOAuthBearerToken}},
 	} {
 		t.Run("multiple matches on "+name, func(t *testing.T) {
 			creds, next, err := UserCredentials(db).List(ctx, opts)
@@ -464,7 +464,9 @@ func createUserCredentialAuths(t *testing.T) map[string]auth.Authenticator {
 	for _, a := range []auth.Authenticator{
 		&auth.OAuthClient{Client: createOAuthClient(t, "abc", "def")},
 		&auth.BasicAuth{Username: "foo", Password: "bar"},
+		&auth.BasicAuthWithSSH{BasicAuth: auth.BasicAuth{Username: "foo", Password: "bar"}, PrivateKey: "private", PublicKey: "public", Passphrase: "pass"},
 		&auth.OAuthBearerToken{Token: "abcdef"},
+		&auth.OAuthBearerTokenWithSSH{OAuthBearerToken: auth.OAuthBearerToken{Token: "abcdef"}, PrivateKey: "private", PublicKey: "public", Passphrase: "pass"},
 		&bitbucketserver.SudoableOAuthClient{
 			Client:   auth.OAuthClient{Client: createOAuthClient(t, "ghi", "jkl")},
 			Username: "neo",

--- a/internal/extsvc/auth/basic.go
+++ b/internal/extsvc/auth/basic.go
@@ -30,7 +30,6 @@ func (basic *BasicAuth) Hash() string {
 type BasicAuthWithSSH struct {
 	BasicAuth
 
-	Token      string
 	PrivateKey string
 	PublicKey  string
 	Passphrase string


### PR DESCRIPTION
This PR exposes a new NullAuthenticator that can be used for scanning and passing auth.Authenticators to the database.
