### PR TITLE
codeintel: fix range-contains off-by-one end character check

### DIFF
--- a/enterprise/lib/codeintel/semantic/util.go
+++ b/enterprise/lib/codeintel/semantic/util.go
@@ -118,7 +118,7 @@ func CompareLocations(a LocationData, b LocationData) int {
 	return 0
 }
 
-// ComparePosition compres the range r with the position constructed from line and character.
+// ComparePosition compares the range r with the position constructed from line and character.
 // Returns -1 if the position occurs before the range, +1 if it occurs after, and 0 if the
 // position is inside of the range.
 func ComparePosition(r RangeData, line, character int) int {
@@ -134,7 +134,7 @@ func ComparePosition(r RangeData, line, character int) int {
 		return 1
 	}
 
-	if line == r.EndLine && character > r.EndCharacter {
+	if line == r.EndLine && character >= r.EndCharacter {
 		return -1
 	}
 

--- a/enterprise/lib/codeintel/semantic/util_test.go
+++ b/enterprise/lib/codeintel/semantic/util_test.go
@@ -55,6 +55,42 @@ func TestFindRanges(t *testing.T) {
 	}
 }
 
+func TestFindNoRanges(t *testing.T) {
+	ranges := []RangeData{
+		{
+			StartLine:      0,
+			StartCharacter: 1,
+			EndLine:        0,
+			EndCharacter:   2,
+		},
+		{
+			StartLine:      1,
+			StartCharacter: 5,
+			EndLine:        1,
+			EndCharacter:   6,
+		},
+		{
+			StartLine:      2,
+			StartCharacter: 3,
+			EndLine:        2,
+			EndCharacter:   4,
+		},
+	}
+
+	m := map[ID]RangeData{}
+	for i, r := range ranges {
+		m[ID(strconv.Itoa(i))] = r
+	}
+
+	for i := range ranges {
+		actual := FindRanges(m, i, 4)
+		var expected []RangeData
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Errorf("unexpected findRanges result %d (-want +got):\n%s", i, diff)
+		}
+	}
+}
+
 func TestFindRangesOrder(t *testing.T) {
 	ranges := []RangeData{
 		{
@@ -99,7 +135,6 @@ func TestFindRangesOrder(t *testing.T) {
 	if diff := cmp.Diff(expected, actual); diff != "" {
 		t.Errorf("unexpected findRanges result (-want +got):\n%s", diff)
 	}
-
 }
 
 func TestComparePosition(t *testing.T) {
@@ -117,7 +152,7 @@ func TestComparePosition(t *testing.T) {
 	}{
 		{5, 11, 0},
 		{5, 12, 0},
-		{5, 13, 0},
+		{5, 13, -1},
 		{4, 12, +1},
 		{5, 10, +1},
 		{5, 14, -1},


### PR DESCRIPTION
Fixes the below issue where hovering the following whitespace would give code intel results for the `apiFlags` variable. This also happens in situations such as `Token)` where hovering the `)` would give the same behaviour. 
This is due to LSIF ranges specifying [half-open intervals](https://mathworld.wolfram.com/Half-ClosedInterval.html) aka a range denoted by start-end chars as 2, 10 would be [2, 10):
`\t\tapiFlags`
` 0  1 234567890`

The `ComparePosition` function changed in this PR did not account for that final index not being part of the range.

![image](https://user-images.githubusercontent.com/18282288/112507336-73087400-8d86-11eb-97cd-4da26c5adc2c.png)
