### PR TITLE
search: don't check rate limit if authenticated

### DIFF
--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -400,7 +400,13 @@ func (bl *BasicLimitWatcher) updateFromConfig(limit int) {
 		log15.Debug("BasicLimiter disabled")
 		return
 	}
-	l, err := throttled.NewGCRARateLimiter(bl.store, throttled.RateQuota{MaxRate: throttled.PerHour(limit)})
+	maxBurstPercentage := 0.2
+	l, err := throttled.NewGCRARateLimiter(
+		bl.store,
+		throttled.RateQuota{
+			MaxRate:  throttled.PerHour(limit),
+			MaxBurst: int(float64(limit) * maxBurstPercentage)},
+	)
 	if err != nil {
 		log15.Warn("error updating BasicLimiter from config")
 		bl.rl.Store(&BasicLimiter{nil, false})

--- a/cmd/frontend/graphqlbackend/rate_limit.go
+++ b/cmd/frontend/graphqlbackend/rate_limit.go
@@ -432,7 +432,7 @@ type BasicLimiter struct {
 // RateLimit limits unauthenticated requests to the GraphQL API with an equal
 // quantity of 1.
 func (bl *BasicLimiter) RateLimit(_ string, _ int, args LimiterArgs) (bool, throttled.RateLimitResult, error) {
-	if args.Anonymous && args.RequestName == "unknown" && args.RequestSource == trace.SourceOther {
+	if args.Anonymous && args.RequestName == "unknown" && args.RequestSource == trace.SourceOther && bl.GCRARateLimiter != nil {
 		return bl.GCRARateLimiter.RateLimit("basic", 1)
 	}
 	return false, throttled.RateLimitResult{}, nil


### PR DESCRIPTION
This removes calls to Redis if the user is authenticated. This is the
most likely cause of the issues we encountered when we first activated
the rate limiter on Cloud.

At the  same time we 
- fix a bug that would have caused nil panics for many customer instances where `ExperimentalFeatures` are nil
- allow a burst of 20% of the limit we set.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
