### PR TITLE
Deprecate icon field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
   - A `repo:` filter is now required. This is due to an existing limitations where only 50 repositories can be searched at a time, so using a `repo:` filter makes sure the right code is being searched. Any existing code monitor without `repo:` in the trigger query will continue to work (with the limitation that not all repositories will be searched) but will require a `repo:` filter to be added when making any changes to it.
   - A `patternType` filter is no longer required. `patternType:literal` will be added to a code monitor query if not specified.
   - Added a new checklist UI to make it more intuitive to create code monitor trigger queries.
+- Deprecated the GraphQL `icon` field on `GenericSearchResultInterface`. It will be removed in a future release. [#]
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
   - A `repo:` filter is now required. This is due to an existing limitations where only 50 repositories can be searched at a time, so using a `repo:` filter makes sure the right code is being searched. Any existing code monitor without `repo:` in the trigger query will continue to work (with the limitation that not all repositories will be searched) but will require a `repo:` filter to be added when making any changes to it.
   - A `patternType` filter is no longer required. `patternType:literal` will be added to a code monitor query if not specified.
   - Added a new checklist UI to make it more intuitive to create code monitor trigger queries.
-- Deprecated the GraphQL `icon` field on `GenericSearchResultInterface`. It will be removed in a future release. [#]
+- Deprecated the GraphQL `icon` field on `GenericSearchResultInterface`. It will be removed in a future release. [#20028](https://github.com/sourcegraph/sourcegraph/pull/20028/files)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1782,7 +1782,7 @@ interface GenericSearchResultInterface {
     """
     DEPRECATED
     """
-    icon: String!  @deprecated(reason: "Our API will not support returning icons in a future release")
+    icon: String! @deprecated(reason: "Our API will not support returning icons in a future release")
     """
     A markdown string that is rendered prominently.
     """
@@ -2491,9 +2491,9 @@ A search result that is a Git commit.
 """
 type CommitSearchResult implements GenericSearchResultInterface {
     """
-	DEPRECATED
+    DEPRECATED
     """
-    icon: String!  @deprecated(reason: "Our API will not support returning icons in a future release")
+    icon: String! @deprecated(reason: "Our API will not support returning icons in a future release")
     """
     A markdown string that is rendered prominently.
     """
@@ -2902,7 +2902,7 @@ type Repository implements Node & GenericSearchResultInterface {
     """
     DEPRECATED
     """
-    icon: String!  @deprecated(reason: "Our API will not support returning icons in a future release")
+    icon: String! @deprecated(reason: "Our API will not support returning icons in a future release")
     """
     A markdown string that is rendered prominently.
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1780,9 +1780,9 @@ A search result. Every type of search result, except FileMatch, must implement t
 """
 interface GenericSearchResultInterface {
     """
-    URL to an icon that is displayed with every search result.
+    DEPRECATED
     """
-    icon: String!
+    icon: String!  @deprecated(reason: "Our API will not support returning icons in a future release")
     """
     A markdown string that is rendered prominently.
     """
@@ -2491,9 +2491,9 @@ A search result that is a Git commit.
 """
 type CommitSearchResult implements GenericSearchResultInterface {
     """
-    Base64 data uri to an icon.
+	DEPRECATED
     """
-    icon: String!
+    icon: String!  @deprecated(reason: "Our API will not support returning icons in a future release")
     """
     A markdown string that is rendered prominently.
     """
@@ -2900,9 +2900,9 @@ type Repository implements Node & GenericSearchResultInterface {
     """
     viewerCanAdminister: Boolean!
     """
-    Base64 data uri to an icon.
+    DEPRECATED
     """
-    icon: String!
+    icon: String!  @deprecated(reason: "Our API will not support returning icons in a future release")
     """
     A markdown string that is rendered prominently.
     """


### PR DESCRIPTION
This deprecates the GraphQL `icon` field of
`GenericSearchResultInterface`. It will be removed in a future release

This PR is opened in favor of #19892



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
