### PR TITLE
Design Refresh - Update color tokens

### DIFF
--- a/client/branded/src/global-styles/code.scss
+++ b/client/branded/src/global-styles/code.scss
@@ -1,14 +1,6 @@
 $code-font-family: sfmono-regular, consolas, menlo, dejavu sans mono, monospace;
 $code-font-size: (12/14) + em;
 
-.theme-dark {
-    --code-bg: var(--color-bg-2);
-}
-
-.theme-light {
-    --code-bg: var(--color-bg-2);
-}
-
 code,
 .text-code {
     font-family: $code-font-family;

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -1,2 +1,186 @@
 // Set to true to enable theme-redesign
-$theme-redesign: true !default;
+$theme-redesign: false !default;
+
+// Redesign colors
+$redesign-gray-01: #f9fafb;
+$redesign-gray-02: #f0f1f2;
+$redesign-gray-03: #e6ebf2;
+$redesign-gray-04: #dbe2f0;
+$redesign-gray-05: #a6b6d9;
+$redesign-gray-06: #778299;
+$redesign-gray-07: #5e6e8c;
+$redesign-gray-08: #343a4d;
+$redesign-gray-09: #262b38;
+$redesign-gray-10: #1d212f;
+$redesign-gray-11: #181b26;
+$redesign-gray-12: #14171f;
+$redesign-black: #0f111a;
+$redesign-blue: #0b70db;
+$redesign-red: $oc-red-9;
+$redesign-pink: #d68cf3; // TODO: check
+$redesign-indigo: #0864c6; // TODO: check
+$redesign-cyan: #72dbe8;
+// These are unchanged, preserved here for simplicity
+$redesign-purple: $oc-violet-7;
+$redesign-orange: $oc-orange-7;
+$redesign-yellow: $oc-yellow-7;
+$redesign-green: $oc-green-7;
+$redesign-teal: $oc-teal-7;
+
+// If `theme-redesign` is enabled, we update our SCSS variables to match the new redesign
+@if $theme-redesign {
+    // Bootstrap colors
+    $blue: $redesign-blue;
+    $indigo: $redesign-indigo;
+    $purple: $redesign-purple;
+    $pink: $redesign-pink;
+    $red: $redesign-red;
+    $orange: $redesign-orange;
+    $yellow: $redesign-yellow;
+    $green: $redesign-green;
+    $teal: $redesign-teal;
+    $cyan: $redesign-cyan;
+
+    // Logo
+    $logo-purple: $redesign-purple;
+
+    // Globals
+    $primary: $redesign-blue;
+    $secondary: $redesign-gray-08;
+    $success: $redesign-green;
+    $info: $redesign-cyan;
+    $warning: $redesign-yellow;
+    $danger: $redesign-red;
+    $secondary-light: $redesign-gray-03; // TODO: Confirm
+    $merged: $redesign-purple;
+
+    // mark- colors
+    $mark-bg-light: rgba(255, 218, 30, 0.5);
+    $mark-bg-dark: rgba(16, 104, 2, 0.5);
+
+    // Additional Bootstrap theming
+    $theme-colors: (
+        'merged': $merged,
+    );
+    $theme-colors-light: (
+        'secondary': $secondary-light,
+    );
+
+    // Bootstrap Tooltip
+    // Assumption: uses light-mode body-color, which matches current behavior
+    $tooltip-bg: $redesign-gray-08;
+
+    // Bootstrap box-shadows
+    // Assumption: Uses light-mode body-color, which matches current behavior
+    $box-shadow: 0 0.25rem 0.5rem rgba($redesign-gray-08, 0.07);
+}
+
+/* REDESIGN STYLES */
+:root.theme-redesign,
+// Descendant selector is required for Storybook `addRedesignVariants` helper.
+:root .theme-redesign {
+    --primary: #0b70db;
+    --primary-hover: #0864c6;
+    --secondary: #a305e1;
+    --secondary-2: #d68cf3;
+    --success: #{$oc-green-7};
+    --success-2: #afe0b8;
+    --info: #72dbe8;
+    --warning: #{$oc-yellow-7};
+    --warning-2: #fbd999;
+    --danger: #{$oc-red-9};
+    --danger-2: #e9aaaa;
+    --merged: #{$oc-violet-7};
+    --merged-2: #c6b6f6;
+    --merged-3: #6b47d6;
+    --line-number-color: #{$redesign-gray-06};
+    --header-icon-color: #{$redesign-gray-05};
+    --reversed-text: #{$white};
+    --logo-orange: #{$logo-orange};
+    --logo-blue: #{$logo-blue};
+    --logo-purple: #{$logo-purple};
+}
+
+.theme-light.theme-redesign,
+.theme-light .theme-redesign {
+    --primary-2: #a3d0ff;
+    --success-3: #319e44;
+    --info-2: #a8dbe2;
+    --info-3: #0bb3ca;
+    --warning-3: #e09200;
+
+    --danger-3: #b52626;
+    --body-color: #{$redesign-gray-08};
+    --body-bg: #{$redesign-gray-01};
+    --color-bg-1: #{$white};
+    --color-bg-2: #{$redesign-gray-03};
+    --color-bg-3: #{$redesign-gray-04};
+
+    // TODO: Check gradient and color
+    --mark-bg: rgba(255, 218, 30, 0.5);
+
+    --text-muted: #{$redesign-gray-07};
+
+    --link-color: var(--primary);
+    --link-active-color: #0c7bf0;
+    --link-hover-color: #0c7bf0;
+    --border-color: #{$redesign-gray-03};
+    --border-color-2: #{$redesign-gray-04};
+    --border-active-color: var(--primary);
+    --search-query-text-color: #{$redesign-gray-12};
+    --search-filter-keyword-color: var(--primary);
+    --search-keyword-color: var(--secondary);
+    --infobar-warning-color: #{$oc-red-8};
+
+    // TODO: Remove from use
+    --link-hover-bg-color: var(--color-bg-2);
+    --link-hover-bg-color-2: var(--color-bg-3);
+    --disabled-action-bg-color: var(--color-bg-3);
+    --disabled-action-text-color: var(--text-muted);
+
+    --icon-color: #{$redesign-gray-06};
+    --code-bg: #{$white};
+    --intel-bg: #{$white};
+}
+
+.theme-dark.theme-redesign,
+.theme-dark .theme-redesign {
+    --primary-2: #0f59aa;
+    --success-3: #237332;
+    --info-2: #99cdd6;
+    --info-3: #005766;
+    --warning-3: #9c6500;
+
+    --danger-3: #801b1b;
+    --body-color: #{$redesign-gray-04};
+    --body-bg: #{$redesign-gray-12};
+    --color-bg-1: #{$redesign-gray-11};
+    --color-bg-2: #{$redesign-gray-10};
+    --color-bg-3: #{$redesign-gray-08};
+
+    // TODO: Check gradient and color
+    --mark-bg: rgba(16, 104, 2, 0.5);
+
+    --text-muted: #{$redesign-gray-05};
+
+    --link-color: #4393e7;
+    --link-active-color: #489ffa;
+    --link-hover-color: #489ffa;
+    --border-color: #{$redesign-gray-09};
+    --border-color-2: #{$redesign-gray-08};
+    --border-active-color: #4393e7;
+    --search-query-text-color: #{$redesign-gray-04};
+    --search-filter-keyword-color: #4393e7;
+    --search-keyword-color: var(--secondary-2);
+    --infobar-warning-color: #f05151;
+
+    // TODO: Remove from use, replace with the variables referenced here
+    --link-hover-bg-color: var(--color-bg-2);
+    --link-hover-bg-color-2: var(--color-bg-3);
+    --disabled-action-bg-color: var(--color-bg-3);
+    --disabled-action-text-color: var(--text-muted);
+
+    --icon-color: #{$redesign-gray-05};
+    --code-bg: #{$redesign-gray-10};
+    --intel-bg: #{$redesign-gray-12};
+}

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -76,7 +76,6 @@ $redesign-teal: $oc-teal-7;
     $box-shadow: 0 0.25rem 0.5rem rgba($redesign-gray-08, 0.07);
 }
 
