### PR TITLE
code monitoring: checklist for trigger creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Changed
 
-- The minimum supported version of Postgres has been bumped from `9.6` to `12`. The upgrade procedure is mostly automated for existing deployments, but may require action if using the single-container deployment or an external database. See the [upgrade documentation](https://docs.sourcegraph.com/admin/updates) for your deployment type for detailed instructions.
+- Bumped the minimum supported version of Postgres from `9.6` to `12`. The upgrade procedure is mostly automated for existing deployments, but may require action if using the single-container deployment or an external database. See the [upgrade documentation](https://docs.sourcegraph.com/admin/updates) for your deployment type for detailed instructions.
 - Changesets in batch changes will now be marked as archived instead of being detached when a new batch spec that doesn't include the changesets is applied. Once they're archived users can manually detach them in the UI. [#19527](https://github.com/sourcegraph/sourcegraph/pull/19527)
 - Changes to code monitor trigger search queries [#19680](https://github.com/sourcegraph/sourcegraph/pull/19680)
-  - A `repo:` filter is now required. This is due to an existing limitations where only 50 repositories can be searched at a time, so using a `repo:` filter is now required to make sure the right code is being searched. Any existing code monitor without `repo:` in the trigger query will continue to work (with the limitation that not all repositories will be searched) but will require a `repo:` filter to be added when making any changes to it.
+  - A `repo:` filter is now required. This is due to an existing limitations where only 50 repositories can be searched at a time, so using a `repo:` filter makes sure the right code is being searched. Any existing code monitor without `repo:` in the trigger query will continue to work (with the limitation that not all repositories will be searched) but will require a `repo:` filter to be added when making any changes to it.
   - A `patternType` filter is no longer required. `patternType:literal` will be added to a code monitor query if not specified.
-  - A new checklist UI has been added to help understand the requirements for a code monitor trigger query.
+  - Added a new checklist UI to make it more intuitive to create code monitor trigger queries.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to Sourcegraph are documented in this file.
 
 - The minimum supported version of Postgres has been bumped from `9.6` to `12`. The upgrade procedure is mostly automated for existing deployments, but may require action if using the single-container deployment or an external database. See the [upgrade documentation](https://docs.sourcegraph.com/admin/updates) for your deployment type for detailed instructions.
 - Changesets in batch changes will now be marked as archived instead of being detached when a new batch spec that doesn't include the changesets is applied. Once they're archived users can manually detach them in the UI. [#19527](https://github.com/sourcegraph/sourcegraph/pull/19527)
+- Changes to code monitor trigger search queries [#19680](https://github.com/sourcegraph/sourcegraph/pull/19680)
+  - A `repo:` filter is now required. This is due to an existing limitations where only 50 repositories can be searched at a time, so using a `repo:` filter is now required to make sure the right code is being searched. Any existing code monitor without `repo:` in the trigger query will continue to work (with the limitation that not all repositories will be searched) but will require a `repo:` filter to be added when making any changes to it.
+  - A `patternType` filter is no longer required. `patternType:literal` will be added to a code monitor query if not specified.
+  - A new checklist UI has been added to help understand the requirements for a code monitor trigger query.
 
 ### Fixed
 

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -54,7 +54,7 @@ describe('CreateCodeMonitorPage', () => {
         const triggerInput = component.find('.test-trigger-input')
         expect(triggerInput.length).toBe(1)
         act(() => {
-            triggerInput.simulate('change', { target: { value: 'test type:diff patterntype:literal' } })
+            triggerInput.simulate('change', { target: { value: 'test type:diff repo:test' } })
             clock.tick(600)
         })
         component = component.update()
@@ -86,7 +86,7 @@ describe('CreateCodeMonitorPage', () => {
         const triggerInput = component.find('.test-trigger-input')
         expect(triggerInput.length).toBe(1)
         act(() => {
-            triggerInput.simulate('change', { target: { value: 'test type:diff patterntype:literal' } })
+            triggerInput.simulate('change', { target: { value: 'test type:diff repo:test' } })
             clock.tick(600)
         })
         component = component.update()

--- a/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/CreateCodeMonitorPage.test.tsx
@@ -58,7 +58,7 @@ describe('CreateCodeMonitorPage', () => {
             clock.tick(600)
         })
         component = component.update()
-        expect(component.find('.is-valid').length).toBe(1)
+        expect(component.find('.test-is-valid').length).toBe(1)
         const submitTrigger = component.find('.test-submit-trigger')
         submitTrigger.simulate('click')
         const actionButton = component.find('.test-action-button')
@@ -90,7 +90,7 @@ describe('CreateCodeMonitorPage', () => {
             clock.tick(600)
         })
         component = component.update()
-        expect(component.find('.is-valid').length).toBe(1)
+        expect(component.find('.test-is-valid').length).toBe(1)
         const submitTrigger = component.find('.test-submit-trigger')
         submitTrigger.simulate('click')
 

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -38,4 +38,15 @@
     &__query-label {
         white-space: pre-wrap;
     }
+
+    &__checklist {
+        list-style-type: none;
+        padding-left: 0;
+
+        &-checkbox {
+            &--checked {
+                color: $success;
+            }
+        }
+    }
 }

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -42,11 +42,22 @@
     &__checklist {
         list-style-type: none;
         padding-left: 0;
+        margin-bottom: 0;
 
         &-checkbox {
-            &--checked {
-                color: $success;
-            }
+            font-size: 0.65rem;
+            margin-right: 0.5rem;
+            color: var(--border-color);
+        }
+
+        &-hint {
+            font-size: 0.65rem;
+            margin-left: 0.25rem;
+        }
+
+        &-tooltip {
+            text-align: left;
+            max-width: 16rem;
         }
     }
 }

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -50,9 +50,19 @@
             color: var(--border-color);
         }
 
+        &-children {
+            &--faded {
+                opacity: 0.4;
+            }
+        }
+
         &-hint {
             font-size: 0.65rem;
             margin-left: 0.25rem;
+
+            &--faded {
+                opacity: 0.4;
+            }
         }
 
         &-tooltip {

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -31,7 +31,7 @@
         &-field {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
-            padding-right: 8rem;
+            font-size: 0.75rem;
         }
     }
 

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -24,14 +24,12 @@
             }
         }
 
-        &-error-message {
-            font-size: 0.75rem;
-        }
-
         &-field {
             border-top-right-radius: 0;
             border-bottom-right-radius: 0;
             font-size: 0.75rem;
+            // stylelint-disable-next-line declaration-property-unit-whitelist
+            height: calc(1rem + 0.5rem * 2 + 1px * 2); // 1rem for text, 0.5rem vertical padding, 1px border
         }
     }
 

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
-import { DeleteMonitorModal } from './DeleteMonitorModal'
 import { storiesOf } from '@storybook/react'
-import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import React from 'react'
 import sinon from 'sinon'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 import { FormTriggerArea } from './FormTriggerArea'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/FormTrigerArea', module).addParameters({
@@ -16,53 +15,47 @@ const { add } = storiesOf('web/enterprise/code-monitoring/FormTrigerArea', modul
     },
 })
 
-add('Open, empty query', () => {
-    return (
-        <EnterpriseWebStory>
-            {props => (
-                <FormTriggerArea
-                    {...props}
-                    query=""
-                    triggerCompleted={false}
-                    onQueryChange={sinon.fake()}
-                    setTriggerCompleted={sinon.fake()}
-                    startExpanded={true}
-                />
-            )}
-        </EnterpriseWebStory>
-    )
-})
+add('Open, empty query', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <FormTriggerArea
+                {...props}
+                query=""
+                triggerCompleted={false}
+                onQueryChange={sinon.fake()}
+                setTriggerCompleted={sinon.fake()}
+                startExpanded={true}
+            />
+        )}
+    </EnterpriseWebStory>
+))
 
