### PR TITLE
search: remove old structural search code

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -362,24 +362,17 @@ func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextPara
 		trace.Stringer("global_search_mode", args.Mode),
 	)
 
-	indexedTyp := textRequest
-	if args.PatternInfo.IsStructuralPat {
-		// Structural Patterns queries zoekt just file files to reduce the set
-		// of files it searches.
-		indexedTyp = fileRequest
-	}
-
 	// performance: for global searches, we avoid calling newIndexedSearchRequest
 	// because zoekt will anyway have to search all its shards.
 	var indexed *indexedSearchRequest
 	if args.Mode == search.ZoektGlobalSearch {
 		indexed = &indexedSearchRequest{
 			args:  args,
-			typ:   indexedTyp,
+			typ:   textRequest,
 			repos: &indexedRepoRevs{},
 		}
 	} else {
-		indexed, err = newIndexedSearchRequest(ctx, db, args, indexedTyp, stream)
+		indexed, err = newIndexedSearchRequest(ctx, db, args, textRequest, stream)
 		if err != nil {
 			return err
 		}
@@ -390,63 +383,43 @@ func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextPara
 		return nil
 	}
 
-	// Indexed regex and literal search go via zoekt
-	isIndexedTextSearch := args.Mode != search.SearcherOnly && !args.PatternInfo.IsStructuralPat
-	// Structural search goes via zoekt then searcher.
-	isStructuralSearch := args.Mode != search.SearcherOnly && args.PatternInfo.IsStructuralPat
-
 	g, ctx := errgroup.WithContext(ctx)
 
-	if isIndexedTextSearch {
-		g.Go(func() error {
-			return indexed.Search(ctx, stream)
-		})
+	if args.Mode != search.SearcherOnly {
+		// Run searches on indexed repositories.
+
+		if !args.PatternInfo.IsStructuralPat {
+			// Run literal and regexp searches.
+			g.Go(func() error {
+				return indexed.Search(ctx, stream)
+			})
+		} else {
+			// Run structural search (fulfilled via searcher).
+			g.Go(func() error {
+				repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
+				for _, repo := range indexed.Repos() {
+					repos = append(repos, repo)
+				}
+				return callSearcherOverRepos(ctx, db, args, stream, repos, true)
+			})
+		}
 	}
 
-	if isStructuralSearch && args.PatternInfo.CombyRule != `where "backcompat" == "backcompat"` {
-		g.Go(func() error {
-			repos := make([]*search.RepositoryRevisions, 0, len(indexed.Repos()))
-			for _, repo := range indexed.Repos() {
-				repos = append(repos, repo)
-			}
-
-			return callSearcherOverRepos(ctx, db, args, stream, repos, nil, true)
-		})
-
-		g.Go(func() error {
-			return callSearcherOverRepos(ctx, db, args, stream, indexed.Unindexed, nil, false)
-		})
-	} else if isStructuralSearch {
-		g.Go(func() error {
-			return structuralSearchBackcompat(ctx, db, args, stream, indexed)
-		})
-	}
-
-	// This guard disables
-	// - unindexed structural search
-	// - unindexed search of negated content
-	if !args.PatternInfo.IsStructuralPat {
-		g.Go(func() error {
-			return callSearcherOverRepos(ctx, db, args, stream, indexed.Unindexed, nil, false)
-		})
-	}
+	// Concurrently run searcher for all unindexed repos regardless whether text, regexp, or structural search.
+	g.Go(func() error {
+		return callSearcherOverRepos(ctx, db, args, stream, indexed.Unindexed, false)
+	})
 
 	return g.Wait()
 }
 
 // callSearcherOverRepos calls searcher on searcherRepos.
