### PR TITLE
Clarify url in quickstart instructions

### DIFF
--- a/doc/code_monitoring/quickstart.md
+++ b/doc/code_monitoring/quickstart.md
@@ -6,7 +6,7 @@ In this tutorial, we will create a new code monitor that monitors new appearance
 
 ## Creating a code monitor
 
-1. On your Sourcegraph instance, click the **Code monitoring** menu item at the top right of your page. Alternatively, go to https://sourcegraph.example.com/code-monitoring.
+1. On your Sourcegraph instance, click the **Code monitoring** menu item at the top right of your page. Alternatively, go to https://sourcegraph.example.com/code-monitoring (where sourcegraph.example.com represents your unique sourcegraph url).
 1. Click the **Create new code monitor** button at the top right of the page.
 1. Fill out the **Name** input with: "TODOs".
 1. Under the **Trigger** section, click **When there are new search results**. 

--- a/doc/code_monitoring/quickstart.md
+++ b/doc/code_monitoring/quickstart.md
@@ -6,7 +6,7 @@ In this tutorial, we will create a new code monitor that monitors new appearance
 
 ## Creating a code monitor
 
-1. On your Sourcegraph instance, click the **Code monitoring** menu item at the top right of your page. Alternatively, go to https://sourcegraph.example.com/code-monitoring (where sourcegraph.example.com represents your unique sourcegraph url).
+1. On your Sourcegraph instance, click the **Code monitoring** menu item at the top right of your page. Alternatively, go to https://sourcegraph.example.com/code-monitoring (where sourcegraph.example.com represents your unique Sourcegraph url).
 1. Click the **Create new code monitor** button at the top right of the page.
 1. Fill out the **Name** input with: "TODOs".
 1. Under the **Trigger** section, click **When there are new search results**. 


### PR DESCRIPTION

Just wanting to clarify that these are examples not dead links
