### PR TITLE
Do not mark closed/merged changesets as to-be-closed on apply

### DIFF
--- a/enterprise/internal/batches/rewirer/rewirer.go
+++ b/enterprise/internal/batches/rewirer/rewirer.go
@@ -186,8 +186,15 @@ func (r *ChangesetRewirer) closeChangeset(changeset *batches.Changeset) {
 		// already and we don't want to detach it.
 		if !changeset.ArchivedIn(r.batchChangeID) {
 			changeset.Archive(r.batchChangeID)
-			changeset.Closing = true
 			reset = true
+
+			// If the changeset hasn't been closed/merged yet, we close it.
+			// Marking it as Closing would be a noop, but it's weird to show a
+			// changeset as will-be-closed on the preview page when it's
+			// already closed.
+			if changeset.Closeable() {
+				changeset.Closing = true
+			}
 		}
 	} else if wasAttached := changeset.Detach(r.batchChangeID); wasAttached {
 		// If not, we simply detach it

--- a/internal/batches/changeset.go
+++ b/internal/batches/changeset.go
@@ -261,6 +261,12 @@ func (c *Changeset) Clone() *Changeset {
 	return &tt
 }
 
+// Closeable returns whether the Changeset is already closed or merged.
+func (c *Changeset) Closeable() bool {
+	return c.ExternalState != ChangesetExternalStateClosed &&
+		c.ExternalState != ChangesetExternalStateMerged
+}
+
 // Published returns whether the Changeset's PublicationState is Published.
 func (c *Changeset) Published() bool { return c.PublicationState.Published() }
 


### PR DESCRIPTION
This fixes #19606

