### PR TITLE
fix bug with gitolite config redaction that caused the config to return empty from the API

### DIFF
--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -66,7 +66,7 @@ func (e *ExternalService) RedactConfigSecrets() error {
 		newCfg, err = redactField(e.Config, "p4.passwd")
 	case *schema.GitoliteConnection:
 		// no secret fields?
-		err = nil
+		newCfg, err = redactField(e.Config, "url")
 	case *schema.OtherExternalServiceConnection:
 		// no secret fields?
 		newCfg, err = redactField(e.Config, "url")
@@ -142,7 +142,7 @@ func (e *ExternalService) UnredactConfig(old *ExternalService) error {
 		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"p4.passwd", &cfg.P4Passwd})
 	case *schema.GitoliteConnection:
 		// no secret fields?
-		err = nil
+		unredacted, err = unredactField(old.Config, e.Config, &cfg)
 	case *schema.OtherExternalServiceConnection:
 		unredacted, err = unredactField(old.Config, e.Config, &cfg, jsonStringField{"url", &cfg.Url})
 	default:


### PR DESCRIPTION
gitolite wasn't tested correctly, because of the way we skip redaction on gitolite we ended up blanking out their config, not ideal.

This PR makes sure we always call redact or unredact on gitolite, just with an empty set of fields.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
