### PR TITLE
search frontend: highlight recognized predicates

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1236,4 +1236,40 @@ describe('getMonacoTokens()', () => {
             ]
         `)
     })
+
+    test('highlight recognized predicate', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains.file(README.md)')), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaPredicateDot"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 18,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 28,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `)
+    })
 })

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -12,6 +12,7 @@ import {
     Group,
     Quantifier,
 } from 'regexpp/ast'
+import { Predicate, scanPredicate } from './predicates'
 
 /* eslint-disable unicorn/better-regex */
 
@@ -35,6 +36,7 @@ export type MetaToken =
     | MetaContextPrefix
     | MetaSelector
     | MetaPath
+    | MetaPredicate
 
 /**
  * Defines common properties for meta tokens.
@@ -169,6 +171,21 @@ export interface MetaPath {
     range: CharacterRange
     kind: MetaPathKind
     value: string
+}
+
+export enum MetaPredicateKind {
+    NameAccess = 'NameAccess',
+    Dot = 'Dot',
+    Parenthesis = 'Parenthesis',
+}
+
+/**
+ * Predicate members for decoration.
+ */
+export interface MetaPredicate {
+    type: 'metaPredicate'
+    range: CharacterRange
+    kind: MetaPredicateKind
 }
 
 /**
@@ -813,6 +830,47 @@ const decorateSelector = (token: Literal): DecoratedToken[] => {
     return [{ type: 'metaSelector', range: token.range, value: token.value, kind }]
 }
 
+const decoratePredicate = (predicate: Predicate, range: CharacterRange): DecoratedToken[] => {
+    let offset = range.start
+    const decorated: DecoratedToken[] = []
+    for (const nameAccess of predicate.path) {
+        decorated.push({
+            type: 'metaPredicate',
+            kind: MetaPredicateKind.NameAccess,
+            range: { start: offset, end: offset + nameAccess.length },
+        })
+        offset = offset + nameAccess.length
+        decorated.push({
+            type: 'metaPredicate',
+            kind: MetaPredicateKind.Dot,
+            range: { start: offset, end: offset + 1 },
+        })
+        offset = offset + 1
+    }
+    decorated.pop() // Pop trailling '.'
+    offset = offset - 1 // Backtrack offset
+    const parametersBody = predicate.parameters.slice(1, -1)
+    decorated.push({
+        type: 'metaPredicate',
+        kind: MetaPredicateKind.Parenthesis,
+        range: { start: offset, end: offset + 1 },
+    })
+    offset = offset + 1
+    decorated.push({
+        type: 'literal',
+        value: parametersBody,
+        range: { start: offset, end: offset + parametersBody.length },
+        quoted: false,
+    })
+    offset = offset + parametersBody.length
+    decorated.push({
+        type: 'metaPredicate',
+        kind: MetaPredicateKind.Parenthesis,
+        range: { start: offset, end: offset + 1 },
+    })
+    return decorated
+}
+
 export const decorate = (token: Token): DecoratedToken[] => {
     const decorated: DecoratedToken[] = []
     switch (token.type) {
@@ -835,6 +893,11 @@ export const decorate = (token: Token): DecoratedToken[] => {
                 range: token.field.range,
                 value: token.field.value,
             })
+            const predicate = scanPredicate(token.field.value, token.value?.value || '')
+            if (predicate && token.value) {
+                decorated.push(...decoratePredicate(predicate, token.value.range))
+                break
+            }
             if (
                 token.value &&
                 token.field.value.toLowerCase().match(/^-?(repo|r)$/i) &&
@@ -888,6 +951,7 @@ const decoratedToMonaco = (token: DecoratedToken): Monaco.languages.IToken => {
         case 'metaRevision':
         case 'metaRegexp':
         case 'metaStructural':
+        case 'metaPredicate':
             // The scopes value is derived from the token type and its kind.
             // E.g., regexpMetaDelimited derives from {@link RegexpMeta} and {@link RegexpMetaKind}.
             return {

--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -42,6 +42,9 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
         // Sourcegraph decorated language tokens
         { token: 'metaRepoRevisionSeparator', foreground: '#569cd9' },
         { token: 'metaContextPrefix', foreground: '#da77f2' },
+        { token: 'metaPredicateNameAccess', foreground: '#da77f2' },
+        { token: 'metaPredicateDot', foreground: '#f2f4f8' },
+        { token: 'metaPredicateParenthesis', foreground: '#f08d58' },
         // Regexp pattern highlighting
         { token: 'metaRegexpDelimited', foreground: '#ff6b6b' },
         { token: 'metaRegexpAssertion', foreground: '#ff6b6b' },
@@ -102,6 +105,9 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
         // Sourcegraph decorated language tokens
         { token: 'metaRepoRevisionSeparator', foreground: '#268bd2' },
         { token: 'metaContextPrefix', foreground: '#ae3ec9' },
+        { token: 'metaPredicateNameAccess', foreground: '#ae3ec9' },
+        { token: 'metaPredicateDot', foreground: '#2b3750' },
+        { token: 'metaPredicateParenthesis', foreground: '#d6550f' },
         // Regexp pattern highlighting
         { token: 'metaRegexpDelimited', foreground: '#c92a2a' },
         { token: 'metaRegexpAssertion', foreground: '#c92a2a' },


### PR DESCRIPTION
First part of predicate highlighting

<img width="559" alt="Screen Shot 2021-04-09 at 1 20 03 PM" src="https://user-images.githubusercontent.com/888624/114236944-310b3080-9937-11eb-857b-f6e433287859.png">
<img width="561" alt="Screen Shot 2021-04-09 at 1 19 53 PM" src="https://user-images.githubusercontent.com/888624/114236946-31a3c700-9937-11eb-9847-3779d32b6037.png">

Doesn't highlight inside the parameter body `(...)` yet, need to update the scanner to do that.