### PR TITLE
Incorporate design feedback into changeset multi-select UI

### DIFF
--- a/client/web/src/components/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection.tsx
@@ -148,10 +148,14 @@ interface ConnectionDisplayProps {
  *
  * @template N The node type of the GraphQL connection, such as GQL.IRepository (if the connection is GQL.IRepositoryConnection)
  * @template NP Props passed to `nodeComponent` in addition to `{ node: N }`
+ * @template HP Props passed to `headComponent` in addition to `{ nodes: N[]; totalCount?: number | null }`.
  */
-interface ConnectionPropsCommon<N, NP = {}> extends ConnectionDisplayProps {
+interface ConnectionPropsCommon<N, NP = {}, HP = {}> extends ConnectionDisplayProps {
     /** Header row to appear above all nodes. */
-    headComponent?: React.ComponentType<{ nodes: N[]; totalCount?: number | null }>
+    headComponent?: React.ComponentType<{ nodes: N[]; totalCount?: number | null } & HP>
+
+    /** Props to pass to each headComponent in addition to `{ nodes: N[]; totalCount?: number | null }`. */
+    headComponentProps?: HP
 
     /** Footer row to appear below all nodes. */
     footComponent?: React.ComponentType<{ nodes: N[] }>
@@ -191,8 +195,8 @@ interface ConnectionStateCommon {
     loading: boolean
 }
 
-interface ConnectionNodesProps<C extends Connection<N>, N, NP = {}>
-    extends ConnectionPropsCommon<N, NP>,
+interface ConnectionNodesProps<C extends Connection<N>, N, NP = {}, HP = {}>
+    extends ConnectionPropsCommon<N, NP, HP>,
         ConnectionStateCommon {
     /** The fetched connection data or an error (if an error occurred). */
     connection: C
@@ -202,7 +206,9 @@ interface ConnectionNodesProps<C extends Connection<N>, N, NP = {}>
     onShowMore: () => void
 }
 
-class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureComponent<ConnectionNodesProps<C, N, NP>> {
+class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> extends React.PureComponent<
+    ConnectionNodesProps<C, N, NP, HP>
+> {
     public render(): JSX.Element | null {
         const NodeComponent = this.props.nodeComponent
         const ListComponent = this.props.listComponent || 'ul'
@@ -290,6 +296,7 @@ class ConnectionNodes<C extends Connection<N>, N, NP = {}> extends React.PureCom
                             <HeadComponent
                                 nodes={this.props.connection.nodes}
                                 totalCount={this.props.connection.totalCount}
+                                {...this.props.headComponentProps!}
                             />
                         )}
                         {ListComponent === 'table' ? <tbody>{nodes}</tbody> : nodes}
@@ -385,9 +392,10 @@ interface FilteredConnectionDisplayProps extends ConnectionDisplayProps {
  * @template C The GraphQL connection type, such as GQL.IRepositoryConnection.
  * @template N The node type of the GraphQL connection, such as GQL.IRepository (if C is GQL.IRepositoryConnection)
  * @template NP Props passed to `nodeComponent` in addition to `{ node: N }`
+ * @template HP Props passed to `headComponent` in addition to `{ nodes: N[]; totalCount?: number | null }`.
  */
-interface FilteredConnectionProps<C extends Connection<N>, N, NP = {}>
-    extends ConnectionPropsCommon<N, NP>,
+interface FilteredConnectionProps<C extends Connection<N>, N, NP = {}, HP = {}>
+    extends ConnectionPropsCommon<N, NP, HP>,
         FilteredConnectionDisplayProps {
     /** Called to fetch the connection data to populate this component. */
     queryConnection: (args: FilteredConnectionQueryArguments) => Observable<C>
@@ -484,12 +492,15 @@ const QUERY_KEY = 'query'
  *
  * @template N The node type of the GraphQL connection, such as `GQL.IRepository` (if `C` is `GQL.IRepositoryConnection`)
  * @template NP Props passed to `nodeComponent` in addition to `{ node: N }`
+ * @template HP Props passed to `headComponent` in addition to `{ nodes: N[]; totalCount?: number | null }`.
  * @template C The GraphQL connection type, such as `GQL.IRepositoryConnection`.
  */
-export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection<N>> extends React.PureComponent<
-    FilteredConnectionProps<C, N, NP>,
-    FilteredConnectionState<C, N>
-> {
+export class FilteredConnection<
+    N,
+    NP = {},
+    HP = {},
+    C extends Connection<N> = Connection<N>
+> extends React.PureComponent<FilteredConnectionProps<C, N, NP, HP>, FilteredConnectionState<C, N>> {
     public static defaultProps: Partial<FilteredConnectionProps<any, any>> = {
         defaultFirst: 20,
         useURLQuery: true,
@@ -498,12 +509,12 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
     private queryInputChanges = new Subject<string>()
     private activeValuesChanges = new Subject<Map<string, FilterValue>>()
     private showMoreClicks = new Subject<void>()
-    private componentUpdates = new Subject<FilteredConnectionProps<C, N, NP>>()
+    private componentUpdates = new Subject<FilteredConnectionProps<C, N, NP, HP>>()
     private subscriptions = new Subscription()
 
     private filterRef: HTMLInputElement | null = null
 
-    constructor(props: FilteredConnectionProps<C, N, NP>) {
+    constructor(props: FilteredConnectionProps<C, N, NP, HP>) {
         super(props)
 
         const searchParameters = new URLSearchParams(this.props.location.search)
@@ -897,6 +908,7 @@ export class FilteredConnection<N, NP = {}, C extends Connection<N> = Connection
                         listComponent={this.props.listComponent}
                         listClassName={this.props.listClassName}
                         headComponent={this.props.headComponent}
+                        headComponentProps={this.props.headComponentProps}
                         footComponent={this.props.footComponent}
                         showMoreClassName={this.props.showMoreClassName}
                         nodeComponent={this.props.nodeComponent}

--- a/client/web/src/components/externalServices/ExternalServicesPage.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.tsx
@@ -101,6 +101,7 @@ export const ExternalServicesPage: React.FunctionComponent<Props> = ({
             <FilteredConnection<
                 ListExternalServiceFields,
                 Omit<ExternalServiceNodeProps, 'node'>,
+                {},
                 ExternalServicesResult['externalServices']
             >
                 className="list-group list-group-flush mt-3"

--- a/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeCloseChangesetsList.tsx
@@ -145,6 +145,7 @@ export const BatchChangeCloseChangesetsList: React.FunctionComponent<Props> = ({
             <FilteredConnection<
                 ChangesetFields,
                 Omit<ChangesetCloseNodeProps, 'node'>,
+                {},
                 (BatchChangeChangesetsResult['node'] & { __typename: 'BatchChange' })['changesets']
             >
                 className="mt-2"

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -115,6 +115,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
         }
     }, [batchChangeID, selectedChangesets, setIsSubmittingSelected, deselectAll, telemetryService])
 
+    // TODO: We need to deselect all of setChangesetFilters is called
     const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
         checkState: null,
         state: null,
@@ -201,14 +202,14 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
 
     return (
         <>
-            {!hideFilters && selectedChangesets.size === 0 && (
+            {!hideFilters && (
                 <ChangesetFilterRow history={history} location={location} onFiltersChange={setChangesetFilters} />
             )}
-            {viewerCanAdminister && selectedChangesets.size > 0 && (
+            {viewerCanAdminister && enableSelect && (
                 <ChangesetSelectRow
                     selected={selectedChangesets}
                     onSubmit={onSubmitSelected}
-                    deselectAll={deselectAll}
+                    // deselectAll={deselectAll}
                     isSubmitting={isSubmittingSelected}
                 />
             )}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export interface BatchChangeChangesetsHeaderProps {
-    // Nothing.
+    //  Nothing
 }
 
 export const BatchChangeChangesetsHeader: React.FunctionComponent<BatchChangeChangesetsHeaderProps> = () => (
@@ -18,6 +18,19 @@ export const BatchChangeChangesetsHeader: React.FunctionComponent<BatchChangeCha
 export const BatchChangeChangesetsHeaderWithCheckboxes: React.FunctionComponent<BatchChangeChangesetsHeaderProps> = () => (
     <>
         <span className="d-none d-md-block" />
-        <BatchChangeChangesetsHeader />
+        <input
+            id="select-all-changesets"
+            type="checkbox"
+            className="btn ml-2"
+            // checked={selected}
+            // onChange={toggleSelected}
+            // disabled={!viewerCanAdminister}
+            data-tooltip="Click to select all changesets"
+        />
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
+        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
     </>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -1,32 +1,31 @@
 import React from 'react'
 
 export interface BatchChangeChangesetsHeaderProps {
-    //  Nothing
+    enableSelect?: boolean
+    selected?: boolean
+    toggleSelectAll?: () => void
+    disabled?: boolean
 }
 
-export const BatchChangeChangesetsHeader: React.FunctionComponent<BatchChangeChangesetsHeaderProps> = () => (
+export const BatchChangeChangesetsHeader: React.FunctionComponent<BatchChangeChangesetsHeaderProps> = ({
+    enableSelect,
+    selected,
+    toggleSelectAll,
+    disabled,
+}) => (
     <>
         <span className="d-none d-md-block" />
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Review state</h5>
-        <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Changes</h5>
-    </>
-)
-
-export const BatchChangeChangesetsHeaderWithCheckboxes: React.FunctionComponent<BatchChangeChangesetsHeaderProps> = () => (
-    <>
-        <span className="d-none d-md-block" />
-        <input
-            id="select-all-changesets"
-            type="checkbox"
-            className="btn ml-2"
-            // checked={selected}
-            // onChange={toggleSelected}
-            // disabled={!viewerCanAdminister}
-            data-tooltip="Click to select all changesets"
-        />
+        {enableSelect && toggleSelectAll && (
+            <input
+                id="select-all-changesets"
+                type="checkbox"
+                className="btn ml-2"
+                checked={selected}
+                onChange={toggleSelectAll}
+                disabled={!!disabled}
+                data-tooltip="Click to select all changesets"
+            />
+        )}
         <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>
         <h5 className="p-2 d-none d-md-block text-uppercase text-nowrap">Changeset information</h5>
         <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Check state</h5>

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -17,13 +17,13 @@ export const BatchChangeChangesetsHeader: React.FunctionComponent<BatchChangeCha
         <span className="d-none d-md-block" />
         {enableSelect && toggleSelectAll && (
             <input
-                id="select-all-changesets"
                 type="checkbox"
                 className="btn ml-2"
                 checked={selected}
                 onChange={toggleSelectAll}
                 disabled={!!disabled}
                 data-tooltip="Click to select all changesets"
+                aria-label="Click to select all changesets"
             />
         )}
         <h5 className="p-2 d-none d-md-block text-uppercase text-center text-nowrap">Status</h5>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import React from 'react'
+import React, { useEffect } from 'react'
 
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
@@ -21,6 +21,7 @@ export interface ChangesetNodeProps extends ThemeProps {
     location: H.Location
     enableSelect?: boolean
     onSelect?: (id: string, selected: boolean) => void
+    reportId?: (id: string) => void
     isSelected?: (id: string) => boolean
     extensionInfo?: {
         hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
@@ -31,7 +32,13 @@ export interface ChangesetNodeProps extends ThemeProps {
     expandByDefault?: boolean
 }
 
-export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({ node, ...props }) => {
+export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({ node, reportId, ...props }) => {
+    useEffect(() => {
+        if (reportId !== undefined) {
+            reportId(node.id)
+        }
+    }, [node.id, reportId])
+
     if (node.__typename === 'ExternalChangeset') {
         return (
             <>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { Hoverifier } from '@sourcegraph/codeintellify'
 import { ActionItemAction } from '@sourcegraph/shared/src/actions/ActionItem'
@@ -21,7 +21,6 @@ export interface ChangesetNodeProps extends ThemeProps {
     location: H.Location
     enableSelect?: boolean
     onSelect?: (id: string, selected: boolean) => void
-    reportId?: (id: string) => void
     isSelected?: (id: string) => boolean
     extensionInfo?: {
         hoverifier: Hoverifier<RepoSpec & RevisionSpec & FileSpec & ResolvedRevisionSpec, HoverMerged, ActionItemAction>
@@ -32,13 +31,7 @@ export interface ChangesetNodeProps extends ThemeProps {
     expandByDefault?: boolean
 }
 
-export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({ node, reportId, ...props }) => {
-    useEffect(() => {
-        if (reportId !== undefined) {
-            reportId(node.id)
-        }
-    }, [node.id, reportId])
-
+export const ChangesetNode: React.FunctionComponent<ChangesetNodeProps> = ({ node, ...props }) => {
     if (node.__typename === 'ExternalChangeset') {
         return (
             <>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -10,7 +10,6 @@ const { add } = storiesOf('web/batches/ChangesetSelectRow', module).addDecorator
 ))
 
 const onSubmit = (): void => {}
-const deselectAll = (): void => {}
 
 add('all states', () => (
     <EnterpriseWebStory>
@@ -19,7 +18,6 @@ add('all states', () => (
                 <ChangesetSelectRow
                     {...props}
                     onSubmit={onSubmit}
-                    deselectAll={deselectAll}
                     selected={new Set(['id-1', 'id-2'])}
                     isSubmitting={false}
                 />
@@ -27,7 +25,6 @@ add('all states', () => (
                 <ChangesetSelectRow
                     {...props}
                     onSubmit={onSubmit}
-                    deselectAll={deselectAll}
                     selected={new Set(['id-1', 'id-2'])}
                     isSubmitting={true}
                 />
@@ -35,7 +32,6 @@ add('all states', () => (
                 <ChangesetSelectRow
                     {...props}
                     onSubmit={onSubmit}
-                    deselectAll={deselectAll}
                     selected={new Set(['id-1', 'id-2'])}
                     isSubmitting={new Error('something went wrong with the backend :(')}
                 />

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -8,43 +8,31 @@ import { ErrorAlert } from '../../../../components/alerts'
 export interface ChangesetSelectRowProps {
     selected: Set<string>
     onSubmit: () => void
-    deselectAll: () => void
     isSubmitting: boolean | Error
 }
 
 export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps> = ({
     selected,
     onSubmit,
-    deselectAll,
     isSubmitting,
 }) => (
     <>
         <div className="row align-items-center no-gutters">
-            <div className="ml-2 col-auto">
-                <input
-                    id="deselect-all"
-                    type="checkbox"
-                    className="btn"
-                    checked={selected.size > 0}
-                    onChange={deselectAll}
-                    data-tooltip="Click to deselect all"
-                />
-            </div>
-            <div className="ml-2 col">
-                {selected.size} archived {pluralize('changeset', selected.size)} selected for detaching.
-            </div>
+            <div className="ml-2 col">Select changesets to detach them</div>
             <div className="w-100 d-block d-md-none" />
             <div className="m-0 col col-md-auto">
                 <div className="row no-gutters">
                     <div className="col my-2 ml-0 ml-sm-2">
                         <button
                             type="button"
-                            className="btn btn-primary text-nowrap"
+                            className="btn btn-secondary text-nowrap"
                             onClick={onSubmit}
-                            disabled={isSubmitting === true}
+                            disabled={selected.size === 0 || isSubmitting === true}
                             data-tooltip={`Click to detach ${selected.size} ${pluralize('changeset', selected.size)}.`}
                         >
-                            Detach {selected.size} {pluralize('changeset', selected.size)}
+                            {selected.size > 0
+                                ? `Detach ${selected.size} ${pluralize('changeset', selected.size)}`
+                                : 'Detach changesets'}
                         </button>
                     </div>
                 </div>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -32,7 +32,6 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                             className="btn btn-secondary text-nowrap"
                             onClick={onSubmit}
                             disabled={selected.size === 0 || isSubmitting === true}
-                            data-tooltip={`Click to detach ${selected.size} ${pluralize('changeset', selected.size)}.`}
                         >
                             {selected.size > 0
                                 ? `Detach ${selected.size} ${pluralize('changeset', selected.size)}`

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -1,3 +1,4 @@
+import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import React from 'react'
 
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
@@ -18,7 +19,10 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
 }) => (
     <>
         <div className="row align-items-center no-gutters">
-            <div className="ml-2 col">Select changesets to detach them</div>
+            <div className="ml-2 col">
+                <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
+                Select changesets to detach them
+            </div>
             <div className="w-100 d-block d-md-none" />
             <div className="m-0 col col-md-auto">
                 <div className="row no-gutters">

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -82,6 +82,18 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
 
     return (
         <>
+            <button
+                type="button"
+                className="btn btn-icon test-batches-expand-changeset d-none d-sm-block"
+                aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
+                onClick={toggleIsExpanded}
+            >
+                {isExpanded ? (
+                    <ChevronDownIcon className="icon-inline" aria-label="Close section" />
+                ) : (
+                    <ChevronRightIcon className="icon-inline" aria-label="Expand section" />
+                )}
+            </button>
             {enableSelect && (
                 <div className="p-2">
                     <input
@@ -95,18 +107,6 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                     />
                 </div>
             )}
-            <button
-                type="button"
-                className="btn btn-icon test-batches-expand-changeset d-none d-sm-block"
-                aria-label={isExpanded ? 'Collapse section' : 'Expand section'}
-                onClick={toggleIsExpanded}
-            >
-                {isExpanded ? (
-                    <ChevronDownIcon className="icon-inline" aria-label="Close section" />
-                ) : (
-                    <ChevronRightIcon className="icon-inline" aria-label="Expand section" />
-                )}
-            </button>
             <ChangesetStatusCell
                 state={node.state}
                 className="p-2 align-self-stretch text-muted external-changeset-node__state d-block d-sm-flex"

--- a/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
@@ -15,6 +15,7 @@ export const HiddenExternalChangesetNode: React.FunctionComponent<HiddenExternal
     enableSelect = false,
 }) => (
     <>
+        <span className="d-none d-sm-block" />
         {enableSelect && (
             <div className="p-2">
                 <input
@@ -27,7 +28,6 @@ export const HiddenExternalChangesetNode: React.FunctionComponent<HiddenExternal
                 />
             </div>
         )}
-        <span className="d-none d-sm-block" />
         <ChangesetStatusCell
             state={node.state}
             className="p-2 hidden-external-changeset-node__status text-muted d-block d-sm-flex"


### PR DESCRIPTION
This fixes https://github.com/sourcegraph/sourcegraph/issues/19702 by incorporating the design feedback into how the multi-select UI for archived changesets works.

Demo video:


https://user-images.githubusercontent.com/1185253/114391128-63b36400-9b97-11eb-86a9-a7537445d1b3.mp4

