### PR TITLE
search: Get search-blitz ready for deployment

### DIFF
--- a/internal/cmd/search-blitz/Dockerfile
+++ b/internal/cmd/search-blitz/Dockerfile
@@ -1,19 +1,17 @@
 FROM golang:1.16 AS builder
 WORKDIR /build
 COPY go.sum go.mod ./
-RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o searchblitz .
+RUN CGO_ENABLED=0 GOOS=linux go build -o searchblitz ./internal/cmd/search-blitz
 
 FROM sourcegraph/alpine:3.12@sha256:133a0a767b836cf86a011101995641cf1b5cbefb3dd212d78d7be145adde636d
-RUN mkdir data
 
 COPY --from=builder /build/searchblitz /usr/local/bin
-COPY data data
+COPY internal/cmd/search-blitz/config.yaml /config.yaml
 
 ARG COMMIT_SHA="unknown"
 
 LABEL org.opencontainers.image.revision=${COMMIT_SHA}
-LABEL org.opencontainers.image.source=https://github.com/sourcegraph/search-blitz/
+LABEL org.opencontainers.image.source=https://github.com/sourcegraph/sourcegraph/internal/cmd/search-blitz
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/searchblitz"]

--- a/internal/cmd/search-blitz/config.yaml
+++ b/internal/cmd/search-blitz/config.yaml
@@ -2,99 +2,89 @@
 groups:
     - name: monitoring_queries
       queries:
-          # Single-term regex searches
-          - query: searchZoekt patterntype:regexp # ~2 results
-            name:  regex_small
-          - query: can_handle_hl_color patterntype:regexp # ~ 50 results
-            name:  regex_medium
-          - query: try_init # 500+ results
-            name:  regexp_large
+          # Regex search
+          - name: regex_small # ~2 results
+            query: >
+              patterntype:regexp
+              se[arc]{3}hZoekt
 
-          # Multi-term regex searches
-          - query: matt senses # ~200 results
-            name: regex_two_sameline
-          - query: mk tim hike # ~70 results
-            name: regex_three_sameline
+          - name: regex_medium # ~50 results
+            query: >
+              patterntype:regexp
+              can_handle_hl_color\b
 
-          # Repo-scoped search
-          - query: repo:^github\.com/sourcegraph/sourcegraph$ searchZoekt # ~2 results
-            name: regex_repo_scope_small
-          - query: repo:^github\.com/sourcegraph/sourcegraph$ fmt.Errorf # 500+ results
-            name: regex_repo_scope_large
+          - name: regex_large # 500+ results
+            query: >
+              patterntype:regexp
+              try_init
 
-          # File-scoped search
-          - query: >
-                  repo:^github\.com/sourcegraph/sourcegraph$
-                  file:search_results.go
-                  error
-            name: regex_file_scope
+          - name: regex_two_sameline # ~200 results
+            query: >
+                patterntype:regexp
+                matt senses
+
+          - name: regex_three_sameline # ~70 results
+            query: >
+                patterntype:regexp
+                mk tim hike
+
+          - name: regex_repo_scope_small # ~3 results
+            query: >
+                patterntype:regexp
+                repo:^github\.com/ianstormtaylor/slate$
+                getfragment
+
+          - name: regex_repo_scope_large # ~600 results
+            query: >
+                patterntype:regexp
+                repo:^github\.com/pichillilorenzo/flutter_inappwebview$
+                count:800
+                add\w+
+
+          - name: regex_file_scope # ~100 results
+            query: >
+                  patterntype:regexp
+                  repo:^github\.com/kubernetes/kubernetes$
+                  file:^cluster/gce/gci
+                  Installing
 
           # Structural search
-          - query: > # ~ 15 results
+          - name: structural_repo_scope_small # ~15 results
+            query: >
                   patterntype:structural
-                  repo:^github\.com/sourcegraph/sourcegraph$
-                  WithLabels(...)
-            name: structural_repo_scope_small
-          - query: > # ~ 51 results
+                  repo:^github\.com/testdrivenio/fastapi-crud-async$
+                  file:^src/app
+                  async def :[1](...)
+
+          - name: structural_multi_repo_small # ~51 results
+            query: >
                   patterntype:structural
                   repo:^github\.com/sourcegraph/
                   strings.ToUpper(...)
-            name: structural_multi_repo_small
 