-add('Open, partially valid query', () => {
-    return (
-        <EnterpriseWebStory>
-            {props => (
-                <FormTriggerArea
-                    {...props}
-                    query="test type:commit"
-                    triggerCompleted={false}
-                    onQueryChange={sinon.fake()}
-                    setTriggerCompleted={sinon.fake()}
-                    startExpanded={true}
-                />
-            )}
-        </EnterpriseWebStory>
-    )
-})
+add('Open, partially valid query', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <FormTriggerArea
+                {...props}
+                query="test type:commit"
+                triggerCompleted={false}
+                onQueryChange={sinon.fake()}
+                setTriggerCompleted={sinon.fake()}
+                startExpanded={true}
+            />
+        )}
+    </EnterpriseWebStory>
+))
 
-add('Open, fully valid query', () => {
-    return (
-        <EnterpriseWebStory>
-            {props => (
-                <FormTriggerArea
-                    {...props}
-                    query="test type:commit repo:test"
-                    triggerCompleted={false}
-                    onQueryChange={sinon.fake()}
-                    setTriggerCompleted={sinon.fake()}
-                    startExpanded={true}
-                />
-            )}
-        </EnterpriseWebStory>
-    )
-})
+add('Open, fully valid query', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <FormTriggerArea
+                {...props}
+                query="test type:commit repo:test"
+                triggerCompleted={false}
+                onQueryChange={sinon.fake()}
+                setTriggerCompleted={sinon.fake()}
+                startExpanded={true}
+            />
+        )}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { DeleteMonitorModal } from './DeleteMonitorModal'
+import { storiesOf } from '@storybook/react'
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+import sinon from 'sinon'
+import { NEVER } from 'rxjs'
+import { mockCodeMonitor } from '../testing/util'
+
+const { add } = storiesOf('web/enterprise/code-monitoring/FormTrigerArea', module).addParameters({
+    design: {
+        type: 'Figma',
+        url:
+            'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=3891%3A41568',
+    },
+})
+
+add('Empty query', () => {}, { design })

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
@@ -3,8 +3,7 @@ import { DeleteMonitorModal } from './DeleteMonitorModal'
 import { storiesOf } from '@storybook/react'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 import sinon from 'sinon'
