### PR TITLE
Follow-up fixes to "archive changesets"

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.scss
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.scss
@@ -5,6 +5,11 @@
             height: 1rem;
             display: inline-block;
         }
+
+        &__archive-icon {
+            width: 1rem;
+            height: 1rem;
+        }
     }
     &__container {
         @include media-breakpoint-down(xs) {

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -15,7 +15,6 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { useObservable } from '../../../../../shared/src/util/useObservable'
 import { queryChangesetCountsOverTime as _queryChangesetCountsOverTime } from './backend'
 import { getYear, parseISO } from 'date-fns'
-import ArchiveIcon from 'mdi-react/ArchiveIcon'
 import { Toggle } from '../../../../../branded/src/components/Toggle'
 
 interface Props {
@@ -168,13 +167,7 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
                         ))}
                 </ComposedChart>
             </ResponsiveContainer>
-            <div className="flex-grow-0 btn-group-vertical ml-2">
-                {archiveEnabled && (
-                    <>
-                        <IncludeArchivedToggle includeArchived={includeArchived} onToggle={toggleIncludeArchived} />
-                        <hr className="flex-grow-1" />
-                    </>
-                )}
+            <div className="flex-grow-0 ml-2">
                 {Object.entries(states).map(([key, state]) => (
                     <LegendLabel
                         key={key}
@@ -185,6 +178,12 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
                         setHiddenStates={setHiddenStates}
                     />
                 ))}
+                {archiveEnabled && (
+                    <>
+                        <hr className="flex-grow-1" />
+                        <IncludeArchivedToggle includeArchived={includeArchived} onToggle={toggleIncludeArchived} />
+                    </>
+                )}
             </div>
         </div>
     )