-# Queries that were previously used, and may still be useful, but are larger than
-# what we want to run against sourcegraph.com every minute.
-    # - name: global_same_line_regex
-    #   queries:
-    #       - query: func rtoorg patterntype:regexp
-    #       - query: func bool bar patterntype:regexp
-    #       - query: func bool patterntype:regexp
-    #       - query: int32 error patterntype:regexp
-    #       - query: func return patterntype:regexp
-    #       - query: config override patterntype:regexp
+          # Literal search
+          - name: literal_small # ~5 results
+            query: >
+                patterntype:literal
+                --exclude-task=test
 
-    # - name: no_scope_content_medium_literal
-    #   queries:
-    #       - query: lang:java kms count:1000
-    #       - query: cfssl lang:go -file:vendor/ count:1000
-    #       - query: setDetails( count:1000
-    #       - query: gcc_build count:1000
-    #       - query: NTG6 count:1000
-    #       - query: daimler count:1000 type:path
-    #       - query: context.WithValue count:1000
-    #       - query: streaming
-    #       - query: converter
-    #       - query: httpclient
+          - name: literal_large # 1000+ results
+            query: >
+                patterntype:literal
+                lang:go
+                -file:vendor/
+                count:1000
+                cfssl
 
-    # - name: no_scope_content_small_literal
-    #   queries:
-    #       - query: --exclude-task=test
-    #       - query: '"adding helm values to the environment"'
-    #       - query: AuthorizationCodeRequestParameters
-    #       - query: CommThread(LPVOID lang:c++
-    #       - query: RemoteTaskAction
-    #       - query: THNN_CudaSpatialConvolutionMM_updateOutput
-    #       - query: Xml_StackOverflow lang:c#
-    #       - query: ale_go_gopls
-    #       - query: bazel:gcc_build
-    #       - query: beaconDataUpdate
-    #       - query: binlog_event.cpp
-    #       - query: corpshare
-    #       - query: init_file_metadata
-    #       - query: k8s-controller-custom-resource
-    #       - query: lang:java aws kms decrypt
-    #       - query: mysql_global_status_slow_queries
+          - name: literal_repo_scope # ~11 results
+            query: >
+                patterntype:literal
+                repo:^github\.com/ElemeFE/element$
+                repeat-click
 
-    # - name: repo_file_scope_content_small_literal
-    #   queries:
-    #       - query: repo:^github\.com/ElemeFE/element$ file:^src/directives repeat-click
-    #       - query: repo:^github\.com/apache/incubator-tvm$ file:^python/tvm/autotvm ApplyGraphBest
-    #       - query: repo:^github\.com/cockroachdb/cockroach-gen$ file:^pkg/ccl/importccl/read_import_csv\.go p.record
-    #       - query: repo:^github\.com/domoticz/domoticz$ file:^main/WebServer\.cpp gettransfer
-    #       - query: repo:^github\.com/ianstormtaylor/slate$ file:^packages/slate-react/src getfragment
-    #       - query: repo:^github\.com/kubernetes/kubernetes$ file:^cluster/gce/gci Installing
-    #       - query: repo:^github\.com/pichillilorenzo/flutter_inappwebview$ file:^lib/src/in_app_webview_controller\.dart addJavaScriptHandler
-    #       - query: repo:^github\.com/testdrivenio/fastapi-crud-async$ file:^src/app async
-
-    # - name: structural_search
-    #   queries:
-    #       - query: repogroup:go-gh-100 language:go -file:test -file:vendor -file:Godeps strings.Index(..., ...) > -1 or strings.Index(..., ...) >= 0 or strings.Index(..., ...) != -1
+          - name: literal_file_scope # ~10 results
+            query: >
+                patterntype:literal
+                repo:^github\.com/cockroachdb/cockroach-gen$
+                file:^pkg/ccl/importccl/read_import_csv\.go
+                p.record

--- a/internal/cmd/search-blitz/config.yaml
+++ b/internal/cmd/search-blitz/config.yaml
@@ -31,20 +31,20 @@ groups:
           - name: regex_repo_scope_small # ~3 results
             query: >
                 patterntype:regexp
-                repo:^github\.com/ianstormtaylor/slate$
+                repo:^github\.com/sgtest/slate$
                 getfragment
 
           - name: regex_repo_scope_large # ~600 results
             query: >
                 patterntype:regexp
