### PR TITLE
Fix burndown chart "min 1 week" behaviour if there are events

### DIFF
--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -208,14 +208,15 @@ func (r *batchChangeResolver) ChangesetCountsOverTime(
 	now := r.store.Clock()()
 	weekAgo := now.Add(-7 * 24 * time.Hour)
 	start := r.batchChange.CreatedAt.UTC()
+	if len(events) > 0 {
+		start = events[0].Timestamp().UTC()
+	}
 	// At least a week lookback, more if the batch change was created earlier.
 	if start.After(weekAgo) {
 		start = weekAgo
 	}
 	if args.From != nil {
 		start = args.From.Time.UTC()
-	} else if len(events) > 0 {
-		start = events[0].Timestamp().UTC()
 	}
 	end := now.UTC()
 	if args.To != nil && args.To.Time.Before(end) {


### PR DESCRIPTION
Before this change a new event would reset the "at least one week of
lookback" beviour by overwriting the start timestamp.

This commit fixes that by using the batch change creation date or the
first events creation date as initial values and *then* overwrites
those.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
