### PR TITLE
search: Use mdi-react icons rather than graphql icons

### DIFF
--- a/client/shared/src/components/ResultContainer.tsx
+++ b/client/shared/src/components/ResultContainer.tsx
@@ -64,7 +64,6 @@ export interface Props {
 
     /** Expand all results */
     allExpanded?: boolean
-    stringIcon?: string
 }
 
 interface State {
@@ -97,7 +96,6 @@ export class ResultContainer extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element | null {
         const Icon = this.props.icon
-        const stringIcon = this.props.stringIcon ? this.props.stringIcon : undefined
         return (
             <div className="test-search-result result-container" data-testid="result-container">
                 {/* TODO: Fix accessibility issues.
@@ -109,11 +107,7 @@ export class ResultContainer extends React.PureComponent<Props, State> {
                     }
                     onClick={this.toggle}
                 >
-                    {stringIcon ? (
-                        <img src={stringIcon} className="icon-inline icon-inline__filtered" alt="" />
-                    ) : (
-                        <Icon className="icon-inline" />
-                    )}
+                    <Icon className="icon-inline" />
                     <div
                         className={`result-container__header-title ${this.props.titleClassName || ''}`}
                         data-testid="result-container-header"

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -1,5 +1,4 @@
 import { decode } from 'he'
-import FileIcon from 'mdi-react/FileIcon'
 import React from 'react'
 import { ResultContainer } from '../../../shared/src/components/ResultContainer'
 import * as GQL from '../../../shared/src/graphql/schema'
@@ -12,6 +11,7 @@ import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 interface Props extends ThemeProps {
     result: Omit<GQL.IGenericSearchResultInterface, '__typename'>
     history: H.History
+    icon: React.ComponentType<{ className?: string }>
 }
 
 export class SearchResult extends React.Component<Props> {
@@ -59,8 +59,7 @@ export class SearchResult extends React.Component<Props> {
     public render(): JSX.Element {
         return (
             <ResultContainer
-                stringIcon={this.props.result.icon}
-                icon={FileIcon}
+                icon={this.props.icon}
                 collapsible={this.props.result && this.props.result.matches.length > 0}
                 defaultExpanded={true}
                 title={this.renderTitle()}

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -4,6 +4,8 @@ import { isEqual } from 'lodash'
 import FileIcon from 'mdi-react/FileIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
+import SourceRepositoryMultipleIcon from 'mdi-react/SourceRepositoryMultipleIcon'
+import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 import { Observable, Subject, Subscription } from 'rxjs'
@@ -520,8 +522,25 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                         settingsCascade={this.props.settingsCascade}
                     />
                 )
+            case 'CommitSearchResult':
+                return (
+                    <SearchResult
+                        icon={SourceCommitIcon}
+                        result={result}
+                        isLightTheme={this.props.isLightTheme}
+                        history={this.props.history}
+                    />
+                )
+            case 'Repository':
+                return (
+                    <SearchResult
+                        icon={SourceRepositoryMultipleIcon}
+                        result={result}
+                        isLightTheme={this.props.isLightTheme}
+                        history={this.props.history}
+                    />
+                )
         }
-        return <SearchResult result={result} isLightTheme={this.props.isLightTheme} history={this.props.history} />
     }
 
     private itemKey = (item: GQL.GenericSearchResultInterface | GQL.IFileMatch): string => {

--- a/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
@@ -1,6 +1,8 @@
 import * as H from 'history'
 import FileIcon from 'mdi-react/FileIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
+import SourceRepositoryMultipleIcon from 'mdi-react/SourceRepositoryMultipleIcon'
+import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import React, { useCallback, useEffect, useState } from 'react'
 import { Observable } from 'rxjs'
 import { FetchFileParameters } from '../../../../../shared/src/components/CodeExcerpt'
@@ -62,25 +64,43 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
 
     const renderResult = useCallback(
         (result: GQL.GenericSearchResultInterface | GQL.IFileMatch): JSX.Element => {
-            if (result.__typename === 'FileMatch') {
-                return (
-                    <FileMatch
-                        location={location}
-                        eventLogger={eventLogger}
-                        icon={result.lineMatches && result.lineMatches.length > 0 ? SourceRepositoryIcon : FileIcon}
-                        result={result}
-                        onSelect={logSearchResultClicked}
-                        expanded={false}
-                        showAllMatches={false}
-                        isLightTheme={isLightTheme}
-                        allExpanded={allExpanded}
-                        fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
-                        repoDisplayName={displayRepoName(result.repository.name)}
-                        settingsCascade={settingsCascade}
-                    />
-                )
+            switch (result.__typename) {
+                case 'FileMatch':
+                    return (
+                        <FileMatch
+                            location={location}
+                            eventLogger={eventLogger}
+                            icon={result.lineMatches && result.lineMatches.length > 0 ? SourceRepositoryIcon : FileIcon}
+                            result={result}
+                            onSelect={logSearchResultClicked}
+                            expanded={false}
+                            showAllMatches={false}
+                            isLightTheme={isLightTheme}
+                            allExpanded={allExpanded}
+                            fetchHighlightedFileLineRanges={fetchHighlightedFileLineRanges}
+                            repoDisplayName={displayRepoName(result.repository.name)}
+                            settingsCascade={settingsCascade}
+                        />
+                    )
+                case 'CommitSearchResult':
+                    return (
+                        <SearchResult
+                            icon={SourceCommitIcon}
+                            result={result}
+                            isLightTheme={isLightTheme}
+                            history={history}
+                        />
+                    )
+                case 'Repository':
+                    return (
+                        <SearchResult
+                            icon={SourceRepositoryMultipleIcon}
+                            result={result}
+                            isLightTheme={isLightTheme}
+                            history={history}
+                        />
+                    )
             }
-            return <SearchResult result={result} isLightTheme={isLightTheme} history={history} />
         },
         [
             isLightTheme,


### PR DESCRIPTION
This commit modifies our result rendering code for commit and repository
results to use a static icon rather than an icon transmitted as part of
the result. It uses the same pattern we currently use for FileMatch.

Motivation: Currently, for every commit and repository result, we send
a base64-encoded SVG along with it. Based on some simple measurements,
this makes up over half of our gzipped payload. It appears that with
streaming, it's even worse since I don't see any gzipping happening.

Additionally, it complicates our resolver interfaces to have to deal with icons from
the backend.

This does not remove the icons from the graphQL schema yet, since I
don't know if we can safely do that without breaking backwards
compatibility.

Note that it appears the material design icon for repositories is slightly 
different than the icon currently being sent as part of the request. I don't
know if that means this needs design approval, or whether it's acceptable.

<img width="437" alt="Screen Shot 2021-03-30 at 15 41 50" src="https://user-images.githubusercontent.com/12631702/113060990-9a888380-916e-11eb-9818-915625699efc.png">
<img width="448" alt="Screen Shot 2021-03-30 at 15 41 58" src="https://user-images.githubusercontent.com/12631702/113060993-9b211a00-916e-11eb-81cb-c2e7950956ec.png">


Please take a somewhat careful look since I'm new to the frontend 
codebase and react in general 😃 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
