### PR TITLE
ci: hack - override the pipeline's github token for the k8s trigger step

### DIFF
--- a/.buildkite/updater/is-tip-of-main.sh
+++ b/.buildkite/updater/is-tip-of-main.sh
@@ -3,6 +3,14 @@
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
 set -euxo pipefail
 
+# HACK: For whatever reason, we hard-code our
+# own, different github token in our pipeline's env settings.
+# This causes authentication requests to fail. Setting this
+# here is a workaround until we can dedicate time to
+# figure out why this is the case.
+# TODO: @sourcegraph/distribution
+export GITHUB_TOKEN="${GITHUB_TOKEN_COPY:-DEPLOY_SOURCEGRAPH_GITHUB_TOKEN}"
+
 COMMIT="${BUILDKITE_COMMIT}"
 
 API_SLUG="repos/sourcegraph/sourcegraph/commits"


### PR DESCRIPTION
cc @sourcegraph/distribution

See https://buildkite.com/sourcegraph/sourcegraph/builds/91625#ed751b71-c5c4-4a40-9a12-93e0dcaecd66 for a concrete example of this happening. The error message it got was the `gh` cli complaining that the authentication was using bad creds. 