### PR TITLE
move syncExternalService in setExternalServiceRepos into goroutine

### DIFF
--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -68,7 +68,11 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 		return nil, err
 	}
 
+	// this kicks off an async job, but has some slow validation before that happens. Considering the user repos page
+	// already handles the async job we don't need to wait for this request. any errors from this should also be picked
+	// up and fed back to the user by the notifications system.
 	go func() {
+		ctx, _ := context.WithTimeout(ctx, 60*time.Second)
 		if err := syncExternalService(ctx, es); err != nil {
 			log15.Error("error syncing external services", "error", err)
 		}

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -67,9 +68,11 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 		return nil, err
 	}
 
-	if err := syncExternalService(ctx, es); err != nil {
-		return nil, err
-	}
+	go func() {
+		if err := syncExternalService(ctx, es); err != nil {
+			log15.Error("error syncing external services", "error", err)
+		}
+	}()
 
 	return &EmptyResponse{}, nil
 }


### PR DESCRIPTION
closes #19235 

We don't really need the output of this request, and it's dispatching an async job anyway, so i've moved it into a goroutine to speed things up. We still need to refactor the handler being called at some point, as it doesn't really do what you expect.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
