### PR TITLE
search contexts: always submit search on change in navbar

### DIFF
--- a/client/web/src/search/input/MonacoQueryInput.tsx
+++ b/client/web/src/search/input/MonacoQueryInput.tsx
@@ -35,6 +35,7 @@ export interface MonacoQueryInputProps
     onSuggestionsInitialized?: (actions: { trigger: () => void }) => void
     autoFocus?: boolean
     keyboardShortcutForFocus?: KeyboardShortcut
+    submitSearchOnSearchContextChange?: boolean
 
     // Whether globbing is enabled for filters.
     globbing: boolean

--- a/client/web/src/search/input/SearchContextDropdown.test.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.test.tsx
@@ -117,9 +117,22 @@ describe('SearchContextDropdown', () => {
         sinon.assert.calledOnce(submitSearch)
     })
 
-    it('should not submit search if query is empty', () => {
+    it('should not submit search if submitSearchOnSearchContextChange is false', () => {
         const submitSearch = sinon.spy()
-        const element = mount(<SearchContextDropdown {...defaultProps} submitSearch={submitSearch} query="" />)
+        const element = mount(
+            <SearchContextDropdown
+                {...defaultProps}
+                submitSearch={submitSearch}
+                submitSearchOnSearchContextChange={false}
+            />
+        )
+
+        act(() => {
+            // Wait for debounce
+            clock.tick(50)
+        })
+        element.update()
+
         const item = element.find(DropdownItem).at(0)
         item.simulate('click')
 

--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -15,6 +15,7 @@ export interface SearchContextDropdownProps
         Pick<CaseSensitivityProps, 'caseSensitive'>,
         VersionContextProps {
     submitSearch: (args: SubmitSearchParameters) => void
+    submitSearchOnSearchContextChange?: boolean
     query: string
     history: H.History
 }
@@ -31,6 +32,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
         submitSearch,
         fetchAutoDefinedSearchContexts,
         fetchSearchContexts,
+        submitSearchOnSearchContextChange = true,
     } = props
 
     const [isOpen, setIsOpen] = useState(false)
@@ -42,7 +44,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
 
     const submitOnToggle = useCallback(
         (selectedSearchContextSpec: string): void => {
-            if (query === '') {
+            if (!submitSearchOnSearchContextChange) {
                 return
             }
             submitSearch({
@@ -55,7 +57,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
                 versionContext,
             })
         },
-        [submitSearch, caseSensitive, history, query, patternType, versionContext]
+        [submitSearch, submitSearchOnSearchContextChange, caseSensitive, history, query, patternType, versionContext]
     )
 
     const selectSearchContextSpec = useCallback(

--- a/client/web/src/search/input/SearchPageInput.tsx
+++ b/client/web/src/search/input/SearchPageInput.tsx
@@ -133,6 +133,7 @@ export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) =>
                     <LazyMonacoQueryInput
                         {...props}
                         {...onboardingTourQueryInputProps}
+                        submitSearchOnSearchContextChange={false}
                         hasGlobalQueryBehavior={true}
                         queryState={userQueryState}
                         onChange={setUserQueryState}


### PR DESCRIPTION
Always submit search on search context change in navbar. Do not submit search on search context change on search index page.

Fixes #19834.