### PR TITLE
search: increase capacity of bufferedSender

### DIFF
--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -329,7 +329,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 
 		// The buffered backend.ZoektStreamFunc allows us to consume events from Zoekt
 		// while we wait for repo resolution.
-		bufSender, cleanup := bufferedSender(30, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
+		bufSender, cleanup := bufferedSender(120, backend.ZoektStreamFunc(func(event *zoekt.SearchResult) {
 
 			mu.Lock()
 			foundResults = foundResults || event.FileCount != 0 || event.MatchCount != 0


### PR DESCRIPTION
We increase capacity of bufferedSender to 4x.

Based on the logs we added in #19358, we can see that
`stream.total_send_time_ms` for `func err patternType:regexp` is around
7 seconds when aggregated across all zoekt instances. The reason is most
likely backpressure created by `bufferedSearcher`. With a capacity of 30
events it can only hold 1-2 events per zoekt instance on Cloud. The
traces show us that we can expect 100+ events for queries such as
`func err patternType:regexp`.

Ideally we find a buffer size that is small enough not to cause OOMs,
and large enough so that it fills up just when repos resolution is done.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
