### PR TITLE
doc: search doc touchups

### DIFF
--- a/doc/code_search/reference/language.md
+++ b/doc/code_search/reference/language.md
@@ -254,7 +254,7 @@ ComplexDiagram(
 			Terminal("-"),
 			Sequence(
 				Terminal("NOT"),
-				Terminal("whitespace", {href: "#whitespace"}))),
+				Terminal("space", {href: "#whitespace"}))),
 		Choice(0,
 			Terminal("file:"),
 			Terminal("f:")),
@@ -291,7 +291,7 @@ ComplexDiagram(
 			Terminal("-"),
 			Sequence(
 				Terminal("NOT"),
-				Terminal("whitespace", {href: "#whitespace"}))),
+				Terminal("space", {href: "#whitespace"}))),
 		Terminal("content:"),
 		Terminal("quoted string", {href: "#quoted-string"})).addTo();
 </script>
@@ -473,7 +473,7 @@ ComplexDiagram(
 			Terminal("-"),
 			Sequence(
 				Terminal("NOT"),
-				Terminal("whitespace", {href: "#whitespace"}))),
+				Terminal("space", {href: "#whitespace"}))),
 		Terminal("repohasfile:"),
 		Terminal("regular expression", {href: "#regular-expression"})).addTo();
 </script>
