### PR TITLE
search: introduce RepoMatch

### DIFF
--- a/cmd/frontend/graphqlbackend/git_blob.go
+++ b/cmd/frontend/graphqlbackend/git_blob.go
@@ -12,7 +12,7 @@ func (r *GitTreeEntryResolver) Blame(ctx context.Context,
 		StartLine int32
 		EndLine   int32
 	}) ([]*hunkResolver, error) {
-	hunks, err := git.BlameFile(ctx, r.commit.repoResolver.name, r.Path(), &git.BlameOptions{
+	hunks, err := git.BlameFile(ctx, r.commit.repoResolver.RepoName(), r.Path(), &git.BlameOptions{
 		NewestCommit: api.CommitID(r.commit.OID()),
 		StartLine:    int(args.StartLine),
 		EndLine:      int(args.EndLine),

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -58,7 +58,7 @@ func toGitCommitResolver(repo *RepositoryResolver, db dbutil.DB, id api.CommitID
 		db:              db,
 		repoResolver:    repo,
 		includeUserInfo: true,
-		gitRepo:         repo.name,
+		gitRepo:         repo.RepoName(),
 		oid:             GitObjectID(id),
 		commit:          commit,
 	}

--- a/cmd/frontend/graphqlbackend/git_commits.go
+++ b/cmd/frontend/graphqlbackend/git_commits.go
@@ -50,7 +50,7 @@ func (r *gitCommitConnectionResolver) compute(ctx context.Context) ([]*git.Commi
 		if r.after != nil {
 			after = *r.after
 		}
-		return git.Commits(ctx, r.repo.name, git.CommitsOptions{
+		return git.Commits(ctx, r.repo.RepoName(), git.CommitsOptions{
 			Range:        r.revisionRange,
 			N:            uint(n),
 			MessageQuery: query,

--- a/cmd/frontend/graphqlbackend/git_object.go
+++ b/cmd/frontend/graphqlbackend/git_object.go
@@ -76,7 +76,7 @@ type gitObjectResolver struct {
 
 func (o *gitObjectResolver) resolve(ctx context.Context) (GitObjectID, gitObjectType, error) {
 	o.once.Do(func() {
-		oid, objectType, err := git.GetObject(ctx, o.repo.name, o.revspec)
+		oid, objectType, err := git.GetObject(ctx, o.repo.RepoName(), o.revspec)
 		if err != nil {
 			o.err = err
 			return

--- a/cmd/frontend/graphqlbackend/git_revision.go
+++ b/cmd/frontend/graphqlbackend/git_revision.go
@@ -16,7 +16,7 @@ type gitRevSpecExpr struct {
 func (r *gitRevSpecExpr) Expr() string { return r.expr }
 
 func (r *gitRevSpecExpr) Object(ctx context.Context) (*gitObject, error) {
-	oid, err := git.ResolveRevision(ctx, r.repo.name, r.expr, git.ResolveRevisionOptions{})
+	oid, err := git.ResolveRevision(ctx, r.repo.RepoName(), r.expr, git.ResolveRevisionOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/git_tree.go
+++ b/cmd/frontend/graphqlbackend/git_tree.go
@@ -40,7 +40,7 @@ func (r *GitTreeEntryResolver) Files(ctx context.Context, args *gitTreeEntryConn
 func (r *GitTreeEntryResolver) entries(ctx context.Context, args *gitTreeEntryConnectionArgs, filter func(fi os.FileInfo) bool) ([]*GitTreeEntryResolver, error) {
 	entries, err := git.ReadDir(
 		ctx,
-		r.commit.repoResolver.name,
+		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),
 		r.Path(),
 		r.isRecursive || args.Recursive,

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -75,7 +75,7 @@ func (r *GitTreeEntryResolver) Content(ctx context.Context) (string, error) {
 
 		r.content, r.contentErr = git.ReadFile(
 			ctx,
-			r.commit.repoResolver.name,
+			r.commit.repoResolver.RepoName(),
 			api.CommitID(r.commit.OID()),
 			r.Path(),
 			0,
@@ -213,7 +213,7 @@ func (r *GitTreeEntryResolver) IsSingleChild(ctx context.Context, args *gitTreeE
 	}
 	entries, err := git.ReadDir(
 		ctx,
-		r.commit.repoResolver.name,
+		r.commit.repoResolver.RepoName(),
 		api.CommitID(r.commit.OID()),
 		path.Dir(r.Path()),
 		false,

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -300,7 +300,7 @@ func (r *schemaResolver) SetRepositoryEnabled(ctx context.Context, args *struct 
 
 	// Trigger update when enabling.
 	if args.Enabled {
-		if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.name); err != nil {
+		if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.RepoName()); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -34,14 +35,13 @@ type RepositoryResolver struct {
 	hydration sync.Once
 	err       error
 
-	// Invariant: name and id are always set and safe to use.
-	// They are used to hydrate the inner repo, and should always
-	// be the same as the name and id of the inner repo, but referring
-	// to the inner repo directly is unsafe because it may cause a race
-	// during hydration.
-	name api.RepoName
-	id   api.RepoID
-	db   dbutil.DB
+	// Invariant: Name and ID of RepoMatch are always set and safe to use. They are
+	// used to hydrate the inner repo, and should always be the same as the name and
+	// id of the inner repo, but referring to the inner repo directly is unsafe
+	// because it may cause a race during hydration.
+	result.RepoMatch
+
+	db dbutil.DB
 
 	// innerRepo may only contain ID and Name information.
 	// To access any other repo information, use repo() instead.
@@ -51,9 +51,6 @@ type RepositoryResolver struct {
 	defaultBranchOnce sync.Once
 	defaultBranch     *GitRefResolver
 	defaultBranchErr  error
-
-	// rev optionally specifies a revision to go to for search results.
-	rev string
 }
 
 func NewRepositoryResolver(db dbutil.DB, repo *types.Repo) *RepositoryResolver {
@@ -68,8 +65,10 @@ func NewRepositoryResolver(db dbutil.DB, repo *types.Repo) *RepositoryResolver {
 	return &RepositoryResolver{
 		db:        db,
 		innerRepo: repo,
-		name:      name,
-		id:        id,
+		RepoMatch: result.RepoMatch{
+			Name: name,
+			ID:   id,
+		},
 	}
 }
 
@@ -98,7 +97,7 @@ func (r *RepositoryResolver) ID() graphql.ID {
 }
 
 func (r *RepositoryResolver) IDInt32() api.RepoID {
-	return r.id
+	return r.RepoMatch.ID
 }
 
 func MarshalRepositoryID(repo api.RepoID) graphql.ID { return relay.MarshalID("Repository", repo) }
@@ -122,8 +121,12 @@ func (r *RepositoryResolver) repo(ctx context.Context) (*types.Repo, error) {
 	return r.innerRepo, err
 }
 
+func (r *RepositoryResolver) RepoName() api.RepoName {
+	return r.RepoMatch.Name
+}
+
 func (r *RepositoryResolver) Name() string {
-	return string(r.name)
+	return string(r.RepoMatch.Name)
 }
 
 func (r *RepositoryResolver) ExternalRepo(ctx context.Context) (*api.ExternalRepoSpec, error) {
@@ -204,12 +207,12 @@ func (r *RepositoryResolver) CommitFromID(ctx context.Context, args *RepositoryC
 
 func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver, error) {
 	do := func() (*GitRefResolver, error) {
-		refBytes, _, exitCode, err := git.ExecSafe(ctx, r.name, []string{"symbolic-ref", "HEAD"})
+		refBytes, _, exitCode, err := git.ExecSafe(ctx, r.RepoName(), []string{"symbolic-ref", "HEAD"})
 		refName := string(bytes.TrimSpace(refBytes))
 
 		if err == nil && exitCode == 0 {
 			// Check that our repo is not empty
-			_, err = git.ResolveRevision(ctx, r.name, "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
+			_, err = git.ResolveRevision(ctx, r.RepoName(), "HEAD", git.ResolveRevisionOptions{NoEnsureRevision: true})
 		}
 
 		// If we fail to get the default branch due to cloning or being empty, we return nothing.
@@ -270,8 +273,8 @@ func (r *RepositoryResolver) UpdatedAt() *DateTime {
 
 func (r *RepositoryResolver) URL() string {
 	url := "/" + escapePathForURL(r.Name())
-	if r.rev != "" {
-		url += "@" + escapePathForURL(r.rev)
+	if r.Rev() != "" {
+		url += "@" + escapePathForURL(r.Rev())
 	}
 	return url
 }
@@ -289,13 +292,13 @@ func (r *RepositoryResolver) Icon() string {
 }
 
 func (r *RepositoryResolver) Rev() string {
-	return r.rev
+	return r.RepoMatch.Rev
 }
 
 func (r *RepositoryResolver) Label() (Markdown, error) {
 	var label string
-	if r.rev != "" {
-		label = r.Name() + "@" + r.rev
+	if r.Rev() != "" {
+		label = r.Name() + "@" + r.Rev()
 	} else {
 		label = r.Name()
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -324,11 +324,6 @@ func (r *RepositoryResolver) ResultCount() int32 {
 	return 1
 }
 
-func (r *RepositoryResolver) Limit(limit int) int {
-	// Always represents one result and limit > 0 so we just return limit - 1.
-	return limit - 1
-}
-
 func (r *RepositoryResolver) Type(ctx context.Context) (*types.Repo, error) {
 	return r.repo(ctx)
 }

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -90,14 +90,14 @@ func NewRepositoryComparison(ctx context.Context, db dbutil.DB, r *RepositoryRes
 		return toGitCommitResolver(r, db, commitID, nil), nil
 	}
 
-	head, err := getCommit(ctx, r.name, headRevspec)
+	head, err := getCommit(ctx, r.RepoName(), headRevspec)
 	if err != nil {
 		return nil, err
 	}
 
 	// Find the common merge-base for the diff. That's the revision the diff applies to,
 	// not the baseRevspec.
-	mergeBaseCommit, err := git.MergeBase(ctx, r.name, api.CommitID(baseRevspec), api.CommitID(headRevspec))
+	mergeBaseCommit, err := git.MergeBase(ctx, r.RepoName(), api.CommitID(baseRevspec), api.CommitID(headRevspec))
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func NewRepositoryComparison(ctx context.Context, db dbutil.DB, r *RepositoryRes
 	// We use the merge-base as the base commit here, as the diff will only be guaranteed to be
 	// applicable to the file from that revision.
 	commitString := strings.TrimSpace(string(mergeBaseCommit))
-	base, err := getCommit(ctx, r.name, commitString)
+	base, err := getCommit(ctx, r.RepoName(), commitString)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +221,7 @@ func computeRepositoryComparisonDiff(cmp *RepositoryComparisonResolver) ComputeD
 
 			var iter *git.DiffFileIterator
 			iter, err = git.Diff(ctx, git.DiffOptions{
-				Repo: cmp.repo.name,
+				Repo: cmp.repo.RepoName(),
 				Base: base,
 				Head: string(cmp.head.OID()),
 			})

--- a/cmd/frontend/graphqlbackend/repository_contributors.go
+++ b/cmd/frontend/graphqlbackend/repository_contributors.go
@@ -52,7 +52,7 @@ func (r *repositoryContributorConnectionResolver) compute(ctx context.Context) (
 		if r.args.After != nil {
 			opt.After = *r.args.After
 		}
-		r.results, r.err = git.ShortLog(ctx, r.repo.name, opt)
+		r.results, r.err = git.ShortLog(ctx, r.repo.RepoName(), opt)
 	})
 	return r.results, r.err
 }

--- a/cmd/frontend/graphqlbackend/repository_git_refs.go
+++ b/cmd/frontend/graphqlbackend/repository_git_refs.go
@@ -35,7 +35,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var branches []*git.Branch
 	if args.Type == nil || *args.Type == gitRefTypeBranch {
 		var err error
-		branches, err = git.ListBranches(ctx, r.name, git.BranchesOptions{
+		branches, err = git.ListBranches(ctx, r.RepoName(), git.BranchesOptions{
 			// We intentionally do not ask for commits here since it requires
 			// a separate git call per branch. We only need the git commits to
 			// sort by author/commit date and there are few enough branches to
@@ -63,7 +63,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 		if args.OrderBy != nil && *args.OrderBy == gitRefOrderAuthoredOrCommittedAt {
 			// Sort branches by most recently committed.
 
-			ok, err := hydrateBranchCommits(ctx, r.name, args.Interactive, branches)
+			ok, err := hydrateBranchCommits(ctx, r.RepoName(), args.Interactive, branches)
 			if err != nil {
 				return nil, err
 			}
@@ -102,7 +102,7 @@ func (r *RepositoryResolver) GitRefs(ctx context.Context, args *refsArgs) (*gitR
 	var tags []*git.Tag
 	if args.Type == nil || *args.Type == gitRefTypeTag {
 		var err error
-		tags, err = git.ListTags(ctx, r.name)
+		tags, err = git.ListTags(ctx, r.RepoName())
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/repository_mirror.go
+++ b/cmd/frontend/graphqlbackend/repository_mirror.go
@@ -39,8 +39,8 @@ type repositoryMirrorInfoResolver struct {
 
 func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*protocol.RepoInfo, error) {
 	r.repoInfoOnce.Do(func() {
-		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.name)
-		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.name], err
+		resp, err := gitserver.DefaultClient.RepoInfo(ctx, r.repository.RepoName())
+		r.repoInfoResponse, r.repoInfoErr = resp.Results[r.repository.RepoName()], err
 	})
 	return r.repoInfoResponse, r.repoInfoErr
 }
@@ -48,7 +48,7 @@ func (r *repositoryMirrorInfoResolver) gitserverRepoInfo(ctx context.Context) (*
 func (r *repositoryMirrorInfoResolver) repoUpdateSchedulerInfo(ctx context.Context) (*repoupdaterprotocol.RepoUpdateSchedulerInfoResult, error) {
 	r.repoUpdateSchedulerInfoOnce.Do(func() {
 		args := repoupdaterprotocol.RepoUpdateSchedulerInfoArgs{
-			RepoName: r.repository.name,
+			RepoName: r.repository.RepoName(),
 			ID:       r.repository.IDInt32(),
 		}
 		r.repoUpdateSchedulerInfoResult, r.repoUpdateSchedulerInfoErr = repoupdater.DefaultClient.RepoUpdateSchedulerInfo(ctx, args)
@@ -92,7 +92,7 @@ func (r *repositoryMirrorInfoResolver) RemoteURL(ctx context.Context) (string, e
 	{
 		// Look up the remote URL in repo-updater.
 		result, err := repoupdater.DefaultClient.RepoLookup(ctx, repoupdaterprotocol.RepoLookupArgs{
-			Repo: r.repository.name,
+			Repo: r.repository.RepoName(),
 		})
 		if err != nil {
 			return "", err
@@ -261,7 +261,7 @@ func (r *schemaResolver) UpdateMirrorRepository(ctx context.Context, args *struc
 		return nil, err
 	}
 
-	if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.name); err != nil {
+	if _, err := repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.RepoName()); err != nil {
 		return nil, err
 	}
 	return &EmptyResponse{}, nil

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	result2 "github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -151,8 +152,10 @@ func assertRepoResolverHydrated(ctx context.Context, t *testing.T, r *Repository
 func TestRepositoryLabel(t *testing.T) {
 	test := func(name string) string {
 		r := &RepositoryResolver{
-			name: api.RepoName(name),
-			id:   api.RepoID(0),
+			RepoMatch: result2.RepoMatch{
+				Name: api.RepoName(name),
+				ID:   api.RepoID(0),
+			},
 		}
 		result, _ := r.Label()
 		return result.HTML()

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
-	result2 "github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -152,7 +152,7 @@ func assertRepoResolverHydrated(ctx context.Context, t *testing.T, r *Repository
 func TestRepositoryLabel(t *testing.T) {
 	test := func(name string) string {
 		r := &RepositoryResolver{
-			RepoMatch: result2.RepoMatch{
+			RepoMatch: result.RepoMatch{
 				Name: api.RepoName(name),
 				ID:   api.RepoID(0),
 			},

--- a/cmd/frontend/graphqlbackend/repository_text_search_index.go
+++ b/cmd/frontend/graphqlbackend/repository_text_search_index.go
@@ -122,7 +122,7 @@ func (r *repositoryTextSearchIndexResolver) Refs(ctx context.Context) ([]*reposi
 	refByName := func(name string) *repositoryTextSearchIndexedRef {
 		possibleRefNames := []string{"refs/heads/" + name, "refs/tags/" + name}
 		for _, ref := range possibleRefNames {
-			if _, err := git.ResolveRevision(ctx, r.repo.name, ref, git.ResolveRevisionOptions{NoEnsureRevision: true}); err == nil {
+			if _, err := git.ResolveRevision(ctx, r.repo.RepoName(), ref, git.ResolveRevisionOptions{NoEnsureRevision: true}); err == nil {
 				name = ref
 				break
 			}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -118,7 +118,7 @@ func repoRevsToSearchResultResolver(ctx context.Context, db dbutil.DB, repos []*
 		for _, rev := range revs {
 			rr := NewRepositoryResolver(db, r.Repo.ToRepo())
 			rr.icon = repoIcon
-			rr.rev = rev
+			rr.RepoMatch.Rev = rev
 			results = append(results, rr)
 		}
 	}

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -139,7 +139,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 		goroutine.Go(func() {
 			defer run.Release()
 
-			invCtx, err := backend.InventoryContext(repos[key.repo].name, key.commitID, true)
+			invCtx, err := backend.InventoryContext(repos[key.repo].RepoName(), key.commitID, true)
 			if err != nil {
 				run.Error(err)
 				return

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1390,7 +1390,9 @@ func commitResult(urlKey string) *CommitSearchResultResolver {
 	return &CommitSearchResultResolver{
 		gitCommitResolver: &GitCommitResolver{
 			repoResolver: &RepositoryResolver{
-				name: api.RepoName(urlKey),
+				RepoMatch: result.RepoMatch{
+					Name: api.RepoName(urlKey),
+				},
 			},
 		},
 	}
@@ -1403,7 +1405,9 @@ func diffResult(urlKey string) *CommitSearchResultResolver {
 		},
 		gitCommitResolver: &GitCommitResolver{
 			repoResolver: &RepositoryResolver{
-				name: api.RepoName(urlKey),
+				RepoMatch: result.RepoMatch{
+					Name: api.RepoName(urlKey),
+				},
 			},
 		},
 	}

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -194,7 +194,7 @@ func computeSymbols(ctx context.Context, db dbutil.DB, commit *GitCommitResolver
 	searchArgs := search.SymbolsParameters{
 		CommitID:        api.CommitID(commit.oid),
 		First:           limitOrDefault(first) + 1, // add 1 so we can determine PageInfo.hasNextPage
-		Repo:            commit.repoResolver.name,
+		Repo:            commit.repoResolver.RepoName(),
 		IncludePatterns: includePatternsSlice,
 	}
 	if query != nil {

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -480,9 +481,11 @@ func (r *UserResolver) PublicRepositories(ctx context.Context) ([]*RepositoryRes
 	var out []*RepositoryResolver
 	for _, repo := range repos {
 		out = append(out, &RepositoryResolver{
-			id:   repo.RepoID,
-			name: api.RepoName(repo.RepoURI),
-			db:   r.db,
+			RepoMatch: result.RepoMatch{
+				ID:   repo.RepoID,
+				Name: api.RepoName(repo.RepoURI),
+			},
+			db: r.db,
 			innerRepo: &types.Repo{
 				ID: repo.RepoID,
 			},

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -197,7 +197,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if repo, ok := result.ToRepository(); ok {
 				display = repo.Limit(display)
 
-				matchesAppend(fromRepository(repo))
+				matchesAppend(fromRepository(repo.RepoMatch))
 			}
 			if commit, ok := result.ToCommitSearchResult(); ok {
 				display = commit.Limit(display)
@@ -436,15 +436,15 @@ func fromSymbolMatch(fm *graphqlbackend.FileMatchResolver, symbols []streamhttp.
 	}
 }
 
-func fromRepository(repo *graphqlbackend.RepositoryResolver) *streamhttp.EventRepoMatch {
+func fromRepository(rm result.RepoMatch) *streamhttp.EventRepoMatch {
 	var branches []string
-	if rev := repo.Rev(); rev != "" {
+	if rev := rm.Rev; rev != "" {
 		branches = []string{rev}
 	}
 
 	return &streamhttp.EventRepoMatch{
 		Type:       streamhttp.RepoMatchType,
-		Repository: repo.Name(),
+		Repository: string(rm.Name),
 		Branches:   branches,
 	}
 }

--- a/internal/search/result/repository.go
+++ b/internal/search/result/repository.go
@@ -1,0 +1,11 @@
+package result
+
+import "github.com/sourcegraph/sourcegraph/internal/api"
+
+type RepoMatch struct {
+	Name api.RepoName
+	ID   api.RepoID
+
+	// rev optionally specifies a revision to go to for search results.
+	Rev string
+}

--- a/internal/search/result/repository.go
+++ b/internal/search/result/repository.go
@@ -9,3 +9,8 @@ type RepoMatch struct {
 	// rev optionally specifies a revision to go to for search results.
 	Rev string
 }
+
+func (r RepoMatch) Limit(limit int) int {
+	// Always represents one result and limit > 0 so we just return limit - 1.
+	return limit - 1
+}


### PR DESCRIPTION
This extracts RepoName, ID, and Rev from RepositoryResolver. The goal is
to remove all *resolvers from streaming search at some point.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
