### PR TITLE
Translate sentinel query dashboard to our generator

### DIFF
--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1424,9 +1424,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- 							    - Look at the breakdown by query to determine if a specific query type is being affected
-								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity
+- Look at the breakdown by query to determine if a specific query type is being affected
+- Check for high CPU usage on zoekt-webserver
+- Check Honeycomb for unusual activity
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1451,9 +1451,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- 							    - Look at the breakdown by query to determine if a specific query type is being affected
-								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity
+- Look at the breakdown by query to determine if a specific query type is being affected
+- Check for high CPU usage on zoekt-webserver
+- Check Honeycomb for unusual activity
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1478,9 +1478,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- 							    - Look at the breakdown by query to determine if a specific query type is being affected
-								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity
+- Look at the breakdown by query to determine if a specific query type is being affected
+- Check for high CPU usage on zoekt-webserver
+- Check Honeycomb for unusual activity
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json
@@ -1505,9 +1505,9 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 **Possible solutions**
 
-- 							    - Look at the breakdown by query to determine if a specific query type is being affected
-								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity
+- Look at the breakdown by query to determine if a specific query type is being affected
+- Check for high CPU usage on zoekt-webserver
+- Check Honeycomb for unusual activity
 - **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
 
 ```json

--- a/doc/admin/observability/alert_solutions.md
+++ b/doc/admin/observability/alert_solutions.md
@@ -1413,6 +1413,114 @@ To learn more about Sourcegraph's alerting and how to set up alerts, see [our al
 
 <br />
 
+## frontend: mean_successful_sentinel_duration_5m
+
+<p class="subtitle">mean successful sentinel search duration over 5m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> frontend: 5s+ mean successful sentinel search duration over 5m for 10m0s
+- <span class="badge badge-critical">critical</span> frontend: 8s+ mean successful sentinel search duration over 5m for 15m0s
+
+**Possible solutions**
+
+- 							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_mean_successful_sentinel_duration_5m",
+  "critical_frontend_mean_successful_sentinel_duration_5m"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+## frontend: mean_sentinel_stream_latency_5m
+
+<p class="subtitle">mean sentinel stream latency over 5m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> frontend: 2s+ mean sentinel stream latency over 5m for 5m0s
+- <span class="badge badge-critical">critical</span> frontend: 3s+ mean sentinel stream latency over 5m for 10m0s
+
+**Possible solutions**
+
+- 							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_mean_sentinel_stream_latency_5m",
+  "critical_frontend_mean_sentinel_stream_latency_5m"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+## frontend: 90th_percentile_successful_sentinel_duration_5m
+
+<p class="subtitle">90th percentile successful sentinel search duration over 5m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> frontend: 5s+ 90th percentile successful sentinel search duration over 5m for 10m0s
+- <span class="badge badge-critical">critical</span> frontend: 10s+ 90th percentile successful sentinel search duration over 5m for 15m0s
+
+**Possible solutions**
+
+- 							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_90th_percentile_successful_sentinel_duration_5m",
+  "critical_frontend_90th_percentile_successful_sentinel_duration_5m"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+## frontend: 90th_percentile_sentinel_stream_latency_5m
+
+<p class="subtitle">90th percentile sentinel stream latency over 5m</p>
+
+**Descriptions**
+
+- <span class="badge badge-warning">warning</span> frontend: 4s+ 90th percentile sentinel stream latency over 5m for 5m0s
+- <span class="badge badge-critical">critical</span> frontend: 6s+ 90th percentile sentinel stream latency over 5m for 10m0s
+
+**Possible solutions**
+
+- 							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity
+- **Silence this alert:** If you are aware of this alert and want to silence notifications for it, add the following to your site configuration and set a reminder to re-evaluate the alert:
+
+```json
+"observability.silenceAlerts": [
+  "warning_frontend_90th_percentile_sentinel_stream_latency_5m",
+  "critical_frontend_90th_percentile_sentinel_stream_latency_5m"
+]
+```
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
 ## gitserver: disk_space_remaining
 
 <p class="subtitle">disk space remaining by instance</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -706,6 +706,78 @@ This panel indicates percentage pods available.
 
 <br />
 
+### Frontend: Sentinel queries (only on sourcegraph.com)
+
+#### frontend: mean_successful_sentinel_duration_5m
+
+This panel indicates mean successful sentinel search duration over 5m.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-mean-successful-sentinel-duration-5m).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### frontend: mean_sentinel_stream_latency_5m
+
+This panel indicates mean sentinel stream latency over 5m.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-mean-sentinel-stream-latency-5m).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### frontend: 90th_percentile_successful_sentinel_duration_5m
+
+This panel indicates 90th percentile successful sentinel search duration over 5m.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-successful-sentinel-duration-5m).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### frontend: 90th_percentile_sentinel_stream_latency_5m
+
+This panel indicates 90th percentile sentinel stream latency over 5m.
+
+> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./alert_solutions.md#frontend-90th-percentile-sentinel-stream-latency-5m).
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### frontend: mean_successful_sentinel_duration_by_query_5m
+
+This panel indicates mean successful sentinel search duration by query over 5m.
+
+								- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### frontend: mean_sentinel_stream_latency_by_query_5m
+
+This panel indicates mean sentinel stream latency by query over 5m.
+
+								- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
+#### frontend: unsuccessful_status_rate_5m
+
+This panel indicates unsuccessful status rate per 5m.
+
+- The rate of unsuccessful sentinel query, broken down by failure type
+
+<sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
+
+<br />
+
 ## Git Server
 
 <p class="subtitle">Stores, manages, and operates Git repositories.</p>

--- a/doc/admin/observability/dashboards.md
+++ b/doc/admin/observability/dashboards.md
@@ -752,7 +752,7 @@ This panel indicates 90th percentile sentinel stream latency over 5m.
 
 This panel indicates mean successful sentinel search duration by query over 5m.
 
-								- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 
@@ -762,7 +762,7 @@ This panel indicates mean successful sentinel search duration by query over 5m.
 
 This panel indicates mean sentinel stream latency by query over 5m.
 
-								- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
 
 <sub>*Managed by the [Sourcegraph Search team](https://about.sourcegraph.com/handbook/engineering/search).*</sub>
 

--- a/go.sum
+++ b/go.sum
@@ -760,6 +760,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -962,6 +963,7 @@ github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkB
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1139,6 +1141,7 @@ github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtb
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1319,15 +1322,19 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.1.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1340,6 +1347,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
+github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
@@ -1363,6 +1371,7 @@ github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPr
 github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -1947,6 +1956,7 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -3,6 +3,7 @@ package definitions
 import (
 	"time"
 
+	"github.com/grafana-tools/sdk"
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -745,6 +746,138 @@ func Frontend() *monitoring.Container {
 					},
 				},
 			},
+			{
+				Title:  "Sentinel queries (only on sourcegraph.com)",
+				Hidden: true,
+				Rows: []monitoring.Row{
+					{
+						{
+							Name:        "mean_successful_sentinel_duration_5m",
+							Description: "mean successful sentinel search duration over 5m",
+							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m]))`,
+							Warning:     monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
+							Critical:    monitoring.Alert().GreaterOrEqual(8, nil).For(15 * time.Minute),
+							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(noLegend()),
+							Owner:       monitoring.ObservableOwnerSearch,
+							PossibleSolutions: `
+							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity`,
+						},
+						{
+							Name:        "mean_sentinel_stream_latency_5m",
+							Description: "mean sentinel stream latency over 5m",
+							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m]))`,
+							Warning:     monitoring.Alert().GreaterOrEqual(2, nil).For(5 * time.Minute),
+							Critical:    monitoring.Alert().GreaterOrEqual(3, nil).For(10 * time.Minute),
+							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(noLegend()).With(blueSeriesOverride("latency")),
+							Owner:       monitoring.ObservableOwnerSearch,
+							PossibleSolutions: `
+							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity`,
+						},
+					},
+					{
+						{
+							Name:        "90th_percentile_successful_sentinel_duration_5m",
+							Description: "90th percentile successful sentinel search duration over 5m",
+							Query:       `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Warning:     monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
+							Critical:    monitoring.Alert().GreaterOrEqual(10, nil).For(15 * time.Minute),
+							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(noLegend()),
+							Owner:       monitoring.ObservableOwnerSearch,
+							PossibleSolutions: `
+							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity`,
+						},
+						{
+							Name:        "90th_percentile_sentinel_stream_latency_5m",
+							Description: "90th percentile sentinel stream latency over 5m",
+							Query:       `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Warning:     monitoring.Alert().GreaterOrEqual(4, nil).For(5 * time.Minute),
+							Critical:    monitoring.Alert().GreaterOrEqual(6, nil).For(10 * time.Minute),
+							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(noLegend()).With(blueSeriesOverride("latency")),
+							Owner:       monitoring.ObservableOwnerSearch,
+							PossibleSolutions: `
+							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Check for high CPU usage on zoekt-webserver
+								- Check Honeycomb for unusual activity`,
+						},
+					},
+					{
+						{
+							Name:        "mean_successful_sentinel_duration_by_query_5m",
+							Description: "mean successful sentinel search duration by query over 5m",
+							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m])) by (source)`,
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(legendOnRight()).With(hoverAllSorted()).With(noFill()),
+							Owner:       monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
+						},
+						{
+							Name:        "mean_sentinel_stream_latency_by_query_5m",
+							Description: "mean sentinel stream latency by query over 5m",
+							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m])) by (source)`,
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(legendOnRight()).With(hoverAllSorted()).With(noFill()),
+							Owner:       monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
+						},
+					},
+					{
+						{
+							Name:        "unsuccessful_status_rate_5m",
+							Description: "unsuccessful status rate per 5m",
+							Query:       `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[5m])) by (status)`,
+							NoAlert:     true,
+							Panel:       monitoring.Panel().LegendFormat("{{status}}").Unit(monitoring.Seconds),
+							Owner:       monitoring.ObservableOwnerSearch,
+							Interpretation: `
+								- The rate of unsuccessful sentinel query, broken down by failure type
+							`,
+						},
+					},
+				},
+			},
 		},
+	}
+}
+
+func blueSeriesOverride(seriesName string) monitoring.ObservablePanelOption {
+	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
+		color := "#8AB8FF"
+		panel.SeriesOverrides = append(panel.SeriesOverrides, sdk.SeriesOverride{
+			Alias: seriesName,
+			Color: &color,
+		})
+	}
+}
+
+func legendOnRight() monitoring.ObservablePanelOption {
+	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
+		panel.Legend.RightSide = true
+	}
+}
+
+func hoverAllSorted() monitoring.ObservablePanelOption {
+	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
+		panel.Tooltip.Shared = true
+		panel.Tooltip.Sort = 2
+	}
+}
+
+func noFill() monitoring.ObservablePanelOption {
+	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
+		panel.Fill = 0
+	}
+}
+
+func noLegend() monitoring.ObservablePanelOption {
+	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
+		panel.Legend.Show = false
 	}
 }

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -753,11 +753,13 @@ func Frontend() *monitoring.Container {
 						{
 							Name:        "mean_successful_sentinel_duration_5m",
 							Description: "mean successful sentinel search duration over 5m",
-							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m]))`,
-							Warning:     monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
-							Critical:    monitoring.Alert().GreaterOrEqual(8, nil).For(15 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
-							Owner:       monitoring.ObservableOwnerSearch,
+							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
+							// since these panels relate to metrics that don't exist on a customer instance.
+							Query:    `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m]))`,
+							Warning:  monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
+							Critical: monitoring.Alert().GreaterOrEqual(8, nil).For(15 * time.Minute),
+							Panel:    monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
+							Owner:    monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
 								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -767,9 +769,11 @@ func Frontend() *monitoring.Container {
 						{
 							Name:        "mean_sentinel_stream_latency_5m",
 							Description: "mean sentinel stream latency over 5m",
-							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m]))`,
-							Warning:     monitoring.Alert().GreaterOrEqual(2, nil).For(5 * time.Minute),
-							Critical:    monitoring.Alert().GreaterOrEqual(3, nil).For(10 * time.Minute),
+							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
+							// since these panels relate to metrics that don't exist on a customer instance.
+							Query:    `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m]))`,
+							Warning:  monitoring.Alert().GreaterOrEqual(2, nil).For(5 * time.Minute),
+							Critical: monitoring.Alert().GreaterOrEqual(3, nil).For(10 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.NoLegend(),
 								monitoring.PanelOptions.ColorOverride("latency", "#8AB8FF"),
@@ -786,11 +790,13 @@ func Frontend() *monitoring.Container {
 						{
 							Name:        "90th_percentile_successful_sentinel_duration_5m",
 							Description: "90th percentile successful sentinel search duration over 5m",
-							Query:       `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
-							Warning:     monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
-							Critical:    monitoring.Alert().GreaterOrEqual(10, nil).For(15 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
-							Owner:       monitoring.ObservableOwnerSearch,
+							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
+							// since these panels relate to metrics that don't exist on a customer instance.
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Warning:  monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
+							Critical: monitoring.Alert().GreaterOrEqual(10, nil).For(15 * time.Minute),
+							Panel:    monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
+							Owner:    monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
 								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -800,9 +806,11 @@ func Frontend() *monitoring.Container {
 						{
 							Name:        "90th_percentile_sentinel_stream_latency_5m",
 							Description: "90th percentile sentinel stream latency over 5m",
-							Query:       `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
-							Warning:     monitoring.Alert().GreaterOrEqual(4, nil).For(5 * time.Minute),
-							Critical:    monitoring.Alert().GreaterOrEqual(6, nil).For(10 * time.Minute),
+							// WARNING: if you change this, ensure that it will not trigger alerts on a customer instance
+							// since these panels relate to metrics that don't exist on a customer instance.
+							Query:    `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
+							Warning:  monitoring.Alert().GreaterOrEqual(4, nil).For(5 * time.Minute),
+							Critical: monitoring.Alert().GreaterOrEqual(6, nil).For(10 * time.Minute),
 							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
 								monitoring.PanelOptions.NoLegend(),
 								monitoring.PanelOptions.ColorOverride("latency", "#8AB8FF"),

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -3,7 +3,6 @@ package definitions
 import (
 	"time"
 
-	"github.com/grafana-tools/sdk"
 	"github.com/sourcegraph/sourcegraph/monitoring/definitions/shared"
 	"github.com/sourcegraph/sourcegraph/monitoring/monitoring"
 )
@@ -757,7 +756,7 @@ func Frontend() *monitoring.Container {
 							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m]))`,
 							Warning:     monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
 							Critical:    monitoring.Alert().GreaterOrEqual(8, nil).For(15 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(noLegend()),
+							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
 							    - Look at the breakdown by query to determine if a specific query type is being affected
@@ -770,8 +769,11 @@ func Frontend() *monitoring.Container {
 							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m]))`,
 							Warning:     monitoring.Alert().GreaterOrEqual(2, nil).For(5 * time.Minute),
 							Critical:    monitoring.Alert().GreaterOrEqual(3, nil).For(10 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(noLegend()).With(blueSeriesOverride("latency")),
-							Owner:       monitoring.ObservableOwnerSearch,
+							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.NoLegend(),
+								monitoring.PanelOptions.ColorOverride("latency", "#8AB8FF"),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
 							    - Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -785,7 +787,7 @@ func Frontend() *monitoring.Container {
 							Query:       `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_response_latency_seconds_bucket{source=~"searchblitz.*", status="success"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:     monitoring.Alert().GreaterOrEqual(5, nil).For(10 * time.Minute),
 							Critical:    monitoring.Alert().GreaterOrEqual(10, nil).For(15 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(noLegend()),
+							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
 							    - Look at the breakdown by query to determine if a specific query type is being affected
@@ -798,8 +800,11 @@ func Frontend() *monitoring.Container {
 							Query:       `histogram_quantile(0.90, sum by (le)(label_replace(rate(src_search_streaming_latency_seconds_bucket{source=~"searchblitz.*"}[5m]), "source", "$1", "source", "searchblitz_(.*)")))`,
 							Warning:     monitoring.Alert().GreaterOrEqual(4, nil).For(5 * time.Minute),
 							Critical:    monitoring.Alert().GreaterOrEqual(6, nil).For(10 * time.Minute),
-							Panel:       monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(noLegend()).With(blueSeriesOverride("latency")),
-							Owner:       monitoring.ObservableOwnerSearch,
+							Panel: monitoring.Panel().LegendFormat("latency").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.NoLegend(),
+								monitoring.PanelOptions.ColorOverride("latency", "#8AB8FF"),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
 							    - Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
@@ -812,8 +817,13 @@ func Frontend() *monitoring.Container {
 							Description: "mean successful sentinel search duration by query over 5m",
 							Query:       `sum(rate(src_search_response_latency_seconds_sum{source=~"searchblitz.*", status="success"}[5m])) by (source) / sum(rate(src_search_response_latency_seconds_count{source=~"searchblitz.*", status="success"}[5m])) by (source)`,
 							NoAlert:     true,
-							Panel:       monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(legendOnRight()).With(hoverAllSorted()).With(noFill()),
-							Owner:       monitoring.ObservableOwnerSearch,
+							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
 							Interpretation: `
 								- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
@@ -822,8 +832,13 @@ func Frontend() *monitoring.Container {
 							Description: "mean sentinel stream latency by query over 5m",
 							Query:       `sum(rate(src_search_streaming_latency_seconds_sum{source=~"searchblitz.*"}[5m])) by (source) / sum(rate(src_search_streaming_latency_seconds_count{source=~"searchblitz.*"}[5m])) by (source)`,
 							NoAlert:     true,
-							Panel:       monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(legendOnRight()).With(hoverAllSorted()).With(noFill()),
-							Owner:       monitoring.ObservableOwnerSearch,
+							Panel: monitoring.Panel().LegendFormat("{{query}}").Unit(monitoring.Seconds).With(
+								monitoring.PanelOptions.LegendOnRight(),
+								monitoring.PanelOptions.HoverShowAll(),
+								monitoring.PanelOptions.HoverSort("descending"),
+								monitoring.PanelOptions.Fill(0),
+							),
+							Owner: monitoring.ObservableOwnerSearch,
 							Interpretation: `
 								- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
 						},
@@ -844,40 +859,5 @@ func Frontend() *monitoring.Container {
 				},
 			},
 		},
-	}
-}
-
-func blueSeriesOverride(seriesName string) monitoring.ObservablePanelOption {
-	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
-		color := "#8AB8FF"
-		panel.SeriesOverrides = append(panel.SeriesOverrides, sdk.SeriesOverride{
-			Alias: seriesName,
-			Color: &color,
-		})
-	}
-}
-
-func legendOnRight() monitoring.ObservablePanelOption {
-	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
-		panel.Legend.RightSide = true
-	}
-}
-
-func hoverAllSorted() monitoring.ObservablePanelOption {
-	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
-		panel.Tooltip.Shared = true
-		panel.Tooltip.Sort = 2
-	}
-}
-
-func noFill() monitoring.ObservablePanelOption {
-	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
-		panel.Fill = 0
-	}
-}
-
-func noLegend() monitoring.ObservablePanelOption {
-	return func(_ monitoring.Observable, panel *sdk.GraphPanel) {
-		panel.Legend.Show = false
 	}
 }

--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -759,9 +759,10 @@ func Frontend() *monitoring.Container {
 							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
-							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity`,
+								- Check Honeycomb for unusual activity
+							`,
 						},
 						{
 							Name:        "mean_sentinel_stream_latency_5m",
@@ -775,9 +776,10 @@ func Frontend() *monitoring.Container {
 							),
 							Owner: monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
-							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity`,
+								- Check Honeycomb for unusual activity
+							`,
 						},
 					},
 					{
@@ -790,9 +792,10 @@ func Frontend() *monitoring.Container {
 							Panel:       monitoring.Panel().LegendFormat("duration").Unit(monitoring.Seconds).With(monitoring.PanelOptions.NoLegend()),
 							Owner:       monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
-							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity`,
+								- Check Honeycomb for unusual activity
+							`,
 						},
 						{
 							Name:        "90th_percentile_sentinel_stream_latency_5m",
@@ -806,9 +809,10 @@ func Frontend() *monitoring.Container {
 							),
 							Owner: monitoring.ObservableOwnerSearch,
 							PossibleSolutions: `
-							    - Look at the breakdown by query to determine if a specific query type is being affected
+								- Look at the breakdown by query to determine if a specific query type is being affected
 								- Check for high CPU usage on zoekt-webserver
-								- Check Honeycomb for unusual activity`,
+								- Check Honeycomb for unusual activity
+							`,
 						},
 					},
 					{
@@ -825,7 +829,8 @@ func Frontend() *monitoring.Container {
 							),
 							Owner: monitoring.ObservableOwnerSearch,
 							Interpretation: `
-								- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
+								- The mean search duration for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+							`,
 						},
 						{
 							Name:        "mean_sentinel_stream_latency_by_query_5m",
@@ -840,7 +845,8 @@ func Frontend() *monitoring.Container {
 							),
 							Owner: monitoring.ObservableOwnerSearch,
 							Interpretation: `
-								- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.`,
+								- The mean streaming search latency for sentinel queries, broken down by query. Useful for debugging whether a slowdown is limited to a specific type of query.
+							`,
 						},
 					},
 					{

--- a/monitoring/monitoring/README.md
+++ b/monitoring/monitoring/README.md
@@ -38,7 +38,7 @@ To learn more about the generator\, see the top\-level program: https://github.c
   - [func (p ObservablePanel) Min(min float64) ObservablePanel](<#func-observablepanel-min>)
   - [func (p ObservablePanel) MinAuto() ObservablePanel](<#func-observablepanel-minauto>)
   - [func (p ObservablePanel) Unit(t UnitType) ObservablePanel](<#func-observablepanel-unit>)
-  - [func (p ObservablePanel) With(op ObservablePanelOption) ObservablePanel](<#func-observablepanel-with>)
+  - [func (p ObservablePanel) With(ops ...ObservablePanelOption) ObservablePanel](<#func-observablepanel-with>)
 - [type ObservablePanelOption](<#type-observablepaneloption>)
 - [type Row](<#type-row>)
 - [type UnitType](<#type-unittype>)
@@ -433,10 +433,10 @@ Unit sets the panel's Y axis unit type\.
 ### func \(ObservablePanel\) [With](<https://github.com/sourcegraph/sourcegraph/blob/main/monitoring/monitoring/panel.go#L104>)
 
 ```go
-func (p ObservablePanel) With(op ObservablePanelOption) ObservablePanel
+func (p ObservablePanel) With(ops ...ObservablePanelOption) ObservablePanel
 ```
 
-With adds the provided option to be applied when building this panel\.
+With adds the provided options to be applied when building this panel\.
 
 Before using this\, check if the customization you want is already included in the default \`Panel\(\)\` or available as a function on \`ObservablePanel\`\, such as \`ObservablePanel\.Unit\(UnitType\)\` for setting the units on a panel\.
 

--- a/monitoring/monitoring/panel.go
+++ b/monitoring/monitoring/panel.go
@@ -101,8 +101,8 @@ func (p ObservablePanel) Interval(ms int) ObservablePanel {
 //
 // Shared customizations are exported by `PanelOptions`, or you can write your option -
 // see `ObservablePanelOption` documentation for more details.
-func (p ObservablePanel) With(op ObservablePanelOption) ObservablePanel {
-	p.options = append(p.options, op)
+func (p ObservablePanel) With(op ...ObservablePanelOption) ObservablePanel {
+	p.options = append(p.options, op...)
 	return p
 }
 

--- a/monitoring/monitoring/panel.go
+++ b/monitoring/monitoring/panel.go
@@ -93,7 +93,7 @@ func (p ObservablePanel) Interval(ms int) ObservablePanel {
 	return p
 }
 
-// With adds the provided option to be applied when building this panel.
+// With adds the provided options to be applied when building this panel.
 //
 // Before using this, check if the customization you want is already included in the
 // default `Panel()` or available as a function on `ObservablePanel`, such as
@@ -101,8 +101,8 @@ func (p ObservablePanel) Interval(ms int) ObservablePanel {
 //
 // Shared customizations are exported by `PanelOptions`, or you can write your option -
 // see `ObservablePanelOption` documentation for more details.
-func (p ObservablePanel) With(op ...ObservablePanelOption) ObservablePanel {
-	p.options = append(p.options, op...)
+func (p ObservablePanel) With(ops ...ObservablePanelOption) ObservablePanel {
+	p.options = append(p.options, ops...)
 	return p
 }
 

--- a/monitoring/monitoring/panel_options.go
+++ b/monitoring/monitoring/panel_options.go
@@ -149,3 +149,58 @@ func (panelOptionsLibrary) AlertThresholds() ObservablePanelOption {
 		}
 	}
 }
+
+// ColorOverride takes a seriesName (which can be a regex pattern) and a color in hex format (#ABABAB).
+// Series that match the seriesName will be colored accordingly.
+func (panelOptionsLibrary) ColorOverride(seriesName string, color string) ObservablePanelOption {
+	return func(_ Observable, panel *sdk.GraphPanel) {
+		panel.SeriesOverrides = append(panel.SeriesOverrides, sdk.SeriesOverride{
+			Alias: seriesName,
+			Color: &color,
+		})
+	}
+}
+
+// LegendOnRight moves the legend to the right side of the panel
+func (panelOptionsLibrary) LegendOnRight() ObservablePanelOption {
+	return func(_ Observable, panel *sdk.GraphPanel) {
+		panel.Legend.RightSide = true
+	}
+}
+
+// HoverShowAll makes hover tooltips show all series rather than just the one being hovered over
+func (panelOptionsLibrary) HoverShowAll() ObservablePanelOption {
+	return func(_ Observable, panel *sdk.GraphPanel) {
+		panel.Tooltip.Shared = true
+	}
+}
+
+// HoverSort sorts the series either "ascending", "descending", or "none".
+// Default is "none".
+func (panelOptionsLibrary) HoverSort(order string) ObservablePanelOption {
+	return func(_ Observable, panel *sdk.GraphPanel) {
+		switch order {
+		case "ascending":
+			panel.Tooltip.Sort = 1
+		case "descending":
+			panel.Tooltip.Sort = 2
+		default:
+			panel.Tooltip.Sort = 0
+		}
+	}
+}
+
+// Fill sets the fill opacity for all series on the panel.
+// Set to 0 to disable fill.
+func (panelOptionsLibrary) Fill(fill int) ObservablePanelOption {
+	return func(_ Observable, panel *sdk.GraphPanel) {
+		panel.Fill = fill
+	}
+}
+
+// NoLegend disables the legend on the panel
+func (panelOptionsLibrary) NoLegend() ObservablePanelOption {
+	return func(_ Observable, panel *sdk.GraphPanel) {
+		panel.Legend.Show = false
+	}
+}


### PR DESCRIPTION
This commit translates our sentinel query dashboard into our dashboard
generation tool. That will allow us to hook into the standard monitoring
and alerting infrastructure as well as (maybe eventually) make this a
useful feature for customers.

This wasn't done initially because it was very much in flux as we
decided what metrics and thresholds would be useful. Additionally, I
didn't realize we needed to go through the generator to hook in to our
standard alerting infrastructure.

<img width="1192" alt="Screen Shot 2021-04-15 at 14 42 38" src="https://user-images.githubusercontent.com/12631702/114935775-d66f4a00-9df8-11eb-9cd4-18c8e344122b.png">

Additional post-motivation (thanks stephen!) is this will bring us in line
with the principals outlined [here](https://about.sourcegraph.com/handbook/engineering/observability/monitoring_pillars#dashboards-should-only-be-created-with-the-monitoring-generator).
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
