### PR TITLE
search: Add query name to user agent string

### DIFF
--- a/internal/cmd/search-blitz/client.go
+++ b/internal/cmd/search-blitz/client.go
@@ -39,7 +39,7 @@ func newClient() (*client, error) {
 	}, nil
 }
 
-func (s *client) search(ctx context.Context, query string) (*metrics, error) {
+func (s *client) search(ctx context.Context, query, queryName string) (*metrics, error) {
 	var body bytes.Buffer
 	m := &metrics{}
 	if err := json.NewEncoder(&body).Encode(map[string]interface{}{
@@ -56,7 +56,7 @@ func (s *client) search(ctx context.Context, query string) (*metrics, error) {
 
 	req.Header.Set("Authorization", "token "+s.token)
 	req.Header.Set("X-Sourcegraph-Should-Trace", "true")
-	req.Header.Set("User-Agent", "SearchBlitz (monitoring)")
+	req.Header.Set("User-Agent", fmt.Sprintf("SearchBlitz (%s)", queryName))
 
 	start := time.Now()
 	resp, err := s.client.Do(req)

--- a/internal/cmd/search-blitz/main.go
+++ b/internal/cmd/search-blitz/main.go
@@ -59,7 +59,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 		defer ticker.Stop()
 
 		for {
-			m, err := c.search(ctx, qc.Query)
+			m, err := c.search(ctx, qc.Query, qc.Name)
 			if err != nil {
 				log15.Error(err.Error())
 			} else {
@@ -98,7 +98,7 @@ func run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 type genericClient interface {
-	search(ctx context.Context, query string) (*metrics, error)
+	search(ctx context.Context, query, queryName string) (*metrics, error)
 	clientType() string
 }
 

--- a/internal/cmd/search-blitz/stream_client.go
+++ b/internal/cmd/search-blitz/stream_client.go
@@ -33,7 +33,7 @@ func newStreamClient() (*streamClient, error) {
 	}, nil
 }
 
-func (s *streamClient) search(ctx context.Context, query string) (*metrics, error) {
+func (s *streamClient) search(ctx context.Context, query, queryName string) (*metrics, error) {
 	req, err := streamhttp.NewRequest(s.endpoint, query)
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
@@ -41,7 +41,7 @@ func (s *streamClient) search(ctx context.Context, query string) (*metrics, erro
 	req = req.WithContext(ctx)
 	req.Header.Set("Authorization", "token "+s.token)
 	req.Header.Set("X-Sourcegraph-Should-Trace", "true")
-	req.Header.Set("User-Agent", "SearchBlitz (monitoring)")
+	req.Header.Set("User-Agent", fmt.Sprintf("SearchBlitz (%s)", queryName))
 
 	start := time.Now()
 	resp, err := s.client.Do(req)


### PR DESCRIPTION
This way we will be able to partition by query name in the prometheus
metrics.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