-/* REDESIGN STYLES */
 :root.theme-redesign,
 // Descendant selector is required for Storybook `addRedesignVariants` helper.
 :root .theme-redesign {
@@ -132,6 +131,7 @@ $redesign-teal: $oc-teal-7;
     --intel-bg: #{$white};
 
     // TODO: Remove from use, replace with the variables referenced here
+    // Issue: https://github.com/sourcegraph/sourcegraph/issues/19973
     --link-hover-bg-color: var(--color-bg-2);
     --link-hover-bg-color-2: var(--color-bg-3);
     --disabled-action-bg-color: var(--color-bg-3);
@@ -168,6 +168,7 @@ $redesign-teal: $oc-teal-7;
     --intel-bg: #{$redesign-gray-12};
 
     // TODO: Remove from use, replace with the variables referenced here
+    // Issue: https://github.com/sourcegraph/sourcegraph/issues/19973
     --link-hover-bg-color: var(--color-bg-2);
     --link-hover-bg-color-2: var(--color-bg-3);
     --disabled-action-bg-color: var(--color-bg-3);

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -52,7 +52,7 @@ $redesign-teal: $oc-teal-7;
     $info: $redesign-cyan;
     $warning: $redesign-yellow;
     $danger: $redesign-red;
-    $secondary-light: $redesign-gray-03; // TODO: Confirm
+    $secondary-light: $redesign-gray-03;
     $merged: $redesign-purple;
 
     // mark- colors

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -131,7 +131,7 @@ $redesign-teal: $oc-teal-7;
     --code-bg: #{$white};
     --intel-bg: #{$white};
 
-    // TODO: Remove from use
+    // TODO: Remove from use, replace with the variables referenced here
     --link-hover-bg-color: var(--color-bg-2);
     --link-hover-bg-color-2: var(--color-bg-3);
     --disabled-action-bg-color: var(--color-bg-3);

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -80,18 +80,18 @@ $redesign-teal: $oc-teal-7;
 :root.theme-redesign,
 // Descendant selector is required for Storybook `addRedesignVariants` helper.
 :root .theme-redesign {
-    --primary: #0b70db;
-    --primary-hover: #0864c6;
+    --primary: #{$redesign-blue};
+    --primary-hover: #{$redesign-indigo};
     --secondary: #a305e1;
-    --secondary-2: #d68cf3;
-    --success: #{$oc-green-7};
+    --secondary-2: #{$redesign-pink};
+    --success: #{$redesign-green};
     --success-2: #afe0b8;
-    --info: #72dbe8;
-    --warning: #{$oc-yellow-7};
+    --info: #{$redesign-cyan};
+    --warning: #{$redesign-yellow};
     --warning-2: #fbd999;
-    --danger: #{$oc-red-9};
+    --danger: #{$redesign-red};
     --danger-2: #e9aaaa;
-    --merged: #{$oc-violet-7};
+    --merged: #{$redesign-purple};
     --merged-2: #c6b6f6;
     --merged-3: #6b47d6;
     --line-number-color: #{$redesign-gray-06};
@@ -109,19 +109,14 @@ $redesign-teal: $oc-teal-7;
     --info-2: #a8dbe2;
     --info-3: #0bb3ca;
     --warning-3: #e09200;
-
     --danger-3: #b52626;
     --body-color: #{$redesign-gray-08};
     --body-bg: #{$redesign-gray-01};
     --color-bg-1: #{$white};
     --color-bg-2: #{$redesign-gray-03};
     --color-bg-3: #{$redesign-gray-04};
-
-    // TODO: Check gradient and color
     --mark-bg: rgba(255, 218, 30, 0.5);
-
     --text-muted: #{$redesign-gray-07};
-
     --link-color: var(--primary);
     --link-active-color: #0c7bf0;
     --link-hover-color: #0c7bf0;
@@ -132,16 +127,15 @@ $redesign-teal: $oc-teal-7;
     --search-filter-keyword-color: var(--primary);
     --search-keyword-color: var(--secondary);
     --infobar-warning-color: #{$oc-red-8};
+    --icon-color: #{$redesign-gray-06};
+    --code-bg: #{$white};
+    --intel-bg: #{$white};
 
     // TODO: Remove from use
     --link-hover-bg-color: var(--color-bg-2);
     --link-hover-bg-color-2: var(--color-bg-3);
     --disabled-action-bg-color: var(--color-bg-3);
     --disabled-action-text-color: var(--text-muted);
-
-    --icon-color: #{$redesign-gray-06};
-    --code-bg: #{$white};
-    --intel-bg: #{$white};
 }
 
 .theme-dark.theme-redesign,
@@ -151,19 +145,14 @@ $redesign-teal: $oc-teal-7;
     --info-2: #99cdd6;
     --info-3: #005766;
     --warning-3: #9c6500;
-
     --danger-3: #801b1b;
     --body-color: #{$redesign-gray-04};
     --body-bg: #{$redesign-gray-12};
     --color-bg-1: #{$redesign-gray-11};
     --color-bg-2: #{$redesign-gray-10};
     --color-bg-3: #{$redesign-gray-08};
-
-    // TODO: Check gradient and color
     --mark-bg: rgba(16, 104, 2, 0.5);
-
     --text-muted: #{$redesign-gray-05};
-
     --link-color: #4393e7;
     --link-active-color: #489ffa;
     --link-hover-color: #489ffa;
@@ -174,14 +163,13 @@ $redesign-teal: $oc-teal-7;
     --search-filter-keyword-color: #4393e7;
     --search-keyword-color: var(--secondary-2);
     --infobar-warning-color: #f05151;
+    --icon-color: #{$redesign-gray-05};
+    --code-bg: #{$redesign-gray-10};
+    --intel-bg: #{$redesign-gray-12};
 
     // TODO: Remove from use, replace with the variables referenced here
     --link-hover-bg-color: var(--color-bg-2);
     --link-hover-bg-color-2: var(--color-bg-3);
     --disabled-action-bg-color: var(--color-bg-3);
     --disabled-action-text-color: var(--text-muted);
-
-    --icon-color: #{$redesign-gray-05};
-    --code-bg: #{$redesign-gray-10};
-    --intel-bg: #{$redesign-gray-12};
 }

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -1,5 +1,5 @@
 // Set to true to enable theme-redesign
