### PR TITLE
search: add contains.file and contains.content builtins

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -957,6 +957,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 1},
 			},
 			{
+				name:   `repo contains content scoped predicate`,
+				query:  `repo:contains.content(nextFileFirstLine)`,
+				counts: counts{Repo: 1},
+			},
+			{
 				name:   `repo contains content default`,
 				query:  `repo:contains(nextFileFirstLine)`,
 				counts: counts{Repo: 1},
@@ -974,6 +979,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 			{
 				name:   `repo contains file then search common`,
 				query:  `repo:contains(file:go.mod) count:100 fmt`,
+				counts: counts{Content: 61},
+			},
+			{
+				name:   `repo contains file scoped predicate`,
+				query:  `repo:contains.file(go.mod) count:100 fmt`,
 				counts: counts{Content: 61},
 			},
 			{

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -28,6 +28,8 @@ type Predicate interface {
 var DefaultPredicateRegistry = predicateRegistry{
 	FieldRepo: {
 		"contains":              func() Predicate { return &RepoContainsPredicate{} },
+		"contains.file":         func() Predicate { return &RepoContainsFilePredicate{} },
+		"contains.content":      func() Predicate { return &RepoContainsContentPredicate{} },
 		"contains.commit.after": func() Predicate { return &RepoContainsCommitAfterPredicate{} },
 	},
 }
@@ -165,6 +167,56 @@ func (f *RepoContainsPredicate) Plan(parent Basic) (Plan, error) {
 	nodes = append(nodes, nonPredicateRepos(parent)...)
 	return ToPlan(Dnf(nodes))
 }
+
+/* repo:contains.content(pattern) */
+
+type RepoContainsContentPredicate struct {
+	Pattern string
+}
+
+func (f *RepoContainsContentPredicate) ParseParams(params string) error {
+	if _, err := regexp.Compile(params); err != nil {
+		return fmt.Errorf("contains.content argument: %w", err)
+	}
+	if params == "" {
+		return fmt.Errorf("contains.content argument should not be empty")
+	}
+	f.Pattern = params
+	return nil
+}
+
+func (f *RepoContainsContentPredicate) Field() string { return FieldRepo }
+func (f *RepoContainsContentPredicate) Name() string  { return "contains.content" }
+func (f *RepoContainsContentPredicate) Plan(parent Basic) (Plan, error) {
+	contains := RepoContainsPredicate{File: "", Content: f.Pattern}
+	return contains.Plan(parent)
+}
+
+/* repo:contains.file(pattern) */
+
+type RepoContainsFilePredicate struct {
+	Pattern string
+}
+
+func (f *RepoContainsFilePredicate) ParseParams(params string) error {
+	if _, err := regexp.Compile(params); err != nil {
+		return fmt.Errorf("contains.file argument: %w", err)
+	}
+	if params == "" {
+		return fmt.Errorf("contains.file argument should not be empty")
+	}
+	f.Pattern = params
+	return nil
+}
+
+func (f *RepoContainsFilePredicate) Field() string { return FieldRepo }
+func (f *RepoContainsFilePredicate) Name() string  { return "contains.file" }
+func (f *RepoContainsFilePredicate) Plan(parent Basic) (Plan, error) {
+	contains := RepoContainsPredicate{File: f.Pattern, Content: ""}
+	return contains.Plan(parent)
+}
+
+/* repo:contains.commit.after(...) */
 
 type RepoContainsCommitAfterPredicate struct {
 	TimeRef string

--- a/internal/search/query/predicate_test.go
+++ b/internal/search/query/predicate_test.go
@@ -20,10 +20,6 @@ func TestRepoContainsPredicate(t *testing.T) {
 			{`unnamed content`, `test`, &RepoContainsPredicate{Content: "test"}},
 			{`file and content`, `file:test.go content:abc`, &RepoContainsPredicate{File: "test.go", Content: "abc"}},
 			{`content and file`, `content:abc file:test.go`, &RepoContainsPredicate{File: "test.go", Content: "abc"}},
-
-			// TODO (@camdencheek) Query parsing currently checks parameter names against an allowlist.
-			// This will be a problem as soon as we add more fields. Might make sense to do
-			// as part of #19075
 			{`unrecognized field`, `abc:test`, &RepoContainsPredicate{Content: "abc:test"}},
 		}
 


### PR DESCRIPTION
This adds backend support for two built in predicates in alignment with our syntax extension in [RFC 353](https://docs.google.com/document/d/1h3WCJEcTeOXwK0DeH8N5QEtPaNta85ddGP4R-2rMdrs/edit#heading=h.ynko232bfib0):

- `repo:contains.file(...)` as an alias for `repo:contains(file:...)`
- `repo.contains.content(...) as an alias for `repo:contains(content:...)`

Small footnote: although that RFC is work-in-progress at time of writing, the syntax extension part is reviewed/approved.