### PR TITLE
codeintel: Add ensureUnambiguousResultSets to lsif-validate

### DIFF
--- a/enterprise/lib/codeintel/lsif/test/README.md
+++ b/enterprise/lib/codeintel/lsif/test/README.md
@@ -46,3 +46,4 @@ This command validates the output of an LSIF indexer. The following properties a
 - Each range belongs to a unique document
 - No two ranges belonging to the same document improperly overlap
 - The inVs of each `item` edge belong to that document referred to by the edge's `document` field
+- Each range and result set has at most one result set attached to it

--- a/enterprise/lib/codeintel/lsif/test/cmd/lsif-validate/internal/validation/validators.go
+++ b/enterprise/lib/codeintel/lsif/test/cmd/lsif-validate/internal/validation/validators.go
@@ -35,4 +35,5 @@ var relationshipValidators = []RelationshipValidator{
 	ensureRangeOwnership,
 	ensureDisjointRanges,
 	ensureItemContains,
+	ensureUnambiguousResultSets,
 }


### PR DESCRIPTION
LSIF spec dictates that a resultSet form a _chain_ and not a tree reachable from a range (so that fallback through the graph is deterministic). Let's validate that.

(This validation pass discovers an implementation issue in https://github.com/sourcegraph/lsif-go/pull/142)