### PR TITLE
Remove emoji from schema.graphql since it breaks the GraphQL plugin for Jetbrains

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -481,7 +481,7 @@ type Mutation {
 
     Only site admins may perform this mutation.
     """
-    # :rotating_light: SECURITY: Only trusted users should be given site admin permissions.
+    # SECURITY: Only trusted users should be given site admin permissions.
     # Site admins have full access to the site configuration and other
     # sensitive data, and they can perform destructive actions such as
     # restarting the site.

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -481,7 +481,7 @@ type Mutation {
 
     Only site admins may perform this mutation.
     """
-    # 🚨 SECURITY: Only trusted users should be given site admin permissions.
+    # :rotating_light: SECURITY: Only trusted users should be given site admin permissions.
     # Site admins have full access to the site configuration and other
     # sensitive data, and they can perform destructive actions such as
     # restarting the site.


### PR DESCRIPTION
Tiny change but UTF-8 still appears to not be everywhere

Stops the Jetbrains Graphql plugin from breaking

Filed issue https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/issues/443


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
