### PR TITLE
db: manually execute deletion of orphaned repos

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -509,8 +509,6 @@ Indexes:
 Foreign-key constraints:
     "external_service_repos_external_service_id_fkey" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE DEFERRABLE
     "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
-Triggers:
-    trig_soft_delete_orphan_repo_by_external_service_repo AFTER DELETE ON external_service_repos FOR EACH STATEMENT EXECUTE PROCEDURE soft_delete_orphan_repo_by_external_service_repos()
 
 ```
 

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -243,8 +243,6 @@ func (s *Store) UpsertSources(ctx context.Context, inserts, updates, deletes map
 
 	var q *sqlf.Query
 
-	// When upserting sources we only want to perform delete statements when there are actual deletes that need to happen
-	// so that we don't inadvertently trigger trig_soft_delete_orphan_repo_by_external_service_repo
 	if len(deletes) > 0 {
 		deletedSources := makeSourceSlices(deletes)
 		q = sqlf.Sprintf(upsertSourcesWithDeletesQueryFmtstr,
@@ -278,9 +276,13 @@ func (s *Store) UpsertSources(ctx context.Context, inserts, updates, deletes map
 		return err
 	}
 
-	// if we deleted some sources we must manually run the soft_delete_orphan_repo_by_external_service_repos function
-	// to cleanup orphaned repos
-	return s.Exec(ctx, sqlf.Sprintf(`SELECT soft_delete_orphan_repo_by_external_service_repos()`))
+	if len(deletes) > 0 {
+		// if we deleted some sources we must manually run the soft_delete_orphan_repo_by_external_service_repos function
+		// to cleanup orphaned repos
+		return s.Exec(ctx, sqlf.Sprintf(`SELECT soft_delete_orphan_repo_by_external_service_repos()`))
+	}
+
+	return nil
 }
 
 var upsertSourcesQueryFmtstr = upsertSourcesFmtstrPrefix + upsertSourcesFmtstrSuffix

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -273,7 +273,14 @@ func (s *Store) UpsertSources(ctx context.Context, inserts, updates, deletes map
 		)
 	}
 
-	return s.Exec(ctx, q)
+	err = s.Exec(ctx, q)
+	if err != nil {
+		return err
+	}
+
+	// if we deleted some sources we must manually run the soft_delete_orphan_repo_by_external_service_repos function
+	// to cleanup orphaned repos
+	return s.Exec(ctx, sqlf.Sprintf(`SELECT soft_delete_orphan_repo_by_external_service_repos()`))
 }
 
 var upsertSourcesQueryFmtstr = upsertSourcesFmtstrPrefix + upsertSourcesFmtstrSuffix

--- a/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.down.sql
+++ b/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.down.sql
@@ -1,0 +1,30 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS soft_delete_orphan_repo_by_external_service_repos();
+
+CREATE FUNCTION soft_delete_orphan_repo_by_external_service_repos() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- When an external service is soft or hard-deleted,
+    -- performs a clean up to soft-delete orphan repositories.
+    UPDATE
+        repo
+    SET
+        name = soft_deleted_repository_name(name),
+        deleted_at = transaction_timestamp()
+    WHERE
+      deleted_at IS NULL
+      AND NOT EXISTS (
+        SELECT FROM external_service_repos WHERE repo_id = repo.id
+    );
+
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER trig_soft_delete_orphan_repo_by_external_service_repo
+    AFTER DELETE ON external_service_repos
+    FOR EACH STATEMENT EXECUTE PROCEDURE soft_delete_orphan_repo_by_external_service_repos();
+
+COMMIT;

--- a/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.up.sql
+++ b/migrations/frontend/1528395803_drop_trig_soft_delete_orphan_repo_by_external_service_repo.up.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+-- Drop trigger as we don't want it to fire anymore.
+DROP TRIGGER IF EXISTS trig_soft_delete_orphan_repo_by_external_service_repo ON external_service_repos;
+DROP FUNCTION IF EXISTS soft_delete_orphan_repo_by_external_service_repos() ;
+
+-- Rewrite the previous function as a standalone function.
+-- The function will be run manually whenever we delete an external service.
+CREATE FUNCTION soft_delete_orphan_repo_by_external_service_repos() RETURNS void
+    AS $$
+BEGIN
+    -- When an external service is soft or hard-deleted,
+    -- performs a clean up to soft-delete orphan repositories.
+    UPDATE
+        repo
+    SET
+        name = soft_deleted_repository_name(name),
+        deleted_at = transaction_timestamp()
+    WHERE
+      deleted_at IS NULL
+      AND NOT EXISTS (
+        SELECT FROM external_service_repos WHERE repo_id = repo.id
+      );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
Orphaned repos cleanup is no longer triggered when we delete rows from `external_service_repos`. Instead, we manually run it when an external service is being deleted or after an external service sync.

Previously, we had a cyclical trigger: 
- External service is soft deleted
- All associated rows in external_service_repo are deleted
  - (1) Trigger: Deletion of orphaned repos.
  - (2) Trigger: Deletion of associated rows in external_service_repos again
  - (1)  Trigger: Deletion of orphaned repos again

When deleting a repo, we don't need to run (1) which is really slow because it needs to scan the whole repo table.

Part of: https://github.com/sourcegraph/customer/issues/263