### PR TITLE
gitserver: handle zero limit correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
+- Setting `gitMaxCodehostRequestsPerSecond` to `0` is now actually blocking all Git operations happening on the gitserver. [#19716](https://github.com/sourcegraph/sourcegraph/pull/19716)
 
 ## 3.26.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
-- Setting `gitMaxCodehostRequestsPerSecond` to `0` is now actually blocking all Git operations happening on the gitserver. [#19716](https://github.com/sourcegraph/sourcegraph/pull/19716)
+- Setting `gitMaxCodehostRequestsPerSecond` to `0` now actually blocks all Git operations happening on the gitserver. [#19716](https://github.com/sourcegraph/sourcegraph/pull/19716)
 
 ## 3.26.1
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -258,8 +258,16 @@ func (s *Server) Handler() http.Handler {
 		if maxRequestsPerSecond := conf.GitMaxCodehostRequestsPerSecond(); maxRequestsPerSecond == -1 {
 			// As a special case, -1 means no limiting
 			s.rpsLimiter.SetLimit(rate.Inf)
+			s.rpsLimiter.SetBurst(10)
+		} else if maxRequestsPerSecond == 0 {
+			// A limiter with zero limit but a non-zero burst is not rejecting all events
+			// because the bucket is being prefill with N tokens per second, where N is the
+			// burst size. See https://github.com/golang/go/issues/18763 for details.
+			s.rpsLimiter.SetLimit(0)
+			s.rpsLimiter.SetBurst(0)
 		} else {
 			s.rpsLimiter.SetLimit(rate.Limit(maxRequestsPerSecond))
+			s.rpsLimiter.SetBurst(10)
 		}
 	}
 	conf.Watch(func() {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -261,8 +261,9 @@ func (s *Server) Handler() http.Handler {
 			s.rpsLimiter.SetBurst(10)
 		} else if maxRequestsPerSecond == 0 {
 			// A limiter with zero limit but a non-zero burst is not rejecting all events
-			// because the bucket is being prefill with N tokens per second, where N is the
-			// burst size. See https://github.com/golang/go/issues/18763 for details.
+			// because the bucket is initially full with N tokens and refilled N tokens
+			// every second, where N is the burst size. See
+			// https://github.com/golang/go/issues/18763 for details.
 			s.rpsLimiter.SetLimit(0)
 			s.rpsLimiter.SetBurst(0)
 		} else {


### PR DESCRIPTION
The pitfall of a limiter with zero limit is that the burst size also has to be set to 0, otherwise, the limiter will be refilled with N tokens every second.

Closes: https://github.com/sourcegraph/sourcegraph/issues/19720