### PR TITLE
init keyring on gitserver, take lock when creating ring

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
+
 	"github.com/inconshreveable/log15"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -47,6 +49,8 @@ var (
 )
 
 func main() {
+	ctx := context.Background()
+
 	env.Lock()
 	env.HandleHelpFlag()
 
@@ -76,6 +80,11 @@ func main() {
 	}
 	repoStore := database.Repos(db)
 	externalServiceStore := database.ExternalServices(db)
+
+	err = keyring.Init(ctx)
+	if err != nil {
+		log.Fatalf("failed to initialise keyring: %s", err)
+	}
 
 	gitserver := server.Server{
 		ReposDir:           reposDir,

--- a/internal/encryption/keyring/ring.go
+++ b/internal/encryption/keyring/ring.go
@@ -42,7 +42,9 @@ func Init(ctx context.Context) error {
 		return err
 	}
 	if ring != nil {
+		mu.Lock()
 		defaultRing = *ring
+		mu.Unlock()
 	}
 
 	conf.ContributeValidator(func(cfg conf.Unified) conf.Problems {


### PR DESCRIPTION
Gitserver was complaining about a nil keyring, we just need to make sure we init the keyring on any service that needs it.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
