### PR TITLE
codeintel: Auto index Go deps of sg/sg on Cloud

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/autoindex/enqueuer/enqueuer.go
+++ b/enterprise/cmd/frontend/internal/codeintel/autoindex/enqueuer/enqueuer.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/opentracing/opentracing-go/log"
-
 	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go/log"
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
@@ -85,6 +84,20 @@ func (s *IndexEnqueuer) queueIndex(ctx context.Context, repositoryID int, force 
 		return errors.Wrap(err, "gitserver.Head")
 	}
 	traceLog(log.String("commit", commit))
+
+	return s.queueIndexForCommit(ctx, repositoryID, commit, force, traceLog)
+}
+
+// sourcegraphRepositoryID is the repository id of sg/sg on Cloud
+const sourcegraphRepositoryID = 36809250
+
+func (s *IndexEnqueuer) queueIndexForCommit(ctx context.Context, repositoryID int, commit string, force bool, traceLog observation.TraceLogger) (err error) {
+	if repositoryID == sourcegraphRepositoryID {
+		// Don't auto-index sg/sg; instead, we'll enqueue index jobs for all of the current commit's
+		// root go module dependencies. This is going to simulate what we _could_ do with dependency
+		// tracking for Go, though this particular implementations SUPER sketchy.
+		return s.enqueueSourcegraphGoRootDependencies(ctx, repositoryID, commit)
+	}
 
 	if !force {
 		isQueued, err := s.dbStore.IsQueued(ctx, repositoryID, commit)

--- a/enterprise/cmd/frontend/internal/codeintel/autoindex/enqueuer/sggodeps.go
+++ b/enterprise/cmd/frontend/internal/codeintel/autoindex/enqueuer/sggodeps.go
@@ -1,0 +1,76 @@
+package enqueuer
+
+import (
+	"context"
+	"strings"
+
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go/log"
+
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
+	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+)
+
+// versionPattern matches the form vX.Y.Z.-yyyymmddhhmmss-abcdefabcdef
+var versionPattern = lazyregexp.New(`^(.*)-(\d{14})-([a-f0-9]{12})$`)
+
+func (s *IndexEnqueuer) enqueueSourcegraphGoRootDependencies(ctx context.Context, repositoryID int, commit string) error {
+	contents, err := s.gitserverClient.RawContents(ctx, repositoryID, commit, "go.mod")
+	if err != nil {
+		return err
+	}
+
+	for _, line := range strings.Split(string(contents), "\n") {
+		repositoryID, commit, ok, err := s.extractTargetFromGoMod(ctx, strings.TrimSpace(line))
+		if err != nil {
+			log15.Error("failed to extract dependency", "error", err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+
+		traceLog := func(fields ...log.Field) {}
+		if err := s.queueIndexForCommit(ctx, repositoryID, commit, false, traceLog); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *IndexEnqueuer) extractTargetFromGoMod(ctx context.Context, line string) (int, string, bool, error) {
+	if !strings.HasPrefix(line, "github.com/") {
+		return 0, "", false, nil
+	}
+
+	parts := strings.Split(line, " ")
+	if len(parts) < 2 {
+		return 0, "", false, nil
+	}
+
+	repoName := api.RepoName(parts[0])
+	gitTagOrCommit := parts[1]
+	if matches := versionPattern.FindStringSubmatch(gitTagOrCommit); len(matches) > 0 {
+		gitTagOrCommit = matches[3]
+	}
+
+	repo, err := database.Repos(s.dbStore.Handle().DB()).GetByName(ctx, repoName)
+	if err != nil {
+		if errcode.IsNotFound(err) {
+			return 0, "", false, nil
+		}
+
+		return 0, "", false, err
+	}
+
+	commit, err := git.ResolveRevision(ctx, repoName, gitTagOrCommit, git.ResolveRevisionOptions{})
+	if err != nil {
+		return 0, "", false, err
+	}
+
+	return int(repo.ID), string(commit), true, nil
+}


### PR DESCRIPTION
Auto-indexing is only enabled on Cloud; this adds a specific check for sg/sg and will enqueue all of the deps in the root go.mod file. This will cheaply simulate what it would be like to have support for dependency indexing in a Go project.

Will want to merge ideas with Olaf to make a system that can support languages in a generic way (not ad-hoc per language).