### PR TITLE
db: Add cascading delete on external_service_sync_jobs

### DIFF
--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -549,7 +549,7 @@ Foreign-key constraints:
 Indexes:
     "external_service_sync_jobs_state_idx" btree (state)
 Foreign-key constraints:
-    "external_services_id_fk" FOREIGN KEY (external_service_id) REFERENCES external_services(id)
+    "external_services_id_fk" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE
 
 ```
 
@@ -580,7 +580,7 @@ Foreign-key constraints:
     "external_services_namepspace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
 Referenced by:
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_external_service_id_fkey" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE DEFERRABLE
-    TABLE "external_service_sync_jobs" CONSTRAINT "external_services_id_fk" FOREIGN KEY (external_service_id) REFERENCES external_services(id)
+    TABLE "external_service_sync_jobs" CONSTRAINT "external_services_id_fk" FOREIGN KEY (external_service_id) REFERENCES external_services(id) ON DELETE CASCADE
 
 ```
 

--- a/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.down.sql
+++ b/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.down.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+SET CONSTRAINTS ALL DEFERRED;
+
+ALTER TABLE external_service_sync_jobs
+    DROP CONSTRAINT external_services_id_fk,
+    ADD CONSTRAINT external_services_id_fk
+        FOREIGN KEY (external_service_id)
+            REFERENCES external_services (id);
+
+COMMIT;

--- a/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.up.sql
+++ b/migrations/frontend/1528395814_add_cascase_delete_on_external_service_sync_jobs.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+SET CONSTRAINTS ALL DEFERRED;
+
+ALTER TABLE external_service_sync_jobs
+    DROP CONSTRAINT external_services_id_fk,
+    ADD CONSTRAINT external_services_id_fk
+        FOREIGN KEY (external_service_id)
+            REFERENCES external_services (id)
+            ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
When an external service is deleted.