@@ -232,9 +231,8 @@ const IncludeArchivedToggle: React.FunctionComponent<{
     includeArchived: boolean
     onToggle: () => void
 }> = ({ includeArchived, onToggle }) => (
-    <div className="d-flex text-right align-items-center text-nowrap p-2">
-        <ArchiveIcon className="text-muted batch-change-burndown-chart-legend__archive-icon mr-2 p-0" />
-        <label htmlFor="include-archived" className="mb-0">
+    <div className="d-flex align-items-center justify-content-between text-nowrap mb-2">
+        <label htmlFor="include-archived" className="mb-0 pt-1">
             Include archived
         </label>
         <Toggle

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -172,7 +172,7 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
                 {archiveEnabled && (
                     <>
                         <IncludeArchivedToggle includeArchived={includeArchived} onToggle={toggleIncludeArchived} />
-                        <hr />
+                        <hr className="flex-grow-1" />
                     </>
                 )}
                 {Object.entries(states).map(([key, state]) => (

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -169,6 +169,12 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
                 </ComposedChart>
             </ResponsiveContainer>
             <div className="flex-grow-0 btn-group-vertical ml-2">
+                {archiveEnabled && (
+                    <>
+                        <IncludeArchivedToggle includeArchived={includeArchived} onToggle={toggleIncludeArchived} />
+                        <hr />
+                    </>
+                )}
                 {Object.entries(states).map(([key, state]) => (
                     <LegendLabel
                         key={key}
@@ -179,12 +185,6 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
                         setHiddenStates={setHiddenStates}
                     />
                 ))}
-                {archiveEnabled && (
-                    <>
-                        <hr />
-                        <IncludeArchivedToggle includeArchived={includeArchived} onToggle={toggleIncludeArchived} />
-                    </>
-                )}
             </div>
         </div>
     )
@@ -232,17 +232,17 @@ const IncludeArchivedToggle: React.FunctionComponent<{
     includeArchived: boolean
     onToggle: () => void
 }> = ({ includeArchived, onToggle }) => (
-    <div className="d-flex align-items-center text-nowrap p-2">
+    <div className="d-flex text-right align-items-center text-nowrap p-2">
         <ArchiveIcon className="text-muted batch-change-burndown-chart-legend__archive-icon mr-2 p-0" />
+        <label htmlFor="include-archived" className="mb-0">
+            Include archived
+        </label>
         <Toggle
             id="include-archived"
             value={includeArchived}
             onToggle={onToggle}
             title="Include archived changesets"
-            className="mr-2"
+            className="ml-2"
         />
-        <label htmlFor="include-archived" className="mb-0">
-            Include archived
-        </label>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeBurndownChart.tsx
@@ -16,6 +16,7 @@ import { useObservable } from '../../../../../shared/src/util/useObservable'
 import { queryChangesetCountsOverTime as _queryChangesetCountsOverTime } from './backend'
 import { getYear, parseISO } from 'date-fns'
 import ArchiveIcon from 'mdi-react/ArchiveIcon'
+import { Toggle } from '../../../../../branded/src/components/Toggle'
 
 interface Props {
     batchChangeID: Scalars['ID']
@@ -179,7 +180,10 @@ export const BatchChangeBurndownChart: React.FunctionComponent<Props> = ({
                     />
                 ))}
                 {archiveEnabled && (
-                    <IncludeArchivedToggle includeArchived={includeArchived} onChangeCheckbox={toggleIncludeArchived} />
+                    <>
+                        <hr />
+                        <IncludeArchivedToggle includeArchived={includeArchived} onToggle={toggleIncludeArchived} />
+                    </>
                 )}
             </div>
         </div>
@@ -226,16 +230,16 @@ const LegendLabel: React.FunctionComponent<{
 
 const IncludeArchivedToggle: React.FunctionComponent<{
     includeArchived: boolean
-    onChangeCheckbox: () => void
-}> = ({ includeArchived, onChangeCheckbox }) => (
+    onToggle: () => void
+}> = ({ includeArchived, onToggle }) => (
     <div className="d-flex align-items-center text-nowrap p-2">
         <ArchiveIcon className="text-muted batch-change-burndown-chart-legend__archive-icon mr-2 p-0" />
-        <input
+        <Toggle
             id="include-archived"
-            type="checkbox"
+            value={includeArchived}
+            onToggle={onToggle}
+            title="Include archived changesets"
             className="mr-2"
-            checked={includeArchived}
-            onChange={onChangeCheckbox}
         />
         <label htmlFor="include-archived" className="mb-0">
             Include archived

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -93,9 +93,16 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
     )
 
     const archiveEnabled = window.context?.experimentalFeatures?.archiveBatchChangeChangesets
-    const urlParameters = new URLSearchParams(location.search)
-    const archivedCount = parseInt(urlParameters.get('archivedCount') ?? '0', 10)
-    const archivedBy = urlParameters.get('archivedBy') ?? ''
+
+    const [archivedCount, archivedBy] = useMemo(() => {
+        const parameters = new URLSearchParams(location.search)
+        const count = parameters.get('archivedCount')
+        parameters.delete('archivedCount')
+
+        const archived = parameters.get('archivedBy')
+        parameters.delete('archivedBy')
+        return [parseInt(count ?? '0', 10), archived ?? '']
+    }, [location.search])
 
     // Is loading.
     if (batchChange === undefined) {

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -102,12 +102,8 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
         const archived = parameters.get('archivedBy')
         parameters.delete('archivedBy')
 
-        if (location.search !== parameters.toString()) {
-            history.replace({ ...location, search: parameters.toString() })
-        }
         return [parseInt(count ?? '0', 10), archived ?? '']
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [history])
+    }, [location.search])
 
     // Is loading.
     if (batchChange === undefined) {

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -158,6 +158,8 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
             <Description history={history} description={batchChange.description} />
             <BatchChangeTabs
                 batchChange={batchChange}
+                changesetsCount={batchChange.changesetsStats.total - batchChange.changesetsStats.archived}
+                archivedCount={batchChange.changesetsStats.archived}
                 extensionsController={extensionsController}
                 history={history}
                 isLightTheme={isLightTheme}

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -101,8 +101,13 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
 
         const archived = parameters.get('archivedBy')
         parameters.delete('archivedBy')
+
+        if (location.search !== parameters.toString()) {
+            history.replace({ ...location, search: parameters.toString() })
+        }
+
         return [parseInt(count ?? '0', 10), archived ?? '']
-    }, [location.search])
+    }, [history, location])
 
     // Is loading.
     if (batchChange === undefined) {

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -105,9 +105,9 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
         if (location.search !== parameters.toString()) {
             history.replace({ ...location, search: parameters.toString() })
         }
-
         return [parseInt(count ?? '0', 10), archived ?? '']
-    }, [history, location])
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [history])
 
     // Is loading.
     if (batchChange === undefined) {

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -29,6 +29,7 @@ import { SupersedingBatchSpecAlert } from './SupersedingBatchSpecAlert'
 import { BatchChangesIcon } from '../icons'
 import { PageHeader } from '../../../components/PageHeader'
 import { ClosedNotice } from './ClosedNotice'
+import { ChangesetsArchivedNotice } from './ChangesetsArchivedNotice'
 
 export interface BatchChangeDetailsPageProps
     extends ThemeProps,
@@ -91,6 +92,11 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
         )
     )
 
