### PR TITLE
Add emailHeader support to http auth proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Experimental: Sync permissions of Perforce depots through the Sourcegraph UI. To enable, use the feature flag `"experimentalFeatures": { "perforce": "enabled" }`. For more information, see [how to enable permissions for your Perforce depots](https://docs.sourcegraph.com/admin/repo/perforce). [#16705](https://github.com/sourcegraph/sourcegraph/issues/16705)
+- Added support for user email headers in the HTTP auth proxy. See [HTTP Auth Proxy docs](https://docs.sourcegraph.com/admin/auth#http-authentication-proxies) for more information.
 
 ### Changed
 

--- a/doc/admin/auth/index.md
+++ b/doc/admin/auth/index.md
@@ -219,7 +219,7 @@ Example [`openidconnect` auth provider](../config/site_config.md#openid-connect-
 
 ## HTTP authentication proxies
 
-You can wrap Sourcegraph in an authentication proxy that authenticates the user and passes the user's username to Sourcegraph via HTTP headers. The most popular such authentication proxy is [pusher/oauth2_proxy](https://github.com/pusher/oauth2_proxy). Another example is [Google Identity-Aware Proxy (IAP)](https://cloud.google.com/iap/). Both work well with Sourcegraph.
+You can wrap Sourcegraph in an authentication proxy that authenticates the user and passes the user's username or email (or both) to Sourcegraph via HTTP headers. The most popular such authentication proxy is [pusher/oauth2_proxy](https://github.com/pusher/oauth2_proxy). Another example is [Google Identity-Aware Proxy (IAP)](https://cloud.google.com/iap/). Both work well with Sourcegraph.
 
 To use an authentication proxy to authenticate users to Sourcegraph, add the following lines to your site configuration:
 
@@ -229,7 +229,8 @@ To use an authentication proxy to authenticate users to Sourcegraph, add the fol
   "auth.providers": [
     {
       "type": "http-header",
-      "usernameHeader": "X-Forwarded-User"
+      "usernameHeader": "X-Forwarded-User",
+      "emailHeader": "X-Forwarded-Email"
     }
   ]
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -751,6 +751,8 @@ type GitoliteConnection struct {
 
 // HTTPHeaderAuthProvider description: Configures the HTTP header authentication provider (which authenticates users by consulting an HTTP request header set by an authentication proxy such as https://github.com/bitly/oauth2_proxy).
 type HTTPHeaderAuthProvider struct {
+	// EmailHeader description: The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.
+	EmailHeader string `json:"emailHeader,omitempty"`
 	// StripUsernameHeaderPrefix description: The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.
 	StripUsernameHeaderPrefix string `json:"stripUsernameHeaderPrefix,omitempty"`
 	Type                      string `json:"type"`

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1143,6 +1143,11 @@
           "description": "The prefix that precedes the username portion of the HTTP header specified in `usernameHeader`. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to `accounts.google.com:`.",
           "type": "string",
           "examples": ["accounts.google.com:"]
+        },
+        "emailHeader": {
+          "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
+          "type": "string",
+          "examples": ["X-App-Email"]
         }
       }
     },

--- a/schema/site_stringdata.go
+++ b/schema/site_stringdata.go
@@ -1148,6 +1148,11 @@ const SiteSchemaJSON = `{
           "description": "The prefix that precedes the username portion of the HTTP header specified in ` + "`" + `usernameHeader` + "`" + `. If specified, the prefix will be stripped from the header value and the remainder will be used as the username. For example, if using Google Identity-Aware Proxy (IAP) with Google Sign-In, set this value to ` + "`" + `accounts.google.com:` + "`" + `.",
           "type": "string",
           "examples": ["accounts.google.com:"]
+        },
+        "emailHeader": {
+          "description": "The name (case-insensitive) of an HTTP header whose value is taken to be the email of the client requesting the page. Set this value when using an HTTP proxy that authenticates requests, and you don't want the extra configurability of the other authentication methods.",
+          "type": "string",
+          "examples": ["X-App-Email"]
         }
       }
     },


### PR DESCRIPTION
In response to a customer issue: https://sourcegraph.slack.com/archives/CHPC7UX16/p1616429541106000

This PR adds support for emailHeader to the http auth proxy, using that to derive the user's email if set. It will create that user with a verified email address if the address is provided.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
