### PR TITLE
codeintel: Refactor data migrator

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/config.go
+++ b/enterprise/cmd/frontend/internal/codeintel/config.go
@@ -10,23 +10,27 @@ import (
 type Config struct {
 	env.BaseConfig
 
-	UploadStoreConfig                     *uploadstore.Config
-	CommitGraphUpdateTaskInterval         time.Duration
-	CleanupTaskInterval                   time.Duration
-	AutoIndexingTaskInterval              time.Duration
-	AutoIndexingSkipManualInterval        time.Duration
-	HunkCacheSize                         int
-	DataTTL                               time.Duration
-	UploadTimeout                         time.Duration
-	IndexBatchSize                        int
-	MinimumTimeSinceLastEnqueue           time.Duration
-	MinimumSearchCount                    int
-	MinimumSearchRatio                    int
-	MinimumPreciseCount                   int
-	DiagnosticsCountMigrationBatchSize    int
-	DefinitionsCountMigrationBatchSize    int
-	ReferencesCountMigrationBatchSize     int
-	DocumentColumnSplitMigrationBatchSize int
+	UploadStoreConfig                         *uploadstore.Config
+	CommitGraphUpdateTaskInterval             time.Duration
+	CleanupTaskInterval                       time.Duration
+	AutoIndexingTaskInterval                  time.Duration
+	AutoIndexingSkipManualInterval            time.Duration
+	HunkCacheSize                             int
+	DataTTL                                   time.Duration
+	UploadTimeout                             time.Duration
+	IndexBatchSize                            int
+	MinimumTimeSinceLastEnqueue               time.Duration
+	MinimumSearchCount                        int
+	MinimumSearchRatio                        int
+	MinimumPreciseCount                       int
+	DiagnosticsCountMigrationBatchSize        int
+	DiagnosticsCountMigrationBatchInterval    time.Duration
+	DefinitionsCountMigrationBatchSize        int
+	DefinitionsCountMigrationBatchInterval    time.Duration
+	ReferencesCountMigrationBatchSize         int
+	ReferencesCountMigrationBatchInterval     time.Duration
+	DocumentColumnSplitMigrationBatchSize     int
+	DocumentColumnSplitMigrationBatchInterval time.Duration
 }
 
 var config = &Config{}
@@ -48,8 +52,12 @@ func init() {
 	config.MinimumSearchCount = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_SEARCH_COUNT", "50", "The minimum number of search-based code intel events that triggers auto-indexing on a repository.")
 	config.MinimumSearchRatio = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_SEARCH_RATIO", "50", "The minimum ratio of search-based to total code intel events that triggers auto-indexing on a repository.")
 	config.MinimumPreciseCount = config.GetInt("PRECISE_CODE_INTEL_MINIMUM_PRECISE_COUNT", "1", "The minimum number of precise code intel events that triggers auto-indexing on a repository.")
-	config.DiagnosticsCountMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_DIAGNOSTICS_COUNT_MIGRATION_BATCH_SIZE", "1000", "The number of document records to migrate per second.")
-	config.DefinitionsCountMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_DEFINITIONS_COUNT_MIGRATION_BATCH_SIZE", "1000", "The number of definition records to migrate per second.")
-	config.ReferencesCountMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_REFERENCES_COUNT_MIGRATION_BATCH_SIZE", "1000", "The number of reference records to migrate per second.")
-	config.DocumentColumnSplitMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_DOCUMENT_COLUMN_SPLIT_MIGRATION_BATCH_SIZE", "100", "The number of document records to migrate per second.")
+	config.DiagnosticsCountMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_DIAGNOSTICS_COUNT_MIGRATION_BATCH_SIZE", "1000", "The maximum number of document records to migrate at a time.")
+	config.DiagnosticsCountMigrationBatchInterval = config.GetInterval("PRECISE_CODE_INTEL_DIAGNOSTICS_COUNT_MIGRATION_MIGRATION_BATCH_INTERVAL", "1s", "The timeout between processing migration batches.")
+	config.DefinitionsCountMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_DEFINITIONS_COUNT_MIGRATION_BATCH_SIZE", "1000", "The maximum number of definition records to migrate at once.")
+	config.DefinitionsCountMigrationBatchInterval = config.GetInterval("PRECISE_CODE_INTEL_DEFINITIONS_COUNT_MIGRATION_MIGRATION_BATCH_INTERVAL", "1s", "The timeout between processing migration batches.")
+	config.ReferencesCountMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_REFERENCES_COUNT_MIGRATION_BATCH_SIZE", "1000", "The maximum number of reference records to migrate at a time.")
+	config.ReferencesCountMigrationBatchInterval = config.GetInterval("PRECISE_CODE_INTEL_REFERENCES_COUNT_MIGRATION_MIGRATION_BATCH_INTERVAL", "1s", "The timeout between processing migration batches.")
+	config.DocumentColumnSplitMigrationBatchSize = config.GetInt("PRECISE_CODE_INTEL_DOCUMENT_COLUMN_SPLIT_MIGRATION_BATCH_SIZE", "100", "The maximum number of document records to migrate at a time.")
+	config.DocumentColumnSplitMigrationBatchInterval = config.GetInterval("PRECISE_CODE_INTEL_DOCUMENT_COLUMN_SPLIT_MIGRATION_MIGRATION_BATCH_INTERVAL", "1s", "The timeout between processing migration batches.")
 }

--- a/enterprise/cmd/frontend/internal/codeintel/migrations.go
+++ b/enterprise/cmd/frontend/internal/codeintel/migrations.go
@@ -2,7 +2,6 @@ package codeintel
 
 import (
 	"context"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore/migration"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -12,17 +11,36 @@ import (
 // registerMigrations registers all out-of-band migration instances that should run for
 // the current version of Sourcegraph.
 func registerMigrations(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner) error {
-	migrators := map[int]oobmigration.Migrator{
-		migration.DiagnosticsCountMigrationID:    migration.NewDiagnosticsCountMigrator(services.lsifStore, config.DiagnosticsCountMigrationBatchSize),
-		migration.DefinitionsCountMigrationID:    migration.NewLocationsCountMigrator(services.lsifStore, "lsif_data_definitions", config.DefinitionsCountMigrationBatchSize),
-		migration.ReferencesCountMigrationID:     migration.NewLocationsCountMigrator(services.lsifStore, "lsif_data_references", config.ReferencesCountMigrationBatchSize),
-		migration.DocumentColumnSplitMigrationID: migration.NewDocumentColumnSplitMigrator(services.lsifStore, config.DocumentColumnSplitMigrationBatchSize),
+	if err := outOfBandMigrationRunner.Register(
+		migration.DiagnosticsCountMigrationID, // 1
+		migration.NewDiagnosticsCountMigrator(services.lsifStore, config.DiagnosticsCountMigrationBatchSize),
+		oobmigration.MigratorOptions{Interval: config.DiagnosticsCountMigrationBatchInterval},
+	); err != nil {
+		return err
 	}
 
-	for id, migrator := range migrators {
-		if err := outOfBandMigrationRunner.Register(id, migrator, oobmigration.MigratorOptions{Interval: time.Second}); err != nil {
-			return err
-		}
+	if err := outOfBandMigrationRunner.Register(
+		migration.DefinitionsCountMigrationID, // 4
+		migration.NewLocationsCountMigrator(services.lsifStore, "lsif_data_definitions", config.DefinitionsCountMigrationBatchSize),
+		oobmigration.MigratorOptions{Interval: config.DefinitionsCountMigrationBatchInterval},
+	); err != nil {
+		return err
+	}
+
+	if err := outOfBandMigrationRunner.Register(
+		migration.ReferencesCountMigrationID, // 5
+		migration.NewLocationsCountMigrator(services.lsifStore, "lsif_data_references", config.ReferencesCountMigrationBatchSize),
+		oobmigration.MigratorOptions{Interval: config.ReferencesCountMigrationBatchInterval},
+	); err != nil {
+		return err
+	}
+
+	if err := outOfBandMigrationRunner.Register(
+		migration.DocumentColumnSplitMigrationID, // 7
+		migration.NewDocumentColumnSplitMigrator(services.lsifStore, config.DocumentColumnSplitMigrationBatchSize),
+		oobmigration.MigratorOptions{Interval: config.DocumentColumnSplitMigrationBatchInterval},
+	); err != nil {
+		return err
 	}
 
 	return nil

--- a/enterprise/internal/codeintel/stores/lsifstore/migration/migrator_test.go
+++ b/enterprise/internal/codeintel/stores/lsifstore/migration/migrator_test.go
@@ -1,0 +1,142 @@
+package migration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+)
+
+func TestMigratorRemovesBoundsWithoutData(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	dbtesting.SetupGlobalTestDB(t)
+	store := lsifstore.NewStore(dbconn.Global, &observation.TestContext)
+	driver := &testMigrationDriver{}
+	migrator := newMigrator(store, driver, migratorOptions{
+		tableName:     "t_test",
+		targetVersion: 2,
+		batchSize:     200,
+		fields: []fieldSpec{
+			{name: "a", postgresType: "integer not null", primaryKey: true},
+			{name: "b", postgresType: "integer not null", readOnly: true},
+			{name: "c", postgresType: "integer not null"},
+		},
+	})
+
+	assertProgress := func(expectedProgress float64) {
+		if progress, err := migrator.Progress(context.Background()); err != nil {
+			t.Fatalf("unexpected error querying progress: %s", err)
+		} else if progress != expectedProgress {
+			t.Errorf("unexpected progress. want=%.2f have=%.2f", expectedProgress, progress)
+		}
+	}
+
+	if err := store.Store.Exec(context.Background(), sqlf.Sprintf(`
+		CREATE TABLE t_test (
+			dump_id        integer not null,
+			a              integer not null,
+			b              integer not null,
+			c              integer not null,
+			schema_version integer not null,
+			primary key (dump_id, a)
+		)
+	`)); err != nil {
+		t.Fatalf("unexpected error creating data table: %s", err)
+	}
+
+	if err := store.Store.Exec(context.Background(), sqlf.Sprintf(`
+		CREATE TABLE t_test_schema_versions (
+				dump_id            integer primary key not null,
+				min_schema_version integer not null,
+				max_schema_version integer not null
+		)
+	`)); err != nil {
+		t.Fatalf("unexpected error creating schema version table: %s", err)
+	}
+
+	n := 600
+
+	for i := 0; i < n; i++ {
+		// 33% id=42, 33% id=43, 33% id=44
+		dumpID := 42 + i/(n/3)
+
+		if err := store.Exec(context.Background(), sqlf.Sprintf(
+			"INSERT INTO t_test (dump_id, a, b, c, schema_version) VALUES (%s, %s, %s, %s, 1)",
+			dumpID,
+			i,
+			i*10,
+			i*100,
+		)); err != nil {
+			t.Fatalf("unexpected error inserting data row: %s", err)
+		}
+	}
+
+	// 42 is missing; 45 is extra
+	for _, dumpID := range []int{43, 44, 45} {
+		if err := store.Exec(context.Background(), sqlf.Sprintf(
+			"INSERT INTO t_test_schema_versions (dump_id, min_schema_version, max_schema_version) VALUES (%s, 1, 1)",
+			dumpID,
+		)); err != nil {
+			t.Fatalf("unexpected error inserting schema version row: %s", err)
+		}
+	}
+
+	assertProgress(0)
+
+	// process dump 43 (updates bounds)
+	if err := migrator.Up(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing up migration: %s", err)
+	}
+	assertProgress(1.0 / 3.0)
+
+	// process dump 44 (updates bounds)
+	if err := migrator.Up(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing up migration: %s", err)
+	}
+	assertProgress(2.0 / 3.0)
+
+	// process dump 45 (deletes schema version record with no data)
+	if err := migrator.Up(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing up migration: %s", err)
+	}
+	assertProgress(1.0)
+
+	// reverse migration of first of remaining two dumps
+	if err := migrator.Down(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing down migration: %s", err)
+	}
+	assertProgress(0.5)
+
+	// reverse migration of second of remaining two dumps
+	if err := migrator.Down(context.Background()); err != nil {
+		t.Fatalf("unexpected error performing down migration: %s", err)
+	}
+	assertProgress(0.0)
+}
+
+type testMigrationDriver struct{}
+
+func (m *testMigrationDriver) MigrateRowUp(scanner scanner) ([]interface{}, error) {
+	var a, b, c int
+	if err := scanner.Scan(&a, &b, &c); err != nil {
+		return nil, err
+	}
+
+	return []interface{}{a, b + c}, nil
+}
+
+func (m *testMigrationDriver) MigrateRowDown(scanner scanner) ([]interface{}, error) {
+	var a, b, c int
+	if err := scanner.Scan(&a, &b, &c); err != nil {
+		return nil, err
+	}
+
+	return []interface{}{a, b - c}, nil
+}

--- a/internal/database/schema.codeintel.md
+++ b/internal/database/schema.codeintel.md
@@ -56,6 +56,7 @@ Associates (document, range) pairs with the import monikers attached to the rang
  max_schema_version | integer |           |          | 
 Indexes:
     "lsif_data_definitions_schema_versions_pkey" PRIMARY KEY, btree (dump_id)
+    "lsif_data_definitions_schema_versions_dump_id_schema_version_bo" btree (dump_id, min_schema_version, max_schema_version)
 
 ```
 
@@ -120,6 +121,7 @@ Stores reference, hover text, moniker, and diagnostic data about a particular te
  max_schema_version | integer |           |          | 
 Indexes:
     "lsif_data_documents_schema_versions_pkey" PRIMARY KEY, btree (dump_id)
+    "lsif_data_documents_schema_versions_dump_id_schema_version_boun" btree (dump_id, min_schema_version, max_schema_version)
 
 ```
 
@@ -189,6 +191,7 @@ Associates (document, range) pairs with the export monikers attached to the rang
  max_schema_version | integer |           |          | 
 Indexes:
     "lsif_data_references_schema_versions_pkey" PRIMARY KEY, btree (dump_id)
+    "lsif_data_references_schema_versions_dump_id_schema_version_bou" btree (dump_id, min_schema_version, max_schema_version)
 
 ```
 

--- a/internal/oobmigration/runner.go
+++ b/internal/oobmigration/runner.go
@@ -244,6 +244,8 @@ func runMigrationFunction(ctx context.Context, store storeIface, migration *Migr
 	}
 
 	if migrationErr := migrationFunc(ctx); migrationErr != nil {
+		log15.Error("Failed to perform migration", "migrationID", migration.ID, "error", migrationErr)
+
 		// Migration resulted in an error. All we'll do here is add this error to the migration's error
 		// message list. Unless _that_ write to the database fails, we'll continue along the happy path
 		// in order to update the migration, which could have made additional progress before failing.

--- a/migrations/codeintel/1000000014_schema_version_index.down.sql
+++ b/migrations/codeintel/1000000014_schema_version_index.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP INDEX IF EXISTS lsif_data_documents_schema_versions_dump_id_schema_version_bounds;
+DROP INDEX IF EXISTS lsif_data_definitions_schema_versions_dump_id_schema_version_bounds;
+DROP INDEX IF EXISTS lsif_data_references_schema_versions_dump_id_schema_version_bounds;
+
+COMMIT;

--- a/migrations/codeintel/1000000014_schema_version_index.up.sql
+++ b/migrations/codeintel/1000000014_schema_version_index.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS lsif_data_documents_schema_versions_dump_id_schema_version_bounds ON lsif_data_documents_schema_versions (dump_id, min_schema_version, max_schema_version);
+CREATE INDEX IF NOT EXISTS lsif_data_definitions_schema_versions_dump_id_schema_version_bounds ON lsif_data_definitions_schema_versions (dump_id, min_schema_version, max_schema_version);
+CREATE INDEX IF NOT EXISTS lsif_data_references_schema_versions_dump_id_schema_version_bounds ON lsif_data_references_schema_versions (dump_id, min_schema_version, max_schema_version);
+
+COMMIT;


### PR DESCRIPTION
This refactors the generic code intelligence oob migrator so that:

- The migrations themselves can be unaware of dump ids
- Can actually tell what stuff is doing (major functionality broken into functions)
- We select records whose bounds need to be updated regardless if there are migrable records (this fixes a 97% complete-now-stuck bug in cloud)
- Fixes contention issue where multiple migrators will select rows from the same dump id (now we lock schema_version records, and not the records in the data table)

Please review migrator.go's new code only (not the diff). Other file's diffs are reasonable :)