-$theme-redesign: true !default;
+$theme-redesign: false !default;
 
 // Redesign colors
 $redesign-gray-01: #f9fafb;

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -1,5 +1,5 @@
 // Set to true to enable theme-redesign
-$theme-redesign: false !default;
+$theme-redesign: true !default;
 
 // Redesign colors
 $redesign-gray-01: #f9fafb;
@@ -15,10 +15,11 @@ $redesign-gray-10: #1d212f;
 $redesign-gray-11: #181b26;
 $redesign-gray-12: #14171f;
 $redesign-black: #0f111a;
+// TODO: Update these values to match new Bootstrap designs
 $redesign-blue: #0b70db;
 $redesign-red: $oc-red-9;
-$redesign-pink: #d68cf3; // TODO: check
-$redesign-indigo: #0864c6; // TODO: check
+$redesign-pink: #d68cf3;
+$redesign-indigo: #0864c6;
 $redesign-cyan: #72dbe8;
 // These are unchanged, preserved here for simplicity
 $redesign-purple: $oc-violet-7;

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -1,0 +1,2 @@
+// Set to true to enable theme-redesign
+$theme-redesign: true !default;

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -1,5 +1,5 @@
-// Set to true to enable theme-redesign
-$theme-redesign: false !default;
+// Set to true to compile Bootstrap with our redesign variables
+$bootstap-use-redesign-variables: false !default;
 
 // Redesign colors
 $redesign-gray-01: #f9fafb;
@@ -28,8 +28,8 @@ $redesign-yellow: $oc-yellow-7;
 $redesign-green: $oc-green-7;
 $redesign-teal: $oc-teal-7;
 
