### PR TITLE
search frontend: better names in scanner

### DIFF
--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -333,9 +333,9 @@ const comment = scanToken(
     (input, { start, end }): Comment => ({ type: 'comment', value: input.slice(start, end), range: { start, end } })
 )
 
-const filterKeyword = scanToken(new RegExp(`-?(${filterTypeKeysWithAliases.join('|')})+(?=:)`, 'i'))
+const filterField = scanToken(new RegExp(`-?(${filterTypeKeysWithAliases.join('|')})+(?=:)`, 'i'))
 
-const filterDelimiter = character(':')
+const filterSeparator = character(':')
 
 const filterValue = oneOf<Literal>(quoted('"'), quoted("'"), scanBalancedLiteral, literal)
 
@@ -375,21 +375,21 @@ const followedBy = (scanToken: Scanner<Token>, scanNext: Scanner<Token>): Scanne
  * in a search query.
  */
 const filter: Scanner<Filter> = (input, start) => {
-    const scannedKeyword = filterKeyword(input, start)
-    if (scannedKeyword.type === 'error') {
-        return scannedKeyword
+    const scannedField = filterField(input, start)
+    if (scannedField.type === 'error') {
+        return scannedField
     }
-    const scannedDelimiter = filterDelimiter(input, scannedKeyword.term.range.end)
-    if (scannedDelimiter.type === 'error') {
-        return scannedDelimiter
+    const scannedSeparator = filterSeparator(input, scannedField.term.range.end)
+    if (scannedSeparator.type === 'error') {
+        return scannedSeparator
     }
     let scannedValue: ScanResult<Literal> | undefined
-    if (input[scannedDelimiter.term.range.end] === undefined) {
+    if (input[scannedSeparator.term.range.end] === undefined) {
         scannedValue = undefined
     } else {
-        scannedValue = scanPredicateValue(input, scannedDelimiter.term.range.end, scannedKeyword.term)
+        scannedValue = scanPredicateValue(input, scannedSeparator.term.range.end, scannedField.term)
         if (scannedValue.type === 'error') {
-            scannedValue = filterValue(input, scannedDelimiter.term.range.end)
+            scannedValue = filterValue(input, scannedSeparator.term.range.end)
         }
     }
     if (scannedValue && scannedValue.type === 'error') {
@@ -399,10 +399,10 @@ const filter: Scanner<Filter> = (input, start) => {
         type: 'success',
         term: {
             type: 'filter',
-            range: { start, end: scannedValue ? scannedValue.term.range.end : scannedDelimiter.term.range.end },
-            field: scannedKeyword.term,
+            range: { start, end: scannedValue ? scannedValue.term.range.end : scannedSeparator.term.range.end },
+            field: scannedField.term,
             value: scannedValue?.term,
-            negated: scannedKeyword.term.value.startsWith('-'),
+            negated: scannedField.term.value.startsWith('-'),
         },
     }
 }
@@ -417,7 +417,7 @@ const createPattern = (value: string, range: CharacterRange, kind: PatternKind):
     },
 })
 
-const scanFilterOrKeyword = oneOf<Literal | Token[]>(filterKeyword, followedBy(keyword, whitespace))
+const scanFilterOrKeyword = oneOf<Literal | Token[]>(filterField, followedBy(keyword, whitespace))
 const keepScanning = (input: string, start: number): boolean => scanFilterOrKeyword(input, start).type !== 'success'
 
 /**


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/19900.

Just some renames that are more suitable.

`filterKeyword` -> `filterField`. We refer to this part as `field` in the backend, and `Keyword` conflicts with a uses of `Keyword` to refer to `and`, `or`, etc. operators.

`filterDelimiter` -> `filterSeparator` to refer to the `:` in `field:value`. `Delimiter` conflicts with uses that refer to `"` or `'` or `/` as quoting delimiters.