### PR TITLE
add go scaffolding to #19479

### DIFF
--- a/cmd/frontend/internal/app/ui/app.html
+++ b/cmd/frontend/internal/app/ui/app.html
@@ -57,7 +57,7 @@
 		<br>
 		You need to enable JavaScript to run this app.
 	</noscript>
-	<script src="{{.AssetURL}}/scripts/app.bundle.js?{{version "scripts/app.bundle.js"}}"></script>
+	<script src="{{.AssetURL}}/scripts/{{.Manifest.AppBundleName}}"></script>
 	{{.Injected.BodyBottom}}
 </body>
 

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -72,7 +72,7 @@ func loadManifest() (*WebpackManifest, error) {
 
 	err := json.Unmarshal(assets.WebpackManifestJSON, &out)
 	if err != nil {
-		return nil, errors.Wrap(err, "when parsing json")
+		return nil, errors.Wrap(err, "parsing manifest json")
 	}
 
 	return &out, nil

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -17,8 +17,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
-	"github.com/sourcegraph/sourcegraph/ui/assets"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
@@ -39,6 +37,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/sourcegraph/sourcegraph/ui/assets"
 )
 
 type InjectedHTML struct {

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"encoding/json"
 	"html/template"
 	"log"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -70,7 +71,7 @@ type WebpackManifest struct {
 func loadManifest() (*WebpackManifest, error) {
 	out := WebpackManifest{}
 
-	err := json.Unmarshal(assets.WebpackManifestJSON, &out)
+	err := jsoniter.Unmarshal(assets.WebpackManifestJSON, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing manifest json")
 	}

--- a/cmd/frontend/internal/app/ui/handlers.go
+++ b/cmd/frontend/internal/app/ui/handlers.go
@@ -143,7 +143,7 @@ func newCommon(w http.ResponseWriter, r *http.Request, title string, serveError 
 
 	manifest, err := loadManifest()
 	if err != nil {
-		return nil, errors.Wrap(err, "when loading webpack manifest")
+		return nil, errors.Wrap(err, "loading webpack manifest")
 	}
 
 	common := &Common{

--- a/cmd/frontend/internal/app/ui/tmpl.go
+++ b/cmd/frontend/internal/app/ui/tmpl.go
@@ -2,17 +2,14 @@ package ui
 
 import (
 	"bytes"
-	"crypto/md5"
 	_ "embed"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/env"
-	"github.com/sourcegraph/sourcegraph/ui/assets"
 )
 
 //go:embed app.html
@@ -29,41 +26,6 @@ var (
 
 	_, noAssetVersionString = os.LookupEnv("WEBPACK_DEV_SERVER")
 )
-
-// Functions that are exposed to templates.
-var funcMap = template.FuncMap{
-	"version": func(fp string) (string, error) {
-		if noAssetVersionString {
-			return "", nil
-		}
-
-		// Check the cache for the version.
-		versionCacheMu.RLock()
-		version, ok := versionCache[fp]
-		versionCacheMu.RUnlock()
-		if ok {
-			return version, nil
-		}
-
-		// Read file contents and calculate MD5 sum to represent version.
-		f, err := assets.Assets.Open(fp)
-		if err != nil {
-			return "", err
-		}
-		defer f.Close()
-		data, err := ioutil.ReadAll(f)
-		if err != nil {
-			return "", err
-		}
-		version = fmt.Sprintf("%x", md5.Sum(data))
-
-		// Update cache.
-		versionCacheMu.Lock()
-		versionCache[fp] = version
-		versionCacheMu.Unlock()
-		return version, nil
-	},
-}
 
 var (
 	loadTemplateMu    sync.RWMutex
@@ -105,7 +67,7 @@ func doLoadTemplate(path string) (*template.Template, error) {
 	default:
 		return nil, fmt.Errorf("invalid template path %q", path)
 	}
-	tmpl, err := template.New(path).Funcs(funcMap).Parse(data)
+	tmpl, err := template.New(path).Parse(data)
 	if err != nil {
 		return nil, fmt.Errorf("ui: failed to parse template %q: %v", path, err)
 	}

--- a/dev/watchmanwrapper/watch.json
+++ b/dev/watchmanwrapper/watch.json
@@ -11,7 +11,9 @@
         ["suffix", "go"],
         ["name", "cmd/frontend/graphqlbackend/schema.graphql", "wholename"],
         ["dirname", "monitoring"],
-        ["match", "schema/*.json", "wholename"]
+        ["match", "schema/*.json", "wholename"],
+        ["match", "cmd/frontend/internal/app/ui/app.html", "wholename"],
+        ["match", "ui/assets/webpack.manifest.json", "wholename"]
       ]
     ],
     "fields": ["name"]

--- a/ui/assets/manifest.go
+++ b/ui/assets/manifest.go
@@ -1,0 +1,14 @@
+package assets
+
+import (
+	_ "embed"
+)
+
+// 🚨 WARNING: This is just a shim implementation that
+// hardcodes the app bundle name.
+//
+// TODO: The webpack configuration will need to be adjusted so that
+// it outputs its manifest file in this folder.
+
+//go:embed webpack.manifest.json
+var WebpackManifestJSON []byte

--- a/ui/assets/webpack.manifest.json
+++ b/ui/assets/webpack.manifest.json
@@ -1,0 +1,3 @@
+{
+  "app.js": "app.bundle.js"
+}


### PR DESCRIPTION
Add-on to https://github.com/sourcegraph/sourcegraph/pull/19479

This PR:

- adds logic to read a manifest file containing the current name of the app bundle, and load it into a go struct 
- modifies the app.html template to read the current name of the app bundle file 
- modifies the watchman config to reload the frontend binary if either the manifest file or app.html file are modified 
- adds a "shim" manifest that contains the current name of the app.bundle.js file (placeholder until the webpack logic is wired up) 
