### PR TITLE
monitoring: Alert on invalid indexes

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -2015,6 +2015,31 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
+## postgres: invalid_indexes
+
+<p class="subtitle">invalid indexes (unusable by the query planner)</p>
+
+**Descriptions**
+
+- <span class="badge badge-critical">critical</span> postgres: 1+ invalid indexes (unusable by the query planner)
+
+**Possible solutions**
+
+- Drop and re-create the invalid trigger - please contact Sourcegraph to supply the trigger definition.
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "critical_postgres_invalid_indexes"
+]
+```
+
+> NOTE: More help interpreting this metric is available in the [dashboards reference](./dashboards.md#postgres-invalid-indexes).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 ## postgres: pg_exporter_err
 
 <p class="subtitle">errors scraping postgres exporter</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -1179,6 +1179,18 @@ A non-zero value indicates the database is online.
 
 <br />
 
+#### postgres: invalid_indexes
+
+This panel indicates invalid indexes (unusable by the query planner).
+
+A non-zero value indicates the that Postgres failed to build an index. Expect degraded performance until the index is manually rebuilt.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-invalid-indexes).
+
+<sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
+
+<br />
+
 #### postgres: pg_exporter_err
 
 This panel indicates errors scraping postgres exporter.
@@ -1200,38 +1212,6 @@ A 0 value indicates that no migration is in progress.
 > NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#postgres-migration-in-progress).
 
 <sub>*Managed by the [Sourcegraph Core application team](https://about.sourcegraph.com/handbook/engineering/core-application).*</sub>
-
-<br />
-
-### Postgres: Table bloat (dead tuples / live tuples)
-
-#### postgres: codeintel_commit_graph_db_bloat
-
-This panel indicates code intelligence commit graph tables.
-
-This value indicates the factor by which a table`s overhead outweighs its minimum overhead.
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
-
-<br />
-
-#### postgres: codeintel_package_versions_db_bloat
-
-This panel indicates code intelligence package version tables.
-
-This value indicates the factor by which a table`s overhead outweighs its minimum overhead.
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
-
-<br />
-
-#### postgres: codeintel_lsif_db_bloat
-
-This panel indicates code intelligence LSIF data tables (codeintel-db).
-
-This value indicates the factor by which a table`s overhead outweighs its minimum overhead.
-
-<sub>*Managed by the [Sourcegraph Code-intelligence team](https://about.sourcegraph.com/handbook/engineering/code-intelligence).*</sub>
 
 <br />
 

--- a/docker-images/postgres_exporter/queries.yaml
+++ b/docker-images/postgres_exporter/queries.yaml
@@ -14,9 +14,32 @@ pg_sg_migration:
               usage: "GAUGE"
               description: "Whether the migration applied successfully"
 
-# From https://github.com/wrouesnel/postgres_exporter/pull/433/
+pg_invalid_index:
+    query: |
+        SELECT
+            current_database() AS datname,
+            pc.relname AS relname,
+            1 AS count
+        FROM pg_class pc
+        JOIN pg_index pi ON pi.indexrelid = pc.oid
+        WHERE
+            NOT indisvalid AND
+            NOT EXISTS (SELECT 1 FROM pg_stat_progress_create_index pci WHERE pci.index_relid = pi.indexrelid)
+    metrics:
+        - datname:
+              usage: "LABEL"
+              description: "Name of current database"
+        - relname:
+              usage: "LABEL"
+              description: "Name of the index"
+        - count:
+              usage: "COUNTER"
+              description: "Non-zero value used to tag existence of an invalid index"
+
+# From https://github.com/prometheus-community/postgres_exporter/pull/433
+# Updated in https://github.com/prometheus-community/postgres_exporter/pull/395
 pg_replication:
-    query: "SELECT EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp())) as lag"
+    query: "SELECT CASE WHEN NOT pg_is_in_recovery() THEN 0 ELSE GREATEST (0, EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))) END AS lag"
     master: true
     metrics:
         - lag:
@@ -174,3 +197,48 @@ pg_database:
         - size_bytes:
               usage: "GAUGE"
               description: "Disk space used by the database"
+
+# From https://github.com/prometheus-community/postgres_exporter/pull/435
+pg_stat_activity:
+  query: |
+    WITH
+      metrics AS (
+        SELECT
+          application_name,
+          SUM(EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change))::bigint)::float AS process_idle_seconds_sum,
+          COUNT(*) AS process_idle_seconds_count
+        FROM pg_stat_activity
+        WHERE state = 'idle'
+        GROUP BY application_name
+      ),
+      buckets AS (
+        SELECT
+          application_name,
+          le,
+          SUM(
+            CASE WHEN EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - state_change)) <= le
+              THEN 1
+              ELSE 0
+            END
+          )::bigint AS bucket
+        FROM
+          pg_stat_activity,
+          UNNEST(ARRAY[1, 2, 5, 15, 30, 60, 90, 120, 300]) AS le
+        GROUP BY application_name, le
+        ORDER BY application_name, le
+      )
+    SELECT
+      application_name,
+      process_idle_seconds_sum,
+      process_idle_seconds_count,
+      ARRAY_AGG(le) AS process_idle_seconds,
+      ARRAY_AGG(bucket) AS process_idle_seconds_bucket
+    FROM metrics JOIN buckets USING (application_name)
+    GROUP BY 1, 2, 3
+  metrics:
+    - application_name:
+        usage: "LABEL"
+        description: "Application Name"
+    - process_idle_seconds:
+        usage: "HISTOGRAM"
+        description: "Idle time of server processes"

