### PR TITLE
Add ctags binary path to zoekt-indexserver

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -227,6 +227,7 @@ commands:
       go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
     env:
       GOGC: 50
+      CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
 
   zoekt-indexserver-1:
     cmd: |
@@ -248,6 +249,7 @@ commands:
       go install github.com/google/zoekt/cmd/zoekt-sourcegraph-indexserver
     env:
       GOGC: 50
+      CTAGS_COMMAND: cmd/symbols/universal-ctags-dev
 
   zoekt-webserver-0:
     cmd: |


### PR DESCRIPTION
Running `sg start` was failing for me because zoekt-indexserver could
not find the ctags binary. This is ostensibly because I don't have
either universal ctags or exuberant ctags installed, but it looks like
elsewhere, we use `cmd/symbols/universal-ctags-dev`, so I copied that same
pattern here.

Fixes #19882 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
