### PR TITLE
search redesign: initial empty sidebar

### DIFF
--- a/client/shared/src/util/useLocalStorage.ts
+++ b/client/shared/src/util/useLocalStorage.ts
@@ -1,24 +1,29 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 /**
  * A React hook to use and set state that is persisted in localStorage.
+ * The getter's value will be updated whenever any setter globally is called.
  *
  * @param key The localStorage key to use for persistence.
  * @param initialValue The initial value to use when there is no value in localStorage for the key.
+ * @param keepUpdated Whether to listen to update events from other useLocalStorage setters and keep the value up to date. (Default: false)
  * @returns A getter and setter for the value (`const [foo, setFoo] = useLocalStorage('key', 123)`).
  */
 export const useLocalStorage = <T>(
     key: string,
-    initialValue: T
+    initialValue: T,
+    { keepUpdated }: { keepUpdated: boolean } = { keepUpdated: false }
 ): [T, (value: T | ((previousValue: T) => T)) => void] => {
-    const [storedValue, setStoredValue] = useState<T>(() => {
+    const getCurrentValue = useCallback((): T => {
         try {
             const item = localStorage.getItem(key)
             return item ? (JSON.parse(item) as T) : initialValue
         } catch {
             return initialValue
         }
-    })
+    }, [initialValue, key])
+
+    const [storedValue, setStoredValue] = useState<T>(getCurrentValue)
 
     // We want `setValue` to have a stable identity like `setState`, so it shouldn't depend on `storedValue`.
     // Instead, have it read from a ref which is updated on each render.
@@ -32,10 +37,30 @@ export const useLocalStorage = <T>(
             const valueToStore =
                 typeof value === 'function' ? (value as (previousValue: T) => T)(storedValueReference.current) : value
             window.localStorage.setItem(key, JSON.stringify(valueToStore))
+
+            // This doesn't normally get fired on the same tab, needs to be fired
+            // manually here so checking the event bellow works
+            window.dispatchEvent(new Event('storage'))
+
             setStoredValue(valueToStore)
         },
         [key]
     )
+
+    // Update value when localStorage changes
+    useEffect(() => {
+        if (!keepUpdated) {
+            return
+        }
+
+        const updateOnStorageEvent = (): void => {
+            const currentValue = getCurrentValue()
+            setStoredValue(currentValue)
+        }
+        window.addEventListener('storage', updateOnStorageEvent)
+
+        return () => window.removeEventListener('storage', updateOnStorageEvent)
+    }, [getCurrentValue, keepUpdated])
 
     return [storedValue, setValue]
 }

--- a/client/shared/src/util/useLocalStorage.ts
+++ b/client/shared/src/util/useLocalStorage.ts
@@ -1,29 +1,24 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 /**
  * A React hook to use and set state that is persisted in localStorage.
- * The getter's value will be updated whenever any setter globally is called.
  *
  * @param key The localStorage key to use for persistence.
  * @param initialValue The initial value to use when there is no value in localStorage for the key.
- * @param keepUpdated Whether to listen to update events from other useLocalStorage setters and keep the value up to date. (Default: false)
  * @returns A getter and setter for the value (`const [foo, setFoo] = useLocalStorage('key', 123)`).
  */
 export const useLocalStorage = <T>(
     key: string,
-    initialValue: T,
-    { keepUpdated }: { keepUpdated: boolean } = { keepUpdated: false }
+    initialValue: T
 ): [T, (value: T | ((previousValue: T) => T)) => void] => {
-    const getCurrentValue = useCallback((): T => {
+    const [storedValue, setStoredValue] = useState<T>(() => {
         try {
             const item = localStorage.getItem(key)
             return item ? (JSON.parse(item) as T) : initialValue
         } catch {
             return initialValue
         }
-    }, [initialValue, key])
-
-    const [storedValue, setStoredValue] = useState<T>(getCurrentValue)
+    })
 
     // We want `setValue` to have a stable identity like `setState`, so it shouldn't depend on `storedValue`.
     // Instead, have it read from a ref which is updated on each render.
@@ -37,30 +32,10 @@ export const useLocalStorage = <T>(
             const valueToStore =
                 typeof value === 'function' ? (value as (previousValue: T) => T)(storedValueReference.current) : value
             window.localStorage.setItem(key, JSON.stringify(valueToStore))
-
-            // This doesn't normally get fired on the same tab, needs to be fired
-            // manually here so checking the event bellow works
-            window.dispatchEvent(new Event('storage'))
-
             setStoredValue(valueToStore)
         },
         [key]
     )