-                repo:^github\.com/pichillilorenzo/flutter_inappwebview$
+                repo:^github\.com/sgtest/flutter_inappwebview$
                 count:800
                 add\w+
 
           - name: regex_file_scope # ~2 results
             query: >
                 patterntype:regexp
-                repo:^github\.com/kubernetes/kubernetes$
+                repo:^github\.com/sgtest/kubernetes$
                 file:^cluster/gce/gci
                 Installing
 
@@ -52,7 +52,7 @@ groups:
           - name: structural_repo_scope_small # ~15 results
             query: >
                 patterntype:structural
-                repo:^github\.com/testdrivenio/fastapi-crud-async$
+                repo:^github\.com/sgtest/fastapi-crud-async$
                 file:^src/app
                 async def :[1](...)
 
@@ -79,12 +79,12 @@ groups:
           - name: literal_repo_scope # ~11 results
             query: >
                 patterntype:literal
-                repo:^github\.com/ElemeFE/element$
+                repo:^github\.com/sgtest/element$
                 repeat-click
 
           - name: literal_file_scope # ~10 results
             query: >
                 patterntype:literal
-                repo:^github\.com/cockroachdb/cockroach-gen$
+                repo:^github\.com/sgtest/cockroach-gen$
                 file:^pkg/ccl/importccl/read_import_csv\.go
                 p.record

--- a/internal/cmd/search-blitz/config.yaml
+++ b/internal/cmd/search-blitz/config.yaml
@@ -1,56 +1,100 @@
+# These queries are currently enabled by default on sourcegraph.com
 groups:
-    - name: global_same_line_regex
+    - name: monitoring_queries
       queries:
-          - query: func rtoorg patterntype:regexp
-          - query: func bool bar patterntype:regexp
-          - query: func bool patterntype:regexp
-          - query: int32 error patterntype:regexp
-          - query: func return patterntype:regexp
-          - query: config override patterntype:regexp
+          # Single-term regex searches
+          - query: searchZoekt patterntype:regexp # ~2 results
+            name:  regex_small
+          - query: can_handle_hl_color patterntype:regexp # ~ 50 results
+            name:  regex_medium
+          - query: try_init # 500+ results
+            name:  regexp_large
 
