### PR TITLE
Document new .batchignore behaviour in src-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - `count:` now supports "all" as value. Queries with `count:all` will return up to 999999 results. [#19756](https://github.com/sourcegraph/sourcegraph/pull/19756)
 - Credentials for Batch Changes are now validated when adding them. [#19602](https://github.com/sourcegraph/sourcegraph/pull/19602)
+- Batch Changes now ignore repositories that contain a `.batchignore` file.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - `count:` now supports "all" as value. Queries with `count:all` will return up to 999999 results. [#19756](https://github.com/sourcegraph/sourcegraph/pull/19756)
 - Credentials for Batch Changes are now validated when adding them. [#19602](https://github.com/sourcegraph/sourcegraph/pull/19602)
-- Batch Changes now ignore repositories that contain a `.batchignore` file.
+- Batch Changes now ignore repositories that contain a `.batchignore` file. [#19877](https://github.com/sourcegraph/sourcegraph/pull/19877) and [src-cli#509](https://github.com/sourcegraph/src-cli/pull/509)
 
 ### Changed
 

--- a/doc/batch_changes/how-tos/index.md
+++ b/doc/batch_changes/how-tos/index.md
@@ -13,3 +13,4 @@ The following is a list of how-tos that show how to use [Sourcegraph Batch Chang
 - [Handling errored changesets](handling_errored_changesets.md)
 - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
 - [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)
+- [Opting out of batch changes](opting_out_of_batch_changes.md)

--- a/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
+++ b/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
@@ -5,6 +5,6 @@
 Repository owners that are not interested in batch change changesets can opt out
 so that their repository will be skipped when a batch spec is executed.
 
-1. Create a file called `.batchignore` in the repository you wish to be skipped.
-2. `src batch [apply|preview]` will now skip that repository if it's yielded by the `on` part of the batch spec.
-3. Use the `-force-override-ignore` flag to override that behaviour and not skip any ignored repositories.
+To opt out: create a file called `.batchignore` at the root of the repository you wish to be skipped. `src batch [apply|preview]` will now skip that repository if it's yielded by the `on` part of the batch spec.
+
+>NOTE: You can use the `-force-override-ignore` flag to override that behaviour and not skip any ignored repositories.

--- a/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
+++ b/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
@@ -1,0 +1,10 @@
+# Opting out of batch changes
+
+> NOTE: This feature is requires [Sourcegraph CLI](https://github.com/sourcegraph/src-cli) 3.26.3 or later.
+
+Repository owners that are not interested in batch change changesets can opt out
+so that their repository will be skipped when a batch spec is executed.
+
+1. Create a file called `.batchignore` in the repository you wish to be skipped.
+2. `src batch [apply|preview]` will now skip that repository if it's yielded by the `on` part of the batch spec.
+3. Use the `-force-override-ignore` flag to override that behaviour and not skip any ignored repositories.

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -90,6 +90,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
 - [Handling errored changesets](how-tos/handling_errored_changesets.md)
 - [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)
+- [Opting out of batch changes](how-tos/opting_out_of_batch_changes.md)
 
 ## Tutorials
 

--- a/doc/cli/references/batch/apply.md
+++ b/doc/cli/references/batch/apply.md
@@ -12,6 +12,7 @@
 | `-clear-cache` | If true, clears the execution cache and executes all steps anew. | `false` |
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-f` | The batch spec file to read. |  |
+| `-force-override-ignore` | Do not ignore repositories that have a .batchignore file. | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-j` | The maximum number of parallel jobs. Default is GOMAXPROCS. | `8` |
@@ -44,6 +45,8 @@ Usage of 'src batch apply':
     	Log GraphQL requests and responses to stdout
   -f string
     	The batch spec file to read.
+  -force-override-ignore
+    	Do not ignore repositories that have a .batchignore file.
   -get-curl
     	Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
   -insecure-skip-verify

--- a/doc/cli/references/batch/preview.md
+++ b/doc/cli/references/batch/preview.md
@@ -12,9 +12,10 @@
 | `-clear-cache` | If true, clears the execution cache and executes all steps anew. | `false` |
 | `-dump-requests` | Log GraphQL requests and responses to stdout | `false` |
 | `-f` | The batch spec file to read. |  |
+| `-force-override-ignore` | Do not ignore repositories that have a .batchignore file. | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
-| `-j` | The maximum number of parallel jobs. Default is GOMAXPROCS. | `8` |
+| `-j` | The maximum number of parallel jobs. Default is GOMAXPROCS. | `16` |
 | `-keep-logs` | Retain logs after executing steps. | `false` |
 | `-n` | Alias for -namespace. |  |
 | `-namespace` | The user or organization namespace to place the batch change within. Default is the currently authenticated user. |  |
@@ -44,12 +45,14 @@ Usage of 'src batch preview':
     	Log GraphQL requests and responses to stdout
   -f string
     	The batch spec file to read.
+  -force-override-ignore
+    	Do not ignore repositories that have a .batchignore file.
   -get-curl
     	Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -j int
-    	The maximum number of parallel jobs. Default is GOMAXPROCS. (default 8)
+    	The maximum number of parallel jobs. Default is GOMAXPROCS. (default 16)
   -keep-logs
     	Retain logs after executing steps.
   -n string

--- a/doc/cli/references/extensions/publish.md
+++ b/doc/cli/references/extensions/publish.md
@@ -9,6 +9,7 @@
 | `-extension-id` | Override the extension ID in the manifest. (default: read from -manifest file) |  |
 | `-force` | Force publish the extension, even if there are validation problems or other warnings. | `false` |
 | `-get-curl` | Print the curl command for executing this query and exit (WARNING: includes printing your access token!) | `false` |
+| `-git-head` | Override the current git commit for the bundle. (default: uses `git rev-parse head` |  |
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-manifest` | The extension manifest file. | `package.json` |
 | `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
@@ -27,6 +28,8 @@ Usage of 'src extensions publish':
     	Force publish the extension, even if there are validation problems or other warnings.
   -get-curl
     	Print the curl command for executing this query and exit (WARNING: includes printing your access token!)
+  -git-head git rev-parse head
+    	Override the current git commit for the bundle. (default: uses git rev-parse head
   -insecure-skip-verify
     	Skip validation of TLS certificates against trusted chains
   -manifest string

--- a/doc/cli/references/search.md
+++ b/doc/cli/references/search.md
@@ -12,7 +12,7 @@
 | `-insecure-skip-verify` | Skip validation of TLS certificates against trusted chains | `false` |
 | `-json` | Whether or not to output results as JSON. | `false` |
 | `-less` | Pipe output to 'less -R' (only if stdout is terminal, and not json flag). | `true` |
-| `-stream` | Consume results as stream. Streaming search only supports a subset of flags and parameters: trace, insecure-skip-verify, display. | `false` |
+| `-stream` | Consume results as stream. Streaming search only supports a subset of flags and parameters: trace, insecure-skip-verify, display, json. | `false` |
 | `-trace` | Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing | `false` |
 
 
@@ -35,7 +35,7 @@ Usage of 'src search':
   -less
     	Pipe output to 'less -R' (only if stdout is terminal, and not json flag). (default true)
   -stream
-    	Consume results as stream. Streaming search only supports a subset of flags and parameters: trace, insecure-skip-verify, display.
+    	Consume results as stream. Streaming search only supports a subset of flags and parameters: trace, insecure-skip-verify, display, json.
   -trace
     	Log the trace ID for requests. See https://docs.sourcegraph.com/admin/observability/tracing
 


### PR DESCRIPTION
This documents the new behaviour in src-cli 3.26.3: https://github.com/sourcegraph/src-cli/releases/tag/3.26.3