-
-    // Update value when localStorage changes
-    useEffect(() => {
-        if (!keepUpdated) {
-            return
-        }
-
-        const updateOnStorageEvent = (): void => {
-            const currentValue = getCurrentValue()
-            setStoredValue(currentValue)
-        }
-        window.addEventListener('storage', updateOnStorageEvent)
-
-        return () => window.removeEventListener('storage', updateOnStorageEvent)
-    }, [getCurrentValue, keepUpdated])
 
     return [storedValue, setValue]
 }

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -3,7 +3,6 @@ import { Page } from 'puppeteer'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { percySnapshot } from '@sourcegraph/shared/src/testing/driver'
 import { readEnvironmentBoolean } from '@sourcegraph/shared/src/testing/utils'
-import { REDESIGN_TOGGLE_KEY } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { WebGraphQlOperations } from '../graphql-operations'
 
@@ -78,6 +77,12 @@ export const setColorScheme = async (
     await page.waitForTimeout(500)
 }
 
+const toggleRedesign = async (page: Page, enabled: boolean): Promise<void> => {
+    await page.evaluate(enabled => document.documentElement.classList.toggle('theme-redesign', enabled), enabled)
+    await page.evaluate(enabled => localStorage.setItem('isRedesignEnabled', enabled ? 'true' : 'false'), enabled)
+    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
+}
+
 export interface PercySnapshotConfig {
     waitForCodeHighlighting: boolean
 }
@@ -105,26 +110,18 @@ export const percySnapshotWithVariants = async (
     await percySnapshot(page, `${name} - light theme`)
 
     // Theme-light with redesign
-    await page.evaluate(() => document.documentElement.classList.add('theme-redesign'))
-    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'true'))
-    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
+    await toggleRedesign(page, true)
     await percySnapshot(page, `${name} - light theme with redesign enabled`)
-    await page.evaluate(() => document.documentElement.classList.remove('theme-redesign'))
-    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'false'))
-    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
+    await toggleRedesign(page, false)
 
     // Theme-dark
     await setColorScheme(page, 'dark', config?.waitForCodeHighlighting)
     await percySnapshot(page, `${name} - dark theme`)
 
     // Theme-dark with redesign
-    await page.evaluate(() => document.documentElement.classList.add('theme-redesign'))
-    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'true'))
-    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
+    await toggleRedesign(page, true)
     await percySnapshot(page, `${name} - dark theme with redesign enabled`)
-    await page.evaluate(() => document.documentElement.classList.remove('theme-redesign'))
-    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'false'))
-    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
+    await toggleRedesign(page, false)
 
     // Reset to light theme
     await setColorScheme(page, 'light', config?.waitForCodeHighlighting)

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -3,6 +3,7 @@ import { Page } from 'puppeteer'
 import { SharedGraphQlOperations } from '@sourcegraph/shared/src/graphql-operations'
 import { percySnapshot } from '@sourcegraph/shared/src/testing/driver'
 import { readEnvironmentBoolean } from '@sourcegraph/shared/src/testing/utils'
+import { REDESIGN_TOGGLE_KEY } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { WebGraphQlOperations } from '../graphql-operations'
 
@@ -105,8 +106,12 @@ export const percySnapshotWithVariants = async (
 
     // Theme-light with redesign
     await page.evaluate(() => document.documentElement.classList.add('theme-redesign'))
+    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'true'))
+    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
     await percySnapshot(page, `${name} - light theme with redesign enabled`)
     await page.evaluate(() => document.documentElement.classList.remove('theme-redesign'))
+    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'false'))
+    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
 
     // Theme-dark
     await setColorScheme(page, 'dark', config?.waitForCodeHighlighting)
