### PR TITLE
uploadstore: Manually expire objects when using MinIO

### DIFF
--- a/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/mock_gcs_api_test.go
@@ -3,11 +3,10 @@
 package uploadstore
 
 import (
+	storage "cloud.google.com/go/storage"
 	"context"
 	"io"
 	"sync"
-
-	storage "cloud.google.com/go/storage"
 )
 
 // MockGcsAPI is a mock implementation of the gcsAPI interface (from the

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_api.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_api.go
@@ -2,9 +2,13 @@ package uploadstore
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/inconshreveable/log15"
 )
 
 type s3API interface {
@@ -16,7 +20,7 @@ type s3API interface {
 	UploadPartCopy(ctx context.Context, input *s3.UploadPartCopyInput) (*s3.UploadPartCopyOutput, error)
 	CompleteMultipartUpload(ctx context.Context, input *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
-	PutBucketLifecycleConfiguration(ctx context.Context, input *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error)
+	EnforceBucketLifecycle(ctx context.Context, bucket string, ttl time.Duration) error
 }
 
 type s3Uploader interface {
@@ -31,10 +35,6 @@ var _ s3Uploader = &s3UploaderShim{}
 
 func (s *s3APIShim) CreateBucket(ctx context.Context, input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
 	return s.S3.CreateBucketWithContext(ctx, input)
-}
-
-func (s *s3APIShim) PutBucketLifecycleConfiguration(ctx context.Context, input *s3.PutBucketLifecycleConfigurationInput) (*s3.PutBucketLifecycleConfigurationOutput, error) {
-	return s.S3.PutBucketLifecycleConfigurationWithContext(ctx, input)
 }
 
 func (s *s3APIShim) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
@@ -68,4 +68,90 @@ func (s *s3APIShim) CompleteMultipartUpload(ctx context.Context, input *s3.Compl
 func (s *s3UploaderShim) Upload(ctx context.Context, input *s3manager.UploadInput) error {
 	_, err := s.Uploader.UploadWithContext(ctx, input)
 	return err
+}
+
+func (s *s3APIShim) EnforceBucketLifecycle(ctx context.Context, bucket string, ttl time.Duration) error {
+	input := &s3.PutBucketLifecycleConfigurationInput{
+		Bucket:                 aws.String(bucket),
+		LifecycleConfiguration: lifecycle(ttl),
+	}
+
+	_, err := s.S3.PutBucketLifecycleConfigurationWithContext(ctx, input)
+	return err
+}
+
+func lifecycle(ttl time.Duration) *s3.BucketLifecycleConfiguration {
+	days := aws.Int64(int64(ttl / (time.Hour * 24)))
+
+	return &s3.BucketLifecycleConfiguration{
+		Rules: []*s3.LifecycleRule{
+			{
+				ID:         aws.String("Expiration Rule"),
+				Status:     aws.String("Enabled"),
+				Filter:     &s3.LifecycleRuleFilter{Prefix: aws.String("")},
+				Expiration: &s3.LifecycleExpiration{Days: days},
+			},
+			{
+				ID:                             aws.String("Abort Incomplete Multipart Upload Rule"),
+				Status:                         aws.String("Enabled"),
+				Filter:                         &s3.LifecycleRuleFilter{Prefix: aws.String("")},
+				AbortIncompleteMultipartUpload: &s3.AbortIncompleteMultipartUpload{DaysAfterInitiation: days},
+			},
+		},
+	}
+}
+
+// minioAPIShim is a decorator around s3APIShim that intercepts invocations of the
+// EnforceBucketLifecycle method. There is a protocol mismatch between the
+// AWS SDK and MinIO, which we distribute as an embedded object store.
+//
+// Instead of nerfing this function in GCS and S3 (where lifecycles are respected),
+// we change the behavior only for the MinIO backend. Instead of pushing a lifecycle
+// configuration to the bucket, we'll periodically scan through the files in the
+// target bucket and delete those older than the threshold age.
+type minioAPIShim struct{ s3APIShim }
+
+// EnforceBucketLifecycle starts two goroutines that communicate via a shared channel. The
+// writer goroutine periodically scans the target bucket for objects older than the given
+// max age, then writes matching keys to the channel. The reader goroutine will delete each
+// key as it is written.
+func (s *minioAPIShim) EnforceBucketLifecycle(ctx context.Context, bucket string, ttl time.Duration) error {
+	// Small buffer allows us to deal with short "bursts" of expired keys without
+	// having to synchronously delete all of the keys before the scan can end.
+	expiredKeys := make(chan *string, 128)
+
+	go func() {
+		for key := range expiredKeys {
+			if _, err := s.S3.DeleteObject(&s3.DeleteObjectInput{Bucket: aws.String(bucket), Key: key}); err != nil {
+				log15.Error("Failed to delete expired upload file", "error", err, "bucket", bucket, "key", *key)
+			}
+		}
+	}()
+
+	go func() {
+		defer close(expiredKeys)
+
+		for {
+			pager := func(output *s3.ListObjectsOutput, lastPage bool) bool {
+				for _, object := range output.Contents {
+					if object.LastModified != nil && object.LastModified.Before(time.Now().Add(-ttl)) {
+						expiredKeys <- object.Key
+					} else {
+					}
+				}
+
+				return true
+			}
+
+			if err := s.S3.ListObjectsPages(&s3.ListObjectsInput{Bucket: aws.String(bucket)}, pager); err != nil {
+				log15.Error("Failed to list upload files to check expiry", "error", err, "bucket", bucket)
+			}
+
+			// Wait 30 +/- 5 minutes between scans of the object store. Expiration is
+			// on the matter of days, so there's no reason to this very frequently.
+			<-time.After(time.Minute*30 + time.Duration(rand.Intn(600)-300)*time.Second)
+		}
+	}()
+
+	return nil
 }

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_api_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_api_test.go
@@ -1,0 +1,40 @@
+package uploadstore
+
+import (
+	"testing"
+	"time"
+)
+
+func TestS3Lifecycle(t *testing.T) {
+	if lifecycle := lifecycle(time.Hour * 24 * 3); lifecycle == nil || len(lifecycle.Rules) != 2 {
+		t.Fatalf("unexpected lifecycle rules")
+	} else {
+		var objectExpiration *int64
+		for _, rule := range lifecycle.Rules {
+			if rule.Expiration != nil {
+				if value := rule.Expiration.Days; value != nil {
+					objectExpiration = value
+				}
+			}
+		}
+		if objectExpiration == nil {
+			t.Fatalf("expected object expiration to be configured")
+		} else if *objectExpiration != 3 {
+			t.Errorf("unexpected ttl for object expiration. want=%d have=%d", 3, *objectExpiration)
+		}
+
+		var multipartExpiration *int64
+		for _, rule := range lifecycle.Rules {
+			if rule.AbortIncompleteMultipartUpload != nil {
+				if value := rule.AbortIncompleteMultipartUpload.DaysAfterInitiation; value != nil {
+					multipartExpiration = value
+				}
+			}
+		}
+		if multipartExpiration == nil {
+			t.Fatalf("expected multipart upload expiration to be configured")
+		} else if *multipartExpiration != 3 {
+			t.Errorf("unexpected ttl for multipart upload expiration. want=%d have=%d", 3, *multipartExpiration)
+		}
+	}
+}

--- a/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
+++ b/enterprise/internal/codeintel/stores/uploadstore/s3_client_test.go
@@ -35,9 +35,9 @@ func TestS3Init(t *testing.T) {
 		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 	}
 
-	if calls := s3Client.PutBucketLifecycleConfigurationFunc.History(); len(calls) != 1 {
-		t.Fatalf("unexpected number of PutBucketLifecycleConfiguration calls. want=%d have=%d", 1, len(calls))
-	} else if value := *calls[0].Arg1.Bucket; value != "test-bucket" {
+	if calls := s3Client.EnforceBucketLifecycleFunc.History(); len(calls) != 1 {
+		t.Fatalf("unexpected number of EnforceBucketLifecycle calls. want=%d have=%d", 1, len(calls))
+	} else if value := calls[0].Arg1; value != "test-bucket" {
 		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 	}
 }
@@ -58,9 +58,9 @@ func TestS3InitBucketExists(t *testing.T) {
 			t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 		}
 
-		if calls := s3Client.PutBucketLifecycleConfigurationFunc.History(); len(calls) != 1 {
-			t.Fatalf("unexpected number of PutBucketLifecycleConfiguration calls. want=%d have=%d", 1, len(calls))
-		} else if value := *calls[0].Arg1.Bucket; value != "test-bucket" {
+		if calls := s3Client.EnforceBucketLifecycleFunc.History(); len(calls) != 1 {
+			t.Fatalf("unexpected number of EnforceBucketLifecycle calls. want=%d have=%d", 1, len(calls))
+		} else if value := calls[0].Arg1; value != "test-bucket" {
 			t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 		}
 	}
@@ -76,8 +76,8 @@ func TestS3UnmanagedInit(t *testing.T) {
 	if calls := s3Client.CreateBucketFunc.History(); len(calls) != 0 {
 		t.Fatalf("unexpected number of CreateBucket calls. want=%d have=%d", 0, len(calls))
 	}
-	if calls := s3Client.PutBucketLifecycleConfigurationFunc.History(); len(calls) != 0 {
-		t.Fatalf("unexpected number of PutBucketLifecycleConfiguration calls. want=%d have=%d", 0, len(calls))
+	if calls := s3Client.EnforceBucketLifecycleFunc.History(); len(calls) != 0 {
+		t.Fatalf("unexpected number of EnforceBucketLifecycle calls. want=%d have=%d", 0, len(calls))
 	}
 }
 
@@ -378,43 +378,6 @@ func TestS3Delete(t *testing.T) {
 		t.Errorf("unexpected bucket argument. want=%s have=%s", "test-bucket", value)
 	} else if value := *calls[0].Arg1.Key; value != "test-key" {
 		t.Errorf("unexpected key argument. want=%s have=%s", "test-key", value)
-	}
-}
-
-func TestS3Lifecycle(t *testing.T) {
-	s3Client := NewMockS3API()
-	client := rawS3Client(s3Client, nil)
-
-	if lifecycle := client.lifecycle(); lifecycle == nil || len(lifecycle.Rules) != 2 {
-		t.Fatalf("unexpected lifecycle rules")
-	} else {
-		var objectExpiration *int64
-		for _, rule := range lifecycle.Rules {
-			if rule.Expiration != nil {
-				if value := rule.Expiration.Days; value != nil {
-					objectExpiration = value
-				}
-			}
-		}
-		if objectExpiration == nil {
-			t.Fatalf("expected object expiration to be configured")
-		} else if *objectExpiration != 3 {
-			t.Errorf("unexpected ttl for object expiration. want=%d have=%d", 3, *objectExpiration)
-		}
-
-		var multipartExpiration *int64
-		for _, rule := range lifecycle.Rules {
-			if rule.AbortIncompleteMultipartUpload != nil {
-				if value := rule.AbortIncompleteMultipartUpload.DaysAfterInitiation; value != nil {
-					multipartExpiration = value
-				}
-			}
-		}
-		if multipartExpiration == nil {
-			t.Fatalf("expected multipart upload expiration to be configured")
-		} else if *multipartExpiration != 3 {
-			t.Errorf("unexpected ttl for multipart upload expiration. want=%d have=%d", 3, *multipartExpiration)
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/19729.

Changes in behavior:

- No changes to (externally configured) S3 or GCS buckets. We can continue to use those lifecycle configuration endpoints and they will work just fine.
- If MinIO is configured, then we don't send a lifecycle configuration update request (it ignores it). Instead, we'll periodically scan the store for expired objects and delete them.

Changes in code:

- If MinIO is configured, we wrap the existing S3 API in a decorator that switches behavior of `PutBucketLifecycleConfiguration`
- The default (externally configured S3) behavior that configure the bucket's lifecycle configuration has moved from the "client" layer (that has application behavior) to the "api" layer (that has backend S3/GCS-specific behavior)
- The decorated lifecycle configuration method (new) starts two goroutines to periodically read and delete expired objects concurrently. This will periodically re-scan the object store every 30 minutes (+/-5 minutes so concurrent scans are less likely). I don't see a need to configure this.