### PR TITLE
textsearch: pass db handle when initialize object

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -367,6 +367,7 @@ func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextPara
 	var indexed *indexedSearchRequest
 	if args.Mode == search.ZoektGlobalSearch {
 		indexed = &indexedSearchRequest{
+			db:    db,
 			args:  args,
 			typ:   textRequest,
 			repos: &indexedRepoRevs{},


### PR DESCRIPTION
This db handle was not passed thus causing panic on DB operations later.

Side note: I continue to dislike GraphQL while debugging this, the call stack is completely opaque and I have to guess.

Fixes https://github.com/sourcegraph/sourcegraph/issues/19949