### PR TITLE
 rename encryption.Key.ID() to Version() & return structured version data

### DIFF
--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -475,10 +475,11 @@ func MaybeEncrypt(ctx context.Context, key encryption.Key, data string) (maybeEn
 			return "", "", err
 		}
 		data = string(encrypted)
-		keyIdent, err = key.ID(ctx)
+		version, err := key.Version(ctx)
 		if err != nil {
 			return "", "", err
 		}
+		keyIdent = version.JSON()
 	}
 
 	return data, keyIdent, nil

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -567,8 +567,8 @@ func (e *ExternalServiceStore) Create(ctx context.Context, confGet func() *conf.
 func (e *ExternalServiceStore) maybeEncryptConfig(ctx context.Context, config string) (string, string, error) {
 	// encrypt the config before writing if we have a key configured
 	var (
-		keyID string
-		key   = keyring.Default().ExternalServiceKey
+		keyVersion string
+		key        = keyring.Default().ExternalServiceKey
 	)
 	if e.key != nil {
 		key = e.key
@@ -579,12 +579,13 @@ func (e *ExternalServiceStore) maybeEncryptConfig(ctx context.Context, config st
 			return "", "", err
 		}
 		config = string(encrypted)
-		keyID, err = key.ID(ctx)
+		version, err := key.Version(ctx)
 		if err != nil {
 			return "", "", err
 		}
+		keyVersion = version.JSON()
 	}
-	return config, keyID, nil
+	return config, keyVersion, nil
 }
 
 func (e *ExternalServiceStore) maybeDecryptConfig(ctx context.Context, config string, keyID string) (string, error) {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -1476,6 +1476,6 @@ func (k testKey) Decrypt(ctx context.Context, ciphertext []byte) (*encryption.Se
 	return &s, err
 }
 
-func (k testKey) ID(ctx context.Context) (string, error) {
-	return "testkey", nil
+func (k testKey) Version(ctx context.Context) (encryption.KeyVersion, error) {
+	return encryption.KeyVersion{Type: "testkey"}, nil
 }

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -82,10 +82,11 @@ func (m *ExternalServiceConfigMigrator) Up(ctx context.Context) (err error) {
 			return err
 		}
 
-		keyIdent, err := key.ID(ctx)
+		version, err := key.Version(ctx)
 		if err != nil {
 			return err
 		}
+		keyIdent := version.JSON()
 
 		// ensure encryption round-trip is valid with keyIdent
 		decrypted, err := key.Decrypt(ctx, encryptedCfg)
@@ -231,10 +232,12 @@ func (m *ExternalAccountsMigrator) Up(ctx context.Context) (err error) {
 		return nil
 	}
 
-	keyIdent, err := key.ID(ctx)
+	version, err := key.Version(ctx)
 	if err != nil {
 		return err
 	}
+
+	keyIdent := version.JSON()
 
 	tx, err := m.store.Transact(ctx)
 	if err != nil {

--- a/internal/database/oob_migrate_test.go
+++ b/internal/database/oob_migrate_test.go
@@ -168,8 +168,8 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 				t.Fatalf("decrypted config is different from the original one")
 			}
 
-			if id, _ := key.ID(ctx); keyID != id {
-				t.Fatalf("wrong encryption_key_id, want %s, got %s", id, keyID)
+			if version, _ := key.Version(ctx); keyID != version.JSON() {
+				t.Fatalf("wrong encryption_key_id, want %s, got %s", version.JSON(), keyID)
 			}
 
 			i++
@@ -285,8 +285,8 @@ func (k invalidKey) Decrypt(ctx context.Context, ciphertext []byte) (*encryption
 	return &s, nil
 }
 
-func (k invalidKey) ID(ctx context.Context) (string, error) {
-	return "invalidKey", nil
+func (k invalidKey) Version(ctx context.Context) (encryption.KeyVersion, error) {
+	return encryption.KeyVersion{Type: "invalidkey"}, nil
 }
 
 func TestExternalAccountsMigrator(t *testing.T) {
@@ -452,8 +452,8 @@ func TestExternalAccountsMigrator(t *testing.T) {
 				t.Fatalf("decrypted data is different from the original one")
 			}
 
-			if id, _ := key.ID(ctx); keyID != id {
-				t.Fatalf("wrong encryption_key_id, want %s, got %s", id, keyID)
+			if version, _ := key.Version(ctx); keyID != string(version.JSON()) {
+				t.Fatalf("wrong encryption_key_id, want %s, got %s", string(version.JSON()), keyID)
 			}
 
 			i++

--- a/internal/database/oob_migrate_test.go
+++ b/internal/database/oob_migrate_test.go
@@ -452,8 +452,8 @@ func TestExternalAccountsMigrator(t *testing.T) {
 				t.Fatalf("decrypted data is different from the original one")
 			}
 
-			if version, _ := key.Version(ctx); keyID != string(version.JSON()) {
-				t.Fatalf("wrong encryption_key_id, want %s, got %s", string(version.JSON()), keyID)
+			if version, _ := key.Version(ctx); keyID != version.JSON() {
+				t.Fatalf("wrong encryption_key_id, want %s, got %s", version.JSON(), keyID)
 			}
 
 			i++

--- a/internal/encryption/key.go
+++ b/internal/encryption/key.go
@@ -7,9 +7,15 @@ type Key interface {
 	Encrypter
 	Decrypter
 
-	// ID returns an identifier string containing anything to concretely identify
+	// Version returns info containing to concretely identify
 	// the underlying key, eg: key type, name, & version.
-	ID(ctx context.Context) (string, error)
+	Version(ctx context.Context) (KeyVersion, error)
+}
+
+type KeyVersion struct {
+	Type    string
+	Name    string
+	Version string
 }
 
 // Encrypter is anything that can encrypt a value

--- a/internal/encryption/key.go
+++ b/internal/encryption/key.go
@@ -16,6 +16,7 @@ type Key interface {
 }
 
 type KeyVersion struct {
+	// TODO: generate this as an enum from JSONSchema
 	Type    string
 	Name    string
 	Version string

--- a/internal/encryption/key.go
+++ b/internal/encryption/key.go
@@ -1,6 +1,9 @@
 package encryption
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+)
 
 // Key combines the Encrypter & Decrypter interfaces.
 type Key interface {
@@ -16,6 +19,11 @@ type KeyVersion struct {
 	Type    string
 	Name    string
 	Version string
+}
+
+func (v KeyVersion) JSON() string {
+	buf, _ := json.Marshal(v)
+	return string(buf)
 }
 
 // Encrypter is anything that can encrypt a value

--- a/internal/encryption/noop.go
+++ b/internal/encryption/noop.go
@@ -1,13 +1,19 @@
 package encryption
 
-import "context"
+import (
+	"context"
+)
 
 var _ Key = &NoopKey{}
 
 type NoopKey struct{}
 
-func (k *NoopKey) ID(ctx context.Context) (string, error) {
-	return "no-op", nil
+func (k *NoopKey) Version(ctx context.Context) (KeyVersion, error) {
+	return KeyVersion{
+		Type:    "noop",
+		Name:    "noop",
+		Version: "",
+	}, nil
 }
 
 func (k *NoopKey) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -839,6 +839,7 @@ type MountedEncryptionKey struct {
 	Filepath   string `json:"filepath,omitempty"`
 	Keyname    string `json:"keyname"`
 	Type       string `json:"type"`
+	Version    string `json:"version,omitempty"`
 }
 
 // NoOpEncryptionKey description: This encryption key is a no op, leaving your data in plaintext (not recommended).

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1405,6 +1405,9 @@
         },
         "envVarName": {
           "type": "string"
+        },
+        "version": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
closes #19701 

This PR replaces `Key.ID()` with `Key.Version()`, returning structured metadata about the key. there are already cases where we might need a better idea of what was used to encrypt data, such as the encryption_key_id field in external_services, if we want to migrate to a different key it's useful to be able to concretely identify the old key.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
