### PR TITLE
search frontend: add printer for human readable queries

### DIFF
--- a/client/shared/src/search/query/printer.test.ts
+++ b/client/shared/src/search/query/printer.test.ts
@@ -1,0 +1,21 @@
+import { stringHuman } from './printer'
+import { ScanResult, scanSearchQuery, ScanSuccess } from './scanner'
+import { Token } from './token'
+
+expect.addSnapshotSerializer({
+    serialize: value => value as string,
+    test: () => true,
+})
+
+const toSuccess = (result: ScanResult<Token[]>): Token[] => (result as ScanSuccess<Token[]>).term
+
+describe('stringHuman', () => {
+    test('complex query', () => {
+        const tokens = toSuccess(
+            scanSearchQuery('(a or b) (-repo:foo    AND file:bar) content:"count:5000" /yowza/ "a\'b" \\d+')
+        )
+        expect(stringHuman(tokens)).toMatchInlineSnapshot(
+            '(a or b) (-repo:foo AND file:bar) content:"count:5000" /yowza/ "a\'b" \\d+'
+        )
+    })
+})

--- a/client/shared/src/search/query/printer.ts
+++ b/client/shared/src/search/query/printer.ts
@@ -1,0 +1,48 @@
+import { Token } from './token'
+
+/**
+ * stringHuman creates a valid query string from a scanned query formatted for human
+ * readability. It should be used in contexts where modified query tokens must be
+ * converted back to human readable form (e.g., for query suggestions).
+ */
+export const stringHuman = (tokens: Token[]): string => {
+    const result: string[] = []
+    for (const token of tokens) {
+        switch (token.type) {
+            case 'whitespace':
+                result.push(' ')
+                break
+            case 'openingParen':
+                result.push('(')
+                break
+            case 'closingParen':
+                result.push(')')
+                break
+            case 'filter':
+                // eslint-disable-next-line no-case-declarations
+                let value = ''
+                if (token.value) {
+                    if (token.value.quoted) {
+                        value = JSON.stringify(token.value.value)
+                    } else {
+                        value = token.value.value
+                    }
+                }
+                result.push(`${token.field.value}:${value}`)
+                break
+            case 'literal':
+                if (token.quoted) {
+                    result.push(JSON.stringify(token.value))
+                } else {
+                    result.push(token.value)
+                }
+                break
+            case 'pattern':
+            case 'keyword':
+            case 'comment':
+                result.push(token.value)
+                break
+        }
+    }
+    return result.join('')
+}


### PR DESCRIPTION
Stacked on #19669.

This is a pretty printer for human readable queries, given an internal representation of (possibly modified) tokens. It's analogous to the backend, except works on the token level and not parse trees.

This printer isn't used anywhere right now, but I figured to add it if it's needed. I started off implementing it for https://github.com/sourcegraph/sourcegraph/pull/19668 but opted to use `range` there instead. There are pros and cons to using range, but there are currently also pros and cons to converting tokens to a human string. Basically, we make some strong assumptions about the string representation of tokens that make it a bit tricky to build an interface around right now ([rough notes in this commit message](https://github.com/sourcegraph/sourcegraph/commit/cc7637e095f6980b0cefa6e3592ed5d741851f36)). Eventually the token/pretty printer interface should be preferred to the range approach.