### PR TITLE
Update code search to Universal Code Search in some places

### DIFF
--- a/doc/_resources/templates/root.html
+++ b/doc/_resources/templates/root.html
@@ -103,7 +103,7 @@
                 <li><a href="/getting-started/personalization">Personalization</a></li>
             </ul>
         </li>
-        <li class="expand"><a href="/code_search">Code search</a>
+        <li class="expand"><a href="/code_search">Universal Code Search</a>
             <ul>
                 <li><a href="code_search/tutorials">Tutorials</a></li>
                 <li><a href="code_search/how-to">How-to guides</a></li>

--- a/doc/admin/search.md
+++ b/doc/admin/search.md
@@ -1,6 +1,6 @@
 # Search configuration
 
-See "[Code search overview](../code_search/index.md)" for general information about Sourcegraph's code search.
+See "[Universal Code Search overview](../code_search/index.md)" for general information about Sourcegraph's code search.
 
 ## Indexed search
 

--- a/doc/code_search/explanations/features.md
+++ b/doc/code_search/explanations/features.md
@@ -2,7 +2,7 @@
 
 ## Powerful, flexible queries
 
-Sourcegraph code search performs full-text searches and supports both regular expression and exact queries. By default, Sourcegraph searches across all your repositories. Our search query syntax allows for advanced queries, such as searching over any branch or commit, narrowing searches by programming language or file pattern, and more.
+Sourcegraph Universal Code Search performs full-text searches and supports both regular expression and exact queries. By default, Sourcegraph searches across all your repositories. Our search query syntax allows for advanced queries, such as searching over any branch or commit, narrowing searches by programming language or file pattern, and more.
 
 See the [query syntax](../reference/queries.md) and [query reference](../reference/language.md) documentation for a comprehensive overview of supported syntax.
 

--- a/doc/code_search/index.md
+++ b/doc/code_search/index.md
@@ -1,4 +1,4 @@
-# Code search
+# Universal Code Search
 
 <p class="subtitle">Search code across all your repositories and code hosts</p>
 
@@ -9,8 +9,7 @@
 - debug issues
 - determine the impact of changes
 
-Sourcegraph code search helps developers perform these tasks more quickly and effectively by providing fast, advanced code search across multiple repositories.
-
+Sourcegraph Universal Code Search helps developers perform these tasks more quickly and effectively by providing fast, advanced code search across multiple repositories.
 
 <div class="cta-group">
 <a class="btn btn-primary" href="reference/queries">★ Search query language</a>
@@ -27,9 +26,9 @@ Sourcegraph code search helps developers perform these tasks more quickly and ef
   </a>
 
   <a href="https://www.youtube.com/watch?v=GQj5jXdON3A" class="btn" alt="Watch the intro to code search video">
-   <span>Intro to code search video</span>
+   <span>Intro to Universal Code Search video</span>
    </br>
-   Watch the intro to code search video to see what you can do with Sourcegraph search.
+   Watch the intro to Universal Code Search video to see what you can do with Sourcegraph search.
   </a>
 
   <a href="reference/queries" class="btn" alt="Learn the search syntax">

--- a/doc/code_search/reference/queries.md
+++ b/doc/code_search/reference/queries.md
@@ -32,7 +32,7 @@ img.toggle {
 
 </style>
 
-This page describes search pattern syntax and keywords available for code search. See the complementary [language reference](language.md) for a visual breakdown. A typical search pattern describes content or filenames to find across all repositories. At the most basic level, a search pattern can simply be a word like `hello`. See our [search patterns](#search-pattern-syntax) documentation for detailed usage. Queries can also include keywords. For example, a typical search query will include a `repo:` keyword that filters search results for a specific repository. See our [keywords](#keywords-all-searches) documentation for more examples.
+This page describes search pattern syntax and keywords available for Universal Code Search. See the complementary [language reference](language.md) for a visual breakdown. A typical search pattern describes content or filenames to find across all repositories. At the most basic level, a search pattern can simply be a word like `hello`. See our [search patterns](#search-pattern-syntax) documentation for detailed usage. Queries can also include keywords. For example, a typical search query will include a `repo:` keyword that filters search results for a specific repository. See our [keywords](#keywords-all-searches) documentation for more examples.
 
 ## Search pattern syntax
 

--- a/doc/sidebar.md
+++ b/doc/sidebar.md
@@ -13,7 +13,7 @@ Keep it as a single list with at most 2 levels. (Anything else may not render co
 - [Getting started](getting-started/index.md)
   - [Product tour](getting-started/tour.md)
   - [Personalization](getting-started/personalization/index.md)
-- [Code search](code_search/index.md)
+- [Universal Code Search](code_search/index.md)
   - [Tutorials](code_search/tutorials/index.md)
   - [How-to guides](code_search/how-to/index.md)
   - [Explanations](code_search/explanations/index.md)


### PR DESCRIPTION
At the request of @tammy-zhu we would like to update reference of code search to Universal Code Search in some places.

Here is the search that shows all the places "code search" appears in our docs: https://sourcegraph.com/search?q=context:global+repo:github.com/sourcegraph/sourcegraph%24+file:doc/.*+%22code+search%22&patternType=regexp

Please review and let me know if there are any other places that need to be updated.