### PR TITLE
Clean up config and improve compile time for storybooks

### DIFF
--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { remove } from 'lodash'
 import MonacoWebpackPlugin from 'monaco-editor-webpack-plugin'
 import TerserPlugin from 'terser-webpack-plugin'
-import { Configuration, DefinePlugin, ProgressPlugin, RuleSetRule } from 'webpack'
+import { Configuration, DefinePlugin, ProgressPlugin } from 'webpack'
 
 const rootPath = path.resolve(__dirname, '../../../')
 const monacoEditorPaths = [path.resolve(rootPath, 'node_modules', 'monaco-editor')]
@@ -23,12 +23,25 @@ const config = {
         './redesign-toggle-toolbar/register.ts',
     ],
 
-    webpackFinal: (config: Configuration) => {
-        // Include sourcemaps
-        config.mode = shouldMinify ? 'production' : 'development'
-        config.devtool = shouldMinify ? 'source-map' : 'cheap-module-eval-source-map'
+    typescript: {
+        check: false,
+        reactDocgen: false,
+    },
 
-        config.plugins?.push(
+    webpackFinal: (config: Configuration) => {
+        config.mode = shouldMinify ? 'production' : 'development'
+
+        // Check the default config is in an expected shape.
+        if (!config.module) {
+            throw new Error(
+                'The format of the default storybook webpack config changed, please check if the config in ./src/main.ts is still valid'
+            )
+        }
+
+        if (!config.plugins) {
+            config.plugins = []
+        }
+        config.plugins.push(
             new DefinePlugin({
                 NODE_ENV: JSON.stringify(config.mode),
                 'process.env.NODE_ENV': JSON.stringify(config.mode),
@@ -54,14 +67,13 @@ const config = {
             }
         }
 
-        // We don't use Storybook's default Babel config for our repo, it doesn't include everything we need.
-        config.module?.rules.splice(0, 1)
-
         if (process.env.CI) {
-            remove(config.plugins || [], plugin => plugin instanceof ProgressPlugin)
+            remove(config.plugins, plugin => plugin instanceof ProgressPlugin)
         }
 
-        config.module?.rules.push({
+        // We don't use Storybook's default Babel config for our repo, it doesn't include everything we need.
+        config.module.rules.splice(0, 1)
+        config.module.rules.unshift({
             test: /\.tsx?$/,
             loader: require.resolve('babel-loader'),
             options: {
@@ -69,7 +81,7 @@ const config = {
             },
         })
 
-        config.plugins?.push(
+        config.plugins.push(
             new MonacoWebpackPlugin({
                 languages: ['json'],
                 features: [
@@ -89,11 +101,10 @@ const config = {
         )
 
         const storybookDirectory = path.resolve(rootPath, 'node_modules/@storybook')
-        config.resolve?.modules?.push('src')
 
         // Put our style rules at the beginning so they're processed by the time it
         // gets to storybook's style rules.
-        config.module?.rules.unshift({
+        config.module.rules.unshift({
             test: /\.(sass|scss)$/,
             use: [
                 'to-string-loader',
@@ -115,10 +126,13 @@ const config = {
         })
 
         // Make sure Storybook style loaders are only evaluated for Storybook styles.
-        const cssRule = config.module?.rules.find(rule => rule.test?.toString() === /\.css$/.toString()) as RuleSetRule
+        const cssRule = config.module.rules.find(rule => rule.test?.toString() === /\.css$/.toString())
+        if (!cssRule) {
+            throw new Error('Cannot find original CSS rule')
+        }
         cssRule.include = storybookDirectory
 
-        config.module?.rules.unshift({
+        config.module.rules.push({
             // CSS rule for external plain CSS (skip SASS and PostCSS for build perf)
             test: /\.css$/,
             // Make sure Storybook styles get handled by the Storybook config
@@ -126,7 +140,7 @@ const config = {
             use: ['to-string-loader', 'css-loader'],
         })
 
-        config.module?.rules.unshift({
+        config.module.rules.push({
             // CSS rule for monaco-editor, it expects styles to be loaded with `style-loader`.
             test: /\.css$/,
             include: monacoEditorPaths,
@@ -135,7 +149,7 @@ const config = {
             use: ['style-loader', 'css-loader'],
         })
 
-        config.module?.rules.unshift({
+        config.module.rules.push({
             test: /\.ya?ml$/,
             use: ['raw-loader'],
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6174,9 +6174,9 @@ axe-core@^3.5.3:
   integrity sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==
 
 axe-core@^4.0.1, axe-core@^4.0.2:
-  version "4.1.3"
-  resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
-  integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
+  version "4.1.4"
+  resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.1.4.tgz#f19cd99a84ee32a318b9c5b5bb8ed373ad94f143"
+  integrity sha512-Pdgfv6iP0gNx9ejRGa3zE7Xgkj/iclXqLfe7BnatdZz0QnLZ3jrRHUVH8wNSdN68w05Sk3ShGTb3ydktMTooig==
 
 axe-puppeteer@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Stacked on top of https://github.com/sourcegraph/sourcegraph/pull/19909

This PR
- Improves compile and recompile times, because we don't use `docgen` anyways and don't require any typechecking while building the storybooks (we have other infrastructure for this)
- Gets rid of the 1k lines log spam by using a webpack-compatible version of axe-core