### PR TITLE
insights: expose job status info over GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/insights.go
+++ b/cmd/frontend/graphqlbackend/insights.go
@@ -16,6 +16,13 @@ type InsightsDataPointResolver interface {
 	Value() float64
 }
 
+type InsightStatusResolver interface {
+	TotalPoints() int32
+	PendingJobs() int32
+	CompletedJobs() int32
+	FailedJobs() int32
+}
+
 type InsightsPointsArgs struct {
 	From *DateTime
 	To   *DateTime
@@ -24,6 +31,7 @@ type InsightsPointsArgs struct {
 type InsightSeriesResolver interface {
 	Label() string
 	Points(ctx context.Context, args *InsightsPointsArgs) ([]InsightsDataPointResolver, error)
+	Status(ctx context.Context) (InsightStatusResolver, error)
 }
 
 type InsightResolver interface {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -797,6 +797,11 @@ type InsightsSeries {
     If no 'to' time range is specified, the current point in time is assumed.
     """
     points(from: DateTime, to: DateTime): [InsightDataPoint!]!
+
+    """
+    The status of this series of data, e.g. progress collecting it.
+    """
+    status: InsightSeriesStatus!
 }
 
 """
@@ -812,6 +817,58 @@ type InsightDataPoint {
     The value of the insight at this point in time.
     """
     value: Float!
+}
+
+"""
+Status indicators for a specific series of insight data.
+"""
+type InsightSeriesStatus {
+    """
+    The total number of points stored for this series, at the finest level
+    (e.g. per repository, or per-repository-per-language) Has no strict relation
+    to the data points shown in the web UI or returned by `points()`, because those
+    are aggregated and this number _can_ report some duplicates points which get
+    stored but removed at query time for the web UI.
+
+    Why its useful: an insight may look like "it is doing nothing" but in reality
+    this number will be increasing by e.g. several thousands of points rapidly.
+    """
+    totalPoints: Int!
+
+    """
+    The total number of jobs currently pending to add new data points for this series.
+
+    Each job may create multiple data points (e.g. a job may create one data point per
+    repo, or language, etc.) This number will go up and down over time until all work
+    is completed (discovering work takes almost as long as doing the work.)
+
+    Why its useful: signals "amount of work still to be done."
+    """
+    pendingJobs: Int!
+
+    """
+    The total number of jobs completed for this series. Note that since pendingJobs will
+    go up/down over time, you CANNOT divide these two numbers to get a percentage as it
+    would be nonsense ("it says 90% complete but has been like that for a really long
+    time!").
+
+    Does not include 'failedJobs'.
+
+    Why its useful: gives an indication of "how much work has been done?"
+    """
+    completedJobs: Int!
+
+    """
+    The total number of jobs that were tried multiple times and outright failed. They will
+    not be retried again, and indicates the series has incomplete data.
+
+    Use ((failedJobs / completedJobs) * 100.0) to get an approximate percentage of how
+    much data the series data may be missing (e.g. ((30 / 150)*100.0) == 20% of the series
+    data is incomplete (rough approximation, not precise).
+
+    Why its useful: signals if there are problems, and how severe they are.
+    """
+    failedJobs: Int!
 }
 
 """

--- a/enterprise/internal/insights/resolvers/insight_series_resolver.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver.go
@@ -5,16 +5,19 @@ import (
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/background/queryrunner"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/discovery"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/insights/store"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 var _ graphqlbackend.InsightSeriesResolver = &insightSeriesResolver{}
 
 type insightSeriesResolver struct {
-	store  store.Interface
-	series *schema.InsightSeries
+	insightsStore   store.Interface
+	workerBaseStore *basestore.Store
+	series          *schema.InsightSeries
 }
 
 func (r *insightSeriesResolver) Label() string { return r.series.Label }
@@ -41,7 +44,7 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 	}
 	// TODO(slimsag): future: Pass through opts.Limit
 
-	points, err := r.store.SeriesPoints(ctx, opts)
+	points, err := r.insightsStore.SeriesPoints(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -50,6 +53,35 @@ func (r *insightSeriesResolver) Points(ctx context.Context, args *graphqlbackend
 		resolvers = append(resolvers, insightsDataPointResolver{point})
 	}
 	return resolvers, nil
+}
+
+func (r *insightSeriesResolver) Status(ctx context.Context) (graphqlbackend.InsightStatusResolver, error) {
+	seriesID, err := discovery.EncodeSeriesID(r.series)
+	if err != nil {
+		return nil, err
+	}
+
+	totalPoints, err := r.insightsStore.CountData(ctx, store.CountDataOpts{
+		SeriesID: &seriesID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := queryrunner.QueryJobsStatus(ctx, r.workerBaseStore, seriesID)
+	if err != nil {
+		return nil, err
+	}
+
+	return insightStatusResolver{
+		totalPoints: int32(totalPoints),
+
+		// Include errored because they'll be retried before becoming failures
+		pendingJobs: int32(status.Queued + status.Processing + status.Errored),
+
+		completedJobs: int32(status.Completed),
+		failedJobs:    int32(status.Failed),
+	}, nil
 }
 
 var _ graphqlbackend.InsightsDataPointResolver = insightsDataPointResolver{}
@@ -61,3 +93,12 @@ func (i insightsDataPointResolver) DateTime() graphqlbackend.DateTime {
 }
 
 func (i insightsDataPointResolver) Value() float64 { return i.p.Value }
+
+type insightStatusResolver struct {
+	totalPoints, pendingJobs, completedJobs, failedJobs int32
+}
+
+func (i insightStatusResolver) TotalPoints() int32   { return i.totalPoints }
+func (i insightStatusResolver) PendingJobs() int32   { return i.pendingJobs }
+func (i insightStatusResolver) CompletedJobs() int32 { return i.completedJobs }
+func (i insightStatusResolver) FailedJobs() int32    { return i.failedJobs }

--- a/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
+++ b/enterprise/internal/insights/resolvers/insight_series_resolver_test.go
@@ -34,9 +34,9 @@ func TestResolver_InsightSeries(t *testing.T) {
 		resolver := newWithClock(timescale, postgres, clock)
 
 		// Create a mock store, delegating any un-mocked methods to the DB store.
-		dbStore := resolver.store
+		dbStore := resolver.insightsStore
 		mockStore := store.NewMockInterfaceFrom(dbStore)
-		resolver.store = mockStore
+		resolver.insightsStore = mockStore
 
 		// Create the insights connection resolver and query series.
 		conn, err := resolver.Insights(ctx)


### PR DESCRIPTION
This exposes some status/progress information we can use in the Code Insights
frontend to communicate to the viewer what is going on, how many points have
been collected, if errors ocurred, etc.

For sure this isn't perfect, the most beautiful API, always super clear, etc.
but it's a _lot_ better than what we have right now (nothing.)

<img width="783" alt="image" src="https://user-images.githubusercontent.com/3173176/115091535-9bd6e180-9ecc-11eb-9856-ba74784ee8e2.png">

Missing tests, but it's a pretty straightforward implementation so I'm content
merging it as-is (especially given the other option is for us to not have this
until we get a backend engineer.)

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