@@ -594,7 +594,7 @@ ComplexDiagram(
 </script>
 
 Any string, including whitespace, may be quoted with single `'` or double `"`
-quotes. Quotes can be escaped with `\`. Literal `\` characters will need to be escaped, eg `\\`.
+quotes. Quotes can be escaped with `\`. Literal `\` characters will need to be escaped, e.g., `\\`.
 
 ## Commit parameter
 
@@ -670,5 +670,3 @@ ComplexDiagram(
 		OneOrMore(
 			Terminal("space"))).addTo();
 </script>
-
-

--- a/doc/code_search/tutorials/examples.md
+++ b/doc/code_search/tutorials/examples.md
@@ -7,7 +7,7 @@ Below are examples that search repositories on [Sourcegraph.com](https://sourceg
 [Recent security-related changes on all branches](https://sourcegraph.com/search?q=type:diff+repo:github%5C.com/kubernetes/kubernetes%24+repo:%40*refs/heads/+after:"5+days+ago"+%5Cb%28auth%5B%5Eo%5D%5B%5Er%5D%7Csecurity%5Cb%7Ccve%7Cpassword%7Csecure%7Cunsafe%7Cperms%7Cpermissions%29)<br/>
 
 ```sgquery
-type:diff repo:@*refs/heads/ after:"5 days ago" 
+type:diff repo:@*refs/heads/ after:"5 days ago"
 \b(auth[^o][^r]|security\b|cve|password|secure|unsafe|perms|permissions)
 ```
 
@@ -21,6 +21,12 @@ type:diff repo:@*refs/heads/ after:"5 days ago"
 
 ```sgquery
 type:diff after:"1 week ago" \.subscribe\( lang:typescript
+```
+
+[Find multiple terms in the same file, like testing of HTTP components ](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/sourcegraph%24+%28test+AND+http+AND+NewRequest%29+lang:go&patternType=regexp)
+
+```sgquery
+repo:github\.com/sourcegraph/sourcegraph$ (test AND http AND NewRequest) lang:go
 ```
 
 [Recent quality related changes on all branches (customize for your linters)](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph/+repo:%40*refs/heads/:%5Emaster+type:diff+after:"1+week+ago"+%28eslint-disable%29)<br/>
@@ -59,7 +65,7 @@ repo:^github\.com/Parsely/pykafka$ Not leader for partition
 
 Regex searches are also useful when searching boundaries that are not delimited by code structures:
 
-[Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%5Cbbtn-secondary%5Cb&patternType=regexp) <br /> 
+[Finding css classes with word boundary regex](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%5Cbbtn-secondary%5Cb&patternType=regexp) <br />
 ```sgquery
 repo:^github\.com/sourcegraph/sourcegraph$ \bbtn-secondary\b
 ```
@@ -69,8 +75,8 @@ repo:^github\.com/sourcegraph/sourcegraph$ \bbtn-secondary\b
 
 Use structural search when you want to match code boundaries such as () or {}:
 
-[Finding try catch statements with varying content](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+try+%7B+:%5Bmatched_statements%5D+%7D+catch+%7B+:%5Bmatched_catch%5D+%7D&patternType=structural)<br/> 
+[Finding try catch statements with varying content](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+try+%7B+:%5Bmatched_statements%5D+%7D+catch+%7B+:%5Bmatched_catch%5D+%7D&patternType=structural)<br/>
 ```sgquery
-repo:^github\.com/sourcegraph/sourcegraph$ 
+repo:^github\.com/sourcegraph/sourcegraph$
 try { :[matched_statements] } catch { :[matched_catch] }
 ```

--- a/doc/code_search/tutorials/search_subexpressions.md
+++ b/doc/code_search/tutorials/search_subexpressions.md
@@ -19,7 +19,7 @@ Here are examples of how they can help you:
 
 → [Noncompliant spelling where case-sensitivity differs depending on the word](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+%28%28Github+case:yes%29+or+%28organisation+case:no%29%29&patternType=literal).
 
-```text
+```sgquery
  repo:sourcegraph ((Github case:yes) or (organisation case:no))
 ```
 
@@ -30,7 +30,7 @@ Here are examples of how they can help you:
 
 → [Search for either a file name or file contents scoped to the same repository](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+-file:html+%28file:router+or+newRouter%29&patternType=literal).
 
-```text
+```sgquery
 repo:sourcegraph -file:html (file:router or newRouter)
 ```
 > Finds both files containing the word `router` or file contents matching `newRouter` in the same repository, while excluding `html` files. Useful when exploring files or code that interact with a general term like `router`.
@@ -40,7 +40,7 @@ repo:sourcegraph -file:html (file:router or newRouter)
 → [Scope file content searches to particular files or repositories](https://sourcegraph.com/search?q=+repo:sourcegraph+%28%28file:schema%5C.graphql+hover%28...%29%29+or+%28file:codeintel%5C.go+%28Line+or+Character%29%29%29&patternType=structural)
 
 
-```text
+```sgquery
  repo:sourcegraph
  (
   (file:schema.graphql hover(...))
@@ -63,7 +63,7 @@ repo:sourcegraph -file:html (file:router or newRouter)
 
 → [Search across multiple repositories at multiple revisions](https://sourcegraph.com/search?q=%28repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40v3.22.0:v3.22.1+or+repo:%5Egithub%5C.com/sourcegraph/src-cli%24%403.22.0:3.22.1%29+file:CHANGELOG+campaigns&patternType=literal).
 
-```text
+```sgquery
  (
    repo:^github\.com/sourcegraph/sourcegraph$@v3.22.0:v3.22.1
    or
@@ -84,17 +84,17 @@ It's best practice to parenthesize
 queries to avoid confusion. For example, there are multiple ways to group the
 query, which is not fully parenthesized:
 
-```text
+```sgquery
 repo:sourcegraph (Github case:yes) or (organisation case:no)
 ```
 
 It could mean either of these:
 
-```text
+```sgquery
 (repo:sourcegraph (Github case:yes)) or (organisation case:no)
 ```
 
-```text
+```sgquery
 repo:sourcegraph ((Github case:yes) or (organisation case:no))
 ```
 
@@ -107,7 +107,7 @@ j)`
 This convention means we would pick the following meaning of the original query,
 but it may not be what you intended:
 
-```text
+```sgquery
 (repo:sourcegraph (Github case:yes)) or (organisation case:no)
 ```
 
@@ -122,26 +122,26 @@ If you're unsure whether a subexpression is valid, it may be useful to think in
 terms of how a subexpression expands to multiple independent queries. Expansion
 relies on a distributive property over `or`-expressions. For example:
 
-```text
+```sgquery
 repo:sourcegraph ((Github case:yes) or (organisation case:no))
 ```
 
 is equivalent to expanding the query by putting `repo:sourcegraph` inside each
 subexpression:
 
-```text
+```sgquery
 (repo:sourcegraph Github case:yes) or (repo:sourcegraph organisation case:no)
 ```
 
 This query is valid because each side of the `or` operator is a valid query. On the other hand, the following query is _invalid_:
 
-```text
+```sgquery
 repo:sourcegraph case:yes (Github or (case:no organisation))
 ```
 
 because after expanding it is equivalent to:
 
-```text
+```sgquery
 (repo:sourcegraph case:yes Github) or (repo:sourcegraph case:yes case:no organisation)
 ```
 


### PR DESCRIPTION
- adds an example with `and` operators to examples.md, just a stopgap for anyone who doesn't find an example here like https://sourcegraph.slack.com/archives/C0W2E592M/p1617041519084400
- use `sgquery` highlighting for subexpressions examples. It's not perfect (sometimes `or`, parens, and fields like `case` inside `(...)` don't get highlighted, but it's better than nothing). I didn't dig into the lexer in `docsite` to try fix this :3
- `whitespace` -> `space` for consistency in language.md
- some typos