-// If `theme-redesign` is enabled, we update our SCSS variables to match the new redesign
-@if $theme-redesign {
+// If `bootstap-use-redesign-variables` is enabled, we update our SCSS variables to match the new redesign
+@if $bootstap-use-redesign-variables {
     // Bootstrap colors
     $blue: $redesign-blue;
     $indigo: $redesign-indigo;

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -1,6 +1,9 @@
 @import 'open-color/open-color.scss'; // Sass variables
 @import '~open-color/open-color.css'; // CSS variables
 
+// Set to true to enable theme-redesign
+$theme-redesign: true !default;
+
 // General reusable colors from our custom color palette
 
 // Gray (blueish) palette
@@ -44,9 +47,17 @@ $redesign-gray-10: #1d212f;
 $redesign-gray-11: #181b26;
 $redesign-gray-12: #14171f;
 $redesign-black: #0f111a;
-$redesign-logo-orange: #f96216;
-$redesign-logo-blue: #00b4f2;
-$redesign-logo-purple: #a305e1;
+$redesign-blue: #0b70db;
+$redesign-red: $oc-red-9;
+$redesign-pink: #d68cf3; // TODO: check
+$redesign-indigo: #0864c6; // TODO: check
+$redesign-cyan: #72dbe8;
+// These are unchanged, preserved here for simplicity
+$redesign-purple: $oc-violet-7;
+$redesign-orange: $oc-orange-7;
+$redesign-yellow: $oc-yellow-7;
+$redesign-green: $oc-green-7;
+$redesign-teal: $oc-teal-7;
 
 // Tell Bootstrap to use colors from OpenColor
 $blue: $oc-blue-7;
@@ -60,11 +71,28 @@ $green: $oc-green-7;
 $teal: $oc-teal-7;
 $cyan: $oc-cyan-3;
 
+@if $theme-redesign {
+    // Redesign Bootstrap colors. Uncomment to compile Bootstrap with redesign colors
+    $blue: $redesign-blue;
+    $indigo: $redesign-indigo;
+    $purple: $redesign-purple;
+    $pink: $redesign-pink;
+    $red: $redesign-red;
+    $orange: $redesign-orange;
+    $yellow: $redesign-yellow;
+    $green: $redesign-green;
+    $teal: $redesign-teal;
+    $cyan: $redesign-cyan;
+}
+
 // Logo colors
 $logo-orange: #f96216;
 $logo-blue: #00b4f2;
 $logo-purple: #b200f8;
+// Redesign logo color. Uncomment to compile Bootstrap with redesign colors
+// $logo-purple: $redesign-purple;
 
+// Globals
 $primary: $blue;
 $secondary: #2b3750;
 $success: $green;
@@ -74,24 +102,43 @@ $danger: $red;
 $secondary-light: darken($gray-01, 5%);
 $merged: $purple;
 
+// Redesign global colors. Uncomment to compile Bootstrap with redesign colors
+// $primary: $redesign-blue;
+// $secondary: #a305e1;
+// $success: $redesign-green;
+// $info: $redesign-cyan;
+// $warning: $redesign-yellow;
+// $danger: $redesign-red;
+// $secondary-light: darken($redesign-gray-01, 5%); // TODO: Confirm we still want this?
+// $merged: $redesign-purple;
+
 // Color for the <mark> element and highlighted/hovered tokens
 $mark-bg-dark: rgba(217, 72, 15, 0.5);
 $mark-bg-light: rgba(255, 192, 120, 0.5);
+// Redesign mark- global colors. Uncomment to compile Bootstrap with redesign colors
+// $mark-bg-light: rgba(255, 218, 30, 0.5);
+// $mark-bg-dark: rgba(16, 104, 2, 0.5);
 
 // Added to bg- and text- utilities because it is commonly needed in our app.
 $theme-colors: (
     'merged': $merged,
 );
-
 $theme-colors-light: (
     'secondary': $secondary-light,
 );
+// Update redesign bootstrap theme colors. Uncomment to compile Bootstrap with redesign colors
+// $theme-colors: (
+//     'merged': $redesign-merged,
+// );
+// $theme-colors-light: (
+//     'secondary': $redesign-secondary-light,
+// );
 
 $body-color: var(--body-color);
 $body-bg: var(--body-bg);
-
 $text-muted: var(--text-muted);
 
+/* CURRENT STYLES */
 :root {
     --primary: #{$primary};
     --secondary: #{$secondary-light};
@@ -104,6 +151,7 @@ $text-muted: var(--text-muted);
     --logo-orange: #{$logo-orange};
     --logo-blue: #{$logo-blue};
     --logo-purple: #{$logo-purple};
+    --code-bg: #{$gray-01};
 }
 .theme-light {
     // Affects default browser styles
@@ -173,6 +221,7 @@ $text-muted: var(--text-muted);
     --disabled-action-text-color: #{$oc-gray-9};
 }
 
+/* REDESIGN STYLES */
 :root.theme-redesign,
 // Descendant selector is required for Storybook `addRedesignVariants` helper.
 :root .theme-redesign {
@@ -193,6 +242,9 @@ $text-muted: var(--text-muted);
     --line-number-color: #{$redesign-gray-06};
     --header-icon-color: #{$redesign-gray-05};
     --reversed-text: #{$white};
+    --logo-orange: #{$logo-orange};
+    --logo-blue: #{$logo-blue};
+    --logo-purple: #{$logo-purple};
 }
 
 .theme-light.theme-redesign,
@@ -268,7 +320,7 @@ $text-muted: var(--text-muted);
     --search-keyword-color: var(--secondary-2);
     --infobar-warning-color: #f05151;
 
-    // TODO: Remove from use
+    // TODO: Remove from use, replace with the variables referenced here
     --link-hover-bg-color: var(--color-bg-2);
     --link-hover-bg-color-2: var(--color-bg-3);
     --disabled-action-bg-color: var(--color-bg-3);

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -30,6 +30,24 @@ $gray-22: #151c28;
 $gray-23: #0e121b;
 $black: #07090d;
 
+// Redesign colors
+$redesign-gray-01: #f9fafb;
+$redesign-gray-02: #f0f1f2;
+$redesign-gray-03: #e6ebf2;
+$redesign-gray-04: #dbe2f0;
+$redesign-gray-05: #a6b6d9;
+$redesign-gray-06: #778299;
+$redesign-gray-07: #5e6e8c;
+$redesign-gray-08: #343a4d;
+$redesign-gray-09: #262b38;
+$redesign-gray-10: #1d212f;
+$redesign-gray-11: #181b26;
+$redesign-gray-12: #14171f;
+$redesign-black: #0f111a;
+$redesign-logo-orange: #f96216;
+$redesign-logo-blue: #00b4f2;
+$redesign-logo-purple: #a305e1;
+
 // Tell Bootstrap to use colors from OpenColor
 $blue: $oc-blue-7;
 $indigo: $oc-indigo-7;
@@ -154,14 +172,109 @@ $text-muted: var(--text-muted);
     --disabled-action-bg-color: #{$oc-gray-8};
     --disabled-action-text-color: #{$oc-gray-9};
 }
-.theme-light.theme-redesign,
+
+:root.theme-redesign,
 // Descendant selector is required for Storybook `addRedesignVariants` helper.
-.theme-light .theme-redesign {
-    --link-color: #0bdbd1;
-    --web-content-link-color: #0bdbd1;
+:root .theme-redesign {
+    --primary: #0b70db;
+    --primary-hover: #0864c6;
+    --secondary: #a305e1;
+    --secondary-2: #d68cf3;
+    --success: #{$oc-green-7};
+    --success-2: #afe0b8;
+    --info: #72dbe8;
+    --warning: #{$oc-yellow-7};
+    --warning-2: #fbd999;
+    --danger: #{$oc-red-9};
+    --danger-2: #e9aaaa;
+    --merged: #{$oc-violet-7};
+    --merged-2: #c6b6f6;
+    --merged-3: #6b47d6;
+    --line-number-color: #{$redesign-gray-06};
+    --header-icon-color: #{$redesign-gray-05};
+    --reversed-text: #{$white};
 }
+
+.theme-light.theme-redesign,
+.theme-light .theme-redesign {
+    --primary-2: #a3d0ff;
+    --success-3: #319e44;
+    --info-2: #a8dbe2;
+    --info-3: #0bb3ca;
+    --warning-3: #e09200;
+
+    --danger-3: #b52626;
+    --body-color: #{$redesign-gray-08};
+    --body-bg: #{$redesign-gray-01};
+    --color-bg-1: #{$white};
+    --color-bg-2: #{$redesign-gray-03};
+    --color-bg-3: #{$redesign-gray-04};
+
+    // TODO: Check gradient and color
+    --mark-bg: rgba(255, 218, 30, 0.5);
+
+    --text-muted: #{$redesign-gray-07};
+
+    --link-color: var(--primary);
+    --link-active-color: #0c7bf0;
+    --link-hover-color: #0c7bf0;
+    --border-color: #{$redesign-gray-03};
+    --border-color-2: #{$redesign-gray-04};
+    --border-active-color: var(--primary);
+    --search-query-text-color: #{$redesign-gray-12};
+    --search-filter-keyword-color: var(--primary);
+    --search-keyword-color: var(--secondary);
+    --infobar-warning-color: #{$oc-red-8};
+
+    // TODO: Remove from use
+    --link-hover-bg-color: var(--color-bg-2);
+    --link-hover-bg-color-2: var(--color-bg-3);
+    --disabled-action-bg-color: var(--color-bg-3);
+    --disabled-action-text-color: var(--text-muted);
+
+    --icon-color: #{$redesign-gray-06};
+    --code-bg: #{$white};
+    --intel-bg: #{$white};
+}
+
 .theme-dark.theme-redesign,
 .theme-dark .theme-redesign {
-    --link-color: #edb1ff;
-    --web-content-link-color: #edb1ff;
+    --primary-2: #0f59aa;
+    --success-3: #237332;
+    --info-2: #99cdd6;
+    --info-3: #005766;
+    --warning-3: #9c6500;
+
+    --danger-3: #801b1b;
+    --body-color: #{$redesign-gray-04};
+    --body-bg: #{$redesign-gray-12};
+    --color-bg-1: #{$redesign-gray-11};
+    --color-bg-2: #{$redesign-gray-10};
+    --color-bg-3: #{$redesign-gray-08};
+
+    // TODO: Check gradient and color
+    --mark-bg: rgba(16, 104, 2, 0.5);
+
+    --text-muted: #{$redesign-gray-05};
+
+    --link-color: #4393e7;
+    --link-active-color: #489ffa;
+    --link-hover-color: #489ffa;
+    --border-color: #{$redesign-gray-09};
+    --border-color-2: #{$redesign-gray-08};
+    --border-active-color: #4393e7;
+    --search-query-text-color: #{$redesign-gray-04};
+    --search-filter-keyword-color: #4393e7;
+    --search-keyword-color: var(--secondary-2);
+    --infobar-warning-color: #f05151;
+
+    // TODO: Remove from use
+    --link-hover-bg-color: var(--color-bg-2);
+    --link-hover-bg-color-2: var(--color-bg-3);
+    --disabled-action-bg-color: var(--color-bg-3);
+    --disabled-action-text-color: var(--text-muted);
+
+    --icon-color: #{$redesign-gray-05};
+    --code-bg: #{$redesign-gray-10};
+    --intel-bg: #{$redesign-gray-12};
 }

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -73,7 +73,6 @@ $body-color: var(--body-color);
 $body-bg: var(--body-bg);
 $text-muted: var(--text-muted);
 
-/* CURRENT STYLES */
 :root {
     --primary: #{$primary};
     --secondary: #{$secondary-light};
@@ -156,5 +155,5 @@ $text-muted: var(--text-muted);
     --disabled-action-text-color: #{$oc-gray-9};
 }
 
-// Load redesign styling
+// Load redesign styles
 @import './colors-redesign';

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -1,9 +1,6 @@
 @import 'open-color/open-color.scss'; // Sass variables
 @import '~open-color/open-color.css'; // CSS variables
 
-// Set to true to enable theme-redesign
-$theme-redesign: true !default;
-
 // General reusable colors from our custom color palette
 
 // Gray (blueish) palette
@@ -33,32 +30,6 @@ $gray-22: #151c28;
 $gray-23: #0e121b;
 $black: #07090d;
 
-// Redesign colors
-$redesign-gray-01: #f9fafb;
-$redesign-gray-02: #f0f1f2;
-$redesign-gray-03: #e6ebf2;
-$redesign-gray-04: #dbe2f0;
-$redesign-gray-05: #a6b6d9;
-$redesign-gray-06: #778299;
-$redesign-gray-07: #5e6e8c;
-$redesign-gray-08: #343a4d;
-$redesign-gray-09: #262b38;
-$redesign-gray-10: #1d212f;
-$redesign-gray-11: #181b26;
-$redesign-gray-12: #14171f;
-$redesign-black: #0f111a;
-$redesign-blue: #0b70db;
-$redesign-red: $oc-red-9;
-$redesign-pink: #d68cf3; // TODO: check
-$redesign-indigo: #0864c6; // TODO: check
-$redesign-cyan: #72dbe8;
-// These are unchanged, preserved here for simplicity
-$redesign-purple: $oc-violet-7;
-$redesign-orange: $oc-orange-7;
-$redesign-yellow: $oc-yellow-7;
-$redesign-green: $oc-green-7;
-$redesign-teal: $oc-teal-7;
-
 // Tell Bootstrap to use colors from OpenColor
 $blue: $oc-blue-7;
 $indigo: $oc-indigo-7;
@@ -71,26 +42,10 @@ $green: $oc-green-7;
 $teal: $oc-teal-7;
 $cyan: $oc-cyan-3;
 
-@if $theme-redesign {
-    // Redesign Bootstrap colors. Uncomment to compile Bootstrap with redesign colors
-    $blue: $redesign-blue;
-    $indigo: $redesign-indigo;
-    $purple: $redesign-purple;
-    $pink: $redesign-pink;
-    $red: $redesign-red;
-    $orange: $redesign-orange;
-    $yellow: $redesign-yellow;
-    $green: $redesign-green;
-    $teal: $redesign-teal;
-    $cyan: $redesign-cyan;
-}
-
 // Logo colors
 $logo-orange: #f96216;
 $logo-blue: #00b4f2;
 $logo-purple: #b200f8;
-// Redesign logo color. Uncomment to compile Bootstrap with redesign colors
-// $logo-purple: $redesign-purple;
 
 // Globals
 $primary: $blue;
@@ -102,22 +57,9 @@ $danger: $red;
 $secondary-light: darken($gray-01, 5%);
 $merged: $purple;
 
-// Redesign global colors. Uncomment to compile Bootstrap with redesign colors
-// $primary: $redesign-blue;
-// $secondary: #a305e1;
-// $success: $redesign-green;
-// $info: $redesign-cyan;
-// $warning: $redesign-yellow;
-// $danger: $redesign-red;
-// $secondary-light: darken($redesign-gray-01, 5%); // TODO: Confirm we still want this?
-// $merged: $redesign-purple;
-
 // Color for the <mark> element and highlighted/hovered tokens
 $mark-bg-dark: rgba(217, 72, 15, 0.5);
 $mark-bg-light: rgba(255, 192, 120, 0.5);
-// Redesign mark- global colors. Uncomment to compile Bootstrap with redesign colors
-// $mark-bg-light: rgba(255, 218, 30, 0.5);
-// $mark-bg-dark: rgba(16, 104, 2, 0.5);
 
 // Added to bg- and text- utilities because it is commonly needed in our app.
 $theme-colors: (
@@ -126,13 +68,6 @@ $theme-colors: (
 $theme-colors-light: (
     'secondary': $secondary-light,
 );
-// Update redesign bootstrap theme colors. Uncomment to compile Bootstrap with redesign colors
-// $theme-colors: (
-//     'merged': $redesign-merged,
-// );
-// $theme-colors-light: (
-//     'secondary': $redesign-secondary-light,
-// );
 
 $body-color: var(--body-color);
 $body-bg: var(--body-bg);
@@ -221,112 +156,5 @@ $text-muted: var(--text-muted);
     --disabled-action-text-color: #{$oc-gray-9};
 }
 
-/* REDESIGN STYLES */
-:root.theme-redesign,
-// Descendant selector is required for Storybook `addRedesignVariants` helper.
-:root .theme-redesign {
-    --primary: #0b70db;
-    --primary-hover: #0864c6;
-    --secondary: #a305e1;
-    --secondary-2: #d68cf3;
-    --success: #{$oc-green-7};
-    --success-2: #afe0b8;
-    --info: #72dbe8;
-    --warning: #{$oc-yellow-7};
-    --warning-2: #fbd999;
-    --danger: #{$oc-red-9};
-    --danger-2: #e9aaaa;
-    --merged: #{$oc-violet-7};
-    --merged-2: #c6b6f6;
-    --merged-3: #6b47d6;
-    --line-number-color: #{$redesign-gray-06};
-    --header-icon-color: #{$redesign-gray-05};
-    --reversed-text: #{$white};
-    --logo-orange: #{$logo-orange};
-    --logo-blue: #{$logo-blue};
-    --logo-purple: #{$logo-purple};
-}
-
-.theme-light.theme-redesign,
-.theme-light .theme-redesign {
-    --primary-2: #a3d0ff;
-    --success-3: #319e44;
-    --info-2: #a8dbe2;
-    --info-3: #0bb3ca;
-    --warning-3: #e09200;
-
-    --danger-3: #b52626;
-    --body-color: #{$redesign-gray-08};
-    --body-bg: #{$redesign-gray-01};
-    --color-bg-1: #{$white};
-    --color-bg-2: #{$redesign-gray-03};
-    --color-bg-3: #{$redesign-gray-04};
-
-    // TODO: Check gradient and color
-    --mark-bg: rgba(255, 218, 30, 0.5);
-
-    --text-muted: #{$redesign-gray-07};
-
-    --link-color: var(--primary);
-    --link-active-color: #0c7bf0;
-    --link-hover-color: #0c7bf0;
-    --border-color: #{$redesign-gray-03};
-    --border-color-2: #{$redesign-gray-04};
-    --border-active-color: var(--primary);
-    --search-query-text-color: #{$redesign-gray-12};
-    --search-filter-keyword-color: var(--primary);
-    --search-keyword-color: var(--secondary);
-    --infobar-warning-color: #{$oc-red-8};
-
-    // TODO: Remove from use
-    --link-hover-bg-color: var(--color-bg-2);
-    --link-hover-bg-color-2: var(--color-bg-3);
-    --disabled-action-bg-color: var(--color-bg-3);
-    --disabled-action-text-color: var(--text-muted);
-
-    --icon-color: #{$redesign-gray-06};
-    --code-bg: #{$white};
-    --intel-bg: #{$white};
-}
-
-.theme-dark.theme-redesign,
-.theme-dark .theme-redesign {
-    --primary-2: #0f59aa;
-    --success-3: #237332;
-    --info-2: #99cdd6;
-    --info-3: #005766;
-    --warning-3: #9c6500;
-
-    --danger-3: #801b1b;
-    --body-color: #{$redesign-gray-04};
-    --body-bg: #{$redesign-gray-12};
-    --color-bg-1: #{$redesign-gray-11};
-    --color-bg-2: #{$redesign-gray-10};
-    --color-bg-3: #{$redesign-gray-08};
-
-    // TODO: Check gradient and color
-    --mark-bg: rgba(16, 104, 2, 0.5);
-
-    --text-muted: #{$redesign-gray-05};
-
-    --link-color: #4393e7;
-    --link-active-color: #489ffa;
-    --link-hover-color: #489ffa;
-    --border-color: #{$redesign-gray-09};
-    --border-color-2: #{$redesign-gray-08};
-    --border-active-color: #4393e7;
-    --search-query-text-color: #{$redesign-gray-04};
-    --search-filter-keyword-color: #4393e7;
-    --search-keyword-color: var(--secondary-2);
-    --infobar-warning-color: #f05151;
-
-    // TODO: Remove from use, replace with the variables referenced here
-    --link-hover-bg-color: var(--color-bg-2);
-    --link-hover-bg-color-2: var(--color-bg-3);
-    --disabled-action-bg-color: var(--color-bg-3);
-    --disabled-action-text-color: var(--text-muted);
-
-    --icon-color: #{$redesign-gray-05};
-    --code-bg: #{$redesign-gray-10};
-    --intel-bg: #{$redesign-gray-12};
-}
+// Load redesign styling
+@import './colors-redesign';

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -30,11 +30,11 @@
 .theme-light .theme-redesign {
     --dropdown-bg: var(--input-bg);
     --dropdown-border-color: var(--input-border-color);
-    --dropdown-link-hover-bg: var(--color-bg-2); // TODO: Check?
-    --dropdown-header-color: var(--text-muted); // TODO: Check?
+    --dropdown-link-hover-bg: var(--color-bg-2);
+    --dropdown-header-color: var(--text-muted);
     .dropdown-menu {
         border-radius: 4px;
-        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085); // TODO: Update?
+        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
     }
 }
 
@@ -42,10 +42,10 @@
 .theme-dark .theme-redesign {
     --dropdown-bg: var(--input-bg);
     --dropdown-border-color: var(--input-border-color);
-    --dropdown-link-hover-bg: var(--color-bg-2); // TODO: Check?
-    --dropdown-header-color: var(--text-muted); // TODO: Check?
+    --dropdown-link-hover-bg: var(--color-bg-2);
+    --dropdown-header-color: var(--text-muted);
     .dropdown-menu {
         border-radius: 4px;
-        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4); // TODO: Update?
+        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
     }
 }

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -25,3 +25,27 @@
         box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
     }
 }
