### PR TITLE
Implement bulk processor background worker

### DIFF
--- a/doc/admin/user_data_deletion.md
+++ b/doc/admin/user_data_deletion.md
@@ -13,3 +13,4 @@ When deleting or nuking a user, the following information is removed:
 - Organization membership information (which organizations the user is a part of, any invitations created by or targeting the user).
 - Sourcegraph extensions published by the user on the instance the deletion request is sent to.
 - User, Organization, or Global settings authored or modified by the user.
+- Bulk operations on changesets and batch changes created by the user.

--- a/enterprise/internal/batches/background/background.go
+++ b/enterprise/internal/batches/background/background.go
@@ -16,10 +16,15 @@ func Routines(ctx context.Context, batchesStore *store.Store, cf *httpcli.Factor
 	metrics := newMetrics()
 
 	routines := []goroutine.BackgroundRoutine{
-		newWorker(ctx, batchesStore, gitserver.DefaultClient, sourcer, metrics),
-		newWorkerResetter(batchesStore, metrics),
+		newReconcilerWorker(ctx, batchesStore, gitserver.DefaultClient, sourcer, metrics),
+		newReconcilerWorkerResetter(batchesStore, metrics),
+
 		newSpecExpireWorker(ctx, batchesStore),
+
 		scheduler.NewScheduler(ctx, batchesStore),
+
+		newBulkJobWorker(ctx, batchesStore, sourcer, metrics),
+		newBulkJobWorkerResetter(batchesStore, metrics),
 	}
 	return routines
 }

--- a/enterprise/internal/batches/background/bulk_processor.go
+++ b/enterprise/internal/batches/background/bulk_processor.go
@@ -1,0 +1,99 @@
+package background
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+)
+
+// unknownJobTypeErr is returned when a ChangesetJob record is of an unknown type
+// and hence cannot be executed.
+type unknownJobTypeErr struct {
+	jobType string
+}
+
+func (e unknownJobTypeErr) Error() string {
+	return fmt.Sprintf("invalid job type %q", e.jobType)
+}
+
+func (e unknownJobTypeErr) NonRetryable() bool {
+	return true
+}
+
+type bulkProcessorWorker struct {
+	store   *store.Store
+	sourcer sources.Sourcer
+}
+
+func (b *bulkProcessorWorker) HandlerFunc() dbworker.HandlerFunc {
+	return func(ctx context.Context, tx dbworkerstore.Store, record workerutil.Record) error {
+		processor := &bulkProcessor{
+			sourcer: b.sourcer,
+			store:   b.store.With(tx),
+		}
+		return processor.process(ctx, record.(*btypes.ChangesetJob))
+	}
+}
+
+type bulkProcessor struct {
+	store   *store.Store
+	sourcer sources.Sourcer
+
+	css  sources.ChangesetSource
+	repo *types.Repo
+	ch   *btypes.Changeset
+}
+
+func (b *bulkProcessor) process(ctx context.Context, job *btypes.ChangesetJob) error {
+	// Load all required dependencies.
+	var err error
+	b.ch, err = b.store.GetChangeset(ctx, store.GetChangesetOpts{ID: job.ChangesetID})
+	if err != nil {
+		return errors.Wrap(err, "loading changeset")
+	}
+	b.repo, err = b.store.Repos().Get(ctx, b.ch.RepoID)
+	if err != nil {
+		return errors.Wrap(err, "loading repo")
+	}
+	b.css, err = b.sourcer.ForRepo(ctx, b.store, b.repo)
+	if err != nil {
+		return errors.Wrap(err, "loading ChangesetSource")
+	}
+	b.css, err = sources.WithAuthenticatorForUser(ctx, b.store, b.css, job.UserID, b.repo)
+	if err != nil {
+		return errors.Wrap(err, "authenticating ChangesetSource")
+	}
+
+	log15.Info("processing changeset job", "type", job.JobType)
+
+	switch job.JobType {
+
+	case btypes.ChangesetJobTypeComment:
+		return b.comment(ctx, job)
+
+	default:
+		return &unknownJobTypeErr{jobType: string(job.JobType)}
+	}
+}
+
+func (b *bulkProcessor) comment(ctx context.Context, job *btypes.ChangesetJob) error {
+	typedPayload, ok := job.Payload.(*btypes.ChangesetJobCommentPayload)
+	if !ok {
+		return fmt.Errorf("invalid payload type for changeset_job, want=%T have=%T", &btypes.ChangesetJobCommentPayload{}, job.Payload)
+	}
+	cs := &sources.Changeset{
+		Changeset: b.ch,
+		Repo:      b.repo,
+	}
+	return b.css.CreateComment(ctx, cs, typedPayload.Message)
+}

