### PR TITLE
globalstatedb: Do not ignore non-nil error in func Get

### DIFF
--- a/internal/database/globalstatedb/globalstatedb.go
+++ b/internal/database/globalstatedb/globalstatedb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
@@ -25,6 +26,10 @@ func Get(ctx context.Context) (*State, error) {
 	configuration, err := getConfiguration(ctx)
 	if err == nil {
 		return configuration, nil
+	}
+
+	if err != sql.ErrNoRows {
+		return nil, errors.Wrap(err, "getConfiguration")
 	}
 
 	b := basestore.NewWithDB(dbconn.Global, sql.TxOptions{})


### PR DESCRIPTION
It makes sense to ignore the error only if it is a sql.ErrNorows. For
anything else we should

Co-authored-by: ᴜɴᴋɴᴡᴏɴ <joe@sourcegraph.com>

Prerequisite to #12229 as we noticed this issue while we were working on it. 
