### PR TITLE
repo-updater: Include sync jobs in repo upater state page

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -258,7 +258,7 @@ func Main(enterpriseInit EnterpriseInit) {
 		Path: "/repo-updater-state",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			dumps := []interface{}{
-				scheduler.DebugDump(),
+				scheduler.DebugDump(r.Context(), db),
 			}
 			for _, dumper := range debugDumpers {
 				dumps = append(dumps, dumper.DebugDump())

--- a/cmd/repo-updater/shared/state.html.tmpl
+++ b/cmd/repo-updater/shared/state.html.tmpl
@@ -97,6 +97,40 @@
                 </tbody>
             </table>
         </div>
+        <div class="mt-5 w-9/12">
+            <h4 class="mb-3">Sync jobs</h4>
+            <p>
+                The current list of external service sync jobs, ordered by start date descending
+            </p>
+            <table class="table text-left mt-4">
+                <thead class="thead-light">
+                <tr>
+                    <th>Service</th>
+                    <th>State</th>
+                    <th>Started</th>
+                    <th>Finished</th>
+                    <th>Failure message</th>
+                </tr>
+                </thead>
+                <tbody>
+                {{range $schedulerDump.SyncJobs}}
+                    <tr>
+                        <td>{{.ExternalServiceID}}</td>
+                        <td>{{.State}}</td>
+                        <td>{{.StartedAt}}</td>
+                        <td>{{.FinishedAt}}</td>
+                        <td>{{.FailureMessage}}</td>
+                    </tr>
+                {{else}}
+                    <tr>
+                        <td colspan="100" class="text-center">
+                            <p class="alert">No sync jobs</p>
+                        </td>
+                    </tr>
+                {{end}}
+                </tbody>
+            </table>
+        </div>
     </div>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -443,6 +443,19 @@ type ExternalService struct {
 	CloudDefault    bool // Whether this external service is our default public service on Cloud
 }
 
+// ExternalServiceSyncJob represents an sync job for an external service
+type ExternalServiceSyncJob struct {
+	ID                int64
+	State             string
+	FailureMessage    string
+	StartedAt         time.Time
+	FinishedAt        time.Time
+	ProcessAfter      time.Time
+	NumResets         int
+	ExternalServiceID int64
+	NumFailures       int
+}
+
 // URN returns a unique resource identifier of this external service,
 // used as the key in a repo's Sources map as well as the SourceInfo ID.
 func (e *ExternalService) URN() string {


### PR DESCRIPTION
We now also include the list of all external service sync jobs on the
debug page for repo updater. The list should never grow too large as we
prune it every 24 hours.

Closes: https://github.com/sourcegraph/sourcegraph/issues/19699