### PR TITLE
Add new ValidateToken method to GitHub & GitLab sources, and use it as a fast-path when hitting syncExternalService

### DIFF
--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -341,11 +341,6 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Enqueue any external services that are due to sync NOW this will cause any
-	// recently updated external service to sync faster than the default enqueue
-	// interval.
-	s.Syncer.TriggerEnqueueSyncJobs()
-
 	src, err := repos.NewSource(&types.ExternalService{
 		ID:          req.ExternalService.ID,
 		Kind:        req.ExternalService.Kind,
@@ -373,6 +368,11 @@ func (s *Server) handleExternalServiceSync(w http.ResponseWriter, r *http.Reques
 		respond(w, http.StatusInternalServerError, err)
 		return
 	}
+
+	// Enqueue any external services that are due to sync NOW this will cause any
+	// recently updated external service to sync faster than the default enqueue
+	// interval.
+	s.Syncer.TriggerEnqueueSyncJobs()
 
 	if s.RateLimitSyncer != nil {
 		err = s.RateLimitSyncer.SyncRateLimiters(ctx)

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -1174,6 +1174,42 @@ func TestServer_handleSchedulePermsSync(t *testing.T) {
 	}
 }
 
+func TestExternalServiceValidate_ValidatesToken(t *testing.T) {
+	var (
+		src    repos.Source
+		called bool
+		ctx    = context.Background()
+	)
+	src = testSource{
+		fn: func() error {
+			called = true
+			return nil
+		},
+	}
+	err := externalServiceValidate(ctx, protocol.ExternalServiceSyncRequest{}, src)
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if !called {
+		t.Errorf("expected called, got not called")
+	}
+}
+
+type testSource struct {
+	fn func() error
+}
+
+func (t testSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
+}
+
+func (t testSource) ExternalServices() types.ExternalServices {
+	return nil
+}
+
+func (t testSource) ValidateToken(ctx context.Context) error {
+	return t.fn()
+}
+
 func formatJSON(s string) string {
 	formatted, err := jsonc.Format(s, nil)
 	if err != nil {

--- a/internal/extsvc/github/user.go
+++ b/internal/extsvc/github/user.go
@@ -36,6 +36,12 @@ func SetExternalAccountData(data *extsvc.AccountData, user *github.User, token *
 	data.SetAuthData(token)
 }
 
+type User struct {
+	Login  string `json:"login,omitempty"`
+	ID     int    `json:"id,omitempty"`
+	NodeID string `json:"node_id,omitempty"`
+}
+
 type UserEmail struct {
 	Email      string `json:"email,omitempty"`
 	Primary    bool   `json:"primary,omitempty"`
@@ -44,6 +50,15 @@ type UserEmail struct {
 }
 
 var MockGetAuthenticatedUserEmails func(ctx context.Context) ([]*UserEmail, error)
+
+func (c *V3Client) GetAuthenticatedUser(ctx context.Context) (*User, error) {
+	var u User
+	err := c.requestGet(ctx, "/user", &u)
+	if err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
 
 // GetAuthenticatedUserEmails returns the first 100 emails associated with the currently
 // authenticated user.

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -267,6 +267,16 @@ func (c *Client) WithAuthenticator(a auth.Authenticator) *Client {
 	return &cc
 }
 
+func (c *Client) ValidateToken(ctx context.Context) error {
+	req, err := http.NewRequest(http.MethodGet, "user", nil)
+	if err != nil {
+		return err
+	}
+	v := struct{}{}
+	_, _, err = c.do(ctx, req, &v)
+	return err
+}
+
 type HTTPError struct {
 	code int
 	body []byte

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -129,7 +129,6 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 	if err != nil {
 		return nil, err
 	}
-
 	token := &auth.OAuthBearerToken{Token: c.Token}
 
 	var (
@@ -195,6 +194,11 @@ func (s GithubSource) WithAuthenticator(a auth.Authenticator) (Source, error) {
 type githubResult struct {
 	err  error
 	repo *github.Repository
+}
+
+func (s GithubSource) ValidateToken(ctx context.Context) error {
+	_, err := s.v3Client.GetAuthenticatedUserEmails(ctx)
+	return err
 }
 
 // ListRepos returns all Github repositories accessible to all connections configured

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -197,7 +197,7 @@ type githubResult struct {
 }
 
 func (s GithubSource) ValidateToken(ctx context.Context) error {
-	_, err := s.v3Client.GetAuthenticatedUserEmails(ctx)
+	_, err := s.v3Client.GetAuthenticatedUser(ctx)
 	return err
 }
 

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -150,6 +150,11 @@ func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (Source, error) {
 	return &sc, nil
 }
 
+func (s GitLabSource) ValidateToken(ctx context.Context) error {
+	err := s.client.ValidateToken(ctx)
+	return err
+}
+
 // ListRepos returns all GitLab repositories accessible to all connections configured
 // in Sourcegraph via the external services configuration.
 func (s GitLabSource) ListRepos(ctx context.Context, results chan SourceResult) {


### PR DESCRIPTION
ref #18740

The reason we weren't seeing errors for bad tokens was that we were trying to list repos when nothing was configured, so we succeeded in listing nothing. This adds a new ValidateToken method that tries to pull info for the authenticated user.

Paired with @ryanslade & @indradhanush