### PR TITLE
search: more logging for meteredSearcher

### DIFF
--- a/internal/search/backend/metered_searcher.go
+++ b/internal/search/backend/metered_searcher.go
@@ -117,15 +117,18 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 	statsAgg := &zoekt.Stats{}
 	nFilesMatches := 0
 	nEvents := 0
+	var totalSendTimeMs int64
 
 	err = m.Streamer.StreamSearch(ctx, q, opts, ZoektStreamFunc(func(zsr *zoekt.SearchResult) {
 		first.Do(func() {
 			if isLeaf {
+				if !writeRequestStart.IsZero() {
+					tr.LogFields(
+						log.Int64("rpc.queue_latency_ms", writeRequestStart.Sub(start).Milliseconds()),
+						log.Int64("rpc.write_duration_ms", writeRequestDone.Sub(writeRequestStart).Milliseconds()),
+					)
+				}
 				tr.LogFields(
-					// TODO (stefan): Remove rpc.* once we have rolled out the new stream client.
-					log.Int64("rpc.queue_latency_ms", writeRequestStart.Sub(start).Milliseconds()),
-					log.Int64("rpc.write_duration_ms", writeRequestDone.Sub(writeRequestStart).Milliseconds()),
-
 					log.Int64("stream.latency_ms", time.Since(start).Milliseconds()),
 				)
 			}
@@ -140,13 +143,18 @@ func (m *meteredSearcher) StreamSearch(ctx context.Context, q query.Q, opts *zoe
 
 			startSend := time.Now()
 			c.Send(zsr)
-			log.Int64("stream.send_duration_ms", time.Since(startSend).Milliseconds())
+			sendTimeMs := time.Since(startSend).Milliseconds()
+
+			mu.Lock()
+			totalSendTimeMs += sendTimeMs
+			mu.Unlock()
 		}
 	}))
 
 	tr.LogFields(
 		log.Int("filematches", nFilesMatches),
 		log.Int("events", nEvents),
+		log.Int64("stream.total_send_time_ms", totalSendTimeMs),
 
 		// Zoekt stats.
 		log.Int64("stats.content_bytes_loaded", statsAgg.ContentBytesLoaded),


### PR DESCRIPTION
This logs `stream.latency_ms` and `stream.total_send_time_ms` to the spans of
`meteredSearcher.` The new data points will help us understand how much
backpressure `meteredSearcher` experiences.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
