### PR TITLE
sg: allow running enterprise env with `sg`, flesh out TODO/Inspiration/Quickstart/Hacking in README

### DIFF
--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -40,7 +40,6 @@ go build -o ~/my/path/sg ./dev/sg
 
 Make sure that `~/my/path` is in your `$PATH` then.
 
-
 ## Inspiration
 
 - [GitLab Developer Kit (GDK)](https://gitlab.com/gitlab-org/gitlab-development-kit)
@@ -244,10 +243,10 @@ tests:
 - [ ] All of the things marked as TODOs above
 - [ ] Add the remaining processes from `<root>/dev/Procfile` to `<root>/sg.config.yaml`
 - [ ] Add a _simple_ way to define in the config file when a restart after a rebuild is not necessary
-    - Something like `check_binary: .bin/frontend` which would take a SHA256 before and after rebuild and only restart if SHA doesn't match
+  - Something like `check_binary: .bin/frontend` which would take a SHA256 before and after rebuild and only restart if SHA doesn't match
 - [ ] Rename `install` to `build` because it's clearer
 - [ ] Add support for "dev environment setup"
-    - Something like `sg check` which runs `check_cmds` in the config file and provides helpful output if one of them failed ("check_cmd postgres failed. Install postgres with...")
+  - Something like `sg check` which runs `check_cmds` in the config file and provides helpful output if one of them failed ("check_cmd postgres failed. Install postgres with...")
 - [ ] Add built-in support for "download binary" so that the `caddy` command, for example, would be 3 lines instead of 20
 
 ## Hacking
@@ -261,4 +260,3 @@ go run . -config ../../sg.config.yaml start
 ```
 
 The `-config` can be anything you want, of course.
-

--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -51,7 +51,7 @@ Make sure that `~/my/path` is in your `$PATH` then.
 ### Start dev environment
 
 ```bash
-# Run complete environment:
+# Run default environment (this starts the 'default' command set defined in config):
 sg start
 
 # Run the enterprise environment:

--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -22,6 +22,8 @@ Run the following to install `sg` from the `main` branch:
 go install github.com/sourcegraph/sourcegraph/dev/sg@latest
 ```
 
+Make sure that `$HOME/go/bin` is in your `$PATH`. (If you use `$GOPATH` then `$GOPATH/bin` needs to be in the `$PATH`)
+
 Then, in the root of `sourcegraph/sourcegraph`, run:
 
 ```

--- a/dev/sg/README.md
+++ b/dev/sg/README.md
@@ -2,7 +2,7 @@
 
 `sg` is the CLI tool that Sourcegraph developers can use to develop Sourcegraph.
 
-- [TODOs](#todos)
+- [Quickstart](#quickstart)
 - [Installation](#installation)
 - [Usage](#usage)
   - [Start dev environment](#start-dev-environment)
@@ -11,26 +11,41 @@
   - [Database migrations](#database-migrations)
   - [Edit configuration files](#edit-configuration-files)
 - [Configuration](#configuration)
+- [TODOs](#todos)
+- [Hacking](#hacking)
 
 ## Quickstart
 
-This is mostly meant for developing `sg`:
+Run the following to install `sg` from the `main` branch:
 
 ```
-go run . -config sg.config.example.yaml start
+go install github.com/sourcegraph/sourcegraph/dev/sg@latest
 ```
 
-This compiles and starts `sg`, starting the `default` command set defined in `sg.config.example.yaml`, which boots up our dev environment.
-
-## TODOs
-
-- [ ] Build everything below
-
-## Installation
+Then, in the root of `sourcegraph/sourcegraph`, run:
 
 ```
-go get github.com/sourcegraph/sourcegraph/dev/sg
+sg start
 ```
+
+This will boot the `default` commands in `sg.config.yaml` in the root of the repository.
+
+**Alternative install method** (if you want to move the binary to a custom location):
+
+In the root of `sourcegraph/sourcegraph`, run the following:
+
+```
+go build -o ~/my/path/sg ./dev/sg
+```
+
+Make sure that `~/my/path` is in your `$PATH` then.
+
+
+## Inspiration
+
+- [GitLab Developer Kit (GDK)](https://gitlab.com/gitlab-org/gitlab-development-kit)
+- Stripe's `pay` command, [described here](https://buttondown.email/nelhage/archive/papers-i-love-gg/)
+- [Stack Exchange Local Environment Setup](https://twitter.com/nick_craver/status/1375871107773956103?s=21) command
 
 ## Usage
 
@@ -40,15 +55,17 @@ go get github.com/sourcegraph/sourcegraph/dev/sg
 # Run complete environment:
 sg start
 
+# Run the enterprise environment:
+sg run-set enterprise
+
 # Run specific commands:
 sg run gitserver
 sg run frontend
 
 # Run predefined sets of commands:
-sg run-set backend
-sg run-set monitoring
+sg run-set enterprise
 
-# Rebuild and restart a command (if it has `build` defined, see Configuration)
+# TODO: Rebuild and restart a command (if it has `build` defined, see Configuration)
 sg build gitserver
 ```
 
@@ -69,11 +86,13 @@ sg test regression
 # Without argument it lists all available tests:
 sg test
 
-# Arguments are passed along to the command
+# TODO: Arguments are passed along to the command
 sg test backend-integration -run TestSearch
 ```
 
 ### Generators
+
+TODO: Build this
 
 ```bash
 # Generate code
@@ -84,6 +103,8 @@ sg generate mocks ./internal/enterprise/batches
 ```
 
 ### Database migrations
+
+TODO: Build this
 
 ```bash
 # Create a new migration
@@ -98,6 +119,8 @@ sg migration down
 
 ### Edit configuration files
 
+TODO: Build this
+
 ```bash
 # Edit the site configuration
 sg edit site-config # opens site-config in $EDITOR
@@ -106,6 +129,8 @@ sg edit external-services # opens external-services.json in $EDITOR
 ```
 
 ### Tail logs
+
+TODO: Build this
 
 ```bash
 # Tail the SQL logs
@@ -213,3 +238,27 @@ tests:
     env:
       TS_NODE_PROJECT: client/web/src/end-to-end/tsconfig.json
 ```
+
+## TODOs
+
+- [ ] All of the things marked as TODOs above
+- [ ] Add the remaining processes from `<root>/dev/Procfile` to `<root>/sg.config.yaml`
+- [ ] Add a _simple_ way to define in the config file when a restart after a rebuild is not necessary
+    - Something like `check_binary: .bin/frontend` which would take a SHA256 before and after rebuild and only restart if SHA doesn't match
+- [ ] Rename `install` to `build` because it's clearer
+- [ ] Add support for "dev environment setup"
+    - Something like `sg check` which runs `check_cmds` in the config file and provides helpful output if one of them failed ("check_cmd postgres failed. Install postgres with...")
+- [ ] Add built-in support for "download binary" so that the `caddy` command, for example, would be 3 lines instead of 20
+
+## Hacking
+
+When you want to hack on `sg` it's best to be in the `dev/sg` directory and run
+it from there:
+
+```
+cd dev/sg
+go run . -config ../../sg.config.yaml start
+```
+
+The `-config` can be anything you want, of course.
+

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -46,13 +46,21 @@ commands:
       - cmd/frontend
 
   enterprise-frontend:
-    cmd: ulimit -n 10000 && .bin/enterprise-frontend
+    cmd: |
+      ulimit -n 10000
+      # TODO: This should be fixed
+      export SOURCEGRAPH_LICENSE_GENERATION_KEY=$(cat ../dev-private/enterprise/dev/test-license-generation-key.pem)
+      .bin/enterprise-frontend
     install: go build -o .bin/enterprise-frontend github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
     env:
       CONFIGURATION_MODE: server
       USE_ENHANCED_LANGUAGE_DETECTION: false
+      ENTERPRISE: 1
+      SITE_CONFIG_FILE: '../dev-private/enterprise/dev/site-config.json'
+      EXTSVC_CONFIG_FILE: '../dev-private/enterprise/dev/external-services-config.json'
     watch:
       - internal
+      - enterprise/internal
       - cmd/frontend
       - enterprise/cmd/frontend
 
@@ -90,8 +98,10 @@ commands:
     install: go build -o .bin/repo-updater github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater
     env:
       HOSTNAME: $SRC_GIT_SERVER_1
+      ENTERPRISE: 1
     watch:
       - internal
+      - enterprise/internal
       - cmd/repo-updater
       - enterprise/cmd/repo-updater
 
@@ -157,6 +167,15 @@ commands:
       NODE_ENV: development
       NODE_OPTIONS: "--max_old_space_size=4096"
 
+  enterprise-web:
+    cmd: ./node_modules/.bin/gulp --silent --color dev
+    install: yarn --no-progress
+    env:
+      ENTERPRISE: 1
+      WEBPACK_DEV_SERVER: 1
+      NODE_ENV: development
+      NODE_OPTIONS: "--max_old_space_size=4096"
+
   docsite:
     cmd: .bin/docsite_${VERSION} -config doc/docsite.json serve -http=localhost:5080
     install: |
@@ -187,10 +206,11 @@ commands:
         -cpu_fraction 0.25
     install: |
       mkdir -p .bin
-      # TODO: Do we need to install these?
-      # go install github.com/google/zoekt/cmd/zoekt-archive-index
-      # go install github.com/google/zoekt/cmd/zoekt-git-index
-      env GOBIN="${PWD}/.bin" GO111MODULE=on go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
+      export GOBIN="${PWD}/.bin"
+      export GO111MODULE=on
+      go install github.com/google/zoekt/cmd/zoekt-archive-index
+      go install github.com/google/zoekt/cmd/zoekt-git-index
+      go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
     env:
       GOGC: 50
 
@@ -204,8 +224,14 @@ commands:
         -listen ":6073" \
         -cpu_fraction 0.25
     install: |
+      # We technically don't need this because indexserver-0 installs it, but
+      # let's keep it here before we have something to remove the duplication
       mkdir -p .bin
-      env GOBIN="${PWD}/.bin" GO111MODULE=on go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
+      export GOBIN="${PWD}/.bin"
+      export GO111MODULE=on
+      go install github.com/google/zoekt/cmd/zoekt-archive-index
+      go install github.com/google/zoekt/cmd/zoekt-git-index
+      go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
     env:
       GOGC: 50
 
@@ -254,11 +280,11 @@ commandsets:
   enterprise:
     - enterprise-frontend
     - enterprise-repo-updater
+    - enterprise-web
     - gitserver
     - searcher
     - symbols
     - query-runner
-    - web
     - caddy
     - docsite
     - syntect_server

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -46,8 +46,11 @@ commands:
       - cmd/frontend
 
   enterprise-frontend:
-    cmd: .bin/enterprise-frontend
+    cmd: ulimit -n 10000 && .bin/enterprise-frontend
     install: go build -o .bin/enterprise-frontend github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
+    env:
+      CONFIGURATION_MODE: server
+      USE_ENHANCED_LANGUAGE_DETECTION: false
     watch:
       - internal
       - cmd/frontend
@@ -184,12 +187,25 @@ commands:
         -cpu_fraction 0.25
     install: |
       mkdir -p .bin
-      export GOBIN="${PWD}/.bin"
-      export GO111MODULE=on
       # TODO: Do we need to install these?
       # go install github.com/google/zoekt/cmd/zoekt-archive-index
       # go install github.com/google/zoekt/cmd/zoekt-git-index
-      go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
+      env GOBIN="${PWD}/.bin" GO111MODULE=on go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
+    env:
+      GOGC: 50
+
+  zoekt-indexserver-1:
+    cmd: |
+      .bin/zoekt-sourcegraph-indexserver \
+        -sourcegraph_url 'http://localhost:3090' \
+        -index "$HOME/.sourcegraph/zoekt/index-1" \
+        -hostname 'localhost:3071' \
+        -interval 1m \
+        -listen ":6073" \
+        -cpu_fraction 0.25
+    install: |
+      mkdir -p .bin
+      env GOBIN="${PWD}/.bin" GO111MODULE=on go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
     env:
       GOGC: 50
 
@@ -200,17 +216,24 @@ commands:
         -pprof -rpc -listen ":3070"
     install: |
       mkdir -p .bin
-      export GOBIN="${PWD}/.bin"
-      export GO111MODULE=on
-      go install github.com/google/zoekt/cmd/zoekt-webserver
+      env GOBIN="${PWD}/.bin" GO111MODULE=on go install github.com/google/zoekt/cmd/zoekt-webserver
+    env:
+      JAEGER_DISABLED: false
+      GOGC: 50
+
+  zoekt-webserver-1:
+    cmd: |
+      .bin/zoekt-webserver \
+        -index "$HOME/.sourcegraph/zoekt/index-1" \
+        -pprof -rpc -listen ":3071"
+    install: |
+      mkdir -p .bin
+      env GOBIN="${PWD}/.bin" GO111MODULE=on go install github.com/google/zoekt/cmd/zoekt-webserver
     env:
       JAEGER_DISABLED: false
       GOGC: 50
 
 commandsets:
-  testing:
-    - frontend
-    - gitserver
   default:
     - frontend
     - repo-updater
@@ -224,13 +247,9 @@ commandsets:
     - syntect_server
     - github-proxy
     - zoekt-indexserver-0
+    - zoekt-indexserver-1
     - zoekt-webserver-0
-
-  zoekt:
-    - frontend
-    - gitserver
-    - zoekt-indexserver-0
-    - zoekt-webserver-0
+    - zoekt-webserver-1
 
   enterprise:
     - enterprise-frontend
@@ -244,13 +263,10 @@ commandsets:
     - docsite
     - syntect_server
     - github-proxy
-
-  # Another set that can be run with `sg run-set monitoring`:
-  monitoring:
-    # - jaeger
-    # - prometheus
-    # - grafana
-    # - postgres_exporter
+    - zoekt-indexserver-0
+    - zoekt-indexserver-1
+    - zoekt-webserver-0
+    - zoekt-webserver-1
 
 tests:
   # These can be run with `sg test [name]`


### PR DESCRIPTION
This updates the `sg.config.yaml` so that `sg run-set enterprise` boots up the enterprise environment (still without the @sourcegraph/code-intel commands though, wink wink, nudge nudge).

It also updates the README to contain more TODOs, an Inspiration section, an updated Quickstart/Installation section and a Hacking section.