### PR TITLE
streaming: log to Honeycomb

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -36,6 +36,8 @@ type searchAlert struct {
 	priority int
 }
 
+func (a searchAlert) PrometheusType() string { return a.prometheusType }
+
 func (a searchAlert) Title() string { return a.title }
 
 func (a searchAlert) Description() *string {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -865,7 +865,6 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 			log15.Warn("slow search request", searchlogs.MapToLog15Ctx(ev.Fields())...)
 		}
 	}
-
 	return srr, err
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -24,12 +24,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
+	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	searchrepos "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
-	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/honey"
@@ -808,76 +808,54 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	srr, err := r.resultsRecursive(ctx, r.Plan)
 	elapsed := time.Since(start)
 
+	// For streams we write logs in streamHandler.
+	if r.stream != nil {
+		return srr, err
+	}
+
+	if srr != nil {
+		srr.elapsed = elapsed
+		LogSearchLatency(ctx, r.db, r.SearchInputs, srr.ElapsedMilliseconds())
+	}
+
 	var status, alertType string
+	status = DetermineStatusForLogs(srr, err)
+	if srr != nil && srr.alert != nil {
+		alertType = srr.alert.PrometheusType()
+	}
+
 	requestSource := string(trace.RequestSource(ctx))
 	requestName := trace.GraphQLRequestName(ctx)
 
-	incCounter := func() {
-		searchResponseCounter.WithLabelValues(
-			status,
-			alertType,
-			requestSource,
-			requestName,
-		).Inc()
-	}
+	searchResponseCounter.WithLabelValues(
+		status,
+		alertType,
+		requestSource,
+		requestName,
+	).Inc()
 
-	if err != nil {
-		// Record what type of response we sent back via Prometheus.
-		status = "error"
-		if err == context.DeadlineExceeded {
-			status = "timeout"
-		}
-		incCounter()
-	} else {
-		srr.elapsed = elapsed
-
-		// Log latency for batch searches. For streams we interpret latency differently
-		// and it makes more sense to log it in streamHandler.
-		if r.stream == nil {
-			LogSearchLatency(ctx, r.db, r.SearchInputs, srr.ElapsedMilliseconds())
-		}
-
-		// Record what type of response we sent back via Prometheus.
-		switch {
-		case srr.allReposTimedout():
-			status = "timeout"
-		case srr.Stats.Status.Any(search.RepoStatusTimedout):
-			status = "partial_timeout"
-		case srr.alert != nil:
-			status = "alert"
-			alertType = srr.alert.prometheusType
-		default:
-			status = "success"
-		}
-		incCounter()
-	}
-
-	isSlow := time.Since(start) > logSlowSearchesThreshold()
+	isSlow := time.Since(start) > searchlogs.LogSlowSearchesThreshold()
 	if honey.Enabled() || isSlow {
-		var act actor.Actor
-		if a := actor.FromContext(ctx); a != nil {
-			act = *a
-		}
-
-		ev := honey.Event("search")
-		ev.AddField("query", r.rawQuery())
-		ev.AddField("actor_uid", act.UID)
-		ev.AddField("actor_internal", act.Internal)
-		ev.AddField("type", trace.GraphQLRequestName(ctx))
-		ev.AddField("source", string(trace.RequestSource(ctx)))
-		ev.AddField("status", status)
-		ev.AddField("alert_type", alertType)
-		ev.AddField("duration_ms", elapsed.Milliseconds())
+		var n int
 		if srr != nil {
-			ev.AddField("result_size", len(srr.SearchResults))
+			n = len(srr.SearchResults)
 		}
+		ev := honey.SearchEvent(ctx, honey.SearchEventArgs{
+			OriginalQuery: r.rawQuery(),
+			Typ:           requestName,
+			Source:        requestSource,
+			Status:        status,
+			AlertType:     alertType,
+			Duration:      elapsed.Milliseconds(),
+			ResultSize:    n,
+		})
 
 		if honey.Enabled() {
 			_ = ev.Send()
 		}
 
 		if isSlow {
-			log15.Warn("slow search request", mapToLog15Ctx(ev.Fields())...)
+			log15.Warn("slow search request", searchlogs.MapToLog15Ctx(ev.Fields())...)
 		}
 	}
 
