### PR TITLE
search: fix result type String method

### DIFF
--- a/internal/search/result/result_type.go
+++ b/internal/search/result/result_type.go
@@ -41,17 +41,12 @@ func (r Types) Without(t Types) Types {
 }
 
 func (r Types) String() string {
-	var s strings.Builder
-	first := true
+	var names []string
 	for name, t := range TypeFromString {
 		if !r.Has(t) {
 			continue
 		}
-		if !first {
-			s.WriteByte('|')
-			first = false
-		}
-		s.WriteString(name)
+		names = append(names, name)
 	}
-	return s.String()
+	return strings.Join(names, "|")
 }


### PR DESCRIPTION
Am using this to debug a refactor and noticed it never prints the `|` separator.