### PR TITLE
types: fix redact Gitolite and Other that have no secret fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
 - New changes of a Perforce depot will now be reflected in `master` branch after the initial clone. [#19718](https://github.com/sourcegraph/sourcegraph/pull/19718)
+- Gitolite and Other type code host connection configuration can be correctly displayed. [#19976](https://github.com/sourcegraph/sourcegraph/pull/19976)
 
 ## 3.26.3
 

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -65,11 +65,11 @@ func (e *ExternalService) RedactConfigSecrets() error {
 	case *schema.PerforceConnection:
 		newCfg, err = redactField(e.Config, "p4.passwd")
 	case *schema.GitoliteConnection:
-		// no secret fields?
-		newCfg, err = redactField(e.Config, "url")
+		// Gitolite has no secret fields
+		newCfg, err = redactField(e.Config)
 	case *schema.OtherExternalServiceConnection:
-		// no secret fields?
-		newCfg, err = redactField(e.Config, "url")
+		// Other has no secret fields
+		newCfg, err = redactField(e.Config)
 	default:
 		// return an error here, it's safer to fail than to incorrectly return unsafe data.
 		err = fmt.Errorf("RedactExternalServiceConfig: kind %q not implemented", e.Kind)

--- a/internal/types/secret.go
+++ b/internal/types/secret.go
@@ -68,8 +68,7 @@ func (e *ExternalService) RedactConfigSecrets() error {
 		// Gitolite has no secret fields
 		newCfg, err = redactField(e.Config)
 	case *schema.OtherExternalServiceConnection:
-		// Other has no secret fields
-		newCfg, err = redactField(e.Config)
+		newCfg, err = redactField(e.Config, "url")
 	default:
 		// return an error here, it's safer to fail than to incorrectly return unsafe data.
 		err = fmt.Errorf("RedactExternalServiceConfig: kind %q not implemented", e.Kind)


### PR DESCRIPTION
Follow up of https://github.com/sourcegraph/sourcegraph/pull/19872/files#r611212720