### PR TITLE
search: move regex helper function to file where used

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -348,6 +348,18 @@ func errorName(diff bool) string {
 	return "commits"
 }
 
+// orderedFuzzyRegexp interpolate a lazy 'match everything' regexp pattern
+// to achieve an ordered fuzzy regexp match.
+func orderedFuzzyRegexp(pieces []string) string {
+	if len(pieces) == 0 {
+		return ""
+	}
+	if len(pieces) == 1 {
+		return pieces[0]
+	}
+	return "(" + strings.Join(pieces, ").*?(") + ")"
+}
+
 func logCommitSearchResultsToResolvers(ctx context.Context, db dbutil.DB, op *search.CommitParameters, repoName types.RepoName, rawResults []*git.LogCommitSearchResult) []*CommitSearchResultResolver {
 	if len(rawResults) == 0 {
 		return nil

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -1888,16 +1887,4 @@ func (r *searchResolver) getExactFilePatterns() map[string]struct{} {
 			}
 		})
 	return m
-}
-
-// orderedFuzzyRegexp interpolate a lazy 'match everything' regexp pattern
-// to achieve an ordered fuzzy regexp match.
-func orderedFuzzyRegexp(pieces []string) string {
-	if len(pieces) == 0 {
-		return ""
-	}
-	if len(pieces) == 1 {
-		return pieces[0]
-	}
-	return "(" + strings.Join(pieces, ").*?(") + ")"
 }


### PR DESCRIPTION
Stacked on #19764.

There's only one use of `orderedFuzzyRegexp` now so move it to `search_commits.go`