### PR TITLE
database: drop mgmt_password columns

### DIFF
--- a/internal/database/globalstatedb/globalstatedb.go
+++ b/internal/database/globalstatedb/globalstatedb.go
@@ -113,14 +113,10 @@ func tryInsertNew(ctx context.Context, dbh execDatabaseHandler) error {
 	err = dbh.Exec(ctx, sqlf.Sprintf(`
 	INSERT INTO global_state(
 		site_id,
-		initialized,
-		mgmt_password_plaintext,
-		mgmt_password_bcrypt
+		initialized
 	) values(
 		%s,
-		EXISTS (SELECT 1 FROM users WHERE deleted_at IS NULL),
-		(SELECT COALESCE((SELECT mgmt_password_plaintext FROM global_state LIMIT 1), '')),
-		(SELECT COALESCE((SELECT mgmt_password_bcrypt FROM global_state LIMIT 1), ''))
+		EXISTS (SELECT 1 FROM users WHERE deleted_at IS NULL)
 	);`, siteID))
 	if err != nil {
 		if pgErr, ok := err.(*pgconn.PgError); ok {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -607,12 +607,10 @@ Foreign-key constraints:
 
 # Table "public.global_state"
 ```
-         Column          |  Type   | Collation | Nullable | Default  
--------------------------+---------+-----------+----------+----------
- site_id                 | uuid    |           | not null | 
- initialized             | boolean |           | not null | false
- mgmt_password_plaintext | text    |           | not null | ''::text
- mgmt_password_bcrypt    | text    |           | not null | ''::text
+   Column    |  Type   | Collation | Nullable | Default 
+-------------+---------+-----------+----------+---------
+ site_id     | uuid    |           | not null | 
+ initialized | boolean |           | not null | false
 Indexes:
     "global_state_pkey" PRIMARY KEY, btree (site_id)
 

--- a/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.down.sql
+++ b/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE global_state
+ADD COLUMN IF NOT EXISTS mgmt_password_plaintext TEXT NOT NULL DEFAULT '',
+ADD COLUMN IF NOT EXISTS mgmt_password_bcrypt TEXT NOT NULL DEFAULT '';
+
+COMMIT;

--- a/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.up.sql
+++ b/migrations/frontend/1528395812_drop_global_state_mgmt_password_columns.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE global_state
+DROP COLUMN IF EXISTS mgmt_password_plaintext,
+DROP COLUMN IF EXISTS mgmt_password_bcrypt;
+
+COMMIT;


### PR DESCRIPTION
We have deleted management console long time ago, clean up unused columns.