### PR TITLE
search tour: fix streaming search dropdown appearing over tour

### DIFF
--- a/client/web/src/Layout.scss
+++ b/client/web/src/Layout.scss
@@ -5,6 +5,10 @@
     flex-direction: column;
     align-items: center;
 
+    // Prevent any internal z-index (heavily used by Bootstrap) from interfering
+    // with global React Portal UI such a Reach modals or Shepherd search onboarding tour.
+    isolation: isolate;
+
     &__app-router-container {
         flex: 1 1 auto;
         min-height: 0;

--- a/client/web/src/search/input/SearchOnboardingTour.scss
+++ b/client/web/src/search/input/SearchOnboardingTour.scss
@@ -15,6 +15,8 @@
 
 .shepherd-element {
     background: var(--color-bg-3);
+    isolation: isolate;
+    z-index: 1001; // Bootstrap's dropdowns are 1000, needs to be higher.
 }
 
 .shepherd-arrow::after {

--- a/client/web/src/search/input/SearchOnboardingTour.scss
+++ b/client/web/src/search/input/SearchOnboardingTour.scss
@@ -15,8 +15,6 @@
 
 .shepherd-element {
     background: var(--color-bg-3);
-    isolation: isolate;
-    z-index: 1001; // Bootstrap's dropdowns are 1000, needs to be higher.
 }
 
 .shepherd-arrow::after {


### PR DESCRIPTION
Fixes #19947

Bootstrap is very z-index trigger-happy, so we have work around this :( Best way to solve this is to wrap the whole webapp in `isolation: isolate;` so it is its own stacking context. This way, Bootstrap won't interfere with React Portal based global UI (eg. Reach or Shepherd)


Before:
![image](https://user-images.githubusercontent.com/206864/114462663-35825400-9b98-11eb-9e96-6f385bcd6bbf.png)

After:
![image](https://user-images.githubusercontent.com/206864/114462960-a164bc80-9b98-11eb-9e56-f5c35c2a3704.png)