--- a/enterprise/internal/batches/background/bulk_processor_test.go
+++ b/enterprise/internal/batches/background/bulk_processor_test.go
@@ -1,0 +1,68 @@
+package background
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+)
+
+func TestBulkProcessor(t *testing.T) {
+	ctx := context.Background()
+	db := dbtesting.GetDB(t)
+	tx := dbtest.NewTx(t, db)
+	bstore := store.New(tx)
+	user := ct.CreateTestUser(t, db, true)
+	repos, _ := ct.CreateTestRepos(t, ctx, db, 1)
+	repo := repos[0]
+	changeset := ct.CreateChangeset(t, ctx, bstore, ct.TestChangesetOpts{Repo: repo.ID})
+
+	t.Run("Unknown job type", func(t *testing.T) {
+		fake := &sources.FakeChangesetSource{}
+		bp := &bulkProcessor{
+			store:   bstore,
+			sourcer: sources.NewFakeSourcer(nil, fake),
+		}
+		job := &types.ChangesetJob{
+			JobType:     types.ChangesetJobTypeComment,
+			ChangesetID: changeset.ID,
+			UserID:      user.ID,
+		}
+		if err := bstore.CreateChangesetJob(ctx, job); err != nil {
+			t.Fatal(err)
+		}
+		job.JobType = types.ChangesetJobType("UNKNOWN")
+		err := bp.process(ctx, job)
+		if err.Error() != `invalid job type "UNKNOWN"` {
+			t.Fatalf("unexpected error returned %s", err)
+		}
+	})
+
+	t.Run("Comment job", func(t *testing.T) {
+		fake := &sources.FakeChangesetSource{}
+		bp := &bulkProcessor{
+			store:   bstore,
+			sourcer: sources.NewFakeSourcer(nil, fake),
+		}
+		job := &types.ChangesetJob{
+			JobType:     types.ChangesetJobTypeComment,
+			ChangesetID: changeset.ID,
+			UserID:      user.ID,
+		}
+		if err := bstore.CreateChangesetJob(ctx, job); err != nil {
+			t.Fatal(err)
+		}
+		err := bp.process(ctx, job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !fake.CreateCommentCalled {
+			t.Fatal("expected CreateComment to be called but wasn't")
+		}
+	})
+}

--- a/enterprise/internal/batches/background/bulk_processor_worker.go
+++ b/enterprise/internal/batches/background/bulk_processor_worker.go
@@ -1,0 +1,84 @@
+package background
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
+	dbworkerstore "github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker/store"
+)
+
+// bulkProcessorMaxNumRetries is the maximum number of attempts the bulkProcessor
+// makes to process a changeset job when it fails.
+const bulkProcessorMaxNumRetries = 10
+
+// bulkProcessorMaxNumResets is the maximum number of attempts the bulkProcessor
+// makes to process a changeset job when it stalls (process crashes, etc.).
+const bulkProcessorMaxNumResets = 60
+
+// newBulkJobWorker creates a dbworker.Worker that fetches enqueued changeset_jobs
+// from the database and passes them to the bulk executor for processing.
+func newBulkJobWorker(
+	ctx context.Context,
+	s *store.Store,
+	sourcer sources.Sourcer,
+	metrics batchChangesMetrics,
+) *workerutil.Worker {
+	r := &bulkProcessorWorker{sourcer: sourcer, store: s}
+
+	options := workerutil.WorkerOptions{
+		Name:        "batches_bulk_processor",
+		NumHandlers: 5,
+		Interval:    5 * time.Second,
+		Metrics:     metrics.bulkProcessorWorkerMetrics,
+	}
+
+	workerStore := createBulkJobDBWorkerStore(s)
+
+	worker := dbworker.NewWorker(ctx, workerStore, r.HandlerFunc(), options)
+	return worker
+}
+
+// newBulkJobWorkerResetter creates a dbworker.Resetter that reenqueues lost jobs
+// for processing.
+func newBulkJobWorkerResetter(s *store.Store, metrics batchChangesMetrics) *dbworker.Resetter {
+	workerStore := createBulkJobDBWorkerStore(s)
+
+	options := dbworker.ResetterOptions{
+		Name:     "batches_bulk_worker_resetter",
+		Interval: 1 * time.Minute,
+		Metrics:  metrics.bulkProcessorWorkerResetterMetrics,
+	}
+
+	resetter := dbworker.NewResetter(workerStore, options)
+	return resetter
+}
+
+func createBulkJobDBWorkerStore(s *store.Store) dbworkerstore.Store {
+	return dbworkerstore.New(s.Handle(), dbworkerstore.Options{
+		Name:              "batches_bulk_worker_store",
+		TableName:         "changeset_jobs",
+		ColumnExpressions: store.ChangesetJobColumns,
+		Scan:              scanFirstChangesetJobRecord,
+
+		OrderByExpression: sqlf.Sprintf("changeset_jobs.state = 'errored', changeset_jobs.updated_at DESC"),
+
+		StalledMaxAge: 60 * time.Second,
+		MaxNumResets:  bulkProcessorMaxNumResets,
+
+		RetryAfter:    5 * time.Second,
+		MaxNumRetries: bulkProcessorMaxNumRetries,
+	})
+}
+
+// scanFirstChangesetJobRecord wraps store.ScanFirstChangesetJob to return a
+// generic workerutil.Record.
+func scanFirstChangesetJobRecord(rows *sql.Rows, err error) (workerutil.Record, bool, error) {
+	return store.ScanFirstChangesetJob(rows, err)
+}

