### PR TITLE
ci: add prefix tag for running only backend tests

### DIFF
--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -40,6 +40,7 @@ type Config struct {
 	patchNoTest         bool
 	isQuick             bool
 	isMasterDryRun      bool
+	isBackendDryRun     bool
 
 	// profilingEnabled, if true, tells buildkite to print timing and resource utilization information
 	// for each command
@@ -71,6 +72,8 @@ func ComputeConfig() Config {
 	if patchNoTest || patch {
 		version = version + "_patch"
 	}
+
+	isBackendDryRun := strings.HasPrefix(branch, "backend-dry-run/")
 
 	isMasterDryRun := strings.HasPrefix(branch, "master-dry-run/")
 
@@ -110,6 +113,7 @@ func ComputeConfig() Config {
 		patchNoTest:         patchNoTest,
 		isQuick:             isQuick,
 		isMasterDryRun:      isMasterDryRun,
+		isBackendDryRun:     isBackendDryRun,
 		profilingEnabled:    profilingEnabled,
 		isBextNightly:       os.Getenv("BEXT_NIGHTLY") == "true",
 	}

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -147,7 +147,7 @@ func addDockerfileLint(pipeline *bk.Pipeline) {
 // Adds backend integration tests step.
 func addBackendIntegrationTests(c Config) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		if !c.isMasterDryRun && c.branch != "master" && c.branch != "main" {
+		if !c.isBackendDryRun && !c.isMasterDryRun && c.branch != "master" && c.branch != "main" {
 			return
 		}
 
@@ -350,7 +350,7 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 			}
 
 		// build candidate images but do not deploy `insiders` images
-		case c.taggedRelease || c.isMasterDryRun || c.shouldRunE2EandQA():
+		case c.taggedRelease || c.isBackendDryRun || c.shouldRunE2EandQA():
 			for _, dockerImage := range images.SourcegraphDockerImages {
 				addDockerImage(c, dockerImage, false)(pipeline)
 			}


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/19314 added logic that we run e2e tests with the `master-dry-run` prefix. This is a good thing to have. Only thing is that if e2e infrastructure fails, it can block merging. Previous to this change, `master-dry-run` was used to exclusively run backend integration tests (which doesn't care about e2e tests). Unfortunately, issues with google cloud [can fail (easily?) on e2e tests](https://buildkite.com/sourcegraph/e2e/builds/13185#11f2f38e-46e3-446a-8821-a619533558c0)

To bring back the ability to run _only_ backend integration tests, I'm introducing `backend-dry-run` as a recognized branch tag. There are other ways to to streamline this, but I don't have time to rework our CI--I just want to reintroduce a capability that we/I relied on before.