-    - name: no_scope_content_medium_literal
-      queries:
-          - query: lang:java kms count:1000
-          - query: cfssl lang:go -file:vendor/ count:1000
-          - query: setDetails( count:1000
-          - query: gcc_build count:1000
-          - query: NTG6 count:1000
-          - query: daimler count:1000 type:path
-          - query: context.WithValue count:1000
-          - query: streaming
-          - query: converter
-          - query: httpclient
+          # Multi-term regex searches
+          - query: matt senses # ~200 results
+            name: regex_two_sameline
+          - query: mk tim hike # ~70 results
+            name: regex_three_sameline
 
-    - name: no_scope_content_small_literal
-      queries:
-          - query: --exclude-task=test
-          - query: '"adding helm values to the environment"'
-          - query: AuthorizationCodeRequestParameters
-          - query: CommThread(LPVOID lang:c++
-          - query: RemoteTaskAction
-          - query: THNN_CudaSpatialConvolutionMM_updateOutput
-          - query: Xml_StackOverflow lang:c#
-          - query: ale_go_gopls
-          - query: bazel:gcc_build
-          - query: beaconDataUpdate
-          - query: binlog_event.cpp
-          - query: corpshare
-          - query: init_file_metadata
-          - query: k8s-controller-custom-resource
-          - query: lang:java aws kms decrypt
-          - query: mysql_global_status_slow_queries
+          # Repo-scoped search
+          - query: repo:^github\.com/sourcegraph/sourcegraph$ searchZoekt # ~2 results
+            name: regex_repo_scope_small
+          - query: repo:^github\.com/sourcegraph/sourcegraph$ fmt.Errorf # 500+ results
+            name: regex_repo_scope_large
 
-    - name: repo_file_scope_content_small_literal
-      queries:
-          - query: repo:^github\.com/ElemeFE/element$ file:^src/directives repeat-click
-          - query: repo:^github\.com/apache/incubator-tvm$ file:^python/tvm/autotvm ApplyGraphBest
-          - query: repo:^github\.com/cockroachdb/cockroach-gen$ file:^pkg/ccl/importccl/read_import_csv\.go p.record
-          - query: repo:^github\.com/domoticz/domoticz$ file:^main/WebServer\.cpp gettransfer
-          - query: repo:^github\.com/ianstormtaylor/slate$ file:^packages/slate-react/src getfragment
-          - query: repo:^github\.com/kubernetes/kubernetes$ file:^cluster/gce/gci Installing
-          - query: repo:^github\.com/pichillilorenzo/flutter_inappwebview$ file:^lib/src/in_app_webview_controller\.dart addJavaScriptHandler
-          - query: repo:^github\.com/testdrivenio/fastapi-crud-async$ file:^src/app async
+          # File-scoped search
+          - query: >
+                  repo:^github\.com/sourcegraph/sourcegraph$
+                  file:search_results.go
+                  error
+            name: regex_file_scope
 
-    - name: structural_search
-      queries:
-          - query: repogroup:go-gh-100 language:go -file:test -file:vendor -file:Godeps strings.Index(..., ...) > -1 or strings.Index(..., ...) >= 0 or strings.Index(..., ...) != -1
+          # Structural search
+          - query: > # ~ 15 results
+                  patterntype:structural
+                  repo:^github\.com/sourcegraph/sourcegraph$
+                  WithLabels(...)
+            name: structural_repo_scope_small
+          - query: > # ~ 51 results
+                  patterntype:structural
+                  repo:^github\.com/sourcegraph/
+                  strings.ToUpper(...)
+            name: structural_multi_repo_small
+
+# Queries that were previously used, and may still be useful, but are larger than
+# what we want to run against sourcegraph.com every minute.
+    # - name: global_same_line_regex
+    #   queries:
+    #       - query: func rtoorg patterntype:regexp
+    #       - query: func bool bar patterntype:regexp
+    #       - query: func bool patterntype:regexp
+    #       - query: int32 error patterntype:regexp
+    #       - query: func return patterntype:regexp
+    #       - query: config override patterntype:regexp
+
+    # - name: no_scope_content_medium_literal
+    #   queries:
+    #       - query: lang:java kms count:1000
+    #       - query: cfssl lang:go -file:vendor/ count:1000
+    #       - query: setDetails( count:1000
+    #       - query: gcc_build count:1000
+    #       - query: NTG6 count:1000
+    #       - query: daimler count:1000 type:path
+    #       - query: context.WithValue count:1000
+    #       - query: streaming
+    #       - query: converter
+    #       - query: httpclient
+
+    # - name: no_scope_content_small_literal
+    #   queries:
+    #       - query: --exclude-task=test
+    #       - query: '"adding helm values to the environment"'
+    #       - query: AuthorizationCodeRequestParameters
+    #       - query: CommThread(LPVOID lang:c++
+    #       - query: RemoteTaskAction
+    #       - query: THNN_CudaSpatialConvolutionMM_updateOutput
+    #       - query: Xml_StackOverflow lang:c#
+    #       - query: ale_go_gopls
+    #       - query: bazel:gcc_build
+    #       - query: beaconDataUpdate
+    #       - query: binlog_event.cpp
+    #       - query: corpshare
+    #       - query: init_file_metadata
+    #       - query: k8s-controller-custom-resource
+    #       - query: lang:java aws kms decrypt
+    #       - query: mysql_global_status_slow_queries
+
+    # - name: repo_file_scope_content_small_literal
+    #   queries:
+    #       - query: repo:^github\.com/ElemeFE/element$ file:^src/directives repeat-click
+    #       - query: repo:^github\.com/apache/incubator-tvm$ file:^python/tvm/autotvm ApplyGraphBest
+    #       - query: repo:^github\.com/cockroachdb/cockroach-gen$ file:^pkg/ccl/importccl/read_import_csv\.go p.record
+    #       - query: repo:^github\.com/domoticz/domoticz$ file:^main/WebServer\.cpp gettransfer
+    #       - query: repo:^github\.com/ianstormtaylor/slate$ file:^packages/slate-react/src getfragment
+    #       - query: repo:^github\.com/kubernetes/kubernetes$ file:^cluster/gce/gci Installing
+    #       - query: repo:^github\.com/pichillilorenzo/flutter_inappwebview$ file:^lib/src/in_app_webview_controller\.dart addJavaScriptHandler
+    #       - query: repo:^github\.com/testdrivenio/fastapi-crud-async$ file:^src/app async
+
+    # - name: structural_search
+    #   queries:
+    #       - query: repogroup:go-gh-100 language:go -file:test -file:vendor -file:Godeps strings.Index(..., ...) > -1 or strings.Index(..., ...) >= 0 or strings.Index(..., ...) != -1

--- a/internal/cmd/search-blitz/config.yaml
+++ b/internal/cmd/search-blitz/config.yaml
@@ -41,26 +41,26 @@ groups:
                 count:800
                 add\w+
 
-          - name: regex_file_scope # ~100 results
+          - name: regex_file_scope # ~2 results
             query: >
-                  patterntype:regexp
-                  repo:^github\.com/kubernetes/kubernetes$
-                  file:^cluster/gce/gci
-                  Installing
+                patterntype:regexp
+                repo:^github\.com/kubernetes/kubernetes$
+                file:^cluster/gce/gci
+                Installing
 
           # Structural search
           - name: structural_repo_scope_small # ~15 results
             query: >
-                  patterntype:structural
-                  repo:^github\.com/testdrivenio/fastapi-crud-async$
-                  file:^src/app
-                  async def :[1](...)
+                patterntype:structural
+                repo:^github\.com/testdrivenio/fastapi-crud-async$
+                file:^src/app
+                async def :[1](...)
 
           - name: structural_multi_repo_small # ~51 results
             query: >
-                  patterntype:structural
-                  repo:^github\.com/sourcegraph/
-                  strings.ToUpper(...)
+                patterntype:structural
+                repo:^github\.com/sourcegraph/
+                strings.ToUpper(...)
 
           # Literal search
           - name: literal_small # ~5 results

--- a/internal/cmd/search-blitz/scripts/build.sh
+++ b/internal/cmd/search-blitz/scripts/build.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+
+set -ex
+pushd "$(dirname "${BASH_SOURCE[0]}")/../../../.." >/dev/null
+
 yes | gcloud auth configure-docker
-docker build --build-arg COMMIT_SHA="$(git rev-parse HEAD)" -t "us.gcr.io/sourcegraph-dev/search-blitz:$1" .
+docker build \
+		-f ./internal/cmd/search-blitz/Dockerfile \
+		--build-arg COMMIT_SHA="$(git rev-parse HEAD)" \
+		-t "us.gcr.io/sourcegraph-dev/search-blitz:$1" \
+		.
 docker push "us.gcr.io/sourcegraph-dev/search-blitz:$1"
+
+popd >/dev/null

--- a/internal/cmd/search-blitz/scripts/build.sh
+++ b/internal/cmd/search-blitz/scripts/build.sh
@@ -5,10 +5,10 @@ pushd "$(dirname "${BASH_SOURCE[0]}")/../../../.." >/dev/null
 
 yes | gcloud auth configure-docker
 docker build \
-		-f ./internal/cmd/search-blitz/Dockerfile \
-		--build-arg COMMIT_SHA="$(git rev-parse HEAD)" \
-		-t "us.gcr.io/sourcegraph-dev/search-blitz:$1" \
-		.
+  -f ./internal/cmd/search-blitz/Dockerfile \
+  --build-arg COMMIT_SHA="$(git rev-parse HEAD)" \
+  -t "us.gcr.io/sourcegraph-dev/search-blitz:$1" \
+  .
 docker push "us.gcr.io/sourcegraph-dev/search-blitz:$1"
 
 popd >/dev/null

--- a/internal/cmd/search-blitz/scripts/update-deploy-sourcegraph-dot-com.sh
+++ b/internal/cmd/search-blitz/scripts/update-deploy-sourcegraph-dot-com.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
+pushd "$(dirname "${BASH_SOURCE[0]}")/../../../.." >/dev/null
 
 sed -i "" "s/search-blitz:.\{1,2\}\..\{1,2\}\..\{1,2\}/search-blitz:$1/" ../deploy-sourcegraph-dot-com/configure/search-blitz/search-blitz.StatefulSet.yaml
+
+popd >/dev/null


### PR DESCRIPTION
This is kinda a combo PR to get search-blitz ready to deploy against sourcegraph.com.

1) Adds the sentinel queries to the config file
2) Modifies the Dockerfile so it can build
3) Adds some randomization to start times so we're not spiking every minute

Fixes #19893 