### PR TITLE
Fix `sg run-set enterprise` not starting on Linux

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -34,6 +34,16 @@ env:
   GLOBAL_SETTINGS_FILE: ./dev/global-settings.json
   GLOBAL_SETTINGS_ALLOW_EDITS: true
 
+  # Point codeintel to the `frontend` database in development
+  CODEINTEL_PGPORT: $PGPORT
+  CODEINTEL_PGHOST: $PGHOST
+  CODEINTEL_PGUSER: $PGUSER
+  CODEINTEL_PGPASSWORD: $PGPASSWORD
+  CODEINTEL_PGDATABASE: $PGDATABASE
+  CODEINTEL_PGSSLMODE: $PGSSLMODE
+  CODEINTEL_PGDATASOURCE: $PGDATASOURCE
+  CODEINTEL_PG_ALLOW_SINGLE_DB: true
+
 commands:
   frontend:
     cmd: ulimit -n 10000 && .bin/frontend


### PR DESCRIPTION
Before this change `sg run-set enterprise` would fail under Linux:

```
[enterprise-frontend] Failed to connect to codeintel database: DB not available: failed to connect to `host=127.0.0.1 user=mrnugget database=sourcegraph`: server error (FATAL: password authentication failed for user "mrnugget" (SQLSTATE 28P01))
--------------------------------------------------------------------------------
Failed to run enterprise-frontend: exited with 1
--------------------------------------------------------------------------------
error: failed to run enterprise-frontend
```

I suspect the reason it worked on macOS is that Postgres.app sets other
defaults (database name, user name, etc.)

In any case: it's good to make this explicit.
