### PR TITLE
search: Fix `contains` not allowing file and content

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -96,6 +96,9 @@ func (f *RepoContainsPredicate) ParseParams(params string) error {
 func (f *RepoContainsPredicate) parseNode(n Node) error {
 	switch v := n.(type) {
 	case Parameter:
+		if v.Negated {
+			return errors.New("predicates do not currently support negated values")
+		}
 		switch strings.ToLower(v.Field) {
 		case "file":
 			if f.File != "" {
@@ -111,13 +114,16 @@ func (f *RepoContainsPredicate) parseNode(n Node) error {
 			return fmt.Errorf("unsupported option %q", v.Field)
 		}
 	case Pattern:
+		if v.Negated {
+			return errors.New("predicates do not currently support negated values")
+		}
 		if f.Content != "" {
 			return errors.New("cannot specify content multiple times")
 		}
 		f.Content = v.Value
 	case Operator:
 		if v.Kind == Or {
-			return errors.New("predicates do not currently support or queries")
+			return errors.New("predicates do not currently support 'or' queries")
 		}
 		for _, operand := range v.Operands {
 			if err := f.parseNode(operand); err != nil {

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -81,29 +81,8 @@ func (f *RepoContainsPredicate) ParseParams(params string) error {
 	}
 
 	for _, node := range nodes {
-		switch v := node.(type) {
-		case Parameter:
-			switch strings.ToLower(v.Field) {
-			case "file":
-				if f.File != "" {
-					return errors.New("cannot specify file multiple times")
-				}
-				f.File = v.Value
-			case "content":
-				if f.Content != "" {
-					return errors.New("cannot specify content multiple times")
-				}
-				f.Content = v.Value
-			default:
-				return fmt.Errorf("unsupported option %q", v.Field)
-			}
-		case Pattern:
-			if f.Content != "" {
-				return errors.New("cannot specify content multiple times")
-			}
-			f.Content = v.Value
-		default:
-			return fmt.Errorf("unsupported node type %T", node)
+		if err := f.parseNode(node); err != nil {
+			return err
 		}
 	}
 
@@ -111,6 +90,43 @@ func (f *RepoContainsPredicate) ParseParams(params string) error {
 		return errors.New("one of file or content must be set")
 	}
 
+	return nil
+}
+
+func (f *RepoContainsPredicate) parseNode(n Node) error {
+	switch v := n.(type) {
+	case Parameter:
+		switch strings.ToLower(v.Field) {
+		case "file":
+			if f.File != "" {
+				return errors.New("cannot specify file multiple times")
+			}
+			f.File = v.Value
+		case "content":
+			if f.Content != "" {
+				return errors.New("cannot specify content multiple times")
+			}
+			f.Content = v.Value
+		default:
+			return fmt.Errorf("unsupported option %q", v.Field)
+		}
+	case Pattern:
+		if f.Content != "" {
+			return errors.New("cannot specify content multiple times")
+		}
+		f.Content = v.Value
+	case Operator:
+		if v.Kind == Or {
+			return errors.New("predicates do not currently support or queries")
+		}
+		for _, operand := range v.Operands {
+			if err := f.parseNode(operand); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported node type %T", n)
+	}
 	return nil
 }
 

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -43,6 +43,8 @@ func TestRepoContainsPredicate(t *testing.T) {
 
 		invalid := []test{
 			{`empty`, ``, nil},
+			{`negated file`, `-file:test`, nil},
+			{`negated content`, `-content:test`, nil},
 		}
 
 		for _, tc := range invalid {

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -18,6 +18,8 @@ func TestRepoContainsPredicate(t *testing.T) {
 			{`file regex`, `file:test(a|b)*.go`, &RepoContainsPredicate{File: "test(a|b)*.go"}},
 			{`content`, `content:test`, &RepoContainsPredicate{Content: "test"}},
 			{`unnamed content`, `test`, &RepoContainsPredicate{Content: "test"}},
+			{`file and content`, `file:test.go content:abc`, &RepoContainsPredicate{File: "test.go", Content: "abc"}},
+			{`content and file`, `content:abc file:test.go`, &RepoContainsPredicate{File: "test.go", Content: "abc"}},
 
 			// TODO (@camdencheek) Query parsing currently checks parameter names against an allowlist.
 			// This will be a problem as soon as we add more fields. Might make sense to do


### PR DESCRIPTION
Previously, parsing `repo:contains(file:a content:b)` would fail with a
cryptic error. This fixes the precicate params parsing so that this
syntax is allowed.

Fixes #19588 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
