### PR TITLE
search frontend: add explicit separator token

### DIFF
--- a/client/shared/src/search/query/scanner.ts
+++ b/client/shared/src/search/query/scanner.ts
@@ -16,6 +16,7 @@ import {
     PatternKind,
     CharacterRange,
     createLiteral,
+    Separator,
 } from './token'
 
 /**
@@ -377,7 +378,7 @@ const filter: Scanner<Filter> = (input, start) => {
     if (result.type === 'error') {
         return result
     }
-    const [field, separator] = result.term as [Literal, Literal]
+    const [field, separator] = result.term as [Literal, Separator]
     let value: ScanResult<Literal> | undefined
     if (input[separator.range.end] === undefined) {
         value = undefined

--- a/client/shared/src/search/query/token.ts
+++ b/client/shared/src/search/query/token.ts
@@ -19,7 +19,16 @@ export interface BaseToken {
 /**
  * All recognized tokens.
  */
-export type Token = Whitespace | OpeningParen | ClosingParen | Keyword | Comment | Literal | Pattern | Filter
+export type Token =
+    | Whitespace
+    | OpeningParen
+    | ClosingParen
+    | Keyword
+    | Comment
+    | Literal
+    | Pattern
+    | Filter
+    | Separator
 
 /**
  * A label associated with a pattern token. We don't use SearchPatternType because
@@ -62,6 +71,13 @@ export interface Filter extends BaseToken {
     field: Literal
     value: Literal | undefined
     negated: boolean
+}
+
+/**
+ * A filter separator, i.e., the `:` in `field:value`.
+ */
+export interface Separator extends BaseToken {
+    type: 'separator'
 }
 
 export enum KeywordKind {


### PR DESCRIPTION
Stacked on #20067.

This just introduces an explicit token type for `:` in `field:value` syntax. It was previously implied by the `Filter` type. This change is needed for upcoming refactor.