### PR TITLE
oobmigration: Fix clashing migration identifiers

### DIFF
--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -201,9 +201,9 @@ func NewExternalAccountsMigratorWithDB(db dbutil.DB) *ExternalAccountsMigrator {
 }
 
 // ID of the migration row in the out_of_band_migrations table.
-// This ID was defined arbitrarily in this migration file: frontend/1528395807_external_account_migration.up.sql
+// This ID was defined arbitrarily in this migration file: frontend/1528395809_external_account_migration.up.sql
 func (m *ExternalAccountsMigrator) ID() int {
-	return 4
+	return 6
 }
 
 // Progress returns a value from 0 to 1 representing the percentage of configuration already migrated.

--- a/migrations/frontend/1528395809_external_account_migration.up.sql
+++ b/migrations/frontend/1528395809_external_account_migration.up.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 INSERT INTO out_of_band_migrations (id, team, component, description, introduced, non_destructive)
-VALUES (4, 'core-application', 'frontend-db.external-accounts', 'Encrypt auth data', '3.26.0', true)
+VALUES (6, 'core-application', 'frontend-db.external-accounts', 'Encrypt auth data', '3.26.0', true)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
OOB migrations with identifiers 4 and 5 were introduced to main before the core-application migration with (clashing) id 4 was merged. This keeps the identifier order serialized with the order the migrators were merged.