### PR TITLE
Fix typo and wrong line-wrapping in batch changes docs

### DIFF
--- a/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
+++ b/doc/batch_changes/how-tos/opting_out_of_batch_changes.md
@@ -1,9 +1,8 @@
 # Opting out of batch changes
 
-> NOTE: This feature is requires [Sourcegraph CLI](https://github.com/sourcegraph/src-cli) 3.26.3 or later.
+> NOTE: This feature requires [Sourcegraph CLI](https://github.com/sourcegraph/src-cli) 3.26.3 or later.
 
-Repository owners that are not interested in batch change changesets can opt out
-so that their repository will be skipped when a batch spec is executed.
+Repository owners that are not interested in batch change changesets can opt out so that their repository will be skipped when a batch spec is executed.
 
 To opt out: create a file called `.batchignore` at the root of the repository you wish to be skipped. `src batch [apply|preview]` will now skip that repository if it's yielded by the `on` part of the batch spec.
 


### PR DESCRIPTION
Follow-up to Chris' comment here: https://github.com/sourcegraph/sourcegraph/pull/19877#discussion_r610911692