### PR TITLE
Document reasoning for enabled by default extensions

### DIFF
--- a/doc/extensions/usage.md
+++ b/doc/extensions/usage.md
@@ -42,4 +42,4 @@ On a self-hosted Sourcegraph instance, add the same JSON above to global setting
 
 The Sourcegraph-maintained Sourcegraph extension [git-extras](https://sourcegraph.com/extensions/sourcegraph/git-extras) and all search-based code intelligence extensions are enabled by default. 
 
-
+We enable these extensions by default because they are essentially native product features that make use of the [Sourcegraph extension API](authoring/index.md), because they are maintained by the Sourcegraph team, and because they don't connect to any outside servers (neither Sourcegraph-owned nor third-party-owned). 


### PR DESCRIPTION
This update [came out of a slack conversation](https://sourcegraph.slack.com/archives/C0C324C91/p1617995290189200) about the history of why we have some enabled-by-default extensions and the criteria we used to make that decision. 