### PR TITLE
Add repo:contains.commit.after() predicate

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -992,6 +992,21 @@ func testSearchClient(t *testing.T, client searchClient) {
 				`repo:sg(test)`,
 				counts{Repo: 6},
 			},
+			{
+				`repo has commit after`,
+				`repo:go-diff repo:contains.commit.after(10 years ago)`,
+				counts{Repo: 1},
+			},
+			{
+				`repo has commit after no results`,
+				`repo:go-diff repo:contains.commit.after(1 second ago)`,
+				counts{Repo: 0},
+			},
+			{
+				`unscoped repo has commit after no results`,
+				`repo:contains.commit.after(1 second ago)`,
+				counts{Repo: 0},
+			},
 		}
 
 		for _, test := range tests {

--- a/internal/search/query/parser.go
+++ b/internal/search/query/parser.go
@@ -434,12 +434,17 @@ func ScanPredicate(field string, buf []byte) (string, int, bool) {
 func ScanPredicateName(fieldRegistry map[string]func() Predicate, buf []byte) (string, int, bool) {
 	var predicateName string
 	var advance int
-	for i, c := range buf {
-		if !unicode.IsLetter(rune(c)) {
-			predicateName = string(buf[:i])
-			advance = i
+	for {
+		r, i := utf8.DecodeRune(buf[advance:])
+		if r == utf8.RuneError {
 			break
 		}
+
+		if !(unicode.IsLetter(r) || r == '.') {
+			predicateName = string(buf[:advance])
+			break
+		}
+		advance += i
 	}
 
 	if _, ok := fieldRegistry[predicateName]; !ok {

--- a/internal/search/query/parser_test.go
+++ b/internal/search/query/parser_test.go
@@ -200,6 +200,16 @@ func TestScanPredicate(t *testing.T) {
 		ResultLabels: "IsPredicate",
 	}).Equal(t, test(`repo:contains(file:test)`))
 
+	autogold.Want("Repo contains commit after predicate", value{
+		Result:       `{"field":"repo","value":"contains.commit.after(last thursday)","negated":false}`,
+		ResultLabels: "IsPredicate",
+	}).Equal(t, test(`repo:contains.commit.after(last thursday)`))
+
+	autogold.Want("Repo contains commit before predicate does not exist", value{
+		Result:       `{"field":"repo","value":"contains.commit.before(yesterday)","negated":false}`,
+		ResultLabels: "None",
+	}).Equal(t, test(`repo:contains.commit.before(yesterday)`))
+
 	autogold.Want("Predicate contains escaped paranthesis", value{
 		Result:       `{"field":"repo","value":"contains(\\()","negated":false}`,
 		ResultLabels: "IsPredicate",


### PR DESCRIPTION
Currently, the predicate just acts as an alias that expands to
repohascommitafter since we don't have a way to run arbitrary predicate
code to expand predicates (they must produce a valid query).



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
