### PR TITLE
Add more memory to chromatic storybook build step

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -100,6 +100,7 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			bk.Cmd("yarn --mutex network --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("yarn gulp generate"),
 			bk.Env("MINIFY", "1"),
+			bk.Env("NODE_OPTIONS", "--max_old_space_size=4096")
 			bk.Cmd(chromaticCommand))
 
 		// Shared tests

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -100,7 +100,7 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			bk.Cmd("yarn --mutex network --frozen-lockfile --network-timeout 60000"),
 			bk.Cmd("yarn gulp generate"),
 			bk.Env("MINIFY", "1"),
-			bk.Env("NODE_OPTIONS", "--max_old_space_size=4096")
+			bk.Env("NODE_OPTIONS", "--max_old_space_size=4096"),
 			bk.Cmd(chromaticCommand))
 
 		// Shared tests


### PR DESCRIPTION
It seems like chromatic is failing with run out of memory error. I've noticed that we have a build storybook script with NODE_OPTION --max_old_space_size=4096 in async-build step - coverage storybook step and we don't have a problem there.

So it might fix the problem with chromatic step in the main pipeline step as well.