### PR TITLE
debugserver: Add /healthz and /ready endpoints

### DIFF
--- a/cmd/github-proxy/github-proxy.go
+++ b/cmd/github-proxy/github-proxy.go
@@ -67,7 +67,10 @@ func main() {
 		os.Exit(0)
 	}()
 
-	go debugserver.Start()
+	// Ready immediately
+	ready := make(chan struct{})
+	close(ready)
+	go debugserver.NewServerRoutine(ready).Start()
 
 	// Use a custom client/transport because GitHub closes keep-alive
 	// connections after 60s. In order to avoid running into EOF errors, we use

--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -138,7 +138,10 @@ func main() {
 	// Create Handler now since it also initializes state
 	handler := ot.Middleware(gitserver.Handler())
 
-	go debugserver.Start()
+	// Ready immediately
+	ready := make(chan struct{})
+	close(ready)
+	go debugserver.NewServerRoutine(ready).Start()
 	go gitserver.Janitor(janitorInterval)
 	go gitserver.SyncRepoState(syncRepoStateInterval, syncRepoStateBatchSize, syncRepoStateUpsertPerSecond)
 

--- a/cmd/query-runner/main.go
+++ b/cmd/query-runner/main.go
@@ -46,7 +46,10 @@ func main() {
 		os.Exit(0)
 	}()
 
-	go debugserver.Start()
+	// Ready immediately
+	ready := make(chan struct{})
+	close(ready)
+	go debugserver.NewServerRoutine(ready).Start()
 
 	ctx := context.Background()
 

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -71,6 +71,40 @@ func Main(enterpriseInit EnterpriseInit) {
 	tracer.Init()
 	trace.Init(true)
 
+	// Signals health of startup
+	ready := make(chan struct{})
+
+	type LazyDebugserverEndpoint struct {
+		repoUpdaterStateEndpoint   http.HandlerFunc
+		listAuthzProvidersEndpoint http.HandlerFunc
+	}
+	debugserverEndpoints := LazyDebugserverEndpoint{}
+
+	// Start debug server
+	go debugserver.NewServerRoutine(
+		ready,
+		debugserver.Endpoint{
+			Name: "Repo Updater State",
+			Path: "/repo-updater-state",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// wait until we're healthy to respond
+				<-ready
+				// repoUpdaterStateEndpoint is guaranteed to be assigned now
+				debugserverEndpoints.repoUpdaterStateEndpoint(w, r)
+			}),
+		},
+		debugserver.Endpoint{
+			Name: "List Authz Providers",
+			Path: "/list-authz-providers",
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// wait until we're healthy to respond
+				<-ready
+				// listAuthzProvidersEndpoint is guaranteed to be assigned now
+				debugserverEndpoints.listAuthzProvidersEndpoint(w, r)
+			}),
+		},
+	).Start()
+
 	clock := func() time.Time { return time.Now().UTC() }
 
 	// Syncing relies on access to frontend and git-server, so wait until they started up.
@@ -253,96 +287,99 @@ func Main(enterpriseInit EnterpriseInit) {
 	}
 
 	globals.WatchExternalURL(nil)
