### PR TITLE
Simplify symbol search file partitioning

### DIFF
--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -185,33 +185,37 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 		// Ask for limit + 1 so we can detect whether there are more results than the limit.
 		First: limit + 1,
 	})
-	fileMatchesByURI := make(map[string]*FileMatchResolver)
-	fileMatches := make([]*FileMatchResolver, 0)
 
+	// All symbols are from the same repo, so we can just partition them by path
+	// to build fileMatches
+	symbolMatchesByPath := make(map[string][]*result.SymbolMatch)
 	for _, symbol := range symbols {
-		symbolRes := &result.SymbolMatch{
+		symbolMatch := &result.SymbolMatch{
 			Symbol:  symbol,
 			BaseURI: baseURI,
 		}
-		newFileMatchResolver := &FileMatchResolver{
-			db: db,
+
+		cur := symbolMatchesByPath[symbol.Path]
+		symbolMatchesByPath[symbol.Path] = append(cur, symbolMatch)
+	}
+
+	// Create file matches from partitioned symbols
+	fileMatchResolvers := make([]*FileMatchResolver, 0, len(symbolMatchesByPath))
+	for path, symbolMatches := range symbolMatchesByPath {
+		fileMatchResolvers = append(fileMatchResolvers, &FileMatchResolver{
+			db:           db,
+			RepoResolver: repoResolver,
 			FileMatch: result.FileMatch{
-				Path:     symbolRes.Symbol.Path,
-				Symbols:  []*result.SymbolMatch{symbolRes},
+				Path:     path,
+				Symbols:  symbolMatches,
 				Repo:     repoRevs.Repo,
 				CommitID: commitID,
 				InputRev: &inputRev,
 			},
-			RepoResolver: repoResolver,
-		}
-		if oldFileMatchResolver, ok := fileMatchesByURI[newFileMatchResolver.URL()]; ok {
-			oldFileMatchResolver.FileMatch.Symbols = append(oldFileMatchResolver.FileMatch.Symbols, symbolRes)
-		} else {
-			fileMatchesByURI[newFileMatchResolver.URL()] = newFileMatchResolver
-			fileMatches = append(fileMatches, newFileMatchResolver)
-		}
+		})
 	}
-	return fileMatches, err
+
+	return fileMatchResolvers, err
 }
 
 // unescapePattern expects a regexp pattern of the form /^ ... $/ and unescapes

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -215,6 +216,9 @@ func searchSymbolsInRepo(ctx context.Context, db dbutil.DB, repoRevs *search.Rep
 		})
 	}
 
+	sort.Slice(fileMatchResolvers, func(i, j int) bool {
+		return fileMatchResolvers[i].Path < fileMatchResolvers[j].Path
+	})
 	return fileMatchResolvers, err
 }
 


### PR DESCRIPTION
Before we were partitioning by file URL, which made this logic very
complicated since we needed to create a file match, calculate its URL,
see if we've already seen that URL, then merge if a file for that URL
already existed.

Instead, we can just partition symbols based on their path, then create
file matches based on those partitions. There is no extra information we
get from the URL since all these results are coming from the same
repository.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
