### PR TITLE
Revert "perforce: sync changes into local branch"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
-- New changes of a Perforce depot will now be reflected in `master` branch after the initial clone. [#19690](https://github.com/sourcegraph/sourcegraph/pull/19690)
 
 ## 3.26.1
 

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -258,8 +258,8 @@ func (s *PerforceDepotSyncer) FetchCommand(ctx context.Context, remoteURL *url.U
 		return nil, false, errors.Wrap(err, "ping with trust")
 	}
 
-	// Example: git p4 sync --branch=refs/heads/master --max-changes 1000
-	args := []string{"p4", "sync", "--branch=refs/heads/master"}
+	// Example: git p4 sync --max-changes 1000
+	args := []string{"p4", "sync"}
 	if s.MaxChanges > 0 {
 		args = append(args, "--max-changes", strconv.Itoa(s.MaxChanges))
 	}


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#19690

The change reverted would end up creating/importing duplicated commits with no changes in Git history, still investigating why.

<img width="506" alt="CleanShot 2021-04-06 at 20 10 29@2x" src="https://user-images.githubusercontent.com/2946214/113708711-26248600-9714-11eb-8892-aa8472a0e18f.png">
