### PR TITLE
Enabling encryption: Handle external account decryption in PermsStore, add docs for reversing OOB migrations.

### DIFF
--- a/doc/dev/background-information/oobmigrations.md
+++ b/doc/dev/background-information/oobmigrations.md
@@ -44,6 +44,8 @@ If a migration is non-destructive (it only adds data), then it is safe to downgr
 
 It is not valid for a user to downgrade beyond the version in which a non-0% migration was introduced. Site-admin must wait for these migrations to completely revert before a downgrade. Otherwise, the instance will have data i a format that is not yet readable by the old version.
 
+In order to run the 'down' side of a migration, set the `apply_reverse` field to the migration row in the `out_of_band_migrations` table via psql or the graphql API.
+
 #### Backwards compatibility
 
 Because this happens in the background over time, the application must able to read both the new and old data formats until the migration has been deprecated. Advice for this is highly dependent on the type of data migration, but there are a few general options:

--- a/enterprise/internal/database/perms_store.go
+++ b/enterprise/internal/database/perms_store.go
@@ -1119,7 +1119,7 @@ SELECT
     service_type, service_id, client_id, account_id,
     auth_data, account_data,
     created_at, updated_at,
-	encryption_key_id
+	  encryption_key_id
 FROM user_external_accounts
 WHERE
     user_id = %s

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -491,11 +491,16 @@ func MaybeDecrypt(ctx context.Context, key encryption.Key, data, keyIdent string
 		// data is not encrypted, return plaintext
 		return data, nil
 	}
+	if data == "" {
+		return data, nil
+	}
 	if key == nil {
 		return data, fmt.Errorf("couldn't decrypt encrypted data, key is nil")
 	}
 	decrypted, err := key.Decrypt(ctx, []byte(data))
 	if err != nil {
+		fmt.Println(data)
+		fmt.Println(keyIdent)
 		return data, err
 	}
 

--- a/internal/database/external_accounts.go
+++ b/internal/database/external_accounts.go
@@ -499,8 +499,6 @@ func MaybeDecrypt(ctx context.Context, key encryption.Key, data, keyIdent string
 	}
 	decrypted, err := key.Decrypt(ctx, []byte(data))
 	if err != nil {
-		fmt.Println(data)
-		fmt.Println(keyIdent)
 		return data, err
 	}
 

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -184,7 +184,7 @@ func (m *ExternalServiceConfigMigrator) listConfigsForUpdate(ctx context.Context
 // external services config on startup.
 // It periodically waits until a keyring is configured to determine
 // how many services it must migrate.
-// Scheduling and progress report is deleguated to the out of band
+// Scheduling and progress report is delegated to the out of band
 // migration package.
 // The migration is non destructive and can be reverted.
 type ExternalAccountsMigrator struct {


### PR DESCRIPTION
probably should be two PRs but it's small and covering issues related to enabling encryption, i was getting an error from repo-updater after configuring encryption keys, looks like we just needed to pass keys to the PermsStore
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
