### PR TITLE
perforce: sync changes into local branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
+- New changes of a Perforce depot will now be reflected in `master` branch after the initial clone. [#19690](https://github.com/sourcegraph/sourcegraph/pull/19690)
 
 ## 3.26.1
 

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -258,8 +258,8 @@ func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, remoteURL *url.U
 		return nil, false, errors.Wrap(err, "ping with trust")
 	}
 
-	// Example: git p4 sync --max-changes 1000
-	args := []string{"p4", "sync"}
+	// Example: git p4 sync --branch=refs/heads/master --max-changes 1000
+	args := []string{"p4", "sync", "--branch=refs/heads/master"}
 	if s.MaxChanges > 0 {
 		args = append(args, "--max-changes", strconv.Itoa(s.MaxChanges))
 	}


### PR DESCRIPTION
By default, new changes fetched by `git p4 sync` are synced into `refs/remotes/p4/master` (as a remote-tracking branch), which makes the local branch `refs/heads/master` always stay at the same commit when the repository was first created using `git p4 clone ...`.

In our use case, we do not take use of `refs/remotes/p4/master` but want all changes to be reflected in a local branch (ie. `master`), and therefore we need explicitly doing do using `git p4 sync --branch=refs/heads/master`.

Found this problem while working on https://github.com/sourcegraph/sourcegraph/issues/17682