### PR TITLE
Add build-browser-extension script

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "deduplicate": "yarn-deduplicate -s fewer",
     "release": "cd dev/release && yarn run release",
     "docsite:serve": "./dev/docsite.sh -config doc/docsite.json serve -http=localhost:5080",
-    "download-puppeteer-browser": "yarn --cwd client/shared download-puppeteer-browser"
+    "download-puppeteer-browser": "yarn --cwd client/shared download-puppeteer-browser",
+    "build-browser-extension": "yarn --cwd client/browser run build"
   },
   "browserslist": [
     "last 1 version",


### PR DESCRIPTION
Add `build-browser-extension` as a yarn script to simplify the process of building the browser extensions.

This is especially valuable when we submit the source code of the browser extension for review. The reviewers at Mozilla need to reproduce the build from source for in order to approve the browser extension. This makes it easier to run it and avoid mistakes such as running `yarn` or `yarn build` from the wrong directory.

With this change, it's now possible to run `yarn run build-browser-extension` from the root of the repository.