--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -1,8 +1,6 @@
 package definitions
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
@@ -10,6 +8,8 @@ import (
 )
 
 func Postgres() *monitoring.Container {
+	sum := "sum"
+
 	// In docker-compose, codeintel-db container is called pgsql
 	// In Kubernetes, codeintel-db container is called codeintel-db
 	// Because of this, we track all database cAdvisor metrics in a single panel using this
@@ -61,6 +61,20 @@ func Postgres() *monitoring.Container {
 							Interpretation:    "A non-zero value indicates the database is online.",
 						},
 						monitoring.Observable{
+							Name:        "invalid_indexes",
+							Description: "invalid indexes (unusable by the query planner)",
+							Owner:       monitoring.ObservableOwnerCoreApplication,
+							Query:       "max by (relname)(pg_invalid_index_count)",
+							Panel:       monitoring.Panel().LegendFormat("{{relname}}"),
+							Critical:    monitoring.Alert().GreaterOrEqual(1, &sum).For(0),
+							PossibleSolutions: `
+								- Drop and re-create the invalid trigger - please contact Sourcegraph to supply the trigger definition.
+							`,
+							Interpretation: "A non-zero value indicates the that Postgres failed to build an index. Expect degraded performance until the index is manually rebuilt.",
+						},
+					},
+					{
+						monitoring.Observable{
 							Name:        "pg_exporter_err",
 							Description: "errors scraping postgres exporter",
 							Owner:       monitoring.ObservableOwnerCoreApplication,
@@ -100,48 +114,6 @@ func Postgres() *monitoring.Container {
 				},
 			},
 			{
-				Title:  "Table bloat (dead tuples / live tuples)",
-				Hidden: true,
-				Rows: []monitoring.Row{
-					{
-						makePostgresTableBloatPanel(
-							"codeintel_commit_graph_db_bloat",
-							"code intelligence commit graph tables",
-							monitoring.ObservableOwnerCodeIntel,
-							50, // Alert on 50x more dead tuples than live tuples
-							[]string{
-								"lsif_nearest_uploads",
-								"lsif_nearest_uploads_links",
-								"lsif_uploads_visible_from_tip",
-							},
-						),
-						makePostgresTableBloatPanel(
-							"codeintel_package_versions_db_bloat",
-							"code intelligence package version tables",
-							monitoring.ObservableOwnerCodeIntel,
-							50, // Alert on 50x more dead tuples than live tuples
-							[]string{
-								"lsif_packages",
-								"lsif_references",
-							},
-						),
-						makePostgresTableBloatPanel(
-							"codeintel_lsif_db_bloat",
-							"code intelligence LSIF data tables (codeintel-db)",
-							monitoring.ObservableOwnerCodeIntel,
-							50, // Alert on 50x more dead tuples than live tuples
-							[]string{
-								"lsif_data_metadata",
-								"lsif_data_documents",
-								"lsif_data_result_chunks",
-								"lsif_data_definitions",
-								"lsif_data_references",
-							},
-						),
-					},
-				},
-			},
-			{
 				Title:  shared.TitleProvisioningIndicators,
 				Hidden: true,
 				// See docstring for databaseContainerNames
@@ -169,36 +141,5 @@ func Postgres() *monitoring.Container {
 
 		// This is third-party service
 		NoSourcegraphDebugServer: true,
-	}
-}
-
-// makePostgresTableBloatPanel returns an observable that tracks the bloat factor of each of the given
-// tables. We define a table's bloat to be the factor by which the table's current overhead exceeds its
-// minimum overhead, e.g., `(live + dead) / live`.
-func makePostgresTableBloatPanel(name, description string, owner monitoring.ObservableOwner, bloatThreshold float64, tableNames []string) monitoring.Observable {
-	query := fmt.Sprintf(
-		`(%[1]s{relname=~"%[3]s"} + %[2]s{relname=~"%[3]s"}) / %[1]s{relname=~"%[3]s"}`,
-		"pg_stat_user_tables_n_live_tup",
-		"pg_stat_user_tables_n_dead_tup",
-		strings.Join(tableNames, "|"),
-	)
-
-	return monitoring.Observable{
-		Name:        name,
-		Description: description,
-		Owner:       owner,
-		Query:       query,
-		Panel:       monitoring.Panel().LegendFormat("{{relname}}"),
-		// TODO(efritz) - re-enable this after we correctly tune autovacuum daemon or have
-		// docs specifying our recommended settings.
-		// Critical:    monitoring.Alert().GreaterOrEqual(bloatThreshold, nil).For(5 * time.Minute),
-		// PossibleSolutions: `
-		// 	- Run ANALYZE on the table to correct its statistics
-		// 	- Run VACUUM on the table manually to remove dead tuples
-		// 	- Run VACUUM FULL on the table manually to remove all dead tuples (requires an exclusive table lock)
-		// 	- Reconfigure the Postgres autovacuum daemon with additional resources
-		// `,
-		NoAlert:        true,
-		Interpretation: "This value indicates the factor by which a table's overhead outweighs its minimum overhead.",
 	}
 }


### PR DESCRIPTION
There are several places where we've used `CREATE INDEX CONCURRENTLY` in our migrations. Developers may not know the caveats, and if they did we have not yet addressed them.

Indexes created concurrently avoid a full table lock (so that reads and writes can still proceed). We've seem to have fallen into a siren's call by leaning on this feature, as concurrently created indexes can fail just ... in the background without indicating that has done so. Describing the table will show an invalid index, but unless you're looking for it, the query planner will just avoid the index on selects and that's the biggest hint you'll get that something is wrong.

This adds a new alarm for all indexes that are (a) invalid, and (b) are associated with an in-progress index creation. This avoid alarms from happening when the index is invalid but still in-progress. This is necessary in Cloud, but even more so on-prem. It is likely that some performance issues have (or will) come from having a broken index on some critical query path.