### PR TITLE
generate clone url from extsvc config with safe type assertions

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -93,8 +94,16 @@ func main() {
 			if err != nil {
 				return "", err
 			}
+
 			for _, info := range r.Sources {
-				return info.CloneURL, nil
+				// build the clone url using the external service config instead of using
+				// the source CloneURL field
+				svc, err := externalServiceStore.GetByID(ctx, info.ExternalServiceID())
+				if err != nil {
+					return "", err
+				}
+
+				return types.RepoCloneURL(svc.Kind, svc.Config, r)
 			}
 			return "", fmt.Errorf("no sources for %q", repo)
 		},

--- a/internal/types/clone_url.go
+++ b/internal/types/clone_url.go
@@ -1,0 +1,311 @@
+package types
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/phabricator"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// RepoCloneURL builds a cloneURL for the given repo based on the
+// external service configuration.
+// If authentication information is found in the configuration,
+// it returns an authenticated URL for the selected code host.
+func RepoCloneURL(kind, config string, repo *Repo) (string, error) {
+	parsed, err := extsvc.ParseConfig(kind, config)
+	if err != nil {
+		return "", errors.Wrap(err, "loading service configuration")
+	}
+
+	switch t := parsed.(type) {
+	case *schema.AWSCodeCommitConnection:
+		if r, ok := repo.Metadata.(*awscodecommit.Repository); ok {
+			return awsCodeCloneURL(r, t), nil
+		}
+	case *schema.BitbucketServerConnection:
+		if r, ok := repo.Metadata.(*bitbucketserver.Repo); ok {
+			return bitbucketServerCloneURL(r, t), nil
+		}
+	case *schema.BitbucketCloudConnection:
+		if r, ok := repo.Metadata.(*bitbucketcloud.Repo); ok {
+			return bitbucketCloudCloneURL(r, t), nil
+		}
+	case *schema.GitHubConnection:
+		if r, ok := repo.Metadata.(*github.Repository); ok {
+			return githubCloneURL(r, t)
+		}
+	case *schema.GitLabConnection:
+		if r, ok := repo.Metadata.(*gitlab.Project); ok {
+			return gitlabCloneURL(r, t), nil
+		}
+	case *schema.GitoliteConnection:
+		if r, ok := repo.Metadata.(*gitolite.Repo); ok {
+			return r.URL, nil
+		}
+	case *schema.PerforceConnection:
+		if r, ok := repo.Metadata.(map[string]interface{}); ok {
+			return perforceCloneURL(r, t), nil
+		}
+	case *schema.PhabricatorConnection:
+		if r, ok := repo.Metadata.(*phabricator.Repo); ok {
+			return phabricatorCloneURL(r, t), nil
+		}
+	case *schema.OtherExternalServiceConnection:
+		return otherCloneURL(repo, t)
+	default:
+		return "", fmt.Errorf("unknown external service kind %q", kind)
+	}
+	return "", fmt.Errorf("unknown repo.Metadata type %T", repo.Metadata)
+}
+
+func awsCodeCloneURL(repo *awscodecommit.Repository, cfg *schema.AWSCodeCommitConnection) string {
+	u, err := url.Parse(repo.HTTPCloneURL)
+	if err != nil {
+		log15.Warn("Error adding authentication to AWS CodeCommit repository Git remote URL.", "url", repo.HTTPCloneURL, "error", err)
+		return repo.HTTPCloneURL
+	}
+
+	username := cfg.GitCredentials.Username
+	password := cfg.GitCredentials.Password
+
+	u.User = url.UserPassword(username, password)
+	return u.String()
+}
+
+func bitbucketServerCloneURL(repo *bitbucketserver.Repo, cfg *schema.BitbucketServerConnection) string {
+	var cloneURL string
+	for _, l := range repo.Links.Clone {
+		if l.Name == "ssh" && cfg.GitURLType == "ssh" {
+			cloneURL = l.Href
+			break
+		}
+		if l.Name == "http" {
+			var password string
+			if cfg.Token != "" {
+				password = cfg.Token // prefer personal access token
+			} else {
+				password = cfg.Password
+			}
+			cloneURL = setUserinfoBestEffort(l.Href, cfg.Username, password)
+			// No break, so that we fallback to http in case of ssh missing
+			// with GitURLType == "ssh"
+		}
+	}
+
+	return cloneURL
+}
+
+// bitbucketCloudCloneURL returns the repository's Git remote URL with the configured
+// Bitbucket Cloud app password inserted in the URL userinfo.
+func bitbucketCloudCloneURL(repo *bitbucketcloud.Repo, cfg *schema.BitbucketCloudConnection) string {
+	if cfg.GitURLType == "ssh" {
+		return fmt.Sprintf("git@%s:%s.git", cfg.Url, repo.FullName)
+	}
+
+	fallbackURL := (&url.URL{
+		Scheme: "https",
+		Host:   cfg.Url,
+		Path:   "/" + repo.FullName,
+	}).String()
+
+	httpsURL, err := repo.Links.Clone.HTTPS()
+	if err != nil {
+		log15.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", "url", repo.Links.Clone, "error", err)
+		return fallbackURL
+	}
+	u, err := url.Parse(httpsURL)
+	if err != nil {
+		log15.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", "url", httpsURL, "error", err)
+		return fallbackURL
+	}
+
+	u.User = url.UserPassword(cfg.Username, cfg.AppPassword)
+	return u.String()
+}
+
+func githubCloneURL(repo *github.Repository, cfg *schema.GitHubConnection) (string, error) {
+	if cfg.GitURLType == "ssh" {
+		baseURL, err := url.Parse(cfg.Url)
+		if err != nil {
+			return "", err
+		}
+		baseURL = extsvc.NormalizeBaseURL(baseURL)
+		originalHostname := baseURL.Hostname()
+		url := fmt.Sprintf("git@%s:%s.git", originalHostname, repo.NameWithOwner)
+		return url, nil
+	}
+
+	if cfg.Token == "" {
+		return repo.URL, nil
+	}
+	u, err := url.Parse(repo.URL)
+	if err != nil {
+		log15.Warn("Error adding authentication to GitHub repository Git remote URL.", "url", repo.URL, "error", err)
+		return repo.URL, nil
+	}
+	u.User = url.User(cfg.Token)
+	return u.String(), nil
+}
+
+// authenticatedRemoteURL returns the GitLab projects's Git remote URL with the
+// configured GitLab personal access token inserted in the URL userinfo.
+func gitlabCloneURL(repo *gitlab.Project, cfg *schema.GitLabConnection) string {
+	if cfg.GitURLType == "ssh" {
+		return repo.SSHURLToRepo // SSH authentication must be provided out-of-band
+	}
+	if cfg.Token == "" {
+		return repo.HTTPURLToRepo
+	}
+	u, err := url.Parse(repo.HTTPURLToRepo)
+	if err != nil {
+		log15.Warn("Error adding authentication to GitLab repository Git remote URL.", "url", repo.HTTPURLToRepo, "error", err)
+		return repo.HTTPURLToRepo
+	}
+	// Any username works; "git" is not special.
+	u.User = url.UserPassword("git", cfg.Token)
+	return u.String()
+}
+
+// perforceCloneURL composes a clone URL for a Perforce depot based on
+// given information. e.g.
+// perforce://admin:password@ssl:111.222.333.444:1666//Sourcegraph/
+func perforceCloneURL(repo map[string]interface{}, cfg *schema.PerforceConnection) string {
+	cloneURL := url.URL{
+		Scheme: "perforce",
+		User:   url.UserPassword(cfg.P4User, cfg.P4Passwd),
+		Host:   cfg.P4Port,
+		Path:   repo["depot"].(string),
+	}
+	return cloneURL.String()
+}
+
+func phabricatorCloneURL(repo *phabricator.Repo, _ *schema.PhabricatorConnection) string {
+	var external []*phabricator.URI
+	builtin := make(map[string]*phabricator.URI)
+
+	for _, u := range repo.URIs {
+		if u.Disabled || u.Normalized == "" {
+			continue
+		} else if u.BuiltinIdentifier != "" {
+			builtin[u.BuiltinProtocol+"+"+u.BuiltinIdentifier] = u
+		} else {
+			external = append(external, u)
+		}
+	}
+
+	var name string
+	if len(external) > 0 {
+		name = external[0].Normalized
+	}
+
+	var cloneURL string
+	for _, alt := range [...]struct {
+		protocol, identifier string
+	}{ // Ordered by priority.
+		{"https", "shortname"},
+		{"https", "callsign"},
+		{"https", "id"},
+		{"ssh", "shortname"},
+		{"ssh", "callsign"},
+		{"ssh", "id"},
+	} {
+		if u, ok := builtin[alt.protocol+"+"+alt.identifier]; ok {
+			cloneURL = u.Effective
+			// TODO(tsenart): Authenticate the cloneURL with the user's
+			// VCS password once we have that setting in the config. The
+			// Conduit token can't be used for cloning.
+			// cloneURL = setUserinfoBestEffort(cloneURL, conn.VCSPassword, "")
+
+			if name == "" {
+				name = u.Normalized
+			}
+		}
+	}
+
+	if cloneURL == "" {
+		log15.Warn("unable to construct clone URL for repo", "name", name, "phabricator_id", repo.PHID)
+	}
+
+	return cloneURL
+}
+
+func otherCloneURL(repo *Repo, cfg *schema.OtherExternalServiceConnection) (string, error) {
+	if cfg.Url == "" {
+		return repo.URI, nil
+	}
+
+	pattern := cfg.RepositoryPathPattern
+	if pattern == "" {
+		pattern = "{base}/{repo}"
+	}
+
+	base, err := url.Parse(cfg.Url)
+	if err != nil {
+		return "", err
+	}
+
+	for _, name := range cfg.Repos {
+		// normalize the repo name for comparison with the unescaped repo.Name
+		uName, err := url.Parse(name)
+		if err != nil {
+			return "", err
+		}
+
+		if reposource.OtherRepoName(pattern, cfg.Url, uName.Path) == string(repo.Name) {
+			u, err := base.Parse(uName.Path)
+			if err != nil {
+				return "", err
+			}
+			return u.String(), nil
+		}
+	}
+
+	return repo.URI, nil
+}
+
+// setUserinfoBestEffort adds the username and password to rawurl. If user is
+// not set in rawurl, username is used. If password is not set and there is a
+// user, password is used. If anything fails, the original rawurl is returned.
+func setUserinfoBestEffort(rawurl, username, password string) string {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return rawurl
+	}
+
+	passwordSet := password != ""
+
+	// Update username and password if specified in rawurl
+	if u.User != nil {
+		if u.User.Username() != "" {
+			username = u.User.Username()
+		}
+		if p, ok := u.User.Password(); ok {
+			password = p
+			passwordSet = true
+		}
+	}
+
+	if username == "" {
+		return rawurl
+	}
+
+	if passwordSet {
+		u.User = url.UserPassword(username, password)
+	} else {
+		u.User = url.User(username)
+	}
+
+	return u.String()
+}

