### PR TITLE
Update Changelog to include a fix that was omitted (from the changelog) in 3.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Commit search returning duplicate commits. [#19460](https://github.com/sourcegraph/sourcegraph/pull/19460)
 - Clicking the Code Monitoring tab tries to take users to a non-existent repo. [#19525](https://github.com/sourcegraph/sourcegraph/pull/19525)
 - Diff and commit search not highlighting search terms correctly for some files. [#19543](https://github.com/sourcegraph/sourcegraph/pull/19543), [#19639](https://github.com/sourcegraph/sourcegraph/pull/19639)
+- File actions weren't appearing on large window sizes in Firefox and Safari. [#19380](https://github.com/sourcegraph/sourcegraph/pull/19380)
 
 ### Removed
 


### PR DESCRIPTION
There was a patch release for 3.26 [that included](https://github.com/sourcegraph/sourcegraph/commits/v3.26.1?after=c73dedef32ef64600e135064b00ea8ef7ef2bb48+69&branch=v3.26.1) this fix (#19380), but for whatever reason the [changelog got missed](https://sourcegraph.slack.com/archives/C01LZKLRF0C/p1617122908218300?thread_ts=1617064662.207300&cid=C01LZKLRF0C) (we'll discuss in our team retro to figure out why). Updating this so it's documented correctly. 

