### PR TITLE
search frontend: add predicate scanner

### DIFF
--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -1,0 +1,32 @@
+import { scanPredicate } from './predicates'
+
+expect.addSnapshotSerializer({
+    serialize: value => (value ? JSON.stringify(value) : 'invalid'),
+    test: () => true,
+})
+
+describe('scanPredicate()', () => {
+    test('scan recognized and valid syntax', () => {
+        expect(scanPredicate('repo', 'contains(stuff)')).toMatchInlineSnapshot(
+            '{"name":"contains","parameters":"(stuff)"}'
+        )
+    })
+
+    test('scan recognized and valid syntax with escapes', () => {
+        expect(scanPredicate('repo', 'contains(\\((stuff))')).toMatchInlineSnapshot(
+            '{"name":"contains","parameters":"(\\\\((stuff))"}'
+        )
+    })
+
+    test('scan valid syntax but not recognized', () => {
+        expect(scanPredicate('foo', 'contains(stuff)')).toMatchInlineSnapshot('invalid')
+    })
+
+    test('scan unbalanced syntax', () => {
+        expect(scanPredicate('repo', 'contains(')).toMatchInlineSnapshot('invalid')
+    })
+
+    test('scan invalid nonalphanumeric name', () => {
+        expect(scanPredicate('repo', 'contains.yoinks(stuff)')).toMatchInlineSnapshot('invalid')
+    })
+})

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -1,0 +1,73 @@
+// Represents recognized predicates associated with fields.
+export const PREDICATES: Record<string, string[]> = {
+    ['repo']: ['contains'],
+    ['r']: ['contains'],
+}
+
+// Represents a predicates components corresponding to the syntax name(parameters).
+export interface Predicate {
+    name: string
+    parameters: string
+}
+
+export const scanBalancedParens = (input: string): string | undefined => {
+    let adjustedStart = 0
+    let balanced = 0
+    let current = ''
+    const result: string[] = []
+
+    const nextChar = (): void => {
+        current = input[adjustedStart]
+        adjustedStart += 1
+    }
+
+    while (input[adjustedStart] !== undefined) {
+        nextChar()
+        if (current === '(') {
+            balanced += 1
+            result.push(current)
+        } else if (current === ')') {
+            balanced -= 1
+            result.push(current)
+        } else if (current === '\\') {
+            if (input[adjustedStart] !== undefined) {
+                nextChar() // consume escaped
+                result.push('\\', current)
+                continue
+            }
+            result.push(current)
+        } else {
+            result.push(current)
+        }
+    }
+
+    if (balanced !== 0) {
+        return undefined
+    }
+    return result.join('')
+}
+
+/**
+ * Scans predicate syntax of the form field:name(parameters) and
+ * returns the name and parameters components. It checks that:
+ *
+ * (1) The (field, name) pair is a recognized predicate.
+ * (2) The parameters value is well-balanced.
+ */
+export const scanPredicate = (field: string, value: string): Predicate | undefined => {
+    const match = value.match(/^[\da-z]+/i)
+    if (!(match && PREDICATES[field] && PREDICATES[field].some(pred => pred === match[0]))) {
+        return undefined
+    }
+    const name = match[0]
+    const rest = value.slice(name.length)
+    if (!rest.startsWith('(') || !rest.endsWith(')')) {
+        return undefined
+    }
+    const parameters = scanBalancedParens(rest)
+    if (!parameters) {
+        return undefined
+    }
+
+    return { name, parameters }
+}


### PR DESCRIPTION
Adds a frontend scanner for recognizing predicate syntax and validity, analogous to the backend code (see https://github.com/sourcegraph/sourcegraph/pull/19308). I'm deciding to keep predicate scanning separate from the main `scanner`, since that means we don't have to change parser logic or other types--I'm not yet convinced predicate syntax should be a first class citizen for the base scanner code.

This PR code is unused currently, I will incorporate it into the token decoration part in a next PR. Since it's close to the backend code I think this is quite fine for @camdencheek to check off on.