+
+.theme-light.theme-redesign,
+.theme-light .theme-redesign {
+    --dropdown-bg: var(--input-bg);
+    --dropdown-border-color: var(--input-border-color);
+    --dropdown-link-hover-bg: var(--color-bg-2); // TODO: Check?
+    --dropdown-header-color: var(--text-muted); // TODO: Check?
+    .dropdown-menu {
+        border-radius: 4px;
+        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085); // TODO: Update?
+    }
+}
+
+.theme-dark.theme-redesign,
+.theme-dark .theme-redesign {
+    --dropdown-bg: var(--input-bg);
+    --dropdown-border-color: var(--input-border-color);
+    --dropdown-link-hover-bg: var(--color-bg-2); // TODO: Check?
+    --dropdown-header-color: var(--text-muted); // TODO: Check?
+    .dropdown-menu {
+        border-radius: 4px;
+        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4); // TODO: Update?
+    }
+}

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -39,7 +39,7 @@
 
 .theme-dark.theme-redesign,
 .theme-dark .theme-redesign {
-    --input-bg: #{$redesign-gray-03};
+    --input-bg: #{$redesign-gray-10};
     --input-disabled-bg: #{$redesign-gray-08};
     --input-border-color: #{$redesign-gray-08};
     --input-color: #{$redesign-gray-04};

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -24,6 +24,31 @@
     --input-group-addon-border-color: var(--color-bg-4);
 }
 
