### PR TITLE
Move sg.config.yaml to repo root & allow private overwrites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,4 +137,4 @@ storybook-static/
 .scannerwork
 
 # sg command specific things, see ./dev/sg
-sg.config.overwrites.yaml
+sg.config.overwrite.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ storybook-static/
 
 # sonarqube
 .scannerwork
+
+# sg command specific things, see ./dev/sg
+sg.config.overwrites.yaml

--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -49,3 +49,23 @@ type Config struct {
 	Commandsets map[string][]string `yaml:"commandsets"`
 	Tests       map[string]Command  `yaml:"tests"`
 }
+
+// Merges merges the top-level entries of two Config objects, with the receiver
+// being modified.
+func (c *Config) Merge(other *Config) {
+	for k, v := range other.Env {
+		c.Env[k] = v
+	}
+
+	for k, v := range other.Commands {
+		c.Commands[k] = v
+	}
+
+	for k, v := range other.Commandsets {
+		c.Commandsets[k] = v
+	}
+
+	for k, v := range other.Tests {
+		c.Tests[k] = v
+	}
+}

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -56,7 +56,7 @@ var (
 var (
 	rootFlagSet         = flag.NewFlagSet("sg", flag.ExitOnError)
 	configFlag          = rootFlagSet.String("config", "sg.config.yaml", "configuration file")
-	overwriteConfigFlag = rootFlagSet.String("overwrite", "sg.config.overwrites.yaml", "configuration overwrites file (for example to add credentials, should be gitignored)")
+	overwriteConfigFlag = rootFlagSet.String("overwrite", "sg.config.overwrite.yaml", "configuration overwrites file (for example to add credentials, should be gitignored)")
 	conf                *Config
 
 	rootCommand = &ffcli.Command{

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -56,7 +56,7 @@ var (
 var (
 	rootFlagSet         = flag.NewFlagSet("sg", flag.ExitOnError)
 	configFlag          = rootFlagSet.String("config", "sg.config.yaml", "configuration file")
-	overwriteConfigFlag = rootFlagSet.String("overwrite", "sg.config.overwrite.yaml", "configuration overwrites file (for example to add credentials, should be gitignored)")
+	overwriteConfigFlag = rootFlagSet.String("overwrite", "sg.config.overwrite.yaml", "configuration overwrites file that is gitignored and can be used to, for example, add credentials")
 	conf                *Config
 
 	rootCommand = &ffcli.Command{
@@ -74,12 +74,14 @@ func main() {
 	var err error
 	conf, err = ParseConfigFile(*configFlag)
 	if err != nil {
+		out.WriteLine(output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s\n", output.StyleBold, *configFlag, output.StyleReset, output.StyleWarning, output.StyleReset, err))
 		os.Exit(1)
 	}
 
 	if ok, _ := fileExists(*overwriteConfigFlag); ok {
 		overwriteConf, err := ParseConfigFile(*overwriteConfigFlag)
 		if err != nil {
+			out.WriteLine(output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s\n", output.StyleBold, *overwriteConfigFlag, output.StyleReset, output.StyleWarning, output.StyleReset, err))
 			os.Exit(1)
 		}
 		conf.Merge(overwriteConf)

--- a/dev/sg/sg.config.example.yaml
+++ b/dev/sg/sg.config.example.yaml
@@ -1,38 +1,21 @@
+###########################################################
+#                                                         #
+#                 EXAMPLE CONFIG FILE                     #
+#                                                         #
+#  See sg.config.yaml in repository root for real config. #
+#                                                         #
+###########################################################
+
 env:
-  SRC_REPOS_DIR: $HOME/.sourcegraph/repos
   SRC_LOG_LEVEL: info
   SRC_LOG_FORMAT: condensed
   SRC_GIT_SERVER_1: 127.0.0.1:3178
   SRC_GIT_SERVERS: 127.0.0.1:3178
 
-  # Enable sharded indexed search mode:
-  INDEXED_SEARCH_SERVERS: localhost:3070 localhost:3071
+  # Env vars are expanded
+  SRC_REPOS_DIR: $HOME/.sourcegraph/repos
 
-  DEPLOY_TYPE: dev
-
-  SRC_HTTP_ADDR: ":3082"
-
-  GITHUB_BASE_URL: http://127.0.0.1:3180
-  # I don't think we even need to set these?
-  SEARCHER_URL: http://127.0.0.1:3181
-  REPO_UPDATER_URL: http://127.0.0.1:3182
-  REDIS_ENDPOINT: 127.0.0.1:6379
-  QUERY_RUNNER_URL: http://localhost:3183
-  SYMBOLS_URL: http://localhost:3184
-  SRC_SYNTECT_SERVER: http://localhost:9238
-  SRC_FRONTEND_INTERNAL: localhost:3090
-  GRAFANA_SERVER_URL: http://localhost:3370
-  PROMETHEUS_URL: http://localhost:9090
-  JAEGER_SERVER_URL: http://localhost:16686
-  ZOEKT_HOST: localhost:3070
-
-  SRC_PROF_HTTP: "" # This needs to be empty?
-  OVERRIDE_AUTH_SECRET: sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ
-  # Settings/config
-  SITE_CONFIG_FILE: ./dev/site-config.json
-  SITE_CONFIG_ALLOW_EDITS: true
-  GLOBAL_SETTINGS_FILE: ./dev/global-settings.json
-  GLOBAL_SETTINGS_ALLOW_EDITS: true
+  # [...]
 
 commands:
   frontend:
@@ -67,61 +50,12 @@ commands:
       - internal
       - cmd/gitserver
 
-  github-proxy:
-    cmd: .bin/github-proxy
-    install: go build -o .bin/github-proxy github.com/sourcegraph/sourcegraph/cmd/github-proxy
-    env:
-      HOSTNAME: 127.0.0.1:3178
-    watch:
-      - cmd/github-proxy
-      - internal/debugserver"
-      - internal/env
-      - internal/logging
-      - internal/trace
-      - internal/tracer
-
   repo-updater:
     cmd: .bin/repo-updater
     install: go build -o .bin/repo-updater github.com/sourcegraph/sourcegraph/cmd/repo-updater
     watch:
       - internal
       - cmd/repo-updater
-
-  enterprise-repo-updater:
-    cmd: .bin/repo-updater
-    install: go build -o .bin/repo-updater github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater
-    watch:
-      - internal
-      - cmd/repo-updater
-      - enterprise/cmd/repo-updater
-
-  query-runner:
-    cmd: .bin/query-runner
-    install: go build -o .bin/query-runner github.com/sourcegraph/sourcegraph/cmd/query-runner
-    watch:
-      - internal
-      - cmd/query-runner
-
-  symbols:
-    cmd: .bin/symbols
-    install: |
-      ./dev/libsqlite3-pcre/build.sh &&
-      ./cmd/symbols/build-ctags.sh &&
-      go build -o .bin/symbols github.com/sourcegraph/sourcegraph/cmd/symbols
-    env:
-      LIBSQLITE3_PCRE: ./dev/libsqlite3-pcre/build.sh libpath
-      CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
-      CTAGS_PROCESSES: 2
-    watch:
-      - internal
-      - cmd/symbols
-
-  searcher:
-    cmd: .bin/searcher
-    install: go build -o .bin/searcher github.com/sourcegraph/sourcegraph/cmd/searcher
-    watch:
-      - internal
-      - cmd/searcher
 
   caddy:
     cmd: .bin/caddy run --watch --config=dev/Caddyfile
@@ -157,106 +91,20 @@ commands:
       NODE_ENV: development
       NODE_OPTIONS: "--max_old_space_size=4096"
 
-  docsite:
-    cmd: .bin/docsite_${VERSION} -config doc/docsite.json serve -http=localhost:5080
-    install: |
-      curl -sS -L -f \
-      "https://github.com/sourcegraph/docsite/releases/download/${VERSION}/docsite_${VERSION}_$(go env GOOS)_$(go env GOARCH)" \
-      -o .bin/docsite_${VERSION} && chmod +x .bin/docsite_${VERSION}
-    env:
-      VERSION: v1.7.0
-
-  syntect_server:
-    cmd: |
-      docker run --name=syntect_server --rm -p9238:9238 \
-      -e WORKERS=1 -e ROCKET_ADDRESS=0.0.0.0 \
-      sourcegraph/syntect_server:9089f98@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
-    install: docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server || true
-    env:
-      # This is not needed actually
-      INSECURE_DEV: 1
-
-  zoekt-indexserver-0:
-    cmd: |
-      .bin/zoekt-sourcegraph-indexserver \
-        -sourcegraph_url 'http://localhost:3090' \
-        -index "$HOME/.sourcegraph/zoekt/index-0" \
-        -hostname 'localhost:3070' \
-        -interval 1m \
-        -listen ":6072" \
-        -cpu_fraction 0.25
-    install: |
-      mkdir -p .bin
-      export GOBIN="${PWD}/.bin"
-      export GO111MODULE=on
-      # TODO: Do we need to install these?
-      # go install github.com/google/zoekt/cmd/zoekt-archive-index
-      # go install github.com/google/zoekt/cmd/zoekt-git-index
-      go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
-    env:
-      GOGC: 50
-
-  zoekt-webserver-0:
-    cmd: |
-      .bin/zoekt-webserver \
-        -index "$HOME/.sourcegraph/zoekt/index-0" \
-        -pprof -rpc -listen ":3070"
-    install: |
-      mkdir -p .bin
-      export GOBIN="${PWD}/.bin"
-      export GO111MODULE=on
-      go install github.com/google/zoekt/cmd/zoekt-webserver
-    env:
-      JAEGER_DISABLED: false
-      GOGC: 50
-
 commandsets:
-  testing:
+  minimal:
     - frontend
     - gitserver
+
   default:
     - frontend
     - repo-updater
     - gitserver
-    - searcher
-    - symbols
-    - query-runner
     - web
-    - caddy
-    - docsite
-    - syntect_server
-    - github-proxy
-    - zoekt-indexserver-0
-    - zoekt-webserver-0
-
-  zoekt:
-    - frontend
-    - gitserver
-    - zoekt-indexserver-0
-    - zoekt-webserver-0
-
-  enterprise:
-    - enterprise-frontend
-    - enterprise-repo-updater
-    - gitserver
-    - searcher
-    - symbols
-    - query-runner
-    - web
-    - caddy
-    - docsite
-    - syntect_server
-    - github-proxy
-
-  # Another set that can be run with `sg run-set monitoring`:
-  monitoring:
-    # - jaeger
-    # - prometheus
-    # - grafana
-    # - postgres_exporter
 
 tests:
   # These can be run with `sg test [name]`
+  # Every command is run from the repository root.
   backend:
     cmd: go test ./...
   backend-integration:
@@ -267,9 +115,3 @@ tests:
       BASE_URL: "http://localhost:3080"
       EMAIL: "joe@sourcegraph.com"
       PASSWORD: "12345"
-  frontend:
-    cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook
-  frontend-e2e:
-    cmd: yarn run mocha ./client/web/src/end-to-end/end-to-end.test.ts
-    env:
-      TS_NODE_PROJECT: client/web/src/end-to-end/tsconfig.json

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -1,0 +1,272 @@
+env:
+  SRC_REPOS_DIR: $HOME/.sourcegraph/repos
+  SRC_LOG_LEVEL: info
+  SRC_LOG_FORMAT: condensed
+  SRC_GIT_SERVER_1: 127.0.0.1:3178
+  SRC_GIT_SERVERS: 127.0.0.1:3178
+
+  # Enable sharded indexed search mode:
+  INDEXED_SEARCH_SERVERS: localhost:3070 localhost:3071
+
+  DEPLOY_TYPE: dev
+
+  SRC_HTTP_ADDR: ":3082"
+
+  GITHUB_BASE_URL: http://127.0.0.1:3180
+  # I don't think we even need to set these?
+  SEARCHER_URL: http://127.0.0.1:3181
+  REPO_UPDATER_URL: http://127.0.0.1:3182
+  REDIS_ENDPOINT: 127.0.0.1:6379
+  QUERY_RUNNER_URL: http://localhost:3183
+  SYMBOLS_URL: http://localhost:3184
+  SRC_SYNTECT_SERVER: http://localhost:9238
+  SRC_FRONTEND_INTERNAL: localhost:3090
+  GRAFANA_SERVER_URL: http://localhost:3370
+  PROMETHEUS_URL: http://localhost:9090
+  JAEGER_SERVER_URL: http://localhost:16686
+  ZOEKT_HOST: localhost:3070
+
+  SRC_PROF_HTTP: "" # This needs to be empty?
+  OVERRIDE_AUTH_SECRET: sSsNGlI8fBDftBz0LDQNXEnP6lrWdt9g0fK6hoFvGQ
+  # Settings/config
+  SITE_CONFIG_FILE: ./dev/site-config.json
+  SITE_CONFIG_ALLOW_EDITS: true
+  GLOBAL_SETTINGS_FILE: ./dev/global-settings.json
+  GLOBAL_SETTINGS_ALLOW_EDITS: true
+
+commands:
+  frontend:
+    cmd: ulimit -n 10000 && .bin/frontend
+    install: go build -o .bin/frontend github.com/sourcegraph/sourcegraph/cmd/frontend
+    env:
+      CONFIGURATION_MODE: server
+      USE_ENHANCED_LANGUAGE_DETECTION: false
+    watch:
+      - internal
+      - cmd/frontend
+
+  enterprise-frontend:
+    cmd: .bin/enterprise-frontend
+    install: go build -o .bin/enterprise-frontend github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
+    watch:
+      - internal
+      - cmd/frontend
+      - enterprise/cmd/frontend
+
+  gitserver:
+    cmd: .bin/gitserver
+    install: go build -o .bin/gitserver github.com/sourcegraph/sourcegraph/cmd/gitserver
+    env:
+      HOSTNAME: 127.0.0.1:3178
+    watch:
+      - internal
+      - cmd/gitserver
+
+  github-proxy:
+    cmd: .bin/github-proxy
+    install: go build -o .bin/github-proxy github.com/sourcegraph/sourcegraph/cmd/github-proxy
+    env:
+      HOSTNAME: 127.0.0.1:3178
+    watch:
+      - cmd/github-proxy
+      - internal/debugserver"
+      - internal/env
+      - internal/logging
+      - internal/trace
+      - internal/tracer
+
+  repo-updater:
+    cmd: .bin/repo-updater
+    install: go build -o .bin/repo-updater github.com/sourcegraph/sourcegraph/cmd/repo-updater
+    watch:
+      - internal
+      - cmd/repo-updater
+
+  enterprise-repo-updater:
+    cmd: .bin/repo-updater
+    install: go build -o .bin/repo-updater github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater
+    env:
+      HOSTNAME: $SRC_GIT_SERVER_1
+    watch:
+      - internal
+      - cmd/repo-updater
+      - enterprise/cmd/repo-updater
+
+  query-runner:
+    cmd: .bin/query-runner
+    install: go build -o .bin/query-runner github.com/sourcegraph/sourcegraph/cmd/query-runner
+    watch:
+      - internal
+      - cmd/query-runner
+
+  symbols:
+    cmd: .bin/symbols
+    install: |
+      ./dev/libsqlite3-pcre/build.sh &&
+      ./cmd/symbols/build-ctags.sh &&
+      go build -o .bin/symbols github.com/sourcegraph/sourcegraph/cmd/symbols
+    env:
+      LIBSQLITE3_PCRE: ./dev/libsqlite3-pcre/build.sh libpath
+      CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
+      CTAGS_PROCESSES: 2
+    watch:
+      - internal
+      - cmd/symbols
+
+  searcher:
+    cmd: .bin/searcher
+    install: go build -o .bin/searcher github.com/sourcegraph/sourcegraph/cmd/searcher
+    watch:
+      - internal
+      - cmd/searcher
+
+  caddy:
+    cmd: .bin/caddy run --watch --config=dev/Caddyfile
+    install: |
+      case "$(go env GOOS)" in
+        linux)
+          os="linux"
+          ;;
+        darwin)
+          os="mac"
+          ;;
+      esac
+      name="caddy_${CADDY_VERSION}_${os}_amd64"
+      target="$PWD/.bin/caddy"
+      url="https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${name}.tar.gz"
+
+      if [ ! -f "${target}" ]; then
+        echo "downloading ${url}" 1>&2
+        curl -sS -L -f "${url}" | tar -xz --to-stdout "caddy" >"${target}.tmp"
+        mv "${target}.tmp" "${target}"
+        chmod +x ${target}
+      fi
+    env:
+      CADDY_VERSION: 2.3.0
+      SOURCEGRAPH_HTTPS_DOMAIN: sourcegraph.test
+      SOURCEGRAPH_HTTPS_PORT: 3443
+
+  web:
+    cmd: ./node_modules/.bin/gulp --silent --color dev
+    install: yarn --no-progress
+    env:
+      WEBPACK_DEV_SERVER: 1
+      NODE_ENV: development
+      NODE_OPTIONS: "--max_old_space_size=4096"
+
+  docsite:
+    cmd: .bin/docsite_${VERSION} -config doc/docsite.json serve -http=localhost:5080
+    install: |
+      curl -sS -L -f \
+      "https://github.com/sourcegraph/docsite/releases/download/${VERSION}/docsite_${VERSION}_$(go env GOOS)_$(go env GOARCH)" \
+      -o .bin/docsite_${VERSION} && chmod +x .bin/docsite_${VERSION}
+    env:
+      VERSION: v1.7.0
+
+  syntect_server:
+    cmd: |
+      docker run --name=syntect_server --rm -p9238:9238 \
+      -e WORKERS=1 -e ROCKET_ADDRESS=0.0.0.0 \
+      sourcegraph/syntect_server:9089f98@sha256:83ff65809e6647b466bd400de4c438a32feeabe8e791b12e15c67c84529ad2de
+    install: docker inspect syntect_server >/dev/null 2>&1 && docker rm -f syntect_server || true
+    env:
+      # This is not needed actually
+      INSECURE_DEV: 1
+
+  zoekt-indexserver-0:
+    cmd: |
+      .bin/zoekt-sourcegraph-indexserver \
+        -sourcegraph_url 'http://localhost:3090' \
+        -index "$HOME/.sourcegraph/zoekt/index-0" \
+        -hostname 'localhost:3070' \
+        -interval 1m \
+        -listen ":6072" \
+        -cpu_fraction 0.25
+    install: |
+      mkdir -p .bin
+      export GOBIN="${PWD}/.bin"
+      export GO111MODULE=on
+      # TODO: Do we need to install these?
+      # go install github.com/google/zoekt/cmd/zoekt-archive-index
+      # go install github.com/google/zoekt/cmd/zoekt-git-index
+      go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
+    env:
+      GOGC: 50
+
+  zoekt-webserver-0:
+    cmd: |
+      .bin/zoekt-webserver \
+        -index "$HOME/.sourcegraph/zoekt/index-0" \
+        -pprof -rpc -listen ":3070"
+    install: |
+      mkdir -p .bin
+      export GOBIN="${PWD}/.bin"
+      export GO111MODULE=on
+      go install github.com/google/zoekt/cmd/zoekt-webserver
+    env:
+      JAEGER_DISABLED: false
+      GOGC: 50
+
+commandsets:
+  testing:
+    - frontend
+    - gitserver
+  default:
+    - frontend
+    - repo-updater
+    - gitserver
+    - searcher
+    - symbols
+    - query-runner
+    - web
+    - caddy
+    - docsite
+    - syntect_server
+    - github-proxy
+    - zoekt-indexserver-0
+    - zoekt-webserver-0
+
+  zoekt:
+    - frontend
+    - gitserver
+    - zoekt-indexserver-0
+    - zoekt-webserver-0
+
+  enterprise:
+    - enterprise-frontend
+    - enterprise-repo-updater
+    - gitserver
+    - searcher
+    - symbols
+    - query-runner
+    - web
+    - caddy
+    - docsite
+    - syntect_server
+    - github-proxy
+
+  # Another set that can be run with `sg run-set monitoring`:
+  monitoring:
+    # - jaeger
+    # - prometheus
+    # - grafana
+    # - postgres_exporter
+
+tests:
+  # These can be run with `sg test [name]`
+  backend:
+    cmd: go test ./...
+  backend-integration:
+    cmd: cd dev/gqltest && go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD ./gqltest
+    env:
+      # These are defaults. They can be overwritten by setting the env vars when
+      # running the command.
+      BASE_URL: "http://localhost:3080"
+      EMAIL: "joe@sourcegraph.com"
+      PASSWORD: "12345"
+  frontend:
+    cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook
+  frontend-e2e:
+    cmd: yarn run mocha ./client/web/src/end-to-end/end-to-end.test.ts
+    env:
+      TS_NODE_PROJECT: client/web/src/end-to-end/tsconfig.json


### PR DESCRIPTION
This moves the sg.config.yaml to the repository root so that one can
just use `sg start` and `sg run gitserver` etc. without having to
specify the `-conf` flag.

It also adds support for a local `.gitignore`d
`sg.config.overwrites.yaml` file that users can add to the repository.
If it exists, it will then get merged with the basic configuration when
`sg` starts.

What's the usecase? Custom command sets, custom env vars, etc. that you
don't want to commit to the repository.


![overwrites](https://user-images.githubusercontent.com/1185253/112650645-e45e2a80-8e4b-11eb-8a34-ed33c5a9d489.png)
