### PR TITLE
search frontend: add updateFilters query helper

### DIFF
--- a/client/shared/src/search/query/transformer.test.ts
+++ b/client/shared/src/search/query/transformer.test.ts
@@ -1,6 +1,6 @@
 import { FilterType } from './filters'
 import { Filter } from './token'
-import { appendContextFilter, omitFilter } from './transformer'
+import { appendContextFilter, omitFilter, updateFilter, updateFilters } from './transformer'
 import { FilterKind, findFilter } from './validate'
 
 describe('appendContextFilter', () => {
@@ -45,5 +45,29 @@ describe('omitContextFilter', () => {
     test('omit context filter from the middle of the query', () => {
         const query = 'bar context:foo bar1'
         expect(omitFilter(query, getGlobalContextFilter(query))).toEqual('bar  bar1')
+    })
+})
+
+describe('updateFilter', () => {
+    test('append count', () => {
+        const query = 'content:"count:200"'
+        expect(updateFilter(query, 'count', '5000')).toMatchInlineSnapshot('"content:\\"count:200\\" count:5000"')
+    })
+
+    test('update first count', () => {
+        const query = '(foo count:5) or (bar count:10)'
+        expect(updateFilter(query, 'count', '5000')).toMatchInlineSnapshot('"(foo count:5000) or (bar count:10)"')
+    })
+})
+
+describe('updateFilters (all filters)', () => {
+    test('append count', () => {
+        const query = 'content:"count:200"'
+        expect(updateFilters(query, 'count', '5000')).toMatchInlineSnapshot('"content:\\"count:200\\" count:5000"')
+    })
+
+    test('update all counts count', () => {
+        const query = '(foo count:5) or (bar count:10)'
+        expect(updateFilters(query, 'count', '5000')).toMatchInlineSnapshot('"(foo count:5000) or (bar count:5000)"')
     })
 })

--- a/client/shared/src/search/query/transformer.ts
+++ b/client/shared/src/search/query/transformer.ts
@@ -1,7 +1,8 @@
 import { replaceRange } from '../../util/strings'
 import { FilterType } from './filters'
-import { Filter } from './token'
-import { filterExists } from './validate'
+import { scanSearchQuery } from './scanner'
+import { Filter, Token } from './token'
+import { filterExists, findFilters } from './validate'
 
 export function appendContextFilter(query: string, searchContextSpec: string | undefined): string {
     return !filterExists(query, FilterType.context) && searchContextSpec
@@ -16,4 +17,42 @@ export function omitFilter(query: string, filter: Filter): string {
         finalQuery = finalQuery.slice(1)
     }
     return finalQuery
+}
+
+const succeedScan = (query: string): Token[] => {
+    const result = scanSearchQuery(query)
+    if (result.type !== 'success') {
+        throw new Error('Internal error: invariant broken: succeedScan callers must be called with a valid query')
+    }
+    return result.term
+}
+
+/**
+ * Updates the first filter with the given value if it exists.
+ * Appends a single filter at the top level of the query if it does not exist.
+ * This function expects a valid query; if it is invalid it throws.
+ */
+export const updateFilter = (query: string, field: string, value: string): string => {
+    const filters = findFilters(succeedScan(query), field)
+    return filters.length > 0
+        ? replaceRange(query, filters[0].range, `${field}:${value}`).trim()
+        : `${query} ${field}:${value}`
+}
+
+/**
+ * Updates all filters with the given value if they exist.
+ * Appends a single filter at the top level of the query if none exist.
+ * This function expects a valid query; if it is invalid it throws.
+ */
+export const updateFilters = (query: string, field: string, value: string): string => {
+    const filters = findFilters(succeedScan(query), field)
+    let modified = false
+    for (const filter of filters.reverse()) {
+        query = replaceRange(query, filter.range, `${field}:${value}`)
+        modified = true
+    }
+    if (modified) {
+        return query.trim()
+    }
+    return `${query} ${field}:${value}`
 }

--- a/client/shared/src/search/query/validate.ts
+++ b/client/shared/src/search/query/validate.ts
@@ -1,6 +1,6 @@
 import { FilterType } from './filters'
 import { scanSearchQuery } from './scanner'
-import { Filter } from './token'
+import { Filter, Token } from './token'
 
 export enum FilterKind {
     Global = 'Global',
@@ -54,6 +54,12 @@ export const findFilter = (query: string, field: string, kind: FilterKind): Filt
     }
     return kind === FilterKind.Global ? filter : undefined
 }
+
+/**
+ * Returns all filters that match field.
+ */
+export const findFilters = (tokens: Token[], field: string): Filter[] =>
+    tokens.filter(token => token.type === 'filter' && token.field.value.toLowerCase() === field) as Filter[]
 
 export function filterExists(query: string, filter: FilterType): boolean {
     const scannedQuery = scanSearchQuery(query)


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/19667.

See [context](https://github.com/sourcegraph/sourcegraph/pull/19645#discussion_r605921650) for this helper. We should generally have an API for this, so this is just a gradual move towards that. Use the `updateFilters` function to:

```
Update all filters with the given value if they exist.
Appends a single filter at the top level of the query if none exist.
This function expects a valid query; if it is invalid it throws.
```

There is also a `updateFilter` (singular) function that will indiscriminately change the first filter (AKA parameter) regardless of whether it is global or in a subexpression (see tests). You may choose to:

- use `updateFilters` if that's acceptable in the context
- use `updateFilter` (singular) if that's acceptable in the context
- Test for whether a query contains a global or subexpression using the [`findFilter` helper](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/shared/src/search/query/validate.ts#L10-28) to drive the logic in whatever context this matters (either `updateFilter, `updateFilters`, or something else).
