### PR TITLE
search frontend: refactor query transformer helpers

### DIFF
--- a/client/shared/src/search/query/transformer.test.ts
+++ b/client/shared/src/search/query/transformer.test.ts
@@ -1,6 +1,6 @@
 import { FilterType } from './filters'
 import { Filter } from './token'
-import { appendContextFilter, omitContextFilter } from './transformer'
+import { appendContextFilter, omitFilter } from './transformer'
 import { FilterKind, findFilter } from './validate'
 
 describe('appendContextFilter', () => {
@@ -34,16 +34,16 @@ describe('omitContextFilter', () => {
 
     test('omit context filter from the start of the query', () => {
         const query = 'context:foo bar'
-        expect(omitContextFilter(query, getGlobalContextFilter(query))).toEqual('bar')
+        expect(omitFilter(query, getGlobalContextFilter(query))).toEqual('bar')
     })
 
     test('omit context filter from the end of the query', () => {
         const query = 'bar context:foo'
-        expect(omitContextFilter(query, getGlobalContextFilter(query))).toEqual('bar ')
+        expect(omitFilter(query, getGlobalContextFilter(query))).toEqual('bar ')
     })
 
     test('omit context filter from the middle of the query', () => {
         const query = 'bar context:foo bar1'
-        expect(omitContextFilter(query, getGlobalContextFilter(query))).toEqual('bar  bar1')
+        expect(omitFilter(query, getGlobalContextFilter(query))).toEqual('bar  bar1')
     })
 })

--- a/client/shared/src/search/query/transformer.ts
+++ b/client/shared/src/search/query/transformer.ts
@@ -1,14 +1,17 @@
 import { replaceRange } from '../../util/strings'
+import { FilterType } from './filters'
 import { Filter } from './token'
-import { isContextFilterInQuery } from './validate'
+import { filterExists } from './validate'
 
 export function appendContextFilter(query: string, searchContextSpec: string | undefined): string {
-    return !isContextFilterInQuery(query) && searchContextSpec ? `context:${searchContextSpec} ${query}` : query
+    return !filterExists(query, FilterType.context) && searchContextSpec
+        ? `context:${searchContextSpec} ${query}`
+        : query
 }
 
-export function omitContextFilter(query: string, contextFilter: Filter): string {
-    let finalQuery = replaceRange(query, contextFilter.range)
-    if (contextFilter.range.start === 0) {
+export function omitFilter(query: string, filter: Filter): string {
+    let finalQuery = replaceRange(query, filter.range)
+    if (filter.range.start === 0) {
         // Remove space at the start
         finalQuery = finalQuery.slice(1)
     }

--- a/client/shared/src/search/query/validate.test.ts
+++ b/client/shared/src/search/query/validate.test.ts
@@ -1,4 +1,5 @@
-import { findFilter, FilterKind, isContextFilterInQuery } from './validate'
+import { FilterType } from './filters'
+import { findFilter, FilterKind, filterExists } from './validate'
 
 expect.addSnapshotSerializer({
     serialize: value => JSON.stringify(value, null, 2),
@@ -41,18 +42,18 @@ describe('finds a filter', () => {
 
 describe('isContextFilterInQuery', () => {
     test('no context filter in query', () => {
-        expect(isContextFilterInQuery('foo')).toBeFalsy()
+        expect(filterExists('foo', FilterType.context)).toBeFalsy()
     })
 
     test('context filter in query', () => {
-        expect(isContextFilterInQuery('context:@user foo')).toBeTruthy()
+        expect(filterExists('context:@user foo', FilterType.context)).toBeTruthy()
     })
 
     test('context filters in both subexpressions', () => {
-        expect(isContextFilterInQuery('(context:@user foo) or (context:@test bar)')).toBeTruthy()
+        expect(filterExists('(context:@user foo) or (context:@test bar)', FilterType.context)).toBeTruthy()
     })
 
     test('context filters in one subexpression', () => {
-        expect(isContextFilterInQuery('foo or (context:@test bar)')).toBeTruthy()
+        expect(filterExists('foo or (context:@test bar)', FilterType.context)).toBeTruthy()
     })
 })

--- a/client/shared/src/search/query/validate.ts
+++ b/client/shared/src/search/query/validate.ts
@@ -55,12 +55,10 @@ export const findFilter = (query: string, field: string, kind: FilterKind): Filt
     return kind === FilterKind.Global ? filter : undefined
 }
 
-export function isContextFilterInQuery(query: string): boolean {
+export function filterExists(query: string, filter: FilterType): boolean {
     const scannedQuery = scanSearchQuery(query)
     return (
         scannedQuery.type === 'success' &&
-        scannedQuery.term.some(
-            token => token.type === 'filter' && token.field.value.toLowerCase() === FilterType.context
-        )
+        scannedQuery.term.some(token => token.type === 'filter' && token.field.value.toLowerCase() === filter)
     )
 }

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -34,7 +34,7 @@ import { ExtensionAlertAnimationProps } from './UserNavItem'
 import { LayoutRouteProps } from '../routes'
 import { CodeMonitoringProps } from '../code-monitoring'
 import { useObservable } from '../../../shared/src/util/useObservable'
-import { omitContextFilter } from '../../../shared/src/search/query/transformer'
+import { omitFilter } from '../../../shared/src/search/query/transformer'
 
 interface Props
     extends SettingsCascadeProps,
@@ -141,7 +141,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
         // query and move it to the search contexts dropdown
         const finalQuery =
             globalSearchContextSpec && isSearchContextAvailable && props.showSearchContext
-                ? omitContextFilter(query, globalSearchContextSpec.filter)
+                ? omitFilter(query, globalSearchContextSpec.filter)
                 : query
 
         onNavbarQueryChange({ query: finalQuery })

--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -6,7 +6,8 @@ import { Dropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 import { SearchContextMenu } from './SearchContextMenu'
 import { SubmitSearchParameters } from '../helpers'
 import { VersionContextProps } from '../../../../shared/src/search/util'
-import { isContextFilterInQuery } from '../../../../shared/src/search/query/validate'
+import { filterExists } from '../../../../shared/src/search/query/validate'
+import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 
 export interface SearchContextDropdownProps
     extends Omit<SearchContextProps, 'showSearchContext'>,
@@ -35,7 +36,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
     const [isDisabled, setIsDisabled] = useState(false)
 
     // Disable the dropdown if the query contains a context filter
-    useEffect(() => setIsDisabled(isContextFilterInQuery(query)), [query])
+    useEffect(() => setIsDisabled(filterExists(query, FilterType.context)), [query])
 
     const submitOnToggle = useCallback(
         (selectedSearchContextSpec: string): void => {


### PR DESCRIPTION
Just a refactor to make transformers on filters more general:

-  `isContextFilterInQuery(query)` -> `filterExists(query, filter)`
- `omitContextFilter` -> `omitFilter`