### PR TITLE
Implement site-admin UI for batch changes site credentials

### DIFF
--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.story.tsx
@@ -21,7 +21,7 @@ add('Requires SSH - step 1', () => {
         (): Promise<BatchChangesCredentialFields> =>
             Promise.resolve({
                 id: '123',
-                createdAt: new Date().toISOString(),
+                isSiteCredential: false,
                 sshPublicKey:
                     'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
             }),

--- a/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
+++ b/client/web/src/enterprise/batches/settings/AddCredentialModal.tsx
@@ -13,7 +13,7 @@ import { ModalHeader } from './ModalHeader'
 export interface AddCredentialModalProps {
     onCancel: () => void
     afterCreate: () => void
-    userID: Scalars['ID']
+    userID: Scalars['ID'] | null
     externalServiceKind: ExternalServiceKind
     externalServiceURL: string
     requiresSSH: boolean

--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.tsx
@@ -14,6 +14,10 @@ export interface BatchChangesSettingsAreaProps extends Pick<RouteComponentProps,
 export const BatchChangesSettingsArea: React.FunctionComponent<BatchChangesSettingsAreaProps> = props => (
     <div className="web-content test-batches-settings-page">
         <PageTitle title="Batch changes settings" />
-        <CodeHostConnections userID={props.user.id} {...props} />
+        <CodeHostConnections
+            headerLine={<p>Add authentication tokens to enable batch changes changeset creation on your code hosts.</p>}
+            userID={props.user.id}
+            {...props}
+        />
     </div>
 )

--- a/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSettingsArea.tsx
@@ -15,7 +15,7 @@ export const BatchChangesSettingsArea: React.FunctionComponent<BatchChangesSetti
     <div className="web-content test-batches-settings-page">
         <PageTitle title="Batch changes settings" />
         <CodeHostConnections
-            headerLine={<p>Add authentication tokens to enable batch changes changeset creation on your code hosts.</p>}
+            headerLine={<p>Add access tokens to enable Batch Changes changeset creation on your code hosts.</p>}
             userID={props.user.id}
             {...props}
         />

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.story.tsx
@@ -3,19 +3,18 @@ import React from 'react'
 import { of } from 'rxjs'
 import { ExternalServiceKind } from '../../../graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
-import { BatchChangesSettingsArea } from './BatchChangesSettingsArea'
+import { BatchChangesSiteConfigSettingsArea } from './BatchChangesSiteConfigSettingsArea'
 
-const { add } = storiesOf('web/batches/settings/BatchChangesSettingsArea', module).addDecorator(story => (
+const { add } = storiesOf('web/batches/settings/BatchChangesSiteConfigSettingsArea', module).addDecorator(story => (
     <div className="p-3 container web-content">{story()}</div>
 ))
 
 add('Overview', () => (
     <EnterpriseWebStory>
         {props => (
-            <BatchChangesSettingsArea
+            <BatchChangesSiteConfigSettingsArea
                 {...props}
-                user={{ id: 'user-id-1' }}
-                queryUserBatchChangesCodeHosts={() =>
+                queryGlobalBatchChangesCodeHosts={() =>
                     of({
                         totalCount: 3,
                         pageInfo: {
@@ -36,12 +35,7 @@ add('Overview', () => (
                                 requiresSSH: false,
                             },
                             {
-                                credential: {
-                                    id: '123',
-                                    isSiteCredential: true,
-                                    sshPublicKey:
-                                        'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
-                                },
+                                credential: null,
                                 externalServiceKind: ExternalServiceKind.BITBUCKETSERVER,
                                 externalServiceURL: 'https://bitbucket.sgdev.org/',
                                 requiresSSH: true,
@@ -57,10 +51,9 @@ add('Overview', () => (
 add('Config added', () => (
     <EnterpriseWebStory>
         {props => (
-            <BatchChangesSettingsArea
+            <BatchChangesSiteConfigSettingsArea
                 {...props}
-                user={{ id: 'user-id-2' }}
-                queryUserBatchChangesCodeHosts={() =>
+                queryGlobalBatchChangesCodeHosts={() =>
                     of({
                         totalCount: 3,
                         pageInfo: {
@@ -71,7 +64,7 @@ add('Config added', () => (
                             {
                                 credential: {
                                     id: '123',
-                                    isSiteCredential: false,
+                                    isSiteCredential: true,
                                     sshPublicKey:
                                         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
                                 },
@@ -82,7 +75,7 @@ add('Config added', () => (
                             {
                                 credential: {
                                     id: '123',
-                                    isSiteCredential: false,
+                                    isSiteCredential: true,
                                     sshPublicKey:
                                         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
                                 },
@@ -93,7 +86,7 @@ add('Config added', () => (
                             {
                                 credential: {
                                     id: '123',
-                                    isSiteCredential: false,
+                                    isSiteCredential: true,
                                     sshPublicKey:
                                         'rsa-ssh randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
                                 },

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
@@ -1,0 +1,31 @@
+import InfoCircleIcon from 'mdi-react/InfoCircleIcon'
+import React from 'react'
+import { RouteComponentProps } from 'react-router'
+import { PageTitle } from '../../../components/PageTitle'
+import { queryGlobalBatchChangesCodeHosts } from './backend'
+import { CodeHostConnections } from './CodeHostConnections'
+
+export interface BatchChangesSiteConfigSettingsAreaProps extends Pick<RouteComponentProps, 'history' | 'location'> {
+    queryGlobalBatchChangesCodeHosts?: typeof queryGlobalBatchChangesCodeHosts
+}
+
+/** The page area for all batch changes settings. It's shown in the site admin settings sidebar. */
+export const BatchChangesSiteConfigSettingsArea: React.FunctionComponent<BatchChangesSiteConfigSettingsAreaProps> = props => (
+    <div className="web-content">
+        <PageTitle title="Batch changes settings" />
+        <CodeHostConnections
+            headerLine={
+                <>
+                    <div className="alert alert-info">
+                        <InfoCircleIcon className="icon-inline mr-2" />
+                        You are configuring a <strong>global service account</strong>. The credentials on this page can
+                        be used by all users of this Sourcegraph instance to create and sync changesets.
+                    </div>
+                    <p>Configure a service account to enable Batch Changes changeset creation for all users.</p>
+                </>
+            }
+            userID={null}
+            {...props}
+        />
+    </div>
+)

--- a/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
+++ b/client/web/src/enterprise/batches/settings/BatchChangesSiteConfigSettingsArea.tsx
@@ -18,10 +18,10 @@ export const BatchChangesSiteConfigSettingsArea: React.FunctionComponent<BatchCh
                 <>
                     <div className="alert alert-info">
                         <InfoCircleIcon className="icon-inline mr-2" />
-                        You are configuring a <strong>global service account</strong>. The credentials on this page can
-                        be used by all users of this Sourcegraph instance to create and sync changesets.
+                        You are configuring <strong>global credentials</strong> for Batch Changes. The credentials on
+                        this page can be used by all users of this Sourcegraph instance to create and sync changesets.
                     </div>
-                    <p>Configure a service account to enable Batch Changes changeset creation for all users.</p>
+                    <p>Add access tokens to enable Batch Changes changeset creation for all users.</p>
                 </>
             }
             userID={null}

--- a/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnectionNode.tsx
@@ -7,10 +7,11 @@ import { AddCredentialModal } from './AddCredentialModal'
 import { RemoveCredentialModal } from './RemoveCredentialModal'
 import { Subject } from 'rxjs'
 import { ViewCredentialModal } from './ViewCredentialModal'
+import InfoCircleIcon from 'mdi-react/InfoCircleIcon'
 
 export interface CodeHostConnectionNodeProps {
     node: BatchChangesCodeHostFields
-    userID: Scalars['ID']
+    userID: Scalars['ID'] | null
     updateList: Subject<void>
 }
 
@@ -43,13 +44,13 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
         updateList.next()
     }, [updateList])
 
-    const isEnabled = node.credential !== null
+    const isEnabled = node.credential !== null && (userID === null || !node.credential.isSiteCredential)
 
     return (
         <>
             <li className="list-group-item p-3 test-code-host-connection-node">
                 <div className="d-flex justify-content-between align-items-center mb-0">
-                    <h3 className="mb-0">
+                    <h3 className="text-nowrap mb-0">
                         {isEnabled && (
                             <CheckCircleOutlineIcon
                                 className="text-success icon-inline test-code-host-connection-node-enabled"
@@ -64,18 +65,28 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                         )}
                         <Icon className="icon-inline mx-2" /> {node.externalServiceURL}
                     </h3>
+                    {!isEnabled && node.credential?.isSiteCredential && (
+                        <span className="text-primary mx-3">
+                            <InfoCircleIcon className="icon-inline" /> Changesets on this code host will be created with
+                            a global token until a personal access token is added.
+                        </span>
+                    )}
                     <div className="mb-0">
                         {isEnabled && (
                             <>
                                 <button
                                     type="button"
-                                    className="btn btn-link text-danger test-code-host-connection-node-btn-remove"
+                                    className="btn btn-link text-danger text-nowrap test-code-host-connection-node-btn-remove"
                                     onClick={onClickRemove}
                                 >
                                     Remove
                                 </button>
                                 {node.requiresSSH && (
-                                    <button type="button" onClick={onClickView} className="btn btn-secondary ml-2">
+                                    <button
+                                        type="button"
+                                        onClick={onClickView}
+                                        className="btn btn-secondary text-nowrap ml-2"
+                                    >
                                         View public key
                                     </button>
                                 )}
@@ -84,7 +95,7 @@ export const CodeHostConnectionNode: React.FunctionComponent<CodeHostConnectionN
                         {!isEnabled && (
                             <button
                                 type="button"
-                                className="btn btn-success test-code-host-connection-node-btn-add"
+                                className="btn btn-success text-nowrap test-code-host-connection-node-btn-add"
                                 onClick={onClickAdd}
                             >
                                 Add credentials

--- a/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostConnections.tsx
@@ -9,20 +9,27 @@ import {
     Scalars,
     UserBatchChangesCodeHostsVariables,
 } from '../../../graphql-operations'
-import { BatchChangesIcon } from '../../../batches/icons'
-import { queryUserBatchChangesCodeHosts as _queryUserBatchChangesCodeHosts } from './backend'
+import { BatchChangesIconFlushLeft } from '../../../batches/icons'
+import {
+    queryUserBatchChangesCodeHosts as _queryUserBatchChangesCodeHosts,
+    queryGlobalBatchChangesCodeHosts as _queryGlobalBatchChangesCodeHosts,
+} from './backend'
 import { CodeHostConnectionNode, CodeHostConnectionNodeProps } from './CodeHostConnectionNode'
 
 export interface CodeHostConnectionsProps extends Pick<RouteComponentProps, 'history' | 'location'> {
-    userID: Scalars['ID']
+    userID: Scalars['ID'] | null
+    headerLine: JSX.Element
     queryUserBatchChangesCodeHosts?: typeof _queryUserBatchChangesCodeHosts
+    queryGlobalBatchChangesCodeHosts?: typeof _queryGlobalBatchChangesCodeHosts
 }
 
 export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsProps> = ({
     userID,
+    headerLine,
     history,
     location,
     queryUserBatchChangesCodeHosts = _queryUserBatchChangesCodeHosts,
+    queryGlobalBatchChangesCodeHosts = _queryGlobalBatchChangesCodeHosts,
 }) => {
     // Subject to fire a reload of the list.
     const updateList = useMemo(() => new Subject<void>(), [])
@@ -30,18 +37,23 @@ export const CodeHostConnections: React.FunctionComponent<CodeHostConnectionsPro
         (args: Partial<UserBatchChangesCodeHostsVariables>) => Observable<BatchChangesCodeHostsFields>
     >(
         args =>
-            queryUserBatchChangesCodeHosts({
-                user: userID,
-                first: args.first ?? null,
-                after: args.after ?? null,
-            }),
-        [queryUserBatchChangesCodeHosts, userID]
+            userID
+                ? queryUserBatchChangesCodeHosts({
+                      user: userID,
+                      first: args.first ?? null,
+                      after: args.after ?? null,
+                  })
+                : queryGlobalBatchChangesCodeHosts({
+                      first: args.first ?? null,
+                      after: args.after ?? null,
+                  }),
+        [queryUserBatchChangesCodeHosts, queryGlobalBatchChangesCodeHosts, userID]
     )
     return (
         <>
-            <PageHeader path={[{ icon: BatchChangesIcon, text: 'Batch Changes' }]} className="mb-3" />
+            <PageHeader path={[{ icon: BatchChangesIconFlushLeft, text: 'Batch Changes' }]} className="mb-3" />
             <h2>Code host tokens</h2>
-            <p>Add authentication tokens to enable batch changes changeset creation on your code hosts.</p>
+            {headerLine}
             <FilteredConnection<BatchChangesCodeHostFields, Omit<CodeHostConnectionNodeProps, 'node'>>
                 history={history}
                 location={location}

--- a/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
+++ b/client/web/src/enterprise/batches/settings/CodeHostSshPublicKey.tsx
@@ -1,4 +1,5 @@
 import copy from 'copy-to-clipboard'
+import { noop } from 'lodash'
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 import React, { useCallback, useState } from 'react'
 import { ExternalServiceKind } from '../../../graphql-operations'
@@ -48,7 +49,7 @@ export const CodeHostSshPublicKey: React.FunctionComponent<CodeHostSshPublicKeyP
                     </button>
                 )}
             </div>
-            <textarea className="form-control text-monospace mb-3" rows={5} value={sshPublicKey} />
+            <textarea className="form-control text-monospace mb-3" rows={5} value={sshPublicKey} onChange={noop} />
             {showInstructionsLink && (
                 <p>
                     <a href={configInstructionLinks[externalServiceKind]} target="_blank" rel="noopener">

--- a/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/RemoveCredentialModal.story.tsx
@@ -16,7 +16,7 @@ const { add } = storiesOf('web/batches/settings/RemoveCredentialModal', module)
 
 const credential = {
     id: '123',
-    createdAt: new Date().toISOString(),
+    isSiteCredential: false,
     sshPublicKey:
         'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 }

--- a/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
+++ b/client/web/src/enterprise/batches/settings/ViewCredentialModal.story.tsx
@@ -16,7 +16,7 @@ const { add } = storiesOf('web/batches/settings/ViewCredentialModal', module)
 
 const credential: BatchChangesCredentialFields = {
     id: '123',
-    createdAt: new Date().toISOString(),
+    isSiteCredential: false,
     sshPublicKey:
         'ssh-rsa randorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorandorando',
 }

--- a/client/web/src/enterprise/batches/settings/backend.ts
+++ b/client/web/src/enterprise/batches/settings/backend.ts
@@ -9,6 +9,8 @@ import {
     CreateBatchChangesCredentialVariables,
     DeleteBatchChangesCredentialResult,
     DeleteBatchChangesCredentialVariables,
+    GlobalBatchChangesCodeHostsResult,
+    GlobalBatchChangesCodeHostsVariables,
     Scalars,
     UserBatchChangesCodeHostsResult,
     UserBatchChangesCodeHostsVariables,
@@ -17,8 +19,8 @@ import {
 export const batchChangesCredentialFieldsFragment = gql`
     fragment BatchChangesCredentialFields on BatchChangesCredential {
         id
-        createdAt
         sshPublicKey
+        isSiteCredential
     }
 `
 
@@ -28,7 +30,7 @@ export function createBatchChangesCredential(
     return requestGraphQL<CreateBatchChangesCredentialResult, CreateBatchChangesCredentialVariables>(
         gql`
             mutation CreateBatchChangesCredential(
-                $user: ID!
+                $user: ID
                 $credential: String!
                 $externalServiceKind: ExternalServiceKind!
                 $externalServiceURL: String!
@@ -69,6 +71,30 @@ export function deleteBatchChangesCredential(id: Scalars['ID']): Promise<void> {
         .toPromise()
 }
 
+const batchChangesCodeHostsFieldsFragment = gql`
+    fragment BatchChangesCodeHostsFields on BatchChangesCodeHostConnection {
+        totalCount
+        pageInfo {
+            hasNextPage
+            endCursor
+        }
+        nodes {
+            ...BatchChangesCodeHostFields
+        }
+    }
+
+    fragment BatchChangesCodeHostFields on BatchChangesCodeHost {
+        externalServiceKind
+        externalServiceURL
+        requiresSSH
+        credential {
+            ...BatchChangesCredentialFields
+        }
+    }
+
+    ${batchChangesCredentialFieldsFragment}
+`
+
 export const queryUserBatchChangesCodeHosts = ({
     user,
     first,
@@ -87,27 +113,7 @@ export const queryUserBatchChangesCodeHosts = ({
                 }
             }
 
-            fragment BatchChangesCodeHostsFields on BatchChangesCodeHostConnection {
-                totalCount
-                pageInfo {
-                    hasNextPage
-                    endCursor
-                }
-                nodes {
-                    ...BatchChangesCodeHostFields
-                }
-            }
-
-            fragment BatchChangesCodeHostFields on BatchChangesCodeHost {
-                externalServiceKind
-                externalServiceURL
-                requiresSSH
-                credential {
-                    ...BatchChangesCredentialFields
-                }
-            }
-
-            ${batchChangesCredentialFieldsFragment}
+            ${batchChangesCodeHostsFieldsFragment}
         `,
         {
             user,
@@ -125,4 +131,27 @@ export const queryUserBatchChangesCodeHosts = ({
             }
             return data.node.batchChangesCodeHosts
         })
+    )
+
+export const queryGlobalBatchChangesCodeHosts = ({
+    first,
+    after,
+}: GlobalBatchChangesCodeHostsVariables): Observable<BatchChangesCodeHostsFields> =>
+    requestGraphQL<GlobalBatchChangesCodeHostsResult, GlobalBatchChangesCodeHostsVariables>(
+        gql`
+            query GlobalBatchChangesCodeHosts($first: Int, $after: String) {
+                batchChangesCodeHosts(first: $first, after: $after) {
+                    ...BatchChangesCodeHostsFields
+                }
+            }
+
+            ${batchChangesCodeHostsFieldsFragment}
+        `,
+        {
+            first,
+            after,
+        }
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(data => data.batchChangesCodeHosts)
     )

--- a/client/web/src/enterprise/site-admin/routes.ts
+++ b/client/web/src/enterprise/site-admin/routes.ts
@@ -71,6 +71,16 @@ export const enterpriseSiteAdminAreaRoutes: readonly SiteAdminAreaRoute[] = [
         exact: true,
     },
 
+    {
+        path: '/batch-changes',
+        exact: true,
+        render: lazyComponent(
+            () => import('../batches/settings/BatchChangesSiteConfigSettingsArea'),
+            'BatchChangesSiteConfigSettingsArea'
+        ),
+        condition: ({ isSourcegraphDotCom }) => !isSourcegraphDotCom && window.context.batchChangesEnabled,
+    },
+
     // Code intelligence upload routes
     {
         path: '/code-intelligence/uploads',

--- a/client/web/src/enterprise/site-admin/sidebaritems.ts
+++ b/client/web/src/enterprise/site-admin/sidebaritems.ts
@@ -11,6 +11,7 @@ import {
     repositoriesGroup,
     usersGroup,
 } from '../../site-admin/sidebaritems'
+import { BatchChangesIcon } from '../../batches/icons'
 
 const configurationGroup: SiteAdminSideBarGroup = {
     ...ossConfigurationGroup,
@@ -32,6 +33,19 @@ const extensionsGroup: SiteAdminSideBarGroup = {
         {
             label: 'Extensions',
             to: '/site-admin/registry/extensions',
+        },
+    ],
+}
+
+export const batchChangesGroup: SiteAdminSideBarGroup = {
+    header: {
+        label: 'Batch Changes',
+        icon: BatchChangesIcon,
+    },
+    items: [
+        {
+            label: 'Batch Changes',
+            to: '/site-admin/batch-changes',
         },
     ],
 }
@@ -81,6 +95,7 @@ export const enterpriseSiteAdminSidebarGroups: SiteAdminSideBarGroups = [
     usersGroup,
     maintenanceGroup,
     extensionsGroup,
+    batchChangesGroup,
     businessGroup,
     apiConsoleGroup,
 ]

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -765,7 +765,7 @@ describe('Batches', () => {
                                     credential: isCreated
                                         ? {
                                               id: '123',
-                                              createdAt: new Date().toISOString(),
+                                              isSiteCredential: false,
                                               sshPublicKey: 'ssh-rsa randorandorandorando',
                                           }
                                         : null,
@@ -780,7 +780,7 @@ describe('Batches', () => {
                     return {
                         createBatchChangesCredential: {
                             id: '123',
-                            createdAt: new Date().toISOString(),
+                            isSiteCredential: false,
                             sshPublicKey: 'ssh-rsa randorandorandorando',
                         },
                     }


### PR DESCRIPTION
This adds a new section to the site-admin menu which allows to configure site-wide credentials for use when syncing and reconciling changesets.