### PR TITLE
frontend: Order user repos by name

### DIFF
--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -397,7 +397,12 @@ func (r *UserResolver) Repositories(ctx context.Context, args *ListUserRepositor
 		opt.CursorValue = ""
 		opt.CursorDirection = "next"
 	}
-	if args.OrderBy != nil {
+	if args.OrderBy == nil {
+		opt.OrderBy = database.RepoListOrderBy{{
+			Field:      "name",
+			Descending: false,
+		}}
+	} else {
 		opt.OrderBy = database.RepoListOrderBy{{
 			Field:      toDBRepoListColumn(*args.OrderBy),
 			Descending: args.Descending,


### PR DESCRIPTION
Ordering by name is less confusing than the old default which was by id,
which is opaque to users.

Part of: https://github.com/sourcegraph/sourcegraph/issues/19884