### PR TITLE
Don't run Batch Changes background jobs on dotcom

### DIFF
--- a/enterprise/cmd/repo-updater/main.go
+++ b/enterprise/cmd/repo-updater/main.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/globals"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/repoupdater"
 	"github.com/sourcegraph/sourcegraph/cmd/repo-updater/shared"
@@ -51,9 +52,13 @@ func enterpriseInit(
 	codemonitorsBackground.StartBackgroundJobs(ctx, db)
 	insightsBackground.StartBackgroundJobs(ctx, db)
 
-	syncRegistry := batches.InitBackgroundJobs(ctx, db, cf)
-	if server != nil {
-		server.ChangesetSyncRegistry = syncRegistry
+	// No Batch Changes on dotcom, so we don't need to spawn the
+	// background jobs for this feature.
+	if !envvar.SourcegraphDotComMode() {
+		syncRegistry := batches.InitBackgroundJobs(ctx, db, cf)
+		if server != nil {
+			server.ChangesetSyncRegistry = syncRegistry
+		}
 	}
 
 	// TODO(jchen): This is an unfortunate compromise to not rewrite ossDB.ExternalServices for now.


### PR DESCRIPTION
Since this feature is not available on Sourcegraph.com yet, we don't need to spawn these jobs in the background.
