### PR TITLE
zoekt: use new scheduler in development

### DIFF
--- a/dev/zoekt/wrapper
+++ b/dev/zoekt/wrapper
@@ -18,6 +18,10 @@ indexport=$((6072 + replica))
 # - https://github.com/sourcegraph/infrastructure/blob/d67cfdaf7760b926df165745e40f7bd9507d1c20/docker-images/zoekt-webserver/Dockerfile#L27-L34
 export GOGC=50
 
+# Test the new scheduler in dev. This can be removed once it is enabled by
+# default. https://github.com/sourcegraph/sourcegraph/issues/18305
+export ZOEKTSCHED="enable=1"
+
 case "$cmd" in
 
 indexserver)

--- a/go.mod
+++ b/go.mod
@@ -210,7 +210,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210331193324-a205a2a1541e
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210408131625-4c31790ba985
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1287,6 +1287,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20210331193324-a205a2a1541e h1:5WeGHlTvOnObKOQhCTL06rpr5/dcLWJdC7vACUlrHI8=
 github.com/sourcegraph/zoekt v0.0.0-20210331193324-a205a2a1541e/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
+github.com/sourcegraph/zoekt v0.0.0-20210408131625-4c31790ba985 h1:MJBKRPWuavG2QHchVNO1lNjV3gXw29DGKX682f1jOM0=
+github.com/sourcegraph/zoekt v0.0.0-20210408131625-4c31790ba985/go.mod h1:1Uv3ThqJ+VWQQS1qFIzufLA8jkQ6a+FDk3OFI6qPZVQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
This commit bumps the version of zoekt to include one new PR: https://github.com/sourcegraph/zoekt/pull/74 shards: introduce a scheduler abstraction.

We enable this scheduler in development mode.

Part of https://github.com/sourcegraph/sourcegraph/issues/18305