### PR TITLE
Revert "move syncExternalService in setExternalServiceRepos into goroutine"

### DIFF
--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
-	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -68,15 +67,9 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 		return nil, err
 	}
 
-	// this kicks off an async job, but has some slow validation before that happens. Considering the user repos page
-	// already handles the async job we don't need to wait for this request. any errors from this should also be picked
-	// up and fed back to the user by the notifications system.
-	go func() {
-		ctx, _ := context.WithTimeout(ctx, 60*time.Second)
-		if err := syncExternalService(ctx, es); err != nil {
-			log15.Error("error syncing external services", "error", err)
-		}
-	}()
+	if err := syncExternalService(ctx, es); err != nil {
+		return nil, err
+	}
 
 	return &EmptyResponse{}, nil
 }

--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/graph-gophers/graphql-go/gqltesting"
 
@@ -70,11 +69,9 @@ func TestSetExternalServiceRepos(t *testing.T) {
 		UID:      1,
 	})
 
-	done := make(chan struct{})
 	oldClient := repoupdater.DefaultClient.HTTPClient
 	repoupdater.DefaultClient.HTTPClient = &http.Client{
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			close(done)
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
@@ -83,10 +80,6 @@ func TestSetExternalServiceRepos(t *testing.T) {
 	}
 
 	defer func() {
-		// wait for the async job to finish
-		<-done
-		time.Sleep(10 * time.Millisecond)
-
 		database.Mocks = database.MockStores{}
 		repoupdater.DefaultClient.HTTPClient = oldClient
 	}()


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#19417

we fixed the root cause of the slowdown in https://github.com/sourcegraph/sourcegraph/pull/19439 so this is not necessary anymore, and means we can get feedback directly from the request