### PR TITLE
Fix node.js OOM errors

### DIFF
--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -37,6 +37,9 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 
 		// Add debug flags for scripts to consume
 		"CI_DEBUG_PROFILE": strconv.FormatBool(c.profilingEnabled),
+
+		// Bump Node.js memory to prevent OOM crashes
+		"NODE_OPTIONS": "--max_old_space_size=4096",
 	}
 
 	// On release branches Percy must compare to the previous commit of the release branch, not main.


### PR DESCRIPTION
Bumping memory for all Node.js processes, should prevent Chromatic crashes.