-	go debugserver.Start(debugserver.Endpoint{
-		Name: "Repo Updater State",
-		Path: "/repo-updater-state",
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			dumps := []interface{}{
-				scheduler.DebugDump(r.Context(), db),
-			}
-			for _, dumper := range debugDumpers {
-				dumps = append(dumps, dumper.DebugDump())
-			}
 
-			const (
-				textPlain       = "text/plain"
-				applicationJson = "application/json"
-			)
+	debugserverEndpoints.repoUpdaterStateEndpoint = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dumps := []interface{}{
+			scheduler.DebugDump(r.Context(), db),
+		}
+		for _, dumper := range debugDumpers {
+			dumps = append(dumps, dumper.DebugDump())
+		}
 
-			// Negotiate the content type.
-			contentTypeOffers := []string{textPlain, applicationJson}
-			defaultOffer := textPlain
-			contentType := httputil.NegotiateContentType(r, contentTypeOffers, defaultOffer)
+		const (
+			textPlain       = "text/plain"
+			applicationJson = "application/json"
+		)
 
-			// Allow users to override the negotiated content type so that e.g. browser
-			// users can easily request json by adding ?format=json to
-			// the URL.
-			switch r.URL.Query().Get("format") {
-			case "json":
-				contentType = applicationJson
-			}
+		// Negotiate the content type.
+		contentTypeOffers := []string{textPlain, applicationJson}
+		defaultOffer := textPlain
+		contentType := httputil.NegotiateContentType(r, contentTypeOffers, defaultOffer)
 
-			switch contentType {
-			case applicationJson:
-				p, err := json.MarshalIndent(dumps, "", "  ")
-				if err != nil {
-					http.Error(w, "failed to marshal snapshot: "+err.Error(), http.StatusInternalServerError)
-					return
-				}
-				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write(p)
+		// Allow users to override the negotiated content type so that e.g. browser
+		// users can easily request json by adding ?format=json to
+		// the URL.
+		switch r.URL.Query().Get("format") {
+		case "json":
+			contentType = applicationJson
+		}
 
-			default:
-				// This case also applies for defaultOffer. Note that this is preferred
-				// over e.g. a 406 status code, according to the MDN:
-				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
-				tmpl := template.New("state.html").Funcs(template.FuncMap{
-					"truncateDuration": func(d time.Duration) time.Duration {
-						return d.Truncate(time.Second)
-					},
-				})
-				template.Must(tmpl.Parse(stateHTMLTemplate))
-				err := tmpl.Execute(w, dumps)
-				if err != nil {
-					http.Error(w, "failed to render template: "+err.Error(), http.StatusInternalServerError)
-					return
-				}
-			}
-		}),
-	}, debugserver.Endpoint{
-		Name: "List Authz Providers",
-		Path: "/list-authz-providers",
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			type providerInfo struct {
-				ServiceType        string `json:"service_type"`
-				ServiceID          string `json:"service_id"`
-				ExternalServiceURL string `json:"external_service_url"`
-			}
-
-			_, providers := authz.GetProviders()
-			infos := make([]providerInfo, len(providers))
-			for i, p := range providers {
-				_, id := extsvc.DecodeURN(p.URN())
-
-				// Note that the ID marshalling below replicates code found in `graphqlbackend`.
-				// We cannot import that package's code into this one (see /dev/check/go-dbconn-import.sh).
-				infos[i] = providerInfo{
-					ServiceType:        p.ServiceType(),
-					ServiceID:          p.ServiceID(),
-					ExternalServiceURL: fmt.Sprintf("%s/site-admin/external-services/%s", globals.ExternalURL(), relay.MarshalID("ExternalService", id)),
-				}
-			}
-
-			resp, err := json.MarshalIndent(infos, "", "  ")
+		switch contentType {
+		case applicationJson:
+			p, err := json.MarshalIndent(dumps, "", "  ")
 			if err != nil {
-				http.Error(w, "failed to marshal infos: "+err.Error(), http.StatusInternalServerError)
+				http.Error(w, "failed to marshal snapshot: "+err.Error(), http.StatusInternalServerError)
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write(resp)
-		}),
-	},
-	)
+			_, _ = w.Write(p)
+
+		default:
+			// This case also applies for defaultOffer. Note that this is preferred
+			// over e.g. a 406 status code, according to the MDN:
+			// https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/406
+			tmpl := template.New("state.html").Funcs(template.FuncMap{
+				"truncateDuration": func(d time.Duration) time.Duration {
+					return d.Truncate(time.Second)
+				},
+			})
+			template.Must(tmpl.Parse(stateHTMLTemplate))
+			err := tmpl.Execute(w, dumps)
+			if err != nil {
+				http.Error(w, "failed to render template: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	})
+
+	debugserverEndpoints.listAuthzProvidersEndpoint = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type providerInfo struct {
+			ServiceType        string `json:"service_type"`
+			ServiceID          string `json:"service_id"`
+			ExternalServiceURL string `json:"external_service_url"`
+		}
+
+		_, providers := authz.GetProviders()
+		infos := make([]providerInfo, len(providers))
+		for i, p := range providers {
+			_, id := extsvc.DecodeURN(p.URN())
+
+			// Note that the ID marshalling below replicates code found in `graphqlbackend`.
+			// We cannot import that package's code into this one (see /dev/check/go-dbconn-import.sh).
+			infos[i] = providerInfo{
+				ServiceType:        p.ServiceType(),
+				ServiceID:          p.ServiceID(),
+				ExternalServiceURL: fmt.Sprintf("%s/site-admin/external-services/%s", globals.ExternalURL(), relay.MarshalID("ExternalService", id)),
+			}
+		}
+
+		resp, err := json.MarshalIndent(infos, "", "  ")
+		if err != nil {
+			http.Error(w, "failed to marshal infos: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(resp)
+	})
+
+	// Migrations may take a while, but after they're done we'll immediately
+	// spin up a server and can accept traffic. Inform external clients we'll
+	// be ready for traffic.
+	//
+	// We also close this channel now AFTER assigning the additional endpoints
+	// in the debugserver. This ensures we don't have a race between becoming
+	// ready and a debugserver request failing directly after being unblocked.
+	close(ready)
 
 	// NOTE: Internal actor is required to have full visibility of the repo table
 	// 	(i.e. bypass repository authorization).

--- a/cmd/searcher/main.go
+++ b/cmd/searcher/main.go
@@ -41,7 +41,10 @@ func main() {
 	tracer.Init()
 	trace.Init(true)
 
-	go debugserver.Start()
+	// Ready immediately
+	ready := make(chan struct{})
+	close(ready)
+	go debugserver.NewServerRoutine(ready).Start()
 
 	var cacheSizeBytes int64
 	if i, err := strconv.ParseInt(cacheSizeMB, 10, 64); err != nil {

--- a/cmd/symbols/main.go
+++ b/cmd/symbols/main.go
@@ -46,7 +46,10 @@ func main() {
 
 	sqliteutil.MustRegisterSqlite3WithPcre()
 
-	go debugserver.Start()
+	// Ready immediately
+	ready := make(chan struct{})
+	close(ready)
+	go debugserver.NewServerRoutine(ready).Start()
 
 	service := symbols.Service{
 		FetchTar: func(ctx context.Context, repo api.RepoName, commit api.CommitID) (io.ReadCloser, error) {

--- a/enterprise/cmd/executor-queue/main.go
+++ b/enterprise/cmd/executor-queue/main.go
@@ -57,10 +57,16 @@ func main() {
 	}
 
 	// Start debug server
-	go debugserver.NewServerRoutine().Start()
+	ready := make(chan struct{})
+	go debugserver.NewServerRoutine(ready).Start()
 
 	// Connect to databases
 	db := connectToDatabase()
+
+	// Migrations may take a while, but after they're done we'll immediately
+	// spin up a server and can accept traffic. Inform external clients we'll
+	// be ready for traffic.
+	close(ready)
 
 	// Initialize queues
 	queueOptions := map[string]apiserver.QueueOptions{

--- a/enterprise/cmd/executor/main.go
+++ b/enterprise/cmd/executor/main.go
@@ -44,8 +44,10 @@ func main() {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
-	// Start debug server
-	go debugserver.NewServerRoutine().Start()
+	// Ready immediately
+	ready := make(chan struct{})
+	close(ready)
+	go debugserver.NewServerRoutine(ready).Start()
 
 	routines := []goroutine.BackgroundRoutine{
 		worker.NewWorker(config.APIWorkerOptions(nil), observationContext),

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -112,7 +112,7 @@ func NewServerRoutine(ready <-chan struct{}, extra ...Endpoint) goroutine.Backgr
 
 		router.Handle("/", index)
 		router.Handle("/healthz", http.HandlerFunc(healthzHandler))
-		router.Handle("/ready", http.HandlerFunc(readyHandler(ready)))
+		router.Handle("/ready", readyHandler(ready))
 		router.Handle("/debug", index)
 		router.Handle("/vars", http.HandlerFunc(expvarHandler))
 		router.Handle("/gc", http.HandlerFunc(gcHandler))

--- a/internal/debugserver/ready.go
+++ b/internal/debugserver/ready.go
@@ -18,7 +18,7 @@ func readyHandler(ready <-chan struct{}) http.HandlerFunc {
 		case <-ready:
 			w.WriteHeader(http.StatusOK)
 		default:
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusServiceUnavailable)
 		}
 	}
 }

--- a/internal/debugserver/ready.go
+++ b/internal/debugserver/ready.go
@@ -1,0 +1,24 @@
+package debugserver
+
+import "net/http"
+
+// healthzHandler is the http.HandlerFunc that responds to /healthz
+// requests on the debugserver port. This always returns a 200 OK
+// while the binary can be reached.
+func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// readyHandler returns an http.HandlerFunc that responds to the /ready
+// requests on the debugserver port. This will return a 200 OK once the
+// given channel is closed, and a 500 Internal Server Error otherwise.
+func readyHandler(ready <-chan struct{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-ready:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}

--- a/internal/debugserver/ready.go
+++ b/internal/debugserver/ready.go
@@ -11,7 +11,7 @@ func healthzHandler(w http.ResponseWriter, r *http.Request) {
 
 // readyHandler returns an http.HandlerFunc that responds to the /ready
 // requests on the debugserver port. This will return a 200 OK once the
-// given channel is closed, and a 500 Internal Server Error otherwise.
+// given channel is closed, and a 503 Service Unavailable otherwise.
 func readyHandler(ready <-chan struct{}) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		select {


### PR DESCRIPTION
This PR adds /healthz and /ready endpoints to the debug server, which is generally started at the top of the application's main function.

This wasn't true for a few services (repo-updater and the frontend), which is corrected here.

Debug servers will respond to 200 OK to all /healthz requests, and will conditionally respond to 200 OK to /ready requests when the channel passed to the debug server is closed. When to close this is on an app-by-app basis. We used the following determination for each service:

- If it does not touch the database, it's ready immediately
- If it touches the database, we wait until the database has migrated before becoming ready

Fixes https://github.com/sourcegraph/sourcegraph/issues/19757 (will need updates on compose and k8s to respect ready status).