### PR TITLE
search: hard-code display limit to 500

### DIFF
--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -120,6 +120,7 @@ export interface Skipped {
      * - repository-missing :: we could not search a repository because it is not cloned and we failed to find it on the remote code host.
      * - excluded-fork :: we did not search a repository because it is a fork.
      * - excluded-archive :: we did not search a repository because it is archived.
+     * - display :: we hit the display limit, so we stopped sending results from the backend.
      */
     reason:
         | 'document-match-limit'
@@ -130,6 +131,7 @@ export interface Skipped {
         | 'repository-missing'
         | 'excluded-fork'
         | 'excluded-archive'
+        | 'display'
         | 'error'
     /**
      * A short message. eg 1,200 timed out.

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -514,7 +514,7 @@ function search({
             ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
-            ['display', 500],
+            ['display', '500'],
         ]
         if (versionContext) {
             parameters.push(['vc', versionContext])

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -514,6 +514,7 @@ function search({
             ['q', `${query} ${caseSensitive ? 'case:yes' : ''}`],
             ['v', version],
             ['t', patternType as string],
+            ['display', 500],
         ]
         if (versionContext) {
             parameters.push(['vc', versionContext])
@@ -521,8 +522,6 @@ function search({
         if (trace) {
             parameters.push(['trace', trace])
         }
-        // We hard-code display=500 for the frontend. The src-cli allows to configure the display limit.
-        parameters.push(['display', '500'])
         const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
 
         const eventSource = new EventSource('/search/stream?' + parameterEncoded)

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -519,6 +519,8 @@ function search({
         if (trace) {
             parameters.push(['trace', trace])
         }
+        // We hard-code display=500 for the frontend. The src-cli allows to configure the display limit.
+        parameters.push(['display', '500'])
         const parameterEncoded = parameters.map(([k, v]) => k + '=' + encodeURIComponent(v)).join('&')
 
         const eventSource = new EventSource('/search/stream?' + parameterEncoded)

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -20,6 +20,10 @@ type progressAggregator struct {
 
 	// Dirty is true if p has changed since the last call to Current.
 	Dirty bool
+
+	// DisplayLimitHit is true if we have hit the display limit but not the match
+	// limit.
+	DisplayLimitHit bool
 }
 
 func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
@@ -60,6 +64,7 @@ func (p *progressAggregator) currentStats() api.ProgressStats {
 		LimitHit:            p.Stats.IsLimitHit,
 		SuggestedLimit:      suggestedLimit,
 		Trace:               p.Trace,
+		DisplayLimitHit:     p.DisplayLimitHit,
 	}
 }
 

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -12,19 +12,15 @@ import (
 )
 
 type progressAggregator struct {
-	Start      time.Time
-	MatchCount int
-	Stats      streaming.Stats
-	Limit      int
-	Trace      string // may be empty
+	Start        time.Time
+	MatchCount   int
+	Stats        streaming.Stats
+	Limit        int
+	DisplayLimit int
+	Trace        string // may be empty
 
 	// Dirty is true if p has changed since the last call to Current.
 	Dirty bool
-
-	// DisplayLimitHit is true if we have hit the display limit but not the match
-	// limit.
-	DisplayLimitHit bool
-	DisplayLimit    int
 }
 
 func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
@@ -65,7 +61,6 @@ func (p *progressAggregator) currentStats() api.ProgressStats {
 		LimitHit:            p.Stats.IsLimitHit,
 		SuggestedLimit:      suggestedLimit,
 		Trace:               p.Trace,
-		DisplayLimitHit:     p.DisplayLimitHit,
 		DisplayLimit:        p.DisplayLimit,
 	}
 }

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -24,6 +24,7 @@ type progressAggregator struct {
 	// DisplayLimitHit is true if we have hit the display limit but not the match
 	// limit.
 	DisplayLimitHit bool
+	DisplayLimit    int
 }
 
 func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
@@ -65,6 +66,7 @@ func (p *progressAggregator) currentStats() api.ProgressStats {
 		SuggestedLimit:      suggestedLimit,
 		Trace:               p.Trace,
 		DisplayLimitHit:     p.DisplayLimitHit,
+		DisplayLimit:        p.DisplayLimit,
 	}
 }
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -92,13 +92,6 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	start := time.Now()
-	progress := progressAggregator{
-		Start: start,
-		Limit: inputs.MaxResults(),
-		Trace: traceURL,
-	}
-
 	// Display is the number of results we send down. If display is < 0 we
 	// want to send everything we find before hitting a limit. Otherwise we
 	// can only send up to limit results.
@@ -106,6 +99,14 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	limit := inputs.MaxResults()
 	if display < 0 || display > limit {
 		display = limit
+	}
+
+	start := time.Now()
+	progress := progressAggregator{
+		Start:        start,
+		Limit:        inputs.MaxResults(),
+		Trace:        traceURL,
+		DisplayLimit: display,
 	}
 
 	sendProgress := func() {
@@ -175,7 +176,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				// that case we will always show all the results the user asked for. Only if the
 				// user asked for limit > args.Display results and we found more than
 				// args.Display results we inform the user that not all results are displayed.
-				if args.Display >= 0 && args.Display < limit {
+				if progress.DisplayLimit >= 0 && progress.DisplayLimit < limit {
 					progress.DisplayLimitHit = true
 				}
 				break

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -100,7 +100,8 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// want to send everything we find before hitting a limit. Otherwise we
 	// can only send up to limit results.
 	display := args.Display
-	if limit := inputs.MaxResults(); display < 0 || display > limit {
+	limit := inputs.MaxResults()
+	if display < 0 || display > limit {
 		display = limit
 	}
 
@@ -167,6 +168,13 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		for _, result := range event.Results {
 			if display <= 0 {
+				// We don't want to report a display limit if args.Display >= limit because in
+				// that case we will always show all the results the user asked for. Only if the
+				// user asked for limit > args.Display results and we found more than
+				// args.Display results we inform the user that not all results are displayed.
+				if args.Display < limit {
+					progress.DisplayLimitHit = true
+				}
 				break
 			}
 

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -2,14 +2,24 @@ package search
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	api2 "github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/search/query"
+	"github.com/sourcegraph/sourcegraph/internal/search/streaming/api"
+	streamhttp "github.com/sourcegraph/sourcegraph/internal/search/streaming/http"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -55,9 +65,143 @@ func TestDefaultNewSearchResolver(t *testing.T) {
 	}
 }
 
+func TestDisplayLimit(t *testing.T) {
+	old := pingTickerInterval
+	pingTickerInterval = time.Millisecond
+	defer func() {
+		pingTickerInterval = old
+	}()
+
+	cases := []struct {
+		queryString         string
+		displayLimit        int
+		wantDisplayLimitHit bool
+		wantMatchCount      int
+	}{
+		{
+			queryString:         "foo count:2",
+			displayLimit:        1,
+			wantDisplayLimitHit: true,
+			wantMatchCount:      2,
+		},
+		{
+			queryString:         "foo count:2",
+			displayLimit:        2,
+			wantDisplayLimitHit: false,
+			wantMatchCount:      2,
+		},
+		{
+			queryString:         "foo count:2",
+			displayLimit:        3,
+			wantDisplayLimitHit: false,
+			wantMatchCount:      2,
+		},
+		{
+			queryString:         "foo count:100",
+			displayLimit:        -1, // no display limit set by caller
+			wantDisplayLimitHit: false,
+			wantMatchCount:      2,
+		},
+		{
+			queryString:         "foo count:1",
+			displayLimit:        -1, // no display limit set by caller
+			wantDisplayLimitHit: false,
+			wantMatchCount:      1,
+		},
+	}
+
+	// any returns true if skipped contains an item matching reason.
+	any := func(reason api.SkippedReason, skipped []api.Skipped) bool {
+		for _, s := range skipped {
+			if s.Reason == reason {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("q=%s;displayLimit=%d", c.queryString, c.displayLimit), func(t *testing.T) {
+			mock := &mockSearchResolver{
+				done: make(chan struct{}),
+			}
+
+			ts := httptest.NewServer(&streamHandler{
+				newSearchResolver: func(_ context.Context, _ dbutil.DB, args *graphqlbackend.SearchArgs) (searchResolver, error) {
+					mock.c = args.Stream
+					q, err := query.Parse(c.queryString, query.Literal)
+					if err != nil {
+						t.Fatal(err)
+					}
+					mock.inputs = &graphqlbackend.SearchInputs{
+						Query: q,
+					}
+					return mock, nil
+				}})
+			defer ts.Close()
+
+			req, _ := streamhttp.NewRequest(ts.URL, c.queryString)
+			if c.displayLimit != -1 {
+				q := req.URL.Query()
+				q.Add("display", strconv.Itoa(c.displayLimit))
+				req.URL.RawQuery = q.Encode()
+			}
+
+			var displayLimitHit bool
+			var matchCount int
+			decoder := streamhttp.Decoder{
+				OnProgress: func(progress *api.Progress) {
+					if any(api.DisplayLimit, progress.Skipped) {
+						displayLimitHit = true
+					}
+					matchCount = progress.MatchCount
+				},
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			// Consume events.
+			g := errgroup.Group{}
+			g.Go(func() error {
+				return decoder.ReadAll(resp.Body)
+			})
+
+			// Send 2 repository matches.
+			mock.c.Send(graphqlbackend.SearchEvent{
+				Results: []graphqlbackend.SearchResultResolver{mkRepoResolver(1), mkRepoResolver(2)},
+			})
+			mock.Close()
+			if err := g.Wait(); err != nil {
+				t.Fatal(err)
+			}
+
+			if matchCount != c.wantMatchCount {
+				t.Fatalf("got %d, want %d", matchCount, c.wantMatchCount)
+			}
+
+			if got := displayLimitHit; got != c.wantDisplayLimitHit {
+				t.Fatalf("got %t, want %t", got, c.wantDisplayLimitHit)
+			}
+		})
+	}
+}
+
+func mkRepoResolver(id int) *graphqlbackend.RepositoryResolver {
+	repo := &types.RepoName{
+		ID:   api2.RepoID(id),
+		Name: api2.RepoName(fmt.Sprintf("repo%d", id)),
+	}
+	return graphqlbackend.NewRepositoryResolver(nil, repo.ToRepo())
+}
+
 type mockSearchResolver struct {
-	done chan struct{}
-	c    graphqlbackend.Sender
+	done   chan struct{}
+	c      graphqlbackend.Sender
+	inputs *graphqlbackend.SearchInputs
 }
 
 func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.SearchResultsResolver, error) {
@@ -80,5 +224,8 @@ func (h *mockSearchResolver) Close() {
 }
 
 func (h *mockSearchResolver) Inputs() graphqlbackend.SearchInputs {
-	return graphqlbackend.SearchInputs{}
+	if h.inputs == nil {
+		return graphqlbackend.SearchInputs{}
+	}
+	return *h.inputs
 }

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -30,6 +30,8 @@ func TestServeStream_empty(t *testing.T) {
 	mock.Close()
 
 	ts := httptest.NewServer(&streamHandler{
+		flushTickerInternal: 1 * time.Millisecond,
+		pingTickerInterval:  1 * time.Millisecond,
 		newSearchResolver: func(context.Context, dbutil.DB, *graphqlbackend.SearchArgs) (searchResolver, error) {
 			return mock, nil
 		}})
@@ -66,12 +68,6 @@ func TestDefaultNewSearchResolver(t *testing.T) {
 }
 
 func TestDisplayLimit(t *testing.T) {
-	old := pingTickerInterval
-	pingTickerInterval = time.Millisecond
-	defer func() {
-		pingTickerInterval = old
-	}()
-
 	cases := []struct {
 		queryString         string
 		displayLimit        int
@@ -129,6 +125,8 @@ func TestDisplayLimit(t *testing.T) {
 			}
 
 			ts := httptest.NewServer(&streamHandler{
+				flushTickerInternal: 1 * time.Millisecond,
+				pingTickerInterval:  1 * time.Millisecond,
 				newSearchResolver: func(_ context.Context, _ dbutil.DB, args *graphqlbackend.SearchArgs) (searchResolver, error) {
 					mock.c = args.Stream
 					q, err := query.Parse(c.queryString, query.Literal)

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -46,6 +46,8 @@ type ProgressStats struct {
 	SuggestedLimit int
 
 	Trace string // only filled if requested
+
+	DisplayLimitHit bool
 }
 
 func skippedReposHandler(repos []Namer, titleVerb, messageReason string, base Skipped) (Skipped, bool) {
@@ -101,6 +103,19 @@ func shardTimeoutHandler(resultsResolver ProgressStats) (Skipped, bool) {
 		Reason:   ShardTimeout,
 		Severity: SeverityWarn,
 	})
+}
+
+func displayLimitHandler(resultsResolver ProgressStats) (Skipped, bool) {
+	if !resultsResolver.DisplayLimitHit {
+		return Skipped{}, false
+	}
+
+	return Skipped{
+		Reason:   DisplayLimit,
+		Title:    "display limit hit",
+		Message:  "By default we only display up to 500 results even if your search returned more results. To see all results and configure the display limit, use our CLI.",
+		Severity: SeverityInfo,
+	}, true
 }
 
 func shardMatchLimitHandler(resultsResolver ProgressStats) (Skipped, bool) {
@@ -175,6 +190,7 @@ var skippedHandlers = []func(stats ProgressStats) (Skipped, bool){
 	shardTimeoutHandler,
 	excludedForkHandler,
 	excludedArchiveHandler,
+	displayLimitHandler,
 }
 
 func number(i int) string {

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -47,8 +47,7 @@ type ProgressStats struct {
 
 	Trace string // only filled if requested
 
-	DisplayLimit    int
-	DisplayLimitHit bool
+	DisplayLimit int
 }
 
 func skippedReposHandler(repos []Namer, titleVerb, messageReason string, base Skipped) (Skipped, bool) {
@@ -107,7 +106,7 @@ func shardTimeoutHandler(resultsResolver ProgressStats) (Skipped, bool) {
 }
 
 func displayLimitHandler(resultsResolver ProgressStats) (Skipped, bool) {
-	if !resultsResolver.DisplayLimitHit {
+	if resultsResolver.DisplayLimit >= resultsResolver.MatchCount {
 		return Skipped{}, false
 	}
 

--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -47,6 +47,7 @@ type ProgressStats struct {
 
 	Trace string // only filled if requested
 
+	DisplayLimit    int
 	DisplayLimitHit bool
 }
 
@@ -110,10 +111,15 @@ func displayLimitHandler(resultsResolver ProgressStats) (Skipped, bool) {
 		return Skipped{}, false
 	}
 
+	result := "results"
+	if resultsResolver.DisplayLimit == 1 {
+		result = "result"
+	}
+
 	return Skipped{
 		Reason:   DisplayLimit,
 		Title:    "display limit hit",
-		Message:  "By default we only display up to 500 results even if your search returned more results. To see all results and configure the display limit, use our CLI.",
+		Message:  fmt.Sprintf("We only display %d %s even if your search returned more results. To see all results and configure the display limit, use our CLI.", resultsResolver.DisplayLimit, result),
 		Severity: SeverityInfo,
 	}, true
 }

--- a/internal/search/streaming/api/progress_test.go
+++ b/internal/search/streaming/api/progress_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"flag"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/testutil"
@@ -31,6 +32,7 @@ func TestSearchProgress(t *testing.T) {
 			Missing:             nil,
 			Cloning:             nil,
 			LimitHit:            false,
+			DisplayLimit:        math.MaxInt32,
 		},
 		"all": {
 			MatchCount:          1,
@@ -43,6 +45,7 @@ func TestSearchProgress(t *testing.T) {
 			Cloning:             []Namer{repo{"cloning-1"}},
 			LimitHit:            true,
 			SuggestedLimit:      1000,
+			DisplayLimit:        math.MaxInt32,
 		},
 		"traced": {
 			Trace: "abcd",

--- a/internal/search/streaming/api/types.go
+++ b/internal/search/streaming/api/types.go
@@ -59,6 +59,9 @@ const (
 	// ShardMatchLimit is when we found too many matches in a
 	// shard/repository, so we stopped searching it.
 	ShardMatchLimit SkippedReason = "shard-match-limit"
+	// DisplayLimit is when we found too many matches during a search so we stopped
+	// displaying results.
+	DisplayLimit SkippedReason = "display"
 	// RepositoryLimit is when we did not search a repository because the set
 	// of repositories to search was too large.
 	RepositoryLimit SkippedReason = "repository-limit"


### PR DESCRIPTION
Relates to #18306 

With this change we send `display=500` as query parameter with every request from the frontend to `/stream`. This means we will never display more than 500 results in the browser. The progress statistics are not affected.

The backend returns a new `skipped` item if (display<count:) AND (display<#matches).

We don't show a `+` if we hit the display limit (see screenshots) but we add a note to the "some results excluded" notification list. 

display=500 (default), count=500
![Screenshot 2021-04-07 at 14 18 39](https://user-images.githubusercontent.com/26413131/113865699-b1515a80-97ac-11eb-875d-95601d402f80.png)

display=500 (default), count=3000
![Screenshot 2021-04-07 at 14 18 18](https://user-images.githubusercontent.com/26413131/113865718-b6aea500-97ac-11eb-97b2-f4a1542db6a6.png)




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