-import { NEVER } from 'rxjs'
-import { mockCodeMonitor } from '../testing/util'
+import { FormTriggerArea } from './FormTriggerArea'
 
 const { add } = storiesOf('web/enterprise/code-monitoring/FormTrigerArea', module).addParameters({
     design: {
@@ -12,6 +11,58 @@ const { add } = storiesOf('web/enterprise/code-monitoring/FormTrigerArea', modul
         url:
             'https://www.figma.com/file/Krh7HoQi0GFxtO2k399ZQ6/RFC-227-%E2%80%93-Code-monitoring-actions-and-notifications?node-id=3891%3A41568',
     },
+    chromatic: {
+        delay: 600, // Delay screenshot for input validation debouncing
+    },
 })
 
-add('Empty query', () => {}, { design })
+add('Open, empty query', () => {
+    return (
+        <EnterpriseWebStory>
+            {props => (
+                <FormTriggerArea
+                    {...props}
+                    query=""
+                    triggerCompleted={false}
+                    onQueryChange={sinon.fake()}
+                    setTriggerCompleted={sinon.fake()}
+                    startExpanded={true}
+                />
+            )}
+        </EnterpriseWebStory>
+    )
+})
+
+add('Open, partially valid query', () => {
+    return (
+        <EnterpriseWebStory>
+            {props => (
+                <FormTriggerArea
+                    {...props}
+                    query="test type:commit"
+                    triggerCompleted={false}
+                    onQueryChange={sinon.fake()}
+                    setTriggerCompleted={sinon.fake()}
+                    startExpanded={true}
+                />
+            )}
+        </EnterpriseWebStory>
+    )
+})
+
+add('Open, fully valid query', () => {
+    return (
+        <EnterpriseWebStory>
+            {props => (
+                <FormTriggerArea
+                    {...props}
+                    query="test type:commit repo:test"
+                    triggerCompleted={false}
+                    onQueryChange={sinon.fake()}
+                    setTriggerCompleted={sinon.fake()}
+                    startExpanded={true}
+                />
+            )}
+        </EnterpriseWebStory>
+    )
+})

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.story.tsx
@@ -12,6 +12,7 @@ const { add } = storiesOf('web/enterprise/code-monitoring/FormTrigerArea', modul
     },
     chromatic: {
         delay: 600, // Delay screenshot for input validation debouncing
+        viewports: [720],
     },
 })
 

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
@@ -74,7 +74,7 @@ describe('FormTriggerArea', () => {
         })
     }
 
