### PR TITLE
Get frontend logs on cluster failure

### DIFF
--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -57,7 +57,7 @@ function cluster_setup() {
     ./create-new-cluster.sh
   )
 
-  kubectl get pods
+  kubectl get -n "$NAMESPACE" pods
 
   trap error_trap ERR
   time kubectl wait --for=condition=Ready -l app=sourcegraph-frontend pod --timeout=20m

--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -8,9 +8,6 @@ root_dir="$(dirname "${BASH_SOURCE[0]}")/../../../.."
 cd "$root_dir"
 
 function error_trap() {
-  # All steps must run, disable early exit
-  set +euo pipefails
-
   kubectl logs --namespace="$NAMESPACE" -l app=sourcegraph-frontend -c frontend
 }
 

--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -18,6 +18,14 @@ function exit_trap() {
   kubectl delete namespace "$NAMESPACE"
 }
 
+function load_profile() {
+  # Load variables set up by init-server, disabling `-x` to avoid printing variables, setting +u to avoid blowing up on ubound ones
+  set +x +u
+  # shellcheck disable=SC1091
+  source /root/.profile
+  set -x -u
+}
+
 function cluster_setup() {
   git clone --depth 1 \
     https://github.com/sourcegraph/deploy-sourcegraph.git \
@@ -59,9 +67,7 @@ function cluster_setup() {
 }
 
 function test_setup() {
-  set +x +u
-  # shellcheck disable=SC1091
-  source /root/.profile
+  load_profile
 
   dev/ci/test/setup-deps.sh
 
@@ -76,10 +82,7 @@ function test_setup() {
     ./init-sg initSG -baseurl="$SOURCEGRAPH_BASE_URL"
   )
 
-  # Load variables set up by init-server, disabling `-x` to avoid printing variables, setting +u to avoid blowing up on ubound ones
-  set +x +u
-  # shellcheck disable=SC1091
-  source /root/.profile
+  load_profile
 
   echo "TEST: Checking Sourcegraph instance is accessible"
 

--- a/dev/ci/test/cluster/cluster-test.sh
+++ b/dev/ci/test/cluster/cluster-test.sh
@@ -73,11 +73,10 @@ function test_setup() {
   curl "$SOURCEGRAPH_BASE_URL"
 
   # setup admin users, etc
-  (
-    pushd internal/cmd/init-sg
-    go build
-    ./init-sg initSG -baseurl="$SOURCEGRAPH_BASE_URL"
-  )
+  pushd internal/cmd/init-sg
+  go build
+  ./init-sg initSG -baseurl="$SOURCEGRAPH_BASE_URL"
+  popd
 
   load_profile
 


### PR DESCRIPTION
If we fail waiting for the frontend to start, pull the logs to help
debugging.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->