### PR TITLE
database: Change DBNameSuffix in internal/database

### DIFF
--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -9,20 +9,16 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "database"
-}
 
 func TestIterateRepoGitserverStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 
 	repo1 := &types.Repo{
@@ -92,7 +88,7 @@ func TestGitserverReposGetByID(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 
 	_, err := GitserverRepos(db).GetByID(ctx, 1)
@@ -142,7 +138,7 @@ func TestSetCloneStatus(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 	const shardID = "test"
 
@@ -242,7 +238,7 @@ func TestSetLastError(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 	const shardID = "test"
 
@@ -333,7 +329,7 @@ func TestGitserverRepoUpsertNullShard(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 
 	repo1 := &types.Repo{
@@ -368,7 +364,7 @@ func TestGitserverRepoUpsert(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	ctx := context.Background()
 
 	repo1 := &types.Repo{

--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func init() {
-	dbtesting.DBNameSuffix = "gitserver"
+	dbtesting.DBNameSuffix = "database"
 }
 
 func TestIterateRepoGitserverStatus(t *testing.T) {

--- a/internal/database/main_test.go
+++ b/internal/database/main_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func init() {
-	// TEMP
-	dbtesting.DBNameSuffix = "gitserver"
+	dbtesting.DBNameSuffix = "database"
 }
 
 func TestMain(m *testing.M) {

--- a/internal/database/main_test.go
+++ b/internal/database/main_test.go
@@ -6,7 +6,13 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
+
+func init() {
+	dbtesting.DBNameSuffix = "database"
+}
 
 func TestMain(m *testing.M) {
 	flag.Parse()

--- a/internal/database/main_test.go
+++ b/internal/database/main_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func init() {
-	dbtesting.DBNameSuffix = "database"
+	// TEMP
+	dbtesting.DBNameSuffix = "gitserver"
 }
 
 func TestMain(m *testing.M) {

--- a/internal/database/main_test.go
+++ b/internal/database/main_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	dbtesting.DBNameSuffix = "database"
+	dbtesting.DBNameSuffix = "internal-database"
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
The previous value of "gitserver" was confusing. Since this case happens
in the "database" package I've gone with the name "internal-database".

I initially tried to simply use "database" but this appears to conflict with something
which I was unable to discover and causes migrations during testing to fail.