--- a/enterprise/internal/batches/background/metrics.go
+++ b/enterprise/internal/batches/background/metrics.go
@@ -1,6 +1,8 @@
 package background
 
 import (
+	"fmt"
+
 	"github.com/inconshreveable/log15"
 	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -8,13 +10,14 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
+	"github.com/sourcegraph/sourcegraph/internal/workerutil/dbworker"
 )
 
 type batchChangesMetrics struct {
-	workerMetrics workerutil.WorkerMetrics
-	resets        prometheus.Counter
-	resetFailures prometheus.Counter
-	errors        prometheus.Counter
+	reconcilerWorkerMetrics            workerutil.WorkerMetrics
+	bulkProcessorWorkerMetrics         workerutil.WorkerMetrics
+	reconcilerWorkerResetterMetrics    dbworker.ResetterMetrics
+	bulkProcessorWorkerResetterMetrics dbworker.ResetterMetrics
 }
 
 func newMetrics() batchChangesMetrics {
@@ -24,28 +27,35 @@ func newMetrics() batchChangesMetrics {
 		Registerer: prometheus.DefaultRegisterer,
 	}
 
+	return batchChangesMetrics{
+		reconcilerWorkerMetrics:            workerutil.NewMetrics(observationContext, "batch_changes_reconciler", nil),
+		bulkProcessorWorkerMetrics:         workerutil.NewMetrics(observationContext, "batch_changes_bulk_processor", nil),
+		reconcilerWorkerResetterMetrics:    makeResetterMetrics(observationContext, "batch_changes_reconciler"),
+		bulkProcessorWorkerResetterMetrics: makeResetterMetrics(observationContext, "batch_changes_bulk_processor"),
+	}
+}
+
+func makeResetterMetrics(observationContext *observation.Context, workerName string) dbworker.ResetterMetrics {
 	resetFailures := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "src_batch_changes_background_reconciler_reset_failures_total",
-		Help: "The number of reconciler reset failures.",
+		Name: fmt.Sprintf("src_%s_reset_failures_total", workerName),
+		Help: "The number of reset failures.",
 	})
 	observationContext.Registerer.MustRegister(resetFailures)
 
 	resets := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "src_batch_changes_background_reconciler_resets_total",
-		Help: "The number of reconciler records reset.",
+		Name: fmt.Sprintf("src_%s_resets_total", workerName),
+		Help: "The number of records reset.",
 	})
 	observationContext.Registerer.MustRegister(resets)
 
 	errors := prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "src_batch_changes_background_errors_total",
-		Help: "The number of errors that occur during a batch changes background job.",
+		Name: fmt.Sprintf("src_%s_reset_errors_total", workerName),
+		Help: "The number of errors that occur when resetting records.",
 	})
 	observationContext.Registerer.MustRegister(errors)
-
-	return batchChangesMetrics{
-		workerMetrics: workerutil.NewMetrics(observationContext, "batch_changes_reconciler", nil),
-		resets:        resets,
-		resetFailures: resetFailures,
-		errors:        errors,
+	return dbworker.ResetterMetrics{
+		RecordResets:        resets,
+		RecordResetFailures: resetFailures,
+		Errors:              errors,
 	}
 }