-    test.only('Append patternType:literal if no patternType is present', () => {
+    test('Append patternType:literal if no patternType is present', () => {
         const onQueryChange = sinon.spy()
         let component = mount(
             <FormTriggerArea

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
@@ -15,10 +15,10 @@ describe('FormTriggerArea', () => {
         clock.restore()
     })
 
-    test('Error message is shown when query is invalid', () => {
+    test('Correct checkboxes shown when query does not fulfill requirements', () => {
         let component = mount(
             <FormTriggerArea
-                query="test"
+                query="test repo:test"
                 triggerCompleted={false}
                 onQueryChange={sinon.spy()}
                 setTriggerCompleted={sinon.spy()}
@@ -31,6 +31,98 @@ describe('FormTriggerArea', () => {
             clock.tick(600)
         })
         component = component.update()
+
         expect(component).toMatchSnapshot()
+    })
+
+    const testCases = [
+        { query: '', typeChecked: false, repoChecked: false, validChecked: false },
+        { query: 'test', typeChecked: false, repoChecked: false, validChecked: true },
+        { query: 'test type:repo', typeChecked: false, repoChecked: false, validChecked: true },
+        { query: 'test type:diff', typeChecked: true, repoChecked: false, validChecked: true },
+        { query: 'test type:commit', typeChecked: true, repoChecked: false, validChecked: true },
+        { query: 'test repo:test', typeChecked: false, repoChecked: true, validChecked: true },
+        { query: 'test repo:test type:diff', typeChecked: true, repoChecked: true, validChecked: true },
+    ]
+
+    for (const testCase of testCases) {
+        test(`Correct checkboxes checked for query '${testCase.query}'`, () => {
+            let component = mount(
+                <FormTriggerArea
+                    query={testCase.query}
+                    triggerCompleted={false}
+                    onQueryChange={sinon.spy()}
+                    setTriggerCompleted={sinon.spy()}
+                    startExpanded={false}
+                />
+            )
+            act(() => {
+                const triggerButton = component.find('.test-trigger-button')
+                triggerButton.simulate('click')
+                clock.tick(600)
+            })
+            component = component.update()
+
+            const typeCheckbox = component.find('.test-type-checkbox input[type="checkbox"]')
+            expect(typeCheckbox.get(0).props?.checked).toBe(testCase.typeChecked)
+
+            const repoCheckbox = component.find('.test-repo-checkbox input[type="checkbox"]')
+            expect(repoCheckbox.get(0).props?.checked).toBe(testCase.repoChecked)
+
+            const validCheckbox = component.find('.test-valid-checkbox input[type="checkbox"]')
+            expect(validCheckbox.get(0).props?.checked).toBe(testCase.validChecked)
+        })
+    }
+
+    test.only('Append patternType:literal if no patternType is present', () => {
+        const onQueryChange = sinon.spy()
+        let component = mount(
+            <FormTriggerArea
+                query=""
+                triggerCompleted={false}
+                onQueryChange={onQueryChange}
+                setTriggerCompleted={sinon.spy()}
+                startExpanded={false}
+            />
+        )
+        const triggerButton = component.find('.test-trigger-button')
+        triggerButton.simulate('click')
+
+        act(() => {
+            const triggerInput = component.find('.test-trigger-input')
+            triggerInput.simulate('change', { target: { value: 'test type:diff repo:test' } })
+            clock.tick(600)
+        })
+        component = component.update()
+        const submitButton = component.find('.test-submit-trigger')
+        submitButton.simulate('click')
+
+        sinon.assert.calledOnceWithExactly(onQueryChange, 'test type:diff repo:test patternType:literal')
+    })
+
+    test('Do not append patternType:literal if no patternType is present', () => {
+        const onQueryChange = sinon.spy()
+        let component = mount(
+            <FormTriggerArea
+                query=""
+                triggerCompleted={false}
+                onQueryChange={onQueryChange}
+                setTriggerCompleted={sinon.spy()}
+                startExpanded={false}
+            />
+        )
+        const triggerButton = component.find('.test-trigger-button')
+        triggerButton.simulate('click')
+
+        act(() => {
+            const triggerInput = component.find('.test-trigger-input')
+            triggerInput.simulate('change', { target: { value: 'test patternType:regexp type:diff repo:test' } })
+            clock.tick(600)
+        })
+        component = component.update()
+        const submitButton = component.find('.test-submit-trigger')
+        submitButton.simulate('click')
+
+        sinon.assert.calledOnceWithExactly(onQueryChange, 'test patternType:regexp type:diff repo:test')
     })
 })

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -49,14 +49,19 @@ const ValidQueryChecklistItem: React.FunctionComponent<{ checked: boolean; hint?
                 <RadioboxBlankIcon className="trigger-area__checklist-checkbox icon-inline" aria-hidden={true} />
             )}
 
-            <span>{children}</span>
+            <span className={checked ? 'trigger-area__checklist-children--faded' : ''}>{children}</span>
 
             {hint && (
                 <>
                     <span className="sr-only"> {hint}</span>
 
                     <span ref={tooltipTarget} className="d-flex">
-                        <HelpCircleIcon className="trigger-area__checklist-hint icon-inline" aria-hidden={true} />
+                        <HelpCircleIcon
+                            className={classNames('trigger-area__checklist-hint', 'icon-inline', {
+                                'trigger-area__checklist-hint--faded': checked,
+                            })}
+                            aria-hidden={true}
+                        />
                     </span>
 
                     <Tooltip

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -22,10 +22,11 @@ interface TriggerAreaProps {
 
 const isDiffOrCommit = (value: string): boolean => value === 'diff' || value === 'commit'
 
-const ValidQueryChecklistItem: React.FunctionComponent<{ checked: boolean; hint?: string }> = ({
+const ValidQueryChecklistItem: React.FunctionComponent<{ checked: boolean; hint?: string; className?: string }> = ({
     checked,
     children,
     hint,
+    className,
 }) => {
     const tooltipTarget = useRef<HTMLElement | null>(null)
     const [tooltipOpen, setTooltipOpen] = useState(false)
@@ -35,7 +36,7 @@ const ValidQueryChecklistItem: React.FunctionComponent<{ checked: boolean; hint?
 
     return (
         <label
-            className="d-flex align-items-center mb-1 text-muted"
+            className={classNames('d-flex align-items-center mb-1 text-muted', className)}
             onMouseOver={showTooltip}
             onMouseOut={hideTooltip}
             onFocus={showTooltip}
@@ -211,6 +212,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                 <ul className="trigger-area__checklist">
                                     <li>
                                         <ValidQueryChecklistItem
+                                            className="test-type-checkbox"
                                             checked={hasTypeDiffOrCommitFilter}
                                             hint="type:diff targets code present in new commits, while type:commit targets commit messages"
                                         >
@@ -219,6 +221,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                     </li>
                                     <li>
                                         <ValidQueryChecklistItem
+                                            className="test-repo-checkbox"
                                             checked={hasRepoFilter}
                                             hint="Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search."
                                         >
@@ -226,7 +229,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                         </ValidQueryChecklistItem>
                                     </li>
                                     <li>
-                                        <ValidQueryChecklistItem checked={isValidQuery}>
+                                        <ValidQueryChecklistItem checked={isValidQuery} className="test-valid-checkbox">
                                             Is a valid search query
                                         </ValidQueryChecklistItem>
                                     </li>

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -18,6 +18,25 @@ interface TriggerAreaProps {
 
 const isDiffOrCommit = (value: string): boolean => value === 'diff' || value === 'commit'
 
+const ValidQueryChecklistItem: React.FunctionComponent<{ checked: boolean; hint?: string }> = ({
+    checked,
+    children,
+    hint,
+}) => (
+    <label>
+        <input type="checkbox" disabled={true} checked={checked} />
+        {children}
+        {hint && (
+            <>
+                <span className="sr-only"> {hint}</span>
+                <span aria-hidden={true} data-tooltip={hint} data-placement="bottom">
+                    ?
+                </span>
+            </>
+        )}
+    </label>
+)
+
 export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
     query,
     onQueryChange,
@@ -150,28 +169,25 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
 
                                 <ul>
                                     <li>
-                                        <input type="checkbox" disabled={true} checked={hasTypeDiffOrCommitFilter} />
-                                        Contains a <code>type:diff</code> or <code>type:commit</code> filter
-                                        <span
-                                            data-tooltip="type:diff targets code present in new commits, while type:commit targets commit messages"
-                                            data-placement="bottom"
+                                        <ValidQueryChecklistItem
+                                            checked={hasTypeDiffOrCommitFilter}
+                                            hint="type:diff targets code present in new commits, while type:commit targets commit messages"
                                         >
-                                            ?
-                                        </span>
+                                            Contains a <code>type:diff</code> or <code>type:commit</code> filter
+                                        </ValidQueryChecklistItem>
                                     </li>
                                     <li>
-                                        <input type="checkbox" disabled={true} checked={hasRepoFilter} />
-                                        Contains a <code>repo:</code> filter
-                                        <span
-                                            data-tooltip="Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search."
-                                            data-placement="bottom"
+                                        <ValidQueryChecklistItem
+                                            checked={hasRepoFilter}
+                                            hint="Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search."
                                         >
-                                            ?
-                                        </span>
+                                            Contains a <code>repo:</code> filter
+                                        </ValidQueryChecklistItem>
                                     </li>
                                     <li>
-                                        <input type="checkbox" disabled={true} checked={isValidQuery} />
-                                        Is a valid search query
+                                        <ValidQueryChecklistItem checked={isValidQuery}>
+                                            Is a valid search query
+                                        </ValidQueryChecklistItem>
                                     </li>
                                 </ul>
                             </div>

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -199,7 +199,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                     type="text"
                                     className={classNames(
                                         'trigger-area__query-input-field form-control mt-2 mb-3 test-trigger-input text-monospace',
-                                        deriveInputClassName(queryState)
+                                        `test-${deriveInputClassName(queryState)}`
                                     )}
                                     onChange={nextQueryFieldChange}
                                     value={queryState.value}

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -8,7 +8,8 @@ import CheckIcon from 'mdi-react/CheckIcon'
 import HelpCircleIcon from 'mdi-react/HelpCircleIcon'
 import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import RadioboxBlankIcon from 'mdi-react/RadioboxBlankIcon'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { Tooltip } from 'reactstrap'
 import { SearchPatternType } from '../../../graphql-operations'
 
 interface TriggerAreaProps {
@@ -25,37 +26,53 @@ const ValidQueryChecklistItem: React.FunctionComponent<{ checked: boolean; hint?
     checked,
     children,
     hint,
-}) => (
-    <label>
-        <input className="sr-only" type="checkbox" disabled={true} checked={checked} />
+}) => {
+    const tooltipTarget = useRef<HTMLElement | null>(null)
+    const [tooltipOpen, setTooltipOpen] = useState(false)
+    const toggleTooltip = useCallback(() => setTooltipOpen(isOpen => !isOpen), [])
+    const showTooltip = useCallback(() => setTooltipOpen(true), [])
+    const hideTooltip = useCallback(() => setTooltipOpen(false), [])
 
-        {checked ? (
-            <span
-                className="trigger-area__checklist-checkbox trigger-area__checklist-checkbox--checked"
-                aria-hidden={true}
-            >
-                <CheckIcon className="icon-inline" />
-            </span>
-        ) : (
-            <span
-                className="trigger-area__checklist-checkbox trigger-area__checklist-checkbox--unchecked"
-                aria-hidden={true}
-            >
-                <RadioboxBlankIcon className="icon-inline" />
-            </span>
-        )}
+    return (
+        <label
+            className="d-flex align-items-center mb-1 text-muted"
+            onMouseOver={showTooltip}
+            onMouseOut={hideTooltip}
+            onFocus={showTooltip}
+            onBlur={hideTooltip}
+        >
+            <input className="sr-only" type="checkbox" disabled={true} checked={checked} />
 
-        {children}
-        {hint && (
-            <>
-                <span className="sr-only"> {hint}</span>
-                <span aria-hidden={true} data-tooltip={hint} data-placement="bottom">
-                    <HelpCircleIcon className="icon-inline" />
-                </span>
-            </>
-        )}
-    </label>
-)
+            {checked ? (
+                <CheckIcon className="trigger-area__checklist-checkbox icon-inline text-success" aria-hidden={true} />
+            ) : (
+                <RadioboxBlankIcon className="trigger-area__checklist-checkbox icon-inline" aria-hidden={true} />
+            )}
+
+            <span>{children}</span>
+
+            {hint && (
+                <>
+                    <span className="sr-only"> {hint}</span>
+
+                    <span ref={tooltipTarget} className="d-flex">
+                        <HelpCircleIcon className="trigger-area__checklist-hint icon-inline" aria-hidden={true} />
+                    </span>
+
+                    <Tooltip
+                        target={tooltipTarget}
+                        toggle={toggleTooltip}
+                        isOpen={tooltipOpen}
+                        placement="bottom"
+                        innerClassName="trigger-area__checklist-tooltip"
+                    >
+                        {hint}
+                    </Tooltip>
+                </>
+            )}
+        </label>
+    )
+}
 
 export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
     query,
@@ -175,7 +192,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                 <input
                                     type="text"
                                     className={classNames(
-                                        'trigger-area__query-input-field form-control my-2 test-trigger-input text-monospace',
+                                        'trigger-area__query-input-field form-control mt-2 mb-3 test-trigger-input text-monospace',
                                         deriveInputClassName(queryState)
                                     )}
                                     onChange={nextQueryFieldChange}

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.tsx
@@ -1,12 +1,15 @@
-import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
-import classNames from 'classnames'
-import React, { useState, useCallback, useMemo } from 'react'
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
-import { useInputValidation, deriveInputClassName } from '@sourcegraph/shared/src/util/useInputValidation'
-import { SearchPatternType } from '../../../graphql-operations'
+import { FilterType, resolveFilter, validateFilter } from '@sourcegraph/shared/src/search/query/filters'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import { resolveFilter, validateFilter, FilterType } from '@sourcegraph/shared/src/search/query/filters'
+import { buildSearchURLQuery } from '@sourcegraph/shared/src/util/url'
+import { deriveInputClassName, useInputValidation } from '@sourcegraph/shared/src/util/useInputValidation'
+import classNames from 'classnames'
+import CheckIcon from 'mdi-react/CheckIcon'
+import HelpCircleIcon from 'mdi-react/HelpCircleIcon'
+import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
+import RadioboxBlankIcon from 'mdi-react/RadioboxBlankIcon'
+import React, { useCallback, useMemo, useState } from 'react'
+import { SearchPatternType } from '../../../graphql-operations'
 
 interface TriggerAreaProps {
     query: string
@@ -24,13 +27,30 @@ const ValidQueryChecklistItem: React.FunctionComponent<{ checked: boolean; hint?
     hint,
 }) => (
     <label>
-        <input type="checkbox" disabled={true} checked={checked} />
+        <input className="sr-only" type="checkbox" disabled={true} checked={checked} />
+
+        {checked ? (
+            <span
+                className="trigger-area__checklist-checkbox trigger-area__checklist-checkbox--checked"
+                aria-hidden={true}
+            >
+                <CheckIcon className="icon-inline" />
+            </span>
+        ) : (
+            <span
+                className="trigger-area__checklist-checkbox trigger-area__checklist-checkbox--unchecked"
+                aria-hidden={true}
+            >
+                <RadioboxBlankIcon className="icon-inline" />
+            </span>
+        )}
+
         {children}
         {hint && (
             <>
                 <span className="sr-only"> {hint}</span>
                 <span aria-hidden={true} data-tooltip={hint} data-placement="bottom">
-                    ?
+                    <HelpCircleIcon className="icon-inline" />
                 </span>
             </>
         )}
@@ -63,7 +83,7 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                     (value: string) => {
                         const tokens = scanSearchQuery(value)
 
-                        const isValidQuery = tokens.type === 'success'
+                        const isValidQuery = !!value && tokens.type === 'success'
                         setIsValidQuery(isValidQuery)
 
                         let hasTypeDiffOrCommitFilter = false
@@ -160,14 +180,13 @@ export const FormTriggerArea: React.FunctionComponent<TriggerAreaProps> = ({
                                     )}
                                     onChange={nextQueryFieldChange}
                                     value={queryState.value}
-                                    required={true}
                                     autoFocus={true}
                                     ref={queryInputReference}
                                     spellCheck={false}
                                     data-testid="trigger-query-edit"
                                 />
 
-                                <ul>
+                                <ul className="trigger-area__checklist">
                                     <li>
                                         <ValidQueryChecklistItem
                                             checked={hasTypeDiffOrCommitFilter}

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormTriggerArea Error message is shown when query is invalid 1`] = `
+exports[`FormTriggerArea Correct checkboxes shown when query does not fulfill requirements 1`] = `
 <FormTriggerArea
   onQueryChange={[Function]}
-  query="test"
+  query="test repo:test"
   setTriggerCompleted={[Function]}
   startExpanded={false}
   triggerCompleted={false}
@@ -38,19 +38,285 @@ exports[`FormTriggerArea Error message is shown when query is invalid 1`] = `
         >
           <input
             autoFocus={true}
-            className="trigger-area__query-input-field form-control my-2 test-trigger-input is-invalid"
+            className="trigger-area__query-input-field form-control mt-2 mb-3 test-trigger-input text-monospace is-invalid"
             data-testid="trigger-query-edit"
             onChange={[Function]}
-            required={true}
             spellCheck={false}
             type="text"
-            value="test"
+            value="test repo:test"
           />
-          <small
-            className="trigger-area__query-input-error-message invalid-feedback test-trigger-error"
+          <ul
+            className="trigger-area__checklist"
           >
-            Code monitors require queries to specify either \`type:commit\` or \`type:diff\`.
-          </small>
+            <li>
+              <ValidQueryChecklistItem
+                checked={false}
+                className="test-type-checkbox"
+                hint="type:diff targets code present in new commits, while type:commit targets commit messages"
+              >
+                <label
+                  className="d-flex align-items-center mb-1 text-muted test-type-checkbox"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <input
+                    checked={false}
+                    className="sr-only"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  <Memo(RadioboxBlankIcon)
+                    aria-hidden={true}
+                    className="trigger-area__checklist-checkbox icon-inline"
+                  />
+                  <span
+                    className=""
+                  >
+                    Contains a 
+                    <code>
+                      type:diff
+                    </code>
+                     or 
+                    <code>
+                      type:commit
+                    </code>
+                     filter
+                  </span>
+                  <span
+                    className="sr-only"
+                  >
+                     
+                    type:diff targets code present in new commits, while type:commit targets commit messages
+                  </span>
+                  <span
+                    className="d-flex"
+                  >
+                    <Memo(HelpCircleIcon)
+                      aria-hidden={true}
+                      className="trigger-area__checklist-hint icon-inline"
+                    />
+                  </span>
+                  <Tooltip
+                    autohide={true}
+                    innerClassName="trigger-area__checklist-tooltip"
+                    isOpen={false}
+                    placement="bottom"
+                    placementPrefix="bs-tooltip"
+                    target={
+                      Object {
+                        "current": <span
+                          class="d-flex"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="mdi-icon trigger-area__checklist-hint icon-inline"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                          >
+                            <path
+                              d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                            />
+                          </svg>
+                        </span>,
+                      }
+                    }
+                    toggle={[Function]}
+                    trigger="hover focus"
+                  >
+                    <TooltipPopoverWrapper
+                      autohide={true}
+                      delay={
+                        Object {
+                          "hide": 50,
+                          "show": 0,
+                        }
+                      }
+                      fade={true}
+                      hideArrow={false}
+                      innerClassName="tooltip-inner trigger-area__checklist-tooltip"
+                      isOpen={false}
+                      placement="bottom"
+                      placementPrefix="bs-tooltip"
+                      popperClassName="tooltip show"
+                      target={
+                        Object {
+                          "current": <span
+                            class="d-flex"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="mdi-icon trigger-area__checklist-hint icon-inline"
+                              fill="currentColor"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                              />
+                            </svg>
+                          </span>,
+                        }
+                      }
+                      toggle={[Function]}
+                      trigger="hover focus"
+                    />
+                  </Tooltip>
+                </label>
+              </ValidQueryChecklistItem>
+            </li>
+            <li>
+              <ValidQueryChecklistItem
+                checked={true}
+                className="test-repo-checkbox"
+                hint="Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search."
+              >
+                <label
+                  className="d-flex align-items-center mb-1 text-muted test-repo-checkbox"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <input
+                    checked={true}
+                    className="sr-only"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  <Memo(CheckIcon)
+                    aria-hidden={true}
+                    className="trigger-area__checklist-checkbox icon-inline text-success"
+                  />
+                  <span
+                    className="trigger-area__checklist-children--faded"
+                  >
+                    Contains a 
+                    <code>
+                      repo:
+                    </code>
+                     filter
+                  </span>
+                  <span
+                    className="sr-only"
+                  >
+                     
+                    Code monitors can watch a maximum of 50 repos at a time. Target your query with repo: filters to narrow down your search.
+                  </span>
+                  <span
+                    className="d-flex"
+                  >
+                    <Memo(HelpCircleIcon)
+                      aria-hidden={true}
+                      className="trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                    />
+                  </span>
+                  <Tooltip
+                    autohide={true}
+                    innerClassName="trigger-area__checklist-tooltip"
+                    isOpen={false}
+                    placement="bottom"
+                    placementPrefix="bs-tooltip"
+                    target={
+                      Object {
+                        "current": <span
+                          class="d-flex"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="mdi-icon trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                          >
+                            <path
+                              d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                            />
+                          </svg>
+                        </span>,
+                      }
+                    }
+                    toggle={[Function]}
+                    trigger="hover focus"
+                  >
+                    <TooltipPopoverWrapper
+                      autohide={true}
+                      delay={
+                        Object {
+                          "hide": 50,
+                          "show": 0,
+                        }
+                      }
+                      fade={true}
+                      hideArrow={false}
+                      innerClassName="tooltip-inner trigger-area__checklist-tooltip"
+                      isOpen={false}
+                      placement="bottom"
+                      placementPrefix="bs-tooltip"
+                      popperClassName="tooltip show"
+                      target={
+                        Object {
+                          "current": <span
+                            class="d-flex"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="mdi-icon trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                              fill="currentColor"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                              />
+                            </svg>
+                          </span>,
+                        }
+                      }
+                      toggle={[Function]}
+                      trigger="hover focus"
+                    />
+                  </Tooltip>
+                </label>
+              </ValidQueryChecklistItem>
+            </li>
+            <li>
+              <ValidQueryChecklistItem
+                checked={true}
+                className="test-valid-checkbox"
+              >
+                <label
+                  className="d-flex align-items-center mb-1 text-muted test-valid-checkbox"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <input
+                    checked={true}
+                    className="sr-only"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  <Memo(CheckIcon)
+                    aria-hidden={true}
+                    className="trigger-area__checklist-checkbox icon-inline text-success"
+                  />
+                  <span
+                    className="trigger-area__checklist-children--faded"
+                  >
+                    Is a valid search query
+                  </span>
+                </label>
+              </ValidQueryChecklistItem>
+            </li>
+          </ul>
         </div>
         <div
           className="trigger-area__query-input-preview-link p-2 my-2"
@@ -59,11 +325,11 @@ exports[`FormTriggerArea Error message is shown when query is invalid 1`] = `
             className="trigger-area__query-input-preview-link-text test-preview-link"
             rel="noopener noreferrer"
             target="_blank"
-            to="/search?q=test&patternType=literal"
+            to="/search?q=test+repo:test&patternType=literal"
           >
             <a
               className="trigger-area__query-input-preview-link-text test-preview-link"
-              href="/search?q=test&patternType=literal"
+              href="/search?q=test+repo:test&patternType=literal"
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`FormTriggerArea Correct checkboxes shown when query does not fulfill re
         >
           <input
             autoFocus={true}
-            className="trigger-area__query-input-field form-control mt-2 mb-3 test-trigger-input text-monospace is-invalid"
+            className="trigger-area__query-input-field form-control mt-2 mb-3 test-trigger-input text-monospace test-is-invalid"
             data-testid="trigger-query-edit"
             onChange={[Function]}
             spellCheck={false}

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -109,16 +109,11 @@ describe('Code monitoring', () => {
             await driver.page.waitForSelector('.test-trigger-input')
             await driver.page.type('.test-trigger-input', 'foobar')
             await driver.page.waitForSelector('.is-invalid')
-            expect(await driver.page.evaluate(() => document.querySelector('.test-trigger-error')?.textContent)).toBe(
-                'Code monitors require queries to specify either `type:commit` or `type:diff`.'
-            )
+
             await driver.page.type('.test-trigger-input', ' type:diff')
             await driver.page.waitForSelector('.is-invalid')
-            await driver.page.waitForSelector('.test-trigger-error')
-            expect(await driver.page.evaluate(() => document.querySelector('.test-trigger-error')?.textContent)).toBe(
-                'Code monitors require queries to specify a `patternType:` of literal or regexp.'
-            )
-            await driver.page.type('.test-trigger-input', ' patterntype:literal')
+
+            await driver.page.type('.test-trigger-input', ' repo:test')
             await driver.page.waitForSelector('.is-valid')
             await driver.page.waitForSelector('.test-preview-link')
             expect(
@@ -144,7 +139,7 @@ describe('Code monitoring', () => {
             await driver.page.click('.test-trigger-button')
 
             await driver.page.waitForSelector('.test-trigger-input')
-            await driver.page.type('.test-trigger-input', 'foobar type:diff patterntype:literal')
+            await driver.page.type('.test-trigger-input', 'foobar type:diff repo:test')
             await driver.page.waitForSelector('.is-valid')
             await driver.page.waitForSelector('.test-preview-link')
             await driver.page.waitForSelector('.test-submit-trigger')
@@ -181,7 +176,7 @@ describe('Code monitoring', () => {
             await driver.page.click('.test-trigger-button')
 
             await driver.page.waitForSelector('.test-trigger-input')
-            await driver.page.type('.test-trigger-input', 'foobar type:diff patterntype:literal')
+            await driver.page.type('.test-trigger-input', 'foobar type:diff repo:test')
             await driver.page.waitForSelector('.is-valid')
             await driver.page.waitForSelector('.test-preview-link')
             await driver.page.waitForSelector('.test-submit-trigger')

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -108,13 +108,13 @@ describe('Code monitoring', () => {
 
             await driver.page.waitForSelector('.test-trigger-input')
             await driver.page.type('.test-trigger-input', 'foobar')
-            await driver.page.waitForSelector('.is-invalid')
+            await driver.page.waitForSelector('.test-is-invalid')
 
             await driver.page.type('.test-trigger-input', ' type:diff')
-            await driver.page.waitForSelector('.is-invalid')
+            await driver.page.waitForSelector('.test-is-invalid')
 
             await driver.page.type('.test-trigger-input', ' repo:test')
-            await driver.page.waitForSelector('.is-valid')
+            await driver.page.waitForSelector('.test-is-valid')
             await driver.page.waitForSelector('.test-preview-link')
             expect(
                 await driver.page.evaluate(() => document.querySelectorAll('.test-preview-link').length)
@@ -140,7 +140,7 @@ describe('Code monitoring', () => {
 
             await driver.page.waitForSelector('.test-trigger-input')
             await driver.page.type('.test-trigger-input', 'foobar type:diff repo:test')
-            await driver.page.waitForSelector('.is-valid')
+            await driver.page.waitForSelector('.test-is-valid')
             await driver.page.waitForSelector('.test-preview-link')
             await driver.page.waitForSelector('.test-submit-trigger')
             await driver.page.click('.test-submit-trigger')
@@ -177,7 +177,7 @@ describe('Code monitoring', () => {
 
             await driver.page.waitForSelector('.test-trigger-input')
             await driver.page.type('.test-trigger-input', 'foobar type:diff repo:test')
-            await driver.page.waitForSelector('.is-valid')
+            await driver.page.waitForSelector('.test-is-valid')
             await driver.page.waitForSelector('.test-preview-link')
             await driver.page.waitForSelector('.test-submit-trigger')
             await driver.page.click('.test-submit-trigger')


### PR DESCRIPTION
Fixes #17603

- Makes validation criteria for code monitor query into a checklist.
- Makes `repo:` filter required for monitors. Existing monitors without this will continue to work but will require adding a `repo:` filter to edit them.
- No longer makes `patternType:` required for monitors. If it is missing, `patternType:literal` will be appended to the query.
- Remove validation state styling from query since we now have the checklist instead

![image](https://user-images.githubusercontent.com/206864/113786060-412fcf80-96ed-11eb-9063-bf82e6b37048.png)

![image](https://user-images.githubusercontent.com/206864/113786109-599fea00-96ed-11eb-8808-5c4568736fd5.png)



