### PR TITLE
search: Add prometheus metric for overall search latency

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -43,12 +43,6 @@ var (
 		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
 	}, []string{"type", "field", "error", "source", "request_name"})
 
-	searchLatencyHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "src_search_response_latency_seconds",
-		Help:    "Search response latencies in seconds.",
-		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
-	}, []string{"error", "source"})
-
 	codeIntelSearchHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_graphql_code_intel_search_seconds",
 		Help:    "Code intel search latencies in seconds.",

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -43,6 +43,12 @@ var (
 		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
 	}, []string{"type", "field", "error", "source", "request_name"})
 
+	searchLatencyHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_search_response_latency_seconds",
+		Help:    "Search response latencies in seconds.",
+		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
+	}, []string{"error", "source"})
+
 	codeIntelSearchHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_graphql_code_intel_search_seconds",
 		Help:    "Code intel search latencies in seconds.",

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -870,6 +870,11 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 		}
 	}
 
+	searchLatencyHistogram.WithLabelValues(
+		strconv.FormatBool(err != nil),
+		string(trace.RequestSource(ctx)),
+	).Observe(time.Since(start).Seconds())
+
 	return srr, err
 }
 

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -329,10 +329,18 @@ loop:
 	return sparkline, nil
 }
 
-var searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "src_graphql_search_response",
-	Help: "Number of searches that have ended in the given status (success, error, timeout, partial_timeout).",
-}, []string{"status", "alert_type", "source", "request_name"})
+var (
+	searchResponseCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "src_graphql_search_response",
+		Help: "Number of searches that have ended in the given status (success, error, timeout, partial_timeout).",
+	}, []string{"status", "alert_type", "source", "request_name"})
+
+	searchLatencyHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "src_search_response_latency_seconds",
+		Help:    "Search response latencies in seconds.",
+		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
+	}, []string{"status", "alert_type", "source", "request_name"})
+)
 
 // LogSearchLatency records search durations in the event database. This
 // function may only be called after a search result is performed, because it
@@ -801,12 +809,15 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	elapsed := time.Since(start)
 
 	var status, alertType string
+	requestSource := string(trace.RequestSource(ctx))
+	requestName := trace.GraphQLRequestName(ctx)
+
 	incCounter := func() {
 		searchResponseCounter.WithLabelValues(
 			status,
 			alertType,
-			string(trace.RequestSource(ctx)),
-			trace.GraphQLRequestName(ctx),
+			requestSource,
+			requestName,
 		).Inc()
 	}
 
@@ -871,8 +882,10 @@ func (r *searchResolver) Results(ctx context.Context) (*SearchResultsResolver, e
 	}
 
 	searchLatencyHistogram.WithLabelValues(
-		strconv.FormatBool(err != nil),
-		string(trace.RequestSource(ctx)),
+		status,
+		alertType,
+		requestSource,
+		requestName,
 	).Observe(time.Since(start).Seconds())
 
 	return srr, err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -337,7 +337,7 @@ var (
 
 	searchLatencyHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "src_search_response_latency_seconds",
-		Help:    "Search response latencies in seconds.",
+		Help:    "Search response latencies in seconds that have ended in the given status (success, error, timeout, partial_timeout).",
 		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
 	}, []string{"status", "alert_type", "source", "request_name"})
 )

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
@@ -512,6 +513,8 @@ var metricLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 	Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30},
 }, []string{"source"})
 
+var searchBlitzUserAgentRegexp = lazyregexp.New(`^SearchBlitz \(([^\)]+)\)$`)
+
 // GuessSource guesses the source the request came from (browser, other HTTP client, etc.)
 func GuessSource(r *http.Request) trace.SourceType {
 	userAgent := r.UserAgent()
@@ -528,5 +531,10 @@ func GuessSource(r *http.Request) trace.SourceType {
 			return trace.SourceBrowser
 		}
 	}
+
+	if match := searchBlitzUserAgentRegexp.FindStringSubmatch(userAgent); match != nil {
+		return trace.SourceType("searchblitz_" + match[1])
+	}
+
 	return trace.SourceOther
 }

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -532,6 +532,7 @@ func GuessSource(r *http.Request) trace.SourceType {
 		}
 	}
 
+	// We send some automated search requests in order to measure baseline search perf. Track the source of these.
 	if match := searchBlitzUserAgentRegexp.FindStringSubmatch(userAgent); match != nil {
 		return trace.SourceType("searchblitz_" + match[1])
 	}


### PR DESCRIPTION
To avoid further increasing the cardinality of the
`src_graphql_field_seconds` metric, this commit creates a new exported
prometheus metric `src_search_response_latency_seconds` which only
tracks the response latency for a single search query.

Additionally, it adds support for parsing the search-blitz query name
from the `User-Agent` string as the source so that we can uniquely
identify named queries to use as sentinels of search performance.

Example showing it works in grafana:
<img width="1205" alt="Screen Shot 2021-03-24 at 17 15 20" src="https://user-images.githubusercontent.com/12631702/112395847-c914e300-8cc4-11eb-8549-2e8fb39248cb.png">



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
