### PR TITLE
web: redirect `/users/:username` -> `/users/:username/settings/profile`

### DIFF
--- a/client/web/src/org/area/routes.tsx
+++ b/client/web/src/org/area/routes.tsx
@@ -6,6 +6,10 @@ import { OrgAreaRoute } from './OrgArea'
 
 const OrgSettingsArea = lazyComponent(() => import('../settings/OrgSettingsArea'), 'OrgSettingsArea')
 
+const redirectToOrganizationProfile: OrgAreaRoute['render'] = props => (
+    <Redirect to={`${props.match.url}/settings/profile`} />
+)
+
 export const orgAreaRoutes: readonly OrgAreaRoute[] = [
     {
         path: '/settings',
@@ -13,9 +17,15 @@ export const orgAreaRoutes: readonly OrgAreaRoute[] = [
     },
     ...namespaceAreaRoutes,
 
-    // Redirect from previous /orgs/:orgname/account -> /orgs/:orgname/settings/profile.
+    // Redirect from /organizations/:orgname -> /organizations/:orgname/settings/profile.
+    {
+        path: '/',
+        exact: true,
+        render: redirectToOrganizationProfile,
+    },
+    // Redirect from previous /organizations/:orgname/account -> /organizations/:orgname/settings/profile.
     {
         path: '/account',
-        render: props => <Redirect to={`${props.match.url}/settings/profile`} />,
+        render: redirectToOrganizationProfile,
     },
 ]

--- a/client/web/src/user/area/routes.tsx
+++ b/client/web/src/user/area/routes.tsx
@@ -6,6 +6,8 @@ import { UserAreaRoute } from './UserArea'
 
 const UserSettingsArea = lazyComponent(() => import('../settings/UserSettingsArea'), 'UserSettingsArea')
 
+const redirectToUserProfile: UserAreaRoute['render'] = props => <Redirect to={`${props.url}/settings/profile`} />
+
 export const userAreaRoutes: readonly UserAreaRoute[] = [
     {
         path: '/settings',
@@ -19,9 +21,15 @@ export const userAreaRoutes: readonly UserAreaRoute[] = [
     },
     ...namespaceAreaRoutes,
 
+    // Redirect from /users/:username -> /users/:username/settings/profile.
+    {
+        path: '/',
+        exact: true,
+        render: redirectToUserProfile,
+    },
     // Redirect from previous /users/:username/account -> /users/:username/settings/profile.
     {
         path: '/account',
-        render: props => <Redirect to={`${props.url}/settings/profile`} />,
+        render: redirectToUserProfile,
     },
 ]


### PR DESCRIPTION
Closes #19407.

The quick fix to avoid showing the `not found` page for `/users/:username` URL.
