### PR TITLE
Use site credentials in reconciler and changeset syncer

### DIFF
--- a/enterprise/internal/batches/background.go
+++ b/enterprise/internal/batches/background.go
@@ -28,9 +28,6 @@ func InitBackgroundJobs(
 } {
 	cstore := store.New(db)
 
-	repoStore := cstore.Repos()
-	esStore := cstore.ExternalServices()
-
 	// We use an internal actor so that we can freely load dependencies from
 	// the database without repository permissions being enforced.
 	// We do check for repository permissions conciously in the Rewirer when
@@ -38,7 +35,7 @@ func InitBackgroundJobs(
 	// host, we manually check for BatchChangesCredentials.
 	ctx = actor.WithInternalActor(ctx)
 
-	syncRegistry := syncer.NewSyncRegistry(ctx, cstore, repoStore, esStore, cf)
+	syncRegistry := syncer.NewSyncRegistry(ctx, cstore, cf)
 
 	go goroutine.MonitorBackgroundRoutines(ctx, background.Routines(ctx, cstore, cf)...)
 

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -233,6 +233,8 @@ func loadAuthenticator(ctx context.Context, s *store.Store, ch *batches.Changese
 			// then we can use the nil return from loadUserCredential() to fall
 			// back to the global credentials used for the code host. If
 			// not, then we need to error out.
+			// Once we tackle https://github.com/sourcegraph/sourcegraph/issues/16814,
+			// this code path should be removed.
 			user, err := database.UsersWith(s).GetByID(ctx, batchChange.LastApplierID)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to load user applying the batch change")

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -630,7 +630,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 	}
 }
 
-func TestExecutor_LoadAuthenticator(t *testing.T) {
+func TestLoadAuthenticator(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
 	db := dbtesting.GetDB(t)
 
@@ -647,11 +647,9 @@ func TestExecutor_LoadAuthenticator(t *testing.T) {
 	userBatchChange := ct.CreateBatchChange(t, ctx, cstore, "reconciler-test-batch-change", user.ID, batchSpec.ID)
 
 	t.Run("imported changeset uses global token", func(t *testing.T) {
-		a, err := (&executor{
-			ch: &batches.Changeset{
-				OwnedByBatchChangeID: 0,
-			},
-		}).loadAuthenticator(ctx)
+		a, err := loadAuthenticator(ctx, cstore, &batches.Changeset{
+			OwnedByBatchChangeID: 0,
+		}, repo)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -661,25 +659,18 @@ func TestExecutor_LoadAuthenticator(t *testing.T) {
 	})
 
 	t.Run("owned by missing batch change", func(t *testing.T) {
-		_, err := (&executor{
-			ch: &batches.Changeset{
-				OwnedByBatchChangeID: 1234,
-			},
-			tx: cstore,
-		}).loadAuthenticator(ctx)
+		_, err := loadAuthenticator(ctx, cstore, &batches.Changeset{
+			OwnedByBatchChangeID: 1234,
+		}, repo)
 		if err == nil {
 			t.Error("unexpected nil error")
 		}
 	})
 
 	t.Run("owned by admin user without credential", func(t *testing.T) {
-		a, err := (&executor{
-			ch: &batches.Changeset{
-				OwnedByBatchChangeID: adminBatchChange.ID,
-			},
-			repo: repo,
-			tx:   cstore,
-		}).loadAuthenticator(ctx)
+		a, err := loadAuthenticator(ctx, cstore, &batches.Changeset{
+			OwnedByBatchChangeID: adminBatchChange.ID,
+		}, repo)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -689,13 +680,9 @@ func TestExecutor_LoadAuthenticator(t *testing.T) {
 	})
 
 	t.Run("owned by normal user without credential", func(t *testing.T) {
-		_, err := (&executor{
-			ch: &batches.Changeset{
-				OwnedByBatchChangeID: userBatchChange.ID,
-			},
-			repo: repo,
-			tx:   cstore,
-		}).loadAuthenticator(ctx)
+		_, err := loadAuthenticator(ctx, cstore, &batches.Changeset{
+			OwnedByBatchChangeID: userBatchChange.ID,
+		}, repo)
 		if err == nil {
 			t.Error("unexpected nil error")
 		}
@@ -712,13 +699,9 @@ func TestExecutor_LoadAuthenticator(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		a, err := (&executor{
-			ch: &batches.Changeset{
-				OwnedByBatchChangeID: adminBatchChange.ID,
-			},
-			repo: repo,
-			tx:   cstore,
-		}).loadAuthenticator(ctx)
+		a, err := loadAuthenticator(ctx, cstore, &batches.Changeset{
+			OwnedByBatchChangeID: adminBatchChange.ID,
+		}, repo)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}
@@ -738,13 +721,9 @@ func TestExecutor_LoadAuthenticator(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		a, err := (&executor{
-			ch: &batches.Changeset{
-				OwnedByBatchChangeID: userBatchChange.ID,
-			},
-			repo: repo,
-			tx:   cstore,
-		}).loadAuthenticator(ctx)
+		a, err := loadAuthenticator(ctx, cstore, &batches.Changeset{
+			OwnedByBatchChangeID: userBatchChange.ID,
+		}, repo)
 		if err != nil {
 			t.Errorf("unexpected non-nil error: %v", err)
 		}

--- a/enterprise/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/internal/batches/resolvers/batch_spec.go
@@ -295,16 +295,6 @@ func (r *batchSpecResolver) ViewerBatchChangesCodeHosts(ctx context.Context, arg
 		return nil, backend.ErrNotAuthenticated
 	}
 
-	// Short path for site-admins when OnlyWithoutCredential is true: It will always be an empty list.
-	if args.OnlyWithoutCredential {
-		if authErr := backend.CheckCurrentUserIsSiteAdmin(ctx); authErr == nil {
-			// For site-admins never return anything
-			return &emptyBatchChangesCodeHostConnectionResolver{}, nil
-		} else if authErr != nil && authErr != backend.ErrMustBeSiteAdmin {
-			return nil, authErr
-		}
-	}
-
 	specs, _, err := r.store.ListChangesetSpecs(ctx, store.ListChangesetSpecsOpts{BatchSpecID: r.batchSpec.ID})
 	if err != nil {
 		return nil, err

--- a/enterprise/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/internal/batches/resolvers/batch_spec_test.go
@@ -217,10 +217,6 @@ func TestBatchSpecResolver(t *testing.T) {
 
 		// Expect creator to not be returned anymore.
 		want.Creator = nil
-		// Expect all set for admin user.
-		want.OnlyWithoutCredential = apitest.BatchChangesCodeHostsConnection{
-			Nodes: []apitest.BatchChangesCodeHost{},
-		}
 		// Expect no superseding batch spec, since this request is run as a
 		// different user.
 		want.SupersedingBatchSpec = nil
@@ -241,10 +237,6 @@ func TestBatchSpecResolver(t *testing.T) {
 
 		// Expect creator to not be returned anymore.
 		want.Creator = nil
-		// Expect all set for admin user.
-		want.OnlyWithoutCredential = apitest.BatchChangesCodeHostsConnection{
-			Nodes: []apitest.BatchChangesCodeHost{},
-		}
 
 		if diff := cmp.Diff(want, response.Node); diff != "" {
 			t.Fatalf("unexpected response (-want +got):\n%s", diff)

--- a/enterprise/internal/batches/resolvers/code_host_connection.go
+++ b/enterprise/internal/batches/resolvers/code_host_connection.go
@@ -155,19 +155,3 @@ type idType struct {
 	externalServiceID   string
 	externalServiceType string
 }
-
-type emptyBatchChangesCodeHostConnectionResolver struct{}
-
-var _ graphqlbackend.BatchChangesCodeHostConnectionResolver = &emptyBatchChangesCodeHostConnectionResolver{}
-
-func (c *emptyBatchChangesCodeHostConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
-	return int32(0), nil
-}
-
-func (c *emptyBatchChangesCodeHostConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
-	return graphqlutil.HasNextPage(false), nil
-}
-
-func (c emptyBatchChangesCodeHostConnectionResolver) Nodes(ctx context.Context) ([]graphqlbackend.BatchChangesCodeHostResolver, error) {
-	return []graphqlbackend.BatchChangesCodeHostResolver{}, nil
-}

--- a/enterprise/internal/batches/syncer/main_test.go
+++ b/enterprise/internal/batches/syncer/main_test.go
@@ -1,7 +1,0 @@
-package syncer
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "batchchangesssyncerdb"
-}

--- a/enterprise/internal/batches/syncer/queue_test.go
+++ b/enterprise/internal/batches/syncer/queue_test.go
@@ -1,0 +1,99 @@
+package syncer
+
+import (
+	"container/heap"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestChangesetPriorityQueue(t *testing.T) {
+	t.Parallel()
+
+	assertOrder := func(t *testing.T, q *changesetPriorityQueue, expected []int64) {
+		t.Helper()
+		ids := make([]int64, len(q.items))
+		for i := range ids {
+			ids[i] = q.items[i].changesetID
+		}
+		if diff := cmp.Diff(expected, ids); diff != "" {
+			t.Fatal(diff)
+		}
+	}
+
+	now := time.Now()
+	q := newChangesetPriorityQueue()
+
+	items := []scheduledSync{
+		{
+			changesetID: 1,
+			nextSync:    now,
+			priority:    priorityNormal,
+		},
+		{
+			changesetID: 2,
+			nextSync:    now,
+			priority:    priorityHigh,
+		},
+		{
+			changesetID: 3,
+			nextSync:    now.Add(-1 * time.Minute),
+			priority:    priorityNormal,
+		},
+		{
+			changesetID: 4,
+			nextSync:    now.Add(-2 * time.Hour),
+			priority:    priorityNormal,
+		},
+		{
+			changesetID: 5,
+			nextSync:    now.Add(1 * time.Hour),
+			priority:    priorityNormal,
+		},
+	}
+
+	for i := range items {
+		q.Upsert(items[i])
+	}
+
+	assertOrder(t, q, []int64{2, 4, 3, 1, 5})
+
+	// Set item to high priority
+	q.Upsert(scheduledSync{
+		changesetID: 4,
+		nextSync:    now.Add(-2 * time.Hour),
+		priority:    priorityHigh,
+	})
+
+	assertOrder(t, q, []int64{4, 2, 3, 1, 5})
+
+	// Can't reduce priority of existing item
+	q.Upsert(scheduledSync{
+		changesetID: 4,
+		nextSync:    now.Add(-2 * time.Hour),
+		priority:    priorityNormal,
+	})
+
+	if q.Len() != len(items) {
+		t.Fatalf("Expected %d, got %d", q.Len(), len(items))
+	}
+
+	assertOrder(t, q, []int64{4, 2, 3, 1, 5})
+
+	for i := 0; i < len(items); i++ {
+		peeked, ok := q.Peek()
+		if !ok {
+			t.Fatalf("Queue should not be empty")
+		}
+		item := heap.Pop(q).(scheduledSync)
+		if peeked.changesetID != item.changesetID {
+			t.Fatalf("Peeked and Popped item should have the same id")
+		}
+	}
+
+	// Len() should be zero after all items popped
+	if q.Len() != 0 {
+		t.Fatalf("Expected %d, got %d", q.Len(), 0)
+	}
+}

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -24,11 +24,9 @@ import (
 
 // SyncRegistry manages a changesetSyncer per code host
 type SyncRegistry struct {
-	ctx                  context.Context
-	syncStore            SyncStore
-	repoStore            RepoStore
-	externalServiceStore ExternalServiceStore
-	httpFactory          *httpcli.Factory
+	ctx         context.Context
+	syncStore   SyncStore
+	httpFactory *httpcli.Factory
 
 	// Used to receive high priority sync requests
 	priorityNotify chan []int64
@@ -38,25 +36,28 @@ type SyncRegistry struct {
 	syncers map[string]*changesetSyncer
 }
 
-type RepoStore interface {
-	Get(ctx context.Context, id api.RepoID) (*types.Repo, error)
-}
-
-type ExternalServiceStore interface {
-	List(context.Context, database.ExternalServicesListOptions) ([]*types.ExternalService, error)
+type SyncStore interface {
+	ListCodeHosts(ctx context.Context, opts store.ListCodeHostsOpts) ([]*batches.CodeHost, error)
+	ListChangesetSyncData(context.Context, store.ListChangesetSyncDataOpts) ([]*batches.ChangesetSyncData, error)
+	GetChangeset(context.Context, store.GetChangesetOpts) (*batches.Changeset, error)
+	UpdateChangeset(ctx context.Context, cs *batches.Changeset) error
+	UpsertChangesetEvents(ctx context.Context, cs ...*batches.ChangesetEvent) error
+	GetSiteCredential(ctx context.Context, opts store.GetSiteCredentialOpts) (*store.SiteCredential, error)
+	Transact(context.Context) (*store.Store, error)
+	Repos() *database.RepoStore
+	ExternalServices() *database.ExternalServiceStore
+	Clock() func() time.Time
 }
 
 // NewSyncRegistry creates a new sync registry which starts a syncer for each code host and will update them
 // when external services are changed, added or removed.
-func NewSyncRegistry(ctx context.Context, cstore SyncStore, repoStore RepoStore, esStore ExternalServiceStore, cf *httpcli.Factory) *SyncRegistry {
+func NewSyncRegistry(ctx context.Context, cstore SyncStore, cf *httpcli.Factory) *SyncRegistry {
 	r := &SyncRegistry{
-		ctx:                  ctx,
-		syncStore:            cstore,
-		repoStore:            repoStore,
-		externalServiceStore: esStore,
-		httpFactory:          cf,
-		priorityNotify:       make(chan []int64, 500),
-		syncers:              make(map[string]*changesetSyncer),
+		ctx:            ctx,
+		syncStore:      cstore,
+		httpFactory:    cf,
+		priorityNotify: make(chan []int64, 500),
+		syncers:        make(map[string]*changesetSyncer),
 	}
 
 	if err := r.syncCodeHosts(ctx); err != nil {
@@ -91,13 +92,11 @@ func (s *SyncRegistry) Add(codeHost *batches.CodeHost) {
 	ctx, cancel := context.WithCancel(s.ctx)
 
 	syncer := &changesetSyncer{
-		syncStore:            s.syncStore,
-		httpFactory:          s.httpFactory,
-		reposStore:           s.repoStore,
-		externalServiceStore: s.externalServiceStore,
-		codeHostURL:          syncerKey,
-		cancel:               cancel,
-		priorityNotify:       make(chan []int64, 500),
+		syncStore:      s.syncStore,
+		httpFactory:    s.httpFactory,
+		codeHostURL:    syncerKey,
+		cancel:         cancel,
+		priorityNotify: make(chan []int64, 500),
 	}
 
 	s.syncers[syncerKey] = syncer
@@ -208,10 +207,8 @@ func (s *SyncRegistry) syncCodeHosts(ctx context.Context) error {
 // A changesetSyncer periodically syncs metadata of changesets
 // saved in the database.
 type changesetSyncer struct {
-	syncStore            SyncStore
-	httpFactory          *httpcli.Factory
-	reposStore           RepoStore
-	externalServiceStore ExternalServiceStore
+	syncStore   SyncStore
+	httpFactory *httpcli.Factory
 
 	codeHostURL string
 
@@ -265,17 +262,6 @@ func init() {
 		Name: "src_repoupdater_changeset_syncer_behind_schedule",
 		Help: "The number of changesets behind schedule",
 	}, []string{"codehost"})
-}
-
-type SyncStore interface {
-	ListCodeHosts(ctx context.Context, opts store.ListCodeHostsOpts) ([]*batches.CodeHost, error)
-	ListChangesetSyncData(context.Context, store.ListChangesetSyncDataOpts) ([]*batches.ChangesetSyncData, error)
-	GetChangeset(context.Context, store.GetChangesetOpts) (*batches.Changeset, error)
-	UpdateChangeset(ctx context.Context, cs *batches.Changeset) error
-	UpsertChangesetEvents(ctx context.Context, cs ...*batches.ChangesetEvent) error
-	Transact(context.Context) (*store.Store, error)
-	Repos() *database.RepoStore
-	Clock() func() time.Time
 }
 
 // Run will start the process of changeset syncing. It is long running
@@ -425,18 +411,12 @@ func (s *changesetSyncer) SyncChangeset(ctx context.Context, id int64) error {
 		return err
 	}
 
-	repo, err := s.reposStore.Get(ctx, cs.RepoID)
+	repo, err := s.syncStore.Repos().Get(ctx, cs.RepoID)
 	if err != nil {
 		return err
 	}
 
-	externalService, err := loadExternalService(ctx, s.externalServiceStore, repo)
-	if err != nil {
-		return err
-	}
-
-	sourcer := repos.NewSourcer(s.httpFactory)
-	source, err := buildChangesetSource(sourcer, externalService)
+	source, err := loadChangesetSource(ctx, repos.NewSourcer(s.httpFactory), s.syncStore, repo)
 	if err != nil {
 		return err
 	}
@@ -485,23 +465,52 @@ func SyncChangeset(ctx context.Context, syncStore SyncStore, source repos.Change
 	return tx.UpsertChangesetEvents(ctx, events...)
 }
 
-// buildChangesetSource returns a ChangesetSource for the given external service.
-func buildChangesetSource(
-	sourcer repos.Sourcer,
-	extSvc *types.ExternalService,
-) (repos.ChangesetSource, error) {
-	sources, err := sourcer(extSvc)
+// loadChangesetSource get an authenticated ChangesetSource for the given repo
+// to load the changeset state from.
+func loadChangesetSource(ctx context.Context, sourcer repos.Sourcer, s SyncStore, r *types.Repo) (repos.ChangesetSource, error) {
+	// First, we need to find an arbitrary external service associated with the repo.
+	// The logic in loadExternalService is a bit more complicated than it needs to be,
+	// because we want to maintain compatibility with the previous behavior of always
+	// syncing with an external service config, when no site-credential is configured.
+	// In 3.28, this is set to disappear, as we will completely disable using external
+	// service tokens for Batch Changes.
+	externalService, err := loadExternalService(ctx, s, r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Then, use the external service to build a ChangesetSource.
+	sources, err := sourcer(externalService)
 	if err != nil {
 		return nil, err
 	}
 	if len(sources) != 1 {
-		return nil, fmt.Errorf("got no Source for external service %q", extSvc.Kind)
+		return nil, fmt.Errorf("got no Source for external service %q", externalService.Kind)
+	}
+	source := sources[0]
+
+	// Try to find a site-credential. If one is configured, use that for syncing the changeset.
+	siteCredential, err := s.GetSiteCredential(ctx, store.GetSiteCredentialOpts{
+		ExternalServiceType: r.ExternalRepo.ServiceType,
+		ExternalServiceID:   r.ExternalRepo.ServiceID,
+	})
+	if err != nil && err != store.ErrNoResults {
+		return nil, err
+	}
+	if siteCredential != nil {
+		userSource, ok := source.(repos.UserSource)
+		if !ok {
+			return nil, fmt.Errorf("cannot create UserSource from external service of kind %q", externalService.Kind)
+		}
+		source, err = userSource.WithAuthenticator(siteCredential.Credential)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	source, ok := sources[0].(repos.ChangesetSource)
+	ccs, ok := source.(repos.ChangesetSource)
 	if !ok {
-		return nil, fmt.Errorf("ChangesetSource cannot be created from external service %q", extSvc.Kind)
+		return nil, fmt.Errorf("cannot create ChangesetSource from external service of kind %q", externalService.Kind)
 	}
-
-	return source, nil
+	return ccs, nil
 }

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -485,7 +485,7 @@ func loadChangesetSource(ctx context.Context, sourcer repos.Sourcer, s SyncStore
 		return nil, err
 	}
 	if len(sources) != 1 {
-		return nil, fmt.Errorf("got no Source for external service %q", externalService.Kind)
+		return nil, fmt.Errorf("got no Source for external service of kind %q", externalService.Kind)
 	}
 	source := sources[0]
 

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/batches"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
 func TestSyncerRun(t *testing.T) {
@@ -251,6 +252,7 @@ type MockSyncStore struct {
 	getChangeset          func(context.Context, store.GetChangesetOpts) (*batches.Changeset, error)
 	updateChangeset       func(context.Context, *batches.Changeset) error
 	upsertChangesetEvents func(context.Context, ...*batches.ChangesetEvent) error
+	getSiteCredential     func(ctx context.Context, opts store.GetSiteCredentialOpts) (*store.SiteCredential, error)
 	transact              func(context.Context) (*store.Store, error)
 }
 
@@ -271,7 +273,7 @@ func (m MockSyncStore) UpsertChangesetEvents(ctx context.Context, cs ...*batches
 }
 
 func (m MockSyncStore) GetSiteCredential(ctx context.Context, opts store.GetSiteCredentialOpts) (*store.SiteCredential, error) {
-	return nil, nil
+	return m.getSiteCredential(ctx, opts)
 }
 
 func (m MockSyncStore) Transact(ctx context.Context) (*store.Store, error) {
@@ -289,7 +291,7 @@ func (m MockSyncStore) ExternalServices() *database.ExternalServiceStore {
 }
 
 func (m MockSyncStore) Clock() func() time.Time {
-	return time.Now
+	return timeutil.Now
 }
 
 func (m MockSyncStore) ListCodeHosts(ctx context.Context, opts store.ListCodeHostsOpts) ([]*batches.CodeHost, error) {

--- a/enterprise/internal/batches/syncer/util.go
+++ b/enterprise/internal/batches/syncer/util.go
@@ -14,8 +14,8 @@ import (
 // loadExternalService looks up all external services that are connected to the given repo.
 // The first external service to have a token configured will be returned then.
 // If no external service matching the above criteria is found, an error is returned.
-func loadExternalService(ctx context.Context, esStore ExternalServiceStore, repo *types.Repo) (*types.ExternalService, error) {
-	es, err := esStore.List(ctx, database.ExternalServicesListOptions{
+func loadExternalService(ctx context.Context, s SyncStore, repo *types.Repo) (*types.ExternalService, error) {
+	es, err := s.ExternalServices().List(ctx, database.ExternalServicesListOptions{
 		// Consider all available external services for this repo.
 		IDs: repo.ExternalServiceIDs(),
 	})


### PR DESCRIPTION
This PR introduces the `site_credentials` table to the mechanisms for determining an authenticator to both the changeset syncer and reconciler.
Also, we now start telling site-admins too when there are no credentials configured for a code host, so they can start finding out about site credentials 😎. The final migration plan and deprecation will come in a separate PR, and this doesn't change any previous behavior, if no site-credentials are configured.