+.theme-light.theme-redesign,
+// Descendant selector is required for Storybook `addRedesignVariants` helper.
+.theme-light .theme-redesign {
+    --input-bg: $white;
+    --input-disabled-bg: #{$redesign-gray-04};
+    --input-border-color: #{$redesign-gray-04};
+    --input-color: #{$redesign-gray-09};
+    --input-placeholder-color: #{$redesign-gray-07};
+    --input-group-addon-color: #{$redesign-gray-08};
+    --input-group-addon-bg: #{$redesign-gray-03};
+    --input-group-addon-border-color: #{$redesign-gray-03};
+}
+
+.theme-dark.theme-redesign,
+.theme-dark .theme-redesign {
+    --input-bg: #{$redesign-gray-03};
+    --input-disabled-bg: #{$redesign-gray-08};
+    --input-border-color: #{$redesign-gray-08};
+    --input-color: #{$redesign-gray-04};
+    --input-placeholder-color: #{$redesign-gray-05};
+    --input-group-addon-color: #{$redesign-gray-01};
+    --input-group-addon-bg: #{$redesign-gray-08};
+    --input-group-addon-border-color: #{$redesign-gray-08};
+}
+
 // Prevent Firefox's default red outline for inputs
 :not(output):-moz-ui-invalid:not(:focus) {
     box-shadow: none;

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -27,7 +27,7 @@
 .theme-light.theme-redesign,
 // Descendant selector is required for Storybook `addRedesignVariants` helper.
 .theme-light .theme-redesign {
-    --input-bg: $white;
+    --input-bg: #{$white};
     --input-disabled-bg: #{$redesign-gray-04};
     --input-border-color: #{$redesign-gray-04};
     --input-color: #{$redesign-gray-09};

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -13,7 +13,11 @@ $border-radius-lg: 4px;
 $font-size-base: 0.875rem;
 $line-height-base: (20/14);
 
+// TODO: Check box-shadow?
 $box-shadow: 0 0.25rem 0.5rem rgba($gray-19, 0.07);
+// Uncomment to compile Bootstrap with updates redesign colors.
+// Uses light-mode body-color, which matches current behavior
+// $box-shadow: 0 0.25rem 0.5rem rgba($redesign-gray-08, 0.07);
 
 $grid-gutter-width: 1.5rem;
 
@@ -21,11 +25,6 @@ $grid-gutter-width: 1.5rem;
 $container-max-widths: (
     xl: 1140px,
 );
-
-$body-color: var(--body-color);
-$body-bg: var(--body-bg);
-
-$text-muted: var(--text-muted);
 
 $border-color: var(--border-color);
 
@@ -57,6 +56,9 @@ $badge-padding-x: 0.6em;
 // Tooltips
 
 $tooltip-bg: $gray-19;
+// Boostrap tooltip redesign color. Uncomment to compile Bootstrap with updated color.
+// Assumption: uses light-mode body-color, which matches current behavior
+// $tooltip-bg: $redesign-gray-08;
 
 // Forms
 

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -13,11 +13,7 @@ $border-radius-lg: 4px;
 $font-size-base: 0.875rem;
 $line-height-base: (20/14);
 
-// TODO: Check box-shadow?
 $box-shadow: 0 0.25rem 0.5rem rgba($gray-19, 0.07);
-// Uncomment to compile Bootstrap with updates redesign colors.
-// Uses light-mode body-color, which matches current behavior
-// $box-shadow: 0 0.25rem 0.5rem rgba($redesign-gray-08, 0.07);
 
 $grid-gutter-width: 1.5rem;
 
@@ -56,9 +52,6 @@ $badge-padding-x: 0.6em;
 // Tooltips
 
 $tooltip-bg: $gray-19;
-// Boostrap tooltip redesign color. Uncomment to compile Bootstrap with updated color.
-// Assumption: uses light-mode body-color, which matches current behavior
-// $tooltip-bg: $redesign-gray-08;
 
 // Forms
 

--- a/client/branded/src/global-styles/web-content.scss
+++ b/client/branded/src/global-styles/web-content.scss
@@ -1,7 +1,7 @@
 // We intentionally want to style all descendants with these classes.
 // stylelint-disable selector-max-compound-selectors
 
-.web-content:not(.theme-redesign .web-content) {
+.web-content {
     .theme-dark & {
         color: var(--body-color);
 

--- a/client/branded/src/global-styles/web-content.scss
+++ b/client/branded/src/global-styles/web-content.scss
@@ -1,7 +1,7 @@
 // We intentionally want to style all descendants with these classes.
 // stylelint-disable selector-max-compound-selectors
 
-.web-content {
+.web-content:not(.theme-redesign .web-content) {
     .theme-dark & {
         color: var(--body-color);
 

--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -13,10 +13,6 @@ $media-md: 768px;
 $media-lg: 992px;
 $media-xl: 1200px;
 
-$theme-colors-light: (
-    'secondary': $secondary-light,
-);
-
 :root {
     --border-color: rgba(0, 0, 0, 0.125);
     --mark-bg: #{$mark-bg-light};


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/19968

Designs: https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization?node-id=908%3A7205

## Description
This PR is the initial work to update our global styles to match the new colors in the design refresh.

- These color changes are scoped under `theme-redesign`, it should not have any impact on current production styles
- This PR does not aim to fully address our Bootstrap styles, this is a larger piece of work which https://github.com/sourcegraph/sourcegraph/issues/19969 will address.
- There is a limitation that our Sass variables (primarily used for Bootstrap) will not dynamically switch depending on our theme, as these have to be set at compile time. This will be addressed as part of https://github.com/sourcegraph/sourcegraph/issues/19969. See also https://github.com/sourcegraph/sourcegraph/pull/19926#discussion_r612511837.
