### PR TITLE
release: update configuration for patch release 3.26.2

### DIFF
--- a/dev/release/release-config.jsonc
+++ b/dev/release/release-config.jsonc
@@ -14,10 +14,10 @@
     "captainGitHubUsername": "ggilmore",
     // Release versions
     "previousRelease": "3.26.1",
-    "upcomingRelease": "3.27.0",
+    "upcomingRelease": "3.26.2",
     // Release dates
-    "releaseDate": "20 April 2021 10:00 PST",
-    "oneWorkingDayAfterRelease": "21 April 2021 10:00 PST",
+    "releaseDate": "07 April 2021 10:00 PST",
+    "oneWorkingDayAfterRelease": "08 April 2021 10:00 PST",
     // Channel where messages from the tooling are posted
     "slackAnnounceChannel": "dev-announce",
     // Email for preparing calendar events


### PR DESCRIPTION
Is it okay to rollback from 3.27.0 to this "older" patch release?