### PR TITLE
Fix file actions for large screens on Firefox/Safari

### DIFF
--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -253,7 +253,7 @@ export const RepoHeader: React.FunctionComponent<Props> = ({
                     </ul>
                 ) : (
                     <ul className="navbar-nav">
-                        <li className="nav-item d-lg-none">
+                        <li className="nav-item">
                             <ButtonDropdown
                                 className="menu-nav-item"
                                 direction="down"


### PR DESCRIPTION
**Bug**: In 3.26, file actions do not appear on large screens in Firefox/Safari.

**Why:**: Firefox/Safari `ResizeObserver` emits single object `ResizeObserverSize`, whereas Chrome `ResizeObserver` emits arrays of `ResizeObserverSize`. [`dom.d.ts`](https://github.com/microsoft/TypeScript/blob/master/lib/lib.dom.d.ts#L12693) seems to reflect Chrome, so our code didn't handle the Firefox/Safari case and fell back to mobile.

This would be okay if we hadn't also set a media query for the file actions dropdown. We would show a dropdown on large screens, but that's not as bad as not showing the file actions at all.

**Fix**: 
- Handle browser `ResizeObserver` quirks
- Remove unnecessary media query

**Before**:

![Screenshot from 2021-03-23 15-00-30](https://user-images.githubusercontent.com/37420160/112203106-8b428c80-8be8-11eb-8c93-4419cbe523b5.png)

**After**:

![Screenshot from 2021-03-23 14-59-24](https://user-images.githubusercontent.com/37420160/112203111-8da4e680-8be8-11eb-86b2-7d80ce786064.png)