### PR TITLE
Remove use of ioutil package

### DIFF
--- a/cmd/frontend/backend/go_importers.go
+++ b/cmd/frontend/backend/go_importers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -93,7 +92,7 @@ func CountGoImporters(ctx context.Context, repo api.RepoName) (count int, err er
 				Path string
 			}
 		}
-		bytes, err := ioutil.ReadAll(response.Body)
+		bytes, err := io.ReadAll(response.Body)
 		if err != nil {
 			return 0, err
 		}

--- a/cmd/frontend/backend/go_importers_test.go
+++ b/cmd/frontend/backend/go_importers_test.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -80,7 +79,7 @@ type mockRoundTripper struct {
 func (t mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(t.response)),
+		Body:       io.NopCloser(bytes.NewBufferString(t.response)),
 		Header:     make(http.Header),
 	}, nil
 }

--- a/cmd/frontend/backend/repos_test.go
+++ b/cmd/frontend/backend/repos_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -159,7 +158,7 @@ func TestReposGetInventory(t *testing.T) {
 		default:
 			panic("unhandled mock ReadFile " + name)
 		}
-		return ioutil.NopCloser(bytes.NewReader(data)), nil
+		return io.NopCloser(bytes.NewReader(data)), nil
 	}
 	defer git.ResetMocks()
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -105,7 +104,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	if !testing.Verbose() {
 		log15.Root().SetHandler(log15.LvlFilterHandler(log15.LvlError, log15.Root().GetHandler()))
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 	os.Exit(m.Run())
 }
@@ -190,7 +189,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 					t.Fatalf("unexpected path: %s", r.URL.Path)
 				}
 				return &http.Response{
-					Body:       ioutil.NopCloser(buf),
+					Body:       io.NopCloser(buf),
 					StatusCode: http.StatusOK,
 				}, nil
 			})

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -49,7 +48,7 @@ func TestRepositoryComparison(t *testing.T) {
 		if len(args) < 1 && args[0] != "diff" {
 			t.Fatalf("gitserver.ExecReader received wrong args: %v", args)
 		}
-		return ioutil.NopCloser(strings.NewReader(testDiff + testCopyDiff)), nil
+		return io.NopCloser(strings.NewReader(testDiff + testCopyDiff)), nil
 	}
 	t.Cleanup(func() { git.Mocks.ExecReader = nil })
 

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -39,7 +38,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 		default:
 			panic("unhandled mock NewFileReader " + name)
 		}
-		return ioutil.NopCloser(bytes.NewReader(data)), nil
+		return io.NopCloser(bytes.NewReader(data)), nil
 	}
 	const wantDefaultBranchRef = "refs/heads/foo"
 	git.Mocks.ExecSafe = func(params []string) (stdout, stderr []byte, exitCode int, err error) {

--- a/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -74,7 +73,7 @@ func TestSetExternalServiceRepos(t *testing.T) {
 		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+				Body:       io.NopCloser(bytes.NewReader([]byte{})),
 			}, nil
 		}),
 	}

