### PR TITLE
database: Faster external service deletion

### DIFF
--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -608,6 +608,9 @@ func (e *ExternalServiceStore) maybeDecryptConfig(ctx context.Context, config st
 
 // Upsert updates or inserts the given ExternalServices.
 //
+// NOTE: Deletion of an external service via Upsert is not allowed. Use Delete()
+// instead.
+//
 // 🚨 SECURITY: The value of `Unrestricted` field is disregarded and will always
 // be recalculated based on whether `"authorization"` is presented in `Config`.
 func (e *ExternalServiceStore) Upsert(ctx context.Context, svcs ...*types.ExternalService) (err error) {
@@ -629,6 +632,30 @@ func (e *ExternalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 	}
 	defer func() { err = tx.Done(err) }()
 
+	// Get the list services that are marked as deleted. We don't know at this point
+	// whether they are marked as deleted in the DB too.
+	var deleted []int64
+	for _, es := range svcs {
+		if es.ID != 0 && es.IsDeleted() {
+			deleted = append(deleted, es.ID)
+		}
+	}
+
+	// Fetch any services marked for deletion. list() only fetches non deleted
+	// services so if we find anything here it indicates that we are marking a
+	// service as deleted that is NOT deleted in the DB
+	if len(deleted) > 0 {
+		existing, err := tx.list(ctx, ExternalServicesListOptions{IDs: deleted})
+		if err != nil {
+			return errors.Wrap(err, "fetching services marked for deletion")
+		}
+		if len(existing) > 0 {
+			// We found services marked for deletion that are currently not deleted in the
+			// DB.
+			return errors.New("deletion via Upsert() not allowed, use Delete()")
+		}
+	}
+
 	q, err := tx.upsertExternalServicesQuery(ctx, svcs)
 	if err != nil {
 		return err
@@ -641,7 +668,6 @@ func (e *ExternalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 	defer func() { err = basestore.CloseRows(rows, err) }()
 
 	i := 0
-	var possiblyOrphaned bool
 	for rows.Next() {
 		var keyIdent string
 		err = rows.Scan(
@@ -668,17 +694,7 @@ func (e *ExternalServiceStore) Upsert(ctx context.Context, svcs ...*types.Extern
 			return err
 		}
 
-		if !svcs[i].DeletedAt.IsZero() {
-			possiblyOrphaned = true
-		}
-
 		i++
-	}
-
-	if possiblyOrphaned {
-		// if we deleted at least one external service we must manually run the soft_delete_orphan_repo_by_external_service_repos function
-		// to cleanup orphaned repos
-		return tx.Exec(ctx, sqlf.Sprintf(`SELECT soft_delete_orphan_repo_by_external_service_repos()`))
 	}
 
 	return nil
@@ -882,8 +898,8 @@ func (e *ExternalServiceStore) Delete(ctx context.Context, id int64) (err error)
 	// Create a temporary table where we'll store repos affected by the deletion of
 	// the external service
 	if err := tx.Exec(ctx, sqlf.Sprintf(`
-CREATE TEMPORARY TABLE
-    deleted_repos(
+CREATE TEMPORARY TABLE IF NOT EXISTS
+    deleted_repos_temp(
     repo_id int
 ) ON COMMIT DROP`)); err != nil {
 		return errors.Wrap(err, "creating temporary table")
@@ -896,7 +912,7 @@ CREATE TEMPORARY TABLE
 	       WHERE external_service_id = %s
 	       RETURNING repo_id
 	)
-	INSERT INTO deleted_repos
+	INSERT INTO deleted_repos_temp
 	SELECT repo_id from deleted
 `, id)); err != nil {
 		return errors.Wrap(err, "populating temporary table")
@@ -908,13 +924,21 @@ CREATE TEMPORARY TABLE
 	SET name       = soft_deleted_repository_name(name),
 	   deleted_at = TRANSACTION_TIMESTAMP()
 	WHERE deleted_at IS NULL
-	 AND EXISTS (SELECT FROM deleted_repos WHERE repo.id = deleted_repos.repo_id)
+	 AND EXISTS (SELECT FROM deleted_repos_temp WHERE repo.id = deleted_repos_temp.repo_id)
 	 AND NOT EXISTS (
 	       SELECT FROM external_service_repos
 	       WHERE repo_id = repo.id
 	   );
 `)); err != nil {
 		return errors.Wrap(err, "cleaning up potentially orphaned repos")
+	}
+
+	// Clear temporary table in case delete is called multiple times within the same
+	// transaction
+	if err := tx.Exec(ctx, sqlf.Sprintf(`
+    DELETE FROM deleted_repos_temp;
+`)); err != nil {
+		return errors.Wrap(err, "clearing temporary table")
 	}
 
 	// Soft delete external service

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -619,6 +619,11 @@ VALUES (%d, 1, ''), (%d, 2, '')
 		t.Errorf("error: want %q but got %q", wantErr, gotErr)
 	}
 
+	_, err = ExternalServices(db).GetByID(ctx, es1.ID)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
 	// Should only get back the repo with ID=2
 	repos, err := Repos(db).GetByIDs(ctx, 1, 2)
 	if err != nil {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1303,14 +1303,13 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 			t.Errorf("List:\n%s", diff)
 		}
 
-		want.Apply(func(e *types.ExternalService) {
-			e.UpdatedAt = now
-			e.DeletedAt = now
-		})
-
-		if err = tx.Upsert(ctx, want.Clone()...); err != nil {
-			t.Errorf("Upsert error: %s", err)
+		// Delete external services
+		for _, es := range want {
+			if err := tx.Delete(ctx, es.ID); err != nil {
+				t.Fatal(err)
+			}
 		}
+
 		have, err = tx.List(ctx, ExternalServicesListOptions{})
 		if err != nil {
 			t.Errorf("List error: %s", err)
@@ -1398,14 +1397,13 @@ func TestExternalServicesStore_Upsert(t *testing.T) {
 			t.Errorf("List:\n%s", diff)
 		}
 
-		want.Apply(func(e *types.ExternalService) {
-			e.UpdatedAt = now
-			e.DeletedAt = now
-		})
-
-		if err = tx.Upsert(ctx, want.Clone()...); err != nil {
-			t.Errorf("Upsert error: %s", err)
+		// Delete external services
+		for _, es := range want {
+			if err := tx.Delete(ctx, es.ID); err != nil {
+				t.Fatal(err)
+			}
 		}
+
 		have, err = tx.List(ctx, ExternalServicesListOptions{})
 		if err != nil {
 			t.Errorf("List error: %s", err)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -562,8 +562,6 @@ Foreign-key constraints:
 Referenced by:
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_external_service_id_fkey" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE DEFERRABLE
     TABLE "external_service_sync_jobs" CONSTRAINT "external_services_id_fk" FOREIGN KEY (external_service_id) REFERENCES external_services(id)
-Triggers:
-    trig_delete_external_service_ref_on_external_service_repos AFTER UPDATE OF deleted_at ON external_services FOR EACH ROW EXECUTE PROCEDURE delete_external_service_ref_on_external_service_repos()
 
 ```
 

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -437,8 +437,7 @@ func testStoreUpsertSources(t *testing.T, store *repos.Store) func(*testing.T) {
 
 			// delete an external service
 			svc := servicesPerKind[extsvc.KindGitHub]
-			svc.DeletedAt = now
-			if err := tx.ExternalServiceStore.Upsert(ctx, svc); err != nil {
+			if err := tx.ExternalServiceStore.Delete(ctx, svc.ID); err != nil {
 				t.Fatalf("Upsert externalServices error: %s", err)
 			}
 

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -2148,8 +2148,7 @@ func testDeleteExternalService(db *sql.DB) func(t *testing.T, store *repos.Store
 			}
 
 			// Delete the first service
-			svc1.DeletedAt = now
-			if err := store.ExternalServiceStore.Upsert(ctx, svc1); err != nil {
+			if err := store.ExternalServiceStore.Delete(ctx, svc1.ID); err != nil {
 				t.Fatal(err)
 			}
 
@@ -2160,8 +2159,7 @@ func testDeleteExternalService(db *sql.DB) func(t *testing.T, store *repos.Store
 			assertDeletedRepoCount(ctx, t, db, 0)
 
 			// Delete the second service
-			svc2.DeletedAt = now
-			if err := store.ExternalServiceStore.Upsert(ctx, svc2); err != nil {
+			if err := store.ExternalServiceStore.Delete(ctx, svc2.ID); err != nil {
 				t.Fatal(err)
 			}
 

--- a/migrations/frontend/1528395804_delete_external_service_trigger.down.sql
+++ b/migrations/frontend/1528395804_delete_external_service_trigger.down.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+CREATE FUNCTION delete_external_service_ref_on_external_service_repos() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- if an external service is soft-deleted, delete every row that references it
+    IF (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL) THEN
+        DELETE FROM
+            external_service_repos
+        WHERE
+                external_service_id = OLD.id;
+    END IF;
+
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER trig_delete_external_service_ref_on_external_service_repos
+    AFTER UPDATE OF deleted_at ON external_services FOR EACH ROW EXECUTE PROCEDURE delete_external_service_ref_on_external_service_repos();
+
+COMMIT;

--- a/migrations/frontend/1528395804_delete_external_service_trigger.up.sql
+++ b/migrations/frontend/1528395804_delete_external_service_trigger.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP TRIGGER IF EXISTS trig_delete_external_service_ref_on_external_service_repos
+ON external_services;
+
+DROP FUNCTION IF EXISTS delete_external_service_ref_on_external_service_repos();
+
+COMMIT;


### PR DESCRIPTION
Instead of scanning the entire repo table looking for orphaned repos
after an external service has been deleted, we instead only scan repos
we know may have been affected.

We had to use a temporary table since if the deletion was done in a CTE
it is not visible in subsequent statements.

We also remove the trigger after external service is deleted as we 
take care of it in code.

Closes: https://github.com/sourcegraph/sourcegraph/issues/19513