### PR TITLE
Fix use of onBlur over onChange for primary email and code host dropdown

### DIFF
--- a/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
+++ b/client/web/src/user/settings/emails/SetUserPrimaryEmailForm.tsx
@@ -79,7 +79,7 @@ export const SetUserPrimaryEmailForm: FunctionComponent<Props> = ({ user, emails
                     id="setUserPrimaryEmailForm-email"
                     className="custom-select form-control-lg mr-sm-2"
                     value={primaryEmail}
-                    onBlur={onPrimaryEmailSelect}
+                    onChange={onPrimaryEmailSelect}
                     required={true}
                     disabled={options.length === 1 || statusOrError === 'loading'}
                 >

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -523,9 +523,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                     className="form-control"
                     name="code-host"
                     aria-label="select code host type"
-                    onBlur={event => {
-                        setCodeHostFilter(event.target.value)
-                    }}
+                    onChange={event => setCodeHostFilter(event.target.value)}
                 >
                     <option key="any" value="" label="Any" />
                     {codeHosts.hosts.map(value => (


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/19410

Previously keyboard users wouldn't be able to trigger `onChange` on `<select>` elements in certain browsers. This has been fixed in browsers that we support. Noticed this is a deprecated rule at [eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-onchange.md):
> This rule is based on reports of behavior of [old browsers (eg. IE 10 and below)](https://www.quirksmode.org/dom/events/change.html#t05). In the meantime, this behavior has been corrected, both in newer versions of browsers as well as [in the DOM spec](https://bugzilla.mozilla.org/show_bug.cgi?id=969068#c2).