--- a/cmd/frontend/hubspot/hubspot.go
+++ b/cmd/frontend/hubspot/hubspot.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -61,7 +60,7 @@ func (c *Client) postForm(methodName string, baseURL *url.URL, suffix string, bo
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusFound {
-		buf, err := ioutil.ReadAll(resp.Body)
+		buf, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return wrapError(methodName, err)
 		}

--- a/cmd/frontend/internal/app/debugproxies/handler_test.go
+++ b/cmd/frontend/internal/app/debugproxies/handler_test.go
@@ -3,7 +3,6 @@ package debugproxies
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -50,7 +49,7 @@ func TestReverseProxyRequestPaths(t *testing.T) {
 	rtr.ServeHTTP(w, req)
 
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	if string(body) != "/metrics" {
 		t.Errorf("expected /metrics to be passed to reverse proxy, got %s", body)
@@ -90,7 +89,7 @@ func TestIndexLinks(t *testing.T) {
 	rtr.ServeHTTP(w, req)
 
 	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 
 	expectedContent := fmt.Sprintf("<a href=\"proxies/%s/\">%s</a><br>", displayName, displayName)
 

--- a/cmd/frontend/internal/app/debugproxies/scanner.go
+++ b/cmd/frontend/internal/app/debugproxies/scanner.go
@@ -3,7 +3,6 @@ package debugproxies
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"strconv"
 	"strings"
 	"time"
@@ -184,7 +183,7 @@ func (cs *clusterScanner) scanCluster() {
 // when the client was created, the official k8s client does not
 func namespace() string {
 	const filename = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		log15.Warn("scanner: falling back to kubernetes default namespace", "filename", filename, "error", err)
 		return "default"

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -4,7 +4,6 @@ package jscontext
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -219,7 +218,7 @@ func isBot(userAgent string) bool {
 }
 
 func likelyDockerOnMac() bool {
-	data, err := ioutil.ReadFile("/proc/cmdline")
+	data, err := os.ReadFile("/proc/cmdline")
 	if err != nil {
 		return false // permission errors, or maybe not a Linux OS, etc. Assume we're not docker for mac.
 	}

--- a/cmd/frontend/internal/app/ping_test.go
+++ b/cmd/frontend/internal/app/ping_test.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,7 +63,7 @@ func TestLatestPingHandler(t *testing.T) {
 			latestPingHandler(db)(rec, req.WithContext(backend.WithAuthzBypass(context.Background())))
 
 			resp := rec.Result()
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/internal/app/ui/tmpl.go
+++ b/cmd/frontend/internal/app/ui/tmpl.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -51,7 +50,7 @@ var funcMap = template.FuncMap{
 			return "", err
 		}
 		defer f.Close()
-		data, err := ioutil.ReadAll(f)
+		data, err := io.ReadAll(f)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/frontend/internal/app/updatecheck/client.go
+++ b/cmd/frontend/internal/app/updatecheck/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"strconv"
@@ -533,7 +532,7 @@ func check(db dbutil.DB) {
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 			var description string
-			if body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 30)); err != nil {
+			if body, err := io.ReadAll(io.LimitReader(resp.Body, 30)); err != nil {
 				description = err.Error()
 			} else if len(body) == 0 {
 				description = "(no response body)"

--- a/cmd/frontend/internal/app/updatecheck/handler.go
+++ b/cmd/frontend/internal/app/updatecheck/handler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -240,7 +239,7 @@ func readPingRequestFromQuery(q url.Values) (*pingRequest, error) {
 
 func readPingRequestFromBody(body io.ReadCloser) (*pingRequest, error) {
 	defer body.Close()
-	contents, err := ioutil.ReadAll(body)
+	contents, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/internal/cli/config.go
+++ b/cmd/frontend/internal/cli/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -65,7 +64,7 @@ func overrideSiteConfig(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		site, err := ioutil.ReadFile(path)
+		site, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrap(err, "reading SITE_CONFIG_FILE")
 		}
@@ -93,7 +92,7 @@ func overrideGlobalSettings(ctx context.Context, db dbutil.DB) error {
 	}
 	settings := database.Settings(db)
 	var update = func(ctx context.Context) error {
-		globalSettingsBytes, err := ioutil.ReadFile(path)
+		globalSettingsBytes, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrap(err, "reading GLOBAL_SETTINGS_FILE")
 		}
@@ -143,7 +142,7 @@ func overrideExtSvcConfig(ctx context.Context, db dbutil.DB) error {
 		}
 		confGet := func() *conf.Unified { return parsed }
 
-		extsvcConfig, err := ioutil.ReadFile(path)
+		extsvcConfig, err := os.ReadFile(path)
 		if err != nil {
 			return errors.Wrap(err, "reading EXTSVC_CONFIG_FILE")
 		}

--- a/cmd/frontend/internal/gosrc/import_path_test.go
+++ b/cmd/frontend/internal/gosrc/import_path_test.go
@@ -7,7 +7,6 @@
 package gosrc
 
 import (
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"runtime"
@@ -26,7 +25,7 @@ func (t testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	resp := &http.Response{
 		StatusCode: statusCode,
-		Body:       ioutil.NopCloser(strings.NewReader(body)),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 	return resp, nil
 }

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -566,7 +565,7 @@ func serveGitExec(w http.ResponseWriter, r *http.Request) error {
 		req.URL.Scheme = "http"
 		req.URL.Host = addr
 		req.URL.Path = "/exec"
-		req.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+		req.Body = io.NopCloser(bytes.NewReader(buf.Bytes()))
 		req.ContentLength = int64(buf.Len())
 	}
 

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -41,7 +40,7 @@ func TestGitServiceHandlers(t *testing.T) {
 
 		resp := w.Result()
 		if resp.StatusCode != http.StatusTemporaryRedirect {
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 			t.Errorf("expected redirect for %q, got status %d. Body: %s", target, resp.StatusCode, body)
 			continue
 		}
@@ -123,7 +122,7 @@ func TestReposIndex(t *testing.T) {
 			}
 
 			resp := w.Result()
-			body, _ := ioutil.ReadAll(resp.Body)
+			body, _ := io.ReadAll(resp.Body)
 
 			if resp.StatusCode != http.StatusOK {
 				t.Errorf("got status %v", resp.StatusCode)

--- a/cmd/frontend/internal/inventory/entries_test.go
+++ b/cmd/frontend/internal/inventory/entries_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -49,7 +48,7 @@ func TestContext_Entries(t *testing.T) {
 			default:
 				panic("unhandled mock ReadFile " + path)
 			}
-			return ioutil.NopCloser(bytes.NewReader(data)), nil
+			return io.NopCloser(bytes.NewReader(data)), nil
 		},
 		CacheGet: func(e os.FileInfo) (Inventory, bool) {
 			cacheGetCalls = append(cacheGetCalls, e.Name())

--- a/cmd/frontend/internal/inventory/inventory_test.go
+++ b/cmd/frontend/internal/inventory/inventory_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -78,7 +77,7 @@ func TestGetLang_language(t *testing.T) {
 
 func makeFileReader(ctx context.Context, path, contents string) func(context.Context, string) (io.ReadCloser, error) {
 	return func(ctx context.Context, path string) (io.ReadCloser, error) {
-		return ioutil.NopCloser(strings.NewReader(contents)), nil
+		return io.NopCloser(strings.NewReader(contents)), nil
 	}
 }
 

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -29,7 +28,7 @@ func TestServeStream_empty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadAll(res.Body)
+	b, err := io.ReadAll(res.Body)
 	res.Body.Close()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/frontend/internal/session/test_util.go
+++ b/cmd/frontend/internal/session/test_util.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 
 func ResetMockSessionStore(t *testing.T) (cleanup func()) {
 	var err error
-	tempdir, err := ioutil.TempDir("", "sourcegraph-oidc-test")
+	tempdir, err := os.MkdirTemp("", "sourcegraph-oidc-test")
 	if err != nil {
 		return func() {}
 	}

--- a/cmd/frontend/internal/vfsutil/github_archive_test.go
+++ b/cmd/frontend/internal/vfsutil/github_archive_test.go
@@ -1,7 +1,6 @@
 package vfsutil
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -36,7 +35,7 @@ func TestGitHubRepoVFS(t *testing.T) {
 }
 
 func useEmptyArchiveCacheDir() func() {
-	d, err := ioutil.TempDir("", "vfsutil_test")
+	d, err := os.MkdirTemp("", "vfsutil_test")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/frontend/webhooks/github_webhooks.go
+++ b/cmd/frontend/webhooks/github_webhooks.go
@@ -3,7 +3,6 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"sync"
@@ -39,7 +38,7 @@ type GitHubWebhook struct {
 }
 
 func (h *GitHubWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log15.Error("Error parsing github webhook event", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -118,7 +117,7 @@ func main() {
 			_, _ = io.Copy(w, resp.Body)
 			return
 		}
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		log15.Warn("proxy error", "status", resp.StatusCode, "body", string(b), "bodyErr", err)
 		_, _ = io.Copy(w, bytes.NewReader(b))
 	})

--- a/cmd/gitserver/server/cleanup.go
+++ b/cmd/gitserver/server/cleanup.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -145,7 +144,7 @@ func (s *Server) cleanupRepos(addrs []string) {
 			reason = "old"
 		}
 		if time.Since(recloneTime) > repoTTLGC+jitterDuration(string(dir), repoTTLGC/4) {
-			if gclog, err := ioutil.ReadFile(dir.Path("gc.log")); err == nil && len(gclog) > 0 {
+			if gclog, err := os.ReadFile(dir.Path("gc.log")); err == nil && len(gclog) > 0 {
 				reason = fmt.Sprintf("git gc %s", string(bytes.TrimSpace(gclog)))
 			}
 		}
@@ -287,7 +286,7 @@ func (s *Server) cleanupRepos(addrs []string) {
 
 	if b, err := json.Marshal(stats); err != nil {
 		log15.Error("cleanup: failed to marshal periodic stats", "error", err)
-	} else if err = ioutil.WriteFile(filepath.Join(s.ReposDir, reposStatsName), b, 0666); err != nil {
+	} else if err = os.WriteFile(filepath.Join(s.ReposDir, reposStatsName), b, 0666); err != nil {
 		log15.Error("cleanup: failed to write periodic stats", "error", err)
 	}
 
@@ -579,7 +578,7 @@ func (s *Server) SetupAndClearTmp() (string, error) {
 		// Rename the current tmp file so we can asynchronously remove it. Use
 		// a consistent pattern so if we get interrupted, we can clean it
 		// another time.
-		oldTmp, err := ioutil.TempDir(s.ReposDir, oldPrefix)
+		oldTmp, err := os.MkdirTemp(s.ReposDir, oldPrefix)
 		if err != nil {
 			return "", err
 		}
@@ -595,7 +594,7 @@ func (s *Server) SetupAndClearTmp() (string, error) {
 	}
 
 	// Asynchronously remove old temporary directories
-	files, err := ioutil.ReadDir(s.ReposDir)
+	files, err := os.ReadDir(s.ReposDir)
 	if err != nil {
 		log15.Error("failed to do tmp cleanup", "error", err)
 	} else {

--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -32,7 +31,7 @@ const (
 )
 
 func TestCleanup_computeStats(t *testing.T) {
-	root, err := ioutil.TempDir("", "gitserver-test-")
+	root, err := os.MkdirTemp("", "gitserver-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +65,7 @@ func TestCleanup_computeStats(t *testing.T) {
 	// we hardcode the name here so the tests break if someone changes the
 	// value of reposStatsName. We don't want it to change without good reason
 	// since it will temporarily break the repo-stats endpoint.
-	b, err := ioutil.ReadFile(filepath.Join(root, "repos-stats.json"))
+	b, err := os.ReadFile(filepath.Join(root, "repos-stats.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +89,7 @@ func TestCleanup_computeStats(t *testing.T) {
 }
 
 func TestCleanupInactive(t *testing.T) {
-	root, err := ioutil.TempDir("", "gitserver-test-")
+	root, err := os.MkdirTemp("", "gitserver-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +173,7 @@ func TestGitGCAuto(t *testing.T) {
 }
 
 func TestCleanupExpired(t *testing.T) {
-	root, err := ioutil.TempDir("", "gitserver-test-")
+	root, err := os.MkdirTemp("", "gitserver-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -434,7 +433,7 @@ func TestSetupAndClearTmp(t *testing.T) {
 	// Wait until async cleaning is done
 	for i := 0; i < 1000; i++ {
 		found := false
-		files, err := ioutil.ReadDir(s.ReposDir)
+		files, err := os.ReadDir(s.ReposDir)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -635,7 +634,7 @@ func (f *fakeDiskSizer) DiskSizeBytes(mountPoint string) (uint64, error) {
 
 func tmpDir(t *testing.T) string {
 	t.Helper()
-	dir, err := ioutil.TempDir("", filepath.Base(t.Name()))
+	dir, err := os.MkdirTemp("", filepath.Base(t.Name()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -655,7 +654,7 @@ func mkFiles(t *testing.T, root string, paths ...string) {
 
 func writeFile(t *testing.T, path string, content []byte) {
 	t.Helper()
-	err := ioutil.WriteFile(path, content, 0666)
+	err := os.WriteFile(path, content, 0666)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -738,7 +737,7 @@ func TestFreeUpSpace(t *testing.T) {
 	})
 	t.Run("oldest repo gets removed to free up space", func(t *testing.T) {
 		// Set up.
-		rd, err := ioutil.TempDir("", "freeUpSpace")
+		rd, err := os.MkdirTemp("", "freeUpSpace")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -787,10 +786,10 @@ func makeFakeRepo(d string, sizeBytes int) error {
 	if err := os.MkdirAll(gd, 0700); err != nil {
 		return errors.Wrap(err, "creating .git dir and any parents")
 	}
-	if err := ioutil.WriteFile(filepath.Join(gd, "HEAD"), nil, 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(gd, "HEAD"), nil, 0666); err != nil {
 		return errors.Wrap(err, "creating HEAD file")
 	}
-	if err := ioutil.WriteFile(filepath.Join(gd, "space_eater"), make([]byte, sizeBytes), 0666); err != nil {
+	if err := os.WriteFile(filepath.Join(gd, "space_eater"), make([]byte, sizeBytes), 0666); err != nil {
 		return errors.Wrapf(err, "writing to space_eater file")
 	}
 	return nil

--- a/cmd/gitserver/server/list-gitolite_test.go
+++ b/cmd/gitserver/server/list-gitolite_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http/httptest"
 	"testing"
 
@@ -50,7 +49,7 @@ func Test_Gitolite_listRepos(t *testing.T) {
 			w := httptest.NewRecorder()
 			g.listRepos(context.Background(), test.gitoliteHost, w)
 			resp := w.Result()
-			respBody, err := ioutil.ReadAll(resp.Body)
+			respBody, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/gitserver/server/repo_info.go
+++ b/cmd/gitserver/server/repo_info.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -99,7 +98,7 @@ func (s *Server) handleRepoInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleReposStats(w http.ResponseWriter, r *http.Request) {
-	b, err := ioutil.ReadFile(filepath.Join(s.ReposDir, reposStatsName))
+	b, err := os.ReadFile(filepath.Join(s.ReposDir, reposStatsName))
 	if err != nil && errors.Is(err, os.ErrNotExist) {
 		// When a gitserver is new this file might not have been computed
 		// yet. Clients are expected to handle this case by noticing UpdatedAt

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -538,7 +537,7 @@ func (s *Server) tempDir(prefix string) (name string, err error) {
 		return "", err
 	}
 
-	return ioutil.TempDir(dir, prefix)
+	return os.MkdirTemp(dir, prefix)
 }
 
 func (s *Server) ignorePath(path string) bool {
@@ -1706,7 +1705,7 @@ func removeBadRefs(ctx context.Context, dir GitDir) {
 func ensureHEAD(dir GitDir) {
 	head, err := os.Stat(dir.Path("HEAD"))
 	if os.IsNotExist(err) || head.Size() == 0 {
-		ioutil.WriteFile(dir.Path("HEAD"), []byte("ref: refs/heads/master"), 0600)
+		os.WriteFile(dir.Path("HEAD"), []byte("ref: refs/heads/master"), 0600)
 	}
 }
 
@@ -1915,7 +1914,7 @@ const headFileRefPrefix = "ref: "
 // It just reads the .git/HEAD file from the bare git repository directory.
 func quickSymbolicRefHead(dir GitDir) (string, error) {
 	// See if HEAD contains a commit hash and fail if so.
-	head, err := ioutil.ReadFile(dir.Path("HEAD"))
+	head, err := os.ReadFile(dir.Path("HEAD"))
 	if err != nil {
 		return "", err
 	}
@@ -1936,7 +1935,7 @@ func quickSymbolicRefHead(dir GitDir) (string, error) {
 // It just reads the relevant files from the bare git repository directory.
 func quickRevParseHead(dir GitDir) (string, error) {
 	// See if HEAD contains a commit hash and return it if so.
-	head, err := ioutil.ReadFile(dir.Path("HEAD"))
+	head, err := os.ReadFile(dir.Path("HEAD"))
 	if err != nil {
 		return "", err
 	}
@@ -1956,7 +1955,7 @@ func quickRevParseHead(dir GitDir) (string, error) {
 		return "", fmt.Errorf("invalid ref format: %s", headRef)
 	}
 	headRefFile := dir.Path(filepath.FromSlash(string(headRef)))
-	if refs, err := ioutil.ReadFile(headRefFile); err == nil {
+	if refs, err := os.ReadFile(headRefFile); err == nil {
 		return string(bytes.TrimSpace(refs)), nil
 	}
 

--- a/cmd/gitserver/server/server_test.go
+++ b/cmd/gitserver/server/server_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -163,7 +162,7 @@ func TestRequest(t *testing.T) {
 				t.Errorf("wrong status: expected %d, got %d", test.ExpectedCode, w.Code)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -239,7 +238,7 @@ func TestServer_handleP4Exec(t *testing.T) {
 				t.Errorf("wrong status: expected %d, got %d", test.ExpectedCode, w.Code)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -257,7 +256,7 @@ func TestServer_handleP4Exec(t *testing.T) {
 }
 
 func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
-	tmp, err := ioutil.TempDir("", "gitserver_test")
+	tmp, err := os.MkdirTemp("", "gitserver_test")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -273,7 +272,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
 	// This simulates the most amount of work quickRevParseHead has to do, and
 	// is also the most common in prod. That is where the final rev is in
 	// packed-refs.
-	err = ioutil.WriteFile(filepath.Join(dir, "HEAD"), []byte(fmt.Sprintf("ref: %s\n", masterRef)), 0600)
+	err = os.WriteFile(filepath.Join(dir, "HEAD"), []byte(fmt.Sprintf("ref: %s\n", masterRef)), 0600)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -335,7 +334,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_packed_refs(b *testing.B) {
 }
 
 func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_unpacked_refs(b *testing.B) {
-	tmp, err := ioutil.TempDir("", "gitserver_test")
+	tmp, err := os.MkdirTemp("", "gitserver_test")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -361,7 +360,7 @@ func BenchmarkQuickRevParseHeadQuickSymbolicRefHead_unpacked_refs(b *testing.B) 
 		if err != nil {
 			b.Fatal(err)
 		}
-		err = ioutil.WriteFile(path, []byte(content), 0600)
+		err = os.WriteFile(path, []byte(content), 0600)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -692,7 +691,7 @@ func TestRemoveBadRefs(t *testing.T) {
 		}
 
 		// Ref
-		if err := ioutil.WriteFile(filepath.Join(dir, ".git", "refs", "heads", name), []byte(wantCommit), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, ".git", "refs", "heads", name), []byte(wantCommit), 0600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -778,7 +777,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 
-		head, err := ioutil.ReadFile(fmt.Sprintf("%s/HEAD", dst))
+		head, err := os.ReadFile(fmt.Sprintf("%s/HEAD", dst))
 		if os.IsNotExist(err) {
 			t.Fatal("expected a reconstituted HEAD, but no file exists")
 		}
@@ -816,7 +815,7 @@ func TestCloneRepo_EnsureValidity(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 
-		head, err := ioutil.ReadFile(fmt.Sprintf("%s/HEAD", dst))
+		head, err := os.ReadFile(fmt.Sprintf("%s/HEAD", dst))
 		if os.IsNotExist(err) {
 			t.Fatal("expected a reconstituted HEAD, but no file exists")
 		}

--- a/cmd/gitserver/server/serverutil.go
+++ b/cmd/gitserver/server/serverutil.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -212,7 +211,7 @@ func configureRemoteGitCommand(cmd *exec.Cmd, tlsConf *tlsConfig) {
 // writeTempFile writes data to the TempFile with pattern. Returns the path of
 // the tempfile.
 func writeTempFile(pattern string, data []byte) (path string, err error) {
-	f, err := ioutil.TempFile("", pattern)
+	f, err := os.CreateTemp("", pattern)
 	if err != nil {
 		return "", err
 	}
@@ -543,7 +542,7 @@ func mapToLog15Ctx(m map[string]interface{}) []interface{} {
 // updateFileIfDifferent will atomically update the file if the contents are
 // different. If it does an update ok is true.
 func updateFileIfDifferent(path string, content []byte) (bool, error) {
-	current, err := ioutil.ReadFile(path)
+	current, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		// If the file doesn't exist we write a new file.
 		return false, err
@@ -554,7 +553,7 @@ func updateFileIfDifferent(path string, content []byte) (bool, error) {
 	}
 
 	// We write to a tempfile first to do the atomic update (via rename)
-	f, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path))
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return false, err
 	}

--- a/cmd/gitserver/server/serverutil_test.go
+++ b/cmd/gitserver/server/serverutil_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -225,7 +224,7 @@ func TestProgressWriter(t *testing.T) {
 }
 
 func TestUpdateFileIfDifferent(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
+	dir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -234,13 +233,13 @@ func TestUpdateFileIfDifferent(t *testing.T) {
 	target := filepath.Join(dir, "sg_refhash")
 
 	write := func(content string) {
-		err := ioutil.WriteFile(target, []byte(content), 0600)
+		err := os.WriteFile(target, []byte(content), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 	read := func() string {
-		b, err := ioutil.ReadFile(target)
+		b, err := os.ReadFile(target)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/searcher/search/search_structural.go
+++ b/cmd/searcher/search/search_structural.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -320,7 +319,7 @@ func structuralSearchWithZoekt(ctx context.Context, p *protocol.Request) (matche
 		return nil, false, false, nil
 	}
 
-	zipFile, err := ioutil.TempFile("", "*.zip")
+	zipFile, err := os.CreateTemp("", "*.zip")
 	if err != nil {
 		return nil, false, false, err
 	}

--- a/cmd/searcher/search/search_test.go
+++ b/cmd/searcher/search/search_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -440,7 +439,7 @@ func doSearch(u string, p *protocol.Request) ([]protocol.FileMatch, error) {
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -483,13 +482,13 @@ func newStore(files map[string]string) (*store.Store, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	d, err := ioutil.TempDir("", "search_test")
+	d, err := os.MkdirTemp("", "search_test")
 	if err != nil {
 		return nil, nil, err
 	}
 	return &store.Store{
 		FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+			return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 		},
 		Path: d,
 	}, func() { os.RemoveAll(d) }, nil

--- a/cmd/server/shared/copy.go
+++ b/cmd/server/shared/copy.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -25,14 +24,14 @@ func copyConfigs() error {
 		src = filepath.Join(os.Getenv("CONFIG_DIR"), src)
 		dst = os.ExpandEnv(dst)
 
-		data, err := ioutil.ReadFile(src)
+		data, err := os.ReadFile(src)
 		if os.IsNotExist(err) {
 			continue
 		} else if err != nil {
 			return errors.Wrapf(err, "failed to copy %s -> %s", src, dst)
 		}
 
-		if err := ioutil.WriteFile(dst, data, 0600); err != nil {
+		if err := os.WriteFile(dst, data, 0600); err != nil {
 			return errors.Wrapf(err, "failed to copy %s -> %s", src, dst)
 		}
 	}

--- a/cmd/server/shared/nginx.go
+++ b/cmd/server/shared/nginx.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -33,14 +32,14 @@ func nginxProcFile() (string, error) {
 func nginxWriteFiles(configDir string) (string, error) {
 	// Check we can read the config
 	path := filepath.Join(configDir, "nginx.conf")
-	_, err := ioutil.ReadFile(path)
+	_, err := os.ReadFile(path)
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
 	}
 
 	// Does not exist
 	if err != nil {
-		err = ioutil.WriteFile(path, []byte(assets.NginxConf), 0600)
+		err = os.WriteFile(path, []byte(assets.NginxConf), 0600)
 		if err != nil {
 			return "", err
 		}
@@ -61,7 +60,7 @@ func nginxWriteFiles(configDir string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		err = ioutil.WriteFile(filepath.Join(nginxDir, p.Name()), data, 0600)
+		err = os.WriteFile(filepath.Join(nginxDir, p.Name()), data, 0600)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/server/shared/nginx_test.go
+++ b/cmd/server/shared/nginx_test.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,14 +10,14 @@ import (
 
 func TestNginx(t *testing.T) {
 	read := func(path string) []byte {
-		b, err := ioutil.ReadFile(path)
+		b, err := os.ReadFile(path)
 		if err != nil {
 			t.Fatal(err)
 		}
 		return b
 	}
 
-	dir, err := ioutil.TempDir("", "nginx_test")
+	dir, err := os.MkdirTemp("", "nginx_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/server/shared/redis.go
+++ b/cmd/server/shared/redis.go
@@ -3,7 +3,6 @@ package shared
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,7 +87,7 @@ func tryCreateRedisConf(c redisProcfileConfig) (string, error) {
 
 	// Always replace redis.conf
 	path := filepath.Join(os.Getenv("CONFIG_DIR"), c.name+".conf")
-	return path, ioutil.WriteFile(path, b.Bytes(), 0644)
+	return path, os.WriteFile(path, b.Bytes(), 0644)
 }
 
 func redisProcFileEntry(name, conf string) string {

--- a/cmd/server/shared/redis_test.go
+++ b/cmd/server/shared/redis_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,7 +18,7 @@ func TestRedisFixAOF(t *testing.T) {
 		t.Skip("redis-check-aof not on path: ", err)
 	}
 
-	dataDir, err := ioutil.TempDir("", t.Name())
+	dataDir, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +34,7 @@ func TestRedisFixAOF(t *testing.T) {
 	bad := b.Bytes()
 	bad = bad[:len(bad)-4]
 	aofPath := filepath.Join(dataDir, "appendonly.aof")
-	if err := ioutil.WriteFile(aofPath, bad, 0600); err != nil {
+	if err := os.WriteFile(aofPath, bad, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -47,7 +46,7 @@ func TestRedisFixAOF(t *testing.T) {
 			dataDir: filepath.Base(dataDir),
 		})
 
-		got, err := ioutil.ReadFile(aofPath)
+		got, err := os.ReadFile(aofPath)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/symbols/internal/symbols/search_test.go
+++ b/cmd/symbols/internal/symbols/search_test.go
@@ -3,7 +3,6 @@ package symbols
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -47,7 +46,7 @@ func BenchmarkSearch(b *testing.B) {
 	runIndexTest := func(test protocol.SearchArgs) {
 		b.Run(fmt.Sprintf("indexing %s@%s", path.Base(string(test.Repo)), test.CommitID[:3]), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
-				tempFile, err := ioutil.TempFile("", "")
+				tempFile, err := os.CreateTemp("", "")
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/cmd/symbols/internal/symbols/service_test.go
+++ b/cmd/symbols/internal/symbols/service_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http/httptest"
 	"os"
 	"reflect"
@@ -59,7 +58,7 @@ func TestIsLiteralEquality(t *testing.T) {
 func TestService(t *testing.T) {
 	sqliteutil.MustRegisterSqlite3WithPcre()
 
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +166,7 @@ func createTar(files map[string]string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 }
 
 type mockParser []string

--- a/dev/corrupt-archives/main.go
+++ b/dev/corrupt-archives/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -10,7 +9,7 @@ import (
 )
 
 func corruptArchives(dir string) error {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
 	}

--- a/dev/depgraph/internal/graph/graph.go
+++ b/dev/depgraph/internal/graph/graph.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -82,7 +81,7 @@ func findRoot() (string, error) {
 	}
 
 	for {
-		contents, err := ioutil.ReadFile(filepath.Join(wd, "go.mod"))
+		contents, err := os.ReadFile(filepath.Join(wd, "go.mod"))
 		if err == nil {
 			for _, line := range strings.Split(string(contents), "\n") {
 				if line == "module github.com/sourcegraph/sourcegraph" {

--- a/dev/depgraph/internal/graph/imports.go
+++ b/dev/depgraph/internal/graph/imports.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -79,7 +78,7 @@ var extractionControlMap = map[bool]struct {
 
 // extractImports returns a set of package paths that are imported by this file.
 func extractImports(path string) (map[string]struct{}, error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/dev/depgraph/internal/graph/names.go
+++ b/dev/depgraph/internal/graph/names.go
@@ -2,7 +2,6 @@ package graph
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -52,7 +51,7 @@ var packagePattern = regexp.MustCompile(`^package (\w+)`)
 
 // extractPackageName returns the package name declared by this file.
 func extractPackageName(path string) (string, error) {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/dev/repogen/main.go
+++ b/dev/repogen/main.go
@@ -9,7 +9,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -30,7 +29,7 @@ func main() {
 
 // repogen creates a repo with nf files, each of the given size.
 func repogen(nf, size int) error {
-	d, err := ioutil.TempDir("/tmp", "repogen")
+	d, err := os.MkdirTemp("/tmp", "repogen")
 	if err != nil {
 		return errors.Wrap(err, "creating temp dir")
 	}

--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -15,7 +14,7 @@ func ParseConfigFile(name string) (*Config, error) {
 	}
 	defer file.Close()
 
-	data, err := ioutil.ReadAll(file)
+	data, err := io.ReadAll(file)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading configuration file")
 	}

--- a/dev/sg/root/root.go
+++ b/dev/sg/root/root.go
@@ -2,7 +2,6 @@ package root
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,7 +28,7 @@ func findRoot() (string, error) {
 	}
 
 	for {
-		contents, err := ioutil.ReadFile(filepath.Join(wd, "go.mod"))
+		contents, err := os.ReadFile(filepath.Join(wd, "go.mod"))
 		if err == nil {
 			for _, line := range strings.Split(string(contents), "\n") {
 				if line == "module github.com/sourcegraph/sourcegraph" {

--- a/dev/src-expose/main.go
+++ b/dev/src-expose/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -114,14 +113,14 @@ func main() {
 
 	newLogger := func(prefix string) *log.Logger {
 		if *globalQuiet {
-			return log.New(ioutil.Discard, "", log.LstdFlags)
+			return log.New(io.Discard, "", log.LstdFlags)
 		}
 		return log.New(os.Stderr, prefix, log.LstdFlags)
 	}
 
 	newVerbose := func(prefix string) *log.Logger {
 		if !*globalVerbose {
-			return log.New(ioutil.Discard, "", log.LstdFlags)
+			return log.New(io.Discard, "", log.LstdFlags)
 		}
 		return log.New(os.Stderr, prefix, log.LstdFlags)
 	}
@@ -129,7 +128,7 @@ func main() {
 	globalSnapshotter := func() (*Snapshotter, error) {
 		var s Snapshotter
 		if *globalConfig != "" {
-			b, err := ioutil.ReadFile(*globalConfig)
+			b, err := os.ReadFile(*globalConfig)
 			if err != nil {
 				return nil, fmt.Errorf("could read configuration at %s: %w", *globalConfig, err)
 			}

--- a/dev/src-expose/serve.go
+++ b/dev/src-expose/serve.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -257,7 +256,7 @@ var postUpdateHook = []byte("#!/bin/sh\nexec git update-server-info\n")
 // for background.
 func configurePostUpdateHook(logger *log.Logger, gitDir string) error {
 	postUpdatePath := filepath.Join(gitDir, "hooks", "post-update")
-	if b, _ := ioutil.ReadFile(postUpdatePath); bytes.Equal(b, postUpdateHook) {
+	if b, _ := os.ReadFile(postUpdatePath); bytes.Equal(b, postUpdateHook) {
 		return nil
 	}
 
@@ -270,7 +269,7 @@ func configurePostUpdateHook(logger *log.Logger, gitDir string) error {
 	if err := os.MkdirAll(filepath.Dir(postUpdatePath), 0755); err != nil {
 		return errors.Wrap(err, "create git hooks dir")
 	}
-	if err := ioutil.WriteFile(postUpdatePath, postUpdateHook, 0755); err != nil {
+	if err := os.WriteFile(postUpdatePath, postUpdateHook, 0755); err != nil {
 		return errors.Wrap(err, "setting post-update hook")
 	}
 

--- a/dev/src-expose/serve_test.go
+++ b/dev/src-expose/serve_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -19,7 +18,7 @@ import (
 
 const testAddress = "test.local:3939"
 
-var discardLogger = log.New(ioutil.Discard, "", log.LstdFlags)
+var discardLogger = log.New(io.Discard, "", log.LstdFlags)
 
 func TestReposHandler(t *testing.T) {
 	cases := []struct {
@@ -102,7 +101,7 @@ func testReposHandler(t *testing.T, h http.Handler, repos []Repo) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		b, err := ioutil.ReadAll(res.Body)
+		b, err := io.ReadAll(res.Body)
 		res.Body.Close()
 		if err != nil {
 			t.Fatal(err)
@@ -149,7 +148,7 @@ func testReposHandler(t *testing.T, h http.Handler, repos []Repo) {
 }
 
 func gitInitRepos(t *testing.T, names ...string) string {
-	root, err := ioutil.TempDir("", "")
+	root, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +170,7 @@ func gitInitRepos(t *testing.T, names ...string) string {
 }
 
 func TestIgnoreGitSubmodules(t *testing.T) {
-	root, err := ioutil.TempDir("", "")
+	root, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +180,7 @@ func TestIgnoreGitSubmodules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(root, "dir", ".git"), []byte("ignore me please"), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "dir", ".git"), []byte("ignore me please"), os.ModePerm); err != nil {
 		t.Fatal(err)
 	}
 

--- a/doc/cli/references/doc.go
+++ b/doc/cli/references/doc.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -36,7 +35,7 @@ func clean(base string) error {
 		return len(dirs[j]) < len(dirs[i])
 	})
 	for _, dir := range dirs {
-		d, err := ioutil.ReadDir(dir)
+		d, err := os.ReadDir(dir)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -60,7 +59,7 @@ func build(base string) error {
 	// github.com/sourcegraph/src-cli/cmd/src@main`, but we're not quite there
 	// yet.
 
-	dir, err := ioutil.TempDir("", "src-cli-doc-gen")
+	dir, err := os.MkdirTemp("", "src-cli-doc-gen")
 	if err != nil {
 		return errors.Wrap(err, "creating temporary directory")
 	}
@@ -88,7 +87,7 @@ func build(base string) error {
 	// here as well.
 	//
 	// In summary, this is _hilariously_ cursed.
-	if err := ioutil.WriteFile("go.mod", []byte(`module github.com/sourcegraph/sourcegraph/doc/cli/references
+	if err := os.WriteFile("go.mod", []byte(`module github.com/sourcegraph/sourcegraph/doc/cli/references
 
 replace github.com/gosuri/uilive v0.0.4 => github.com/mrnugget/uilive v0.0.4-fix-escape
 

--- a/docker-images/prometheus/cmd/prom-wrapper/alertmanager.go
+++ b/docker-images/prometheus/cmd/prom-wrapper/alertmanager.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -61,7 +60,7 @@ func reloadAlertmanager(ctx context.Context) error {
 	}
 	if resp.StatusCode >= 300 {
 		defer resp.Body.Close()
-		data, err := ioutil.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("reload failed with status %d", resp.StatusCode)
 		}
@@ -88,7 +87,7 @@ func applyConfiguration(ctx context.Context, cfg *amconfig.Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate Alertmanager configuration: %w", err)
 	}
-	if err := ioutil.WriteFile(alertmanagerConfigPath, amConfigData, os.ModePerm); err != nil {
+	if err := os.WriteFile(alertmanagerConfigPath, amConfigData, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to write Alertmanager configuration: %w", err)
 	}
 	if err := reloadAlertmanager(ctx); err != nil {

--- a/enterprise/cmd/executor/internal/apiclient/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/client_test.go
@@ -3,7 +3,6 @@ package apiclient
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -323,7 +322,7 @@ func testServer(t *testing.T, spec routeSpec) *httptest.Server {
 			t.Errorf("unexpected password. want=%s have=%s", spec.expectedPassword, password)
 		}
 
-		content, err := ioutil.ReadAll(r.Body)
+		content, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("unexpected error reading payload: %s", err)
 		}

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -76,7 +75,7 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 			return fmt.Errorf("refusing to write outside of working directory")
 		}
 
-		if err := ioutil.WriteFile(path, []byte(content), os.ModePerm); err != nil {
+		if err := os.WriteFile(path, []byte(content), os.ModePerm); err != nil {
 			return err
 		}
 	}
@@ -110,7 +109,7 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 		scriptName := scriptNameFromJobStep(job, i)
 		scriptPath := filepath.Join(workingDirectory, command.ScriptsPath, scriptName)
 
-		if err := ioutil.WriteFile(scriptPath, buildScript(dockerStep), os.ModePerm); err != nil {
+		if err := os.WriteFile(scriptPath, buildScript(dockerStep), os.ModePerm); err != nil {
 			return err
 		}
 

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -90,8 +89,8 @@ func makeTemporaryDirectory() (string, error) {
 		if err := os.MkdirAll(tempdir, os.ModePerm); err != nil {
 			return "", err
 		}
-		return ioutil.TempDir(tempdir, "")
+		return os.MkdirTemp(tempdir, "")
 	}
 
-	return ioutil.TempDir("", "")
+	return os.MkdirTemp("", "")
 }

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/middleware_test.go
@@ -3,7 +3,6 @@ package githuboauth
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -93,7 +92,7 @@ func TestMiddleware(t *testing.T) {
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got response code %v, want %v", resp.StatusCode, want)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -243,7 +242,7 @@ func TestMiddleware(t *testing.T) {
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got response code %v, want %v", resp.StatusCode, want)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -256,7 +255,7 @@ func TestMiddleware(t *testing.T) {
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got response code %v, want %v", resp.StatusCode, want)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -3,7 +3,6 @@ package gitlaboauth
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -97,7 +96,7 @@ func TestMiddleware(t *testing.T) {
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got response code %v, want %v", resp.StatusCode, want)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -247,7 +246,7 @@ func TestMiddleware(t *testing.T) {
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got response code %v, want %v", resp.StatusCode, want)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -260,7 +259,7 @@ func TestMiddleware(t *testing.T) {
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got response code %v, want %v", resp.StatusCode, want)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -111,7 +110,7 @@ func previewAndDuplicateReader(reader io.ReadCloser) (preview string, freshReade
 		return "", reader, nil
 	}
 	defer reader.Close()
-	b, err := ioutil.ReadAll(reader)
+	b, err := io.ReadAll(reader)
 	if err != nil {
 		return "", nil, err
 	}
@@ -119,7 +118,7 @@ func previewAndDuplicateReader(reader io.ReadCloser) (preview string, freshReade
 	if len(preview) > 1000 {
 		preview = preview[:1000]
 	}
-	return preview, ioutil.NopCloser(bytes.NewReader(b)), nil
+	return preview, io.NopCloser(bytes.NewReader(b)), nil
 }
 
 func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {

--- a/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/openidconnect/middleware_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -60,7 +59,7 @@ func newOIDCIDServer(t *testing.T, code string, oidcProvider *schema.OpenIDConne
 			http.Error(w, "unexpected", http.StatusBadRequest)
 			return
 		}
-		b, _ := ioutil.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
 		values, _ := url.ParseQuery(string(b))
 
 		if values.Get("code") != code {
@@ -120,7 +119,7 @@ func TestMiddleware(t *testing.T) {
 
 	defer licensing.TestingSkipFeatureChecks()()
 
-	tempdir, err := ioutil.TempDir("", "sourcegraph-oidc-test")
+	tempdir, err := os.MkdirTemp("", "sourcegraph-oidc-test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -302,7 +301,7 @@ func TestMiddleware_NoOpenRedirect(t *testing.T) {
 
 	defer licensing.TestingSkipFeatureChecks()()
 
-	tempdir, err := ioutil.TempDir("", "sourcegraph-oidc-test-no-open-redirect")
+	tempdir, err := os.MkdirTemp("", "sourcegraph-oidc-test-no-open-redirect")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/middleware_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -371,7 +370,7 @@ func TestMiddleware(t *testing.T) {
 	})
 	t.Run("authenticated request to home page", func(t *testing.T) {
 		resp := doRequest("GET", "http://example.com/", "", loggedInCookies, true, nil)
-		respBody, _ := ioutil.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(resp.Body)
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got status code %v, want %v", resp.StatusCode, want)
 		}
@@ -381,7 +380,7 @@ func TestMiddleware(t *testing.T) {
 	})
 	t.Run("authenticated request to sub page", func(t *testing.T) {
 		resp := doRequest("GET", "http://example.com/page", "", loggedInCookies, true, nil)
-		respBody, _ := ioutil.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(resp.Body)
 		if want := http.StatusOK; resp.StatusCode != want {
 			t.Errorf("got status code %v, want %v", resp.StatusCode, want)
 		}

--- a/enterprise/cmd/frontend/internal/auth/saml/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/saml/provider.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -273,7 +272,7 @@ func readIdentityProviderMetadata(ctx context.Context, c *providerConfig) ([]byt
 		return nil, fmt.Errorf("non-200 HTTP response for SAML Identity Provider metadata URL: %s", c.identityProviderMetadataURL)
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.WithMessage(err, "reading SAML Identity Provider metadata")
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -213,7 +212,7 @@ func (h *UploadHandler) handleEnqueueSinglePayload(r *http.Request, uploadArgs U
 		// Replace the body of the request with a reader that will produce all of the same
 		// content: all of the data that was already read from r.Body, plus the remaining
 		// content from r.Body.
-		r.Body = ioutil.NopCloser(io.MultiReader(bytes.NewReader(buf.Bytes()), r.Body))
+		r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(buf.Bytes()), r.Body))
 	}
 
 	tx, err := h.dbStore.Transact(ctx)

--- a/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/httpapi/upload_handler_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -104,7 +103,7 @@ func TestHandleEnqueueSinglePayload(t *testing.T) {
 			t.Errorf("unexpected bundle id. want=%s have=%s", "upload-42.lsif.gz", call.Arg1)
 		}
 
-		contents, err := ioutil.ReadAll(call.Arg2)
+		contents, err := io.ReadAll(call.Arg2)
 		if err != nil {
 			t.Fatalf("unexpected error reading payload: %s", err)
 		}
@@ -170,7 +169,7 @@ func TestHandleEnqueueSinglePayloadNoIndexerName(t *testing.T) {
 			t.Errorf("unexpected bundle id. want=%s have=%s", "upload-42.lsif.gz", call.Arg1)
 		}
 
-		contents, err := ioutil.ReadAll(call.Arg2)
+		contents, err := io.ReadAll(call.Arg2)
 		if err != nil {
 			t.Fatalf("unexpected error reading payload: %s", err)
 		}
@@ -304,7 +303,7 @@ func TestHandleEnqueueMultipartUpload(t *testing.T) {
 			t.Errorf("unexpected bundle id. want=%s have=%s", "upload-42.3.lsif.gz", call.Arg1)
 		}
 
-		contents, err := ioutil.ReadAll(call.Arg2)
+		contents, err := io.ReadAll(call.Arg2)
 		if err != nil {
 			t.Fatalf("unexpected error reading payload: %s", err)
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/position.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/position.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"strconv"
 	"strings"
 
@@ -129,7 +128,7 @@ func (p *positionAdjuster) readHunks(ctx context.Context, repo *types.Repo, sour
 	}
 	defer reader.Close()
 
-	output, err := ioutil.ReadAll(reader)
+	output, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/position_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/position_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -41,7 +40,7 @@ func TestAdjustPosition(t *testing.T) {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
 
-		return ioutil.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
+		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
 	}
 
 	posIn := lsifstore.Position{Line: 302, Character: 15}
@@ -70,7 +69,7 @@ func TestAdjustPositionEmptyDiff(t *testing.T) {
 		git.Mocks.ExecReader = nil
 	})
 	git.Mocks.ExecReader = func(args []string) (reader io.ReadCloser, err error) {
-		return ioutil.NopCloser(bytes.NewReader(nil)), nil
+		return io.NopCloser(bytes.NewReader(nil)), nil
 	}
 
 	posIn := lsifstore.Position{Line: 10, Character: 15}
@@ -102,7 +101,7 @@ func TestAdjustPositionReverse(t *testing.T) {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
 
-		return ioutil.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
+		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
 	}
 
 	posIn := lsifstore.Position{Line: 302, Character: 15}
@@ -136,7 +135,7 @@ func TestAdjustRange(t *testing.T) {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
 
-		return ioutil.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
+		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
 	}
 
 	rIn := lsifstore.Range{
@@ -171,7 +170,7 @@ func TestAdjustRangeEmptyDiff(t *testing.T) {
 		git.Mocks.ExecReader = nil
 	})
 	git.Mocks.ExecReader = func(args []string) (reader io.ReadCloser, err error) {
-		return ioutil.NopCloser(bytes.NewReader(nil)), nil
+		return io.NopCloser(bytes.NewReader(nil)), nil
 	}
 
 	rIn := lsifstore.Range{
@@ -206,7 +205,7 @@ func TestAdjustRangeReverse(t *testing.T) {
 			t.Errorf("unexpected exec reader args (-want +got):\n%s", diff)
 		}
 
-		return ioutil.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
+		return io.NopCloser(bytes.NewReader([]byte(hugoDiff))), nil
 	}
 
 	rIn := lsifstore.Range{

--- a/enterprise/cmd/frontend/internal/executor/internal_proxy_handler.go
+++ b/enterprise/cmd/frontend/internal/executor/internal_proxy_handler.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -148,7 +147,7 @@ var getRest = func(r *http.Request) string {
 // 307 Temporary Redirect can be followed when making POST requests. This is necessary to
 // properly proxy git service operations without being redirected to an inaccessible API.
 func makeProxyRequest(r *http.Request, target *url.URL) (*http.Request, error) {
-	content, err := ioutil.ReadAll(r.Body)
+	content, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +163,7 @@ func makeProxyRequest(r *http.Request, target *url.URL) (*http.Request, error) {
 	}
 
 	copyHeader(req.Header, r.Header)
-	req.GetBody = func() (io.ReadCloser, error) { return ioutil.NopCloser(bytes.NewReader(content)), nil }
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(content)), nil }
 	return req, nil
 }
 

--- a/enterprise/cmd/frontend/internal/executor/internal_proxy_handler_test.go
+++ b/enterprise/cmd/frontend/internal/executor/internal_proxy_handler_test.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -177,7 +176,7 @@ func TestReverseProxyRedirectWithPayload(t *testing.T) {
 			return
 		}
 
-		contents, err := ioutil.ReadAll(r.Body)
+		contents, err := io.ReadAll(r.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/enterprise/cmd/frontend/internal/registry/http_api.go
+++ b/enterprise/cmd/frontend/internal/registry/http_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -239,7 +238,7 @@ func init() {
 	}
 
 	readFakeExtensions := func() ([]*registry.Extension, error) {
-		data, err := ioutil.ReadFile(path)
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}

--- a/enterprise/internal/batches/resolvers/main_test.go
+++ b/enterprise/internal/batches/resolvers/main_test.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -208,7 +207,7 @@ func mockRepoComparison(t *testing.T, baseRev, headRev, diff string) {
 		if have, want := args[len(args)-2], spec; have != want {
 			t.Fatalf("gitserver.ExecReader received wrong spec: %q, want %q", have, want)
 		}
-		return ioutil.NopCloser(strings.NewReader(diff)), nil
+		return io.NopCloser(strings.NewReader(diff)), nil
 	}
 	t.Cleanup(func() { git.Mocks.ExecReader = nil })
 

--- a/enterprise/internal/batches/testing/mock_sync_state.go
+++ b/enterprise/internal/batches/testing/mock_sync_state.go
@@ -2,7 +2,6 @@ package testing
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -70,7 +69,7 @@ index 884601b..c4886d5 100644
 			}
 			return nil, errors.New("cannot handle non-diff command in mock ExecReader")
 		}
-		return ioutil.NopCloser(strings.NewReader(testGitHubDiff)), nil
+		return io.NopCloser(strings.NewReader(testGitHubDiff)), nil
 	}
 
 	git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {

--- a/enterprise/internal/batches/webhooks/webhooks.go
+++ b/enterprise/internal/batches/webhooks/webhooks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -809,7 +808,7 @@ func (h *BitbucketServerWebhook) ServeHTTP(w http.ResponseWriter, r *http.Reques
 }
 
 func (h *BitbucketServerWebhook) parseEvent(r *http.Request) (interface{}, *types.ExternalService, *httpError) {
-	payload, err := ioutil.ReadAll(r.Body)
+	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, nil, &httpError{http.StatusInternalServerError, err}
 	}

--- a/enterprise/internal/batches/webhooks/webhooks_gitlab.go
+++ b/enterprise/internal/batches/webhooks/webhooks_gitlab.go
@@ -3,7 +3,6 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -55,7 +54,7 @@ func (h *GitLabWebhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		respond(w, http.StatusBadRequest, "missing request body")
 		return
 	}
-	payload, err := ioutil.ReadAll(r.Body)
+	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		respond(w, http.StatusInternalServerError, errors.Wrap(err, "reading payload"))
 		return

--- a/enterprise/internal/batches/webhooks/webhooks_gitlab_test.go
+++ b/enterprise/internal/batches/webhooks/webhooks_gitlab_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -841,7 +840,7 @@ func gitLabTestSetup(t *testing.T, db *sql.DB) *store.Store {
 // body, and generates a test error if the substring is not found. This is
 // mostly useful to look for wrapped errors in the output.
 func assertBodyIncludes(t *testing.T, r io.Reader, want string) {
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/batches/webhooks/webhooks_test.go
+++ b/enterprise/internal/batches/webhooks/webhooks_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -195,7 +194,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					err = ioutil.WriteFile(fixtureFile, data, 0666)
+					err = os.WriteFile(fixtureFile, data, 0666)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -377,7 +376,7 @@ func testBitbucketWebhook(db *sql.DB, userID int32) func(*testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					err = ioutil.WriteFile(fixtureFile, data, 0666)
+					err = os.WriteFile(fixtureFile, data, 0666)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -430,7 +429,7 @@ type webhookTestCase struct {
 func loadWebhookTestCase(t testing.TB, path string) webhookTestCase {
 	t.Helper()
 
-	bs, err := ioutil.ReadFile(path)
+	bs, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/codeintel/commitgraph/commit_graph_test.go
+++ b/enterprise/internal/codeintel/commitgraph/commit_graph_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -240,7 +239,7 @@ func readBenchmarkFile(path string) ([]byte, error) {
 	}
 	defer r.Close()
 
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codeintel/stores/dbstore/commits_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/commits_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -626,7 +625,7 @@ func readBenchmarkFile(path string) ([]byte, error) {
 	}
 	defer r.Close()
 
-	contents, err := ioutil.ReadAll(r)
+	contents, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/enterprise/internal/codeintel/stores/lsifstore/helpers_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/helpers_test.go
@@ -1,7 +1,6 @@
 package lsifstore
 
 import (
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 const testBundleID = 39162
 
 func populateTestStore(t testing.TB) *Store {
-	contents, err := ioutil.ReadFile("./testdata/lsif-go@ad3507cb.sql")
+	contents, err := os.ReadFile("./testdata/lsif-go@ad3507cb.sql")
 	if err != nil {
 		t.Fatalf("unexpected error reading testdata: %s", err)
 	}

--- a/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/gcs_client_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -92,7 +91,7 @@ func TestGCSGet(t *testing.T) {
 	objectHandle := NewMockGcsObjectHandle()
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
-	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
+	objectHandle.NewRangeReaderFunc.SetDefaultReturn(io.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
 	client := testGCSClient(gcsClient, false)
 	rc, err := client.Get(context.Background(), "test-key")
@@ -101,7 +100,7 @@ func TestGCSGet(t *testing.T) {
 	}
 
 	defer rc.Close()
-	contents, err := ioutil.ReadAll(rc)
+	contents, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("unexpected error reading object: %s", err)
 	}
@@ -232,7 +231,7 @@ func TestGCSDelete(t *testing.T) {
 	objectHandle := NewMockGcsObjectHandle()
 	gcsClient.BucketFunc.SetDefaultReturn(bucketHandle)
 	bucketHandle.ObjectFunc.SetDefaultReturn(objectHandle)
-	objectHandle.NewRangeReaderFunc.SetDefaultReturn(ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
+	objectHandle.NewRangeReaderFunc.SetDefaultReturn(io.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))), nil)
 
 	client := testGCSClient(gcsClient, false)
 	if err := client.Delete(context.Background(), "test-key"); err != nil {

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"sync"
 	"time"
@@ -130,7 +129,7 @@ func (s *s3Store) Get(ctx context.Context, key string) (_ io.ReadCloser, err err
 		}
 	})
 
-	return ioutil.NopCloser(reader), nil
+	return io.NopCloser(reader), nil
 }
 
 // ioCopyHook is a pointer to io.Copy. This function is replaced in unit tests so that we can

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"sort"
 	"strconv"
@@ -84,7 +83,7 @@ func TestS3UnmanagedInit(t *testing.T) {
 func TestS3Get(t *testing.T) {
 	s3Client := NewMockS3API()
 	s3Client.GetObjectFunc.SetDefaultReturn(&s3.GetObjectOutput{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
+		Body: io.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
 	}, nil)
 
 	client := newS3WithClients(s3Client, nil, "test-bucket", time.Hour*24, false, newOperations(&observation.TestContext))
@@ -94,7 +93,7 @@ func TestS3Get(t *testing.T) {
 	}
 	defer rc.Close()
 
-	contents, err := ioutil.ReadAll(rc)
+	contents, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("unexpected error reading object: %s", err)
 	}
@@ -146,7 +145,7 @@ func TestS3GetTransientErrors(t *testing.T) {
 	}
 	defer rc.Close()
 
-	contents, err := ioutil.ReadAll(rc)
+	contents, err := io.ReadAll(rc)
 	if err != nil {
 		t.Fatalf("unexpected error reading object: %s", err)
 	}
@@ -175,7 +174,7 @@ func TestS3GetReadNothingLoop(t *testing.T) {
 	}
 	defer rc.Close()
 
-	if _, err := ioutil.ReadAll(rc); err != errNoDownloadProgress {
+	if _, err := io.ReadAll(rc); err != errNoDownloadProgress {
 		t.Fatalf("unexpected error reading object. want=%q have=%q", errNoDownloadProgress, err)
 	}
 }
@@ -201,7 +200,7 @@ func fullContentsS3API() *MockS3API {
 		}
 
 		out := &s3.GetObjectOutput{
-			Body: ioutil.NopCloser(bytes.NewReader(fullContents[offset:])),
+			Body: io.NopCloser(bytes.NewReader(fullContents[offset:])),
 		}
 
 		return out, nil
@@ -217,7 +216,7 @@ func TestS3Upload(t *testing.T) {
 		// Synchronously read the reader so that we trigger the
 		// counting reader inside the Upload method and test the
 		// count.
-		contents, err := ioutil.ReadAll(input.Body)
+		contents, err := io.ReadAll(input.Body)
 		if err != nil {
 			return err
 		}
@@ -364,7 +363,7 @@ func TestS3Combine(t *testing.T) {
 func TestS3Delete(t *testing.T) {
 	s3Client := NewMockS3API()
 	s3Client.GetObjectFunc.SetDefaultReturn(&s3.GetObjectOutput{
-		Body: ioutil.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
+		Body: io.NopCloser(bytes.NewReader([]byte("TEST PAYLOAD"))),
 	}, nil)
 
 	client := testS3Client(s3Client, nil)

--- a/enterprise/internal/license/generate-license.go
+++ b/enterprise/internal/license/generate-license.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"time"
 
@@ -59,7 +58,7 @@ func main() {
 	if *privateKeyFile == "" {
 		log.Fatal("A private key file must be explicitly indicated, but was not.")
 	}
-	b, err = ioutil.ReadFile(*privateKeyFile)
+	b, err = os.ReadFile(*privateKeyFile)
 	if err != nil {
 		log.Fatalf("Unable to read private key: %v\n", err)
 	}

--- a/enterprise/internal/license/read-license.go
+++ b/enterprise/internal/license/read-license.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -32,7 +31,7 @@ func (noopPublicKey) Verify(data []byte, sig *ssh.Signature) error { return erro
 func main() {
 	log.SetFlags(0)
 
-	data, err := ioutil.ReadAll(os.Stdin)
+	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/enterprise/lib/codeintel/bloomfilter/helpers_test.go
+++ b/enterprise/lib/codeintel/bloomfilter/helpers_test.go
@@ -3,13 +3,12 @@ package bloomfilter
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
 
 func readTestFilter(t testing.TB, dirname, filename string) []byte {
-	content, err := ioutil.ReadFile(fmt.Sprintf("./testdata/filters/%s/%s", dirname, filename))
+	content, err := os.ReadFile(fmt.Sprintf("./testdata/filters/%s/%s", dirname, filename))
 	if err != nil {
 		t.Fatalf("unexpected error reading: %s", err)
 	}
@@ -23,7 +22,7 @@ func readTestFilter(t testing.TB, dirname, filename string) []byte {
 }
 
 func readTestWords(t testing.TB, filename string) []string {
-	content, err := ioutil.ReadFile(fmt.Sprintf("./testdata/words/%s", filename))
+	content, err := os.ReadFile(fmt.Sprintf("./testdata/words/%s", filename))
 	if err != nil {
 		t.Fatalf("unexpected error reading %s: %s", filename, err)
 	}

--- a/enterprise/lib/codeintel/lsif/conversion/correlate_test.go
+++ b/enterprise/lib/codeintel/lsif/conversion/correlate_test.go
@@ -3,7 +3,6 @@ package conversion
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestCorrelate(t *testing.T) {
-	input, err := ioutil.ReadFile("../testdata/dump1.lsif")
+	input, err := os.ReadFile("../testdata/dump1.lsif")
 	if err != nil {
 		t.Fatalf("unexpected error reading test file: %s", err)
 	}
@@ -189,7 +188,7 @@ func TestCorrelate(t *testing.T) {
 }
 
 func TestCorrelateMetaDataRoot(t *testing.T) {
-	input, err := ioutil.ReadFile("../testdata/dump2.lsif")
+	input, err := os.ReadFile("../testdata/dump2.lsif")
 	if err != nil {
 		t.Fatalf("unexpected error reading test file: %s", err)
 	}
@@ -229,7 +228,7 @@ func TestCorrelateMetaDataRoot(t *testing.T) {
 }
 
 func TestCorrelateMetaDataRootX(t *testing.T) {
-	input, err := ioutil.ReadFile("../testdata/dump3.lsif")
+	input, err := os.ReadFile("../testdata/dump3.lsif")
 	if err != nil {
 		t.Fatalf("unexpected error reading test file: %s", err)
 	}

--- a/internal/api/internal_client.go
+++ b/internal/api/internal_client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -48,7 +47,7 @@ func (c *internalClient) WaitForFrontend(ctx context.Context) error {
 		if resp.StatusCode != http.StatusOK {
 			return fmt.Errorf("ping: bad HTTP response status %d", resp.StatusCode)
 		}
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/internal/authz/gitlab/oauth_test.go
+++ b/internal/authz/gitlab/oauth_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -83,7 +82,7 @@ func TestOAuthProvider_FetchUserPerms(t *testing.T) {
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+					Body:       io.NopCloser(bytes.NewReader([]byte(body))),
 				}, nil
 			},
 		},
@@ -176,7 +175,7 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+					Body:       io.NopCloser(bytes.NewReader([]byte(body))),
 				}, nil
 			},
 		},

--- a/internal/authz/gitlab/sudo_test.go
+++ b/internal/authz/gitlab/sudo_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"reflect"
 	"testing"
@@ -288,7 +287,7 @@ func TestSudoProvider_FetchUserPerms(t *testing.T) {
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+					Body:       io.NopCloser(bytes.NewReader([]byte(body))),
 				}, nil
 			},
 		},
@@ -381,7 +380,7 @@ func TestSudoProvider_FetchRepoPerms(t *testing.T) {
 				return &http.Response{
 					Status:     http.StatusText(http.StatusOK),
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+					Body:       io.NopCloser(bytes.NewReader([]byte(body))),
 				}, nil
 			},
 		},

--- a/internal/authz/perforce/perforce.go
+++ b/internal/authz/perforce/perforce.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"strings"
 
@@ -128,7 +127,7 @@ func (p *Provider) FetchAccount(ctx context.Context, user *types.User, _ []*exts
 	}
 
 	// Drain remaining body
-	_, _ = io.Copy(ioutil.Discard, rc)
+	_, _ = io.Copy(io.Discard, rc)
 	return nil, nil
 }
 
@@ -335,7 +334,7 @@ func (p *Provider) getGroupMembers(ctx context.Context, group string) ([]string,
 	}
 
 	// Drain remaining body
-	_, _ = io.Copy(ioutil.Discard, rc)
+	_, _ = io.Copy(io.Discard, rc)
 
 	p.cachedGroupMembers[group] = members
 	return p.cachedGroupMembers[group], nil

--- a/internal/cmd/ghe-feeder/main.go
+++ b/internal/cmd/ghe-feeder/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"net/http"
@@ -84,7 +83,7 @@ func main() {
 	}
 
 	if len(*scratchDir) == 0 {
-		d, err := ioutil.TempDir("", "ghe-feeder")
+		d, err := os.MkdirTemp("", "ghe-feeder")
 		if err != nil {
 			log15.Error("failed to create scratch dir", "error", err)
 			os.Exit(1)

--- a/internal/cmd/init-sg/repos.go
+++ b/internal/cmd/init-sg/repos.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -53,7 +52,7 @@ func addReposCommand() {
 		Config      Config `json:"Config"`
 	}
 
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 
 	var externalsvcs []ExternalSvc
 

--- a/internal/cmd/precise-code-intel-tester/upload.go
+++ b/internal/cmd/precise-code-intel-tester/upload.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -74,7 +73,7 @@ var indexFilenamePattern = regexp.MustCompile(`^(.+)\.\d+\.([0-9A-Fa-f]{40})\.du
 
 // readRevsByRepo returns a list of revisions by repository names for which there is an index file.
 func readRevsByRepo() (map[string][]string, error) {
-	infos, err := ioutil.ReadDir(indexDir)
+	infos, err := os.ReadDir(indexDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/precise-code-intel-tester/util/graphql.go
+++ b/internal/cmd/precise-code-intel-tester/util/graphql.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/hashicorp/go-multierror"
@@ -47,7 +46,7 @@ func QueryGraphQL(ctx context.Context, endpoint, token, query string, variables 
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	contents, err := ioutil.ReadAll(resp.Body)
+	contents, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/resources-report/slack.go
+++ b/internal/cmd/resources-report/slack.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 )
@@ -102,7 +101,7 @@ func sendSlackBlocks(ctx context.Context, webhook string, blocks []slackBlock) e
 	}
 	if resp.StatusCode != 200 {
 		defer resp.Body.Close()
-		message, err := ioutil.ReadAll(resp.Body)
+		message, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("failed to post report to slack: %s", resp.Status)
 		}

--- a/internal/cmd/search-blitz/client.go
+++ b/internal/cmd/search-blitz/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -49,7 +48,7 @@ func (s *client) search(ctx context.Context, qc QueryConfig) (*result, *metrics,
 		return nil, nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", s.url(qc.Name), ioutil.NopCloser(&body))
+	req, err := http.NewRequestWithContext(ctx, "POST", s.url(qc.Name), io.NopCloser(&body))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cmd/tracking-issue/main_test.go
+++ b/internal/cmd/tracking-issue/main_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -76,14 +75,14 @@ func getOrUpdateLastUpdateTime(update bool) (time.Time, error) {
 
 	if update {
 		now := time.Now().UTC()
-		if err := ioutil.WriteFile(lastUpdateFile, []byte(now.Format(time.RFC3339)), os.ModePerm); err != nil {
+		if err := os.WriteFile(lastUpdateFile, []byte(now.Format(time.RFC3339)), os.ModePerm); err != nil {
 			return time.Time{}, err
 		}
 
 		return now, nil
 	}
 
-	content, err := ioutil.ReadFile(lastUpdateFile)
+	content, err := os.ReadFile(lastUpdateFile)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -166,7 +165,7 @@ func updateTestFixtures() (trackingIssues []*Issue, issues []*Issue, pullRequest
 }
 
 func readFixturesFile() (trackingIssues []*Issue, issues []*Issue, pullRequests []*PullRequest, _ error) {
-	contents, err := ioutil.ReadFile(filepath.Join("testdata", "fixtures.json"))
+	contents, err := os.ReadFile(filepath.Join("testdata", "fixtures.json"))
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -189,5 +188,5 @@ func writeFixturesFile(trackingIssues []*Issue, issues []*Issue, pullRequests []
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join("testdata", "fixtures.json"), contents, os.ModePerm)
+	return os.WriteFile(filepath.Join("testdata", "fixtures.json"), contents, os.ModePerm)
 }

--- a/internal/comby/comby.go
+++ b/internal/comby/comby.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -72,7 +71,7 @@ func waitForCompletion(cmd *exec.Cmd, stdout, stderr io.ReadCloser, w io.Writer)
 	// Read stderr in goroutine so we don't potentially block reading stdout
 	stderrMsgC := make(chan []byte, 1)
 	go func() {
-		msg, _ := ioutil.ReadAll(stderr)
+		msg, _ := io.ReadAll(stderr)
 		stderrMsgC <- msg
 		close(stderrMsgC)
 	}()

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -3,7 +3,6 @@ package conf
 
 import (
 	"context"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -200,7 +199,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 				time.Sleep(1 * time.Second)
 				continue
 			}
-			if err := ioutil.WriteFile(siteConfigEscapeHatchPath, []byte(config.Site), 0644); err != nil {
+			if err := os.WriteFile(siteConfigEscapeHatchPath, []byte(config.Site), 0644); err != nil {
 				log15.Error("config: failed to write site config file, trying again in 1s", "error", err)
 				time.Sleep(1 * time.Second)
 				continue
@@ -214,7 +213,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 		for {
 			// If the file changes from what we last wrote, an admin made an edit to the file and
 			// we should propagate it to the database for them.
-			newFileContents, err := ioutil.ReadFile(siteConfigEscapeHatchPath)
+			newFileContents, err := os.ReadFile(siteConfigEscapeHatchPath)
 			if err != nil {
 				log15.Error("config: failed to read site config from disk, trying again in 1s", "path", siteConfigEscapeHatchPath)
 				time.Sleep(1 * time.Second)
@@ -249,7 +248,7 @@ func startSiteConfigEscapeHatchWorker(c ConfigurationSource) {
 				continue
 			}
 			if newDBConfig.Site != lastKnownDBContents {
-				if err := ioutil.WriteFile(siteConfigEscapeHatchPath, []byte(newDBConfig.Site), 0644); err != nil {
+				if err := os.WriteFile(siteConfigEscapeHatchPath, []byte(newDBConfig.Site), 0644); err != nil {
 					log15.Error("config: failed to write site config file, trying again in 1s", "error", err)
 					time.Sleep(1 * time.Second)
 					continue

--- a/internal/database/schemadoc/main.go
+++ b/internal/database/schemadoc/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -108,7 +107,7 @@ func generateAndWrite(database *dbconn.Database, dataSource string, commandPrefi
 		return err
 	}
 
-	return ioutil.WriteFile(destinationFile, []byte(out), os.ModePerm)
+	return os.WriteFile(destinationFile, []byte(out), os.ModePerm)
 }
 
 func startDocker() (commandPrefix []string, shutdown func(), _ error) {

--- a/internal/diskcache/cache.go
+++ b/internal/diskcache/cache.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -230,7 +229,7 @@ func (s *Store) Evict(maxCacheSizeBytes int64) (stats EvictStats, err error) {
 		return strings.HasSuffix(fi.Name(), ".zip")
 	}
 
-	list, err := ioutil.ReadDir(s.Dir)
+	list, err := os.ReadDir(s.Dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return EvictStats{

--- a/internal/diskcache/cache_test.go
+++ b/internal/diskcache/cache_test.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 )
 
 func TestOpen(t *testing.T) {
-	dir, err := ioutil.TempDir("", "diskcache_test")
+	dir, err := os.MkdirTemp("", "diskcache_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,12 +25,12 @@ func TestOpen(t *testing.T) {
 		calledFetcher := false
 		f, err := store.Open(context.Background(), "key", func(ctx context.Context) (io.ReadCloser, error) {
 			calledFetcher = true
-			return ioutil.NopCloser(bytes.NewReader([]byte(want))), nil
+			return io.NopCloser(bytes.NewReader([]byte(want))), nil
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
-		got, err := ioutil.ReadAll(f.File)
+		got, err := io.ReadAll(f.File)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -5,7 +5,6 @@ package endpoint
 import (
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"net/url"
 	"sort"
 	"strings"
@@ -285,7 +284,7 @@ func newConsistentHashMap(keys []string) *hashMap {
 // when the client was created, the official k8s client does not
 func namespace() string {
 	const filename = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		log15.Warn("endpoint: falling back to kubernetes default namespace", "error", filename+" is empty")
 		return "default"

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -4,7 +4,6 @@ import (
 	"expvar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -80,7 +79,7 @@ func init() {
 	lvlFilterStderr := func(maxLvl log15.Lvl) io.Writer {
 		// Note that log15 values look like e.g. LvlCrit == 0, LvlDebug == 4
 		if lvl > maxLvl {
-			return ioutil.Discard
+			return io.Discard
 		}
 		return os.Stderr
 	}

--- a/internal/extsvc/bitbucketcloud/client.go
+++ b/internal/extsvc/bitbucketcloud/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -174,7 +173,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 
 	defer resp.Body.Close()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -889,7 +888,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 
 	defer resp.Body.Close()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
@@ -749,12 +748,12 @@ func checkGolden(t *testing.T, name string, got interface{}) {
 
 	path := "testdata/golden/" + name
 	if *update {
-		if err = ioutil.WriteFile(path, data, 0640); err != nil {
+		if err = os.WriteFile(path, data, 0640); err != nil {
 			t.Fatalf("failed to update golden file %q: %s", path, err)
 		}
 	}
 
-	golden, err := ioutil.ReadFile(path)
+	golden, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed to read golden file %q: %s", path, err)
 	}

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -89,7 +88,7 @@ func doRequest(ctx context.Context, apiURL *url.URL, auth auth.Authenticator, ra
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		var err APIError
-		if body, readErr := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<13)); readErr != nil { // 8kb
+		if body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<13)); readErr != nil { // 8kb
 			err.Message = fmt.Sprintf("failed to read error response from GitHub API: %v: %q", readErr, string(body))
 		} else if decErr := json.Unmarshal(body, &err); decErr != nil {
 			err.Message = fmt.Sprintf("failed to decode error response from GitHub API: %v: %q", decErr, string(body))

--- a/internal/extsvc/github/repos_test.go
+++ b/internal/extsvc/github/repos_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -45,7 +44,7 @@ func (s *mockHTTPResponseBody) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Request:    req,
 		StatusCode: status,
-		Body:       ioutil.NopCloser(strings.NewReader(s.responseBody)),
+		Body:       io.NopCloser(strings.NewReader(s.responseBody)),
 	}, nil
 }
 
@@ -57,7 +56,7 @@ func (s mockHTTPEmptyResponse) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Request:    req,
 		StatusCode: s.statusCode,
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 	}, nil
 }
 

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -243,7 +242,7 @@ func (c *Client) do(ctx context.Context, req *http.Request, result interface{}) 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		// We swallow the error here, because we don't want to fail. Parsing the body
 		// is just optional to provide some more context.
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		err := NewHTTPError(resp.StatusCode, body)
 		return nil, resp.StatusCode, errors.Wrap(err, fmt.Sprintf("unexpected response from GitLab API (%s)", req.URL))
 	}

--- a/internal/extsvc/gitlab/testing.go
+++ b/internal/extsvc/gitlab/testing.go
@@ -2,7 +2,6 @@ package gitlab
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -23,7 +22,7 @@ func (s *mockHTTPResponseBody) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Request:    req,
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(strings.NewReader(s.responseBody)),
+		Body:       io.NopCloser(strings.NewReader(s.responseBody)),
 		Header:     s.header,
 	}, nil
 }
@@ -36,7 +35,7 @@ func (s mockHTTPEmptyResponse) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		Request:    req,
 		StatusCode: s.statusCode,
-		Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+		Body:       io.NopCloser(bytes.NewReader(nil)),
 	}, nil
 }
 

--- a/internal/extsvc/phabricator/client_test.go
+++ b/internal/extsvc/phabricator/client_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -96,12 +95,12 @@ func TestClient_ListRepos(t *testing.T) {
 
 			path := fmt.Sprintf("testdata/golden/ListRepos-%s.json", tc.name)
 			if *update {
-				if err = ioutil.WriteFile(path, bs, 0640); err != nil {
+				if err = os.WriteFile(path, bs, 0640); err != nil {
 					t.Fatalf("failed to update golden file %q: %s", path, err)
 				}
 			}
 
-			golden, err := ioutil.ReadFile(path)
+			golden, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("failed to read golden file %q: %s", path, err)
 			}
@@ -160,12 +159,12 @@ func TestClient_GetRawDiff(t *testing.T) {
 
 			path := "testdata/golden/GetRawDiff-" + strconv.Itoa(tc.id)
 			if *update {
-				if err = ioutil.WriteFile(path, []byte(diff), 0640); err != nil {
+				if err = os.WriteFile(path, []byte(diff), 0640); err != nil {
 					t.Fatalf("failed to update golden file %q: %s", path, err)
 				}
 			}
 
-			golden, err := ioutil.ReadFile(path)
+			golden, err := os.ReadFile(path)
 			if err != nil {
 				t.Fatalf("failed to read golden file %q: %s", path, err)
 			}

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -363,7 +362,7 @@ func (c *Cmd) DividedOutput(ctx context.Context) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 
-	stdout, err := ioutil.ReadAll(rc)
+	stdout, err := io.ReadAll(rc)
 	rc.Close()
 	if err != nil {
 		return nil, nil, err
@@ -611,7 +610,7 @@ func (c *Client) RequestRepoUpdate(ctx context.Context, repo api.RepoName, since
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return nil, &url.Error{URL: resp.Request.URL.String(), Op: "RepoInfo", Err: fmt.Errorf("RepoInfo: http status %d: %s", resp.StatusCode, body)}
 	}
 
@@ -637,7 +636,7 @@ func (c *Client) IsRepoCloneable(ctx context.Context, repo api.RepoName) error {
 		return err
 	}
 	defer r.Body.Close()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return err
 	}
@@ -897,7 +896,7 @@ func (c *Client) Remove(ctx context.Context, repo api.RepoName) error {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		// best-effort inclusion of body in error message
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return &url.Error{URL: resp.Request.URL.String(), Op: "RepoRemove", Err: fmt.Errorf("RepoRemove: http status %d: %s", resp.StatusCode, string(body))}
 	}
 	return nil
@@ -974,7 +973,7 @@ func (c *Client) CreateCommitFromPatch(ctx context.Context, req protocol.CreateC
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log15.Warn("reading gitserver create-commit-from-patch response", "err", err.Error())
 		return "", &url.Error{URL: resp.Request.URL.String(), Op: "CreateCommitFromPatch", Err: fmt.Errorf("CreateCommitFromPatch: http status %d %s", resp.StatusCode, err.Error())}

--- a/internal/gitserver/client_test.go
+++ b/internal/gitserver/client_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -35,11 +34,11 @@ func TestClient_ListCloned(t *testing.T) {
 			switch r.URL.String() {
 			case "http://gitserver-0/list?cloned":
 				return &http.Response{
-					Body: ioutil.NopCloser(bytes.NewBufferString(`["repo0-a", "repo0-b"]`)),
+					Body: io.NopCloser(bytes.NewBufferString(`["repo0-a", "repo0-b"]`)),
 				}, nil
 			case "http://gitserver-1/list?cloned":
 				return &http.Response{
-					Body: ioutil.NopCloser(bytes.NewBufferString(`["repo1-a", "repo1-b"]`)),
+					Body: io.NopCloser(bytes.NewBufferString(`["repo1-a", "repo1-b"]`)),
 				}, nil
 			default:
 				return nil, fmt.Errorf("unexpected url: %s", r.URL.String())
@@ -60,7 +59,7 @@ func TestClient_ListCloned(t *testing.T) {
 }
 
 func TestClient_Archive(t *testing.T) {
-	root, err := ioutil.TempDir("", t.Name())
+	root, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +127,7 @@ func TestClient_Archive(t *testing.T) {
 			}
 
 			defer rc.Close()
-			data, err := ioutil.ReadAll(rc)
+			data, err := io.ReadAll(rc)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -144,7 +143,7 @@ func TestClient_Archive(t *testing.T) {
 					t.Errorf("failed to open %q because %s", f.Name, err)
 					continue
 				}
-				contents, err := ioutil.ReadAll(r)
+				contents, err := io.ReadAll(r)
 				_ = r.Close()
 				if err != nil {
 					t.Errorf("Read(%q): %s", f.Name, err)
@@ -215,7 +214,7 @@ filemode=true
 		if err := os.MkdirAll(filepath.Dir(name), 0700); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(name, []byte(data), 0600); err != nil {
+		if err := os.WriteFile(name, []byte(data), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -289,7 +288,7 @@ func TestAddrForRepo(t *testing.T) {
 }
 
 func TestClient_P4Exec(t *testing.T) {
-	root, err := ioutil.TempDir("", t.Name())
+	root, err := os.MkdirTemp("", t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/goremancmd/main.go
+++ b/internal/goremancmd/main.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -16,7 +15,7 @@ func do() error {
 		return fmt.Errorf("USAGE: %s Procfile", os.Args[0])
 	}
 
-	procfile, err := ioutil.ReadFile(os.Args[1])
+	procfile, err := os.ReadFile(os.Args[1])
 	if err != nil {
 		return err
 	}

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -3,7 +3,6 @@ package gqltestutil
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -21,7 +20,7 @@ func NeedsSiteInit(baseURL string) (bool, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	p, err := ioutil.ReadAll(resp.Body)
+	p, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, errors.Wrap(err, "read body")
 	}
@@ -109,7 +108,7 @@ func newClient(baseURL string) (*Client, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	p, err := ioutil.ReadAll(resp.Body)
+	p, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "read GET body")
 	}
@@ -160,7 +159,7 @@ func (c *Client) authenticate(path string, body interface{}) error {
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		p, err := ioutil.ReadAll(resp.Body)
+		p, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrap(err, "read response body")
 		}
@@ -256,7 +255,7 @@ func (c *Client) GraphQL(token, query string, variables map[string]interface{}, 
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, err = ioutil.ReadAll(resp.Body)
+	body, err = io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "read response body")
 	}

--- a/internal/httptestutil/client.go
+++ b/internal/httptestutil/client.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -27,7 +26,7 @@ func (t handlerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	rw.Body = new(bytes.Buffer)
 	if req.Body == nil {
 		// For server requests the Request Body is always non-nil.
-		req.Body = ioutil.NopCloser(bytes.NewReader(nil))
+		req.Body = io.NopCloser(bytes.NewReader(nil))
 	}
 	t.Handler.ServeHTTP(rw, req)
 	return rw.Result(), nil
@@ -48,8 +47,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 	resp, err := c.Client.Do(req)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
-		body, _ := ioutil.ReadAll(resp.Body)
-		resp.Body = ioutil.NopCloser(bytes.NewReader(body))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body = io.NopCloser(bytes.NewReader(body))
 	}
 	if err != nil {
 		return resp, err

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -88,7 +87,7 @@ func TestMustRegisterDiskMonitor(t *testing.T) {
 
 	want := []string{}
 	for i := 0; i <= 2; i++ {
-		path, err := ioutil.TempDir("", "")
+		path, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/repos/bitbucketcloud_test.go
+++ b/internal/repos/bitbucketcloud_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -111,7 +110,7 @@ func TestBitbucketCloudSource_ListRepos(t *testing.T) {
 }
 
 func TestBitbucketCloudSource_makeRepo(t *testing.T) {
-	b, err := ioutil.ReadFile(filepath.Join("testdata", "bitbucketcloud-repos.json"))
+	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud-repos.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +169,7 @@ func TestBitbucketCloudSource_makeRepo(t *testing.T) {
 }
 
 func TestBitbucketCloudSource_Exclude(t *testing.T) {
-	b, err := ioutil.ReadFile(filepath.Join("testdata", "bitbucketcloud-repos.json"))
+	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud-repos.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/bitbucketserver_test.go
+++ b/internal/repos/bitbucketserver_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,7 @@ import (
 )
 
 func TestBitbucketServerSource_MakeRepo(t *testing.T) {
-	b, err := ioutil.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
+	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +75,7 @@ func TestBitbucketServerSource_MakeRepo(t *testing.T) {
 }
 
 func TestBitbucketServerSource_Exclude(t *testing.T) {
-	b, err := ioutil.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
+	b, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver-repos.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -510,7 +509,7 @@ func TestGithubSource_GetRepo(t *testing.T) {
 }
 
 func TestGithubSource_makeRepo(t *testing.T) {
-	b, err := ioutil.ReadFile(filepath.Join("testdata", "github-repos.json"))
+	b, err := os.ReadFile(filepath.Join("testdata", "github-repos.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/gitlab_test.go
+++ b/internal/repos/gitlab_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -167,7 +166,7 @@ func TestGitLabSource_GetRepo(t *testing.T) {
 }
 
 func TestGitLabSource_makeRepo(t *testing.T) {
-	b, err := ioutil.ReadFile(filepath.Join("testdata", "gitlab-repos.json"))
+	b, err := os.ReadFile(filepath.Join("testdata", "gitlab-repos.json"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -3,7 +3,6 @@ package repos
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -157,7 +156,7 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 	}
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response from src-expose")
 	}

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -100,7 +99,7 @@ func (c *Client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 
 	if resp.StatusCode != http.StatusOK {
 		// best-effort inclusion of body in error message
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return nil, errors.Errorf("RepoLookup for %+v failed with http status %d: %s", args, resp.StatusCode, string(body))
 	}
 
@@ -147,7 +146,7 @@ func (c *Client) EnqueueRepoUpdate(ctx context.Context, repo api.RepoName) (*pro
 	}
 	defer resp.Body.Close()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
@@ -177,7 +176,7 @@ func (c *Client) EnqueueChangesetSync(ctx context.Context, ids []int64) error {
 	}
 	defer resp.Body.Close()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "failed to read response body")
 	}
@@ -202,7 +201,7 @@ func (c *Client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncR
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "read response body")
 	}
@@ -229,7 +228,7 @@ func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 	}
 	defer resp.Body.Close()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
@@ -263,7 +262,7 @@ func (c *Client) RepoExternalServices(ctx context.Context, id api.RepoID) ([]api
 	}
 	defer resp.Body.Close()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}
@@ -292,7 +291,7 @@ func (c *Client) ExcludeRepo(ctx context.Context, id api.RepoID) (*protocol.Excl
 	}
 	defer resp.Body.Close()
 
-	bs, err := ioutil.ReadAll(resp.Body)
+	bs, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read response body")
 	}

--- a/internal/search/searcher/client.go
+++ b/internal/search/searcher/client.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -183,7 +182,7 @@ func textSearchURL(ctx context.Context, url string) ([]*protocol.FileMatch, bool
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return nil, false, err
 		}

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -86,7 +85,7 @@ func (c *Client) Post(ctx context.Context, payload *Payload) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/internal/src-cli/version.go
+++ b/internal/src-cli/version.go
@@ -3,7 +3,6 @@ package srccli
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"sort"
 
@@ -97,7 +96,7 @@ func releaseVersionsPage(url string) ([]*semver.Version, string, error) {
 	}
 	defer resp.Body.Close()
 
-	respContent, err := ioutil.ReadAll(resp.Body)
+	respContent, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/store/retry_test.go
+++ b/internal/store/retry_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -50,7 +49,7 @@ func TestGetZipFileWithRetry(t *testing.T) {
 			tries := 0
 			get := func() (string, *ZipFile, error) {
 				var err error
-				tmp, err = ioutil.TempFile("", "")
+				tmp, err = os.CreateTemp("", "")
 				if err != nil {
 					t.Fatalf("TempFile(%v)", err)
 				}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -65,7 +64,7 @@ func TestPrepareZip(t *testing.T) {
 	// use the disk cache.
 	onDisk := false
 	for i := 0; i < 500; i++ {
-		files, _ := ioutil.ReadDir(s.Path)
+		files, _ := os.ReadDir(s.Path)
 		if len(files) != 0 {
 			onDisk = true
 			break
@@ -106,7 +105,7 @@ func TestPrepareZip_errHeader(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 	}
 	_, err := s.PrepareZip(context.Background(), "foo", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 	if got, want := errors.Cause(err).Error(), tar.ErrHeader.Error(); got != want {
@@ -149,7 +148,7 @@ func TestIngoreSizeMax(t *testing.T) {
 }
 
 func tmpStore(t *testing.T) (*Store, func()) {
-	d, err := ioutil.TempDir("", "store_test")
+	d, err := os.MkdirTemp("", "store_test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,5 +164,5 @@ func emptyTar(t *testing.T) io.ReadCloser {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
+	return io.NopCloser(bytes.NewReader(buf.Bytes()))
 }

--- a/internal/symbols/client.go
+++ b/internal/symbols/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -95,7 +94,7 @@ func (c *Client) Search(ctx context.Context, args search.SymbolsParameters) (res
 
 	if resp.StatusCode != http.StatusOK {
 		// best-effort inclusion of body in error message
-		body, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 200))
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
 		return nil, errors.Errorf("Symbol.Search http status %d for %+v: %s", resp.StatusCode, resp.StatusCode, string(body))
 	}
 

--- a/internal/testutil/diff.go
+++ b/internal/testutil/diff.go
@@ -1,20 +1,19 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 )
 
 func Diff(b1, b2 string) (string, error) {
-	f1, err := ioutil.TempFile("", "diff_test")
+	f1, err := os.CreateTemp("", "diff_test")
 	if err != nil {
 		return "", err
 	}
 	defer os.Remove(f1.Name())
 	defer f1.Close()
 
-	f2, err := ioutil.TempFile("", "diff_test")
+	f2, err := os.CreateTemp("", "diff_test")
 	if err != nil {
 		return "", err
 	}

--- a/internal/testutil/golden.go
+++ b/internal/testutil/golden.go
@@ -2,7 +2,6 @@ package testutil
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,12 +18,12 @@ func AssertGolden(t testing.TB, path string, update bool, want interface{}) {
 		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 			t.Fatalf("failed to update golden file %q: %s", path, err)
 		}
-		if err := ioutil.WriteFile(path, data, 0640); err != nil {
+		if err := os.WriteFile(path, data, 0640); err != nil {
 			t.Fatalf("failed to update golden file %q: %s", path, err)
 		}
 	}
 
-	golden, err := ioutil.ReadFile(path)
+	golden, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("failed to read golden file %q: %s", path, err)
 	}

--- a/internal/testutil/store.go
+++ b/internal/testutil/store.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -39,13 +38,13 @@ func NewStore(files map[string]string) (*store.Store, func(), error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	d, err := ioutil.TempDir("", "search_test")
+	d, err := os.MkdirTemp("", "search_test")
 	if err != nil {
 		return nil, nil, err
 	}
 	return &store.Store{
 		FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {
-			return ioutil.NopCloser(bytes.NewReader(buf.Bytes())), nil
+			return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
 		},
 		Path: d,
 	}, func() { os.RemoveAll(d) }, nil

--- a/internal/testutil/zip.go
+++ b/internal/testutil/zip.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -71,11 +70,11 @@ func TempZipFileOnDisk(data []byte) (string, func(), error) {
 	if err != nil {
 		return "", nil, err
 	}
-	d, err := ioutil.TempDir("", "temp_zip_dir")
+	d, err := os.MkdirTemp("", "temp_zip_dir")
 	if err != nil {
 		return "", nil, err
 	}
-	f, err := ioutil.TempFile(d, "temp_zip")
+	f, err := os.CreateTemp(d, "temp_zip")
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/usagestats/usage_stats_test.go
+++ b/internal/usagestats/usage_stats_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"reflect"
 	"testing"
 	"time"
@@ -85,7 +84,7 @@ func TestGetArchive(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		have, err := ioutil.ReadAll(rc)
+		have, err := io.ReadAll(rc)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/vcs/git/blob.go
+++ b/internal/vcs/git/blob.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -69,7 +68,7 @@ func readFileBytes(ctx context.Context, repo api.RepoName, commit api.CommitID, 
 	if maxBytes > 0 {
 		r = io.LimitReader(r, maxBytes)
 	}
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/vcs/git/blob_test.go
+++ b/internal/vcs/git/blob_test.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -61,7 +60,7 @@ func TestRead(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer rc.Close()
-			data, err := ioutil.ReadAll(rc)
+			data, err := io.ReadAll(rc)
 			test.checkFn(t, err, data)
 		})
 	}

--- a/internal/vcs/git/diff_test.go
+++ b/internal/vcs/git/diff_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 )
@@ -132,7 +131,7 @@ index 9bd8209..d2acfa9 100644
 		}
 
 		Mocks.ExecReader = func(args []string) (io.ReadCloser, error) {
-			return ioutil.NopCloser(strings.NewReader(testDiff)), nil
+			return io.NopCloser(strings.NewReader(testDiff)), nil
 		}
 		defer ResetMocks()
 

--- a/internal/vcs/git/main_test.go
+++ b/internal/vcs/git/main_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -53,7 +52,7 @@ func init() {
 		log.Fatalf("listen failed: %s", err)
 	}
 
-	root, err = ioutil.TempDir("", "test")
+	root, err = os.MkdirTemp("", "test")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -103,7 +102,7 @@ func InitGitRepository(t testing.TB, cmds ...string) string {
 	if err := os.MkdirAll(remotes, 0700); err != nil {
 		t.Fatal(err)
 	}
-	dir, err := ioutil.TempDir(remotes, strings.ReplaceAll(t.Name(), "/", "__"))
+	dir, err := os.MkdirTemp(remotes, strings.ReplaceAll(t.Name(), "/", "__"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vcs/util/keyfile.go
+++ b/internal/vcs/util/keyfile.go
@@ -3,7 +3,6 @@ package util
 import (
 	"crypto/sha256"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 )
 
@@ -17,7 +16,7 @@ func WriteKeyTempFile(namePrefix string, keyData []byte) (filename string, tmp *
 	_, _ = hasher.Write([]byte(namePrefix))
 	hash := base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 
-	tmpfile, err := ioutil.TempFile("", "go-vcs-"+hash+"-")
+	tmpfile, err := os.CreateTemp("", "go-vcs-"+hash+"-")
 	if err != nil {
 		return "", nil, err
 	}

--- a/internal/vcs/util/script.go
+++ b/internal/vcs/util/script.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,7 +19,7 @@ func ScriptFile(prefix string) (filePath string, rootPath string, err error) {
 		suffix = ".bat"
 	}
 
-	tempDir, err := ioutil.TempDir("", prefix)
+	tempDir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		return "", "", err
 	}
@@ -29,7 +28,7 @@ func ScriptFile(prefix string) (filePath string, rootPath string, err error) {
 
 // Wrapper around ioutil.WriteFile that updates permissions regardless if file existed before
 func WriteFileWithPermissions(file string, content []byte, perm os.FileMode) error {
-	err := ioutil.WriteFile(file, content, perm)
+	err := os.WriteFile(file, content, perm)
 	if err != nil {
 		return err
 	}

--- a/lib/codeintel/utils/gzip_test.go
+++ b/lib/codeintel/utils/gzip_test.go
@@ -3,7 +3,6 @@ package codeintelutils
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -15,7 +14,7 @@ func TestGzip(t *testing.T) {
 		uncompressed = append(uncompressed, byte(i))
 	}
 
-	contents, err := ioutil.ReadAll(Gzip(bytes.NewReader(uncompressed)))
+	contents, err := io.ReadAll(Gzip(bytes.NewReader(uncompressed)))
 	if err != nil {
 		t.Fatalf("unexpected error reading from gzip reader: %s", err)
 	}
@@ -24,7 +23,7 @@ func TestGzip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating gzip.Reader: %s", err)
 	}
-	decompressed, err := ioutil.ReadAll(gzipReader)
+	decompressed, err := io.ReadAll(gzipReader)
 	if err != nil {
 		t.Fatalf("unexpected error reading from gzip.Reader: %s", err)
 	}

--- a/lib/codeintel/utils/split_file.go
+++ b/lib/codeintel/utils/split_file.go
@@ -3,7 +3,6 @@ package codeintelutils
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/go-multierror"
@@ -47,7 +46,7 @@ func SplitReaderIntoFiles(r io.ReaderAt, maxPayloadSize int) (files []string, _ 
 	makeNextReader := SplitReader(r, maxPayloadSize)
 
 	for {
-		partFile, err := ioutil.TempFile("", "")
+		partFile, err := os.CreateTemp("", "")
 		if err != nil {
 			return nil, nil, err
 		}

--- a/lib/codeintel/utils/split_file_test.go
+++ b/lib/codeintel/utils/split_file_test.go
@@ -1,7 +1,6 @@
 package codeintelutils
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -9,7 +8,7 @@ import (
 )
 
 func TestSplitFile(t *testing.T) {
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("unexpected error creating temp file: %s", err)
 	}
@@ -34,7 +33,7 @@ func TestSplitFile(t *testing.T) {
 
 	var contents []byte
 	for _, file := range files {
-		temp, err := ioutil.ReadFile(file)
+		temp, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatalf("unexpected error reading file: %s", err)
 		}

--- a/lib/codeintel/utils/stitch_files_test.go
+++ b/lib/codeintel/utils/stitch_files_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +14,7 @@ import (
 
 func TestStitchMultipart(t *testing.T) {
 	for _, compress := range []bool{true, false} {
-		tempDir, err := ioutil.TempDir("", "codeintel-")
+		tempDir, err := os.MkdirTemp("", "codeintel-")
 		if err != nil {
 			t.Fatalf("unexpected error creating temp directory: %s", err)
 		}
@@ -44,7 +43,7 @@ func TestStitchMultipart(t *testing.T) {
 				t.Fatalf("unexpected error closing gzip writer: %s", err)
 			}
 
-			if err := ioutil.WriteFile(partFilename(i), buf.Bytes(), os.ModePerm); err != nil {
+			if err := os.WriteFile(partFilename(i), buf.Bytes(), os.ModePerm); err != nil {
 				t.Fatalf("unexpected error writing file: %s", err)
 			}
 		}
@@ -64,7 +63,7 @@ func TestStitchMultipart(t *testing.T) {
 			t.Fatalf("unexpected error opening gzip reader: %s", err)
 		}
 
-		contents, err := ioutil.ReadAll(gzipReader)
+		contents, err := io.ReadAll(gzipReader)
 		if err != nil {
 			t.Fatalf("unexpected error reading file: %s", err)
 		}

--- a/lib/codeintel/utils/upload.go
+++ b/lib/codeintel/utils/upload.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -197,7 +196,7 @@ func compressFile(filename string) (_ string, err error) {
 	}
 	defer rawFile.Close()
 
-	compressedFile, err := ioutil.TempFile("", "")
+	compressedFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return "", err
 	}
@@ -358,7 +357,7 @@ func makeUploadRequest(args requestArgs, payload io.Reader, target *int, logger 
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if logger != nil {
 		logger.LogResponse(req, resp, body, time.Since(started))
 	}

--- a/lib/codeintel/utils/upload_test.go
+++ b/lib/codeintel/utils/upload_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -22,7 +21,7 @@ func TestUploadIndex(t *testing.T) {
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		payload, err := ioutil.ReadAll(r.Body)
+		payload, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("unexpected error reading request body: %s", err)
 		}
@@ -31,7 +30,7 @@ func TestUploadIndex(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error creating gzip.Reader: %s", err)
 		}
-		decompressed, err := ioutil.ReadAll(gzipReader)
+		decompressed, err := io.ReadAll(gzipReader)
 		if err != nil {
 			t.Fatalf("unexpected error reading from gzip.Reader: %s", err)
 		}
@@ -45,7 +44,7 @@ func TestUploadIndex(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("unexpected error creating temp file: %s", err)
 	}
@@ -90,7 +89,7 @@ func TestUploadIndexMultipart(t *testing.T) {
 		}
 
 		if r.URL.Query().Get("index") != "" {
-			payload, err := ioutil.ReadAll(r.Body)
+			payload, err := io.ReadAll(r.Body)
 			if err != nil {
 				t.Fatalf("unexpected error reading request body: %s", err)
 			}
@@ -105,7 +104,7 @@ func TestUploadIndexMultipart(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	f, err := ioutil.TempFile("", "")
+	f, err := os.CreateTemp("", "")
 	if err != nil {
 		t.Fatalf("unexpected error creating temp file: %s", err)
 	}
@@ -145,7 +144,7 @@ func TestUploadIndexMultipart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error creating gzip.Reader: %s", err)
 	}
-	decompressed, err := ioutil.ReadAll(gzipReader)
+	decompressed, err := io.ReadAll(gzipReader)
 	if err != nil {
 		t.Fatalf("unexpected error reading from gzip.Reader: %s", err)
 	}

--- a/monitoring/monitoring/generator.go
+++ b/monitoring/monitoring/generator.go
@@ -3,7 +3,6 @@ package monitoring
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Containe
 			}
 			// #nosec G306  prometheus runs as nobody
 			generatedDashboard := container.Name + ".json"
-			err = ioutil.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm)
+			err = os.WriteFile(filepath.Join(opts.GrafanaDir, generatedDashboard), data, os.ModePerm)
 			if err != nil {
 				clog.Crit("Could not write dashboard to output", "error", err)
 				return err
@@ -100,7 +99,7 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Containe
 			}
 			fileName := strings.ReplaceAll(container.Name, "-", "_") + alertRulesFileSuffix
 			generatedAssets = append(generatedAssets, fileName)
-			err = ioutil.WriteFile(filepath.Join(opts.PrometheusDir, fileName), data, os.ModePerm)
+			err = os.WriteFile(filepath.Join(opts.PrometheusDir, fileName), data, os.ModePerm)
 			if err != nil {
 				clog.Crit("Could not write rules to output", "error", err)
 				return err
@@ -141,7 +140,7 @@ func Generate(logger log15.Logger, opts GenerateOptions, containers ...*Containe
 			{path: filepath.Join(opts.DocsDir, alertSolutionsFile), data: docs.alertSolutions.Bytes()},
 			{path: filepath.Join(opts.DocsDir, dashboardsDocsFile), data: docs.dashboards.Bytes()},
 		} {
-			err = ioutil.WriteFile(docOut.path, docOut.data, os.ModePerm)
+			err = os.WriteFile(docOut.path, docOut.data, os.ModePerm)
 			if err != nil {
 				logger.Crit("Could not write docs to path", "path", docOut.path, "error", err)
 				return err


### PR DESCRIPTION
Removes usage of the deprecated ioutil package as described [here](https://golang.org/doc/go1.16#ioutil)

[_Created by Sourcegraph batch change `rslade/deprecate-ioutil`._](https://k8s.sgdev.org/users/rslade/batch-changes/deprecate-ioutil)