### PR TITLE
postgresql upgrade docs

### DIFF
--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -41,7 +41,9 @@ RUN apk update && apk add --no-cache \
     'git>=2.18' \
     git-p4 \
     python2 \
-    'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=14.5.0-r0'
+    'nginx>=1.18.0' openssh-client pcre sqlite-libs su-exec 'nodejs-current=14.5.0-r0' \
+    postgresql=12.6-r0 \
+    postgresql-contrib
 
 # IMPORTANT: If you update the syntect_server version below, you MUST confirm
 # the ENV variables from its Dockerfile (https://github.com/sourcegraph/syntect_server/blob/master/Dockerfile)
@@ -50,15 +52,6 @@ RUN apk update && apk add --no-cache \
 COPY --from=comby/comby:0.18.4@sha256:b47ce282778bfea7f80d45f5ef0cc546ba0d6347baccebaf171a7866143b2593 /usr/local/bin/comby /usr/local/bin/comby
 # hadolint ignore=DL3022
 COPY --from=sourcegraph/syntect_server:331beda@sha256:6b8950b41993af3d10300b5a160fab1c06c337cb4614978f4fdb76e2588afbfe /syntect_server /usr/local/bin/
-
-# install postgres 11
-# hadolint ignore=DL3022,DL3003,DL3018,DL3019,SC2035
-RUN wget https://storage.googleapis.com/apktmp/postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
-    tar -xzf postgres-11-5-for-alpine-3-12-4cc8106a5e.tar.gz && \
-    cd target/main/x86_64/ && \
-    apk add --allow-untrusted *.apk && \
-    cd ../../../ && \
-    rm -rf target/
 
 # install minio (keep this up to date with docker-images/minio/Dockerfile)
 ENV MINIO_VERSION=RELEASE.2020-10-18T21-54-12Z

--- a/dev/db/squash_migrations.sh
+++ b/dev/db/squash_migrations.sh
@@ -66,11 +66,11 @@ fi
 DBNAME='squasher'
 SERVER_VERSION=$(psql --version)
 
-if [ "${SERVER_VERSION}" != 9.6 ]; then
-  echo "running PostgreSQL 9.6 in docker since local version is ${SERVER_VERSION}"
-  docker image inspect postgres:9.6 >/dev/null || docker pull postgres:9.6
+if [ "${SERVER_VERSION}" != 12.6 ]; then
+  echo "running PostgreSQL 12.6 in docker since local version is ${SERVER_VERSION}"
+  docker image inspect postgres:12.6 >/dev/null || docker pull postgres:12.6
   docker rm --force "${DBNAME}" 2>/dev/null || true
