### PR TITLE
search: update or append count for "Search again"

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.test.tsx
@@ -25,7 +25,6 @@ import {
     REPO_MATCH_RESULT,
     RESULT,
 } from '../../../../../shared/src/util/searchTestHelpers'
-import { forEach } from 'lodash'
 
 describe('StreamingSearchResults', () => {
     const history = createBrowserHistory()

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -176,7 +176,15 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
 
     const onSearchAgain = useCallback(
         (additionalFilters: string[]) => {
-            const newQuery = [query, ...additionalFilters].join(' ')
+            const countRe = new RegExp(/count:\d+/, 'gim')
+            let newQuery = query
+            for (const value of additionalFilters) {
+                if (!value.startsWith('count')) {
+                    newQuery = newQuery + ' ' + value
+                    continue
+                }
+                newQuery = newQuery.search(countRe) >= 0 ? newQuery.replace(countRe, value) : newQuery + ' ' + value
+            }
             telemetryService.log('SearchSkippedResultsAgainClicked')
             submitSearch({ ...props, query: newQuery, source: 'excludedResults' })
         },


### PR DESCRIPTION
fixes: #19612

So far we appended an increased count to the query if the user clicked
on "Search again". This led to invalid queries if count was already
present. With this change we update the count if it is present or append
it otherwise.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
