### PR TITLE
code insights: make pings data weekly

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1447,11 +1447,11 @@ type ExtensionUsageStatistics struct {
 }
 
 type CodeInsightsUsageStatistics struct {
-	UsageStatisticsByInsight       []*InsightUsageStatistics
-	InsightsPageViews              *int32
-	InsightsUniquePageViews        *int32
-	InsightConfigureClick          *int32
-	InsightAddMoreClick            *int32
+	WeeklyUsageStatisticsByInsight []*InsightUsageStatistics
+	WeeklyInsightsPageViews        *int32
+	WeeklyInsightsUniquePageViews  *int32
+	WeeklyInsightConfigureClick    *int32
+	WeeklyInsightAddMoreClick      *int32
 	WeekStart                      time.Time
 	WeeklyInsightCreators          *int32
 	WeeklyFirstTimeInsightCreators *int32

--- a/internal/usagestats/code_insights.go
+++ b/internal/usagestats/code_insights.go
@@ -15,12 +15,12 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db dbutil.DB) (*types.C
 		COUNT(*) FILTER (WHERE name = 'ViewInsights')                       AS insights_page_views,
 		COUNT(distinct user_id) FILTER (WHERE name = 'ViewInsights')        AS insights_unique_page_views,
 		COUNT(distinct anonymous_user_id)
-			FILTER (WHERE name = 'InsightAddition'
-				AND timestamp > DATE_TRUNC('week', $1::timestamp))			AS weekly_insight_creators,
+			FILTER (WHERE name = 'InsightAddition')							AS weekly_insight_creators,
 		COUNT(*) FILTER (WHERE name = 'InsightConfigureClick') 				AS insight_configure_click,
 		COUNT(*) FILTER (WHERE name = 'InsightAddMoreClick') 				AS insight_add_more_click
 	FROM event_logs
-	WHERE name in ('ViewInsights', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick');
+	WHERE name in ('ViewInsights', 'InsightAddition', 'InsightConfigureClick', 'InsightAddMoreClick')
+		AND timestamp > DATE_TRUNC('week', $1::timestamp);
 	`
 
 	if err := db.QueryRowContext(ctx, platformQuery, timeNow()).Scan(
@@ -43,11 +43,12 @@ func GetCodeInsightsUsageStatistics(ctx context.Context, db dbutil.DB) (*types.C
 		COUNT(*) FILTER (WHERE name = 'InsightDataPointClick') 	AS data_point_clicks
 	FROM event_logs
 	WHERE name in ('InsightAddition', 'InsightEdit', 'InsightRemoval', 'InsightHover', 'InsightUICustomization', 'InsightDataPointClick')
+		AND timestamp > DATE_TRUNC('week', $1::timestamp)
 	GROUP BY insight_type;
 	`
 
 	usageStatisticsByInsight := []*types.InsightUsageStatistics{}
-	rows, err := db.QueryContext(ctx, metricsByInsightQuery)
+	rows, err := db.QueryContext(ctx, metricsByInsightQuery, timeNow())
 
 	if err != nil {
 		return nil, err

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -30,10 +30,10 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 		VALUES
 			(1, 'ViewInsights', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '1 day'),
 			(2, 'ViewInsights', '{}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '1 day'),
-			(3, 'InsightAddition', '{"insightType": "searchInsights"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '1 days'),
+			(3, 'InsightAddition', '{"insightType": "searchInsights"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '1 day'),
 			(4, 'InsightAddition', '{"insightType": "codeStatsInsights"}', '', 2, '420657f0-d443-4d16-ac7d-003d8cdc19ac', 'WEB', '3.23.0', $1::timestamp - interval '1 day'),
 			(5, 'InsightAddition', '{"insightType": "searchInsights"}', '', 2, '420657f0-d443-4d16-ac7d-003d8cdc19ac', 'WEB', '3.23.0', $1::timestamp - interval '1 day'),
-			(6, 'InsightEdit', '{"insightType": "searchInsights"}', '', 2, '420657f0-d443-4d16-ac7d-003d8cdc19ac', 'WEB', '3.23.0', $1::timestamp - interval '8 days'),
+			(6, 'InsightEdit', '{"insightType": "searchInsights"}', '', 2, '420657f0-d443-4d16-ac7d-003d8cdc19ac', 'WEB', '3.23.0', $1::timestamp - interval '2 days'),
 			(7, 'InsightAddition', '{"insightType": "codeStatsInsights"}', '', 1, '420657f0-d443-4d16-ac7d-003d8cdc91ef', 'WEB', '3.23.0', $1::timestamp - interval '8 days')
 	`, now)
 	if err != nil {
@@ -54,18 +54,18 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 
 	usageStatisticsByInsight := []*types.InsightUsageStatistics{
 		{
-			InsightType:      &searchInsightsType,
-			Additions:        &twoInt,
-			Edits:            &oneInt,
+			InsightType:      &codeStatsInsightsType,
+			Additions:        &oneInt,
+			Edits:            &zeroInt,
 			Removals:         &zeroInt,
 			Hovers:           &zeroInt,
 			UICustomizations: &zeroInt,
 			DataPointClicks:  &zeroInt,
 		},
 		{
-			InsightType:      &codeStatsInsightsType,
+			InsightType:      &searchInsightsType,
 			Additions:        &twoInt,
-			Edits:            &zeroInt,
+			Edits:            &oneInt,
 			Removals:         &zeroInt,
 			Hovers:           &zeroInt,
 			UICustomizations: &zeroInt,

--- a/internal/usagestats/code_insights_test.go
+++ b/internal/usagestats/code_insights_test.go
@@ -52,7 +52,7 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	searchInsightsType := "searchInsights"
 	codeStatsInsightsType := "codeStatsInsights"
 
-	usageStatisticsByInsight := []*types.InsightUsageStatistics{
+	weeklyUsageStatisticsByInsight := []*types.InsightUsageStatistics{
 		{
 			InsightType:      &codeStatsInsightsType,
 			Additions:        &oneInt,
@@ -74,11 +74,11 @@ func TestCodeInsightsUsageStatistics(t *testing.T) {
 	}
 
 	want := &types.CodeInsightsUsageStatistics{
-		UsageStatisticsByInsight:       usageStatisticsByInsight,
-		InsightsPageViews:              &twoInt,
-		InsightsUniquePageViews:        &oneInt,
-		InsightConfigureClick:          &zeroInt,
-		InsightAddMoreClick:            &zeroInt,
+		WeeklyUsageStatisticsByInsight: weeklyUsageStatisticsByInsight,
+		WeeklyInsightsPageViews:        &twoInt,
+		WeeklyInsightsUniquePageViews:  &oneInt,
+		WeeklyInsightConfigureClick:    &zeroInt,
+		WeeklyInsightAddMoreClick:      &zeroInt,
 		WeekStart:                      weekStart,
 		WeeklyInsightCreators:          &twoInt,
 		WeeklyFirstTimeInsightCreators: &oneInt,


### PR DESCRIPTION
Close #19906.

Should we:
1) change the field names to reflect that they're all weekly now
2) remove "weekly" prefix from `weekly_insight_creators` 
3) leave all names as is