### PR TITLE
gitserver: Abort doBackgroundRepoUpdate when rate limiter is zero

### DIFF
--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1596,6 +1596,7 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 	if doBackgroundRepoUpdateMock != nil {
 		return doBackgroundRepoUpdateMock(repo)
 	}
+
 	// background context.
 	ctx, cancel1 := s.serverContext()
 	defer cancel1()
@@ -1606,6 +1607,9 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 	}
 	defer cancel2()
 
+	if s.rpsLimiter.Limit() == 0 && s.rpsLimiter.Burst() == 0 {
+		return errors.New("doBackgroundRepoUpdate aborted as rate limit set to zero")
+	}
 	if err = s.rpsLimiter.Wait(ctx); err != nil {
 		return err
 	}

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1608,7 +1608,7 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 	defer cancel2()
 
 	if s.rpsLimiter.Limit() == 0 && s.rpsLimiter.Burst() == 0 {
-		// If both limit and burst are zero the call to wait below would block forever
+		// If both limit and burst are zero the call to Wait() below would block forever
 		return errors.New("doBackgroundRepoUpdate aborted as rate limit set to zero")
 	}
 	if err = s.rpsLimiter.Wait(ctx); err != nil {

--- a/cmd/gitserver/server/server.go
+++ b/cmd/gitserver/server/server.go
@@ -1608,6 +1608,7 @@ func (s *Server) doBackgroundRepoUpdate(repo api.RepoName) error {
 	defer cancel2()
 
 	if s.rpsLimiter.Limit() == 0 && s.rpsLimiter.Burst() == 0 {
+		// If both limit and burst are zero the call to wait below would block forever
 		return errors.New("doBackgroundRepoUpdate aborted as rate limit set to zero")
 	}
 	if err = s.rpsLimiter.Wait(ctx); err != nil {


### PR DESCRIPTION
If we don't abort then the background job can potentially block forever
if a zero rate limit has been set. This would leak goroutines and hold a
cloneLimiter lock.

We do not add a timeout as it's hard to pick on as this is a legitimate
background process that could take a long time to complete for large
repos.

Closes: https://github.com/sourcegraph/sourcegraph/issues/19720