### PR TITLE
streaming: refactor diff/commit search

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -546,7 +546,7 @@ func searchCommitsInRepos(ctx context.Context, db dbutil.DB, args *search.TextPa
 		rr := repoRev
 		g.Go(
 			func() error {
-				err = repoSearch(ctx, rr)
+				err := repoSearch(ctx, rr)
 				if err != nil {
 					tr.LogFields(otlog.String("repo", string(rr.Repo.Name)), otlog.String("err", err.Error()), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
 				}

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -548,7 +548,7 @@ func searchCommitsInRepos(ctx context.Context, db dbutil.DB, args *search.TextPa
 			func() error {
 				err = repoSearch(ctx, rr)
 				if err != nil {
-					tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.String("err", err.Error()), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
+					tr.LogFields(otlog.String("repo", string(rr.Repo.Name)), otlog.String("err", err.Error()), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
 				}
 				return err
 			})

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -268,26 +268,6 @@ func commitParametersToDiffParameters(ctx context.Context, op *search.CommitPara
 	}, nil
 }
 
-type searchCommitsInRepoEvent struct {
-	// Results are new commit results found.
-	Results []*CommitSearchResultResolver
-
-	// LimitHit is true if we stopped searching since we found FileMatchLimit
-	// results.
-	LimitHit bool
-
-	// TimedOut is true when the results may have been parsed from only
-	// partial output from the underlying git command (because, e.g., it timed
-	// out during execution and only returned partial output).
-	TimedOut bool
-
-	// Error is non-nil if an error occurred. It will be the last event if
-	// set.
-	//
-	// Note: Results will be empty if Error is set.
-	Error error
-}
-
 // searchCommitsInRepoStream searches for commits based on op.
 func searchCommitsInRepoStream(ctx context.Context, db dbutil.DB, op search.CommitParameters, s Sender) (limitHit, timedOut bool, err error) {
 	resultCount := 0

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -305,8 +305,10 @@ func Benchmark_highlightMatches(b *testing.B) {
 // searchCommitsInRepo is a blocking version of searchCommitsInRepoStream.
 func searchCommitsInRepo(ctx context.Context, db dbutil.DB, op search.CommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
 	var srr []SearchResultResolver
-	limitHit, timedOut, err = searchCommitsInRepoStream(ctx, db, op, StreamFunc(func(event SearchEvent) {
+	err = searchCommitsInRepoStream(ctx, db, op, StreamFunc(func(event SearchEvent) {
 		srr = append(srr, event.Results...)
+		timedOut = timedOut || event.Stats.Status.Any(search.RepoStatusTimedout)
+		limitHit = limitHit || event.Stats.Status.Any(search.RepoStatusLimitHit)
 	}))
 	for _, s := range srr {
 		results = append(results, s.(*CommitSearchResultResolver))


### PR DESCRIPTION
This refactor simplifies diff/commit search and at the same time aligns
its structure with that of the other search types.

The essence of the change is not to return a channel from
`searchCommitsInRepoStream` but instead take a `Sender` and
return a simple error.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