-  docker run --rm --name "${DBNAME}" -p 5433:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -d postgres:9.6
+  docker run --rm --name "${DBNAME}" -p 5433:5432 -e POSTGRES_HOST_AUTH_METHOD=trust -d postgres:12.6
 
   function kill() {
     docker kill "${DBNAME}" >/dev/null

--- a/dev/start.sh
+++ b/dev/start.sh
@@ -34,11 +34,11 @@ fi
 
 # Verify postgresql config.
 hash psql 2>/dev/null || {
-  # "brew install postgresql@9.6" does not put psql on the $PATH by default;
+  # "brew install postgres" does not put psql on the $PATH by default;
   # try to fix this automatically if we can.
   hash brew 2>/dev/null && {
-    if [[ -x "$(brew --prefix)/opt/postgresql@9.6/bin/psql" ]]; then
-      PATH="$(brew --prefix)/opt/postgresql@9.6/bin:$PATH"
+    if [[ -x "$(brew --prefix)/opt/postgres/bin/psql" ]]; then
+      PATH="$(brew --prefix)/opt/postgres/bin:$PATH"
       export PATH
     fi
   }

--- a/doc/admin/postgres.md
+++ b/doc/admin/postgres.md
@@ -37,59 +37,23 @@ between major versions.
 
 When running a new version of Sourcegraph, it will check if the PostgreSQL data needs upgrading upon initialization.
 
-There are two ways that the PostgreSQL data can be updated:
+See the following steps to upgrade between major postgresql versions
 
-- On start-up with access to the Docker socket.
-- Running a script that uses the PostgreSQL upgrade container directly.
-
-### Option 1. Upgrading on start-up using the Docker socket
-
-<p class="container">
-  <div style="padding:56.25% 0 0 0;position:relative;">
-    <iframe src="https://player.vimeo.com/video/315980428?color=0CB6F4&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-  </div>
-</p>
-
-**1.** Stop the `sourcegraph/server` container.
-
-**2.** Add the volume mount code to your existing `docker run` command: `-v /var/run/docker.sock:/var/run/docker.sock:ro`.
-
-See a complete example below:
-
-```bash
-# Add "--env=SRC_LOG_LEVEL=dbug" below for verbose logging.
-docker run -p 7080:7080 -p 2633:2633 --rm \
-  -v ~/.sourcegraph/config:/etc/sourcegraph \
-  -v ~/.sourcegraph/data:/var/opt/sourcegraph \
-  -v /var/run/docker.sock:/var/run/docker.sock:ro \
-  sourcegraph/server:3.26.1
-```
-
-**3.** When the upgrade has been completed, stop the Sourcegraph container, then run again using the original `docker run` command (without mounting the Docker socket).
-
-### Option 2. Upgrading with a script that uses the PostgreSQL upgrade container directly
-
-<p class="container">
-  <div style="padding:56.25% 0 0 0;position:relative;">
-    <iframe src="https://player.vimeo.com/video/315980439?color=0CB6F4&title=0&byline=0&portrait=0" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-  </div>
-</p>
-
-You may need to manually upgrade the PostgreSQL data, e.g, if mounting the Docker socket isn't an option.
+### Upgrade the postgresql db using an external postgres upgrade container
 
 **1.** Stop the `sourcegraph/server` container.
 
 **2.** Save this script and give it executable permissions (`chmod + x`).
 
-> NOTE: The script presumes your data is being upgraded from `9.6` to `11` and your Sourcegraph directory is at `~/.sourcegraph/`. Change the values in the code below if that's not the case.
+> NOTE: The script presumes your data is being upgraded from `11` to `12` and your Sourcegraph directory is at `~/.sourcegraph/`. Change the values in the code below if that's not the case.
 
 ```bash
 #!/usr/bin/env bash
 
 set -xeuo pipefail
 
-export OLD=${OLD:-"9.6"}
-export NEW=${NEW:-"11"}
+export OLD=${OLD:-"11"}
+export NEW=${NEW:-"12"}
 export SRC_DIR=${SRC_DIR:-"$HOME/.sourcegraph"}
 
 docker run \
@@ -119,7 +83,7 @@ docker run \
 
 ## Upgrading Kubernetes PostgreSQL instances
 
-The upgrade process is different for [Sourcegraph cluster deployments](https://github.com/sourcegraph/deploy-sourcegraph) because [by default](https://github.com/sourcegraph/deploy-sourcegraph/blob/7edcadbc3ebf46cb1bc1198f8a3e359a2380e22a/base/pgsql/pgsql.Deployment.yaml#L29), it uses `sourcegraph/postgres-11.1:19-02-07_17a4376e` which can be [customized with environment variables](https://github.com/sourcegraph/deploy-sourcegraph/blob/7edcadb/docs/configure.md#configure-custom-postgresql).
+The upgrade process is different for [Sourcegraph cluster deployments](https://github.com/sourcegraph/deploy-sourcegraph) because [by default](https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/postgres-12.6/build.sh#L10), it uses `sourcegraph/postgres-12.6:21-03-26_5d7084279` which can be [customized with environment variables](https://github.com/sourcegraph/deploy-sourcegraph/blob/7edcadb/docs/configure.md#configure-custom-postgresql).
 
 If you have changed `PGUSER`, `PGDATABASE` or `PGDATA`, then the `PG*OLD` and `PG*NEW` environment variables are required. Below are the defaults and documentation on what each variable is used for:
 
@@ -128,8 +92,8 @@ If you have changed `PGUSER`, `PGDATABASE` or `PGDATA`, then the `PG*OLD` and `P
 - `PGUSERNEW=sg`: A user that must exist in the new database after the upgrade is done (i.e. it'll be created if it didn't exist already).
 - `PGDATABASEOLD=sg`: A database that exists in the old database that can be used to authenticate intermediate upgrade operations. (e.g `psql -d`)
 - `PGDATABASENEW=sg`: A database that must exist in the new database after the upgrade is done (i.e. it'll be created if it didn't exist already).
-- `PGDATAOLD=/data/pgdata`: The data directory containing the files of the old PostgreSQL database to be upgraded.
-- `PGDATANEW=/data/pgdata-11`: The data directory containing the upgraded PostgreSQL data files, used by the new version of PostgreSQL.
+- `PGDATAOLD=/data/pgdata-11`: The data directory containing the files of the old PostgreSQL database to be upgraded.
+- `PGDATANEW=/data/pgdata-12`: The data directory containing the upgraded PostgreSQL data files, used by the new version of PostgreSQL.
 
 Additionally the upgrade process assumes it can write to the parent directory of `PGDATAOLD`.
 


### PR DESCRIPTION
remove any reference to old upgrade process, and ensures versions are correct.