+    const archiveEnabled = window.context?.experimentalFeatures?.archiveBatchChangeChangesets
+    const urlParameters = new URLSearchParams(location.search)
+    const archivedCount = parseInt(urlParameters.get('archivedCount') ?? '0', 10)
+    const archivedBy = urlParameters.get('archivedBy') ?? ''
+
     // Is loading.
     if (batchChange === undefined) {
         return (
@@ -142,6 +148,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                 total={batchChange.changesetsStats.total}
                 className="mb-3"
             />
+            {archiveEnabled && <ChangesetsArchivedNotice archivedCount={archivedCount} specID={archivedBy} />}
             <BatchChangeStatsCard
                 closedAt={batchChange.closedAt}
                 stats={batchChange.changesetsStats}

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -94,17 +94,6 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
 
     const archiveEnabled = window.context?.experimentalFeatures?.archiveBatchChangeChangesets
 
-    const [archivedCount, archivedBy] = useMemo(() => {
-        const parameters = new URLSearchParams(location.search)
-        const count = parameters.get('archivedCount')
-        parameters.delete('archivedCount')
-
-        const archived = parameters.get('archivedBy')
-        parameters.delete('archivedBy')
-
-        return [parseInt(count ?? '0', 10), archived ?? '']
-    }, [location.search])
-
     // Is loading.
     if (batchChange === undefined) {
         return (
@@ -156,7 +145,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                 total={batchChange.changesetsStats.total}
                 className="mb-3"
             />
-            {archiveEnabled && <ChangesetsArchivedNotice archivedCount={archivedCount} specID={archivedBy} />}
+            {archiveEnabled && <ChangesetsArchivedNotice history={history} location={location} />}
             <BatchChangeStatsCard
                 closedAt={batchChange.closedAt}
                 stats={batchChange.changesetsStats}

--- a/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
@@ -27,6 +27,8 @@ export interface BatchChangeTabsProps
         PlatformContextProps,
         TelemetryProps {
     batchChange: BatchChangeFields
+    changesetsCount: number
+    archivedCount: number
     history: H.History
     location: H.Location
     /** For testing only. */
@@ -45,6 +47,8 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     platformContext,
     telemetryService,
     batchChange,
+    changesetsCount,
+    archivedCount,
     queryChangesets,
     queryChangesetCountsOverTime,
     queryExternalChangesetWithFileDiffs,
@@ -123,7 +127,8 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                             onClick={onSelectChangesets}
                             className={classNames('nav-link', selectedTab === 'changesets' && 'active')}
                         >
-                            <SourceBranchIcon className="icon-inline text-muted mr-1" /> Changesets
+                            <SourceBranchIcon className="icon-inline text-muted mr-1" />{' '}
+                            {changesetsCount === 1 ? '1 Changeset' : `${changesetsCount} Changesets`}
                         </a>
                     </li>
                     <li className="nav-item test-batches-chart-tab">
@@ -151,7 +156,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                                 onClick={onSelectArchived}
                                 className={classNames('nav-link', selectedTab === 'archived' && 'active')}
                             >
-                                <ArchiveIcon className="icon-inline text-muted mr-1" /> Archived
+                                <ArchiveIcon className="icon-inline text-muted mr-1" /> {archivedCount} Archived
                             </a>
                         </li>
                     )}

--- a/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import * as H from 'history'
 import { ExtensionsControllerProps } from '../../../../../shared/src/extensions/controller'
 import { ThemeProps } from '../../../../../shared/src/theme'
@@ -53,20 +53,16 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     queryChangesetCountsOverTime,
     queryExternalChangesetWithFileDiffs,
 }) => {
-    const archiveEnabled = window.context?.experimentalFeatures?.archiveBatchChangeChangesets
-    const [selectedTab, setSelectedTab] = useState<SelectedTab>(() => {
-        const urlParameters = new URLSearchParams(location.search)
-        if (urlParameters.get('tab') === 'chart') {
-            return 'chart'
+    const archiveEnabled = window.context?.experimentalFeatures?.archiveBatchChangeChangesets ?? false
+    const [selectedTab, setSelectedTab] = useState<SelectedTab>(
+        selectedTabFromLocation(location.search, archiveEnabled)
+    )
+    useEffect(() => {
+        const newTab = selectedTabFromLocation(location.search, archiveEnabled)
+        if (newTab !== selectedTab) {
+            setSelectedTab(newTab)
         }
-        if (urlParameters.get('tab') === 'spec') {
-            return 'spec'
-        }
-        if (urlParameters.get('tab') === 'archived') {
-            return archiveEnabled ? 'archived' : 'changesets'
-        }
-        return 'changesets'
-    })
+    }, [location.search, selectedTab, archiveEnabled])
 
     const onSelectChangesets = useCallback<React.MouseEventHandler>(
         event => {
@@ -205,4 +201,18 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
             )}
         </>
     )
+}
+
+function selectedTabFromLocation(locationSearch: string, archiveEnabled: boolean): SelectedTab {
+    const urlParameters = new URLSearchParams(locationSearch)
+    if (urlParameters.get('tab') === 'chart') {
+        return 'chart'
+    }
+    if (urlParameters.get('tab') === 'spec') {
+        return 'spec'
+    }
+    if (urlParameters.get('tab') === 'archived') {
+        return archiveEnabled ? 'archived' : 'changesets'
+    }
+    return 'changesets'
 }

--- a/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
@@ -127,8 +127,8 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                             onClick={onSelectChangesets}
                             className={classNames('nav-link', selectedTab === 'changesets' && 'active')}
                         >
-                            <SourceBranchIcon className="icon-inline text-muted mr-1" />{' '}
-                            {changesetsCount === 1 ? '1 Changeset' : `${changesetsCount} Changesets`}
+                            <SourceBranchIcon className="icon-inline text-muted mr-1" />
+                            Changesets <span className="badge badge-pill badge-secondary ml-1">{changesetsCount}</span>
                         </a>
                     </li>
                     <li className="nav-item test-batches-chart-tab">
@@ -156,7 +156,8 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                                 onClick={onSelectArchived}
                                 className={classNames('nav-link', selectedTab === 'archived' && 'active')}
                             >
-                                <ArchiveIcon className="icon-inline text-muted mr-1" /> {archivedCount} Archived
+                                <ArchiveIcon className="icon-inline text-muted mr-1" /> Archived{' '}
+                                <span className="badge badge-pill badge-secondary ml-1">{archivedCount}</span>
                             </a>
                         </li>
                     )}

