### PR TITLE
Faster user repos listing

### DIFF
--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
@@ -36,14 +37,18 @@ func TestRepo(t *testing.T, store *database.ExternalServiceStore, serviceKind st
 		t.Fatalf("failed to insert external services: %v", err)
 	}
 
+	return TestRepoWithExternalService(&svc, rand.Int())
+}
+
+func TestRepoWithExternalService(svc *types.ExternalService, id int) *types.Repo {
 	return &types.Repo{
-		Name:    api.RepoName(fmt.Sprintf("repo-%d", svc.ID)),
-		URI:     fmt.Sprintf("repo-%d", svc.ID),
+		Name:    api.RepoName(fmt.Sprintf("repo-%d", id)),
+		URI:     fmt.Sprintf("repo-%d", id),
 		Private: true,
 		ExternalRepo: api.ExternalRepoSpec{
-			ID:          fmt.Sprintf("external-id-%d", svc.ID),
-			ServiceType: extsvc.KindToType(serviceKind),
-			ServiceID:   fmt.Sprintf("https://%s.com/", strings.ToLower(serviceKind)),
+			ID:          fmt.Sprintf("external-id-%d", id),
+			ServiceType: extsvc.KindToType(svc.Kind),
+			ServiceID:   fmt.Sprintf("https://%s.com/", strings.ToLower(svc.Kind)),
 		},
 		Sources: map[string]*types.SourceInfo{
 			svc.URN(): {
@@ -82,7 +87,7 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db dbutil.DB, count int)
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepo(t, esStore, extsvc.KindGitHub)
+		r := TestRepoWithExternalService(ext, rand.Int())
 		r.Sources = map[string]*types.SourceInfo{ext.URN(): {
 			ID:       ext.URN(),
 			CloneURL: "https://secrettoken@github.com/" + string(r.Name),
@@ -119,7 +124,7 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count 
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepo(t, esStore, extsvc.KindGitLab)
+		r := TestRepoWithExternalService(ext, rand.Int())
 		r.Sources = map[string]*types.SourceInfo{ext.URN(): {
 			ID:       ext.URN(),
 			CloneURL: "https://git:gitlab-token@gitlab.com/" + string(r.Name),
@@ -211,7 +216,7 @@ func createBbsRepos(t *testing.T, ctx context.Context, db dbutil.DB, ext *types.
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepo(t, esStore, extsvc.KindBitbucketServer)
+		r := TestRepoWithExternalService(ext, rand.Int())
 		r.Sources = map[string]*types.SourceInfo{
 			ext.URN(): {
 				ID:       ext.URN(),

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -801,10 +801,7 @@ func (s *RepoStore) listSQL(ctx context.Context, opt ReposListOptions) (*sqlf.Qu
 }
 
 const userReposQuery = `
-SELECT repo_id as id
-FROM external_service_repos esr
-JOIN external_services es ON esr.external_service_id = es.id
-WHERE es.namespace_user_id = %d AND es.deleted_at IS NULL
+SELECT repo_id as id FROM external_service_repos WHERE user_id = %d
 `
 
 const userPublicReposQuery = `
@@ -1118,13 +1115,16 @@ insert_sources AS (
   INSERT INTO external_service_repos (
     external_service_id,
     repo_id,
+    user_id,
     clone_url
   )
   SELECT
     external_service_id,
     repo_id,
+    es.namespace_user_id,
     clone_url
   FROM sources_list
+  JOIN external_services es ON (es.id = external_service_id)
   ON CONFLICT ON CONSTRAINT external_service_repos_repo_id_external_service_id_unique
   DO
     UPDATE SET clone_url = EXCLUDED.clone_url

--- a/internal/database/repos_perm_test.go
+++ b/internal/database/repos_perm_test.go
@@ -269,9 +269,9 @@ func TestRepos_getReposBySQL_checkPermissions(t *testing.T) {
 	}
 
 	q := sqlf.Sprintf(`
-INSERT INTO external_service_repos (external_service_id, repo_id, clone_url)
-VALUES (%s, %s, '')
-`, cindyExternalService.ID, cindyPrivateRepo.ID)
+INSERT INTO external_service_repos (external_service_id, repo_id, user_id, clone_url)
+VALUES (%s, %s, NULLIF(%s, 0), '')
+`, cindyExternalService.ID, cindyPrivateRepo.ID, cindyExternalService.NamespaceUserID)
 	_, err = db.ExecContext(ctx, q.Query(sqlf.PostgresBindVar), q.Args()...)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -518,13 +518,16 @@ Check constraints:
  external_service_id | bigint  |           | not null | 
  repo_id             | integer |           | not null | 
  clone_url           | text    |           | not null | 
+ user_id             | integer |           |          | 
 Indexes:
     "external_service_repos_repo_id_external_service_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_service_id)
     "external_service_repos_external_service_id" btree (external_service_id)
     "external_service_repos_idx" btree (external_service_id, repo_id)
+    "external_service_user_repos_idx" btree (user_id, repo_id) WHERE user_id IS NOT NULL
 Foreign-key constraints:
     "external_service_repos_external_service_id_fkey" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE DEFERRABLE
     "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
+    "external_service_repos_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
 
 ```
 
@@ -1596,6 +1599,7 @@ Referenced by:
     TABLE "discussion_comments" CONSTRAINT "discussion_comments_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_mail_reply_tokens" CONSTRAINT "discussion_mail_reply_tokens_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE RESTRICT
     TABLE "discussion_threads" CONSTRAINT "discussion_threads_author_user_id_fkey" FOREIGN KEY (author_user_id) REFERENCES users(id) ON DELETE RESTRICT
+    TABLE "external_service_repos" CONSTRAINT "external_service_repos_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "external_services" CONSTRAINT "external_services_namepspace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "names" CONSTRAINT "names_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON UPDATE CASCADE ON DELETE CASCADE
     TABLE "org_invitations" CONSTRAINT "org_invitations_recipient_user_id_fkey" FOREIGN KEY (recipient_user_id) REFERENCES users(id)

--- a/internal/repos/store.go
+++ b/internal/repos/store.go
@@ -316,12 +316,15 @@ update_sources AS (
 INSERT INTO external_service_repos (
   external_service_id,
   repo_id,
+  user_id,
   clone_url
 ) SELECT
   external_service_id,
   repo_id,
+  es.namespace_user_id,
   clone_url
 FROM inserted_sources_list
+JOIN external_services es ON (id = external_service_id)
 ON CONFLICT ON CONSTRAINT external_service_repos_repo_id_external_service_id_unique
 DO
   UPDATE SET clone_url = EXCLUDED.clone_url

--- a/migrations/frontend/1528395807_add_user_id_column_to_external_service_repos.down.sql
+++ b/migrations/frontend/1528395807_add_user_id_column_to_external_service_repos.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP INDEX external_service_user_repos_idx;
+ALTER TABLE external_service_repos DROP COLUMN user_id;
+
+COMMIT;

--- a/migrations/frontend/1528395807_add_user_id_column_to_external_service_repos.up.sql
+++ b/migrations/frontend/1528395807_add_user_id_column_to_external_service_repos.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+ALTER TABLE external_service_repos ADD COLUMN user_id int REFERENCES users(id) ON DELETE CASCADE DEFERRABLE;
+
+UPDATE external_service_repos
+SET user_id = es.namespace_user_id
+FROM external_services es
+WHERE es.id = external_service_id AND es.namespace_user_id IS NOT NULL;
+
+CREATE INDEX external_service_user_repos_idx ON external_service_repos(user_id, repo_id) WHERE user_id IS NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
This PR denormalizes the namespace_user_id in external_services, by adding it to external_service_repos too. As described in https://github.com/sourcegraph/sourcegraph/issues/19561#issuecomment-811031184, avoiding the join with external services should completely bypass the problem.

- Here's the new plan: https://explain.dalibo.com/plan/ZfB
- And the old plan: https://explain.dalibo.com/plan/7zc

@ryanslade @asdine: I chose to fill in the user_id via SQL join with external_services in the queries, instead of passing that value in from application code. The change would be much larger if we did that change in application code, and I didn't feel comfortable with it. Maybe we should do it though? This "Sources" code is a bit hard to reason about, compared to the database schema itself.

Fixes #19561