### PR TITLE
Support a service account file on cloudkms encryption key

### DIFF
--- a/internal/encryption/cloudkms/cloud_kms.go
+++ b/internal/encryption/cloudkms/cloud_kms.go
@@ -7,8 +7,6 @@ import (
 	"hash/crc32"
 	"strings"
 
-	"github.com/sourcegraph/sourcegraph/schema"
-
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/api/option"
@@ -16,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 func NewKey(ctx context.Context, config schema.CloudKMSEncryptionKey) (encryption.Key, error) {

--- a/internal/encryption/cloudkms/cloud_kms.go
+++ b/internal/encryption/cloudkms/cloud_kms.go
@@ -7,21 +7,28 @@ import (
 	"hash/crc32"
 	"strings"
 
+	"github.com/sourcegraph/sourcegraph/schema"
+
 	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/cockroachdb/errors"
+	"google.golang.org/api/option"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 )
 
-func NewKey(ctx context.Context, keyName string) (encryption.Key, error) {
-	client, err := kms.NewKeyManagementClient(ctx)
+func NewKey(ctx context.Context, config schema.CloudKMSEncryptionKey) (encryption.Key, error) {
+	opts := []option.ClientOption{}
+	if config.CredentialsFile != "" {
+		opts = append(opts, option.WithCredentialsFile(config.CredentialsFile))
+	}
+	client, err := kms.NewKeyManagementClient(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}
 	k := &Key{
-		name:   keyName,
+		name:   config.Keyname,
 		client: client,
 	}
 	_, err = k.Version(ctx)

--- a/internal/encryption/keyring/ring.go
+++ b/internal/encryption/keyring/ring.go
@@ -105,7 +105,7 @@ func NewKey(ctx context.Context, k *schema.EncryptionKey) (encryption.Key, error
 	}
 	switch {
 	case k.Cloudkms != nil:
-		return cloudkms.NewKey(ctx, k.Cloudkms.Keyname)
+		return cloudkms.NewKey(ctx, *k.Cloudkms)
 	case k.Mounted != nil:
 		return mounted.NewKey(ctx, *k.Mounted)
 	case k.Noop != nil:

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -376,8 +376,9 @@ type CloneURLToRepositoryName struct {
 
 // CloudKMSEncryptionKey description: Google Cloud KMS Encryption Key, used to encrypt data in Google Cloud environments
 type CloudKMSEncryptionKey struct {
-	Keyname string `json:"keyname"`
-	Type    string `json:"type"`
+	CredentialsFile string `json:"credentialsFile,omitempty"`
+	Keyname         string `json:"keyname"`
+	Type            string `json:"type"`
 }
 
 // CustomGitFetchMapping description: Mapping from Git clone URl domain/path to git fetch command. The `domainPath` field contains the Git clone URL domain/path part. The `fetch` field contains the custom git fetch command.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1430,6 +1430,9 @@
         },
         "keyname": {
           "type": "string"
+        },
+        "credentialsFile": {
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
Managing roles on a top level service account is complicated, it's much easier to create a service account for KMS with only that role assigned, and specifically load that account for the kms client.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