-//
-// searcherReposFilteredFiles is an optional map of {repo name => file list}
-// that forces the searcher to only include the file list in the search. It is
-// currently only set when Zoekt restricts the file list for structural
-// search.
 func callSearcherOverRepos(
 	ctx context.Context,
 	db dbutil.DB,
 	args *search.TextParameters,
 	stream Sender,
 	searcherRepos []*search.RepositoryRevisions,
-	searcherReposFilteredFiles map[string][]string,
 	index bool,
 ) (err error) {
 	tr, ctx := trace.New(ctx, "searcherOverRepos", fmt.Sprintf("query: %s", args.PatternInfo.Pattern))
@@ -474,7 +447,6 @@ func callSearcherOverRepos(
 	tr.LogFields(
 		otlog.Int64("fetch_timeout_ms", fetchTimeout.Milliseconds()),
 		otlog.Int64("repos_count", int64(len(searcherRepos))),
-		otlog.Int64("repos_filtered_files_count", int64(len(searcherReposFilteredFiles))),
 	)
 
 	if len(searcherRepos) == 0 {
@@ -510,18 +482,6 @@ func callSearcherOverRepos(
 
 				// Make a new repoRev for just the operation of searching this revspec.
 				repoRev := &search.RepositoryRevisions{Repo: repoAllRevs.Repo, Revs: []search.RevisionSpecifier{{RevSpec: rev}}}
-
-				args := *args
-				if args.PatternInfo.IsStructuralPat && searcherReposFilteredFiles != nil {
-					// Modify the search query to only run for the filtered files
-					if v, ok := searcherReposFilteredFiles[string(repoRev.Repo.Name)]; ok {
-						patternCopy := *args.PatternInfo
-						args.PatternInfo = &patternCopy
-						includePatternsCopy := []string{}
-						args.PatternInfo.IncludePatterns = append(includePatternsCopy, v...)
-					}
-				}
-
 				g.Go(func() error {
 					ctx, done := limitCtx, limitDone
 					defer done()
@@ -546,63 +506,6 @@ func callSearcherOverRepos(
 	})
 
 	return g.Wait()
-}
-
-// structuralSearchBackcompat is the old way we did structural search. It runs
-// a query through zoekt first to get back a list of filepaths to search. Then
-// calls searcher limiting it to just those files.
-func structuralSearchBackcompat(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream Sender, indexed *indexedSearchRequest) (err error) {
-	tr, ctx := trace.New(ctx, "structuralSearchBackcompt", "")
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
-
-	g, ctx := errgroup.WithContext(ctx)
-
-	err = indexed.Search(ctx, StreamFunc(func(event SearchEvent) {
-		g.Go(func() error {
-			tr.LogFields(otlog.Int("matches.len", len(event.Results)))
-			stream.Send(SearchEvent{
-				Stats: event.Stats,
-			})
-
-			if len(event.Results) == 0 {
-				return nil
-			}
-
-			// For structural search, we run callSearcherOverRepos
-			// over the set of repos and files known to contain
-			// parts of the pattern as determined by Zoekt.
-
-			// A partition of {repo name => file list} that we will build from Zoekt matches
-			partition := make(map[string][]string)
-			var repos []*search.RepositoryRevisions
-
-			for _, m := range event.Results {
-				fm, ok := m.ToFileMatch()
-				if !ok {
-					return errors.New("structual search: Events from indexed.Search could not be converted to FileMatch")
-				}
-				name := string(fm.Repo.Name)
-				partition[name] = append(partition[name], fm.Path)
-			}
-
-			// Filter Zoekt repos that didn't contain matches
-			for _, repo := range indexed.Repos() {
-				if _, ok := partition[string(repo.Repo.Name)]; ok {
-					repos = append(repos, repo)
-				}
-			}
-
-			return callSearcherOverRepos(ctx, db, args, stream, repos, partition, true)
-		})
-	}))
-
-	if gErr := g.Wait(); gErr != nil {
-		err = gErr
-	}
-	return err
 }
 
 // limitSearcherRepos limits the number of repo@revs searched by the unindexed searcher codepath.

--- a/cmd/searcher/search/search.go
+++ b/cmd/searcher/search/search.go
@@ -194,7 +194,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 		}
 	}(time.Now())
 
-	if p.IsStructuralPat && p.Indexed && p.CombyRule != `where "backcompat" == "backcompat"` {
+	if p.IsStructuralPat && p.Indexed {
 		// Execute the new structural search path that directly calls Zoekt.
 		return structuralSearchWithZoekt(ctx, p)
 	}
@@ -242,9 +242,7 @@ func (s *Service) search(ctx context.Context, p *protocol.Request) (matches []pr
 	archiveFiles.Observe(float64(nFiles))
 	archiveSize.Observe(float64(bytes))
 
-	if p.IsStructuralPat && p.CombyRule == `where "backcompat" == "backcompat"` {
-		matches, limitHit, err = structuralSearch(ctx, zipPath, p.Pattern, p.CombyRule, "", p.Languages, p.IncludePatterns, p.Repo)
-	} else if p.IsStructuralPat {
+	if p.IsStructuralPat {
 		matches, limitHit, err = filteredStructuralSearch(ctx, zipPath, zf, &p.PatternInfo, p.Repo)
 	} else {
 		matches, limitHit, err = regexSearch(ctx, rg, zf, p.FileMatchLimit, p.PatternMatchesContent, p.PatternMatchesPath, p.IsNegated)


### PR DESCRIPTION
We have the backcompat layer for 2 prior versions, so time to remove. Easy by commit, see inline comments.

Closes #11902.
Relates to https://github.com/sourcegraph/sourcegraph/issues/17616