### PR TITLE
web: fix CSS modules watch command

### DIFF
--- a/client/shared/dev/generateCssModulesTypes.js
+++ b/client/shared/dev/generateCssModulesTypes.js
@@ -21,7 +21,7 @@ function cssModulesTypings() {
  * Watch CSS modules and generates the TypeScript types for them.
  */
 function watchCSSModulesTypings() {
-  return spawn(BIN, ARGS, {
+  return spawn(BIN, [...ARGS, '--watch'], {
     stdio: 'inherit',
     shell: true,
   })


### PR DESCRIPTION
After fixing a few comments in the initial PR `--watch` flag was lost in updates. 
