### PR TITLE
Use the Select implementation on result types

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -107,10 +107,14 @@ func UnmarshalRepositoryID(id graphql.ID) (repo api.RepoID, err error) {
 }
 
 func (r *RepositoryResolver) Select(path filter.SelectPath) SearchResultResolver {
-	switch path.Type {
-	case filter.Repository:
-		return r
+	match := r.RepoMatch.Select(path)
+
+	// Turn result type back into a resolver
+	switch v := match.(type) {
+	case *result.RepoMatch:
+		return NewRepositoryResolver(r.db, &types.Repo{Name: v.Name, ID: v.ID})
 	}
+
 	return nil
 }
 

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -42,12 +42,16 @@ type CommitSearchResultResolver struct {
 }
 
 func (r *CommitSearchResultResolver) Select(path filter.SelectPath) SearchResultResolver {
-	switch path.Type {
-	case filter.Repository:
-		return r.Commit().Repository()
-	case filter.Commit:
-		return r
+	match := r.CommitMatch.Select(path)
+
+	// Turn result type back into a resolver
+	switch v := match.(type) {
+	case *result.RepoMatch:
+		return NewRepositoryResolver(r.db, &types.Repo{Name: v.Name, ID: v.ID})
+	case *result.CommitMatch:
+		return &CommitSearchResultResolver{db: r.db, CommitMatch: *v, gitCommitResolver: r.gitCommitResolver}
 	}
+
 	return nil
 }
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -132,36 +132,16 @@ func (fm *FileMatchResolver) ResultCount() int32 {
 }
 
 func (fm *FileMatchResolver) Select(t filter.SelectPath) SearchResultResolver {
-	switch t.Type {
-	case filter.Repository:
-		return fm.Repository()
-	case filter.File:
-		fm.FileMatch.LineMatches = nil
-		fm.FileMatch.Symbols = nil
-		return fm
-	case filter.Symbol:
-		if len(fm.FileMatch.Symbols) > 0 {
-			fm.FileMatch.LineMatches = nil // Only return symbol match if symbols exist
-			if len(t.Fields) > 0 {
-				filteredSymbols := result.SelectSymbolKind(fm.FileMatch.Symbols, t.Fields[0])
-				if len(filteredSymbols) == 0 {
-					return nil // Remove file match if there are no symbol results after filtering
-				}
-				fm.FileMatch.Symbols = filteredSymbols
-			}
-			return fm
-		}
-		return nil
-	case filter.Content:
-		// Only return file match if line matches exist
-		if len(fm.FileMatch.LineMatches) > 0 {
-			fm.FileMatch.Symbols = nil
-			return fm
-		}
-		return nil
-	case filter.Commit:
-		return nil
+	match := fm.FileMatch.Select(t)
+
+	// Turn the result type back to a resolver
+	switch v := match.(type) {
+	case *result.RepoMatch:
+		return NewRepositoryResolver(fm.db, &types.Repo{Name: v.Name, ID: v.ID})
+	case *result.FileMatch:
+		return &FileMatchResolver{db: fm.db, RepoResolver: fm.RepoResolver, FileMatch: *v}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
We made result types implement the `Select()` method, however, we weren't
using it, so that was dead code. This plugs those methods into
the resolver `Select()` implementations.

It does some duplicate work (converts to a match and back), but this 
should be temporary since we should (hopefully) be eventually selecting 
on result types and not resolvers.

Fixes #19979


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
