### PR TITLE
conf: correctly handle default value of `GitMaxCodehostRequestsPerSecond`

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -255,7 +255,7 @@ func (s *Server) Handler() http.Handler {
 
 	s.rpsLimiter = rate.NewLimiter(rate.Inf, 10)
 	setRPSLimiter := func() {
-		if maxRequestsPerSecond := conf.Get().GitMaxCodehostRequestsPerSecond; maxRequestsPerSecond == -1 {
+		if maxRequestsPerSecond := conf.GitMaxCodehostRequestsPerSecond(); maxRequestsPerSecond == -1 {
 			// As a special case, -1 means no limiting
 			s.rpsLimiter.SetLimit(rate.Inf)
 		} else {

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -379,3 +379,14 @@ func ExternalServiceUserMode() ExternalServiceMode {
 		return ExternalServiceModeDisabled
 	}
 }
+
+// GitMaxCodehostRequestsPerSecond returns maximum number of remote code host
+// git operations to be run per second per gitserver. If not set, it returns the
+// default value -1.
+func GitMaxCodehostRequestsPerSecond() int {
+	val := Get().GitMaxCodehostRequestsPerSecond
+	if val == nil || *val < -1 {
+		return -1
+	}
+	return *val
+}

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -115,7 +115,6 @@ func TestAuthPasswordResetLinkDuration(t *testing.T) {
 }
 
 func TestGitMaxCodehostRequestsPerSecond(t *testing.T) {
-
 	tests := []struct {
 		name string
 		sc   *Unified

--- a/internal/conf/computed_test.go
+++ b/internal/conf/computed_test.go
@@ -114,6 +114,44 @@ func TestAuthPasswordResetLinkDuration(t *testing.T) {
 	}
 }
 
+func TestGitMaxCodehostRequestsPerSecond(t *testing.T) {
+
+	tests := []struct {
+		name string
+		sc   *Unified
+		want int
+	}{
+		{
+			name: "not set should return default",
+			sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{}},
+			want: -1,
+		},
+		{
+			name: "bad value should return default",
+			sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{GitMaxCodehostRequestsPerSecond: intPtr(-100)}},
+			want: -1,
+		},
+		{
+			name: "set 0 should return 0",
+			sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{GitMaxCodehostRequestsPerSecond: intPtr(0)}},
+			want: 0,
+		},
+		{
+			name: "set non-0 should return non-0",
+			sc:   &Unified{SiteConfiguration: schema.SiteConfiguration{GitMaxCodehostRequestsPerSecond: intPtr(100)}},
+			want: 100,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			Mock(test.sc)
+			if got, want := GitMaxCodehostRequestsPerSecond(), test.want; got != want {
+				t.Fatalf("GitMaxCodehostRequestsPerSecond() = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func setenv(t *testing.T, keyval string) func() {
 	t.Helper()
 
@@ -141,4 +179,8 @@ func setenv(t *testing.T, keyval string) func() {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func intPtr(i int) *int {
+	return &i
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1350,7 +1350,7 @@ type SiteConfiguration struct {
 	// GitCloneURLToRepositoryName description: JSON array of configuration that maps from Git clone URL to repository name. Sourcegraph automatically resolves remote clone URLs to their proper code host. However, there may be non-remote clone URLs (e.g., in submodule declarations) that Sourcegraph cannot automatically map to a code host. In this case, use this field to specify the mapping. The mappings are tried in the order they are specified and take precedence over automatic mappings.
 	GitCloneURLToRepositoryName []*CloneURLToRepositoryName `json:"git.cloneURLToRepositoryName,omitempty"`
 	// GitMaxCodehostRequestsPerSecond description: Maximum number of remote code host git operations (e.g. clone or ls-remote) to be run per second per gitserver. Default is -1, which is unlimited.
-	GitMaxCodehostRequestsPerSecond int `json:"gitMaxCodehostRequestsPerSecond,omitempty"`
+	GitMaxCodehostRequestsPerSecond *int `json:"gitMaxCodehostRequestsPerSecond,omitempty"`
 	// GitMaxConcurrentClones description: Maximum number of git clone processes that will be run concurrently per gitserver to update repositories. Note: the global git update scheduler respects gitMaxConcurrentClones. However, we allow each gitserver to run upto gitMaxConcurrentClones to allow for urgent fetches. Urgent fetches are used when a user is browsing a PR and we do not have the commit yet.
 	GitMaxConcurrentClones int `json:"gitMaxConcurrentClones,omitempty"`
 	// GitUpdateInterval description: JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -392,6 +392,7 @@
     "gitMaxCodehostRequestsPerSecond": {
       "description": "Maximum number of remote code host git operations (e.g. clone or ls-remote) to be run per second per gitserver. Default is -1, which is unlimited.",
       "type": "integer",
+      "!go": { "pointer": true },
       "default": -1,
       "group": "External services"
     },


### PR DESCRIPTION
Follow up of https://github.com/sourcegraph/sourcegraph/pull/19504#pullrequestreview-623290709