### PR TITLE
frontend: Reduce steps needed to add repositories

### DIFF
--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -92,7 +92,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         services.length > 0 ? (
             <div className="alert alert-success mb-4" role="alert" key="add-repos">
                 Connected with {services.join(', ')}. Next,{' '}
-                <Link className="text-primary" to={`${routingPrefix}/repositories`}>
+                <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
                     <b>add your repositories →</b>
                 </Link>
             </div>
@@ -220,7 +220,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                 </div>
                 <p className="text-muted">
                     Connect with your code hosts. Then,{' '}
-                    <Link className="text-primary" to={`${routingPrefix}/repositories`}>
+                    <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
                         add repositories
                     </Link>{' '}
                     to search with Sourcegraph.


### PR DESCRIPTION
When first adding a code host the user is presented with linked to "add
repositories". The link now takes them directly to the manage page where
they can add repos instead of to the "code host connections" page where
they would again have to click on the "add repositories" button.