--- a/enterprise/internal/batches/background/reconciler_worker_test.go
+++ b/enterprise/internal/batches/background/reconciler_worker_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
-func TestWorkerView(t *testing.T) {
+func TestReconcilerWorkerView(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -1,0 +1,232 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/keegancsmith/sqlf"
+
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+)
+
+// changesetJobInsertColumns is the list of changeset_jobs columns that are
+// modified in CreateChangesetJob and UpdateChangesetJob.
+var changesetJobInsertColumns = []*sqlf.Query{
+	sqlf.Sprintf("bulk_group"),
+	sqlf.Sprintf("user_id"),
+	sqlf.Sprintf("batch_change_id"),
+	sqlf.Sprintf("changeset_id"),
+	sqlf.Sprintf("job_type"),
+	sqlf.Sprintf("payload"),
+	sqlf.Sprintf("state"),
+	sqlf.Sprintf("failure_message"),
+	sqlf.Sprintf("started_at"),
+	sqlf.Sprintf("finished_at"),
+	sqlf.Sprintf("process_after"),
+	sqlf.Sprintf("num_resets"),
+	sqlf.Sprintf("num_failures"),
+	sqlf.Sprintf("created_at"),
+	sqlf.Sprintf("updated_at"),
+}
+
+// ChangesetJobColumns are used by the batch change related Store methods to insert,
+// update and query batches.
+var ChangesetJobColumns = []*sqlf.Query{
+	sqlf.Sprintf("changeset_jobs.id"),
+	sqlf.Sprintf("changeset_jobs.bulk_group"),
+	sqlf.Sprintf("changeset_jobs.user_id"),
+	sqlf.Sprintf("changeset_jobs.batch_change_id"),
+	sqlf.Sprintf("changeset_jobs.changeset_id"),
+	sqlf.Sprintf("changeset_jobs.job_type"),
+	sqlf.Sprintf("changeset_jobs.payload"),
+	sqlf.Sprintf("changeset_jobs.state"),
+	sqlf.Sprintf("changeset_jobs.failure_message"),
+	sqlf.Sprintf("changeset_jobs.started_at"),
+	sqlf.Sprintf("changeset_jobs.finished_at"),
+	sqlf.Sprintf("changeset_jobs.process_after"),
+	sqlf.Sprintf("changeset_jobs.num_resets"),
+	sqlf.Sprintf("changeset_jobs.num_failures"),
+	sqlf.Sprintf("changeset_jobs.created_at"),
+	sqlf.Sprintf("changeset_jobs.updated_at"),
+}
+
+// CreateBatchChange creates the given batch change.
+func (s *Store) CreateChangesetJob(ctx context.Context, c *btypes.ChangesetJob) error {
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = s.now()
+	}
+
+	if c.UpdatedAt.IsZero() {
+		c.UpdatedAt = c.CreatedAt
+	}
+
+	q, err := createChangesetJobQuery(c)
+	if err != nil {
+		return err
+	}
+
+	return s.query(ctx, q, func(sc scanner) (err error) {
+		return scanChangesetJob(c, sc)
+	})
+}
+
+var createChangesetJobQueryFmtstr = `
+-- source: enterprise/internal/batches/store/changeset_jobs.go:CreateChangesetJob
+INSERT INTO changeset_jobs (%s)
+VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+RETURNING %s
+`
+
+func createChangesetJobQuery(c *btypes.ChangesetJob) (*sqlf.Query, error) {
+	payload, err := jsonbColumn(c.Payload)
+	if err != nil {
+		return nil, err
+	}
+	return sqlf.Sprintf(
+		createChangesetJobQueryFmtstr,
+		sqlf.Join(changesetJobInsertColumns, ", "),
+		c.BulkGroup,
+		c.UserID,
+		c.BatchChangeID,
+		c.ChangesetID,
+		c.JobType,
+		payload,
+		c.State,
+		c.FailureMessage,
+		&dbutil.NullTime{Time: &c.StartedAt},
+		&dbutil.NullTime{Time: &c.FinishedAt},
+		&dbutil.NullTime{Time: &c.ProcessAfter},
+		c.NumResets,
+		c.NumFailures,
+		c.CreatedAt,
+		c.UpdatedAt,
+		sqlf.Join(ChangesetJobColumns, ", "),
+	), nil
+}
+
+// GetChangesetJobOpts captures the query options needed for getting a BatchSpec
+type GetChangesetJobOpts struct {
+	ID            int64
+	States        []string
+	BatchChangeID int64
+	ChangesetID   int64
+}
+
+// GetChangesetJob gets a BatchSpec matching the given options.
+func (s *Store) GetChangesetJob(ctx context.Context, opts GetChangesetJobOpts) (*btypes.ChangesetJob, error) {
+	q := getChangesetJobQuery(&opts)
+
+	var c btypes.ChangesetJob
+	err := s.query(ctx, q, func(sc scanner) (err error) {
+		return scanChangesetJob(&c, sc)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if c.ID == 0 {
+		return nil, ErrNoResults
+	}
+
+	return &c, nil
+}
+
+var getChangesetJobsQueryFmtstr = `
+-- source: enterprise/internal/batches/store/changeset_jobs.go:GetChangesetJob
+SELECT %s FROM changeset_jobs
+WHERE %s
+LIMIT 1
+`
+
+func getChangesetJobQuery(opts *GetChangesetJobOpts) *sqlf.Query {
+	var preds []*sqlf.Query
+	if opts.ID != 0 {
+		preds = append(preds, sqlf.Sprintf("id = %s", opts.ID))
+	}
+	if opts.BatchChangeID != 0 {
+		preds = append(preds, sqlf.Sprintf("batch_change_id = %s", opts.BatchChangeID))
+	}
+	if opts.ChangesetID != 0 {
+		preds = append(preds, sqlf.Sprintf("changeset_id = %s", opts.ChangesetID))
+	}
+	if opts.ID != 0 {
+		preds = append(preds, sqlf.Sprintf("id = %s", opts.ID))
+	}
+
+	if len(opts.States) != 0 {
+		states := []*sqlf.Query{}
+		for _, state := range opts.States {
+			states = append(states, sqlf.Sprintf("%s", state))
+		}
+		preds = append(preds, sqlf.Sprintf("state IN (%s)", sqlf.Join(states, ",")))
+	}
+
+	if len(preds) == 0 {
+		preds = append(preds, sqlf.Sprintf("TRUE"))
+	}
+
+	return sqlf.Sprintf(
+		getChangesetJobsQueryFmtstr,
+		sqlf.Join(ChangesetJobColumns, ", "),
+		sqlf.Join(preds, "\n AND "),
+	)
+}
+
+func scanChangesetJob(c *btypes.ChangesetJob, s scanner) error {
+	var raw json.RawMessage
+	if err := s.Scan(
+		&c.ID,
+		&c.BulkGroup,
+		&c.UserID,
+		&c.BatchChangeID,
+		&c.ChangesetID,
+		&c.JobType,
+		&raw,
+		&c.State,
+		&dbutil.NullString{S: c.FailureMessage},
+		&dbutil.NullTime{Time: &c.StartedAt},
+		&dbutil.NullTime{Time: &c.FinishedAt},
+		&dbutil.NullTime{Time: &c.ProcessAfter},
+		&c.NumResets,
+		&c.NumFailures,
+		&c.CreatedAt,
+		&c.UpdatedAt,
+	); err != nil {
+		return err
+	}
+	switch c.JobType {
+	case btypes.ChangesetJobTypeComment:
+		c.Payload = new(btypes.ChangesetJobCommentPayload)
+	default:
+		return fmt.Errorf("unknown job type %q", c.JobType)
+	}
+	return json.Unmarshal(raw, &c.Payload)
+}
+
+func ScanFirstChangesetJob(rows *sql.Rows, err error) (*btypes.ChangesetJob, bool, error) {
+	jobs, err := scanChangesetJobs(rows, err)
+	if err != nil || len(jobs) == 0 {
+		return nil, false, err
+	}
+	return jobs[0], true, nil
+}
+
+func scanChangesetJobs(rows *sql.Rows, queryErr error) ([]*btypes.ChangesetJob, error) {
+	if queryErr != nil {
+		return nil, queryErr
+	}
+
+	var jobs []*btypes.ChangesetJob
+
+	return jobs, scanAll(rows, func(sc scanner) (err error) {
+		var j btypes.ChangesetJob
+		if err = scanChangesetJob(&j, sc); err != nil {
+			return err
+		}
+		jobs = append(jobs, &j)
+		return nil
+	})
+}

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -107,7 +107,7 @@ func createChangesetJobQuery(c *btypes.ChangesetJob) (*sqlf.Query, error) {
 	), nil
 }
 
-// GetChangesetJobOpts captures the query options needed for getting a BatchSpec
+// GetChangesetJobOpts captures the query options needed for getting a ChangesetJob
 type GetChangesetJobOpts struct {
 	ID int64
 }

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -53,7 +53,7 @@ var ChangesetJobColumns = []*sqlf.Query{
 	sqlf.Sprintf("changeset_jobs.updated_at"),
 }
 
-// CreateBatchChange creates the given batch change.
+// CreateChangesetJob creates the given changeset job.
 func (s *Store) CreateChangesetJob(ctx context.Context, c *btypes.ChangesetJob) error {
 	if c.CreatedAt.IsZero() {
 		c.CreatedAt = s.now()

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -143,9 +143,7 @@ LIMIT 1
 func getChangesetJobQuery(opts *GetChangesetJobOpts) *sqlf.Query {
 	preds := []*sqlf.Query{
 		sqlf.Sprintf("repo.deleted_at IS NULL"),
-	}
-	if opts.ID != 0 {
-		preds = append(preds, sqlf.Sprintf("changeset_jobs.id = %s", opts.ID))
+		sqlf.Sprintf("changeset_jobs.id = %s", opts.ID),
 	}
 
 	return sqlf.Sprintf(

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -112,7 +112,7 @@ type GetChangesetJobOpts struct {
 	ID int64
 }
 
-// GetChangesetJob gets a BatchSpec matching the given options.
+// GetChangesetJob gets a ChangesetJob matching the given options.
 func (s *Store) GetChangesetJob(ctx context.Context, opts GetChangesetJobOpts) (*btypes.ChangesetJob, error) {
 	q := getChangesetJobQuery(&opts)
 

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -33,7 +33,7 @@ var changesetJobInsertColumns = []*sqlf.Query{
 }
 
 // ChangesetJobColumns are used by the batch change related Store methods to insert,
-// update and query batches.
+// update and query changeset jobs.
 var ChangesetJobColumns = []*sqlf.Query{
 	sqlf.Sprintf("changeset_jobs.id"),
 	sqlf.Sprintf("changeset_jobs.bulk_group"),

--- a/enterprise/internal/batches/store/changeset_jobs_test.go
+++ b/enterprise/internal/batches/store/changeset_jobs_test.go
@@ -1,0 +1,105 @@
+package store
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func testStoreChangesetJobs(t *testing.T, ctx context.Context, s *Store, clock ct.Clock) {
+	repoStore := database.ReposWith(s)
+	esStore := database.ExternalServicesWith(s)
+
+	repo := ct.TestRepo(t, esStore, extsvc.KindGitHub)
+	deletedRepo := ct.TestRepo(t, esStore, extsvc.KindGitHub).With(types.Opt.RepoDeletedAt(clock.Now()))
+
+	if err := repoStore.Create(ctx, repo, deletedRepo); err != nil {
+		t.Fatal(err)
+	}
+	if err := repoStore.Delete(ctx, deletedRepo.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	changeset := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{Repo: repo.ID})
+	changesetWithDeletedRepo := ct.CreateChangeset(t, ctx, s, ct.TestChangesetOpts{Repo: deletedRepo.ID})
+
+	jobs := make([]*btypes.ChangesetJob, 0, 3)
+	for i := 0; i < cap(jobs); i++ {
+		c := &btypes.ChangesetJob{
+			UserID:        int32(i + 1234),
+			BatchChangeID: int64(i + 910),
+			ChangesetID:   changeset.ID,
+			JobType:       btypes.ChangesetJobTypeComment,
+		}
+
+		if i == cap(jobs)-1 {
+			c.ChangesetID = changesetWithDeletedRepo.ID
+		}
+		jobs = append(jobs, c)
+	}
+
+	t.Run("Create", func(t *testing.T) {
+
+		for _, c := range jobs {
+			want := *c
+			have := c
+
+			err := s.CreateChangesetJob(ctx, have)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if have.ID == 0 {
+				t.Fatal("ID should not be zero")
+			}
+
+			want.ID = have.ID
+			want.Payload = &btypes.ChangesetJobCommentPayload{}
+			want.CreatedAt = clock.Now()
+			want.UpdatedAt = clock.Now()
+
+			if diff := cmp.Diff(have, &want); diff != "" {
+				t.Fatal(diff)
+			}
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		for i, job := range jobs {
+			t.Run(strconv.Itoa(i), func(t *testing.T) {
+				have, err := s.GetChangesetJob(ctx, GetChangesetJobOpts{ID: job.ID})
+				if i == cap(jobs)-1 {
+					if err != ErrNoResults {
+						t.Fatal("unexpected non-no-results error")
+					}
+					return
+				} else if err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(have, job); diff != "" {
+					t.Fatal(diff)
+				}
+			})
+		}
+
+		t.Run("NoResults", func(t *testing.T) {
+			opts := GetChangesetJobOpts{ID: 0xdeadbeef}
+
+			_, have := s.GetChangesetJob(ctx, opts)
+			want := ErrNoResults
+
+			if have != want {
+				t.Fatalf("have err %v, want %v", have, want)
+			}
+		})
+	})
+}

--- a/enterprise/internal/batches/store/integration_test.go
+++ b/enterprise/internal/batches/store/integration_test.go
@@ -30,5 +30,6 @@ func TestIntegration(t *testing.T) {
 		t.Run("CodeHosts", storeTest(db, testStoreCodeHost))
 		t.Run("UserDeleteCascades", storeTest(db, testUserDeleteCascades))
 		t.Run("SiteCredentials", storeTest(db, testStoreSiteCredentials))
+		t.Run("ChangesetJobs", storeTest(db, testStoreChangesetJobs))
 	})
 }

--- a/enterprise/internal/batches/testing/db.go
+++ b/enterprise/internal/batches/testing/db.go
@@ -9,7 +9,7 @@ import (
 func TruncateTables(t *testing.T, db *sql.DB, tables ...string) {
 	t.Helper()
 
-	_, err := db.Exec("TRUNCATE " + strings.Join(tables, ", ") + " RESTART IDENTITY")
+	_, err := db.Exec("TRUNCATE " + strings.Join(tables, ", ") + " RESTART IDENTITY CASCADE")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -16,13 +16,17 @@ type ChangesetJobCommentPayload struct {
 
 // ChangesetJob describes a one-time action to be taken on a changeset.
 type ChangesetJob struct {
-	ID            int64
+	ID int64
+	// BulkGroup is a random string that can be used to group jobs together in a
+	// single invocation.
 	BulkGroup     string
 	BatchChangeID int64
 	UserID        int32
 	ChangesetID   int64
 	JobType       ChangesetJobType
 	Payload       interface{}
+
+	// workerutil fields
 
 	State          string
 	FailureMessage *string

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -1,0 +1,41 @@
+package types
+
+import "time"
+
+// ChangesetJobType specifies all valid type of jobs that the bulk processor
+// understands.
+type ChangesetJobType string
+
+var (
+	ChangesetJobTypeComment ChangesetJobType = "commentatore"
+)
+
+type ChangesetJobCommentPayload struct {
+	Message string `json:"message"`
+}
+
+// ChangesetJob describes a one-time action to be taken on a changeset.
+type ChangesetJob struct {
+	ID            int64
+	BulkGroup     string
+	BatchChangeID int64
+	UserID        int32
+	ChangesetID   int64
+	JobType       ChangesetJobType
+	Payload       interface{}
+
+	State          string
+	FailureMessage *string
+	StartedAt      time.Time
+	FinishedAt     time.Time
+	ProcessAfter   time.Time
+	NumResets      int64
+	NumFailures    int64
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (j *ChangesetJob) RecordID() int {
+	return int(j.ID)
+}

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -51,6 +51,7 @@ Foreign-key constraints:
     "batch_changes_namespace_org_id_fkey" FOREIGN KEY (namespace_org_id) REFERENCES orgs(id) ON DELETE CASCADE DEFERRABLE
     "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
 Referenced by:
+    TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_batch_change_id_fkey" FOREIGN KEY (batch_change_id) REFERENCES batch_changes(id) ON DELETE CASCADE DEFERRABLE
     TABLE "changesets" CONSTRAINT "changesets_owned_by_batch_spec_id_fkey" FOREIGN KEY (owned_by_batch_change_id) REFERENCES batch_changes(id) ON DELETE SET NULL DEFERRABLE
 Triggers:
     trig_delete_batch_change_reference_on_changesets AFTER DELETE ON batch_changes FOR EACH ROW EXECUTE FUNCTION delete_batch_change_reference_on_changesets()
@@ -119,6 +120,38 @@ Check constraints:
     "changeset_events_metadata_check" CHECK (jsonb_typeof(metadata) = 'object'::text)
 Foreign-key constraints:
     "changeset_events_changeset_id_fkey" FOREIGN KEY (changeset_id) REFERENCES changesets(id) ON DELETE CASCADE DEFERRABLE
+
+```
+
+# Table "public.changeset_jobs"
+```
+     Column      |           Type           | Collation | Nullable |                  Default                   
+-----------------+--------------------------+-----------+----------+--------------------------------------------
+ id              | bigint                   |           | not null | nextval('changeset_jobs_id_seq'::regclass)
+ bulk_group      | text                     |           | not null | 
+ user_id         | integer                  |           | not null | 
+ batch_change_id | integer                  |           | not null | 
+ changeset_id    | integer                  |           | not null | 
+ job_type        | text                     |           | not null | 
+ payload         | jsonb                    |           |          | '{}'::jsonb
+ state           | text                     |           |          | 'queued'::text
+ failure_message | text                     |           |          | 
+ started_at      | timestamp with time zone |           |          | 
+ finished_at     | timestamp with time zone |           |          | 
+ process_after   | timestamp with time zone |           |          | 
+ num_resets      | integer                  |           | not null | 0
+ num_failures    | integer                  |           | not null | 0
+ execution_logs  | json[]                   |           |          | 
+ created_at      | timestamp with time zone |           | not null | now()
+ updated_at      | timestamp with time zone |           | not null | now()
+Indexes:
+    "changeset_jobs_pkey" PRIMARY KEY, btree (id)
+Check constraints:
+    "changeset_jobs_payload_check" CHECK (jsonb_typeof(payload) = 'object'::text)
+Foreign-key constraints:
+    "changeset_jobs_batch_change_id_fkey" FOREIGN KEY (batch_change_id) REFERENCES batch_changes(id) ON DELETE CASCADE DEFERRABLE
+    "changeset_jobs_changeset_id_fkey" FOREIGN KEY (changeset_id) REFERENCES changesets(id) ON DELETE CASCADE DEFERRABLE
+    "changeset_jobs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
 
 ```
 
@@ -216,6 +249,7 @@ Foreign-key constraints:
     "changesets_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
 Referenced by:
     TABLE "changeset_events" CONSTRAINT "changeset_events_changeset_id_fkey" FOREIGN KEY (changeset_id) REFERENCES changesets(id) ON DELETE CASCADE DEFERRABLE
+    TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_changeset_id_fkey" FOREIGN KEY (changeset_id) REFERENCES changesets(id) ON DELETE CASCADE DEFERRABLE
 
 ```
 
@@ -1586,6 +1620,7 @@ Referenced by:
     TABLE "batch_changes" CONSTRAINT "batch_changes_last_applier_id_fkey" FOREIGN KEY (last_applier_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "batch_changes" CONSTRAINT "batch_changes_namespace_user_id_fkey" FOREIGN KEY (namespace_user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "batch_specs" CONSTRAINT "batch_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
+    TABLE "changeset_jobs" CONSTRAINT "changeset_jobs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
     TABLE "changeset_specs" CONSTRAINT "changeset_specs_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL DEFERRABLE
     TABLE "cm_emails" CONSTRAINT "cm_emails_changed_by_fk" FOREIGN KEY (changed_by) REFERENCES users(id) ON DELETE CASCADE
     TABLE "cm_emails" CONSTRAINT "cm_emails_created_by_fk" FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE

--- a/migrations/frontend/1528395816_changeset_bulk_jobs_table.down.sql
+++ b/migrations/frontend/1528395816_changeset_bulk_jobs_table.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS changeset_jobs;
+
+COMMIT;

--- a/migrations/frontend/1528395816_changeset_bulk_jobs_table.up.sql
+++ b/migrations/frontend/1528395816_changeset_bulk_jobs_table.up.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS changeset_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    bulk_group text NOT NULL,
+    user_id integer NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    batch_change_id integer NOT NULL REFERENCES batch_changes(id) ON DELETE CASCADE,
+    changeset_id integer NOT NULL REFERENCES changesets(id) ON DELETE CASCADE,
+
+    job_type text NOT NULL,
+    payload jsonb DEFAULT '{}'::jsonb CHECK (jsonb_typeof(payload) = 'object'::text),
+
+    state text DEFAULT 'queued'::text,
+    failure_message text,
+    started_at timestamp with time zone,
+    finished_at timestamp with time zone,
+    process_after timestamp with time zone,
+    num_resets integer NOT NULL DEFAULT 0,
+    num_failures integer NOT NULL DEFAULT 0,
+    execution_logs json[],
+
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+COMMIT;

--- a/migrations/frontend/1528395816_changeset_bulk_jobs_table.up.sql
+++ b/migrations/frontend/1528395816_changeset_bulk_jobs_table.up.sql
@@ -3,9 +3,9 @@ BEGIN;
 CREATE TABLE IF NOT EXISTS changeset_jobs (
     id BIGSERIAL PRIMARY KEY,
     bulk_group text NOT NULL,
-    user_id integer NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    batch_change_id integer NOT NULL REFERENCES batch_changes(id) ON DELETE CASCADE,
-    changeset_id integer NOT NULL REFERENCES changesets(id) ON DELETE CASCADE,
+    user_id integer NOT NULL REFERENCES users(id) ON DELETE CASCADE DEFERRABLE,
+    batch_change_id integer NOT NULL REFERENCES batch_changes(id) ON DELETE CASCADE DEFERRABLE,
+    changeset_id integer NOT NULL REFERENCES changesets(id) ON DELETE CASCADE DEFERRABLE,
 
     job_type text NOT NULL,
     payload jsonb DEFAULT '{}'::jsonb CHECK (jsonb_typeof(payload) = 'object'::text),


### PR DESCRIPTION
This PR adds a new entity `ChangesetJob` to the database, which is used with a new dbworker. It represents a single invocation of the new `bulkProcessor` and the first supported type is `comment` which then in turn calls `CreateComment` on the changeset source, per changeset, asynchronously in the background.