@@ -889,6 +867,25 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	).Observe(time.Since(start).Seconds())
 
 	return srr, err
+}
+
+// DetermineStatusForLogs determines the final status of a search for logging
+// purposes.
+func DetermineStatusForLogs(srr *SearchResultsResolver, err error) string {
+	switch {
+	case err == context.DeadlineExceeded:
+		return "timeout"
+	case err != nil:
+		return "error"
+	case srr.allReposTimedout():
+		return "timeout"
+	case srr.Stats.Status.Any(search.RepoStatusTimedout):
+		return "partial_timeout"
+	case srr.alert != nil:
+		return "alert"
+	default:
+		return "success"
+	}
 }
 
 func (r *searchResolver) resultsRecursive(ctx context.Context, plan query.Plan) (srr *SearchResultsResolver, err error) {
@@ -2123,33 +2120,4 @@ func orderedFuzzyRegexp(pieces []string) string {
 		return pieces[0]
 	}
 	return "(" + strings.Join(pieces, ").*?(") + ")"
-}
-
-// logSlowSearchesThreshold returns the minimum duration configured in site
-// settings for logging slow searches.
-func logSlowSearchesThreshold() time.Duration {
-	ms := conf.Get().ObservabilityLogSlowSearches
-	if ms == 0 {
-		return time.Duration(math.MaxInt64)
-	}
-	return time.Duration(ms) * time.Millisecond
-}
-
-// mapToLog15Ctx translates a map to log15 context fields.
-func mapToLog15Ctx(m map[string]interface{}) []interface{} {
-	// sort so its stable
-	keys := make([]string, len(m))
-	i := 0
-	for k := range m {
-		keys[i] = k
-		i++
-	}
-	sort.Strings(keys)
-	ctx := make([]interface{}, len(m)*2)
-	for i, k := range keys {
-		j := i * 2
-		ctx[j] = k
-		ctx[j+1] = m[k]
-	}
-	return ctx
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -846,7 +846,7 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 			Source:        requestSource,
 			Status:        status,
 			AlertType:     alertType,
-			Duration:      elapsed.Milliseconds(),
+			DurationMs:    elapsed.Milliseconds(),
 			ResultSize:    n,
 		})
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -834,6 +834,13 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 		requestName,
 	).Inc()
 
+	searchLatencyHistogram.WithLabelValues(
+		status,
+		alertType,
+		requestSource,
+		requestName,
+	).Observe(elapsed.Seconds())
+
 	isSlow := time.Since(start) > searchlogs.LogSlowSearchesThreshold()
 	if honey.Enabled() || isSlow {
 		var n int
@@ -858,13 +865,6 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 			log15.Warn("slow search request", searchlogs.MapToLog15Ctx(ev.Fields())...)
 		}
 	}
-
-	searchLatencyHistogram.WithLabelValues(
-		status,
-		alertType,
-		requestSource,
-		requestName,
-	).Observe(time.Since(start).Seconds())
 
 	return srr, err
 }

