### PR TITLE
Implement source methods for `CreateComment`

### DIFF
--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -88,11 +88,11 @@ func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (Changese
 // AuthenticatedUsername uses the underlying bitbucketserver.Client to get the
 // username belonging to the credentials associated with the
 // BitbucketServerSource.
-func (s *BitbucketServerSource) AuthenticatedUsername(ctx context.Context) (string, error) {
+func (s BitbucketServerSource) AuthenticatedUsername(ctx context.Context) (string, error) {
 	return s.client.AuthenticatedUsername(ctx)
 }
 
-func (s *BitbucketServerSource) ValidateAuthenticator(ctx context.Context) error {
+func (s BitbucketServerSource) ValidateAuthenticator(ctx context.Context) error {
 	_, err := s.client.AuthenticatedUsername(ctx)
 	return err
 }
@@ -238,4 +238,14 @@ func (s BitbucketServerSource) ReopenChangeset(ctx context.Context, c *Changeset
 	}
 
 	return c.Changeset.SetMetadata(pr)
+}
+
+// CreateComment posts a comment on the Changeset.
+func (s BitbucketServerSource) CreateComment(ctx context.Context, c *Changeset, text string) error {
+	pr, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
+	if !ok {
+		return errors.New("Changeset is not a Bitbucket Server pull request")
+	}
+
+	return s.client.CreatePullRequestComment(ctx, pr, text)
 }

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -426,6 +426,68 @@ func TestBitbucketServerSource_UpdateChangeset(t *testing.T) {
 	}
 }
 
+func TestBitbucketServerSource_CreateComment(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		// The test fixtures and golden files were generated with
+		// this config pointed to bitbucket.sgdev.org
+		instanceURL = "https://bitbucket.sgdev.org"
+	}
+
+	pr := &bitbucketserver.PullRequest{ID: 59, Version: 4}
+	pr.ToRef.Repository.Slug = "automation-testing"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+
+	testCases := []struct {
+		name string
+		cs   *Changeset
+		err  string
+	}{
+		{
+			name: "success",
+			cs:   &Changeset{Changeset: &btypes.Changeset{Metadata: pr}},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		tc.name = "BitbucketServerSource_CreateComment_" + strings.ReplaceAll(tc.name, " ", "_")
+
+		t.Run(tc.name, func(t *testing.T) {
+			cf, save := newClientFactory(t, tc.name)
+			defer save(t)
+
+			lg := log15.New()
+			lg.SetHandler(log15.DiscardHandler())
+
+			svc := &types.ExternalService{
+				Kind: extsvc.KindBitbucketServer,
+				Config: marshalJSON(t, &schema.BitbucketServerConnection{
+					Url:   instanceURL,
+					Token: os.Getenv("BITBUCKET_SERVER_TOKEN"),
+				}),
+			}
+
+			bbsSrc, err := NewBitbucketServerSource(svc, cf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ctx := context.Background()
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			err = bbsSrc.CreateComment(ctx, tc.cs, "test-comment")
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Errorf("error:\nhave: %q\nwant: %q", have, want)
+			}
+		})
+	}
+}
+
 func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 	svc := &types.ExternalService{
 		Kind: extsvc.KindBitbucketServer,

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -65,6 +65,8 @@ type ChangesetSource interface {
 	// ReopenChangeset will reopen the Changeset on the source, if it's closed.
 	// If not, it's a noop.
 	ReopenChangeset(context.Context, *Changeset) error
+	// CreateComment posts a comment on the Changeset.
+	CreateComment(context.Context, *Changeset, string) error
 }
 
 // A Changeset of an existing Repo.

--- a/enterprise/internal/batches/sources/fake.go
+++ b/enterprise/internal/batches/sources/fake.go
@@ -47,6 +47,7 @@ type FakeChangesetSource struct {
 	LoadChangesetCalled         bool
 	CloseChangesetCalled        bool
 	ReopenChangesetCalled       bool
+	CreateCommentCalled         bool
 	AuthenticatedUsernameCalled bool
 	ValidateAuthenticatorCalled bool
 
@@ -248,6 +249,11 @@ func (s *FakeChangesetSource) ReopenChangeset(ctx context.Context, c *Changeset)
 	s.ReopenedChangesets = append(s.ReopenedChangesets, c)
 
 	return c.SetMetadata(s.FakeMetadata)
+}
+
+func (s *FakeChangesetSource) CreateComment(ctx context.Context, c *Changeset, body string) error {
+	s.CreateCommentCalled = true
+	return s.Err
 }
 
 func (s *FakeChangesetSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -240,3 +240,13 @@ func (s GithubSource) ReopenChangeset(ctx context.Context, c *Changeset) error {
 
 	return c.Changeset.SetMetadata(pr)
 }
+
+// CreateComment posts a comment on the Changeset.
+func (s GithubSource) CreateComment(ctx context.Context, c *Changeset, text string) error {
+	pr, ok := c.Changeset.Metadata.(*github.PullRequest)
+	if !ok {
+		return errors.New("Changeset is not a GitHub pull request")
+	}
+
+	return s.client.CreatePullRequestComment(ctx, pr, text)
+}

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -411,3 +411,14 @@ func (s *GitLabSource) UndraftChangeset(ctx context.Context, c *Changeset) error
 	c.Title = gitlab.UnsetWIP(c.Title)
 	return s.UpdateChangeset(ctx, c)
 }
+
+// CreateComment posts a comment on the Changeset.
+func (s *GitLabSource) CreateComment(ctx context.Context, c *Changeset, text string) error {
+	project := c.Repo.Metadata.(*gitlab.Project)
+	mr, ok := c.Changeset.Metadata.(*gitlab.MergeRequest)
+	if !ok {
+		return errors.New("Changeset is not a GitLab merge request")
+	}
+
+	return s.client.CreateMergeRequestNote(ctx, project, mr, text)
+}

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateComment_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateComment_success.yaml
@@ -1,0 +1,44 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"text":"test-comment"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/59/comments?version=4
+    method: POST
+  response:
+    body: '{"properties":{"repositoryId":10070},"id":2793,"version":0,"text":"test-comment","author":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"createdDate":1618449547126,"updatedDate":1618449547126,"comments":[],"tasks":[],"severity":"NORMAL","state":"OPEN","permittedOperations":{"editable":true,"transitionable":true,"deletable":true}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 15 Apr 2021 01:19:07 GMT
+      Location:
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/59/comments/2793?version=4
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@1MUQQ7Jx79x454561x0'
+      X-Asessionid:
+      - 1d1kcjr
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/GithubSource_CreateComment_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/GithubSource_CreateComment_success.yaml
@@ -1,0 +1,58 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nmutation CreatePullRequestComment($input: AddCommentInput!)
+      {\n  addComment(input: $input) {\n    subject { id }\n  }\n}\n","variables":{"input":{"subjectId":"MDExOlB1bGxSZXF1ZXN0MzQ5NTIzMzE0","body":"test-comment"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"addComment":{"subject":{"id":"MDExOlB1bGxSZXF1ZXN0MzQ5NTIzMzE0"}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 15 Apr 2021 01:19:11 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - C2CF:12D14:5DF4D5F:5F6A495:6077948F
+      X-Oauth-Scopes:
+      - read:discussion, read:org, repo, workflow
+      X-Ratelimit-Used:
+      - "22"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/enterprise/internal/batches/sources/testdata/sources/GitlabSource_CreateComment_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/GitlabSource_CreateComment_success.yaml
@@ -1,0 +1,58 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"body":"test-comment"}'
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://gitlab.com/api/v4/projects/16606088/merge_requests/2/notes
+    method: POST
+  response:
+    body: '{"id":552054539,"type":null,"body":"test-comment","attachment":null,"author":{"id":5005329,"name":"Erik
+      Seliger","username":"eseliger","state":"active","avatar_url":"https://secure.gravatar.com/avatar/2582d91847f35b619bea3bd0f910964d?s=80\u0026d=identicon","web_url":"https://gitlab.com/eseliger"},"created_at":"2021-04-15T01:24:03.306Z","updated_at":"2021-04-15T01:24:03.306Z","system":false,"noteable_id":48629396,"noteable_type":"MergeRequest","resolvable":false,"confidential":false,"noteable_iid":2,"commands_changes":{}}'
+    headers:
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Cf-Cache-Status:
+      - DYNAMIC
+      Cf-Ray:
+      - 64015f3f5911ad18-OTP
+      Cf-Request-Id:
+      - 0974b9db930000ad1808831000000001
+      Content-Length:
+      - "526"
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 15 Apr 2021 01:24:03 GMT
+      Etag:
+      - W/"159d66b1b17addcb551cdcabbfb16efa"
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Gitlab-Lb:
+      - fe-12-lb-gprd
+      Gitlab-Sv:
+      - api-06-sv-gprd
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Gitlab-Feature-Category:
+      - code_review
+      X-Request-Id:
+      - 01F39J1H0Q4J2W4PCVEQPFXC1Q
+      X-Runtime:
+      - "0.156449"
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1408,3 +1408,30 @@ func (c *Client) AuthenticatedUsername(ctx context.Context) (username string, er
 
 	return username, nil
 }
+
+func (c *Client) CreatePullRequestComment(ctx context.Context, pr *PullRequest, body string) error {
+	if pr.ToRef.Repository.Slug == "" {
+		return errors.New("repository slug empty")
+	}
+
+	if pr.ToRef.Repository.Project.Key == "" {
+		return errors.New("project key empty")
+	}
+
+	path := fmt.Sprintf(
+		"rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/comments",
+		pr.ToRef.Repository.Project.Key,
+		pr.ToRef.Repository.Slug,
+		pr.ID,
+	)
+
+	qry := url.Values{"version": {strconv.Itoa(pr.Version)}}
+
+	payload := map[string]interface{}{
+		"text": body,
+	}
+
+	var resp *Comment
+	_, err := c.send(ctx, "POST", path, qry, &payload, &resp)
+	return err
+}

--- a/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequestComment-success.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequestComment-success.yaml
@@ -1,0 +1,39 @@
+---
+version: 1
+interactions:
+- request:
+    body: |
+      {"text":"test_comment"}
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/63/comments?version=2
+    method: POST
+  response:
+    body: '{"properties":{"repositoryId":10070},"id":2790,"version":0,"text":"test_comment","author":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"createdDate":1618447968919,"updatedDate":1618447968919,"comments":[],"tasks":[],"severity":"NORMAL","state":"OPEN","permittedOperations":{"editable":true,"transitionable":true,"deletable":true}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 15 Apr 2021 00:52:48 GMT
+      Location:
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/63/comments/2790?version=2
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@1MUQQ7Jx52x452530x0'
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/internal/extsvc/github/pulls.go
+++ b/internal/extsvc/github/pulls.go
@@ -907,6 +907,31 @@ func (c *V4Client) GetOpenPullRequestByRefs(ctx context.Context, owner, name, ba
 	return &pr, nil
 }
 
+const createPullRequestCommentMutation = `
+mutation CreatePullRequestComment($input: AddCommentInput!) {
+  addComment(input: $input) {
+    subject { id }
+  }
+}
+`
+
+// CreatePullRequestComment creates a comment on the PullRequest on Github.
+func (c *V4Client) CreatePullRequestComment(ctx context.Context, pr *PullRequest, body string) error {
+	var result struct {
+		AddComment struct {
+			Subject struct {
+				ID string
+			} `json:"subject"`
+		} `json:"addComment"`
+	}
+
+	input := map[string]interface{}{"input": struct {
+		SubjectID string `json:"subjectId"`
+		Body      string `json:"body"`
+	}{SubjectID: pr.ID, Body: body}}
+	return c.requestGraphQL(ctx, createPullRequestCommentMutation, input, &result)
+}
+
 func (c *V4Client) loadRemainingTimelineItems(ctx context.Context, prID string, pageInfo PageInfo) (items []TimelineItem, err error) {
 	version := c.determineGitHubVersion(ctx)
 	timelineItemTypes, err := timelineItemTypes(version)

--- a/internal/extsvc/github/testdata/vcr/CreatePullRequestComment.yaml
+++ b/internal/extsvc/github/testdata/vcr/CreatePullRequestComment.yaml
@@ -1,0 +1,64 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nmutation CreatePullRequestComment($input: AddCommentInput!)
+      {\n  addComment(input: $input) {\n    subject { id }\n  }\n}\n","variables":{"input":{"subjectId":"MDExOlB1bGxSZXF1ZXN0MzQxMDU5OTY5","body":"test-comment"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"addComment":{"subject":{"id":"MDExOlB1bGxSZXF1ZXN0MzQxMDU5OTY5"}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes,
+        X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 15 Apr 2021 01:03:27 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - C0EC:F0ED:C0B70A:CEF33B:607790DF
+      X-Oauth-Scopes:
+      - read:discussion, read:org, repo, workflow
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4987"
+      X-Ratelimit-Reset:
+      - "1618450390"
+      X-Ratelimit-Used:
+      - "13"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -372,7 +372,7 @@ func TestCreatePullRequestComment(t *testing.T) {
 	defer save()
 
 	pr := &PullRequest{
-		// github.com/sourcegraph/automation-testing/pull/44
+		// https://github.com/sourcegraph/automation-testing/pull/44
 		ID: "MDExOlB1bGxSZXF1ZXN0MzQxMDU5OTY5",
 	}
 

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -367,6 +367,21 @@ func TestMarkPullRequestReadyForReview(t *testing.T) {
 	}
 }
 
+func TestCreatePullRequestComment(t *testing.T) {
+	cli, save := newV4Client(t, "CreatePullRequestComment")
+	defer save()
+
+	pr := &PullRequest{
+		// github.com/sourcegraph/automation-testing/pull/44
+		ID: "MDExOlB1bGxSZXF1ZXN0MzQxMDU5OTY5",
+	}
+
+	err := cli.CreatePullRequestComment(context.Background(), pr, "test-comment")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestEstimateGraphQLCost(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/internal/extsvc/gitlab/mock.go
+++ b/internal/extsvc/gitlab/mock.go
@@ -44,3 +44,7 @@ var MockGetOpenMergeRequestByRefs func(c *Client, ctx context.Context, project *
 // MockUpdateMergeRequest, if non-nil, will be called instead of
 // Client.UpdateMergeRequest
 var MockUpdateMergeRequest func(c *Client, ctx context.Context, project *Project, mr *MergeRequest, opts UpdateMergeRequestOpts) (*MergeRequest, error)
+
+// MockCreateMergeRequestNote, if non-nil, will be called instead of
+// Client.CreateMergeRequestNote
+var MockCreateMergeRequestNote func(c *Client, ctx context.Context, project *Project, mr *MergeRequest, body string) error


### PR DESCRIPTION
This PR implements the `CreateComment` method on our three supported code hosts, and add the required functionality to the clients. This PR is part of the bulk commenting functionality.