### PR TITLE
search contexts: prevent flickering navbar

### DIFF
--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -47,9 +47,6 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
 
     const submitOnToggle = useCallback(
         (selectedSearchContextSpec: string): void => {
-            if (!submitSearchOnSearchContextChange) {
-                return
-            }
             submitSearch({
                 history,
                 query,
@@ -60,15 +57,18 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
                 versionContext,
             })
         },
-        [submitSearch, submitSearchOnSearchContextChange, caseSensitive, history, query, patternType, versionContext]
+        [submitSearch, caseSensitive, history, query, patternType, versionContext]
     )
 
     const selectSearchContextSpec = useCallback(
         (spec: string): void => {
-            submitOnToggle(spec)
-            setSelectedSearchContextSpec(spec)
+            if (submitSearchOnSearchContextChange) {
+                submitOnToggle(spec)
+            } else {
+                setSelectedSearchContextSpec(spec)
+            }
         },
-        [submitOnToggle, setSelectedSearchContextSpec]
+        [submitSearchOnSearchContextChange, submitOnToggle, setSelectedSearchContextSpec]
     )
 
     return (


### PR DESCRIPTION
While we wait for the result of the `isSearchContextSpecAvailable` call, we assume the context is available
to prevent flashing and moving content in the query bar. This optimizes for the most common use case where
user selects a search context from the dropdown.

If a search context is unavailable (e.g. visiting a link from other users), the flicker will still happen, but it should be largely unnoticeable because the rest of the page will still be loading too.

Fixes #19918