### PR TITLE
enterprise: Enforce user and external service limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A regression caused by search onboarding tour logic to never focus input in the search bar on the homepage. Input now focuses on the homepage if the search tour isn't in effect. [#19678](https://github.com/sourcegraph/sourcegraph/pull/19678)
 - New changes of a Perforce depot will now be reflected in `master` branch after the initial clone. [#19718](https://github.com/sourcegraph/sourcegraph/pull/19718)
 - Gitolite and Other type code host connection configuration can be correctly displayed. [#19976](https://github.com/sourcegraph/sourcegraph/pull/19976)
+- Fixed a regression that caused user and code host limits to be ignored. [#20089](https://github.com/sourcegraph/sourcegraph/pull/20089)
 
 ## 3.26.3
 

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/external_services_test.go
@@ -54,22 +54,14 @@ func TestNewPreCreateExternalServiceHook(t *testing.T) {
 			}
 			defer func() { licensing.MockGetConfiguredProductLicenseInfo = nil }()
 
-			store := mockExternalServicesStore{extSvcCount: test.externalServiceCount}
-			err := NewPreCreateExternalServiceHook(&store)(context.Background())
+			database.Mocks.ExternalServices.Count = func(ctx context.Context, opt database.ExternalServicesListOptions) (int, error) {
+				return test.externalServiceCount, nil
+			}
+			t.Cleanup(func() { database.Mocks.ExternalServices.Count = nil })
+			err := NewBeforeCreateExternalServiceHook()(context.Background(), nil)
 			if gotErr := err != nil; gotErr != test.wantErr {
 				t.Errorf("got error %v, want %v", gotErr, test.wantErr)
 			}
 		})
 	}
-}
-
-// A mockExternalServicesStore implements the ExternalServicesStore interface for test purposes.
-type mockExternalServicesStore struct {
-	extSvcCount int
-	err         error
-}
-
-// Count returns the number of external services currently configured.
-func (m *mockExternalServicesStore) Count(_ context.Context, _ database.ExternalServicesListOptions) (int, error) {
-	return m.extSvcCount, m.err
 }

--- a/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
+++ b/enterprise/cmd/frontend/internal/licensing/enforcement/users.go
@@ -16,8 +16,8 @@ import (
 
 // NewBeforeCreateUserHook returns a BeforeCreateUserHook closure with the given UsersStore
 // that determines whether new user is allowed to be created.
-func NewBeforeCreateUserHook(s licensing.UsersStore) func(context.Context) error {
-	return func(ctx context.Context) error {
+func NewBeforeCreateUserHook() func(context.Context, dbutil.DB) error {
+	return func(ctx context.Context, db dbutil.DB) error {
 		info, err := licensing.GetConfiguredProductLicenseInfo()
 		if err != nil {
 			return err
@@ -36,7 +36,7 @@ func NewBeforeCreateUserHook(s licensing.UsersStore) func(context.Context) error
 		}
 
 		// Block creation of a new user beyond the licensed user count (unless true-up is allowed).
-		userCount, err := s.Count(ctx)
+		userCount, err := database.Users(db).Count(ctx, nil)
 		if err != nil {
 			return err
 		}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -124,9 +124,3 @@ type usersStore struct {
 func (u *usersStore) Count(ctx context.Context) (int, error) {
 	return database.Users(u.db).Count(ctx, nil)
 }
-
-type externalServicesStore struct{}
-
-func (externalServicesStore) Count(ctx context.Context, opts database.ExternalServicesListOptions) (int, error) {
-	return database.GlobalExternalServices.Count(ctx, opts)
-}

--- a/enterprise/cmd/frontend/internal/licensing/init/init.go
+++ b/enterprise/cmd/frontend/internal/licensing/init/init.go
@@ -27,15 +27,15 @@ import (
 func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services) error {
 	// Enforce the license's max user count by preventing the creation of new users when the max is
 	// reached.
-	database.GlobalUsers.BeforeCreateUser = enforcement.NewBeforeCreateUserHook(&usersStore{})
+	database.BeforeCreateUser = enforcement.NewBeforeCreateUserHook()
 
 	// Enforce non-site admin roles in Free tier.
-	database.GlobalUsers.AfterCreateUser = enforcement.NewAfterCreateUserHook()
-	database.GlobalUsers.BeforeSetUserIsSiteAdmin = enforcement.NewBeforeSetUserIsSiteAdmin()
+	database.AfterCreateUser = enforcement.NewAfterCreateUserHook()
+	database.BeforeSetUserIsSiteAdmin = enforcement.NewBeforeSetUserIsSiteAdmin()
 
 	// Enforce the license's max external service count by preventing the creation of new external
 	// services when the max is reached.
-	database.GlobalExternalServices.PreCreateExternalService = enforcement.NewPreCreateExternalServiceHook(&externalServicesStore{})
+	database.BeforeCreateExternalService = enforcement.NewBeforeCreateExternalServiceHook()
 
 	// Enforce the license's feature check for monitoring. If the license does not support the monitoring
 	// feature, then alternative debug handlers will be invoked.
@@ -106,7 +106,9 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 	enterpriseServices.LicenseResolver = resolvers.LicenseResolver{}
 
 	goroutine.Go(func() {
-		licensing.StartMaxUserCount(&usersStore{})
+		licensing.StartMaxUserCount(&usersStore{
+			db: db,
+		})
 	})
 	if envvar.SourcegraphDotComMode() {
 		goroutine.Go(productsubscription.StartCheckForUpcomingLicenseExpirations)
@@ -115,10 +117,12 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 	return nil
 }
 
-type usersStore struct{}
+type usersStore struct {
+	db dbutil.DB
+}
 
-func (usersStore) Count(ctx context.Context) (int, error) {
-	return database.GlobalUsers.Count(ctx, nil)
+func (u *usersStore) Count(ctx context.Context) (int, error) {
+	return database.Users(u.db).Count(ctx, nil)
 }
 
 type externalServicesStore struct{}

--- a/enterprise/internal/batches/testing/user.go
+++ b/enterprise/internal/batches/testing/user.go
@@ -16,7 +16,7 @@ var CreateTestUser = func() func(*testing.T, dbutil.DB, bool) *types.User {
 	var mu sync.Mutex
 	count := 0
 
-	// This function replicates the minium amount of work required by
+	// This function replicates the minimum amount of work required by
 	// database.Users.Create to create a new user, but it doesn't require passing in
 	// a full database.NewUser every time.
 	return func(t *testing.T, db dbutil.DB, siteAdmin bool) *types.User {

--- a/internal/database/external_services_test.go
+++ b/internal/database/external_services_test.go
@@ -13,12 +13,11 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/keegancsmith/sqlf"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"


### PR DESCRIPTION
We now properly enforces the 10-user limit (including when users sign in via
SSO rather than being explicitly created by the site admin) and
X-external-services limit for non-enterprise instances.

We were setting hook functions to check enforced limits in an `Init`
function which set the hooks on our global database struct and in the
move away from using globals some instances were being used without the
trigger functions.

This is a minimal changes that defines the trigger functions globally
instead.

Old init function:
https://github.com/sourcegraph/sourcegraph/blob/9e35730ee86edfa25c50623db13fe83ea57ceb15/enterprise/cmd/frontend/internal/licensing/init/init.go#L28-L38

An example where we create a store *without* the hooks:
https://github.com/sourcegraph/sourcegraph/blob/243e44d5079e4d9970955f5828a0ac0bf265f5b4/internal/database/external_accounts.go#L266
