### PR TITLE
search contexts: default to global

### DIFF
--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -255,6 +255,8 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
               undefined
             : undefined
 
+        const selectedSearchContextSpec = localStorage.getItem(LAST_SEARCH_CONTEXT_KEY) || 'global'
+
         this.state = {
             themePreference: readStoredThemePreference(),
             systemIsLightTheme: !this.darkThemeMediaList.matches,
@@ -272,7 +274,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             showOnboardingTour: false,
             showSearchContext: false,
             availableSearchContexts: [],
-            selectedSearchContextSpec: 'global',
+            selectedSearchContextSpec,
             defaultSearchContextSpec: 'global', // global is default for now, user will be able to change this at some point
             hasUserAddedRepositories: false,
             showEnterpriseHomePanels: false,
@@ -347,20 +349,6 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                     const hasUserAddedRepositories = userRepositories !== null && userRepositories.nodes.length > 0
                     this.setState({ hasUserAddedRepositories })
                 })
-        )
-
-        this.subscriptions.add(
-            authenticatedUser.subscribe(authenticatedUser => {
-                if (authenticatedUser === null) {
-                    return
-                }
-                const previousSearchContextSpec = localStorage.getItem(LAST_SEARCH_CONTEXT_KEY)
-                const context = `@${authenticatedUser.username}`
-                this.setState({
-                    defaultSearchContextSpec: context,
-                    selectedSearchContextSpec: previousSearchContextSpec || context,
-                })
-            })
         )
 
         /**

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -575,6 +575,10 @@ describe('Search', () => {
             testContext.overrideGraphQL(testContextForSearchContexts)
         })
 
+        afterEach(async () => {
+            await driver.page.evaluate(() => localStorage.clear())
+        })
+
         const getSelectedSearchContextSpec = () =>
             driver.page.evaluate(() => document.querySelector('.test-selected-search-context-spec')?.textContent)
 
@@ -593,10 +597,10 @@ describe('Search', () => {
             expect(await getSelectedSearchContextSpec()).toStrictEqual('context:@test')
         })
 
-        test('Missing context param should default to users context', async () => {
+        test('Missing context param should default to global context', async () => {
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=test&patternType=regexp')
             await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
-            expect(await getSelectedSearchContextSpec()).toStrictEqual('context:@test')
+            expect(await getSelectedSearchContextSpec()).toStrictEqual('context:global')
         })
 
         test('Unavailable search context should remain in the query and disable the search context dropdown', async () => {


### PR DESCRIPTION
Search contexts should default to global if not previously saved in local storage.