### PR TITLE
search frontend: highlight query predicate bodies

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1238,7 +1238,7 @@ describe('getMonacoTokens()', () => {
         `)
     })
 
-    test('highlight recognized predicate', () => {
+    test('highlight recognized predicate with body as regexp', () => {
         expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains.file(README.md)')), true))
             .toMatchInlineSnapshot(`
             [
@@ -1267,7 +1267,67 @@ describe('getMonacoTokens()', () => {
                 "scopes": "identifier"
               },
               {
+                "startIndex": 25,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 26,
+                "scopes": "identifier"
+              },
+              {
                 "startIndex": 28,
+                "scopes": "metaPredicateParenthesis"
+              }
+            ]
+        `)
+    })
+
+    test('highlight recognized predicate with multiple fields', () => {
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains(file:README.md content:fix)')), true))
+            .toMatchInlineSnapshot(`
+            [
+              {
+                "startIndex": 0,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 5,
+                "scopes": "metaPredicateNameAccess"
+              },
+              {
+                "startIndex": 13,
+                "scopes": "metaPredicateParenthesis"
+              },
+              {
+                "startIndex": 14,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 19,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 25,
+                "scopes": "metaRegexpCharacterSet"
+              },
+              {
+                "startIndex": 26,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 28,
+                "scopes": "whitespace"
+              },
+              {
+                "startIndex": 29,
+                "scopes": "field"
+              },
+              {
+                "startIndex": 37,
+                "scopes": "identifier"
+              },
+              {
+                "startIndex": 40,
                 "scopes": "metaPredicateParenthesis"
               }
             ]

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -11,8 +11,10 @@ import {
     Group,
     Quantifier,
 } from 'regexpp/ast'
+import { SearchPatternType } from '../../graphql-operations'
 
 import { Predicate, scanPredicate } from './predicates'
+import { scanSearchQuery } from './scanner'
 import { Token, Pattern, Literal, PatternKind, CharacterRange, createLiteral } from './token'
 
 /* eslint-disable unicorn/better-regex */
@@ -831,6 +833,60 @@ const decorateSelector = (token: Literal): DecoratedToken[] => {
     return [{ type: 'metaSelector', range: token.range, value: token.value, kind }]
 }
 
+/**
+ * Adds offset to the range of a given token and returns that token.
+ * Note that the offset change is side-effecting.
+ */
+const mapOffset = (token: Token, offset: number): Token => {
+    switch (token.type) {
+        case 'filter':
+            token.range = { start: token.range.start + offset, end: token.range.end + offset }
+            token.field.range = token.range = {
+                start: token.field.range.start + offset,
+                end: token.field.range.end + offset,
+            }
+            if (token.value) {
+                token.value.range = token.range = {
+                    start: token.value.range.start + offset,
+                    end: token.value.range.end + offset,
+                }
+            }
+        default:
+            token.range = { start: token.range.start + offset, end: token.range.end + offset }
+    }
+    return token
+}
+
+/**
+ * Decorates the body part of predicate syntax `name(body)`.
+ */
+const decoratePredicateBody = (path: string[], body: string, offset: number): DecoratedToken[] => {
+    const decorated: DecoratedToken[] = []
+    switch (path.join('.')) {
+        case 'contains':
+            const tokens = scanSearchQuery(body, false, SearchPatternType.regexp)
+            if (tokens.type === 'success') {
+                return tokens.term.flatMap(token => decorate(mapOffset(token, offset)))
+            }
+            break
+        case 'contains.file':
+        case 'contains.content':
+            return mapRegexpMetaSucceed({
+                type: 'pattern',
+                range: { start: offset, end: body.length },
+                value: body,
+                kind: PatternKind.Regexp,
+            })
+    }
+    decorated.push({
+        type: 'literal',
+        value: body,
+        range: { start: offset, end: offset + body.length },
+        quoted: false,
+    })
+    return decorated
+}
+
 const decoratePredicate = (predicate: Predicate, range: CharacterRange): DecoratedToken[] => {
     let offset = range.start
     const decorated: DecoratedToken[] = []
@@ -850,20 +906,15 @@ const decoratePredicate = (predicate: Predicate, range: CharacterRange): Decorat
     }
     decorated.pop() // Pop trailling '.'
     offset = offset - 1 // Backtrack offset
-    const parametersBody = predicate.parameters.slice(1, -1)
+    const body = predicate.parameters.slice(1, -1)
     decorated.push({
         type: 'metaPredicate',
         kind: MetaPredicateKind.Parenthesis,
         range: { start: offset, end: offset + 1 },
     })
     offset = offset + 1
-    decorated.push({
-        type: 'literal',
-        value: parametersBody,
-        range: { start: offset, end: offset + parametersBody.length },
-        quoted: false,
-    })
-    offset = offset + parametersBody.length
+    decorated.push(...decoratePredicateBody(predicate.path, body, offset))
+    offset = offset + body.length
     decorated.push({
         type: 'metaPredicate',
         kind: MetaPredicateKind.Parenthesis,

--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -11,6 +11,7 @@ import {
     Group,
     Quantifier,
 } from 'regexpp/ast'
+
 import { SearchPatternType } from '../../graphql-operations'
 
 import { Predicate, scanPredicate } from './predicates'
@@ -864,6 +865,7 @@ const decoratePredicateBody = (path: string[], body: string, offset: number): De
     const decorated: DecoratedToken[] = []
     switch (path.join('.')) {
         case 'contains':
+            // eslint-disable-next-line no-case-declarations
             const tokens = scanSearchQuery(body, false, SearchPatternType.regexp)
             if (tokens.type === 'success') {
                 return tokens.term.flatMap(token => decorate(mapOffset(token, offset)))


### PR DESCRIPTION
Highlights query predicate body based on filters or regex patterns.

<img width="769" alt="Screen Shot 2021-04-13 at 2 38 37 PM" src="https://user-images.githubusercontent.com/888624/114627032-6da59780-9c69-11eb-9b21-b07b6299c5c2.png">
<img width="408" alt="Screen Shot 2021-04-13 at 3 03 00 PM" src="https://user-images.githubusercontent.com/888624/114627038-7007f180-9c69-11eb-9e40-04db722e2a1b.png">
