### PR TITLE
search contexts: resolve namespaced contexts

### DIFF
--- a/cmd/frontend/internal/search/searchcontexts/search_contexts.go
+++ b/cmd/frontend/internal/search/searchcontexts/search_contexts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -20,12 +21,12 @@ const (
 	searchContextSpecPrefix = "@"
 )
 
-var namespacedSearchContextSpecRegexp = regexp.MustCompile(searchContextSpecPrefix + `(.*?)\/(.*)`)
+var namespacedSearchContextSpecRegexp = lazyregexp.New(searchContextSpecPrefix + `(.*?)\/(.*)`)
 
 func ResolveSearchContextSpec(ctx context.Context, db dbutil.DB, searchContextSpec string) (*types.SearchContext, error) {
 	if IsGlobalSearchContextSpec(searchContextSpec) {
 		return GetGlobalSearchContext(), nil
-	} else if submatches := namespacedSearchContextSpecRegexp.FindStringSubmatch(searchContextSpec); len(submatches) == 3 {
+	} else if submatches := namespacedSearchContextSpecRegexp.FindStringSubmatch(searchContextSpec); submatches != nil {
 		// We expect 3 submatches, because FindStringSubmatch returns entire string as first submatch, and 2 captured groups
 		// as additional submatches
 		namespaceName, searchContextName := submatches[1], submatches[2]

--- a/cmd/frontend/internal/search/searchcontexts/search_contexts.go
+++ b/cmd/frontend/internal/search/searchcontexts/search_contexts.go
@@ -20,19 +20,34 @@ const (
 	searchContextSpecPrefix = "@"
 )
 
+var namespacedSearchContextSpecRegexp = regexp.MustCompile(searchContextSpecPrefix + `(.*?)\/(.*)`)
+
 func ResolveSearchContextSpec(ctx context.Context, db dbutil.DB, searchContextSpec string) (*types.SearchContext, error) {
 	if IsGlobalSearchContextSpec(searchContextSpec) {
 		return GetGlobalSearchContext(), nil
+	} else if submatches := namespacedSearchContextSpecRegexp.FindStringSubmatch(searchContextSpec); len(submatches) == 3 {
+		// We expect 3 submatches, because FindStringSubmatch returns entire string as first submatch, and 2 captured groups
+		// as additional submatches
+		namespaceName, searchContextName := submatches[1], submatches[2]
+		namespace, err := database.Namespaces(db).GetByName(ctx, namespaceName)
+		if err != nil {
+			return nil, err
+		}
+		return database.SearchContexts(db).GetSearchContext(ctx, database.GetSearchContextOptions{
+			Name:            searchContextName,
+			NamespaceUserID: namespace.User,
+			NamespaceOrgID:  namespace.Organization,
+		})
 	} else if strings.HasPrefix(searchContextSpec, searchContextSpecPrefix) {
-		name := searchContextSpec[1:]
-		namespace, err := database.Namespaces(db).GetByName(ctx, name)
+		namespaceName := searchContextSpec[1:]
+		namespace, err := database.Namespaces(db).GetByName(ctx, namespaceName)
 		if err != nil {
 			return nil, err
 		}
 		if namespace.User == 0 {
 			return nil, fmt.Errorf("search context '%s' not found", searchContextSpec)
 		}
-		return GetUserSearchContext(name, namespace.User), nil
+		return GetUserSearchContext(namespaceName, namespace.User), nil
 	}
 	// Check if instance-level context
 	searchContext, err := database.SearchContexts(db).GetSearchContext(ctx, database.GetSearchContextOptions{Name: searchContextSpec})
@@ -112,8 +127,17 @@ func GetGlobalSearchContext() *types.SearchContext {
 func GetSearchContextSpec(searchContext *types.SearchContext) string {
 	if IsInstanceLevelSearchContext(searchContext) {
 		return searchContext.Name
+	} else if IsAutoDefinedSearchContext(searchContext) {
+		return searchContextSpecPrefix + searchContext.Name
+	} else {
+		var namespaceName string
+		if searchContext.NamespaceUserName != "" {
+			namespaceName = searchContext.NamespaceUserName
+		} else {
+			namespaceName = searchContext.NamespaceOrgName
+		}
+		return searchContextSpecPrefix + namespaceName + "/" + searchContext.Name
 	}
-	return searchContextSpecPrefix + searchContext.Name
 }
 
 func getVersionContextRepositoryRevisions(ctx context.Context, db dbutil.DB, versionContext *schema.VersionContext) ([]*types.SearchContextRepositoryRevisions, error) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1500,6 +1500,13 @@ type SearchContext struct {
 	Public          bool
 	NamespaceUserID int32 // if non-zero, the owner is this user. NamespaceUserID/NamespaceOrgID are mutually exclusive.
 	NamespaceOrgID  int32 // if non-zero, the owner is this organization. NamespaceUserID/NamespaceOrgID are mutually exclusive.
+
+	// We cache namespace names to avoid separate database lookups when constructing the search context spec
+
+	// NamespaceUserName is the name of the user if NamespaceUserID is present.
+	NamespaceUserName string
+	// NamespaceUserName is the name of the org if NamespaceOrgID is present.
+	NamespaceOrgName string
 }
 
 // SearchContextRepositoryRevisions is a simple wrapper for a repository and its revisions


### PR DESCRIPTION
Added support for resolving namespaced contexts: `@user/context`, `@org/context`, etc.

To avoid overloading the DB when constructing search context specs (e.g. when listing search contexts), I also cache the namespace names (username and org name) in the struct.