### PR TITLE
search frontend: refactor query completion

### DIFF
--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -274,18 +274,6 @@ async function completeFilter(
         return null
     }
     if (resolvedFilter.definition.suggestions) {
-        if (Array.isArray(resolvedFilter.definition.suggestions)) {
-            // what is the significance of this if it's not a discrete value?
-            return {
-                suggestions: resolvedFilter.definition.suggestions.map(label => ({
-                    label,
-                    kind: Monaco.languages.CompletionItemKind.Text,
-                    insertText: label + ' ',
-                    range: value ? toMonacoRange(value.range) : defaultRange,
-                    command: COMPLETION_ITEM_SELECTED,
-                })),
-            }
-        }
         // If the filter definition has an associated suggestion type,
         // use it to filter dynamic suggestions.
         const suggestions = await dynamicSuggestions.pipe(first()).toPromise()

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -274,8 +274,8 @@ async function completeFilter(
         return null
     }
     if (resolvedFilter.definition.suggestions) {
-        // If the filter definition has an associated suggestion type,
-        // use it to filter dynamic suggestions.
+        // If the filter definition has an associated dynamic suggestion type,
+        // use it to retrieve dynamic suggestions from the backend.
         const suggestions = await dynamicSuggestions.pipe(first()).toPromise()
         return {
             suggestions: suggestions
@@ -285,8 +285,9 @@ async function completeFilter(
                 .map(partialCompletionItem => ({
                     ...partialCompletionItem,
                     // Set the current value as filterText, so that all dynamic suggestions
-                    // returned by the server are displayed. otherwise, if the current filter value
-                    // is a regex pattern, Monaco's filtering might hide some suggestions.
+                    // returned by the server are displayed. Otherwise, if the current filter value
+                    // is a regex pattern like `repo:^` Monaco's filtering will try match `^` against the
+                    // suggestions, and not display them because they don't match.
                     filterText: value?.value,
                     range: value ? toMonacoRange(value.range) : defaultRange,
                     command: COMPLETION_ITEM_SELECTED,

--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -112,7 +112,7 @@ interface BaseFilterDefinition {
     alias?: string
     description: string
     discreteValues?: (value: Literal | undefined) => string[]
-    suggestions?: SearchSuggestion['__typename'] | string[]
+    suggestions?: SearchSuggestion['__typename']
     default?: string
     /** Whether the filter may only be used 0 or 1 times in a query. */
     singular?: boolean
@@ -211,9 +211,9 @@ export const FILTERS: Record<NegatableFilter, NegatableFilterDefinition> &
         singular: true,
     },
     [FilterType.lang]: {
+        discreteValues: () => LANGUAGES,
         negatable: true,
         description: negated => `${negated ? 'Exclude' : 'Include only'} results from the given language`,
-        suggestions: LANGUAGES,
     },
     [FilterType.message]: {
         negatable: true,


### PR DESCRIPTION
Stacked on #20069.

This looks noisy but it's only:

- splitting up a big function into 3 separate functions (first commit)
- simplifying logic where we can use a simpler type for static suggestions used by the lang filter (second commit)
- adding a clarifying commit about completion logic (third commit)