### PR TITLE
code monitoring: always show create monitor button

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -7,7 +7,7 @@ import DownloadIcon from 'mdi-react/DownloadIcon'
 import FormatQuoteOpenIcon from 'mdi-react/FormatQuoteOpenIcon'
 import React, { useMemo } from 'react'
 import { ContributableMenu } from '../../../../shared/src/api/protocol'
-import { Link } from '../../../../shared/src/components/Link'
+import { ButtonLink } from '../../../../shared/src/components/LinkOrButton'
 import { ExtensionsControllerProps } from '../../../../shared/src/extensions/controller'
 import { PlatformContextProps } from '../../../../shared/src/platform/context'
 import { FilterKind, findFilter } from '../../../../shared/src/search/query/validate'
@@ -17,7 +17,6 @@ import { CodeMonitoringProps } from '../../code-monitoring'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { SearchPatternType } from '../../graphql-operations'
-import { ButtonLink } from '../../../../shared/src/components/LinkOrButton'
 
 export interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'extHostAPI'>,

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -17,6 +17,7 @@ import { CodeMonitoringProps } from '../../code-monitoring'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { SearchPatternType } from '../../graphql-operations'
+import { ButtonLink } from '../../../../shared/src/components/LinkOrButton'
 
 export interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'extHostAPI'>,
@@ -78,18 +79,26 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
         const globalTypeFilterInQuery = findFilter(props.query, 'type', FilterKind.Global)
         const globalTypeFilterValue = globalTypeFilterInQuery?.value ? globalTypeFilterInQuery.value.value : undefined
         const canCreateMonitorFromQuery = globalTypeFilterValue === 'diff' || globalTypeFilterValue === 'commit'
-        if (!canCreateMonitorFromQuery) {
-            return null
-        }
         const searchParameters = new URLSearchParams(props.location.search)
         searchParameters.set('trigger-query', `${props.query} patterntype:${props.patternType}`)
         const toURL = `/code-monitoring/new?${searchParameters.toString()}`
         return (
-            <li className="nav-item">
-                <Link to={toURL} className="btn btn-sm btn-link nav-link text-decoration-none">
+            <li
+                className="nav-item"
+                data-tooltip={
+                    !canCreateMonitorFromQuery
+                        ? 'Code monitors only support type:diff or type:commit searches.'
+                        : undefined
+                }
+            >
+                <ButtonLink
+                    disabled={!canCreateMonitorFromQuery}
+                    to={toURL}
+                    className="btn btn-sm btn-link nav-link text-decoration-none"
+                >
                     <CodeMonitoringLogo className="icon-inline mr-1" />
                     Monitor
-                </Link>
+                </ButtonLink>
             </li>
         )
     }, [props.enableCodeMonitoring, props.query, props.authenticatedUser, props.location.search, props.patternType])

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -91,6 +91,9 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         <a
           className="btn btn-sm btn-link nav-link text-decoration-none"
           href="/code-monitoring/new?trigger-query=foo+type%3Adiff+patterntype%3Aliteral"
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          tabIndex={0}
         >
           <svg
             className="icon-inline mr-1"
@@ -221,6 +224,36 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         aria-hidden="true"
         className="search-results-info-bar__divider"
       />
+      <li
+        className="nav-item"
+        data-tooltip="Code monitors only support type:diff or type:commit searches."
+      >
+        <a
+          className="btn btn-sm btn-link nav-link text-decoration-none disabled"
+          href=""
+          onAuxClick={[Function]}
+          onClick={[Function]}
+          onKeyPress={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <svg
+            className="icon-inline mr-1"
+            fill="currentColor"
+            height="20"
+            viewBox="0 0 20 20"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              clipRule="evenodd"
+              d="M18.01 8.01C18.01 8.29 18.23 8.51 18.51 8.51C18.79 8.51 19.01 8.29 19.01 8.01C19.01 4.15 15.87 1 12 1C11.72 1 11.5 1.22 11.5 1.5C11.5 1.78 11.72 2 12 2C15.31 2 18.01 4.7 18.01 8.01ZM16.1801 7.96002C15.9001 7.96002 15.6801 7.74002 15.6801 7.46002C15.6801 5.81002 14.3301 4.46002 12.6801 4.46002C12.4001 4.46002 12.1801 4.24002 12.1801 3.96002C12.1801 3.68002 12.4001 3.46002 12.6801 3.46002C14.8901 3.46002 16.6801 5.25002 16.6801 7.46002C16.6801 7.74002 16.4601 7.96002 16.1801 7.96002ZM4.83996 6.79999L13.34 15.3C12.39 15.88 11.29 16.18 10.15 16.18C8.49996 16.18 6.93996 15.54 5.76996 14.37C4.59996 13.2 3.94996 11.65 3.94996 9.98999C3.94996 8.84999 4.25996 7.74999 4.83996 6.79999ZM4.70996 4.54999C1.70996 7.54999 1.70996 12.43 4.70996 15.43C6.20996 16.93 8.17996 17.68 10.15 17.68C12.12 17.68 14.09 16.93 15.59 15.43L4.70996 4.54999ZM4 16.14C3.7 15.84 3.43 15.52 3.18 15.18L2.89 15.69L1 18.97H4.79H8.59L8.31 18.49C6.69 18.14 5.2 17.34 4 16.14ZM13.85 8.04999C13.85 9.01999 13.07 9.79999 12.1 9.79999C11.13 9.79999 10.35 9.01999 10.35 8.04999C10.35 7.07999 11.13 6.29999 12.1 6.29999C13.07 6.29999 13.85 7.07999 13.85 8.04999Z"
+              fillRule="evenodd"
+            />
+          </svg>
+          Monitor
+        </a>
+      </li>
       <li
         className="nav-item"
       >

--- a/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.story.tsx
@@ -103,6 +103,26 @@ add('diffs tab selected, code monitoring enabled, user logged in', () => (
     </WebStory>
 ))
 
+add('code tab selected, code monitoring enabled, user logged in', () => (
+    <WebStory>
+        {() => (
+            <StreamingSearchResults
+                {...defaultProps}
+                parsedSearchQuery="r:golang/oauth2 test f:travis"
+                enableCodeMonitoring={true}
+                authenticatedUser={
+                    {
+                        url: '/users/alice',
+                        displayName: 'Alice',
+                        username: 'alice',
+                        email: 'alice@email.test',
+                    } as AuthenticatedUser
+                }
+            />
+        )}
+    </WebStory>
+))
+
 add('search with quotes', () => (
     <WebStory>
         {() => <StreamingSearchResults {...defaultProps} parsedSearchQuery='r:golang/oauth2 test f:travis "test"' />}


### PR DESCRIPTION
Stacked on #19180
Part of #18281

Always show create monitor button.
If search is not `type:diff` or `type:commit`, the button will be disabled and will show a tooltip explaining why.

![image](https://user-images.githubusercontent.com/206864/112669511-09877480-8e1d-11eb-845d-74ceef96427f.png)
