### PR TITLE
search: Fix logic for multiple repohasfile

### DIFF
--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -182,7 +182,7 @@ func matchRepos(pattern *regexp.Regexp, resolved []*search.RepositoryRevisions, 
 // reposToAdd determines which repositories should be included in the result set based on whether they fit in the subset
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
 func reposToAdd(ctx context.Context, db dbutil.DB, args *search.TextParameters, repos []*search.RepositoryRevisions) ([]*search.RepositoryRevisions, error) {
-	// matchingIds will contain the count of repohasfile patterns that matched.
+	// matchCounts will contain the count of repohasfile patterns that matched.
 	// For negations, we will explicitly set this to -1 if it matches.
 	matchCounts := make(map[api.RepoID]int)
 	if len(args.PatternInfo.FilePatternsReposMustInclude) > 0 {

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -182,7 +182,9 @@ func matchRepos(pattern *regexp.Regexp, resolved []*search.RepositoryRevisions, 
 // reposToAdd determines which repositories should be included in the result set based on whether they fit in the subset
 // of repostiories specified in the query's `repohasfile` and `-repohasfile` fields if they exist.
 func reposToAdd(ctx context.Context, db dbutil.DB, args *search.TextParameters, repos []*search.RepositoryRevisions) ([]*search.RepositoryRevisions, error) {
-	matchingIDs := make(map[api.RepoID]bool)
+	// matchingIds will contain the count of repohasfile patterns that matched.
+	// For negations, we will explicitly set this to -1 if it matches.
+	matchCounts := make(map[api.RepoID]int)
 	if len(args.PatternInfo.FilePatternsReposMustInclude) > 0 {
 		for _, pattern := range args.PatternInfo.FilePatternsReposMustInclude {
 			// The high FileMatchLimit here is to make sure we get all the repo matches we can. Setting it to
@@ -202,14 +204,22 @@ func reposToAdd(ctx context.Context, db dbutil.DB, args *search.TextParameters, 
 			if err != nil {
 				return nil, err
 			}
+
+			// deduplicate repo results
+			matchedIDs := make(map[api.RepoID]struct{})
 			for _, m := range matches {
-				matchingIDs[m.Repo.ID] = true
+				matchedIDs[m.Repo.ID] = struct{}{}
+			}
+
+			// increment the count for all seen repos
+			for id := range matchedIDs {
+				matchCounts[id] += 1
 			}
 		}
 	} else {
 		// Default to including all the repos, then excluding some of them below.
 		for _, r := range repos {
-			matchingIDs[r.Repo.ID] = true
+			matchCounts[r.Repo.ID] = 0
 		}
 	}
 
@@ -231,14 +241,14 @@ func reposToAdd(ctx context.Context, db dbutil.DB, args *search.TextParameters, 
 				return nil, err
 			}
 			for _, m := range matches {
-				matchingIDs[m.Repo.ID] = false
+				matchCounts[m.Repo.ID] = -1
 			}
 		}
 	}
 
 	var rsta []*search.RepositoryRevisions
 	for _, r := range repos {
-		if matchingIDs[r.Repo.ID] {
+		if count, ok := matchCounts[r.Repo.ID]; ok && count == len(args.PatternInfo.FilePatternsReposMustInclude) {
 			rsta = append(rsta, r)
 		}
 	}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -273,6 +273,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query: "repohasfile:README",
 			},
 			{
+				name:       "multiple repohasfile returns no results if one doesn't match",
+				query:      "repohasfile:README repohasfile:thisfiledoesnotexist_1571751",
+				zeroResult: true,
+			},
+			{
 				name:  "repo search by name, nonzero result",
 				query: "repo:go-diff$",
 			},

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -967,6 +967,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 1},
 			},
 			{
+				name:   `and-expression on repo:contains`,
+				query:  `repo:contains(content:does-not-exist-D2E1E74C7279) and repo:contains(content:nextFileFirstLine)`,
+				counts: counts{Repo: 0},
+			},
+			{
 				name:   `repo contains file then search common`,
 				query:  `repo:contains(file:go.mod) count:100 fmt`,
 				counts: counts{Content: 61},


### PR DESCRIPTION
When multiple `repohasfile` parameters are set, we weren't checking that
all matched, only that at least one of them matched.

Fixes https://github.com/sourcegraph/sourcegraph/issues/11865
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
