### PR TITLE
lint: fix import order

### DIFF
--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -1,6 +1,7 @@
 import { SearchPatternType } from '../../graphql-operations'
 
 import { filterTypeKeysWithAliases } from './filters'
+import { scanPredicate } from './predicates'
 import {
     Token,
     Whitespace,
@@ -16,7 +17,6 @@ import {
     CharacterRange,
     createLiteral,
 } from './token'
-import { scanPredicate } from './predicates'
 
 /**
  * A scanner produces a term, which is either a token or a list of tokens.


### PR DESCRIPTION
We activated a new eslint rule that I had not rebased on top of. Will merge without review since this is breaking main build.