### PR TITLE
clarify docs on using configID in SAML auth providers, and referencing those providers in external service config

### DIFF
--- a/doc/admin/auth/saml/azure_ad.md
+++ b/doc/admin/auth/saml/azure_ad.md
@@ -26,6 +26,7 @@
  "auth.providers": [
    {
      "type": "saml",
+     "configID": "azure",
      "identityProviderMetadataURL": "https://login.microsoftonline.com/7d2a00ed-73e8-4920-bbfa-ef68effe2d1e/federationmetadata/2007-06/federationmetadata.xml?appid=eff20ae4-145b-4bd3-ff3f-21edab43fe99"
    }
  ]

--- a/doc/admin/auth/saml/generic.md
+++ b/doc/admin/auth/saml/generic.md
@@ -40,6 +40,7 @@ Example 1:
   "auth.providers": [
     {
       "type": "saml",
+      "configID": "generic",
       "identityProviderMetadataURL": "https://example.com/saml-metadata"
     }
   ]
@@ -55,6 +56,7 @@ Example 2:
   "auth.providers": [
     {
       "type": "saml",
+      "configID": "generic",
 
       // This is a long XML string you download from your identity provider.
       // You can escape it to a JSON string using a tool like

--- a/doc/admin/auth/saml/jump_cloud.md
+++ b/doc/admin/auth/saml/jump_cloud.md
@@ -36,6 +36,7 @@ Once the application is created, look for a tiny link called **export metadata**
     {
       "type": "saml",
       // This value must match the "SP Entity ID" of your JumpCloud application.
+      "configID": "jumpcloud",
       "serviceProviderIssuer": "Sourcegraph",
       // You can escape the metadata to a JSON string using a tool like https://json-escape-text.now.sh.
       // Please be noted it is an online tool and could leak or record your confidential information.

--- a/doc/admin/auth/saml/microsoft_adfs.md
+++ b/doc/admin/auth/saml/microsoft_adfs.md
@@ -93,6 +93,7 @@ Click **OK** to apply the new claim rules and close the window.
       "auth.providers": [
         {
           "type": "saml",
+          "configID": "ms_adfs"
           "identityProviderMetadataURL": "https://adfs.example.com/federationmetadata/2007-06/federationmetadata.xml"
         }
       ]

--- a/doc/admin/auth/saml/okta.md
+++ b/doc/admin/auth/saml/okta.md
@@ -30,6 +30,7 @@
  "auth.providers": [
    {
      "type": "saml",
+     "configID": "okta",
      "identityProviderMetadataURL": "https://okta.example.com/app/8VglnckX0yyhdkp0bk00/sso/saml/metadata",
      "allowSignup": true 
    }

--- a/doc/admin/auth/saml/one_login.md
+++ b/doc/admin/auth/saml/one_login.md
@@ -33,6 +33,7 @@
  "auth.providers": [
    {
      "type": "saml",
+     "configID": "onelogin",
      "identityProviderMetadataURL": "<issuer URL>"
    }
  ]

--- a/doc/admin/repo/permissions.md
+++ b/doc/admin/repo/permissions.md
@@ -82,7 +82,7 @@ Then, [add or edit a GitLab connection](../external_service/gitlab.md#repository
 
 `$AUTH_PROVIDER_ID` and `$AUTH_PROVIDER_TYPE` identify the authentication provider to use and should
 match the fields specified in the authentication provider config
-(`auth.providers`). 
+(`auth.providers`). The authProviderID can be found in the `configID` field of the auth provider config.
 
 `$AUTH_PROVIDER_GITLAB_ID` should match the `identities.provider` returned by
 [the admin GitLab Users API endpoint](https://docs.gitlab.com/ee/api/users.html#for-admins).


### PR DESCRIPTION
The docs didn't clearly explain what this authProviderID field actually was, and the examples of saml config never used configIDs, so it seemed like they didn't exist. hopefully this change can reduce confusion.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