--- a/cmd/frontend/internal/search/logs/logs.go
+++ b/cmd/frontend/internal/search/logs/logs.go
@@ -1,0 +1,38 @@
+package logs
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+)
+
+// LogSlowSearchesThreshold returns the minimum duration configured in site
+// settings for logging slow searches.
+func LogSlowSearchesThreshold() time.Duration {
+	ms := conf.Get().ObservabilityLogSlowSearches
+	if ms == 0 {
+		return time.Duration(math.MaxInt64)
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// MapToLog15Ctx translates a map to log15 context fields.
+func MapToLog15Ctx(m map[string]interface{}) []interface{} {
+	// sort so its stable
+	keys := make([]string, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	ctx := make([]interface{}, len(m)*2)
+	for i, k := range keys {
+		j := i * 2
+		ctx[j] = k
+		ctx[j+1] = m[k]
+	}
+	return ctx
+}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -15,13 +15,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	searchlogs "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/logs"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/honey"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
@@ -242,7 +245,8 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if alert := resultsResolver.Alert(); alert != nil {
+	alert := resultsResolver.Alert()
+	if alert != nil {
 		var pqs []streamhttp.ProposedQuery
 		if proposed := alert.ProposedQueries(); proposed != nil {
 			for _, pq := range *proposed {
@@ -260,6 +264,33 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_ = eventWriter.Event("progress", progress.Final())
+
+	var status, alertType string
+	status = graphqlbackend.DetermineStatusForLogs(resultsResolver, err)
+	if alert != nil {
+		alertType = alert.PrometheusType()
+	}
+
+	isSlow := time.Since(start) > searchlogs.LogSlowSearchesThreshold()
+	if honey.Enabled() || isSlow {
+		ev := honey.SearchEvent(ctx, honey.SearchEventArgs{
+			OriginalQuery: inputs.OriginalQuery,
+			Typ:           "stream",
+			Source:        string(trace.RequestSource(ctx)),
+			Status:        status,
+			AlertType:     alertType,
+			Duration:      time.Since(start).Milliseconds(),
+			ResultSize:    progress.MatchCount,
+		})
+
+		if honey.Enabled() {
+			_ = ev.Send()
+		}
+
+		if isSlow {
+			log15.Warn("streaming: slow search request", searchlogs.MapToLog15Ctx(ev.Fields())...)
+		}
+	}
 }
 
 // startSearch will start a search. It returns the events channel which

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -279,7 +279,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Source:        string(trace.RequestSource(ctx)),
 			Status:        status,
 			AlertType:     alertType,
-			Duration:      time.Since(start).Milliseconds(),
+			DurationMs:    time.Since(start).Milliseconds(),
 			ResultSize:    progress.MatchCount,
 		})
 

--- a/internal/honey/search.go
+++ b/internal/honey/search.go
@@ -14,7 +14,7 @@ type SearchEventArgs struct {
 	Source        string
 	Status        string
 	AlertType     string
-	Duration      int64
+	DurationMs    int64
 	ResultSize    int
 }
 
@@ -32,7 +32,7 @@ func SearchEvent(ctx context.Context, args SearchEventArgs) *libhoney.Event {
 	ev.AddField("source", args.Source)
 	ev.AddField("Status", args.Status)
 	ev.AddField("alert_type", args.AlertType)
-	ev.AddField("duration_ms", args.Duration)
+	ev.AddField("duration_ms", args.DurationMs)
 	ev.AddField("result_size", args.ResultSize)
 	return ev
 }

--- a/internal/honey/search.go
+++ b/internal/honey/search.go
@@ -1,0 +1,38 @@
+package honey
+
+import (
+	"context"
+
+	"github.com/honeycombio/libhoney-go"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+)
+
+type SearchEventArgs struct {
+	OriginalQuery string
+	Typ           string
+	Source        string
+	Status        string
+	AlertType     string
+	Duration      int64
+	ResultSize    int
+}
+
+// SearchEvent returns a honey event for the dataset "search".
+func SearchEvent(ctx context.Context, args SearchEventArgs) *libhoney.Event {
+	var act actor.Actor
+	if a := actor.FromContext(ctx); a != nil {
+		act = *a
+	}
+	ev := Event("search")
+	ev.AddField("query", args.OriginalQuery)
+	ev.AddField("actor_uid", act.UID)
+	ev.AddField("actor_internal", act.Internal)
+	ev.AddField("type", args.Typ)
+	ev.AddField("source", args.Source)
+	ev.AddField("Status", args.Status)
+	ev.AddField("alert_type", args.AlertType)
+	ev.AddField("duration_ms", args.Duration)
+	ev.AddField("result_size", args.ResultSize)
+	return ev
+}


### PR DESCRIPTION
This adds logging to Honeycomb for streaming search. To make this
change easier I refactored parts of our logging in `graphqlbackend`.

The first commit is a pure refactor of `graphqlbackend`. The second 
commit adds logging to `streamHandler`.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
