### PR TITLE
extensions: log extension activation events from extension host

### DIFF
--- a/client/shared/src/api/client/mainthread-api.ts
+++ b/client/shared/src/api/client/mainthread-api.ts
@@ -71,6 +71,7 @@ export const initMainThreadAPI = (
         | 'sideloadedExtensionURL'
         | 'getScriptURLForExtension'
         | 'getStaticExtensions'
+        | 'telemetryService'
     >
 ): { api: MainThreadAPI; exposedToClient: ExposedToClient; subscription: Subscription } => {
     const subscription = new Subscription()
@@ -169,6 +170,7 @@ export const initMainThreadAPI = (
 
             return proxySubscribable(getEnabledExtensions(platformContext))
         },
+        logEvent: (eventName, eventProperties) => platformContext.telemetryService?.log(eventName, eventProperties),
     }
 
     return { api, exposedToClient, subscription }

--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -202,4 +202,9 @@ export interface MainThreadAPI {
         | (((bundleURLs: string[]) => Promise<(string | ErrorLike)[]>) & ProxyMarked)
 
     getEnabledExtensions: () => ProxySubscribable<(ConfiguredExtension | ExecutableExtension)[]>
+
+    /**
+     * Log an event (by sending it to the server).
+     */
+    logEvent: (eventName: string, eventProperties?: any) => void
 }

--- a/client/shared/src/api/extension/activation.ts
+++ b/client/shared/src/api/extension/activation.ts
@@ -1,6 +1,6 @@
 import { Remote } from 'comlink'
 import { BehaviorSubject, combineLatest, from, Observable, Subscription } from 'rxjs'
-import { catchError, concatMap, distinctUntilChanged, map, tap, withLatestFrom } from 'rxjs/operators'
+import { catchError, concatMap, distinctUntilChanged, map, tap } from 'rxjs/operators'
 
 import { ConfiguredExtension, getScriptURLFromExtensionManifest, splitExtensionID } from '../../extensions/extension'
 import { areExtensionsSame, getEnabledExtensionsForSubject } from '../../extensions/extensions'

--- a/client/shared/src/api/extension/test/activation.test.ts
+++ b/client/shared/src/api/extension/test/activation.test.ts
@@ -1,0 +1,59 @@
+import { BehaviorSubject } from 'rxjs'
+import { filter, first } from 'rxjs/operators'
+import sinon from 'sinon'
+
+import { SettingsCascade } from '../../../settings/settings'
+import { MainThreadAPI } from '../../contract'
+import { Contributions } from '../../protocol'
+import { pretendRemote } from '../../util'
+import { activateExtensions, ExecutableExtension } from '../activation'
+import { ExtensionHostState } from '../extensionHostState'
+
+describe('Extension activation', () => {
+    describe('activateExtensions()', () => {
+        it('logs events for activated extensions', async () => {
+            const logEvent = sinon.spy()
+
+            const mockMain = pretendRemote<Pick<MainThreadAPI, 'getScriptURLForExtension' | 'logEvent'>>({
+                getScriptURLForExtension: () => undefined,
+                logEvent,
+            })
+
+            const FIXTURE_EXTENSION: ExecutableExtension = {
+                scriptURL: 'https://fixture.extension',
+                id: 'sourcegraph/fixture-extension',
+                manifest: { url: 'a', activationEvents: ['*'] },
+            }
+
+            const haveInitialExtensionsLoaded = new BehaviorSubject<boolean>(false)
+
+            const mockState: Pick<
+                ExtensionHostState,
+                'activeExtensions' | 'contributions' | 'haveInitialExtensionsLoaded' | 'settings'
+            > = {
+                activeExtensions: new BehaviorSubject([FIXTURE_EXTENSION]),
+                contributions: new BehaviorSubject<readonly Contributions[]>([]),
+                haveInitialExtensionsLoaded,
+                settings: new BehaviorSubject<Readonly<SettingsCascade>>({
+                    subjects: [],
+                    final: {},
+                }),
+            }
+
+            // Noop for activation and deactivation
+            const noopPromise = () => Promise.resolve()
+
+            activateExtensions(mockState, mockMain, noopPromise, noopPromise)
+
+            // Wait for extensions to load to check on the spy
+            await haveInitialExtensionsLoaded
+                .pipe(
+                    filter(haveLoaded => haveLoaded),
+                    first()
+                )
+                .toPromise()
+
+            sinon.assert.calledWith(logEvent, 'ExtensionActivation', { extension_id: 'sourcegraph/fixture-extension' })
+        })
+    })
+})


### PR DESCRIPTION
We stopped logging extension activation events after the extension host refactor in #18898 

- Add `logEvent` to main thread API so we can track events from the extension host
- Log extension activation events through `MainThreadAPI#logEvent`