### PR TITLE
ci: trigger image updates on downstream k8s deployments

### DIFF
--- a/.buildkite/updater/is-tip-of-main.sh
+++ b/.buildkite/updater/is-tip-of-main.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+set -euxo pipefail
+
+COMMIT="${BUILDKITE_COMMIT}"
+
+API_SLUG="repos/sourcegraph/sourcegraph/commits"
+function get_branch_tip() {
+  local ref="$1"
+
+  # https://docs.github.com/en/rest/reference/repos#list-commits
+  gh api "${API_SLUG}?sha=${ref}&per_page=1" --jq '.[].sha'
+}
+
+REF="main"
+tip_of_main="$(get_branch_tip ${REF})"
+
+[[ "$tip_of_main" == "$COMMIT" ]]

--- a/.buildkite/updater/pipeline.update-trigger.yaml
+++ b/.buildkite/updater/pipeline.update-trigger.yaml
@@ -1,0 +1,7 @@
+steps:
+- trigger: 'ds-updater-test-cron-non-gitserver'
+  label: ':k8s: :arrows_counterclockwise: :construction: Trigger update pipeline for deploy-sourcegraph-updater-test (non gitserver)'
+  branches: 'master'
+  async: true
+  env:
+    TARGET_COMMIT: "${BUILDKITE_COMMIT}"

--- a/.buildkite/updater/pipeline.update-trigger.yaml
+++ b/.buildkite/updater/pipeline.update-trigger.yaml
@@ -1,6 +1,6 @@
 steps:
-- trigger: 'ds-updater-test-cron-non-gitserver'
-  label: ':k8s: :arrows_counterclockwise: :construction: Trigger update pipeline for deploy-sourcegraph-updater-test (non gitserver)'
+- trigger: 'ds-updater-test-image-updater'
+  label: ':k8s: :arrows_counterclockwise: :construction: Trigger update pipeline for deploy-sourcegraph-updater-test'
   branches: 'master'
   async: true
   env:

--- a/.buildkite/updater/trigger-if-tip-of-main.sh
+++ b/.buildkite/updater/trigger-if-tip-of-main.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../.."
+set -euo pipefail
+
+if ! .buildkite/updater/is-tip-of-main.sh; then
+  echo "🚨 This commit is not the tip of main (either it's behind or an unrelated commit). Skipping deployment triggers..."
+  exit 0 # This is not a failure condition.
+fi
+
+buildkite-agent pipeline upload '.buildkite/updater/pipeline.update-trigger.yaml'

--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -128,6 +128,10 @@ func (c Config) shortCommit() string {
 	return c.commit[:12]
 }
 
+func (c *Config) isMainBranch() bool {
+	return c.branch == "main"
+}
+
 func (c Config) ensureCommit() error {
 	if len(c.mustIncludeCommit) == 0 {
 		return nil
@@ -157,7 +161,7 @@ func (c Config) isPR() bool {
 		!c.releaseBranch &&
 		!c.taggedRelease &&
 		c.branch != "master" &&
-		c.branch != "main" &&
+		!c.isMainBranch() &&
 		!c.isMasterDryRun &&
 		!c.patch
 }
@@ -181,7 +185,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.branch == "main" || c.isMasterDryRun
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.isMainBranch() || c.isMasterDryRun
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -148,7 +148,7 @@ func addDockerfileLint(pipeline *bk.Pipeline) {
 // Adds backend integration tests step.
 func addBackendIntegrationTests(c Config) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		if !c.isBackendDryRun && !c.isMasterDryRun && c.branch != "master" && c.branch != "main" {
+		if !c.isBackendDryRun && !c.isMasterDryRun && c.branch != "master" && !c.isMainBranch() {
 			return
 		}
 
@@ -253,7 +253,7 @@ func clusterDockerImages(images []string) string {
 
 func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 	var async bool
-	if c.branch == "main" {
+	if c.isMainBranch() {
 		async = true
 	} else {
 		async = false
@@ -346,7 +346,7 @@ func addDockerImages(c Config, final bool) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
 		switch {
 		// build candidate images and deploy `insiders` images
-		case c.branch == "main":
+		case c.isMainBranch():
 			for _, dockerImage := range images.SourcegraphDockerImages {
 				addDockerImage(c, dockerImage, true)(pipeline)
 			}

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -239,6 +239,21 @@ func triggerAsync(c Config) func(*bk.Pipeline) {
 	}
 }
 
+func triggerUpdaterPipeline(c Config) func(*bk.Pipeline) {
+	if !c.isMainBranch() {
+		// no-op
+		return func(*bk.Pipeline) {}
+	}
+
+	return func(pipeline *bk.Pipeline) {
+		pipeline.AddStep(":github: :date: :k8s: Trigger k8s updates if current commit is tip of 'main'",
+			bk.Cmd(".buildkite/updater/trigger-if-tip-of-main.sh"),
+			bk.Concurrency(1),
+			bk.ConcurrencyGroup("sourcegraph/sourcegraph-k8s-update-trigger"),
+		)
+	}
+}
+
 // images used by cluster-qa test
 func clusterDockerImages(images []string) string {
 	var clusterImages []string

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -146,6 +146,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 			triggerE2EandQA(c, env),  // trigger e2e late so that it can leverage candidate images
 			addDockerImages(c, true), // publish final images
+			wait,
+
+			triggerUpdaterPipeline(c),
 		}
 	}
 


### PR DESCRIPTION
This PR adds the scaffolding to have the sourcegraph/sourcegraph pipeline trigger image updates on our deploy-sourcegraph-FOO repositories. 

After all the "final" docker images have been built (and the current branch is `main`):

There is a final script that checks that:

1. Checks to see if the current buildkite commit is the same as the tip of the `main` branch:
2. Iff the current commit is the tip, then it [dynamically uploads](https://buildkite.com/docs/pipelines/defining-steps#dynamic-pipelines) a second pipeline file that actually contains the trigger step that triggers all the downstream deployment pipeline (with TARGET_COMMIT as the environment variable that provides that tells the image updater scripts what image tag to pull)


I do it that way to make sure that the deployment triggers only execute with the latest docker images (and will avoid triggers if we are rebuilding an old sourcegraph/sourcegraph commit, etc.). Also note that the check script runs inside a concurrency group to protect against possible execution order issues 


