### PR TITLE
Convert to short duration types in Grafana

### DIFF
--- a/monitoring/monitoring/README.md
+++ b/monitoring/monitoring/README.md
@@ -500,10 +500,10 @@ const (
     Number UnitType = "short"
 
     // Milliseconds for representing time.
-    Milliseconds UnitType = "dtdurationms"
+    Milliseconds UnitType = "ms"
 
     // Seconds for representing time.
-    Seconds UnitType = "dtdurations"
+    Seconds UnitType = "s"
 
     // Percentage in the range of 0-100.
     Percentage UnitType = "percent"

--- a/monitoring/monitoring/dashboards.go
+++ b/monitoring/monitoring/dashboards.go
@@ -41,10 +41,10 @@ const (
 	Number UnitType = "short"
 
 	// Milliseconds for representing time.
-	Milliseconds UnitType = "dtdurationms"
+	Milliseconds UnitType = "ms"
 
 	// Seconds for representing time.
-	Seconds UnitType = "dtdurations"
+	Seconds UnitType = "s"
 
 	// Percentage in the range of 0-100.
 	Percentage UnitType = "percent"


### PR DESCRIPTION
This converts from `dtdurationms` and `dtdurations` to `ms` and `s`
Grafana unit types for durations. This changes the displayed units to
show their short version rather than the verbose version. For example,
before, labels might be long like `1 second, 0 milliseconds`, and now,
it will be reduced to `1.00 s`.

Before:
<img width="595" alt="Screen Shot 2021-03-31 at 15 19 08" src="https://user-images.githubusercontent.com/12631702/113213637-b014b080-9235-11eb-9e93-386d7bcfd361.png">

After
<img width="589" alt="Screen Shot 2021-03-31 at 15 20 55" src="https://user-images.githubusercontent.com/12631702/113213650-b2770a80-9235-11eb-87f3-14efba1d8ce8.png">



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
