### PR TITLE
search: humanize integers under 10k correctly for progress

### DIFF
--- a/internal/search/streaming/api/progress.go
+++ b/internal/search/streaming/api/progress.go
@@ -203,7 +203,7 @@ func number(i int) string {
 		return strconv.Itoa(i)
 	}
 	if i < 10000 {
-		return fmt.Sprintf("%d,%d", i/1000, i%1000)
+		return fmt.Sprintf("%d,%0.3d", i/1000, i%1000)
 	}
 	return fmt.Sprintf("%dk", i/1000)
 }

--- a/internal/search/streaming/api/progress_test.go
+++ b/internal/search/streaming/api/progress_test.go
@@ -61,6 +61,30 @@ func TestSearchProgress(t *testing.T) {
 	}
 }
 
+func TestNumber(t *testing.T) {
+	cases := map[int]string{
+		0:     "0",
+		1:     "1",
+		100:   "100",
+		999:   "999",
+		1000:  "1,000",
+		1234:  "1,234",
+		3004:  "3,004",
+		3040:  "3,040",
+		3400:  "3,400",
+		9999:  "9,999",
+		10000: "10k",
+		10400: "10k",
+		54321: "54k",
+	}
+	for n, want := range cases {
+		got := number(n)
+		if got != want {
+			t.Errorf("number(%d) got %q want %q", n, got, want)
+		}
+	}
+}
+
 type repo struct {
 	name string
 }


### PR DESCRIPTION
Previously a number like 3004 would be formatted as "3,4" instead of "3,004".