### PR TITLE
search frontend: resolve predicate access paths

### DIFF
--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -40,19 +40,19 @@ describe('scanPredicate', () => {
 describe('resolveAccess', () => {
     test('resolves partial access tree', () => {
         expect(resolveAccess(['repo', 'contains'], PREDICATES)).toMatchInlineSnapshot(
-            `[{"name":"file"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]`
+            '[{"name":"file"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]'
         )
     })
 
     test('resolves partial access tree depth 2', () => {
-        expect(resolveAccess(['repo', 'contains', 'commit'], PREDICATES)).toMatchInlineSnapshot(`[{"name":"after"}]`)
+        expect(resolveAccess(['repo', 'contains', 'commit'], PREDICATES)).toMatchInlineSnapshot('[{"name":"after"}]')
     })
 
     test('resolves fully qualified path', () => {
-        expect(resolveAccess(['repo', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot(`[]`)
+        expect(resolveAccess(['repo', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot('[]')
     })
 
     test('undefind path', () => {
-        expect(resolveAccess(['OCOTILLO', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot(`invalid`)
+        expect(resolveAccess(['OCOTILLO', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot('invalid')
     })
 })

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -8,19 +8,19 @@ expect.addSnapshotSerializer({
 describe('scanPredicate', () => {
     test('scan recognized and valid syntax', () => {
         expect(scanPredicate('repo', 'contains(stuff)')).toMatchInlineSnapshot(
-            `{"path":["contains"],"parameters":"(stuff)"}`
+            '{"path":["contains"],"parameters":"(stuff)"}'
         )
     })
 
     test('scan recognized dot syntax', () => {
         expect(scanPredicate('repo', 'contains.commit.after(stuff)')).toMatchInlineSnapshot(
-            `{"path":["contains","commit","after"],"parameters":"(stuff)"}`
+            '{"path":["contains","commit","after"],"parameters":"(stuff)"}'
         )
     })
 
     test('scan recognized and valid syntax with escapes', () => {
         expect(scanPredicate('repo', 'contains(\\((stuff))')).toMatchInlineSnapshot(
-            `{"path":["contains"],"parameters":"(\\\\((stuff))"}`
+            '{"path":["contains"],"parameters":"(\\\\((stuff))"}'
         )
     })
 

--- a/client/shared/src/search/query/predicates.test.ts
+++ b/client/shared/src/search/query/predicates.test.ts
@@ -1,20 +1,26 @@
-import { scanPredicate } from './predicates'
+import { scanPredicate, resolveAccess, PREDICATES } from './predicates'
 
 expect.addSnapshotSerializer({
     serialize: value => (value ? JSON.stringify(value) : 'invalid'),
     test: () => true,
 })
 
-describe('scanPredicate()', () => {
+describe('scanPredicate', () => {
     test('scan recognized and valid syntax', () => {
         expect(scanPredicate('repo', 'contains(stuff)')).toMatchInlineSnapshot(
-            '{"name":"contains","parameters":"(stuff)"}'
+            `{"path":["contains"],"parameters":"(stuff)"}`
+        )
+    })
+
+    test('scan recognized dot syntax', () => {
+        expect(scanPredicate('repo', 'contains.commit.after(stuff)')).toMatchInlineSnapshot(
+            `{"path":["contains","commit","after"],"parameters":"(stuff)"}`
         )
     })
 
     test('scan recognized and valid syntax with escapes', () => {
         expect(scanPredicate('repo', 'contains(\\((stuff))')).toMatchInlineSnapshot(
-            '{"name":"contains","parameters":"(\\\\((stuff))"}'
+            `{"path":["contains"],"parameters":"(\\\\((stuff))"}`
         )
     })
 
@@ -27,6 +33,26 @@ describe('scanPredicate()', () => {
     })
 
     test('scan invalid nonalphanumeric name', () => {
-        expect(scanPredicate('repo', 'contains.yoinks(stuff)')).toMatchInlineSnapshot('invalid')
+        expect(scanPredicate('repo', 'contains.yo?inks(stuff)')).toMatchInlineSnapshot('invalid')
+    })
+})
+
+describe('resolveAccess', () => {
+    test('resolves partial access tree', () => {
+        expect(resolveAccess(['repo', 'contains'], PREDICATES)).toMatchInlineSnapshot(
+            `[{"name":"file"},{"name":"content"},{"name":"commit","fields":[{"name":"after"}]}]`
+        )
+    })
+
+    test('resolves partial access tree depth 2', () => {
+        expect(resolveAccess(['repo', 'contains', 'commit'], PREDICATES)).toMatchInlineSnapshot(`[{"name":"after"}]`)
+    })
+
+    test('resolves fully qualified path', () => {
+        expect(resolveAccess(['repo', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot(`[]`)
+    })
+
+    test('undefind path', () => {
+        expect(resolveAccess(['OCOTILLO', 'contains', 'file'], PREDICATES)).toMatchInlineSnapshot(`invalid`)
     })
 })

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -93,7 +93,7 @@ export const scanBalancedParens = (input: string): string | undefined => {
  * (2) The parameters value is well-balanced.
  */
 export const scanPredicate = (field: string, value: string): Predicate | undefined => {
-    const match = value.match(/^[a-z.]+/i)
+    const match = value.match(/^[.a-z]+/i)
     if (!match) {
         return undefined
     }


### PR DESCRIPTION
Updates frontend predicate scanner to recognize dot access. Adds a function to resolve access paths. This will be used to generate autocomplete suggestions.

None of this is being used yet, just building the functionality I'll hook into.