### PR TITLE
perforce: force update the master branch after fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
+- New changes of a Perforce depot will now be reflected in `master` branch after the initial clone. [#19718](https://github.com/sourcegraph/sourcegraph/pull/19718)
 
 ## 3.26.1
 

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1623,22 +1623,16 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 		return errors.Wrap(err, "get VCS syncer")
 	}
 
-	cmd, configRemoteOpts, err := syncer.FetchCommand(ctx, remoteURL)
-	if err != nil {
-		return errors.Wrap(err, "get fetch command")
-	}
-
-	dir.Set(cmd)
-
 	// drop temporary pack files after a fetch. this function won't
 	// return until this fetch has completed or definitely-failed,
 	// either way they can't still be in use. we don't care exactly
 	// when the cleanup happens, just that it does.
 	defer s.cleanTmpFiles(dir)
 
-	if output, err := runWith(ctx, cmd, configRemoteOpts, nil); err != nil {
-		log15.Error("Failed to update", "repo", repo, "error", err, "output", string(output))
-		return errors.Wrap(err, "failed to update")
+	err = syncer.Fetch(ctx, remoteURL, dir)
+	if err != nil {
+		log15.Error("Failed to fetch", "repo", repo, "error", err)
+		return errors.Wrap(err, "failed to fetch")
 	}
 
 	removeBadRefs(ctx, dir)

--- a/cmd/gitserver/server/vcs_syncer.go
+++ b/cmd/gitserver/server/vcs_syncer.go
@@ -276,15 +276,19 @@ func (s *PerforceDepotSyncer) Fetch(ctx context.Context, remoteURL *url.URL, dir
 		"P4USER="+username,
 		"P4PASSWD="+password,
 	)
-
 	dir.Set(cmd)
-
 	if output, err := runWith(ctx, cmd, false, nil); err != nil {
 		return errors.Wrapf(err, "failed to update with output %q", string(output))
 	}
 
 	// Force update "master" to "refs/remotes/p4/master" where changes are synced into
-	cmd.Args = []string{"branch", "-f", "master", "refs/remotes/p4/master"}
+	cmd = exec.CommandContext(ctx, "git", "branch", "-f", "master", "refs/remotes/p4/master")
+	cmd.Env = append(os.Environ(),
+		"P4PORT="+host,
+		"P4USER="+username,
+		"P4PASSWD="+password,
+	)
+	dir.Set(cmd)
 	if output, err := runWith(ctx, cmd, false, nil); err != nil {
 		return errors.Wrapf(err, "failed to force update branch with output %q", string(output))
 	}


### PR DESCRIPTION
Following previous unsuccessfully attempt in https://github.com/sourcegraph/sourcegraph/pull/19690, which used `git p4 sync --branch refs/heads/master`. However, every run of the command would create/import duplicated commits.

In this PR, a new attempt is to force update `master` to point to `refs/remotes/p4/master` (which `git p4 sync` imports changes by default) after every `git p4 sync`, where the former is guaranteed to be not ahead of the latter in our use case.