@@ -114,8 +119,12 @@ export const percySnapshotWithVariants = async (
 
     // Theme-dark with redesign
     await page.evaluate(() => document.documentElement.classList.add('theme-redesign'))
+    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'true'))
+    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
     await percySnapshot(page, `${name} - dark theme with redesign enabled`)
     await page.evaluate(() => document.documentElement.classList.remove('theme-redesign'))
+    await page.evaluate(() => localStorage.setItem(REDESIGN_TOGGLE_KEY, 'false'))
+    await page.evaluate(() => window.dispatchEvent(new Event('storage')))
 
     // Reset to light theme
     await setColorScheme(page, 'light', config?.waitForCodeHighlighting)

--- a/client/web/src/integration/utils.ts
+++ b/client/web/src/integration/utils.ts
@@ -82,8 +82,8 @@ const toggleRedesign = async (page: Page, enabled: boolean): Promise<void> => {
     await page.evaluate(
         (className: string, storageKey: string, enabled: boolean) => {
             document.documentElement.classList.toggle(className, enabled)
-            localStorage.setItem(storageKey, enabled ? 'true' : 'false')
-            window.dispatchEvent(new StorageEvent('storage', { key: storageKey, newValue: enabled ? 'true' : 'false' }))
+            localStorage.setItem(storageKey, String(enabled))
+            window.dispatchEvent(new StorageEvent('storage', { key: storageKey, newValue: String(enabled) }))
         },
         REDESIGN_CLASS_NAME,
         REDESIGN_TOGGLE_KEY,

--- a/client/web/src/search/results/streaming/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/SearchSidebar.tsx
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const SearchSidebar: React.FunctionComponent<{}> = props => <div>Sidebar goes here</div>

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Observable } from 'rxjs'
@@ -13,6 +14,7 @@ import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryServi
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { asError } from '@sourcegraph/shared/src/util/errors'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import {
     CaseSensitivityProps,
@@ -35,6 +37,7 @@ import { SearchResultTypeTabs } from '../SearchResultTypeTabs'
 import { VersionContextWarning } from '../VersionContextWarning'
 
 import { StreamingProgress } from './progress/StreamingProgress'
+import { SearchSidebar } from './SearchSidebar'
 import { StreamingSearchResultsFilterBars } from './StreamingSearchResultsFilterBars'
 import { StreamingSearchResultsList } from './StreamingSearchResultsList'
 
@@ -190,17 +193,27 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         [query, telemetryService, props]
     )
 
+    const { isRedesignEnabled } = useRedesignToggle()
+
     return (
-        <div className="test-search-results search-results d-flex flex-column w-100">
+        <div
+            className={classNames(
+                'test-search-results search-results d-flex w-100',
+                isRedesignEnabled ? 'flex-row' : 'flex-column'
+            )}
+        >
             <PageTitle key="page-title" title={query} />
-            <StreamingSearchResultsFilterBars {...props} results={results} />
+
+            {isRedesignEnabled ? <SearchSidebar /> : <StreamingSearchResultsFilterBars {...props} results={results} />}
             <div className="search-results-list">
                 <div className="d-lg-flex mb-2 align-items-end flex-wrap">
-                    <SearchResultTypeTabs
-                        {...props}
-                        query={props.navbarSearchQueryState.query}
-                        className="search-results-list__tabs"
-                    />
+                    {!isRedesignEnabled && (
+                        <SearchResultTypeTabs
+                            {...props}
+                            query={props.navbarSearchQueryState.query}
+                            className="search-results-list__tabs"
+                        />
+                    )}
 
                     <SearchResultsInfoBar
                         {...props}

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -193,7 +193,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
         [query, telemetryService, props]
     )
 
-    const { isRedesignEnabled } = useRedesignToggle()
+    const [isRedesignEnabled] = useRedesignToggle()
 
     return (
         <div


### PR DESCRIPTION
Fixes #19936

- In the streaming search results page, when the redesign toggle is enabled:
  - A sidebar is displayed. This sidebar right now only displays dummy text and is not styled correctly, this will be addressed later on.
  - Tabs and filter bars are hidden.
- Percy will now also add the right localStorage key and fire storage event when redesign is toggled

![image](https://user-images.githubusercontent.com/206864/115079659-5efff000-9eb6-11eb-9e0a-6a2e7490d44b.png)
