### PR TITLE
search: Configurable intervals for search-blitz

### DIFF
--- a/internal/cmd/search-blitz/config.go
+++ b/internal/cmd/search-blitz/config.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type Config struct {
 	Groups []QueryGroupConfig
@@ -14,6 +17,9 @@ type QueryGroupConfig struct {
 type QueryConfig struct {
 	Query string
 	Name  string
+
+	// An unset interval defaults to 1m
+	Interval time.Duration
 
 	// An empty value for Protocols means "all"
 	Protocols []Protocol

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -152,7 +152,7 @@ func main() {
 // SignalSensitiveContext returns a background context that is canceled after receiving an
 // interrupt or terminate signal. A second signal will abort the program. This function returns
 // the context and a function that should be  deferred by the caller to clean up internal channels.
-func SignalSensitiveContext() (context.Context, func()) {
+func SignalSensitiveContext() (ctx context.Context, cleanup func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	signals := make(chan os.Signal, 1)

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -52,7 +52,10 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	loopSearch := func(ctx context.Context, c genericClient, group string, qc QueryConfig) {
-		ticker := time.NewTicker(300 * time.Second)
+		if qc.Interval == 0 {
+			qc.Interval = time.Minute
+		}
+		ticker := time.NewTicker(qc.Interval)
 		defer ticker.Stop()
 
 		for {


### PR DESCRIPTION
This adds an optional `interval:` configuration to each of our query
configs. This allows us to run queries on independent intervals, so for
expensive or long-running queries, we can make them run more
infrequently.

Additionally, it reduces the default interval from 5 minutes to 1 minute 
so we can get better resolution. 

Depends on #19578 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
