### PR TITLE
search contexts: paginated API

### DIFF
--- a/client/shared/src/search/query/transformer.ts
+++ b/client/shared/src/search/query/transformer.ts
@@ -6,7 +6,7 @@ export function appendContextFilter(query: string, searchContextSpec: string | u
     return !isContextFilterInQuery(query) && searchContextSpec ? `context:${searchContextSpec} ${query}` : query
 }
 
-export const omitContextFilter = (query: string, contextFilter: Filter): string => {
+export function omitContextFilter(query: string, contextFilter: Filter): string {
     let finalQuery = replaceRange(query, contextFilter.range)
     if (contextFilter.range.start === 0) {
         // Remove space at the start

--- a/client/web/src/Layout.test.tsx
+++ b/client/web/src/Layout.test.tsx
@@ -61,7 +61,7 @@ describe('Layout', () => {
             { attachTo: document.querySelector('#root') as HTMLElement }
         )
 
-        sinon.assert.calledOnce(setParsedSearchQuery)
+        sinon.assert.called(setParsedSearchQuery)
         sinon.assert.calledWith(setParsedSearchQuery, 'r:golang/oauth2 test f:travis2')
 
         element.unmount()
@@ -108,7 +108,7 @@ describe('Layout', () => {
             { attachTo: document.querySelector('#root') as HTMLElement }
         )
 
-        sinon.assert.calledOnce(setParsedSearchQuery)
+        sinon.assert.called(setParsedSearchQuery)
         sinon.assert.calledWith(setParsedSearchQuery, '')
 
         element.unmount()
@@ -133,7 +133,7 @@ describe('Layout', () => {
             { attachTo: document.querySelector('#root') as HTMLElement }
         )
 
-        sinon.assert.calledOnce(setPatternTypeSpy)
+        sinon.assert.called(setPatternTypeSpy)
         sinon.assert.calledWith(setPatternTypeSpy, SearchPatternType.regexp)
 
         element.unmount()
@@ -206,7 +206,7 @@ describe('Layout', () => {
             { attachTo: document.querySelector('#root') as HTMLElement }
         )
 
-        sinon.assert.calledOnce(setCaseSensitivitySpy)
+        sinon.assert.called(setCaseSensitivitySpy)
         sinon.assert.calledWith(setCaseSensitivitySpy, true)
 
         element.unmount()
@@ -285,7 +285,7 @@ describe('Layout', () => {
             { attachTo: document.querySelector('#root') as HTMLElement }
         )
 
-        sinon.assert.calledOnce(setVersionContextSpy)
+        sinon.assert.called(setVersionContextSpy)
         sinon.assert.calledWith(setVersionContextSpy, 'test')
 
         element.unmount()
@@ -346,7 +346,7 @@ describe('Layout', () => {
             { attachTo: document.querySelector('#root') as HTMLElement }
         )
 
-        sinon.assert.calledOnce(setVersionContextSpy)
+        sinon.assert.called(setVersionContextSpy)
         sinon.assert.calledWith(setVersionContextSpy, undefined)
 
         element.unmount()

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -42,7 +42,7 @@ import {
     MutableVersionContextProps,
     parseSearchURL,
     SearchContextProps,
-    getGlobalSearchContext,
+    getGlobalSearchContextFilter,
 } from './search'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
 import { SiteAdminSideBarGroups } from './site-admin/SiteAdminSidebar'
@@ -169,7 +169,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
         location.search,
     ])
 
-    const searchContextSpec = useMemo(() => getGlobalSearchContext(query)?.spec, [query])
+    const searchContextSpec = useMemo(() => getGlobalSearchContextFilter(query)?.spec, [query])
 
     useEffect(() => {
         if (query !== currentQuery) {

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -561,10 +561,12 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
     private setSelectedSearchContextSpec = (spec: string): void => {
         const { defaultSearchContextSpec } = this.state
         this.subscriptions.add(
-            resolveSearchContextSpecOrDefault(spec, defaultSearchContextSpec).subscribe(resolvedSearchContextSpec => {
-                this.setState({ selectedSearchContextSpec: resolvedSearchContextSpec })
-                localStorage.setItem(LAST_SEARCH_CONTEXT_KEY, resolvedSearchContextSpec)
-            })
+            resolveSearchContextSpecOrDefault({ spec, defaultSpec: defaultSearchContextSpec }).subscribe(
+                resolvedSearchContextSpec => {
+                    this.setState({ selectedSearchContextSpec: resolvedSearchContextSpec })
+                    localStorage.setItem(LAST_SEARCH_CONTEXT_KEY, resolvedSearchContextSpec)
+                }
+            )
         )
     }
 }

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -7,7 +7,7 @@ import { hot } from 'react-hot-loader/root'
 import { Route } from 'react-router'
 import { BrowserRouter } from 'react-router-dom'
 import { combineLatest, from, Subscription, fromEvent, of, Subject } from 'rxjs'
-import { bufferCount, startWith, switchMap } from 'rxjs/operators'
+import { bufferCount, map, startWith, switchMap } from 'rxjs/operators'
 import { setLinkComponent } from '../../shared/src/components/Link'
 import {
     Controller as ExtensionsController,
@@ -41,6 +41,7 @@ import {
     fetchSavedSearches,
     fetchRecentSearches,
     fetchRecentFileViews,
+    fetchAutoDefinedSearchContexts,
     fetchSearchContexts,
 } from './search/backend'
 import { SiteAdminAreaRoute } from './site-admin/SiteAdminArea'
@@ -52,7 +53,7 @@ import { UserAreaRoute } from './user/area/UserArea'
 import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
-import { resolveVersionContext, parseSearchURL, resolveSearchContextSpec } from './search'
+import { resolveVersionContext, parseSearchURL, resolveSearchContextSpecOrDefault } from './search'
 import { KeyboardShortcutsProps } from './keyboardShortcuts/keyboardShortcuts'
 import { QueryState } from './search/helpers'
 import { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
@@ -333,9 +334,16 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         )
 
         this.subscriptions.add(
-            fetchSearchContexts.subscribe(contexts => {
-                this.setState({ availableSearchContexts: contexts })
-            })
+            combineLatest([fetchAutoDefinedSearchContexts, fetchSearchContexts(10).pipe(map(({ nodes }) => nodes))])
+                .pipe(
+                    map(([autoDefinedSearchContexts, searchContexts]) => [
+                        ...autoDefinedSearchContexts,
+                        ...searchContexts,
+                    ])
+                )
+                .subscribe(contexts => {
+                    this.setState({ availableSearchContexts: contexts })
+                })
         )
 
         this.subscriptions.add(
@@ -551,14 +559,13 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         this.canShowSearchContext() ? this.state.selectedSearchContextSpec : undefined
 
     private setSelectedSearchContextSpec = (spec: string): void => {
-        const { availableSearchContexts, defaultSearchContextSpec } = this.state
-        const resolvedSearchContextSpec = resolveSearchContextSpec(
-            spec,
-            availableSearchContexts,
-            defaultSearchContextSpec
+        const { defaultSearchContextSpec } = this.state
+        this.subscriptions.add(
+            resolveSearchContextSpecOrDefault(spec, defaultSearchContextSpec).subscribe(resolvedSearchContextSpec => {
+                this.setState({ selectedSearchContextSpec: resolvedSearchContextSpec })
+                localStorage.setItem(LAST_SEARCH_CONTEXT_KEY, resolvedSearchContextSpec)
+            })
         )
-        this.setState({ selectedSearchContextSpec: resolvedSearchContextSpec })
-        localStorage.setItem(LAST_SEARCH_CONTEXT_KEY, resolvedSearchContextSpec)
     }
 }
 

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -53,7 +53,7 @@ import { UserAreaRoute } from './user/area/UserArea'
 import { UserAreaHeaderNavItem } from './user/area/UserAreaHeader'
 import { UserSettingsAreaRoute } from './user/settings/UserSettingsArea'
 import { UserSettingsSidebarItems } from './user/settings/UserSettingsSidebar'
-import { resolveVersionContext, parseSearchURL, resolveSearchContextSpecOrDefault } from './search'
+import { resolveVersionContext, parseSearchURL, getAvailableSearchContextSpecOrDefault } from './search'
 import { KeyboardShortcutsProps } from './keyboardShortcuts/keyboardShortcuts'
 import { QueryState } from './search/helpers'
 import { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
@@ -561,10 +561,10 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
     private setSelectedSearchContextSpec = (spec: string): void => {
         const { defaultSearchContextSpec } = this.state
         this.subscriptions.add(
-            resolveSearchContextSpecOrDefault({ spec, defaultSpec: defaultSearchContextSpec }).subscribe(
-                resolvedSearchContextSpec => {
-                    this.setState({ selectedSearchContextSpec: resolvedSearchContextSpec })
-                    localStorage.setItem(LAST_SEARCH_CONTEXT_KEY, resolvedSearchContextSpec)
+            getAvailableSearchContextSpecOrDefault({ spec, defaultSpec: defaultSearchContextSpec }).subscribe(
+                availableSearchContextSpecOrDefault => {
+                    this.setState({ selectedSearchContextSpec: availableSearchContextSpecOrDefault })
+                    localStorage.setItem(LAST_SEARCH_CONTEXT_KEY, availableSearchContextSpecOrDefault)
                 }
             )
         )

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -49,8 +49,8 @@ describe('Code monitoring', () => {
             RepoGroups: () => ({
                 repoGroups: [],
             }),
-            SearchContexts: () => ({
-                searchContexts: [],
+            AutoDefinedSearchContexts: () => ({
+                autoDefinedSearchContexts: [],
             }),
             ViewerSettings: () => ({
                 viewerSettings: {

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -142,8 +142,8 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
             alwaysNil: null,
         },
     }),
-    SearchContexts: () => ({
-        searchContexts: [
+    AutoDefinedSearchContexts: () => ({
+        autoDefinedSearchContexts: [
             {
                 __typename: 'SearchContext',
                 id: '1',
@@ -159,6 +159,16 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
                 description: 'Your repositories on Sourcegraph',
             },
         ],
+    }),
+    ListSearchContexts: () => ({
+        searchContexts: {
+            nodes: [],
+            totalCount: 0,
+            pageInfo: { endCursor: null },
+        },
+    }),
+    ResolveSearchContextSpec: () => ({
+        resolveSearchContextSpec: null,
     }),
     UserRepositories: () => ({
         node: {

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -167,8 +167,8 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
             pageInfo: { endCursor: null },
         },
     }),
-    ResolveSearchContextSpec: () => ({
-        resolveSearchContextSpec: null,
+    IsSearchContextAvailable: () => ({
+        isSearchContextAvailable: false,
     }),
     UserRepositories: () => ({
         node: {

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -49,8 +49,8 @@ describe('Search onboarding', () => {
             RepoGroups: () => ({
                 repoGroups: [],
             }),
-            SearchContexts: () => ({
-                searchContexts: [],
+            AutoDefinedSearchContexts: () => ({
+                autoDefinedSearchContexts: [],
             }),
             ViewerSettings: () => ({
                 viewerSettings: {

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -5,7 +5,7 @@ import {
     SearchResult,
     SearchSuggestionsResult,
     WebGraphQlOperations,
-    SearchContextsResult,
+    AutoDefinedSearchContextsResult,
 } from '../graphql-operations'
 import { Driver, createDriverForTest, percySnapshot } from '../../../shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '../../../shared/src/testing/screenshotReporter'
@@ -82,8 +82,8 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
     RepoGroups: (): RepoGroupsResult => ({
         repoGroups: [],
     }),
-    SearchContexts: (): SearchContextsResult => ({
-        searchContexts: [],
+    AutoDefinedSearchContexts: (): AutoDefinedSearchContextsResult => ({
+        autoDefinedSearchContexts: [],
     }),
 }
 
@@ -576,8 +576,8 @@ describe('Search', () => {
         const testContextForSearchContexts: Partial<WebGraphQlOperations> = {
             ...commonSearchGraphQLResults,
             ...viewerSettingsWithSearchContexts,
-            SearchContexts: () => ({
-                searchContexts: [
+            AutoDefinedSearchContexts: () => ({
+                autoDefinedSearchContexts: [
                     {
                         __typename: 'SearchContext',
                         id: '1',
@@ -637,9 +637,23 @@ describe('Search', () => {
                 () => document.querySelector<HTMLButtonElement>('.test-search-context-dropdown')?.disabled
             )
         test('Search context selected based on URL', async () => {
-            await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=context:%40test+test&patternType=regexp')
-            await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
-            expect(await getSelectedSearchContextSpec()).toStrictEqual('context:@test')
+            testContext.overrideGraphQL({
+                ...testContextForSearchContexts,
+                ResolveSearchContextSpec: () => ({
+                    resolveSearchContextSpec: {
+                        __typename: 'SearchContext',
+                        id: '1',
+                        spec: 'global',
+                        description: '',
+                        autoDefined: true,
+                    },
+                }),
+            })
+            await testContext.waitForGraphQLRequest(async () => {
+                await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=context:global+test&patternType=regexp')
+                await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
+            }, 'ResolveSearchContextSpec')
+            expect(await getSelectedSearchContextSpec()).toStrictEqual('context:global')
         })
 
         test('Missing context param should default to global context', async () => {
@@ -649,11 +663,13 @@ describe('Search', () => {
         })
 
         test('Unavailable search context should remain in the query and disable the search context dropdown', async () => {
-            await driver.page.goto(
-                driver.sourcegraphBaseUrl + '/search?q=context:%40unavailableCtx+test&patternType=regexp'
-            )
-            await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
-            await driver.page.waitForSelector('#monaco-query-input')
+            await testContext.waitForGraphQLRequest(async () => {
+                await driver.page.goto(
+                    driver.sourcegraphBaseUrl + '/search?q=context:%40unavailableCtx+test&patternType=regexp'
+                )
+                await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
+                await driver.page.waitForSelector('#monaco-query-input')
+            }, 'ResolveSearchContextSpec')
             expect(await getSearchFieldValue(driver)).toStrictEqual('context:@unavailableCtx test')
             expect(await isSearchContextDropdownDisabled()).toBeTruthy()
         })

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -639,20 +639,14 @@ describe('Search', () => {
         test('Search context selected based on URL', async () => {
             testContext.overrideGraphQL({
                 ...testContextForSearchContexts,
-                ResolveSearchContextSpec: () => ({
-                    resolveSearchContextSpec: {
-                        __typename: 'SearchContext',
-                        id: '1',
-                        spec: 'global',
-                        description: '',
-                        autoDefined: true,
-                    },
+                IsSearchContextAvailable: () => ({
+                    isSearchContextAvailable: true,
                 }),
             })
             await testContext.waitForGraphQLRequest(async () => {
                 await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=context:global+test&patternType=regexp')
                 await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
-            }, 'ResolveSearchContextSpec')
+            }, 'IsSearchContextAvailable')
             expect(await getSelectedSearchContextSpec()).toStrictEqual('context:global')
         })
 
@@ -669,7 +663,7 @@ describe('Search', () => {
                 )
                 await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
                 await driver.page.waitForSelector('#monaco-query-input')
-            }, 'ResolveSearchContextSpec')
+            }, 'IsSearchContextAvailable')
             expect(await getSearchFieldValue(driver)).toStrictEqual('context:@unavailableCtx test')
             expect(await isSearchContextDropdownDisabled()).toBeTruthy()
         })

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -1,5 +1,6 @@
 import * as H from 'history'
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
+import { of } from 'rxjs'
 import { ActivationProps } from '../../../shared/src/components/activation/Activation'
 import { ExtensionsControllerProps } from '../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../shared/src/platform/context'
@@ -12,6 +13,8 @@ import {
     OnboardingTourProps,
     ParsedSearchQueryProps,
     SearchContextProps,
+    isSearchContextSpecAvailable,
+    getGlobalSearchContext,
 } from '../search'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
 import { showDotComMarketing } from '../util/features'
@@ -30,6 +33,8 @@ import { LinkOrSpan } from '../../../shared/src/components/LinkOrSpan'
 import { ExtensionAlertAnimationProps } from './UserNavItem'
 import { LayoutRouteProps } from '../routes'
 import { CodeMonitoringProps } from '../code-monitoring'
+import { useObservable } from '../../../shared/src/util/useObservable'
+import { omitContextFilter } from '../../../shared/src/search/query/transformer'
 
 interface Props
     extends SettingsCascadeProps,
@@ -111,6 +116,14 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
 
     const query = props.parsedSearchQuery
 
+    const globalSearchContextSpec = useMemo(() => getGlobalSearchContext(query), [query])
+    const isSearchContextAvailable = useObservable(
+        useMemo(
+            () => (globalSearchContextSpec ? isSearchContextSpecAvailable(globalSearchContextSpec.spec) : of(false)),
+            [globalSearchContextSpec]
+        )
+    )
+
     useEffect(() => {
         // On a non-search related page or non-repo page, we clear the query in
         // the main query input to avoid misleading users
@@ -123,8 +136,23 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         if (!query) {
             return
         }
-        onNavbarQueryChange({ query })
-    }, [isSearchRelatedPage, onNavbarQueryChange, query])
+
+        // If a global search context spec is available to the user, we omit it from the
+        // query and move it to the search contexts dropdown
+        const finalQuery =
+            globalSearchContextSpec && isSearchContextAvailable && props.showSearchContext
+                ? omitContextFilter(query, globalSearchContextSpec.filter)
+                : query
+
+        onNavbarQueryChange({ query: finalQuery })
+    }, [
+        isSearchRelatedPage,
+        onNavbarQueryChange,
+        query,
+        globalSearchContextSpec,
+        isSearchContextAvailable,
+        props.showSearchContext,
+    ])
 
     const logo = (
         <LinkOrSpan to={authRequired ? undefined : '/search'} className="global-navbar__logo-link">

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -14,7 +14,7 @@ import {
     ParsedSearchQueryProps,
     SearchContextProps,
     isSearchContextSpecAvailable,
-    getGlobalSearchContext,
+    getGlobalSearchContextFilter,
 } from '../search'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
 import { showDotComMarketing } from '../util/features'
@@ -116,7 +116,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
 
     const query = props.parsedSearchQuery
 
-    const globalSearchContextSpec = useMemo(() => getGlobalSearchContext(query), [query])
+    const globalSearchContextSpec = useMemo(() => getGlobalSearchContextFilter(query), [query])
     const isSearchContextAvailable = useObservable(
         useMemo(
             () => (globalSearchContextSpec ? isSearchContextSpecAvailable(globalSearchContextSpec.spec) : of(false)),

--- a/client/web/src/search/backend.tsx
+++ b/client/web/src/search/backend.tsx
@@ -24,8 +24,8 @@ import {
     ListSearchContextsVariables,
     AutoDefinedSearchContextsResult,
     AutoDefinedSearchContextsVariables,
-    ResolveSearchContextSpecResult,
-    ResolveSearchContextSpecVariables,
+    IsSearchContextAvailableResult,
+    IsSearchContextAvailableVariables,
     Scalars,
 } from '../graphql-operations'
 
@@ -276,23 +276,17 @@ export function fetchSearchContexts(
     )
 }
 
-export function resolveSearchContextSpec(
+export function isSearchContextAvailable(
     spec: string
-): Observable<ResolveSearchContextSpecResult['resolveSearchContextSpec']> {
-    return requestGraphQL<ResolveSearchContextSpecResult, ResolveSearchContextSpecVariables>(
+): Observable<IsSearchContextAvailableResult['isSearchContextAvailable']> {
+    return requestGraphQL<IsSearchContextAvailableResult, IsSearchContextAvailableVariables>(
         gql`
-            query ResolveSearchContextSpec($spec: String!) {
-                resolveSearchContextSpec(spec: $spec) {
-                    __typename
-                    id
-                    spec
-                    description
-                    autoDefined
-                }
+            query IsSearchContextAvailable($spec: String!) {
+                isSearchContextAvailable(spec: $spec)
             }
         `,
         { spec }
-    ).pipe(map(result => result.data?.resolveSearchContextSpec ?? null))
+    ).pipe(map(result => result.data?.isSearchContextAvailable ?? false))
 }
 
 export function fetchSuggestions(query: string): Observable<SearchSuggestion[]> {

--- a/client/web/src/search/backend.tsx
+++ b/client/web/src/search/backend.tsx
@@ -20,8 +20,12 @@ import {
     DeleteSavedSearchVariables,
     UpdateSavedSearchResult,
     UpdateSavedSearchVariables,
-    SearchContextsResult,
-    SearchContextsVariables,
+    ListSearchContextsResult,
+    ListSearchContextsVariables,
+    AutoDefinedSearchContextsResult,
+    AutoDefinedSearchContextsVariables,
+    ResolveSearchContextSpecResult,
+    ResolveSearchContextSpecVariables,
     Scalars,
 } from '../graphql-operations'
 
@@ -223,10 +227,10 @@ const repogroupSuggestions = defer(() =>
     refCount()
 )
 
-export const fetchSearchContexts = defer(() =>
-    requestGraphQL<SearchContextsResult, SearchContextsVariables>(gql`
-        query SearchContexts {
-            searchContexts {
+export const fetchAutoDefinedSearchContexts = defer(() =>
+    requestGraphQL<AutoDefinedSearchContextsResult, AutoDefinedSearchContextsVariables>(gql`
+        query AutoDefinedSearchContexts {
+            autoDefinedSearchContexts {
                 __typename
                 id
                 spec
@@ -237,15 +241,64 @@ export const fetchSearchContexts = defer(() =>
     `)
 ).pipe(
     map(dataOrThrowErrors),
-    map(({ searchContexts }) => searchContexts as GQL.ISearchContext[]),
+    map(({ autoDefinedSearchContexts }) => autoDefinedSearchContexts as GQL.ISearchContext[]),
     publishReplay(1),
     refCount()
 )
 
+export function fetchSearchContexts(
+    first: number,
+    query?: string,
+    after?: string
+): Observable<ListSearchContextsResult['searchContexts']> {
+    return requestGraphQL<ListSearchContextsResult, ListSearchContextsVariables>(
+        gql`
+            query ListSearchContexts($first: Int!, $after: String, $query: String) {
+                searchContexts(first: $first, after: $after, query: $query) {
+                    nodes {
+                        __typename
+                        id
+                        spec
+                        description
+                        autoDefined
+                    }
+                    pageInfo {
+                        endCursor
+                    }
+                    totalCount
+                }
+            }
+        `,
+        { first, after: after ?? null, query: query ?? null }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.searchContexts)
+    )
+}
+
+export function resolveSearchContextSpec(
+    spec: string
+): Observable<ResolveSearchContextSpecResult['resolveSearchContextSpec']> {
+    return requestGraphQL<ResolveSearchContextSpecResult, ResolveSearchContextSpecVariables>(
+        gql`
+            query ResolveSearchContextSpec($spec: String!) {
+                resolveSearchContextSpec(spec: $spec) {
+                    __typename
+                    id
+                    spec
+                    description
+                    autoDefined
+                }
+            }
+        `,
+        { spec }
+    ).pipe(map(result => result.data?.resolveSearchContextSpec ?? null))
+}
+
 export function fetchSuggestions(query: string): Observable<SearchSuggestion[]> {
     return combineLatest([
         repogroupSuggestions,
-        fetchSearchContexts,
+        fetchAutoDefinedSearchContexts,
         queryGraphQL(
             gql`
                 query SearchSuggestions($query: String!) {
@@ -292,9 +345,9 @@ export function fetchSuggestions(query: string): Observable<SearchSuggestion[]> 
             })
         ),
     ]).pipe(
-        map(([repogroups, searchContexts, dynamicSuggestions]) => [
+        map(([repogroups, autoDefinedSearchContexts, dynamicSuggestions]) => [
             ...repogroups,
-            ...searchContexts,
+            ...autoDefinedSearchContexts,
             ...dynamicSuggestions,
         ])
     )

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -4,8 +4,9 @@ import { discreteValueAliases, escapeSpaces } from '../../../shared/src/search/q
 import { VersionContext } from '../schema/site.schema'
 import { SearchPatternType } from '../../../shared/src/graphql-operations'
 import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { ISavedSearch, ISearchContext } from '../../../shared/src/graphql/schema'
-import { EventLogResult } from './backend'
+import { EventLogResult, resolveSearchContextSpec } from './backend'
 import { AggregateStreamingSearchResults, StreamSearchOptions } from './stream'
 import { findFilter, FilterKind } from '../../../shared/src/search/query/validate'
 import { VersionContextProps } from '../../../shared/src/search/util'
@@ -229,14 +230,10 @@ export function resolveVersionContext(
     return versionContext
 }
 
-export function isSearchContextSpecAvailable(spec: string, availableSearchContexts: ISearchContext[]): boolean {
-    return availableSearchContexts.map(item => item.spec).includes(spec)
+export function isSearchContextSpecAvailable(spec: string): Observable<boolean> {
+    return resolveSearchContextSpec(spec).pipe(map(searchContext => !!searchContext))
 }
 
-export function resolveSearchContextSpec(
-    spec: string,
-    availableSearchContexts: ISearchContext[],
-    defaultSpec: string
-): string {
-    return isSearchContextSpecAvailable(spec, availableSearchContexts) ? spec : defaultSpec
+export function resolveSearchContextSpecOrDefault(spec: string, defaultSpec: string): Observable<string> {
+    return resolveSearchContextSpec(spec).pipe(map(searchContext => (searchContext ? searchContext.spec : defaultSpec)))
 }

--- a/client/web/src/search/index.tsx
+++ b/client/web/src/search/index.tsx
@@ -7,7 +7,7 @@ import { SearchPatternType } from '../../../shared/src/graphql-operations'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import { ISavedSearch, ISearchContext } from '../../../shared/src/graphql/schema'
-import { EventLogResult, resolveSearchContextSpec } from './backend'
+import { EventLogResult, isSearchContextAvailable } from './backend'
 import { AggregateStreamingSearchResults, StreamSearchOptions } from './stream'
 import { findFilter, FilterKind } from '../../../shared/src/search/query/validate'
 import { VersionContextProps } from '../../../shared/src/search/util'
@@ -232,7 +232,7 @@ export function resolveVersionContext(
     return versionContext
 }
 
-export function getGlobalSearchContext(query: string): { filter: Filter; spec: string } | null {
+export function getGlobalSearchContextFilter(query: string): { filter: Filter; spec: string } | null {
     const globalContextFilter = findFilter(query, FilterType.context, FilterKind.Global)
     if (!globalContextFilter) {
         return null
@@ -242,12 +242,12 @@ export function getGlobalSearchContext(query: string): { filter: Filter; spec: s
 }
 
 export const isSearchContextSpecAvailable = memoizeObservable(
-    (spec: string) => resolveSearchContextSpec(spec).pipe(map(searchContext => !!searchContext)),
+    (spec: string) => isSearchContextAvailable(spec),
     parameters => parameters
 )
 
-export const resolveSearchContextSpecOrDefault = memoizeObservable(
+export const getAvailableSearchContextSpecOrDefault = memoizeObservable(
     ({ spec, defaultSpec }: { spec: string; defaultSpec: string }) =>
-        resolveSearchContextSpec(spec).pipe(map(searchContext => (searchContext ? searchContext.spec : defaultSpec))),
+        isSearchContextAvailable(spec).pipe(map(isAvailable => (isAvailable ? spec : defaultSpec))),
     ({ spec, defaultSpec }) => `${spec}:${defaultSpec}`
 )

--- a/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
@@ -36,7 +36,6 @@ const defaultProps: StreamingSearchResultsProps = {
     caseSensitive: false,
     patternType: SearchPatternType.literal,
     versionContext: undefined,
-    selectedSearchContextSpec: 'global',
     availableVersionContexts: [],
     previousVersionContext: null,
 

--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -45,7 +45,6 @@ describe('StreamingSearchResults', () => {
         caseSensitive: false,
         patternType: SearchPatternType.literal,
         versionContext: undefined,
-        selectedSearchContextSpec: 'global',
         availableVersionContexts: [],
         previousVersionContext: null,
 
@@ -95,7 +94,6 @@ describe('StreamingSearchResults', () => {
             patternType: SearchPatternType.regexp,
             caseSensitive: true,
             versionContext: 'test',
-            searchContextSpec: 'global',
             trace: undefined,
         })
 
@@ -129,7 +127,6 @@ describe('StreamingSearchResults', () => {
             patternType: SearchPatternType.regexp,
             caseSensitive: false,
             versionContext: undefined,
-            searchContextSpec: 'global',
             trace: undefined,
         })
 

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -31,7 +31,6 @@ import {
     resolveVersionContext,
     ParsedSearchQueryProps,
     MutableVersionContextProps,
-    SearchContextProps,
 } from '../..'
 import { StreamingSearchResultsList } from './StreamingSearchResultsList'
 
@@ -46,8 +45,7 @@ export interface StreamingSearchResultsProps
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
         TelemetryProps,
         ThemeProps,
-        CodeMonitoringProps,
-        Pick<SearchContextProps, 'selectedSearchContextSpec'> {
+        CodeMonitoringProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History
@@ -69,7 +67,6 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         previousVersionContext,
         authenticatedUser,
         telemetryService,
-        selectedSearchContextSpec,
     } = props
 
     // Log view event on first load
@@ -103,19 +100,9 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                     patternType: patternType ?? SearchPatternType.literal,
                     caseSensitive,
                     versionContext: resolveVersionContext(versionContext, availableVersionContexts),
-                    searchContextSpec: selectedSearchContextSpec,
                     trace,
                 }).pipe(debounceTime(500)),
-            [
-                streamSearch,
-                query,
-                patternType,
-                caseSensitive,
-                versionContext,
-                availableVersionContexts,
-                trace,
-                selectedSearchContextSpec,
-            ]
+            [streamSearch, query, patternType, caseSensitive, versionContext, availableVersionContexts, trace]
         )
     )
 

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -2,7 +2,6 @@
 import { Observable, fromEvent, Subscription, OperatorFunction, pipe, Subscriber, Notification } from 'rxjs'
 import { defaultIfEmpty, map, materialize, scan } from 'rxjs/operators'
 import * as GQL from '../../../shared/src/graphql/schema'
-import { appendContextFilter } from '../../../shared/src/search/query/transformer'
 import { asError, ErrorLike, isErrorLike } from '../../../shared/src/util/errors'
 import { SearchPatternType } from '../graphql-operations'
 
@@ -489,7 +488,6 @@ export interface StreamSearchOptions {
     patternType: SearchPatternType
     caseSensitive: boolean
     versionContext: string | undefined
-    searchContextSpec: string | undefined
     trace: string | undefined
 }
 
@@ -505,14 +503,11 @@ function search({
     patternType,
     caseSensitive,
     versionContext,
-    searchContextSpec,
     trace,
 }: StreamSearchOptions): Observable<SearchEvent> {
     return new Observable<SearchEvent>(observer => {
-        const finalQuery = appendContextFilter(`${query} ${caseSensitive ? 'case:yes' : ''}`, searchContextSpec)
-
         const parameters = [
-            ['q', finalQuery],
+            ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
         ]

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1370,9 +1370,30 @@ type Query {
     """
     versionContexts: [VersionContext!]!
     """
-    (experimental) All search contexts.
+    (experimental) Auto-defined search contexts available to the current user.
     """
-    searchContexts: [SearchContext!]!
+    autoDefinedSearchContexts: [SearchContext!]!
+    """
+    (experimental) All available user-defined search contexts. Excludes auto-defined contexts.
+    """
+    searchContexts(
+        """
+        Returns the first n search contexts from the list.
+        """
+        first: Int = 50
+        """
+        Opaque pagination cursor.
+        """
+        after: String
+        """
+        Query to filter the search contexts by spec.
+        """
+        query: String
+    ): SearchContextConnection!
+    """
+    (experimental) Resolves search context spec into a search context if it exists.
+    """
+    resolveSearchContextSpec(spec: String!): SearchContext
     """
     (experimental) Return the parse tree of a search query.
     """
@@ -3221,6 +3242,26 @@ type SearchContext implements Node {
     default organization search context ("@org").
     """
     autoDefined: Boolean!
+}
+
+"""
+A list of search contexts
+"""
+type SearchContextConnection {
+    """
+    A list of search contexts.
+    """
+    nodes: [SearchContext!]!
+
+    """
+    The total number of search contexts in the connection.
+    """
+    totalCount: Int!
+
+    """
+    Pagination information.
+    """
+    pageInfo: PageInfo!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1391,9 +1391,10 @@ type Query {
         query: String
     ): SearchContextConnection!
     """
-    (experimental) Resolves search context spec into a search context if it exists.
+    (experimental) Determines whether the search context is within the set of search contexts available to the current user.
+    The set consists of contexts created by the user, contexts created by the users' organizations, and instance-level contexts.
     """
-    resolveSearchContextSpec(spec: String!): SearchContext
+    isSearchContextAvailable(spec: String!): Boolean!
     """
     (experimental) Return the parse tree of a search query.
     """

--- a/cmd/frontend/graphqlbackend/search_contexts.go
+++ b/cmd/frontend/graphqlbackend/search_contexts.go
@@ -8,8 +8,10 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -17,41 +19,142 @@ import (
 
 type searchContextResolver struct {
 	sc *types.SearchContext
-
 	db dbutil.DB
+}
+
+type listSearchContextsArgs struct {
+	First int32
+	After *string
+	Query *string
+}
+
+type searchContextConnection struct {
+	searchContexts []*searchContextResolver
+	totalCount     int32
+	hasNextPage    bool
+}
+
+func (s *searchContextConnection) Nodes(ctx context.Context) ([]*searchContextResolver, error) {
+	return s.searchContexts, nil
+}
+
+func (s *searchContextConnection) TotalCount(ctx context.Context) (int32, error) {
+	return s.totalCount, nil
+}
+
+func (s *searchContextConnection) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	if len(s.searchContexts) == 0 || !s.hasNextPage {
+		return graphqlutil.HasNextPage(false), nil
+	}
+	return graphqlutil.NextPageCursor(string(s.searchContexts[len(s.searchContexts)-1].DatabaseID())), nil
 }
 
 func marshalSearchContextID(searchContextSpec string) graphql.ID {
 	return relay.MarshalID("SearchContext", searchContextSpec)
 }
 
-func (r searchContextResolver) ID() graphql.ID {
+func marshalSearchContextDatabaseID(id int64) graphql.ID {
+	return relay.MarshalID("SearchContext", id)
+}
+
+func unmarshalSearchContextCursor(after *string) (int64, error) {
+	var id int64
+	if after == nil {
+		id = 0
+	} else {
+		err := relay.UnmarshalSpec(graphql.ID(*after), &id)
+		if err != nil {
+			return -1, err
+		}
+	}
+	return id, nil
+}
+
+func (r *searchContextResolver) ID() graphql.ID {
 	return marshalSearchContextID(searchcontexts.GetSearchContextSpec(r.sc))
 }
 
-func (r searchContextResolver) Description(ctx context.Context) string {
+func (r *searchContextResolver) DatabaseID() graphql.ID {
+	return marshalSearchContextDatabaseID(r.sc.ID)
+}
+
+func (r *searchContextResolver) Description(ctx context.Context) string {
 	return r.sc.Description
 }
 
-func (r searchContextResolver) AutoDefined(ctx context.Context) bool {
+func (r *searchContextResolver) AutoDefined(ctx context.Context) bool {
 	return searchcontexts.IsAutoDefinedSearchContext(r.sc)
 }
 
-func (r searchContextResolver) Spec(ctx context.Context) string {
+func (r *searchContextResolver) Spec(ctx context.Context) string {
 	return searchcontexts.GetSearchContextSpec(r.sc)
 }
 
-func (r *schemaResolver) SearchContexts(ctx context.Context) ([]*searchContextResolver, error) {
-	searchContexts, err := searchcontexts.GetUsersSearchContexts(ctx, r.db)
+func (r *schemaResolver) AutoDefinedSearchContexts(ctx context.Context) ([]*searchContextResolver, error) {
+	searchContexts, err := searchcontexts.GetAutoDefinedSearchContexts(ctx, r.db)
+	if err != nil {
+		return nil, err
+	}
+	return searchContextsToResolvers(searchContexts, r.db), nil
+}
+
+func (r *schemaResolver) SearchContexts(ctx context.Context, args *listSearchContextsArgs) (*searchContextConnection, error) {
+	// Request one extra to determine if there are more pages
+	newArgs := *args
+	newArgs.First += 1
+
+	var searchContextName string
+	if args.Query != nil {
+		searchContextName = *args.Query
+	}
+
+	afterCursor, err := unmarshalSearchContextCursor(newArgs.After)
 	if err != nil {
 		return nil, err
 	}
 
+	searchContextsStore := database.SearchContexts(r.db)
+	opts := database.ListSearchContextsOptions{Name: searchContextName, IncludeAll: true}
+	pageOpts := database.ListSearchContextsPageOptions{First: newArgs.First, AfterID: afterCursor}
+	searchContexts, err := searchContextsStore.ListSearchContexts(ctx, pageOpts, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	count, err := searchContextsStore.CountSearchContexts(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	hasNextPage := false
+	if len(searchContexts) == int(args.First)+1 {
+		hasNextPage = true
+		searchContexts = searchContexts[:len(searchContexts)-1]
+	}
+
+	return &searchContextConnection{
+		searchContexts: searchContextsToResolvers(searchContexts, r.db),
+		totalCount:     count,
+		hasNextPage:    hasNextPage,
+	}, nil
+}
+
+func searchContextsToResolvers(searchContexts []*types.SearchContext, db dbutil.DB) []*searchContextResolver {
 	searchContextResolvers := make([]*searchContextResolver, len(searchContexts))
 	for idx, searchContext := range searchContexts {
-		searchContextResolvers[idx] = &searchContextResolver{searchContext, r.db}
+		searchContextResolvers[idx] = &searchContextResolver{searchContext, db}
 	}
-	return searchContextResolvers, nil
+	return searchContextResolvers
+}
+
+func (r *schemaResolver) ResolveSearchContextSpec(ctx context.Context, args struct {
+	Spec string
+}) (*searchContextResolver, error) {
+	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, args.Spec)
+	if err != nil {
+		return nil, err
+	}
+	return &searchContextResolver{searchContext, r.db}, nil
 }
 
 func resolveVersionContext(versionContext string) (*schema.VersionContext, error) {

--- a/cmd/frontend/graphqlbackend/search_contexts.go
+++ b/cmd/frontend/graphqlbackend/search_contexts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/searchcontexts"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -98,6 +99,8 @@ func (r *schemaResolver) AutoDefinedSearchContexts(ctx context.Context) ([]*sear
 	return searchContextsToResolvers(searchContexts, r.db), nil
 }
 
+// TODO: Create a separate 'UsersSearchContexts' function that returns instance-level search contexts,
+// search contexts owned by the user, and search contexts owned by users organizations (to populate the dropdown).
 func (r *schemaResolver) SearchContexts(ctx context.Context, args *listSearchContextsArgs) (*searchContextConnection, error) {
 	// Request one extra to determine if there are more pages
 	newArgs := *args
@@ -147,14 +150,40 @@ func searchContextsToResolvers(searchContexts []*types.SearchContext, db dbutil.
 	return searchContextResolvers
 }
 
-func (r *schemaResolver) ResolveSearchContextSpec(ctx context.Context, args struct {
+func (r *schemaResolver) IsSearchContextAvailable(ctx context.Context, args struct {
 	Spec string
-}) (*searchContextResolver, error) {
+}) (bool, error) {
 	searchContext, err := searchcontexts.ResolveSearchContextSpec(ctx, r.db, args.Spec)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
-	return &searchContextResolver{searchContext, r.db}, nil
+
+	if searchcontexts.IsInstanceLevelSearchContext(searchContext) {
+		// Instance-level search contexts are available to everyone
+		return true, nil
+	}
+
+	a := actor.FromContext(ctx)
+	if !a.IsAuthenticated() {
+		return false, nil
+	}
+
+	if searchContext.NamespaceUserID != 0 {
+		// Is search context created by the current user
+		return a.UID == searchContext.NamespaceUserID, nil
+	} else {
+		// Is search context created by one of the users' organizations
+		orgs, err := database.Orgs(r.db).GetByUserID(ctx, a.UID)
+		if err != nil {
+			return false, err
+		}
+		for _, org := range orgs {
+			if org.ID == searchContext.NamespaceOrgID {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
 }
 
 func resolveVersionContext(versionContext string) (*schema.VersionContext, error) {

--- a/cmd/frontend/graphqlbackend/search_contexts_test.go
+++ b/cmd/frontend/graphqlbackend/search_contexts_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func TestSearchContexts(t *testing.T) {
+func TestAutoDefinedSearchContexts(t *testing.T) {
 	key := int32(1)
 	username := "alice"
 	ctx := context.Background()
@@ -30,7 +30,7 @@ func TestSearchContexts(t *testing.T) {
 	}
 	defer resetMocks()
 
-	searchContexts, err := (&schemaResolver{db: db}).SearchContexts(ctx)
+	searchContexts, err := (&schemaResolver{db: db}).AutoDefinedSearchContexts(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/frontend/graphqlbackend/search_contexts_test.go
+++ b/cmd/frontend/graphqlbackend/search_contexts_test.go
@@ -22,12 +22,6 @@ func TestAutoDefinedSearchContexts(t *testing.T) {
 	database.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
 		return &types.User{Username: username}, nil
 	}
-	database.Mocks.SearchContexts.ListSearchContextsByUserID = func(ctx context.Context, userID int32) ([]*types.SearchContext, error) {
-		return []*types.SearchContext{}, nil
-	}
-	database.Mocks.SearchContexts.ListInstanceLevelSearchContexts = func(ctx context.Context) ([]*types.SearchContext, error) {
-		return []*types.SearchContext{}, nil
-	}
 	defer resetMocks()
 
 	searchContexts, err := (&schemaResolver{db: db}).AutoDefinedSearchContexts(ctx)

--- a/cmd/frontend/internal/search/searchcontexts/search_contexts.go
+++ b/cmd/frontend/internal/search/searchcontexts/search_contexts.go
@@ -54,7 +54,7 @@ func CreateSearchContextWithRepositoryRevisions(ctx context.Context, db dbutil.D
 	return searchContext, nil
 }
 
-func GetUsersSearchContexts(ctx context.Context, db dbutil.DB) ([]*types.SearchContext, error) {
+func GetAutoDefinedSearchContexts(ctx context.Context, db dbutil.DB) ([]*types.SearchContext, error) {
 	searchContexts := []*types.SearchContext{GetGlobalSearchContext()}
 	a := actor.FromContext(ctx)
 	if a.IsAuthenticated() {
@@ -63,19 +63,7 @@ func GetUsersSearchContexts(ctx context.Context, db dbutil.DB) ([]*types.SearchC
 			return nil, err
 		}
 		searchContexts = append(searchContexts, GetUserSearchContext(user.Username, a.UID))
-
-		userCreatedSearchContexts, err := database.SearchContexts(db).ListSearchContextsByUserID(ctx, a.UID)
-		if err != nil {
-			return nil, err
-		}
-		searchContexts = append(searchContexts, userCreatedSearchContexts...)
 	}
-
-	instanceLevelSearchContexts, err := database.SearchContexts(db).ListInstanceLevelSearchContexts(ctx)
-	if err != nil {
-		return nil, err
-	}
-	searchContexts = append(searchContexts, instanceLevelSearchContexts...)
 	return searchContexts, nil
 }
 

--- a/internal/database/search_contexts_mock.go
+++ b/internal/database/search_contexts_mock.go
@@ -8,7 +8,5 @@ import (
 
 type MockSearchContexts struct {
 	GetSearchContext                    func(ctx context.Context, opts GetSearchContextOptions) (*types.SearchContext, error)
-	ListSearchContextsByUserID          func(ctx context.Context, userID int32) ([]*types.SearchContext, error)
-	ListInstanceLevelSearchContexts     func(ctx context.Context) ([]*types.SearchContext, error)
 	GetSearchContextRepositoryRevisions func(ctx context.Context, searchContextID int64) ([]*types.SearchContextRepositoryRevisions, error)
 }


### PR DESCRIPTION
This PR is a further preparation for user-defined search contexts. Since we anticipate a lot of user-defined search contexts (even in early stages), we need to prepare a paginated API resource for such contexts. They will most likely come from converting a large number of version contexts.

Right now, all functionality will stay the same, UI-wise. Before we can fully use the paginated API, we need to implement infinite scrolling in the search contexts dropdown and a search contexts list page.

I have also decided to separate the auto-defined and user-defined search contexts in the API. The reason is that we can't reliably paginate them together without introducing a lot of complexity and confusion. Auto-defined contexts are generated on the fly (fixed number, `global` + `@user` + `@org1` + `@orgN`), meanwhile user-defined contexts are pulled from the DB (where pagination makes sense). Any potential merging should be handled by the client.