### PR TITLE
web: bump @sourcegraph/eslint-config version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,25 +35,6 @@ const config = {
   rules: {
     // Rules that are specific to this repo
     // All other rules should go into https://github.com/sourcegraph/eslint-config
-    'import/order': [
-      'error',
-      {
-        'newlines-between': 'always',
-        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
-        alphabetize: {
-          order: 'asc',
-          caseInsensitive: true,
-        },
-        pathGroups: [
-          {
-            pattern: '@sourcegraph/**',
-            group: 'external',
-            position: 'after',
-          },
-        ],
-        pathGroupsExcludedImportTypes: [],
-      },
-    ],
     'monorepo/no-relative-import': 'error',
     '@sourcegraph/sourcegraph/check-help-links': 'error',
     'no-restricted-imports': [

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@pollyjs/persister-fs": "^5.0.0",
     "@slack/web-api": "^5.10.0",
     "@sourcegraph/babel-plugin-transform-react-hot-loader-wrapper": "^1.0.0",
-    "@sourcegraph/eslint-config": "^0.23.0",
+    "@sourcegraph/eslint-config": "^0.24.0",
     "@sourcegraph/eslint-plugin-sourcegraph": "1.0.0",
     "@sourcegraph/prettierrc": "^3.0.3",
     "@sourcegraph/stylelint-config": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,10 +2787,10 @@
     sourcegraph "^24.0.0"
     ts-key-enum "^2.0.0"
 
-"@sourcegraph/eslint-config@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.23.0.tgz#cbbd14200c7db3e97eb9cb6331d22588c3db41cb"
-  integrity sha512-J62vio5xe26PVIY+6LaIwEZJCFwGgNo5LTvHmj1n8La/Rymt3QGRtwgHAAyIvr5w0RMH2EN5qNZ9HTx8SSNuig==
+"@sourcegraph/eslint-config@^0.24.0":
+  version "0.24.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.24.0.tgz#0bc0a090863da12b92fde0e6ec9d4f2d55be5c8b"
+  integrity sha512-cQH/rIxSmvtxKx1MSZWTCwfQacPBnbex+iElK7Hlo76M06SkL0dstHLUiu/9p7x9TWv3loI67uOKK+e03njt7A==
   dependencies:
     "@sourcegraph/prettierrc" "^3.0.3"
     "@typescript-eslint/eslint-plugin" "^4.9.1"


### PR DESCRIPTION
### Changes

- Remove local `import/order` ESLint rule.
- Bump `@sourcegraph/eslint-config` that includes `import/order` rule.