--- a/client/web/src/enterprise/batches/detail/ChangesetsArchivedNotice.tsx
+++ b/client/web/src/enterprise/batches/detail/ChangesetsArchivedNotice.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { DismissibleAlert } from '../../../components/DismissibleAlert'
+import ArchiveIcon from 'mdi-react/ArchiveIcon'
+
+export interface ChangesetsArchivedNoticeProps {
+    archivedCount: number
+    specID: string
+}
+
+export const ChangesetsArchivedNotice: React.FunctionComponent<ChangesetsArchivedNoticeProps> = ({
+    archivedCount,
+    specID,
+}) => {
+    if (archivedCount === 0 || specID === '') {
+        return <></>
+    }
+
+    return (
+        <DismissibleAlert className="alert alert-info" partialStorageKey={`changesets-archived-by-${specID}`}>
+            <div className="d-flex align-items-center">
+                <div className="d-none d-md-block">
+                    <ArchiveIcon className="icon icon-inline mr-2" />
+                </div>
+                <div className="flex-grow-1">
+                    {archivedCount === 1
+                        ? '1 changeset has been archived'
+                        : `${archivedCount} changesets have been archived.`}
+                </div>
+            </div>
+        </DismissibleAlert>
+    )
+}

--- a/client/web/src/enterprise/batches/detail/ChangesetsArchivedNotice.tsx
+++ b/client/web/src/enterprise/batches/detail/ChangesetsArchivedNotice.tsx
@@ -1,30 +1,51 @@
-import React from 'react'
+import * as H from 'history'
+import React, { useEffect, useState } from 'react'
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
 import ArchiveIcon from 'mdi-react/ArchiveIcon'
