### PR TITLE
Improve a11y of survey page

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -252,6 +252,11 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
         props.location.pathname === '/sign-up' ||
         props.location.pathname === '/password-reset'
 
+    // TODO Change this behavior when we have global focus management system
+    // Need to know this for disable autofocus on nav search input
+    // and preserve autofocus for first textarea at survey page
+    const isSurveyPage = routeMatch === '/survey/:score?'
+
     const authRequired = useObservable(authRequiredObservable)
 
     const hideGlobalSearchInput: boolean =
@@ -308,6 +313,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                     }
                     hideNavLinks={false}
                     minimalNavLinks={minimalNavLinks}
+                    isSearchAutoFocusRequired={!isSurveyPage}
                     isExtensionAlertAnimating={isExtensionAlertAnimating}
                 />
             )}

--- a/client/web/src/marketing/SurveyPage.tsx
+++ b/client/web/src/marketing/SurveyPage.tsx
@@ -56,10 +56,15 @@ class SurveyForm extends React.Component<SurveyFormProps, SurveyFormState> {
         return (
             <Form className="survey-form" onSubmit={this.handleSubmit}>
                 {this.state.error && <p className="survey-form__error">{this.state.error.message}</p>}
-                <label className="survey-form__label">
+                <label id="survey-form-scores" className="survey-form__label">
                     How likely is it that you would recommend Sourcegraph to a friend?
                 </label>
-                <SurveyCTA className="survey-form__scores" onChange={this.onScoreChange} score={this.props.score} />
+                <SurveyCTA
+                    ariaLabelledby="survey-form-scores"
+                    className="survey-form__scores"
+                    onChange={this.onScoreChange}
+                    score={this.props.score}
+                />
                 {!this.props.authenticatedUser && (
                     <div className="form-group">
                         <input

--- a/client/web/src/marketing/SurveyPage.tsx
+++ b/client/web/src/marketing/SurveyPage.tsx
@@ -59,7 +59,7 @@ class SurveyForm extends React.Component<SurveyFormProps, SurveyFormState> {
                 <label className="survey-form__label">
                     How likely is it that you would recommend Sourcegraph to a friend?
                 </label>
-                <SurveyCTA className="survey-form__scores" onClick={this.onScoreChange} score={this.props.score} />
+                <SurveyCTA className="survey-form__scores" onChange={this.onScoreChange} score={this.props.score} />
                 {!this.props.authenticatedUser && (
                     <div className="form-group">
                         <input

--- a/client/web/src/marketing/SurveyToast.tsx
+++ b/client/web/src/marketing/SurveyToast.tsx
@@ -11,6 +11,7 @@ import { AuthenticatedUser } from '../auth'
 const HAS_DISMISSED_TOAST_KEY = 'has-dismissed-survey-toast'
 
 interface SurveyCTAProps {
+    ariaLabelledby?: string
     className?: string
     score?: number
     onChange?: (score: number) => void
@@ -39,7 +40,12 @@ export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
     }
 
     return (
-        <fieldset aria-label="Survey score radio toggle button group" className={props.className} onBlur={handleBlur}>
+        <fieldset
+            aria-labelledby={props.ariaLabelledby}
+            role="radiogroup"
+            className={props.className}
+            onBlur={handleBlur}
+        >
             {range(0, 11).map(score => {
                 const pressed = score === props.score
                 const focused = score === focusedIndex

--- a/client/web/src/marketing/SurveyToast.tsx
+++ b/client/web/src/marketing/SurveyToast.tsx
@@ -1,6 +1,7 @@
 import EmoticonIcon from 'mdi-react/EmoticonIcon'
-import * as React from 'react'
-import { Link } from 'react-router-dom'
+import React, { useState } from 'react'
+import { useHistory } from 'react-router'
+import cln from 'classnames'
 import { eventLogger } from '../tracking/eventLogger'
 import { Toast } from './Toast'
 import { daysActiveCount } from './util'
@@ -12,41 +13,57 @@ const HAS_DISMISSED_TOAST_KEY = 'has-dismissed-survey-toast'
 interface SurveyCTAProps {
     className?: string
     score?: number
-    onClick?: (score: number) => void
+    onChange?: (score: number) => void
     openSurveyInNewTab?: boolean
 }
 
-export class SurveyCTA extends React.PureComponent<SurveyCTAProps> {
-    public render(): JSX.Element | null {
-        return (
-            <div className={this.props.className}>
-                {range(0, 11).map(score => {
-                    const pressed = score === this.props.score
-                    return (
-                        /* eslint-disable react/jsx-no-bind */
-                        <Link
-                            key={score}
-                            className={`btn btn-primary toast__rating-btn ${pressed ? 'active' : ''}`}
-                            aria-pressed={pressed || undefined}
-                            onClick={() => this.onClick(score)}
-                            to={`/survey/${score}`}
-                            target={this.props.openSurveyInNewTab ? '_blank' : undefined}
-                        >
-                            {score}
-                        </Link>
-                        /* eslint-enable react/jsx-no-bind */
-                    )
-                })}
-            </div>
-        )
+export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
+    const history = useHistory()
+    const [focusedIndex, setFocusedIndex] = useState<number | null>(null)
+
+    const handleFocus = (index: number): void => {
+        setFocusedIndex(index)
     }
 
-    private onClick = (score: number): void => {
+    const handleBlur = (): void => {
+        setFocusedIndex(null)
+    }
+
+    const handleChange = (score: number): void => {
         eventLogger.log('SurveyButtonClicked', { score })
-        if (this.props.onClick) {
-            this.props.onClick(score)
+        history.push(`/survey/${score}`)
+
+        if (props.onChange) {
+            props.onChange(score)
         }
     }
+
+    return (
+        <div className={props.className} onBlur={handleBlur}>
+            {range(0, 11).map(score => {
+                const pressed = score === props.score
+                const focused = score === focusedIndex
+
+                return (
+                    <label
+                        key={score}
+                        className={cln('btn btn-primary toast__rating-btn', { active: pressed, focus: focused })}
+                    >
+                        <input
+                            type="radio"
+                            name="survey-score"
+                            value={score}
+                            onChange={() => handleChange(score)}
+                            onFocus={() => handleFocus(score)}
+                            className="toast__rating-radio"
+                        />
+
+                        {score}
+                    </label>
+                )
+            })}
+        </div>
+    )
 }
 
 interface Props {
@@ -81,13 +98,13 @@ export class SurveyToast extends React.Component<Props, State> {
                 icon={<EmoticonIcon className="icon-inline" />}
                 title="Tell us what you think"
                 subtitle="How likely is it that you would recommend Sourcegraph to a friend?"
-                cta={<SurveyCTA onClick={this.onClickScore} openSurveyInNewTab={true} />}
+                cta={<SurveyCTA onChange={this.onChangeScore} openSurveyInNewTab={true} />}
                 onDismiss={this.onDismiss}
             />
         )
     }
 
-    private onClickScore = (): void => this.onDismiss()
+    private onChangeScore = (): void => this.onDismiss()
 
     private onDismiss = (): void => {
         localStorage.setItem(HAS_DISMISSED_TOAST_KEY, 'true')

--- a/client/web/src/marketing/SurveyToast.tsx
+++ b/client/web/src/marketing/SurveyToast.tsx
@@ -39,7 +39,11 @@ export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
     }
 
     return (
-        <div className={props.className} onBlur={handleBlur}>
+        <div
+            aria-label="Survey score radio toggle button group"
+            className={props.className}
+            onBlur={handleBlur}>
+
             {range(0, 11).map(score => {
                 const pressed = score === props.score
                 const focused = score === focusedIndex

--- a/client/web/src/marketing/SurveyToast.tsx
+++ b/client/web/src/marketing/SurveyToast.tsx
@@ -39,11 +39,7 @@ export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
     }
 
     return (
-        <div
-            aria-label="Survey score radio toggle button group"
-            className={props.className}
-            onBlur={handleBlur}>
-
+        <div aria-label="Survey score radio toggle button group" className={props.className} onBlur={handleBlur}>
             {range(0, 11).map(score => {
                 const pressed = score === props.score
                 const focused = score === focusedIndex

--- a/client/web/src/marketing/SurveyToast.tsx
+++ b/client/web/src/marketing/SurveyToast.tsx
@@ -1,7 +1,7 @@
 import EmoticonIcon from 'mdi-react/EmoticonIcon'
 import React, { useState } from 'react'
 import { useHistory } from 'react-router'
-import cln from 'classnames'
+import classNames from 'classnames'
 import { eventLogger } from '../tracking/eventLogger'
 import { Toast } from './Toast'
 import { daysActiveCount } from './util'
@@ -39,7 +39,7 @@ export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
     }
 
     return (
-        <div aria-label="Survey score radio toggle button group" className={props.className} onBlur={handleBlur}>
+        <fieldset aria-label="Survey score radio toggle button group" className={props.className} onBlur={handleBlur}>
             {range(0, 11).map(score => {
                 const pressed = score === props.score
                 const focused = score === focusedIndex
@@ -47,7 +47,7 @@ export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
                 return (
                     <label
                         key={score}
-                        className={cln('btn btn-primary toast__rating-btn', { active: pressed, focus: focused })}
+                        className={classNames('btn btn-primary toast__rating-btn', { active: pressed, focus: focused })}
                     >
                         <input
                             type="radio"
@@ -62,7 +62,7 @@ export const SurveyCTA: React.FunctionComponent<SurveyCTAProps> = props => {
                     </label>
                 )
             })}
-        </div>
+        </fieldset>
     )
 }
 

--- a/client/web/src/marketing/Toast.scss
+++ b/client/web/src/marketing/Toast.scss
@@ -43,7 +43,7 @@
 
     &__rating-radio {
         position: absolute;
-        clip: rect(0,0,0,0);
+        clip: rect(0, 0, 0, 0);
         pointer-events: none;
     }
 

--- a/client/web/src/marketing/Toast.scss
+++ b/client/web/src/marketing/Toast.scss
@@ -41,6 +41,12 @@
         padding: 0.5rem 0;
     }
 
+    &__rating-radio {
+        position: absolute;
+        clip: rect(0,0,0,0);
+        pointer-events: none;
+    }
+
     &__rating-btn:not(:first-of-type) {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -78,6 +78,7 @@ interface Props
     availableVersionContexts: VersionContext[] | undefined
 
     minimalNavLinks?: boolean
+    isSearchAutoFocusRequired?: boolean
     branding?: typeof window.context.branding
 
     /** For testing only. Used because reactstrap's Popover is incompatible with react-test-renderer. */

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -33,12 +33,15 @@ interface Props
     onChange: (newValue: QueryState) => void
     globbing: boolean
     enableSmartQuery: boolean
+    isSearchAutoFocusRequired?: boolean
 }
 
 /**
  * The search item in the navbar
  */
 export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) => {
+    const autoFocus = props.isSearchAutoFocusRequired ?? true
+
     const onSubmit = useCallback(
         (event?: React.FormEvent): void => {
             event?.preventDefault()
@@ -52,6 +55,7 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
         queryState: props.navbarSearchState,
         setQueryState: props.onChange,
     })
+
     return (
         <Form
             className="search--navbar-item d-flex align-items-flex-start flex-grow-1 flex-shrink-past-contents"
@@ -63,7 +67,7 @@ export const SearchNavbarItem: React.FunctionComponent<Props> = (props: Props) =
                 hasGlobalQueryBehavior={true}
                 queryState={props.navbarSearchState}
                 onSubmit={onSubmit}
-                autoFocus={true}
+                autoFocus={autoFocus}
             />
             <SearchButton />
         </Form>


### PR DESCRIPTION
Fixes #19219

This PR improves a little bit score picker component at survey page. Before we had picker with links inside to pick a score, now we have picker with radio buttons group and wrapper with arial-label for this group which is good because now it's much easy to navigate with keyboard and voice over does his job properly (see video below for example)

Also turned out we have autofocus on first textarea at survey page which is useful because user wants to fill survey fields first before using main code search. But this thing did't work properly because we had autofocus: true on main nav search at header on this page as well. So there was autofocus problem which this PR solved as well. 


https://user-images.githubusercontent.com/18492575/112286179-19c41600-8c9c-11eb-9acc-a227c0694383.mov

