### PR TITLE
codeintel: Optimize out-of-band migration queries

### DIFF
--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
@@ -225,11 +225,11 @@ func (m *Migrator) selectAndProcess(ctx context.Context, tx *lsifstore.Store, ve
 
 	rows, err := tx.Query(ctx, sqlf.Sprintf(
 		selectAndProcessQuery,
-		sqlf.Sprintf(m.options.tableName),
-		version,
-		version,
 		sqlf.Join(fieldQueries, ", "),
 		sqlf.Sprintf(m.options.tableName),
+		sqlf.Sprintf(m.options.tableName),
+		version,
+		version,
 		version,
 		m.options.batchSize,
 	))
@@ -253,17 +253,17 @@ func (m *Migrator) selectAndProcess(ctx context.Context, tx *lsifstore.Store, ve
 
 const selectAndProcessQuery = `
 -- source: enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go:selectAndProcess
-WITH candidates AS (
-	SELECT dump_id
-	FROM %s_schema_versions
-	WHERE
-		min_schema_version <= %s AND
-		max_schema_version >= %s
-)
 SELECT dump_id, %s
-FROM %s
+FROM %s t
 WHERE
-	dump_id IN (SELECT dump_id FROM candidates) AND
+	EXISTS (
+		SELECT 1
+		FROM %s_schema_versions sv
+		WHERE
+			sv.dump_id = t.dump_id AND
+			min_schema_version <= %s AND
+			max_schema_version >= %s
+	) AND
 	schema_version = %s
 ORDER BY dump_id
 LIMIT %s

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migrator.go
@@ -263,6 +263,13 @@ SELECT dump_id, %s
 FROM %s t1
 WHERE
 	dump_id = (
+		-- First, we select an index that has at least one record with the target schema
+		-- version. We do this so that we can efficiently select from the target table,
+		-- which are all keyed on dump_id.
+		--
+		-- This is more efficient than scanning the entire target table looking for a matching
+		-- schema version especially when that schema version is a small subset of the table.
+
 		SELECT sv.dump_id
 		FROM %s_schema_versions sv
 		WHERE

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -27,6 +27,7 @@ Holds a single column storing the status of the most recent migration attempt.
  num_locations  | integer |           | not null | 
 Indexes:
     "lsif_data_definitions_pkey" PRIMARY KEY, btree (dump_id, scheme, identifier)
+    "lsif_data_definitions_dump_id_schema_version" btree (dump_id, schema_version)
 Triggers:
     lsif_data_definitions_schema_versions_insert AFTER INSERT ON lsif_data_definitions REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_lsif_data_definitions_schema_versions_insert()
 
@@ -77,6 +78,7 @@ Tracks the range of schema_versions for each upload in the lsif_data_definitions
  num_diagnostics | integer |           | not null | 
 Indexes:
     "lsif_data_documents_pkey" PRIMARY KEY, btree (dump_id, path)
+    "lsif_data_documents_dump_id_schema_version" btree (dump_id, schema_version)
 Triggers:
     lsif_data_documents_schema_versions_insert AFTER INSERT ON lsif_data_documents REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_lsif_data_documents_schema_versions_insert()
 
@@ -143,6 +145,7 @@ Stores the number of result chunks associated with a dump.
  num_locations  | integer |           | not null | 
 Indexes:
     "lsif_data_references_pkey" PRIMARY KEY, btree (dump_id, scheme, identifier)
+    "lsif_data_references_dump_id_schema_version" btree (dump_id, schema_version)
 Triggers:
     lsif_data_references_schema_versions_insert AFTER INSERT ON lsif_data_references REFERENCING NEW TABLE AS newtab FOR EACH STATEMENT EXECUTE FUNCTION update_lsif_data_references_schema_versions_insert()
 

--- a/migrations/codeintel/1000000009_documents_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000009_documents_schema_version_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS lsif_data_documents_dump_id_schema_version;
+
+COMMIT;

--- a/migrations/codeintel/1000000009_documents_schema_version_index.up.sql
+++ b/migrations/codeintel/1000000009_documents_schema_version_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_data_documents_dump_id_schema_version ON lsif_data_documents (dump_id, schema_version);

--- a/migrations/codeintel/1000000010_definitions_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000010_definitions_schema_version_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS lsif_data_definitions_dump_id_schema_version;
+
+COMMIT;

--- a/migrations/codeintel/1000000010_definitions_schema_version_index.up.sql
+++ b/migrations/codeintel/1000000010_definitions_schema_version_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_data_definitions_dump_id_schema_version ON lsif_data_definitions (dump_id, schema_version);

--- a/migrations/codeintel/1000000011_references_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000011_references_schema_version_index.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX IF EXISTS lsif_data_references_dump_id_schema_version;
+
+COMMIT;

--- a/migrations/codeintel/1000000011_references_schema_version_index.up.sql
+++ b/migrations/codeintel/1000000011_references_schema_version_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS lsif_data_references_dump_id_schema_version ON lsif_data_references (dump_id, schema_version);

--- a/migrations/codeintel/1000000012_delete_missing_schema_versions.down.sql
+++ b/migrations/codeintel/1000000012_delete_missing_schema_versions.down.sql
@@ -1,0 +1,1 @@
+-- Nothing to do.

--- a/migrations/codeintel/1000000012_delete_missing_schema_versions.up.sql
+++ b/migrations/codeintel/1000000012_delete_missing_schema_versions.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+-- Delete data from the schema version count tables that was inserted from the metadata table but does
+-- not actually exist in the table that it shadows. This should only delete some records that we inserted
+-- in 1000000007_definitions_locations_counts.up.sql and 1000000008_references_locations_counts.up.sql.
+
+DELETE FROM lsif_data_documents_schema_versions sv WHERE NOT EXISTS (SELECT 1 FROM lsif_data_documents d WHERE d.dump_id = sv.dump_id);
+DELETE FROM lsif_data_definitions_schema_versions sv WHERE NOT EXISTS (SELECT 1 FROM lsif_data_definitions d WHERE d.dump_id = sv.dump_id);
+DELETE FROM lsif_data_references_schema_versions sv WHERE NOT EXISTS (SELECT 1 FROM lsif_data_references r WHERE r.dump_id = sv.dump_id);
+
+COMMIT;


### PR DESCRIPTION
This replaces the old selection query with one that runs efficiently with additional indexes. This takes the time to select a batch of definition records to migrate from 15 seconds to a few millisecond (on a clone of the production code intelligence database).

The indexes take about 45 minutes to create concurrently. I've added an alert in  https://github.com/sourcegraph/sourcegraph/pull/19694 to invalid indexes in our database layer to detect when they fail to create asynchronously.

**New selection query**:

On a clone of the production cloudintel-db (`select dump_id, scheme, identifier, length(data) from lsif_data_references t1 where dump_id = (select sv.dump_Id from lsif_data_references_schema_versions sv where sv.min_schema_version<=1 and sv.max_schema_version>=1 and exists (select 1 from lsif_data_references t2 where t2.dump_id=sv.dump_id and t2.schema_version=1) order by dump_id limit 1) and schema_version=1 limit 1000 for update skip locked`):

```sql
                                                                                                   QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8.69..1105.94 rows=1000 width=59) (actual time=12.460..14.949 rows=1000 loops=1)
   InitPlan 1 (returns $1)
     ->  Limit  (cost=0.86..8.12 rows=1 width=4) (actual time=9.884..9.887 rows=1 loops=1)
           ->  Nested Loop Semi Join  (cost=0.86..30395.75 rows=4187 width=4) (actual time=9.883..9.885 rows=1 loops=1)
                 ->  Index Scan using lsif_data_references_schema_versions_pkey on lsif_data_references_schema_versions sv  (cost=0.29..22678.00 rows=12512 width=4) (actual time=0.126..3.328 rows=741 loops=1)
                       Filter: ((min_schema_version <= 1) AND (max_schema_version >= 1))
                       Rows Removed by Filter: 11476
                 ->  Index Only Scan using lsif_data_references_dump_id_schema_version on lsif_data_references t2  (cost=0.57..818.20 rows=28995 width=4) (actual time=0.009..0.009 rows=0 loops=741)
                       Index Cond: ((dump_id = sv.dump_id) AND (schema_version = 1))
                       Heap Fetches: 4001
   ->  LockRows  (cost=0.57..31815.38 rows=28995 width=59) (actual time=12.459..14.818 rows=1000 loops=1)
         ->  Index Scan using lsif_data_references_dump_id_schema_version on lsif_data_references t1  (cost=0.57..31525.43 rows=28995 width=59) (actual time=10.741..12.711 rows=2000 loops=1)
               Index Cond: ((dump_id = $1) AND (schema_version = 1))
 Planning Time: 0.304 ms
 Execution Time: 15.128 ms
(15 rows)
```