### PR TITLE
search frontend: update scanner to recognize predicates before patterns

### DIFF
--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -74,6 +74,9 @@ export const scanBalancedParens = (input: string): string | undefined => {
                 continue
             }
             result.push(current)
+        } else if (current.match(/^\s+/) && balanced <= 0) {
+            // Whitespace signals we've reached the end of this parenthesized expr.
+            break
         } else {
             result.push(current)
         }
@@ -104,11 +107,11 @@ export const scanPredicate = (field: string, value: string): Predicate | undefin
         return undefined
     }
     const rest = value.slice(name.length)
-    if (!rest.startsWith('(') || !rest.endsWith(')')) {
-        return undefined
-    }
     const parameters = scanBalancedParens(rest)
     if (!parameters) {
+        return undefined
+    }
+    if (!parameters.startsWith('(') || !parameters.endsWith(')')) {
         return undefined
     }
 

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -197,3 +197,17 @@ thing`
         )
     })
 })
+
+describe('scanSearchQuery() with predicate', () => {
+    test('recognize predicate', () => {
+        expect(scanSearchQuery('repo:contains(file:README.md)')).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":29},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"contains(file:README.md)","range":{"start":5,"end":29},"quoted":false},"negated":false}]}'
+        )
+    })
+
+    test('recognize multiple predicates over whitespace', () => {
+        expect(scanSearchQuery('repo:contains(file:README.md)\n\nrepo:contains.file(foo)')).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":29},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"contains(file:README.md)","range":{"start":5,"end":29},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":29,"end":31}},{"type":"filter","range":{"start":31,"end":54},"field":{"type":"literal","value":"repo","range":{"start":31,"end":35}},"value":{"type":"literal","value":"contains.file(foo)","range":{"start":36,"end":54},"quoted":false},"negated":false}]}'
+        )
+    })
+})


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/19894.

This is a change in the scanner to recognize predicates before attempting a (pretty important) heuristic that identifies patterns. It is analogous to backend treatment. Visually:

Previously:

<img width="366" alt="Screen Shot 2021-04-09 at 4 23 06 PM" src="https://user-images.githubusercontent.com/888624/114249586-e518b580-994f-11eb-8792-dd2b342190cf.png">

Here, predicate scanning is not attempted, that the syntax is _interpreted_ as:

`repo:contains (file:CHANGELOG content:fix)`

This is/was a technically correct interpretation before search predicates (despite the slightly off highlighting of a dangling paren there).

Now:

<img width="364" alt="Screen Shot 2021-04-09 at 4 22 41 PM" src="https://user-images.githubusercontent.com/888624/114249578-e1852e80-994f-11eb-8dfc-22c9727487b5.png">

More highlighting changes to come to highlight inside the `(...)` later. Clean up/reorg of scanner logic to come later.

