### PR TITLE
Change misleading "no locations found" text

### DIFF
--- a/client/branded/src/components/panel/views/FileLocations.tsx
+++ b/client/branded/src/components/panel/views/FileLocations.tsx
@@ -29,6 +29,12 @@ export const FileLocationsNotFound: React.FunctionComponent = () => (
     </div>
 )
 
+export const FileLocationsNoGroupSelected: React.FunctionComponent = () => (
+    <div className="file-locations__no-group-selected m-2">
+        <MapSearchIcon className="icon-inline" /> No locations found in the current repository
+    </div>
+)
+
 interface Props extends SettingsCascadeProps, VersionContextProps {
     location: H.Location
     /**
@@ -47,6 +53,9 @@ interface Props extends SettingsCascadeProps, VersionContextProps {
     isLightTheme: boolean
 
     fetchHighlightedFileLineRanges: (parameters: FetchFileParameters, force?: boolean) => Observable<string[][]>
+
+    /** Whether or not there are other groups in the parent container with results. */
+    parentContainerIsEmpty: boolean
 }
 
 const LOADING = 'loading' as const
@@ -116,7 +125,7 @@ export class FileLocations extends React.PureComponent<Props, State> {
             return <LoadingSpinner className="icon-inline m-1" />
         }
         if (this.state.locationsOrError === null || this.state.locationsOrError.length === 0) {
-            return <FileLocationsNotFound />
+            return this.props.parentContainerIsEmpty ? <FileLocationsNotFound /> : <FileLocationsNoGroupSelected />
         }
 
         // Locations by fully qualified URI, like git://github.com/gorilla/mux?revision#mux.go

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -175,7 +175,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
             })
         }
 
-        const { groups, selectedGroups, visibleLocations } = groupLocations<Location, string>(
+        const { groups, selectedGroups, visibleLocations } = groupLocations(
             this.state.locationsOrError.result.locations,
             this.state.selectedGroups || null,
             GROUPS.map(({ key }) => key),
@@ -280,6 +280,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                         fetchHighlightedFileLineRanges={this.props.fetchHighlightedFileLineRanges}
                         settingsCascade={this.props.settingsCascade}
                         versionContext={this.props.versionContext}
+                        parentContainerIsEmpty={this.state.locationsOrError.result.locations.length === 0}
                     />
                 </div>
             </div>


### PR DESCRIPTION
This replaces the text "No locations found" with "No locations found in the current repository" when the location set to display is non-empty (regardless if the panel has anything to display due to not having any repository selected).

This clears up a misleading UX edge case where it states there are no locations found, when it's actually just that no locations are _currently visible_ based on the user's selection.