### PR TITLE
search frontend: fix homepage autofocus conflict with onboarding tour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
 
 ## 3.26.1
 

--- a/client/web/src/search/input/SearchOnboardingTour.ts
+++ b/client/web/src/search/input/SearchOnboardingTour.ts
@@ -447,7 +447,7 @@ export const useSearchOnboardingTour = ({
             tour.start()
         }
     }, [shouldShowTour, tour, inputLocation])
-    const shouldFocusQueryInput = useMemo(() => shouldShowTour && inputLocation !== 'search-homepage', [
+    const shouldFocusQueryInput = useMemo(() => (shouldShowTour ? inputLocation !== 'search-homepage' : true), [
         shouldShowTour,
         inputLocation,
     ])


### PR DESCRIPTION
`shouldFocusQueryInput` was set unconditionally false on the `search-homepage` because of this logic in onboarding tour. Probably a multi-month regression.

Tested manually. Other suggestions to help test this?

Fixes feature request https://sourcegraph.slack.com/archives/C015JREMBTR/p1617394946016600?thread_ts=1617394942.016500&cid=C015JREMBTR