### PR TITLE
Validate authenticators when storing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - `count:` now supports "all" as value. Queries with `count:all` will return up to 999999 results. [#19756](https://github.com/sourcegraph/sourcegraph/pull/19756)
+- Credentials for Batch Changes are now validated when adding them. [#19602](https://github.com/sourcegraph/sourcegraph/pull/19602)
 
 ### Changed
 

--- a/cmd/repo-updater/repoupdater/server.go
+++ b/cmd/repo-updater/repoupdater/server.go
@@ -401,8 +401,10 @@ func externalServiceValidate(ctx context.Context, req protocol.ExternalServiceSy
 
 	results := make(chan repos.SourceResult)
 
-	if v, ok := src.(TokenValidator); ok {
-		return v.ValidateToken(ctx)
+	if v, ok := src.(repos.UserSource); ok {
+		if err := v.ValidateAuthenticator(ctx); err != nil {
+			return err
+		}
 	} else {
 		go func() {
 			src.ListRepos(ctx, results)
@@ -725,8 +727,4 @@ func isUnauthorized(err error) bool {
 
 func isTemporarilyUnavailable(err error) bool {
 	return github.IsRateLimitExceeded(err)
-}
-
-type TokenValidator interface {
-	ValidateToken(ctx context.Context) error
 }

--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -1199,6 +1200,9 @@ type testSource struct {
 	fn func() error
 }
 
+var _ repos.Source = &testSource{}
+var _ repos.UserSource = &testSource{}
+
 func (t testSource) ListRepos(ctx context.Context, results chan repos.SourceResult) {
 }
 
@@ -1206,7 +1210,11 @@ func (t testSource) ExternalServices() types.ExternalServices {
 	return nil
 }
 
-func (t testSource) ValidateToken(ctx context.Context) error {
+func (t testSource) WithAuthenticator(a auth.Authenticator) (repos.Source, error) {
+	return t, nil
+}
+
+func (t testSource) ValidateAuthenticator(ctx context.Context) error {
 	return t.fn()
 }
 

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -877,6 +877,18 @@ func (r *Resolver) CreateBatchChangesCredential(ctx context.Context, args *graph
 		return nil, err
 	}
 
+	var userID int32
+	if args.User != nil {
+		userID, err = graphqlbackend.UnmarshalUserID(*args.User)
+		if err != nil {
+			return nil, err
+		}
+
+		if userID == 0 {
+			return nil, ErrIDIsZero{}
+		}
+	}
+
 	// Need to validate externalServiceKind, otherwise this'll panic.
 	kind, valid := extsvc.ParseServiceKind(args.ExternalServiceKind)
 	if !valid {
@@ -887,54 +899,14 @@ func (r *Resolver) CreateBatchChangesCredential(ctx context.Context, args *graph
 		return nil, errors.New("empty credential not allowed")
 	}
 
-	// TODO: Do we want to validate the URL, or even if such an external service exists? Or better, would the DB have a constraint?
-
-	var a auth.Authenticator
-	keypair, err := encryption.GenerateRSAKey()
-	if err != nil {
-		return nil, err
-	}
-	if kind == extsvc.KindBitbucketServer {
-		svc := service.New(r.store)
-		username, err := svc.FetchUsernameForBitbucketServerToken(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), args.Credential)
-		if err != nil {
-			if bitbucketserver.IsUnauthorized(err) {
-				return nil, &ErrVerifyCredentialFailed{SourceErr: err}
-			}
-			return nil, err
-		}
-		a = &auth.BasicAuthWithSSH{
-			BasicAuth:  auth.BasicAuth{Username: username, Password: args.Credential},
-			PrivateKey: keypair.PrivateKey,
-			PublicKey:  keypair.PublicKey,
-			Passphrase: keypair.Passphrase,
-		}
-	} else {
-		a = &auth.OAuthBearerTokenWithSSH{
-			OAuthBearerToken: auth.OAuthBearerToken{Token: args.Credential},
-			PrivateKey:       keypair.PrivateKey,
-			PublicKey:        keypair.PublicKey,
-			Passphrase:       keypair.Passphrase,
-		}
+	if userID != 0 {
+		return r.createBatchChangesUserCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), userID, args.Credential)
 	}
 
-	if args.User != nil {
-		userID, err := graphqlbackend.UnmarshalUserID(*args.User)
-		if err != nil {
-			return nil, err
-		}
-
-		if userID == 0 {
-			return nil, ErrIDIsZero{}
-		}
-
-		return r.createBatchChangesUserCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), a, userID)
-	}
-
-	return r.createBatchChangesSiteCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), a)
+	return r.createBatchChangesSiteCredential(ctx, args.ExternalServiceURL, extsvc.KindToType(kind), args.Credential)
 }
 
-func (r *Resolver) createBatchChangesUserCredential(ctx context.Context, externalServiceURL, externalServiceType string, a auth.Authenticator, userID int32) (graphqlbackend.BatchChangesCredentialResolver, error) {
+func (r *Resolver) createBatchChangesUserCredential(ctx context.Context, externalServiceURL, externalServiceType string, userID int32, credential string) (graphqlbackend.BatchChangesCredentialResolver, error) {
 	// 🚨 SECURITY: Check that the requesting user can create the credential.
 	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
 		return nil, err
@@ -955,6 +927,10 @@ func (r *Resolver) createBatchChangesUserCredential(ctx context.Context, externa
 		return nil, ErrDuplicateCredential{}
 	}
 
+	a, err := r.generateAuthenticatorForCredential(ctx, externalServiceType, externalServiceURL, credential)
+	if err != nil {
+		return nil, err
+	}
 	cred, err := r.store.UserCredentials().Create(ctx, userCredentialScope, a)
 	if err != nil {
 		return nil, err
@@ -963,7 +939,7 @@ func (r *Resolver) createBatchChangesUserCredential(ctx context.Context, externa
 	return &batchChangesUserCredentialResolver{credential: cred}, nil
 }
 
-func (r *Resolver) createBatchChangesSiteCredential(ctx context.Context, externalServiceURL, externalServiceType string, a auth.Authenticator) (graphqlbackend.BatchChangesCredentialResolver, error) {
+func (r *Resolver) createBatchChangesSiteCredential(ctx context.Context, externalServiceURL, externalServiceType string, credential string) (graphqlbackend.BatchChangesCredentialResolver, error) {
 	// 🚨 SECURITY: Check that a site credential can only be created
 	// by a site-admin.
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
@@ -982,6 +958,10 @@ func (r *Resolver) createBatchChangesSiteCredential(ctx context.Context, externa
 		return nil, ErrDuplicateCredential{}
 	}
 
+	a, err := r.generateAuthenticatorForCredential(ctx, externalServiceType, externalServiceURL, credential)
+	if err != nil {
+		return nil, err
+	}
 	cred := &store.SiteCredential{
 		ExternalServiceID:   externalServiceURL,
 		ExternalServiceType: externalServiceType,
@@ -992,6 +972,45 @@ func (r *Resolver) createBatchChangesSiteCredential(ctx context.Context, externa
 	}
 
 	return &batchChangesSiteCredentialResolver{credential: cred}, nil
+}
+
+func (r *Resolver) generateAuthenticatorForCredential(ctx context.Context, externalServiceType, externalServiceURL, credential string) (auth.Authenticator, error) {
+	svc := service.New(r.store)
+
+	var a auth.Authenticator
+	keypair, err := encryption.GenerateRSAKey()
+	if err != nil {
+		return nil, err
+	}
+	if externalServiceType == extsvc.TypeBitbucketServer {
+		// We need to fetch the username for the token, as just an OAuth token isn't enough for some reason..
+		username, err := svc.FetchUsernameForBitbucketServerToken(ctx, externalServiceURL, externalServiceType, credential)
+		if err != nil {
+			if bitbucketserver.IsUnauthorized(err) {
+				return nil, &ErrVerifyCredentialFailed{SourceErr: err}
+			}
+			return nil, err
+		}
+		a = &auth.BasicAuthWithSSH{
+			BasicAuth:  auth.BasicAuth{Username: username, Password: credential},
+			PrivateKey: keypair.PrivateKey,
+			PublicKey:  keypair.PublicKey,
+			Passphrase: keypair.Passphrase,
+		}
+	} else {
+		a = &auth.OAuthBearerTokenWithSSH{
+			OAuthBearerToken: auth.OAuthBearerToken{Token: credential},
+			PrivateKey:       keypair.PrivateKey,
+			PublicKey:        keypair.PublicKey,
+			Passphrase:       keypair.Passphrase,
+		}
+	}
+
+	// Validate the newly created authenticator.
+	if err := svc.ValidateAuthenticator(ctx, externalServiceURL, externalServiceType, a); err != nil {
+		return nil, &ErrVerifyCredentialFailed{SourceErr: err}
+	}
+	return a, nil
 }
 
 func (r *Resolver) DeleteBatchChangesCredential(ctx context.Context, args *graphqlbackend.DeleteBatchChangesCredentialArgs) (_ *graphqlbackend.EmptyResponse, err error) {

--- a/enterprise/internal/batches/service/mocks.go
+++ b/enterprise/internal/batches/service/mocks.go
@@ -1,0 +1,17 @@
+package service
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+)
+
+type ServiceMocks struct {
+	ValidateAuthenticator func(ctx context.Context, externalServiceID, externalServiceType string, a auth.Authenticator) error
+}
+
+func (sm ServiceMocks) Reset() {
+	sm.ValidateAuthenticator = nil
+}
+
+var Mocks ServiceMocks = ServiceMocks{}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -638,13 +638,3 @@ func (s *Service) DetachChangesets(ctx context.Context, batchChangeID int64, ids
 
 	return nil
 }
-
-type ServiceMocks struct {
-	ValidateAuthenticator func(ctx context.Context, externalServiceID, externalServiceType string, a auth.Authenticator) error
-}
-
-func (sm ServiceMocks) Reset() {
-	sm.ValidateAuthenticator = nil
-}
-
-var Mocks ServiceMocks = ServiceMocks{}

--- a/enterprise/internal/batches/syncer/syncer_test.go
+++ b/enterprise/internal/batches/syncer/syncer_test.go
@@ -311,10 +311,7 @@ func TestLoadChangesetSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	type tokenValidator interface {
-		ValidateToken(ctx context.Context) error
-	}
-	if err := src.ChangesetSource.(tokenValidator).ValidateToken(ctx); err == nil {
+	if err := src.ValidateAuthenticator(ctx); err == nil {
 		t.Fatal("unexpected nil error")
 	} else if have, want := err.Error(), "Bearer 123"; have != want {
 		t.Fatalf("invalid token used, want=%q have=%q", want, have)
@@ -326,7 +323,7 @@ func TestLoadChangesetSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := src.ChangesetSource.(tokenValidator).ValidateToken(ctx); err == nil {
+	if err := src.ValidateAuthenticator(ctx); err == nil {
 		t.Fatal("unexpected nil error")
 	} else if have, want := err.Error(), "Bearer 456"; have != want {
 		t.Fatalf("invalid token used, want=%q have=%q", want, have)

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -436,7 +436,6 @@ func (s *BitbucketServerSource) listAllRepos(ctx context.Context, results chan S
 				seen[repo.ID] = true
 			}
 		}
-
 	}
 }
 
@@ -470,4 +469,9 @@ func (s *BitbucketServerSource) listAllLabeledRepos(ctx context.Context, label s
 // BitbucketServerSource.
 func (s *BitbucketServerSource) AuthenticatedUsername(ctx context.Context) (string, error) {
 	return s.client.AuthenticatedUsername(ctx)
+}
+
+func (s *BitbucketServerSource) ValidateAuthenticator(ctx context.Context) error {
+	_, err := s.client.AuthenticatedUsername(ctx)
+	return err
 }

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -155,7 +155,6 @@ func newGithubSource(svc *types.ExternalService, c *schema.GitHubConnection, cf 
 				},
 			})
 		}
-
 	}
 
 	return &GithubSource{
@@ -196,7 +195,7 @@ type githubResult struct {
 	repo *github.Repository
 }
 
-func (s GithubSource) ValidateToken(ctx context.Context) error {
+func (s GithubSource) ValidateAuthenticator(ctx context.Context) error {
 	_, err := s.v3Client.GetAuthenticatedUser(ctx)
 	return err
 }

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -150,9 +150,8 @@ func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (Source, error) {
 	return &sc, nil
 }
 
-func (s GitLabSource) ValidateToken(ctx context.Context) error {
-	err := s.client.ValidateToken(ctx)
-	return err
+func (s GitLabSource) ValidateAuthenticator(ctx context.Context) error {
+	return s.client.ValidateToken(ctx)
 }
 
 // ListRepos returns all GitLab repositories accessible to all connections configured

--- a/internal/repos/sources.go
+++ b/internal/repos/sources.go
@@ -97,6 +97,9 @@ type UserSource interface {
 	// the given authenticator, provided that authenticator type is supported by
 	// the code host.
 	WithAuthenticator(auth.Authenticator) (Source, error)
+	// ValidateAuthenticator validates the currently set authenticator is usable.
+	// Returns an error, when validating the Authenticator yielded an error.
+	ValidateAuthenticator(ctx context.Context) error
 }
 
 // A DraftChangesetSource can create draft changesets and undraft them.


### PR DESCRIPTION
When creating an authenticator in the `createBatchChangesCredential` mutation, we now properly validate the authenticator and throw an error otherwise.

Closes #15692