### PR TITLE
search: front load predicate validation, make less strict

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1016,27 +1016,17 @@ func substitutePredicates(q query.Basic, evaluate func(query.Predicate) (*Search
 			Annotation: ann,
 		}
 
+		if !ann.Labels.IsSet(query.IsPredicate) {
+			return orig
+		}
+
 		if topErr != nil {
 			return orig
 		}
 
-		name, params, err := query.ParseAsPredicate(value)
-		if err != nil {
-			// This doesn't look like a predicate, so skip it
-			return orig
-		}
-
-		predicate, err := query.DefaultPredicateRegistry.Get(field, name, params)
-		if err != nil {
-			topErr = err
-			return orig
-		}
-
-		if neg {
-			topErr = errors.New("predicates do not currently support negation")
-			return nil
-		}
-
+		name, params := query.ParseAsPredicate(value)
+		predicate := query.DefaultPredicateRegistry.Get(field, name)
+		predicate.ParseParams(params)
 		srr, err := evaluate(predicate)
 		if err != nil {
 			topErr = err

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -987,6 +987,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				`repo:contains(file:diff.pb.go) type:commit LSIF`,
 				counts{Commit: 1},
 			},
+			{
+				`predicate logic does not conflict with unrecognized patterns`,
+				`repo:sg(test)`,
+				counts{Repo: 6},
+			},
 		}
 
 		for _, test := range tests {

--- a/internal/search/query/labels.go
+++ b/internal/search/query/labels.go
@@ -3,7 +3,7 @@ package query
 import "sort"
 
 // Labels are general-purpose annotations that store information about a node.
-type labels uint8
+type labels uint16
 
 const (
 	None    labels = 0
@@ -14,6 +14,7 @@ const (
 	HeuristicDanglingParens
 	HeuristicHoisted
 	Structural
+	IsPredicate
 )
 
 var allLabels = map[labels]string{
@@ -25,9 +26,10 @@ var allLabels = map[labels]string{
 	HeuristicDanglingParens:   "HeuristicDanglingParens",
 	HeuristicHoisted:          "HeuristicHoisted",
 	Structural:                "Structural",
+	IsPredicate:               "IsPredicate",
 }
 
-func (l *labels) isSet(label labels) bool {
+func (l *labels) IsSet(label labels) bool {
 	return *l&label != 0
 }
 
@@ -45,7 +47,7 @@ func (l *labels) String() []string {
 	}
 	var s []string
 	for k, v := range allLabels {
-		if l.isSet(k) {
+		if l.IsSet(k) {
 			s = append(s, v)
 		}
 	}

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -717,16 +717,17 @@ func (p *parser) TryParseDelimiter() (string, rune, bool) {
 }
 
 // ParseFieldValue parses a value after a field like "repo:". It returns the
-// parsed value and whether it was quoted. If the value starts with a recognized
-// quoting delimiter but does not close it, an error is returned.
-func (p *parser) ParseFieldValue(field string) (string, bool, error) {
-	delimited := func(delimiter rune) (string, bool, error) {
+// parsed value and any labels to annotate this alue with. If the value starts
+// with a recognized quoting delimiter but does not close it, an error is
+// returned.
+func (p *parser) ParseFieldValue(field string) (string, labels, error) {
+	delimited := func(delimiter rune) (string, labels, error) {
 		value, advance, err := ScanDelimited(p.buf[p.pos:], true, delimiter)
 		if err != nil {
-			return "", false, err
+			return "", None, err
 		}
 		p.pos += advance
-		return value, true, nil
+		return value, Quoted, nil
 	}
 	if p.match(SQUOTE) {
 		return delimited('\'')
@@ -738,7 +739,7 @@ func (p *parser) ParseFieldValue(field string) (string, bool, error) {
 	value, advance, ok := ScanPredicate(field, p.buf[p.pos:])
 	if ok {
 		p.pos += advance
-		return value, false, nil
+		return value, IsPredicate, nil
 	}
 
 	// First try scan a field value for cases like (a b repo:foo), where a
@@ -746,14 +747,14 @@ func (p *parser) ParseFieldValue(field string) (string, bool, error) {
 	value, advance, ok = ScanBalancedPattern(p.buf[p.pos:])
 	if ok {
 		p.pos += advance
-		return value, false, nil
+		return value, None, nil
 
 	}
 
 	// The above failed, so attempt a best effort.
 	value, advance = ScanValue(p.buf[p.pos:], false)
 	p.pos += advance
-	return value, false, nil
+	return value, None, nil
 }
 
 // Try parse a delimited pattern, quoted as "...", '...', or /.../.
@@ -796,7 +797,7 @@ func newPattern(value string, negated bool, labels labels, range_ Range) Pattern
 // Note that ParsePattern may be called multiple times (a query can have
 // multiple Patterns concatenated together).
 func (p *parser) ParsePattern(label labels) Pattern {
-	if label.isSet(Regexp) {
+	if label.IsSet(Regexp) {
 		// First try parse delimited values for regexp.
 		if pattern, ok := p.TryParseDelimitedPattern(); ok {
 			return pattern
@@ -812,7 +813,7 @@ func (p *parser) ParsePattern(label labels) Pattern {
 	start := p.pos
 	var value string
 	var advance int
-	if label.isSet(Regexp) {
+	if label.IsSet(Regexp) {
 		value, advance = ScanValue(p.buf[p.pos:], isSet(p.heuristics, allowDanglingParens))
 	} else {
 		value, advance = ScanAnyPattern(p.buf[p.pos:])
@@ -837,13 +838,9 @@ func (p *parser) ParseParameter() (Parameter, bool, error) {
 	}
 
 	p.pos += advance
-	value, quoted, err := p.ParseFieldValue(field)
+	value, labels, err := p.ParseFieldValue(field)
 	if err != nil {
 		return Parameter{}, false, err
-	}
-	var labels labels
-	if quoted {
-		labels.set(Quoted)
 	}
 	return Parameter{
 		Field:      field,
@@ -902,7 +899,7 @@ loop:
 		case p.match(LPAREN) && !isSet(p.heuristics, allowDanglingParens):
 			if isSet(p.heuristics, parensAsPatterns) {
 				if value, advance, ok := ScanBalancedPattern(p.buf[p.pos:]); ok {
-					if label.isSet(Literal) {
+					if label.IsSet(Literal) {
 						label.set(HeuristicParensAsPatterns)
 					}
 					pattern := newPattern(value, false, label, newRange(p.pos, p.pos+advance))

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -717,7 +717,7 @@ func (p *parser) TryParseDelimiter() (string, rune, bool) {
 }
 
 // ParseFieldValue parses a value after a field like "repo:". It returns the
-// parsed value and any labels to annotate this alue with. If the value starts
+// parsed value and any labels to annotate this value with. If the value starts
 // with a recognized quoting delimiter but does not close it, an error is
 // returned.
 func (p *parser) ParseFieldValue(field string) (string, labels, error) {

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -60,28 +60,14 @@ func TestParseAsPredicate(t *testing.T) {
 		input  string
 		name   string
 		params string
-		err    bool
 	}{
-		{`()`, "", "", true},
-		{`a()`, "a", "", false},
-		{`a(b)`, "a", "b", false},
-		{``, "", "", true},
-		{`a)(`, "", "", true},
+		{`a()`, "a", ""},
+		{`a(b)`, "a", "b"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.input, func(t *testing.T) {
-			name, params, err := ParseAsPredicate(tc.input)
-			if tc.err {
-				if err == nil {
-					t.Fatal("expected err, but got none")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected err: %s", err)
-			}
-
+			name, params := ParseAsPredicate(tc.input)
 			if name != tc.name {
 				t.Fatalf("expected name %s, got %s", tc.name, name)
 			}

--- a/internal/search/query/printer.go
+++ b/internal/search/query/printer.go
@@ -12,7 +12,7 @@ func stringHumanPattern(nodes []Node) string {
 		switch n := node.(type) {
 		case Pattern:
 			v := n.Value
-			if n.Annotation.Labels.isSet(Quoted) {
+			if n.Annotation.Labels.IsSet(Quoted) {
 				v = strconv.Quote(v)
 			}
 			if n.Negated {
@@ -41,7 +41,7 @@ func stringHumanParameters(parameters []Parameter) string {
 	var result []string
 	for _, p := range parameters {
 		v := p.Value
-		if p.Annotation.Labels.isSet(Quoted) {
+		if p.Annotation.Labels.IsSet(Quoted) {
 			v = strconv.Quote(v)
 		}
 		if p.Negated {

--- a/internal/search/query/transformer.go
+++ b/internal/search/query/transformer.go
@@ -471,7 +471,7 @@ func fuzzyRegexp(patterns []Pattern) Pattern {
 	}
 	var values []string
 	for _, p := range patterns {
-		if p.Annotation.Labels.isSet(Literal) {
+		if p.Annotation.Labels.IsSet(Literal) {
 			values = append(values, regexp.QuoteMeta(p.Value))
 		} else {
 			values = append(values, p.Value)
@@ -617,7 +617,7 @@ func escapeParens(s string) string {
 // escapeParensHeuristic escapes certain parentheses in search patterns (see escapeParens).
 func escapeParensHeuristic(nodes []Node) []Node {
 	return MapPattern(nodes, func(value string, negated bool, annotation Annotation) Node {
-		if !annotation.Labels.isSet(Quoted) {
+		if !annotation.Labels.IsSet(Quoted) {
 			value = escapeParens(value)
 		}
 		return Pattern{

--- a/internal/search/query/types.go
+++ b/internal/search/query/types.go
@@ -292,10 +292,10 @@ func (q Q) valueToTypedValue(field, value string, label labels) []*Value {
 	switch field {
 	case
 		FieldDefault:
-		if label.isSet(Literal) {
+		if label.IsSet(Literal) {
 			return []*Value{{String: &value}}
 		}
-		if label.isSet(Regexp) {
+		if label.IsSet(Regexp) {
 			regexp, err := regexp.Compile(value)
 			if err != nil {
 				panic(fmt.Sprintf("Invariant broken: value must have been checked to be valid regexp. Error: %s", err))


### PR DESCRIPTION
Motivation:

- Predicate validation is too strict, potential regexes like `source(graph)` aren't allowed. We'll need to keep an eye out that nobody who upgrades to previous release runs into this (should be unlikely).

<img width="713" alt="Screen Shot 2021-03-31 at 1 51 40 PM" src="https://user-images.githubusercontent.com/888624/113209811-5d80c780-9228-11eb-92cb-d22d6b9d642c.png">

- Validation in `search_results.go` should be front loaded as much as possible (the above really happened because too much validation started happening in `search_results.go`--instead we should gatekeep everything that reaches that point)

Changes:

- Use the parser logic to annotate parameters with `IsPredicate` when they are recognized
- Validate predicates according to their logic in `validate.go`

Everything else is a follow on change to these two changes. The above ensures that after `validate` runs for predicates, only syntactically valid and recognized predicates are evaluated in `search_results.go`, while lifting the strictness on the syntactic form. It was difficult to break this up, so see inline comments for more.