### PR TITLE
mark calendar event as free, not busy

### DIFF
--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -87,7 +87,7 @@ export async function ensureEvent(
             end: { date: endDate, dateTime: endDateTime },
             description,
             summary: title,
-            transparency: transparency,
+            transparency,
         },
     })
 }

--- a/dev/release/src/google-calendar.ts
+++ b/dev/release/src/google-calendar.ts
@@ -53,6 +53,7 @@ export interface EventOptions {
     endDateTime?: string
     description?: string
     title: string
+    transparency: string
 }
 
 export async function ensureEvent(
@@ -65,6 +66,7 @@ export async function ensureEvent(
         endDateTime,
         description = '',
         title,
+        transparency,
     }: EventOptions,
     auth: OAuth2Client
 ): Promise<void> {
@@ -85,6 +87,7 @@ export async function ensureEvent(
             end: { date: endDate, dateTime: endDateTime },
             description,
             summary: title,
+            transparency: transparency,
         },
     })
 }

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -597,6 +597,7 @@ Campaign: ${campaignURL}`,
                     title: 'TEST EVENT',
                     startDateTime: new Date(config.releaseDate).toISOString(),
                     endDateTime: addMinutes(new Date(config.releaseDate), 1).toISOString(),
+                    transparency: 'transparent',
                 },
                 googleCalendar
             )

--- a/dev/release/src/release.ts
+++ b/dev/release/src/release.ts
@@ -107,6 +107,7 @@ const steps: Step[] = [
                     description: '(This is not an actual event to attend, just a calendar marker.)',
                     anyoneCanAddSelf: true,
                     attendees: [config.teamEmail],
+                    transparency: 'transparent',
                     ...calendarTime(config.releaseDate),
                 },
                 {
@@ -114,6 +115,7 @@ const steps: Step[] = [
                     description: '(This is not an actual event to attend, just a calendar marker.)',
                     anyoneCanAddSelf: true,
                     attendees: [config.teamEmail],
+                    transparency: 'transparent',
                     ...calendarTime(config.oneWorkingDayAfterRelease),
                 },
             ]


### PR DESCRIPTION
stops the release calendar events from blocking time in calendars requested by @felixfbecker [here](https://sourcegraph.slack.com/archives/CJX299FGE/p1616180431042500)