### PR TITLE
search: Add dashboard panels for sentinel queries

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1413,6 +1413,29 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
+## frontend: 90th_percentile_sentinel_search_request_duration
+
+<p class="subtitle">90th percentile successful sentinel search request duration over 5m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> frontend: 1s+ 90th percentile successful sentinel search request duration over 5m
+
+**Possible solutions**
+
+- Check the associated panel that partitions this result by query to see if there is a particular query that regressed
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_90th_percentile_sentinel_search_request_duration"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
 ## gitserver: disk_space_remaining
 
 <p class="subtitle">disk space remaining by instance</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -706,7 +706,7 @@ This panel indicates percentage pods available.
 
 <br />
 
-### Frontend: Sentinel Search Queries
+### Frontend: Sentinel Search Queries (currently only available on Cloud)
 
 #### frontend: 90th_percentile_sentinel_search_request_duration
 

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -706,6 +706,28 @@ This panel indicates percentage pods available.
 
 <br />
 
+### Frontend: Sentinel Search Queries
+
+#### frontend: 90th_percentile_sentinel_search_request_duration
+
+This panel indicates 90th percentile successful sentinel search request duration over 5m.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-search-request-duration).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### frontend: 90th_percentile_sentinel_search_request_duration_by_query
+
+This panel indicates 90th percentile successful sentinel search request duration by query over 5m.
+
+Shows the search duration for sentinel queries by query so it`s easier to pinpoint whether a specific query is having performance issues or whether the issues apply to all sentinel queries.
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
 ## Git Server
 
 <p class="subtitle">Stores, manages, and operates Git repositories.</p>

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -746,7 +746,8 @@ func Frontend() *monitoring.Container {
 				},
 			},
 			{
-				Title: "Sentinel Search Queries",
+				Title:  "Sentinel Search Queries (currently only available on Cloud)",
+				Hidden: true,
 				Rows: []monitoring.Row{
 					{
 						{

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -768,7 +768,7 @@ func Frontend() *monitoring.Container {
 							Query:       `histogram_quantile(0.90, sum by (source,le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
 
 							NoAlert:        true,
-							Panel:          monitoring.Panel().LegendFormat(`{{ slice .source 1 }}`).Unit(monitoring.Seconds),
+							Panel:          monitoring.Panel().Unit(monitoring.Seconds),
 							Owner:          monitoring.ObservableOwnerSearch,
 							Interpretation: `Shows the search duration for sentinel queries by query so it's easier to pinpoint whether a specific query is having performance issues or whether the issues apply to all sentinel queries.`,
 						},


### PR DESCRIPTION
This adds two panels to Grafana for monitoring sentinel queries. Quite
minimal right now. Just one that has the 90th percentile for all
sentinel queries, and one that has it split up by query. The first one
has an alert attached to it, the second is just for debugging if the
alert fires.

Followup work includes adding panels for error rates from sentinel
queries.


<img width="1203" alt="Screen Shot 2021-03-31 at 15 15 46" src="https://user-images.githubusercontent.com/12631702/113212444-fff27800-9233-11eb-809e-a6b81b6fa61a.png">


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