+import { pluralize } from '../../../../../shared/src/util/strings'
+import { Link } from '../../../../../shared/src/components/Link'
 
 export interface ChangesetsArchivedNoticeProps {
-    archivedCount: number
-    specID: string
+    history: H.History
+    location: H.Location
 }
 
 export const ChangesetsArchivedNotice: React.FunctionComponent<ChangesetsArchivedNoticeProps> = ({
-    archivedCount,
-    specID,
+    history,
+    location,
 }) => {
-    if (archivedCount === 0 || specID === '') {
+    const [archivedCount, setArchivedCount] = useState<number | undefined>()
+    const [archivedBy, setArchivedBy] = useState<string | undefined>()
+    useEffect(() => {
+        const parameters = new URLSearchParams(location.search)
+
+        const count = parameters.get('archivedCount')
+        parameters.delete('archivedCount')
+        const archived = parameters.get('archivedBy')
+        parameters.delete('archivedBy')
+        if (count !== null && archived !== null) {
+            setArchivedCount(parseInt(count, 10))
+            setArchivedBy(archived)
+        }
+
+        if (new URLSearchParams(location.search).toString() !== parameters.toString()) {
+            history.replace({ ...location, search: parameters.toString() })
+        }
+    }, [history, location])
+
+    if (!archivedCount || !archivedBy) {
         return <></>
     }
 
     return (
-        <DismissibleAlert className="alert alert-info" partialStorageKey={`changesets-archived-by-${specID}`}>
+        <DismissibleAlert className="alert alert-info" partialStorageKey={`changesets-archived-by-${archivedBy}`}>
             <div className="d-flex align-items-center">
                 <div className="d-none d-md-block">
                     <ArchiveIcon className="icon icon-inline mr-2" />
                 </div>
                 <div className="flex-grow-1">
-                    {archivedCount === 1
-                        ? '1 changeset has been archived.'
-                        : `${archivedCount} changesets have been archived.`}
+                    {archivedCount} {pluralize('changeset', archivedCount)} {pluralize('has', archivedCount, 'have')}{' '}
+                    been <Link to="?tab=archived">archived</Link>.
                 </div>
             </div>
         </DismissibleAlert>

--- a/client/web/src/enterprise/batches/detail/ChangesetsArchivedNotice.tsx
+++ b/client/web/src/enterprise/batches/detail/ChangesetsArchivedNotice.tsx
@@ -23,7 +23,7 @@ export const ChangesetsArchivedNotice: React.FunctionComponent<ChangesetsArchive
                 </div>
                 <div className="flex-grow-1">
                     {archivedCount === 1
-                        ? '1 changeset has been archived'
+                        ? '1 changeset has been archived.'
                         : `${archivedCount} changesets have been archived.`}
                 </div>
             </div>

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -422,14 +422,15 @@ const changesetCountsOverTimeFragment = gql`
 
 export const queryChangesetCountsOverTime = ({
     batchChange,
+    includeArchived,
 }: ChangesetCountsOverTimeVariables): Observable<ChangesetCountsOverTimeFields[]> =>
     requestGraphQL<ChangesetCountsOverTimeResult, ChangesetCountsOverTimeVariables>(
         gql`
-            query ChangesetCountsOverTime($batchChange: ID!) {
+            query ChangesetCountsOverTime($batchChange: ID!, $includeArchived: Boolean!) {
                 node(id: $batchChange) {
                     __typename
                     ... on BatchChange {
-                        changesetCountsOverTime {
+                        changesetCountsOverTime(includeArchived: $includeArchived) {
                             ...ChangesetCountsOverTimeFields
                         }
                     }
@@ -438,7 +439,7 @@ export const queryChangesetCountsOverTime = ({
 
             ${changesetCountsOverTimeFragment}
         `,
-        { batchChange }
+        { batchChange, includeArchived }
     ).pipe(
         map(dataOrThrowErrors),
         map(({ node }) => {

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewPage.tsx
@@ -102,6 +102,7 @@ export const BatchChangePreviewPage: React.FunctionComponent<BatchChangePreviewP
             <CreateUpdateBatchChangeAlert
                 history={history}
                 specID={spec.id}
+                toBeArchived={spec.applyPreview.stats.archive}
                 batchChange={spec.appliesToBatchChange}
                 viewerCanAdminister={spec.viewerCanAdminister}
                 telemetryService={telemetryService}

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewStatsBar.tsx
@@ -19,47 +19,67 @@ export interface BatchChangePreviewStatsBarProps {
     batchSpec: BatchSpecFields
 }
 
-export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePreviewStatsBarProps> = ({ batchSpec }) => (
-    <div className="d-flex flex-wrap mb-3 align-items-center">
-        <h2 className="m-0 align-self-center">
-            <span className="badge badge-info text-uppercase mb-0">Preview</span>
-        </h2>
-        <div className="batch-change-preview-stats-bar__divider d-none d-sm-block mx-3" />
-        <DiffStat
-            {...batchSpec.diffStat}
-            separateLines={true}
-            expandedCounts={true}
-            className="batch-change-preview-stats-bar__diff"
-        />
-        <div className="batch-change-preview-stats-bar__horizontal-divider d-block d-sm-none my-3" />
-        <div className="batch-change-preview-stats-bar__divider mx-3 d-none d-sm-block d-md-none" />
-        <div className="flex-grow-1 d-flex justify-content-end batch-change-preview-stats-bar__metrics">
-            <PreviewStatsAdded count={batchSpec.applyPreview.stats.added} />
-            <PreviewStatsRemoved count={batchSpec.applyPreview.stats.removed} />
-            <PreviewStatsModified count={batchSpec.applyPreview.stats.modified} />
+export const BatchChangePreviewStatsBar: React.FunctionComponent<BatchChangePreviewStatsBarProps> = ({ batchSpec }) => {
+    const archiveEnabled = window.context?.experimentalFeatures?.archiveBatchChangeChangesets
+
+    return (
+        <div className="d-flex flex-wrap mb-3 align-items-center">
+            <h2 className="m-0 align-self-center">
+                <span className="badge badge-info text-uppercase mb-0">Preview</span>
+            </h2>
+            <div className="batch-change-preview-stats-bar__divider d-none d-sm-block mx-3" />
+            <DiffStat
+                {...batchSpec.diffStat}
+                separateLines={true}
+                expandedCounts={true}
+                className="batch-change-preview-stats-bar__diff"
+            />
+            <div className="batch-change-preview-stats-bar__horizontal-divider d-block d-sm-none my-3" />
+            <div className="batch-change-preview-stats-bar__divider mx-3 d-none d-sm-block d-md-none" />
+            <div className="flex-grow-1 d-flex justify-content-end batch-change-preview-stats-bar__metrics">
+                <PreviewStatsAdded count={batchSpec.applyPreview.stats.added} />
+                <PreviewStatsRemoved count={batchSpec.applyPreview.stats.removed} />
+                <PreviewStatsModified count={batchSpec.applyPreview.stats.modified} />
+            </div>
+            <div className="batch-change-preview-stats-bar__horizontal-divider d-block d-md-none my-3" />
+            <div className="batch-change-preview-stats-bar__divider d-none d-md-block ml-3 mr-2" />
+            <div className="batch-change-preview-stats-bar__states d-flex justify-content-end">
+                <PreviewActionReopen
+                    className={actionClassNames}
+                    label={`${batchSpec.applyPreview.stats.reopen} reopen`}
+                />
+                <PreviewActionClose
+                    className={actionClassNames}
+                    label={`${batchSpec.applyPreview.stats.reopen} close`}
+                />
+                <PreviewActionUpdate
+                    className={actionClassNames}
+                    label={`${batchSpec.applyPreview.stats.update} update`}
+                />
+                <PreviewActionUndraft
+                    className={actionClassNames}
+                    label={`${batchSpec.applyPreview.stats.undraft} undraft`}
+                />
+                <PreviewActionPublish
+                    className={actionClassNames}
+                    label={`${
+                        batchSpec.applyPreview.stats.publish + batchSpec.applyPreview.stats.publishDraft
+                    } publish`}
+                />
+                <PreviewActionImport
+                    className={actionClassNames}
+                    label={`${batchSpec.applyPreview.stats.import} import`}
+                />
+                {archiveEnabled && (
+                    <PreviewActionArchive
+                        className={actionClassNames}
+                        label={`${batchSpec.applyPreview.stats.archive} archive`}
+                    />
+                )}
+            </div>
         </div>
-        <div className="batch-change-preview-stats-bar__horizontal-divider d-block d-md-none my-3" />
-        <div className="batch-change-preview-stats-bar__divider d-none d-md-block ml-3 mr-2" />
-        <div className="batch-change-preview-stats-bar__states d-flex justify-content-end">
-            <PreviewActionReopen className={actionClassNames} label={`${batchSpec.applyPreview.stats.reopen} reopen`} />
-            <PreviewActionClose className={actionClassNames} label={`${batchSpec.applyPreview.stats.reopen} close`} />
-            <PreviewActionUpdate className={actionClassNames} label={`${batchSpec.applyPreview.stats.update} update`} />
-            <PreviewActionUndraft
-                className={actionClassNames}
-                label={`${batchSpec.applyPreview.stats.undraft} undraft`}
-            />
-            <PreviewActionPublish
-                className={actionClassNames}
-                label={`${batchSpec.applyPreview.stats.publish + batchSpec.applyPreview.stats.publishDraft} publish`}
-            />
-            <PreviewActionImport className={actionClassNames} label={`${batchSpec.applyPreview.stats.import} import`} />
-            <PreviewActionArchive
-                className={actionClassNames}
-                label={`${batchSpec.applyPreview.stats.archive} archive`}
-            />
-        </div>
-    </div>
-)
+    )
+}
 
 export const PreviewStatsAdded: React.FunctionComponent<{ count: number }> = ({ count }) => (
     <div className="d-flex flex-column batch-change-preview-stats-bar__stat mr-2 text-nowrap">

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.story.tsx
@@ -18,6 +18,7 @@ add('Create', () => (
             <CreateUpdateBatchChangeAlert
                 {...props}
                 specID="123"
+                toBeArchived={18}
                 batchChange={null}
                 viewerCanAdminister={boolean('viewerCanAdminister', true)}
             />
@@ -30,6 +31,7 @@ add('Update', () => (
             <CreateUpdateBatchChangeAlert
                 {...props}
                 specID="123"
+                toBeArchived={199}
                 batchChange={{ id: '123', name: 'awesome-batch-change', url: 'http://test.test/awesome' }}
                 viewerCanAdminister={boolean('viewerCanAdminister', true)}
             />

--- a/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
+++ b/client/web/src/enterprise/batches/preview/CreateUpdateBatchChangeAlert.tsx
@@ -11,6 +11,7 @@ import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 
 export interface CreateUpdateBatchChangeAlertProps extends TelemetryProps {
     specID: string
+    toBeArchived: number
     batchChange: BatchSpecFields['appliesToBatchChange']
     viewerCanAdminister: boolean
     history: H.History
@@ -18,6 +19,7 @@ export interface CreateUpdateBatchChangeAlertProps extends TelemetryProps {
 
 export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateBatchChangeAlertProps> = ({
     specID,
+    toBeArchived,
     batchChange,
     viewerCanAdminister,
     history,
@@ -34,12 +36,17 @@ export const CreateUpdateBatchChangeAlert: React.FunctionComponent<CreateUpdateB
             const batchChange = batchChangeID
                 ? await applyBatchChange({ batchSpec: specID, batchChange: batchChangeID })
                 : await createBatchChange({ batchSpec: specID })
-            history.push(batchChange.url)
+
+            if (toBeArchived > 0) {
+                history.push(`${batchChange.url}?archivedCount=${toBeArchived}&archivedBy=${specID}`)
+            } else {
+                history.push(batchChange.url)
+            }
             telemetryService.logViewEvent(`BatchChangeDetailsPageAfter${batchChangeID ? 'Create' : 'Update'}`)
         } catch (error) {
             setIsLoading(error)
         }
-    }, [specID, setIsLoading, history, batchChangeID, telemetryService])
+    }, [specID, setIsLoading, history, batchChangeID, telemetryService, toBeArchived])
     return (
         <>
             <div className="alert alert-info p-3 mb-3 d-block d-md-flex align-items-center body-lead">

--- a/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
+++ b/client/web/src/enterprise/batches/preview/list/PreviewActions.tsx
@@ -205,7 +205,7 @@ export const PreviewActionArchive: React.FunctionComponent<{ label?: string; cla
     <div className={classNames(className, iconClassNames)}>
         <ArchiveIcon
             className="text-muted mr-1 icon-inline"
-            data-tooltip="This changeset will be archived in this batch change"
+            data-tooltip="This changeset will be kept and marked as archived in this batch change"
         />
         <span>{label}</span>
     </div>

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -689,7 +689,9 @@ describe('Batches', () => {
                 // Expect to be back at batch change overview page.
                 assert.strictEqual(
                     await driver.page.evaluate(() => window.location.href),
-                    testContext.driver.sourcegraphBaseUrl + namespaceURL + '/batch-changes/test-batch-change'
+                    testContext.driver.sourcegraphBaseUrl +
+                        namespaceURL +
+                        '/batch-changes/test-batch-change?archivedCount=10&archivedBy=spec123'
                 )
             })
         }

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -462,8 +462,9 @@ type BatchChangesCredentialResolver interface {
 }
 
 type ChangesetCountsArgs struct {
-	From *DateTime
-	To   *DateTime
+	From            *DateTime
+	To              *DateTime
+	IncludeArchived bool
 }
 
 type ListChangesetsArgs struct {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -10080,6 +10080,10 @@ type BatchChange implements Node {
         current time.
         """
         to: DateTime
+        """
+        Include archived changesets in the calculation.
+        """
+        includeArchived: Boolean = false
     ): [ChangesetCounts!]!
 
     """

--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -182,7 +182,8 @@ func (r *batchChangeResolver) ChangesetCountsOverTime(
 ) ([]graphqlbackend.ChangesetCountsResolver, error) {
 	publishedState := batches.ChangesetPublicationStatePublished
 	opts := store.ListChangesetsOpts{
-		BatchChangeID: r.batchChange.ID,
+		BatchChangeID:   r.batchChange.ID,
+		IncludeArchived: args.IncludeArchived,
 		// Only load fully-synced changesets, so that the data we use for computing the changeset counts is complete.
 		PublicationState: &publishedState,
 	}

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -917,7 +917,11 @@ WHERE
 `
 
 func archivedInBatchChange(batchChangeID string) *sqlf.Query {
-	return sqlf.Sprintf("COALESCE((batch_change_ids->%s->>'isArchived')::bool, false)", batchChangeID)
+	return sqlf.Sprintf(
+		"(COALESCE((batch_change_ids->%s->>'isArchived')::bool, false) OR COALESCE((batch_change_ids->%s->>'archive')::bool, false))",
+		batchChangeID,
+		batchChangeID,
+	)
 }
 
 func getChangesetsStatsQuery(batchChangeID int64) *sqlf.Query {

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -909,7 +909,7 @@ SELECT
 	COUNT(*) FILTER (WHERE %s AND changesets.external_state = 'MERGED'  AND NOT %s) AS merged,
 	COUNT(*) FILTER (WHERE %s AND changesets.external_state = 'OPEN'    AND NOT %s) AS open,
 	COUNT(*) FILTER (WHERE %s AND changesets.external_state = 'DELETED' AND NOT %s) AS deleted,
-	COUNT(*) FILTER (WHERE %s                                           AND %s) AS archived
+	COUNT(*) FILTER (WHERE %s)                                                      AS archived
 FROM changesets
 INNER JOIN repo on repo.id = changesets.repo_id
 WHERE
@@ -942,7 +942,7 @@ func getChangesetsStatsQuery(batchChangeID int64) *sqlf.Query {
 		publishedAndCompleted, archived,
 		publishedAndCompleted, archived,
 		publishedAndCompleted, archived,
-		publishedAndCompleted, archived,
+		archived,
 		sqlf.Join(preds, " AND "),
 	)
 }

--- a/enterprise/internal/batches/store/changesets_test.go
+++ b/enterprise/internal/batches/store/changesets_test.go
@@ -434,8 +434,15 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		})
 
 		t.Run("OnlyArchived", func(t *testing.T) {
+			// Changeset is archived
 			archivedChangeset := updateForThisTest(t, changesets[0], func(ch *batches.Changeset) {
 				ch.BatchChanges[0].IsArchived = true
+			})
+
+			// This changeset is marked as to-be-archived
+			_ = updateForThisTest(t, changesets[1], func(ch *batches.Changeset) {
+				ch.BatchChanges[0].BatchChangeID = archivedChangeset.BatchChanges[0].BatchChangeID
+				ch.BatchChanges[0].Archive = true
 			})
 
 			opts := CountChangesetsOpts{
@@ -447,8 +454,8 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 				t.Fatal(err)
 			}
 
-			if count != 1 {
-				t.Fatalf("got count %d, want: %d", count, 1)
+			if count != 2 {
+				t.Fatalf("got count %d, want: %d", count, 2)
 			}
 
 			opts.OnlyArchived = false
@@ -462,13 +469,21 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 		})
 
 		t.Run("IncludeArchived", func(t *testing.T) {
+			// Changeset is archived
 			archivedChangeset := updateForThisTest(t, changesets[0], func(ch *batches.Changeset) {
 				ch.BatchChanges[0].IsArchived = true
 			})
 
+			// Not archived, not marked as to-be-archived
 			_ = updateForThisTest(t, changesets[1], func(ch *batches.Changeset) {
 				ch.BatchChanges[0].BatchChangeID = archivedChangeset.BatchChanges[0].BatchChangeID
 				ch.BatchChanges[0].IsArchived = false
+			})
+
+			// Marked as to-be-archived
+			_ = updateForThisTest(t, changesets[2], func(ch *batches.Changeset) {
+				ch.BatchChanges[0].BatchChangeID = archivedChangeset.BatchChanges[0].BatchChangeID
+				ch.BatchChanges[0].Archive = true
 			})
 
 			opts := CountChangesetsOpts{
@@ -480,8 +495,8 @@ func testStoreChangesets(t *testing.T, ctx context.Context, s *Store, clock ct.C
 				t.Fatal(err)
 			}
 
-			if count != 2 {
-				t.Fatalf("got count %d, want: %d", count, 1)
+			if count != 3 {
+				t.Fatalf("got count %d, want: %d", count, 3)
 			}
 
 			opts.IncludeArchived = false

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -40,8 +40,9 @@ type TestChangesetOpts struct {
 
 	OwnedByBatchChange int64
 
-	Closing  bool
-	Archived bool
+	Closing    bool
+	IsArchived bool
+	Archive    bool
 
 	Metadata interface{}
 }
@@ -106,7 +107,7 @@ func BuildChangeset(opts TestChangesetOpts) *batches.Changeset {
 
 	if opts.BatchChange != 0 {
 		changeset.BatchChanges = []batches.BatchChangeAssoc{
-			{BatchChangeID: opts.BatchChange, IsArchived: opts.Archived},
+			{BatchChangeID: opts.BatchChange, IsArchived: opts.IsArchived, Archive: opts.Archive},
 		}
 	}
 


### PR DESCRIPTION
This is the follow-up PR to #18559 and fixes the TODOs from this comment https://github.com/sourcegraph/sourcegraph/issues/16031#issuecomment-804723900:

- [x] Add button to burndown chart that toggles archived changesets on/off
- [x] Add number of archived changesets next to "archived" tab
- [x] After applying a spec and that archived changesets, show a dismissable note "14 changesets have been archived"
- [x] Backend: change the default scope to also exclude changesets where "Archive: true" so that they don't show up in the "changesets" tab when they're being reconciled to be archived, but instead show up in the "archived" tab
- [x] Add tooltips to operations, see https://github.com/sourcegraph/sourcegraph/pull/18559#issuecomment-802861387

### Demo Video


https://user-images.githubusercontent.com/1185253/112147918-89bf9700-8bdd-11eb-9602-26caec57db8c.mp4

Update: now there's a toggle

![image](https://user-images.githubusercontent.com/1185253/112171680-576d6400-8bf4-11eb-85fe-c81557700e43.png)
