### PR TITLE
search: Fix commit search duplicated results issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Commit search returning duplicate commits. [#19460](https://github.com/sourcegraph/sourcegraph/pull/19460)
 
 ### Removed
 

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -363,7 +363,6 @@ func rawShowSearch(ctx context.Context, repo api.RepoName, opt RawLogDiffSearchO
 	showArgs := append([]string{}, "show")
 	showArgs = append(showArgs, "--no-patch") // will be overridden if opt.FormatArgs has --patch
 	showArgs = append(showArgs, opt.FormatArgs...)
-	showArgs = append(showArgs, opt.Args...)
 	showArgs = append(showArgs, commitOIDs...)
 	// Need --patch (TODO(sqs): or just --raw, which is smaller) if we are filtering by file paths,
 	// because we post-filter by path since we need to support regexps. Just the commit message


### PR DESCRIPTION
Fixes #17483 

This commit fixes an issue where a commit would show up twice in the
results. What was happening is we would first do a search for commits
containing a specific pattern. Then, using those results, we'd make a
second request for the commit content so we can filter on the files
modified by the commit (and maybe get some other things too).

However, the issue was that in the second request, the original query
args were being added to the command. This is problematic because
sometimes, the first query will return incomplete results so we could
get partial results faster. But, since the second query has all the
original query args, it would return _all_ the results, without caring
about the commit OIDs passed in to it.

This commit removes the original query args from the rawShowSearch
function so we only return results for the commit OIDs passed to it.

For the sample function in #17483, I've grabbed the changed args below.

Removed args:

```
--no-prefix
--max-count=501
--extended-regexp
--regexp-ignore-case
--all-match
--grep=highlight
--all-match
--author=rijnard
```

Remaining args:

```
show
--no-patch
--no-merges
-z
--decorate=full
--format=format:%H%x00%D%x00%aN%x00%aE%x00%at%x00%cN%x00%cE%x00%ct%x00%B%x00%P%x00
0babc177e8e776fe7b6f4ddbbed09762d867aad7
dd6a4b1f3825b0c6f308c760409c21df3bca3031
--extended-regexp
--
```



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
