### PR TITLE
repoupdater: Add func NewClient

### DIFF
--- a/cmd/repo-updater/repoupdater/server_test.go
+++ b/cmd/repo-updater/repoupdater/server_test.go
@@ -344,7 +344,7 @@ func testServerSetRepoEnabled(t *testing.T, store *repos.Store) func(t *testing.
 				s := &Server{Store: store}
 				srv := httptest.NewServer(s.Handler())
 				defer srv.Close()
-				cli := repoupdater.Client{URL: srv.URL}
+				cli := repoupdater.NewClient(srv.URL)
 
 				if tc.err == "" {
 					tc.err = "<nil>"
@@ -480,7 +480,7 @@ func testServerEnqueueRepoUpdate(t *testing.T, store *repos.Store) func(t *testi
 				s := &Server{Store: tc.store, Scheduler: &fakeScheduler{}}
 				srv := httptest.NewServer(s.Handler())
 				defer srv.Close()
-				cli := repoupdater.Client{URL: srv.URL}
+				cli := repoupdater.NewClient(srv.URL)
 
 				if tc.err == "" {
 					tc.err = "<nil>"
@@ -581,7 +581,7 @@ func testServerRepoExternalServices(t *testing.T, store *repos.Store) func(t *te
 		s := &Server{Store: store}
 		srv := httptest.NewServer(s.Handler())
 		defer srv.Close()
-		cli := repoupdater.Client{URL: srv.URL}
+		cli := repoupdater.NewClient(srv.URL)
 		for _, tc := range testCases {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
@@ -1043,7 +1043,7 @@ func testRepoLookup(db *sql.DB) func(t *testing.T, repoStore *repos.Store) func(
 					srv := httptest.NewServer(s.Handler())
 					defer srv.Close()
 
-					cli := repoupdater.Client{URL: srv.URL}
+					cli := repoupdater.NewClient(srv.URL)
 
 					if tc.err == "" {
 						tc.err = "<nil>"

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -21,27 +21,12 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 )
 
-var repoupdaterURL = env.Get("REPO_UPDATER_URL", "http://repo-updater:3182", "repo-updater server URL")
-
 var requestMeter = metrics.NewRequestMeter("repoupdater", "Total number of requests sent to repoupdater.")
 
-// DefaultClient is the default Client. Unless overwritten, it is connected to the server specified by the
-// REPO_UPDATER_URL environment variable.
-var DefaultClient = &Client{
-	URL: repoupdaterURL,
-	HTTPClient: &http.Client{
-		// ot.Transport will propagate opentracing spans and whether or not to trace
-		Transport: &ot.Transport{
-			RoundTripper: requestMeter.Transport(&http.Transport{
-				// Default is 2, but we can send many concurrent requests
-				MaxIdleConnsPerHost: 500,
-			}, func(u *url.URL) string {
-				// break it down by API function call (ie "/repo-update-scheduler-info", "/repo-lookup", etc)
-				return u.Path
-			}),
-		},
-	},
-}
+// DefaultClient is the default Client. Unless overwritten, it is
+// connected to the server specified by the REPO_UPDATER_URL
+// environment variable.
+var DefaultClient = NewClient(env.Get("REPO_UPDATER_URL", "http://repo-updater:3182", "repo-updater server URL"))
 
 // Client is a repoupdater client.
 type Client struct {
@@ -50,6 +35,24 @@ type Client struct {
 
 	// HTTP client to use
 	HTTPClient *http.Client
+}
+
+func NewClient(serverURL string) *Client {
+	return &Client{
+		URL: serverURL,
+		HTTPClient: &http.Client{
+			// ot.Transport will propagate opentracing spans and whether or not to trace
+			Transport: &ot.Transport{
+				RoundTripper: requestMeter.Transport(&http.Transport{
+					// Default is 2, but we can send many concurrent requests
+					MaxIdleConnsPerHost: 500,
+				}, func(u *url.URL) string {
+					// break it down by API function call (ie "/repo-update-scheduler-info", "/repo-lookup", etc)
+					return u.Path
+				}),
+			},
+		},
+	}
 }
 
 // RepoUpdateSchedulerInfo returns information about the state of the repo in the update scheduler.

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -28,8 +28,8 @@ var requestMeter = metrics.NewRequestMeter("repoupdater", "Total number of reque
 // environment variable.
 var DefaultClient = NewClient(env.Get("REPO_UPDATER_URL", "http://repo-updater:3182", "repo-updater server URL"))
 
-// client is a repoupdater client.
-type client struct {
+// Client is a repoupdater client.
+type Client struct {
 	// URL to repoupdater server.
 	URL string
 
@@ -37,8 +37,8 @@ type client struct {
 	HTTPClient *http.Client
 }
 
-func NewClient(serverURL string) *client {
-	return &client{
+func NewClient(serverURL string) *Client {
+	return &Client{
 		URL: serverURL,
 		HTTPClient: &http.Client{
 			// ot.Transport will propagate opentracing spans and whether or not to trace
@@ -56,7 +56,7 @@ func NewClient(serverURL string) *client {
 }
 
 // RepoUpdateSchedulerInfo returns information about the state of the repo in the update scheduler.
-func (c *client) RepoUpdateSchedulerInfo(ctx context.Context, args protocol.RepoUpdateSchedulerInfoArgs) (result *protocol.RepoUpdateSchedulerInfoResult, err error) {
+func (c *Client) RepoUpdateSchedulerInfo(ctx context.Context, args protocol.RepoUpdateSchedulerInfoArgs) (result *protocol.RepoUpdateSchedulerInfoResult, err error) {
 	resp, err := c.httpPost(ctx, "repo-update-scheduler-info", args)
 	if err != nil {
 		return nil, err
@@ -71,16 +71,16 @@ func (c *client) RepoUpdateSchedulerInfo(ctx context.Context, args protocol.Repo
 	return result, err
 }
 
-// MockRepoLookup mocks (*client).RepoLookup for tests.
+// MockRepoLookup mocks (*Client).RepoLookup for tests.
 var MockRepoLookup func(protocol.RepoLookupArgs) (*protocol.RepoLookupResult, error)
 
 // RepoLookup retrieves information about the repository on repoupdater.
-func (c *client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (result *protocol.RepoLookupResult, err error) {
+func (c *Client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (result *protocol.RepoLookupResult, err error) {
 	if MockRepoLookup != nil {
 		return MockRepoLookup(args)
 	}
 
-	span, ctx := ot.StartSpanFromContext(ctx, "client.RepoLookup")
+	span, ctx := ot.StartSpanFromContext(ctx, "Client.RepoLookup")
 	defer func() {
 		if result != nil {
 			span.SetTag("found", result.Repo != nil)
@@ -130,12 +130,12 @@ func (c *client) RepoLookup(ctx context.Context, args protocol.RepoLookupArgs) (
 	return result, err
 }
 
-// MockEnqueueRepoUpdate mocks (*client).EnqueueRepoUpdate for tests.
+// MockEnqueueRepoUpdate mocks (*Client).EnqueueRepoUpdate for tests.
 var MockEnqueueRepoUpdate func(ctx context.Context, repo api.RepoName) (*protocol.RepoUpdateResponse, error)
 
 // EnqueueRepoUpdate requests that the named repository be updated in the near
 // future. It does not wait for the update.
-func (c *client) EnqueueRepoUpdate(ctx context.Context, repo api.RepoName) (*protocol.RepoUpdateResponse, error) {
+func (c *Client) EnqueueRepoUpdate(ctx context.Context, repo api.RepoName) (*protocol.RepoUpdateResponse, error) {
 	if MockEnqueueRepoUpdate != nil {
 		return MockEnqueueRepoUpdate(ctx, repo)
 	}
@@ -165,10 +165,10 @@ func (c *client) EnqueueRepoUpdate(ctx context.Context, repo api.RepoName) (*pro
 	return &res, nil
 }
 
-// MockEnqueueChangesetSync mocks (*client).EnqueueChangesetSync for tests.
+// MockEnqueueChangesetSync mocks (*Client).EnqueueChangesetSync for tests.
 var MockEnqueueChangesetSync func(ctx context.Context, ids []int64) error
 
-func (c *client) EnqueueChangesetSync(ctx context.Context, ids []int64) error {
+func (c *Client) EnqueueChangesetSync(ctx context.Context, ids []int64) error {
 	if MockEnqueueChangesetSync != nil {
 		return MockEnqueueChangesetSync(ctx, ids)
 	}
@@ -198,7 +198,7 @@ func (c *client) EnqueueChangesetSync(ctx context.Context, ids []int64) error {
 	return errors.New(res.Error)
 }
 
-func (c *client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncRequest) error {
+func (c *Client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncRequest) error {
 	resp, err := c.httpPost(ctx, "schedule-perms-sync", args)
 	if err != nil {
 		return err
@@ -224,7 +224,7 @@ func (c *client) SchedulePermsSync(ctx context.Context, args protocol.PermsSyncR
 }
 
 // SyncExternalService requests the given external service to be synced.
-func (c *client) SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error) {
+func (c *Client) SyncExternalService(ctx context.Context, svc api.ExternalService) (*protocol.ExternalServiceSyncResult, error) {
 	req := &protocol.ExternalServiceSyncRequest{ExternalService: svc}
 	resp, err := c.httpPost(ctx, "sync-external-service", req)
 	if err != nil {
@@ -258,7 +258,7 @@ func (c *client) SyncExternalService(ctx context.Context, svc api.ExternalServic
 
 // RepoExternalServices requests the external services associated with a
 // repository with the given id.
-func (c *client) RepoExternalServices(ctx context.Context, id api.RepoID) ([]api.ExternalService, error) {
+func (c *Client) RepoExternalServices(ctx context.Context, id api.RepoID) ([]api.ExternalService, error) {
 	req := protocol.RepoExternalServicesRequest{ID: id}
 	resp, err := c.httpPost(ctx, "repo-external-services", &req)
 	if err != nil {
@@ -283,7 +283,7 @@ func (c *client) RepoExternalServices(ctx context.Context, id api.RepoID) ([]api
 
 // ExcludeRepo adds the repository with the given id to all of the
 // external services exclude lists that match its kind.
-func (c *client) ExcludeRepo(ctx context.Context, id api.RepoID) (*protocol.ExcludeRepoResponse, error) {
+func (c *Client) ExcludeRepo(ctx context.Context, id api.RepoID) (*protocol.ExcludeRepoResponse, error) {
 	if id == 0 {
 		return &protocol.ExcludeRepoResponse{}, nil
 	}
@@ -310,7 +310,7 @@ func (c *client) ExcludeRepo(ctx context.Context, id api.RepoID) (*protocol.Excl
 	return &res, nil
 }
 
-func (c *client) httpPost(ctx context.Context, method string, payload interface{}) (resp *http.Response, err error) {
+func (c *Client) httpPost(ctx context.Context, method string, payload interface{}) (resp *http.Response, err error) {
 	reqBody, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -324,8 +324,8 @@ func (c *client) httpPost(ctx context.Context, method string, payload interface{
 	return c.do(ctx, req)
 }
 
-func (c *client) do(ctx context.Context, req *http.Request) (_ *http.Response, err error) {
-	span, ctx := ot.StartSpanFromContext(ctx, "client.do")
+func (c *Client) do(ctx context.Context, req *http.Request) (_ *http.Response, err error) {
+	span, ctx := ot.StartSpanFromContext(ctx, "Client.do")
 	defer func() {
 		if err != nil {
 			ext.Error.Set(span, true)

--- a/internal/repoupdater/client.go
+++ b/internal/repoupdater/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	HTTPClient *http.Client
 }
 
+// NewClient will initiate a new repoupdater Client with the given serverURL.
 func NewClient(serverURL string) *Client {
 	return &Client{
 		URL: serverURL,

--- a/internal/repoupdater/client_test.go
+++ b/internal/repoupdater/client_test.go
@@ -1,0 +1,14 @@
+package repoupdater
+
+import "testing"
+
+func TestNewClient(t *testing.T) {
+	t.Run("successful creation of client with custom URL", func(t *testing.T) {
+		expected := "foo"
+		c := NewClient(expected)
+
+		if c.URL != expected {
+			t.Errorf("Expected URL %q, but got %q", expected, c.URL)
+		}
+	})
+}


### PR DESCRIPTION
# Why this PR was created?

I was originally working on #19447 which had a limited scope. However I ran into data races that required me to maintain a private repoupdater client instead of using `repoupdater.DefaultClient`. As a result the scope of that PR changed rather quickly and in an effort to keep my PRs well scoped to do only one thing, this PR was born.

This is now a prerequisite of #19447 and to make it easier to instantiate a repoupdater client from other packages, this PR adds a function `NewClient` (this is in line with the gitserver client and is one small step for man, one giant step for consistency in our codebase).

~~And once `repoupdater.NewClient` was defined, it made little sense to allow `repoupdater.Client` to be public, thus it was given the privacy it deserved and has now become `repoupdater.client`.~~

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
