### PR TITLE
sg: Provide better error message if command does not start up or then fails

### DIFF
--- a/dev/sg/run.go
+++ b/dev/sg/run.go
@@ -104,7 +104,7 @@ func printCmdError(out *output.Output, cmdName string, err error) {
 		message = "Failed to rebuild " + cmdName
 		cmdOut = e.output
 	default:
-		message = fmt.Sprintf("Error running %s: %s", cmdName, err)
+		message = fmt.Sprintf("Failed to run %s: %s", cmdName, err)
 	}
 
 	separator := strings.Repeat("-", 80)

--- a/dev/sg/run.go
+++ b/dev/sg/run.go
@@ -36,7 +36,7 @@ func run(ctx context.Context, cmds ...Command) error {
 	}
 
 	wg := sync.WaitGroup{}
-	errs := make(chan error, len(cmds))
+	failures := make(chan cmdFailed, len(cmds))
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -48,7 +48,7 @@ func run(ctx context.Context, cmds ...Command) error {
 
 			if err := runWatch(ctx, cmd, root, ch); err != nil {
 				if err != ctx.Err() {
-					errs <- errors.Wrap(err, fmt.Sprintf("%s failed", cmd.Name))
+					failures <- cmdFailed{cmdName: cmd.Name, err: err}
 					cancel()
 				}
 			}
@@ -56,7 +56,61 @@ func run(ctx context.Context, cmds ...Command) error {
 	}
 
 	wg.Wait()
-	return <-errs
+
+	fail := <-failures
+	printCmdError(out, fail.err)
+	return fail
+}
+
+// cmdFailed is returned by run when a command failed to run and run exits
+type cmdFailed struct {
+	cmdName string
+	err     error
+}
+
+func (e cmdFailed) Error() string {
+	return fmt.Sprintf("failed to run %s", e.cmdName)
+}
+
+// installErr is returned by runWatch if the cmd.Install step fails.
+type installErr struct {
+	cmdName string
+	output  string
+}
+
+func (e installErr) Error() string {
+	return fmt.Sprintf("install of %s failed: %s", e.cmdName, e.output)
+}
+
+// reinstallErr is used internally by runWatch to print a message when a
+// command failed to reinstall.
+type reinstallErr struct {
+	cmdName string
+	output  string
+}
+
+func (e reinstallErr) Error() string {
+	return fmt.Sprintf("reinstalling %s failed: %s", e.cmdName, e.output)
+}
+
+func printCmdError(out *output.Output, err error) {
+	var message, cmdName, cmdOut string
+
+	switch e := errors.Cause(err).(type) {
+	case installErr:
+		message = "Failed to install"
+		cmdOut = e.output
+		cmdName = e.cmdName
+	}
+
+	separator := strings.Repeat("-", 80)
+	line := output.Linef(
+		"", output.StyleWarning,
+		"%s\n%s%s %s%s: \n%s%s%s%s",
+		separator, output.StyleBold, message, cmdName, output.StyleReset,
+		cmdOut, output.StyleWarning, separator, output.StyleReset,
+	)
+	out.WriteLine(line)
 }
 
 func runWatch(ctx context.Context, cmd Command, root string, reload <-chan struct{}) error {
@@ -72,11 +126,9 @@ func runWatch(ctx context.Context, cmd Command, root string, reload <-chan struc
 		cmdOut, err := c.CombinedOutput()
 		if err != nil {
 			if !startedOnce {
-				// TODO: This should return something like an InstallErr that has nice formatting
-				return fmt.Errorf("failed to install %q: %s (output: %s)", cmd.Name, err, cmdOut)
+				return installErr{cmdName: cmd.Name, output: string(cmdOut)}
 			} else {
-				line := strings.Repeat("-", 80)
-				out.WriteLine(output.Linef("", output.StyleWarning, "%s\n%sFailed to reinstall %s%s: \n%s%s%s%s", line, output.StyleBold, cmd.Name, output.StyleReset, cmdOut, output.StyleWarning, line, output.StyleReset))
+				printCmdError(out, reinstallErr{cmdName: cmd.Name, output: string(cmdOut)})
 				// Now we wait for a reload signal before we start to build it again
 				select {
 				case <-reload:


### PR DESCRIPTION
Previously only the "failed to rebuild" message was nice. Now the "failed even install it" message is formatted too.

![image](https://user-images.githubusercontent.com/1185253/112629075-1c597380-8e34-11eb-8259-a8e56fc3a870.png)


Yes, the error handling is not the nicest yet, but I think it's okay for now.