### PR TITLE
streaming search: fix diff result highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Commit search returning duplicate commits. [#19460](https://github.com/sourcegraph/sourcegraph/pull/19460)
 - Clicking the Code Monitoring tab tries to take users to a non-existent repo. [#19525](https://github.com/sourcegraph/sourcegraph/pull/19525)
+- Diff search not highlighting search terms correctly for some files. [#19543](https://github.com/sourcegraph/sourcegraph/pull/19543)
 
 ### Removed
 

--- a/client/web/src/components/SearchResultMatch.scss
+++ b/client/web/src/components/SearchResultMatch.scss
@@ -79,6 +79,7 @@
         padding-bottom: 1rem;
         padding-left: 0.5rem;
         padding-right: 0;
+        color: var(--body-color);
 
         table {
             margin-bottom: 0 !important; // Override docsite Markdown table CSS. A currently open PR removes that CSS and lets us remove this override.

--- a/client/web/src/search/stream.test.ts
+++ b/client/web/src/search/stream.test.ts
@@ -1,4 +1,4 @@
-import { toGQLRepositoryMatch, RepositoryMatch } from './stream'
+import { RepositoryMatch, toGQLRepositoryMatch, toMarkdownCodeHtml } from './stream'
 
 expect.addSnapshotSerializer({
     serialize: value => JSON.stringify(value),
@@ -14,6 +14,36 @@ describe('escapeSpaces', () => {
     test('escapes spaces in value', () => {
         expect(toGQLRepositoryMatch(REPO_MATCH_CONTAINING_SPACES).label).toMatchInlineSnapshot(
             '{"__typename":"Markdown","text":"[github.com/save/the andimals](/github.com/save/the%20andimals)"}'
+        )
+    })
+})
+
+describe('markdown cleanup', () => {
+    test('markdown cleaned up correctly for diff match', () => {
+        const diffMatch = `\`\`\`diff
+test
+\`\`\`
+test
+\`\`\`diff
+test
+\`\`\``
+
+        expect(toMarkdownCodeHtml(diffMatch)).toMatchInlineSnapshot(
+            '{"__typename":"Markdown","html":"test\\n```\\ntest\\n```diff\\ntest\\n","text":"```diff\\ntest\\n```\\ntest\\n```diff\\ntest\\n```"}'
+        )
+    })
+
+    test('markdown cleaned up correctly for commit match', () => {
+        const diffMatch = `\`\`\`COMMIT_EDITMSG
+test
+\`\`\`
+test
+\`\`\`COMMIT_EDITMSG
+test
+\`\`\``
+
+        expect(toMarkdownCodeHtml(diffMatch)).toMatchInlineSnapshot(
+            '{"__typename":"Markdown","html":"test\\n```\\ntest\\n```COMMIT_EDITMSG\\ntest\\n","text":"```COMMIT_EDITMSG\\ntest\\n```\\ntest\\n```COMMIT_EDITMSG\\ntest\\n```"}'
         )
     })
 })

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -245,6 +245,12 @@ const toGQLSymbolMatch = (fm: FileSymbolMatch): GQL.IFileMatch => ({
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 const toMarkdown = (text: string | MarkdownText): GQL.IMarkdown => ({ __typename: 'Markdown', text } as GQL.IMarkdown)
 
+export const toMarkdownCodeHtml = (text: string | MarkdownText): GQL.IMarkdown => ({
+    __typename: 'Markdown',
+    html: text.replace(/^```[_a-z]*\n/i, '').replace(/```$/i, ''), // Remove Markdown code indicators to render code as plain text
+    text, // The full result with Markdown code indicators is still needed as SearchResultMatch.tsx uses this to determine syntax highlighting
+})
+
 // copy-paste from search_repositories.go. When we move away from GQL types this shouldn't be part of the API.
 const repoIcon =
     'data:image/svg+xml;base64,PHN2ZyB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4PSIwcHgiIHk9IjBweCIKCSB2aWV3Qm94PSIwIDAgNjQgNjQiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDY0IDY0OyIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5JY29ucyA0MDA8L3RpdGxlPgo8Zz4KCTxwYXRoIGQ9Ik0yMywyMi40YzEuMywwLDIuNC0xLjEsMi40LTIuNHMtMS4xLTIuNC0yLjQtMi40Yy0xLjMsMC0yLjQsMS4xLTIuNCwyLjRTMjEuNywyMi40LDIzLDIyLjR6Ii8+Cgk8cGF0aCBkPSJNMzUsMjYuNGMxLjMsMCwyLjQtMS4xLDIuNC0yLjRzLTEuMS0yLjQtMi40LTIuNHMtMi40LDEuMS0yLjQsMi40UzMzLjcsMjYuNCwzNSwyNi40eiIvPgoJPHBhdGggZD0iTTIzLDQyLjRjMS4zLDAsMi40LTEuMSwyLjQtMi40cy0xLjEtMi40LTIuNC0yLjRzLTIuNCwxLjEtMi40LDIuNFMyMS43LDQyLjQsMjMsNDIuNHoiLz4KCTxwYXRoIGQ9Ik01MCwxNmgtMS41Yy0wLjMsMC0wLjUsMC4yLTAuNSwwLjV2MzVjMCwwLjMtMC4yLDAuNS0wLjUsMC41aC0yN2MtMC41LDAtMS0wLjItMS40LTAuNmwtMC42LTAuNmMtMC4xLTAuMS0wLjEtMC4yLTAuMS0wLjQKCQljMC0wLjMsMC4yLTAuNSwwLjUtMC41SDQ0YzEuMSwwLDItMC45LDItMlYxMmMwLTEuMS0wLjktMi0yLTJIMTRjLTEuMSwwLTIsMC45LTIsMnYzNi4zYzAsMS4xLDAuNCwyLjEsMS4yLDIuOGwzLjEsMy4xCgkJYzEuMSwxLjEsMi43LDEuOCw0LjIsMS44SDUwYzEuMSwwLDItMC45LDItMlYxOEM1MiwxNi45LDUxLjEsMTYsNTAsMTZ6IE0xOSwyMGMwLTIuMiwxLjgtNCw0LTRjMS40LDAsMi44LDAuOCwzLjUsMgoJCWMxLjEsMS45LDAuNCw0LjMtMS41LDUuNFYzM2MxLTAuNiwyLjMtMC45LDQtMC45YzEsMCwyLTAuNSwyLjgtMS4zQzMyLjUsMzAsMzMsMjkuMSwzMywyOHYtMC42Yy0xLjItMC43LTItMi0yLTMuNQoJCWMwLTIuMiwxLjgtNCw0LTRjMi4yLDAsNCwxLjgsNCw0YzAsMS41LTAuOCwyLjctMiwzLjVoMGMtMC4xLDIuMS0wLjksNC40LTIuNSw2Yy0xLjYsMS42LTMuNCwyLjQtNS41LDIuNWMtMC44LDAtMS40LDAuMS0xLjksMC4zCgkJYy0wLjIsMC4xLTEsMC44LTEuMiwwLjlDMjYuNiwzOCwyNywzOC45LDI3LDQwYzAsMi4yLTEuOCw0LTQsNHMtNC0xLjgtNC00YzAtMS41LDAuOC0yLjcsMi0zLjRWMjMuNEMxOS44LDIyLjcsMTksMjEuNCwxOSwyMHoiLz4KPC9nPgo8L3N2Zz4K'
@@ -270,12 +276,12 @@ export function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
 }
 
 function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
-    const match = {
+    const match: GQL.ISearchResultMatch = {
         __typename: 'SearchResultMatch',
         url: commit.url,
-        body: toMarkdown(commit.content),
+        body: toMarkdownCodeHtml(commit.content),
         highlights: commit.ranges.map(([line, character, length]) => ({
-            __typename: 'IHighlight',
+            __typename: 'Highlight',
             line,
             character,
             length,
@@ -283,7 +289,7 @@ function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
     }
 
     // We only need to return the subset defined in IGenericSearchResultInterface
-    const gqlCommit: unknown = {
+    const gqlCommit: Partial<GQL.ICommitSearchResult> = {
         __typename: 'CommitSearchResult',
         icon: commit.icon,
         label: toMarkdown(commit.label),


### PR DESCRIPTION
Fixes #19403

Decided to go with a front-end only solution because we still need the full Markdown code indicators to determine file type for `SearchResultMatch.tsx` to know the contents are code and what type of code they are for syntax highlighting. 

There could be loads of ways to improve this in the future but this was the quickest relatively-clean solution to fix this bug now. In the future, `SearchResultMatch.tsx` could know that this is a diff/commit result and treat it in a more specialized way. Also, search results could be returned already syntax-highlighted so we don't have to call another API to get the highlighted code.

Also fixes font color for search results without syntax highlighting (eg. `type:commit`)