### PR TITLE
There is more to ratelimits than meets the eye

### DIFF
--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -42,7 +42,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 7200,
           "minimum": 0

--- a/schema/bitbucket_cloud.schema.json
+++ b/schema/bitbucket_cloud.schema.json
@@ -42,7 +42,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 7200,
           "minimum": 0

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -34,7 +34,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 28800,
           "minimum": 0

--- a/schema/bitbucket_server.schema.json
+++ b/schema/bitbucket_server.schema.json
@@ -34,7 +34,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 28800,
           "minimum": 0

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -42,7 +42,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 5000,
           "minimum": 0

--- a/schema/github.schema.json
+++ b/schema/github.schema.json
@@ -42,7 +42,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 5000,
           "minimum": 0

--- a/schema/gitlab.schema.json
+++ b/schema/gitlab.schema.json
@@ -42,7 +42,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 36000,
           "minimum": 0

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -46,7 +46,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 5000,
           "minimum": 0

--- a/schema/perforce.schema.json
+++ b/schema/perforce.schema.json
@@ -46,7 +46,7 @@
           "default": true
         },
         "requestsPerHour": {
-          "description": "Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
+          "description": "Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.",
           "type": "number",
           "default": 5000,
           "minimum": 0

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -187,7 +187,7 @@ type BitbucketCloudConnection struct {
 type BitbucketCloudRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
@@ -305,7 +305,7 @@ type BitbucketServerPluginWebhooks struct {
 type BitbucketServerRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type BitbucketServerUsernameIdentity struct {
@@ -640,7 +640,7 @@ type GitHubConnection struct {
 type GitHubRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type GitHubWebhook struct {
@@ -1064,7 +1064,7 @@ type PerforceConnection struct {
 type PerforceRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally, the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -187,7 +187,7 @@ type BitbucketCloudConnection struct {
 type BitbucketCloudRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 
@@ -305,7 +305,7 @@ type BitbucketServerPluginWebhooks struct {
 type BitbucketServerRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 500, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 500 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type BitbucketServerUsernameIdentity struct {
@@ -640,7 +640,7 @@ type GitHubConnection struct {
 type GitHubRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type GitHubWebhook struct {
@@ -730,7 +730,7 @@ type GitLabProject struct {
 type GitLabRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 type GitLabWebhook struct {
@@ -1064,7 +1064,7 @@ type PerforceConnection struct {
 type PerforceRateLimit struct {
 	// Enabled description: true if rate limiting is enabled.
 	Enabled bool `json:"enabled"`
-	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second.
+	// RequestsPerHour description: Requests per hour permitted. This is an average, calculated per second. Internally the burst limit is set to 100, which implies that for a requests per hour limit as low as 1, users will continue to be able to send a maximum of 100 requests immediately, provided that the complexity cost of each request is 1.
 	RequestsPerHour float64 `json:"requestsPerHour"`
 }
 


### PR DESCRIPTION
We should explain the concept behind bursts and how beyond a certain minimum rate limit, any values will default to at least the value as same as the burst configured for that rate limiter. Here's how the docs popup would look like with this change:

![s_2021-04-08_174916](https://user-images.githubusercontent.com/2682729/114026573-04eaa380-9894-11eb-8a0e-bcdb9c228ef2.png)
