### PR TITLE
Colorise command name in `sg` command output

### DIFF
--- a/dev/sg/go.mod
+++ b/dev/sg/go.mod
@@ -3,6 +3,7 @@ module github.com/sourcegraph/sourcegraph/dev/sg
 go 1.16
 
 require (
+	github.com/fatih/color v1.10.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/peterbourgon/ff/v3 v3.0.0

--- a/dev/sg/go.sum
+++ b/dev/sg/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
+github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -10,6 +12,8 @@ github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
+github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
@@ -33,6 +37,7 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210316092937-0b90fd5c4c48 h1:70qalHWW1n9yoI8B8zEQxFJO/D6NUWIX8SNmJO+rvNw=
 golang.org/x/sys v0.0.0-20210316092937-0b90fd5c4c48/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/dev/sg/logger.go
+++ b/dev/sg/logger.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"bytes"
+	"hash/fnv"
 	"time"
+
+	"github.com/fatih/color"
 
 	"github.com/sourcegraph/batch-change-utils/output"
 )
@@ -53,7 +56,7 @@ func (l *cmdLogger) flush() {
 	// we flush partial lines, we don't want to add a newline character. What
 	// we need to do: extend the `*output.Output` type to have a
 	// `WritefNoNewline` (yes, bad name) method.
-	l.out.Writef("%s[%s]%s %s", output.StyleBold, l.name, output.StyleReset, l.buf.String())
+	l.out.Writef("%s[%s]%s %s", output.StyleBold, hashColor(l.name), output.StyleReset, l.buf.String())
 	l.buf.Reset()
 }
 
@@ -109,4 +112,23 @@ func (l *cmdLogger) writeLines() {
 			tick.Stop()
 		}
 	}
+}
+
+func hashColor(s string, v ...interface{}) string {
+	colors := []func(string, ...interface{}) string{
+		color.GreenString,
+		color.CyanString,
+		color.YellowString,
+		color.BlueString,
+		color.MagentaString,
+		color.HiGreenString,
+		color.HiCyanString,
+		color.HiYellowString,
+		color.HiBlueString,
+		color.HiMagentaString,
+	}
+	h := fnv.New32()
+	h.Write([]byte(s))
+	colorFunc := colors[int(h.Sum32())%len(colors)]
+	return colorFunc(s, v...)
 }

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -67,12 +67,14 @@ var (
 
 func main() {
 	if err := rootCommand.Parse(os.Args[1:]); err != nil {
+		fmt.Println(rootCommand.ShortUsage)
 		os.Exit(1)
 	}
 
 	var err error
 	conf, err = ParseConfigFile(*configFlag)
 	if err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 

--- a/dev/sg/run.go
+++ b/dev/sg/run.go
@@ -14,6 +14,7 @@ import (
 
 	// TODO - deduplicate me
 	"github.com/sourcegraph/batch-change-utils/output"
+
 	"github.com/sourcegraph/sourcegraph/dev/sg/root"
 )
 


### PR DESCRIPTION
I need the colours to make sense of the world.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
