### PR TITLE
Fix and enforce govet lints

### DIFF
--- a/.golangci.enforced.yml
+++ b/.golangci.enforced.yml
@@ -16,6 +16,7 @@ linters:
     - bodyclose
     - deadcode
     - gocritic
+    - govet
 
 linters-settings:
   gocritic:
@@ -27,6 +28,9 @@ linters-settings:
       - exitAfterDefer    # Only occurs in auxiliary tools
       - ifElseChain       # Noisy for not much gain
       - singleCaseSwitch  # Noisy for not much gain
+  govet:
+      disable:
+          - composites
 
 issues:
   exclude-rules:

--- a/cmd/frontend/graphqlbackend/search_alert_test.go
+++ b/cmd/frontend/graphqlbackend/search_alert_test.go
@@ -364,6 +364,7 @@ func TestAlertForOverRepoLimit(t *testing.T) {
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			if test.cancelContext {
 				cancel()
 			}

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -701,9 +701,9 @@ func zoektIndexedRepos(indexedSet map[string]*zoekt.Repository, revs []*search.R
 
 		unindexedRevs := indexed.Add(reporev, repo)
 		if len(unindexedRevs) > 0 {
-			copy := *reporev
+			copy := reporev.Copy()
 			copy.Revs = unindexedRevs
-			unindexed = append(unindexed, &copy)
+			unindexed = append(unindexed, copy)
 		}
 	}
 

--- a/cmd/frontend/internal/vfsutil/archive.go
+++ b/cmd/frontend/internal/vfsutil/archive.go
@@ -65,6 +65,10 @@ func (fs *ArchiveFS) fetchOrWait(ctx context.Context) error {
 
 		fs.ar, fs.err = fs.fetch(ctx)
 		if fs.err == nil {
+			//nolint:govet // This is not a false positive, but there is no easy fix.
+			// The issue comes down to the fact that a `zip.ReadCloser` takes a reader by value,
+			// but NewReader returns a pointer, so there is no way to create a ReadCloser from
+			// a Reader without a pointer dereference, which copies the mutex.
 			fs.fs = zipfs.New(&zip.ReadCloser{Reader: *fs.ar.Reader}, "")
 			if fs.ar.StripTopLevelDir {
 				entries, err := fs.fs.ReadDir("/")

--- a/internal/search/repo_revs.go
+++ b/internal/search/repo_revs.go
@@ -75,6 +75,17 @@ type RepositoryRevisions struct {
 	ListRefs func(context.Context, api.RepoName) ([]git.Ref, error)
 }
 
+func (r *RepositoryRevisions) Copy() *RepositoryRevisions {
+	repo := *r.Repo
+	revs := make([]RevisionSpecifier, len(r.Revs))
+	copy(revs, r.Revs)
+	return &RepositoryRevisions{
+		Repo:     &repo,
+		Revs:     revs,
+		ListRefs: r.ListRefs,
+	}
+}
+
 // Equal provides custom comparison which is used by go-cmp
 func (r *RepositoryRevisions) Equal(other *RepositoryRevisions) bool {
 	return reflect.DeepEqual(r.Repo, other.Repo) && reflect.DeepEqual(r.Revs, other.Revs)


### PR DESCRIPTION
Progresses #18720 

Note that I disabled the "unkeyed struct literal" lint because it's often much easier to read without keys. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