--- a/internal/types/clone_url_test.go
+++ b/internal/types/clone_url_test.go
@@ -1,0 +1,275 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
+	"github.com/sourcegraph/sourcegraph/internal/timeutil"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestAWSCodeCloneURLs(t *testing.T) {
+	clock := timeutil.NewFakeClock(time.Now(), 0)
+	now := clock.Now()
+
+	repo := &awscodecommit.Repository{
+		ARN:          "arn:aws:codecommit:us-west-1:999999999999:stripe-go",
+		AccountID:    "999999999999",
+		ID:           "f001337a-3450-46fd-b7d2-650c0EXAMPLE",
+		Name:         "stripe-go",
+		Description:  "The stripe-go lib",
+		HTTPCloneURL: "https://git-codecommit.us-west-1.amazonaws.com/v1/repos/stripe-go",
+		LastModified: &now,
+	}
+
+	cfg := schema.AWSCodeCommitConnection{
+		GitCredentials: schema.AWSCodeCommitGitCredentials{
+			Username: "username",
+			Password: "password",
+		},
+	}
+
+	got := awsCodeCloneURL(repo, &cfg)
+	want := "https://username:password@git-codecommit.us-west-1.amazonaws.com/v1/repos/stripe-go"
+	if got != want {
+		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
+	}
+}
+
+func TestBitbucketServerCloneURLs(t *testing.T) {
+	repo := &bitbucketserver.Repo{
+		ID:   1,
+		Slug: "bar",
+		Project: &bitbucketserver.Project{
+			Key: "foo",
+		},
+	}
+
+	cfg := schema.BitbucketServerConnection{
+		Token:    "abc",
+		Username: "username",
+		Password: "password",
+	}
+
+	t.Run("ssh", func(t *testing.T) {
+		repo.Links.Clone = []struct {
+			Href string "json:\"href\""
+			Name string "json:\"name\""
+		}{
+			// even if the first link is http, ssh should prevail
+			{Name: "http", Href: "https://asdine@bitbucket.example.com/scm/sg/sourcegraph.git"},
+			{Name: "ssh", Href: "ssh://git@bitbucket.example.com:7999/sg/sourcegraph.git"},
+		}
+
+		cfg.GitURLType = "ssh" // use ssh in the config as well
+
+		got := bitbucketServerCloneURL(repo, &cfg)
+		want := "ssh://git@bitbucket.example.com:7999/sg/sourcegraph.git"
+		if got != want {
+			t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
+		}
+	})
+
+	t.Run("http", func(t *testing.T) {
+		// Second test: http
+		repo.Links.Clone = []struct {
+			Href string "json:\"href\""
+			Name string "json:\"name\""
+		}{
+			{Name: "http", Href: "https://asdine@bitbucket.example.com/scm/sg/sourcegraph.git"},
+		}
+
+		got := bitbucketServerCloneURL(repo, &cfg)
+		want := "https://asdine:abc@bitbucket.example.com/scm/sg/sourcegraph.git"
+		if got != want {
+			t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
+		}
+	})
+
+	t.Run("no token", func(t *testing.T) {
+		// Third test: no token
+		cfg.Token = ""
+
+		got := bitbucketServerCloneURL(repo, &cfg)
+		want := "https://asdine:password@bitbucket.example.com/scm/sg/sourcegraph.git"
+		if got != want {
+			t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
+		}
+	})
+}
+
+func TestBitbucketCloudCloneURLs(t *testing.T) {
+	repo := &bitbucketcloud.Repo{
+		FullName: "sg/sourcegraph",
+	}
+
+	repo.Links.Clone = []struct {
+		Href string "json:\"href\""
+		Name string "json:\"name\""
+	}{
+		{Name: "https", Href: "https://asdine@bitbucket.org/sg/sourcegraph.git"},
+		{Name: "ssh", Href: "git@bitbucket.org/sg/sourcegraph.git"},
+	}
+
+	cfg := schema.BitbucketCloudConnection{
+		Url:         "bitbucket.org",
+		Username:    "username",
+		AppPassword: "password",
+	}
+
+	t.Run("ssh", func(t *testing.T) {
+		cfg.GitURLType = "ssh"
+
+		got := bitbucketCloudCloneURL(repo, &cfg)
+		want := "git@bitbucket.org:sg/sourcegraph.git"
+		if got != want {
+			t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
+		}
+	})
+
+	t.Run("http", func(t *testing.T) {
+		cfg.GitURLType = "http"
+
+		got := bitbucketCloudCloneURL(repo, &cfg)
+		want := "https://username:password@bitbucket.org/sg/sourcegraph.git"
+		if got != want {
+			t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
+		}
+	})
+}
+
+func TestGithubCloneURLs(t *testing.T) {
+	var repo github.Repository
+	repo.NameWithOwner = "foo/bar"
+
+	tests := []struct {
+		InstanceUrl string
+		RepoURL     string
+		Token       string
+		GitURLType  string
+		Want        string
+	}{
+		{"https://github.com", "https://github.com/foo/bar", "", "", "https://github.com/foo/bar"},
+		{"https://github.com", "https://github.com/foo/bar", "abcd", "", "https://abcd@github.com/foo/bar"},
+		{"https://github.com", "https://github.com/foo/bar", "abcd", "ssh", "git@github.com:foo/bar.git"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("URL(%q) / Token(%q) / URLType(%q)", test.InstanceUrl, test.Token, test.GitURLType), func(t *testing.T) {
+			cfg := schema.GitHubConnection{
+				Url:        test.InstanceUrl,
+				Token:      test.Token,
+				GitURLType: test.GitURLType,
+			}
+
+			repo.URL = test.RepoURL
+
+			got, err := githubCloneURL(&repo, &cfg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.Want {
+				t.Fatalf("wrong cloneURL, got: %q, want: %q", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestGitlabCloneURLs(t *testing.T) {
+	repo := &gitlab.Project{
+		ProjectCommon: gitlab.ProjectCommon{
+			ID:                1,
+			PathWithNamespace: "foo/bar",
+			SSHURLToRepo:      "git@gitlab.com:gitlab-org/gitaly.git",
+			HTTPURLToRepo:     "https://gitlab.com/gitlab-org/gitaly.git",
+		},
+	}
+
+	tests := []struct {
+		Token      string
+		GitURLType string
+		Want       string
+	}{
+		{"", "", "https://gitlab.com/gitlab-org/gitaly.git"},
+		{"abcd", "", "https://git:abcd@gitlab.com/gitlab-org/gitaly.git"},
+		{"abcd", "ssh", "git@gitlab.com:gitlab-org/gitaly.git"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Token(%q) / URLType(%q)", test.Token, test.GitURLType), func(t *testing.T) {
+			cfg := schema.GitLabConnection{
+				Token:      test.Token,
+				GitURLType: test.GitURLType,
+			}
+
+			got := gitlabCloneURL(repo, &cfg)
+			if got != test.Want {
+				t.Fatalf("wrong cloneURL, got: %q, want: %q", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestPerforceCloneURL(t *testing.T) {
+	cfg := schema.PerforceConnection{
+		P4Port:   "ssl:111.222.333.444:1666",
+		P4User:   "admin",
+		P4Passwd: "pa$$word",
+	}
+
+	repo := map[string]interface{}{
+		"depot": "//Sourcegraph",
+	}
+
+	got := perforceCloneURL(repo, &cfg)
+	want := "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Sourcegraph"
+	if got != want {
+		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
+	}
+}
+
+func TestSetUserinfoBestEffort(t *testing.T) {
+	cases := []struct {
+		rawurl   string
+		username string
+		password string
+		want     string
+	}{
+		// no-op
+		{"https://foo.com/foo/bar", "", "", "https://foo.com/foo/bar"},
+		// invalid name is returned as is
+		{":/foo.com/foo/bar", "u", "p", ":/foo.com/foo/bar"},
+
+		// no user details in rawurl
+		{"https://foo.com/foo/bar", "u", "p", "https://u:p@foo.com/foo/bar"},
+		{"https://foo.com/foo/bar", "u", "", "https://u@foo.com/foo/bar"},
+		{"https://foo.com/foo/bar", "", "p", "https://foo.com/foo/bar"},
+
+		// user set already
+		{"https://x@foo.com/foo/bar", "u", "p", "https://x:p@foo.com/foo/bar"},
+		{"https://x@foo.com/foo/bar", "u", "", "https://x@foo.com/foo/bar"},
+		{"https://x@foo.com/foo/bar", "", "p", "https://x:p@foo.com/foo/bar"},
+
+		// user and password set already
+		{"https://x:y@foo.com/foo/bar", "u", "p", "https://x:y@foo.com/foo/bar"},
+		{"https://x:y@foo.com/foo/bar", "u", "", "https://x:y@foo.com/foo/bar"},
+		{"https://x:y@foo.com/foo/bar", "", "p", "https://x:y@foo.com/foo/bar"},
+
+		// empty password
+		{"https://x:@foo.com/foo/bar", "u", "p", "https://x:@foo.com/foo/bar"},
+		{"https://x:@foo.com/foo/bar", "u", "", "https://x:@foo.com/foo/bar"},
+		{"https://x:@foo.com/foo/bar", "", "p", "https://x:@foo.com/foo/bar"},
+	}
+	for _, c := range cases {
+		got := setUserinfoBestEffort(c.rawurl, c.username, c.password)
+		if got != c.want {
+			t.Errorf("setUserinfoBestEffort(%q, %q, %q): got %q want %q", c.rawurl, c.username, c.password, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
closes #20074 

looks like we had an instance of a nil repo.Metadata for a perforce repo 🤔 

i've updated the type assertions to be safe, though i really wish you could do a double switch, eg: 

```go
switch a, b := foo.(type), bar.(type) {
 case Cool, Type: 
}
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
