### PR TITLE
search: Run each query independently in search-blitz

### DIFF
--- a/internal/cmd/search-blitz/config.go
+++ b/internal/cmd/search-blitz/config.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type Config struct {
 	Groups []QueryGroupConfig
@@ -14,6 +17,9 @@ type QueryGroupConfig struct {
 type QueryConfig struct {
 	Query string
 	Name  string
+
+	// An unset interval defaults to 1m
+	Interval time.Duration
 
 	// An empty value for Protocols means "all"
 	Protocols []Protocol

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -52,7 +52,10 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	loopSearch := func(ctx context.Context, c genericClient, group string, qc QueryConfig) {
-		ticker := time.NewTicker(300 * time.Second)
+		if qc.Interval == 0 {
+			qc.Interval = time.Minute
+		}
+		ticker := time.NewTicker(qc.Interval)
 		defer ticker.Stop()
 
 		for {
@@ -149,7 +152,7 @@ func main() {
 // SignalSensitiveContext returns a background context that is canceled after receiving an
 // interrupt or terminate signal. A second signal will abort the program. This function returns
 // the context and a function that should be  deferred by the caller to clean up internal channels.
-func SignalSensitiveContext() (context.Context, func()) {
+func SignalSensitiveContext() (ctx context.Context, cleanup func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	signals := make(chan os.Signal, 1)


### PR DESCRIPTION
This change spins up a goroutine per query so that they each execute on
an independent interval. This way, one long-running query won't block
the other queries, and we can get a more consistent interval between
queries. It also gives us the ability to run queries with an independent
interval.

Note that time.Ticker only "stacks" one tick, so a long-running query
won't cause a flood of queries after it completes.

Depends on #19575 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
