### PR TITLE
Add mute comment for stopPropagation at insight description 

### DIFF
--- a/client/web/src/repo/tree/ViewGrid.tsx
+++ b/client/web/src/repo/tree/ViewGrid.tsx
@@ -70,6 +70,7 @@ const InsightDescription: React.FunctionComponent<InsightDescriptionProps> = pro
     const { icon: Icon, title } = props
 
     return (
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
         <small title={title} className="insight-description text-muted" onMouseDown={stopPropagation}>
             <Icon className="icon-inline" /> {title}
         </small>

--- a/client/web/src/repo/tree/ViewGrid.tsx
+++ b/client/web/src/repo/tree/ViewGrid.tsx
@@ -64,6 +64,10 @@ interface InsightDescriptionProps {
     icon: MdiReactIconComponentType
 }
 
+// Since we use react-grid-layout for build draggable insight cards at insight dashboard
+// to support text selection within insight card at InsightDescription component we have to
+// capture mouse event to prevent all action from react-grid-layout library which will prevent
+// default behavior and the text will become unavailable for selection
 const stopPropagation: React.MouseEventHandler<HTMLElement> = event => event.stopPropagation()
 
 const InsightDescription: React.FunctionComponent<InsightDescriptionProps> = props => {


### PR DESCRIPTION
This PR is about to fix our problem with a11y linting at Insight page. 

**A bit context about stopPropagation at description insight component.**

Since we use react-grid-layout for build draggable insight cards at insight dashboard
to support text selection within insight card at InsightDescription component we have to
capture mouse event to prevent all action from react-grid-layout library which will prevent
default behavior and the text will become unavailable for selection

This element where we use stopPropagation is not about interactions (and we can't use some tag like button because this is not) and that's why linter is telling that thing is a problem but according thing above we have to have it for now.