### PR TITLE
oobmigration: Mark all existing migrations as non-deprecated

### DIFF
--- a/migrations/frontend/1528395815_undeprecate_oob_migrations.down.sql
+++ b/migrations/frontend/1528395815_undeprecate_oob_migrations.down.sql
@@ -1,0 +1,1 @@
+-- Nothing to do.

--- a/migrations/frontend/1528395815_undeprecate_oob_migrations.up.sql
+++ b/migrations/frontend/1528395815_undeprecate_oob_migrations.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+-- No out of band migrations should be marked as deprecated yet
+-- as we don't have any utilities in place to check whether or
+-- not migrations have yet completed.
+
+UPDATE out_of_band_migrations SET deprecated = NULL;
+
+COMMIT;


### PR DESCRIPTION
We currently have no way to check whether a required out-of-band migration has completed on startup. There are a few current migrations that mark 3.27 as the deprecation version (meaning that in 3.27 the migrations will no longer run and the migrations must have completed).

This seems incorrect. Two of these are on 0% on Cloud and if this feature were complete, Cloud would be unable to boot.

This just resets the deprecation date and assumes that all the registered migrators were not going to be removed prior to the upcoming branch cut. If this is wrong YELL.