### PR TITLE
lsif/protocol: implement Sourcegraph documentation extension

### DIFF
--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -1,0 +1,78 @@
+package protocol
+
+// Documentation is a Vertex which includes a DocumentationResult.
+type Documentation struct {
+	Vertex
+	Result *DocumentationResult `json:"result"`
+}
+
+func NewDocumentation(id uint64, result *DocumentationResult) Documentation {
+	return Documentation{
+		Vertex: Vertex{
+			Element: Element{
+				ID:   id,
+				Type: ElementVertex,
+			},
+			Label: VertexDocumentation,
+		},
+		Result: result,
+	}
+}
+
+// DocumentationEdge is an edge which connects a Documentation Vertex to a Moniker
+// Vertex.
+type DocumentationEdge struct {
+	Edge
+	InV  uint64 `json:"inV"`
+	OutV uint64 `json:"outV"`
+}
+
+func NewDocumentationEdge(id, inV, outV uint64) DocumentationEdge {
+	return DocumentationEdge{
+		Edge: Edge{
+			Element: Element{
+				ID:   id,
+				Type: ElementEdge,
+			},
+			Label: EdgeDocumentation,
+		},
+		OutV: outV,
+		InV:  inV,
+	}
+}
+
+type DocumentationResult struct {
+	// Slug is a human-readable URL slug identifier for this documentation. It should be unique
+	// relative to sibling Documentation.
+	Slug          string
+	NewChapter    bool
+	Label, Detail InteractiveMarkupContent
+	Visibility    DocumentationVisibility
+
+	// VertexDocumentation IDs
+	Children []uint64
+}
+
+type InteractiveMarkupContent struct {
+	Content MarkupContent
+
+	// Content Range -> VertexDocumentation ID
+	Documentation map[Range]uint64
+
+	// Content Range -> VertexHoverResult ID
+	Hover map[Range]uint64
+
+	// Content Range -> VertexDefinitionResult ID
+	Definition map[Range]uint64
+
+	// Content Range -> VertexReferencesResult ID
+	References map[Range]uint64
+}
+
+type DocumentationVisibility string
+
+const (
+	Deprecated DocumentationVisibility = "deprecated"
+	Exported   DocumentationVisibility = "exported"
+	Unexported DocumentationVisibility = "unexported"
+)

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -7,7 +7,7 @@ package protocol
 // "documentationResult" vertex.
 //
 // It allows one to attach extensive documentation to a project or range (via being attached to a
-// "resultSet" vertex). Combined with the "documentationResultChildren" edge, this can be used to
+// "resultSet" vertex). Combined with the "documentationChildren" edge, this can be used to
 // represent hierarchical documentation.
 type DocumentationResultEdge struct {
 	Edge
@@ -47,7 +47,7 @@ func NewDocumentationResultEdge(id, inV, outV uint64) DocumentationResultEdge {
 //
 // Note: the "project" -> "documentationResult" attachment above is expressed via a
 // "documentationResult" edge, since the parent is not a "documentationResult" vertex.
-type DocumentationResultChildrenEdge struct {
+type DocumentationChildrenEdge struct {
 	Edge
 
 	// The parent "documentationResult" vertex ID.
@@ -57,14 +57,14 @@ type DocumentationResultChildrenEdge struct {
 	OutVs []uint64 `json:"outVs"`
 }
 
-func NewDocumentationResultChildrenEdge(id, inV uint64, outVs []uint64) DocumentationResultChildrenEdge {
-	return DocumentationResultChildrenEdge{
+func NewDocumentationChildrenEdge(id, inV uint64, outVs []uint64) DocumentationChildrenEdge {
+	return DocumentationChildrenEdge{
 		Edge: Edge{
 			Element: Element{
 				ID:   id,
 				Type: ElementEdge,
 			},
-			Label: EdgeSourcegraphDocumentationResultChildren,
+			Label: EdgeSourcegraphDocumentationChildren,
 		},
 		OutVs: outVs,
 		InV:   inV,

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -105,8 +105,16 @@ func NewDocumentationResult(id uint64, result Documentation) DocumentationResult
 // 1. A "documentationString" vertex with `type: "detail"`, which is a multi-line detailed string
 //    for this section of documentation.
 //
-// Both are attached to the documentationResult via a "documentationString" edge. A strict client
-// should treat the entire LSIF dump as malformed/invalid if one of the two is not present.
+// Both are attached to the documentationResult via a "documentationString" edge.
+//
+// If the label or detail vertex is missing, or the label string is empty (has no content) then a
+// client should consider all "documentationResult" vertices in the entire LSIF dump to be invalid
+// and malformed, and ignore them.
+//
+// If no detail is available (such as a function with no documentation), a `type:"detail"`
+// "documentationString" should still be emitted - but with an empty string for the MarkupContent.
+// This enables validators to ensure the indexer knows how to emit both label and detail strings
+// properly, and just chose to emit none specifically.
 type Documentation struct {
 	// A human-readable URL slug identifier for this documentation. It should be unique relative to
 	// sibling Documentation.

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -19,7 +19,7 @@ func NewDocumentation(id uint64, result *DocumentationResult) Documentation {
 	}
 }
 
-// DocumentationEdge is an edge which connects a Documentation Vertex to a Moniker
+// DocumentationEdge is an edge which connects a Documentation Vertex to a Project
 // Vertex.
 type DocumentationEdge struct {
 	Edge
@@ -72,7 +72,7 @@ type InteractiveMarkupContent struct {
 type DocumentationVisibility string
 
 const (
-	Deprecated DocumentationVisibility = "deprecated"
-	Exported   DocumentationVisibility = "exported"
-	Unexported DocumentationVisibility = "unexported"
+	DocumentationDeprecated DocumentationVisibility = "deprecated"
+	DocumentationExported   DocumentationVisibility = "exported"
+	DocumentationUnexported DocumentationVisibility = "unexported"
 )

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -110,7 +110,7 @@ type Documentation struct {
 	Slug string `json:"slug"`
 
 	// Whether or not this Documentation is the beginning of a new major section, meaning it and its
-	// its children should be e.g. displayed on their own dedicate page.
+	// its children should be e.g. displayed on their own dedicated page.
 	NewPage bool `json:"newPage"`
 
 	// Tags about the type of content this documentation contains.

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -1,23 +1,7 @@
 package protocol
 
-// Documentation is a Vertex which includes a DocumentationResult.
-type Documentation struct {
-	Vertex
-	Result *DocumentationResult `json:"result"`
-}
-
-func NewDocumentation(id uint64, result *DocumentationResult) Documentation {
-	return Documentation{
-		Vertex: Vertex{
-			Element: Element{
-				ID:   id,
-				Type: ElementVertex,
-			},
-			Label: VertexDocumentation,
-		},
-		Result: result,
-	}
-}
+// Sourcegraph extension to LSIF: documentation.
+// See https://github.com/slimsag/language-server-protocol/pull/2
 
 // DocumentationEdge is an edge which connects a Documentation Vertex to a Project
 // Vertex.
@@ -41,7 +25,15 @@ func NewDocumentationEdge(id, inV, outV uint64) DocumentationEdge {
 	}
 }
 
-type DocumentationResult struct {
+// A Documentation vertex describes hierarchial project-wide documentation.
+// It represents documentation for a programming construct (variable, function, etc.) or group of
+// programming constructs in a workspace (library, package, crate, module, etc.)
+//
+// The exact structure of the documentation depends on what makes sense for the specific language
+// and concepts being described.
+type Documentation struct {
+	Vertex
+
 	// A human-readable URL slug identifier for this documentation. It should be unique relative to
 	// sibling Documentation.
 	Slug string `json:"slug"`
@@ -66,6 +58,20 @@ type DocumentationResult struct {
 	// "documentation" vertex IDs. For example, this documentation may describe a class and have
 	// children describing each method of the class.
 	Children []uint64 `json:"children"`
+}
+
+// NewDocumentation initializes a "documentation" vertex with the given ID. The caller should then
+// populate the required fields.
+func NewDocumentation(id uint64) Documentation {
+	return Documentation{
+		Vertex: Vertex{
+			Element: Element{
+				ID:   id,
+				Type: ElementVertex,
+			},
+			Label: VertexDocumentation,
+		},
+	}
 }
 
 type InteractiveMarkupContent struct {

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -12,10 +12,10 @@ package protocol
 type DocumentationResultEdge struct {
 	Edge
 
-	// A "project" or "resultSet" vertex ID.
+	// The "documentationResult" vertex ID.
 	InV uint64 `json:"inV"`
 
-	// The "documentationResult" vertex ID.
+	// A "project" or "resultSet" vertex ID.
 	OutV uint64 `json:"outV"`
 }
 
@@ -50,14 +50,14 @@ func NewDocumentationResultEdge(id, inV, outV uint64) DocumentationResultEdge {
 type DocumentationChildrenEdge struct {
 	Edge
 
-	// The parent "documentationResult" vertex ID.
-	InV uint64 `json:"inV"`
-
 	// The ordered children "documentationResult" vertex IDs.
-	OutVs []uint64 `json:"outVs"`
+	InVs []uint64 `json:"inV"`
+
+	// The parent "documentationResult" vertex ID.
+	OutV uint64 `json:"outVs"`
 }
 
-func NewDocumentationChildrenEdge(id, inV uint64, outVs []uint64) DocumentationChildrenEdge {
+func NewDocumentationChildrenEdge(id uint64, inVs []uint64, outV uint64) DocumentationChildrenEdge {
 	return DocumentationChildrenEdge{
 		Edge: Edge{
 			Element: Element{
@@ -66,8 +66,8 @@ func NewDocumentationChildrenEdge(id, inV uint64, outVs []uint64) DocumentationC
 			},
 			Label: EdgeSourcegraphDocumentationChildren,
 		},
-		OutVs: outVs,
-		InV:   inV,
+		OutVs: outV,
+		InV:   inVs,
 	}
 }
 
@@ -140,18 +140,18 @@ const (
 // 	{id: 53, type:"vertex", label:"documentationResult", result:{slug:"httpserver", ...}}
 // 	{id: 54, type:"vertex", label:"documentationString", result:{kind:"plaintext", "value": "A single-line label for an HTTPServer instance"}}
 // 	{id: 55, type:"vertex", label:"documentationString", result:{kind:"plaintext", "value": "A multi-line\n detailed\n explanation of an HTTPServer instance, what it does, etc."}}
-// 	{id: 54, type:"edge", label:"documentationString", inV: 53, outV: 54, type:"label"}
-// 	{id: 54, type:"edge", label:"documentationString", inV: 53, outV: 55, type:"detail"}
+// 	{id: 54, type:"edge", label:"documentationString", inV: 54, outV: 53, type:"label"}
+// 	{id: 54, type:"edge", label:"documentationString", inV: 55, outV: 53, type:"detail"}
 //
 // Hover, definition, etc. results can then be attached to ranges within the "documentationString"
 // vertices themselves (vertex 54 / 55), see the docs for DocumentationString for more details.
 type DocumentationStringEdge struct {
 	Edge
 
-	// The "documentationResult" vertex ID.
+	// The "documentationString" vertex ID.
 	InV uint64 `json:"inV"`
 
-	// The "documentationString" vertex ID.
+	// The "documentationResult" vertex ID.
 	OutV uint64 `json:"outV"`
 
 	// Whether this links the "label" or "detail" string of the documentation.

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -141,7 +141,7 @@ type DocumentationStringEdge struct {
 	// The "documentationString" vertex ID.
 	OutV uint64 `json:"outV"`
 
-	// Whether this links the "label"" or "detail" string of the documentation.
+	// Whether this links the "label" or "detail" string of the documentation.
 	Type DocumentationStringType `json:"type"`
 }
 

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -66,8 +66,8 @@ func NewDocumentationChildrenEdge(id uint64, inVs []uint64, outV uint64) Documen
 			},
 			Label: EdgeSourcegraphDocumentationChildren,
 		},
-		OutVs: outV,
-		InV:   inVs,
+		OutV: outV,
+		InVs: inVs,
 	}
 }
 

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -42,37 +42,69 @@ func NewDocumentationEdge(id, inV, outV uint64) DocumentationEdge {
 }
 
 type DocumentationResult struct {
-	// Slug is a human-readable URL slug identifier for this documentation. It should be unique
-	// relative to sibling Documentation.
-	Slug          string
-	NewChapter    bool
-	Label, Detail InteractiveMarkupContent
-	Visibility    DocumentationVisibility
+	// A human-readable URL slug identifier for this documentation. It should be unique relative to
+	// sibling Documentation.
+	Slug string `json:"slug"`
 
-	// VertexDocumentation IDs
-	Children []uint64
+	// Whether or not this Documentation is the beginning of a new major section, meaning it and its
+	// its children should be e.g. displayed on their own dedicate page.
+	NewPage bool `json:"newPage"`
+
+	// A single-line label to display for this documentation in e.g. the index of a book. For
+	// example, the name of a group of documentation, the name of a library, the signature of a
+	// function or class, etc.
+	Title InteractiveMarkupContent `json:"title"`
+
+	// A detailed multi-line string that contains detailed documentation for the section described by
+	// the title.
+	Detail InteractiveMarkupContent `json:"detail"`
+
+	// Tags about the type of content this documentation contains.
+	Tags []DocumentationTag `json:"tags"`
+
+	// Documentation that should be logically nested below this documentation itself, expressed as
+	// "documentation" vertex IDs. For example, this documentation may describe a class and have
+	// children describing each method of the class.
+	Children []uint64 `json:"children"`
 }
 
 type InteractiveMarkupContent struct {
-	Content MarkupContent
+	// The actual content which should be considered interactive.
+	Content MarkupContent `json:"content"`
 
-	// Content Range -> VertexDocumentation ID
-	Documentation map[Range]uint64
+	// Ranges in the `content` string mapping to an associated "documentation" vertex ID, allowing
+	// for text in one piece of documentation to link to another.
+	Documentation map[Range]uint64 `json:"documentation"`
 
-	// Content Range -> VertexHoverResult ID
-	Hover map[Range]uint64
+	// Ranges in the `content` string mapping to an associated "hoverResult" vertex ID, allowing
+	// for text in one piece of documentation to include a hover result.
+	//
+	// The hover result could be specific to the documentation itself, or e.g. part of a type
+	// signature being hovered over.
+	Hover map[Range]uint64 `json:"hover"`
 
-	// Content Range -> VertexDefinitionResult ID
-	Definition map[Range]uint64
+	// Ranges in the `content` string mapping to an associated "definitionResult" vertex ID,
+	// allowing for text in one piece of documentation to include a definition result.
+	//
+	// This enables users to e.g. go-to-definition on a type signature inside documentation.
+	Definition map[Range]uint64 `json:"definition"`
 
-	// Content Range -> VertexReferencesResult ID
-	References map[Range]uint64
+	// Ranges in the `content` string mapping to an associated "referenceResult" vertex ID,
+	// allowing for text in one piece of documentation to include a definition result.
+	//
+	// This enables users to e.g. find-references on a type signature inside documentation.
+	References map[Range]uint64 `json:"references"`
 }
 
-type DocumentationVisibility string
+type DocumentationTag string
 
 const (
-	DocumentationDeprecated DocumentationVisibility = "deprecated"
-	DocumentationExported   DocumentationVisibility = "exported"
-	DocumentationUnexported DocumentationVisibility = "unexported"
+	// The documentation describes a concept that is exported externally.
+	DocumentationExported DocumentationTag = "exported"
+
+	// The documentation describes a concept that is unexported / internal.
+	DocumentationUnexported DocumentationTag = "unexported"
+
+	// The documentation describes a concept that is deprecated.
+	DocumentationDeprecated DocumentationTag = "deprecated"
 )

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -100,10 +100,13 @@ func NewDocumentationResult(id uint64, result Documentation) DocumentationResult
 //
 // Attached to this vertex MUST be two "documentationString" vertices:
 //
-// 1. The {type: "label"} string, a one-line label or this section of documentation.
-// 1. The {type: "detail"} string, a multi-line detailed string for this section of documentation.
+// 1. A "documentationString" vertex with `type: "label"`, which is a one-line label or this section
+//    of documentation.
+// 1. A "documentationString" vertex with `type: "detail"`, which is a multi-line detailed string
+//    for this section of documentation.
 //
-// They can be attached using a "documentationStringEdge".
+// Both are attached to the documentationResult via a "documentationString" edge. A strict client
+// should treat the entire LSIF dump as malformed/invalid if one of the two is not present.
 type Documentation struct {
 	// A human-readable URL slug identifier for this documentation. It should be unique relative to
 	// sibling Documentation.
@@ -130,8 +133,18 @@ const (
 	DocumentationDeprecated DocumentationTag = "deprecated"
 )
 
-// A "documentationStringEdge" is an edge which connects a "documentationResult" vertex to its
-// label or detail strings, which are "documentationString" vertices.
+// A "documentationString" edge connects a "documentationResult" vertex to its label or detail
+// strings, which are "documentationString" vertices. The overall structure looks like the
+// following roughly:
+//
+// 	{id: 53, type:"vertex", label:"documentationResult", result:{slug:"httpserver", ...}}
+// 	{id: 54, type:"vertex", label:"documentationString", result:{kind:"plaintext", "value": "A single-line label for an HTTPServer instance"}}
+// 	{id: 55, type:"vertex", label:"documentationString", result:{kind:"plaintext", "value": "A multi-line\n detailed\n explanation of an HTTPServer instance, what it does, etc."}}
+// 	{id: 54, type:"edge", label:"documentationString", inV: 53, outV: 54, type:"label"}
+// 	{id: 54, type:"edge", label:"documentationString", inV: 53, outV: 55, type:"detail"}
+//
+// Hover, definition, etc. results can then be attached to ranges within the "documentationString"
+// vertices themselves (vertex 54 / 55), see the docs for DocumentationString for more details.
 type DocumentationStringEdge struct {
 	Edge
 

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -17,12 +17,20 @@ package protocol
 //
 type DocumentationResultEdge struct {
 	Edge
-	
-	// A "project" or "resultSet" vertex ID.
-	InV  uint64 `json:"inV"`
 
-	// The "sourcegraph:documentationResult" vertex ID.
+	// A "project" or "resultSet" vertex ID.
+	InV uint64 `json:"inV"`
+
+	// The "documentationResult" vertex ID.
 	OutV uint64 `json:"outV"`
+
+	// A string that should be used when comparing this item with other items. Useful when a
+	// "documentationResult" vertex has many children documentationResult vertices and they should
+	// have a specific ordering.
+	//
+	// If not present, the "label" "documentationString" vertex attached to the documentation
+	// result will be used as the sort text for this item.
+	SortText *string `json:"sortText,omitempty"`
 }
 
 func NewDocumentationResultEdge(id, inV, outV uint64) DocumentationResultEdge {
@@ -39,13 +47,13 @@ func NewDocumentationResultEdge(id, inV, outV uint64) DocumentationResultEdge {
 	}
 }
 
-// A "documentationResult" vertex 
+// A "documentationResult" vertex
 type DocumentationResult struct {
 	Vertex
 	Result Documentation `json:"result"`
 }
 
-// NewDocumentationResult creates a new "sourcegraph:documentationResult" vertex.
+// NewDocumentationResult creates a new "documentationResult" vertex.
 func NewDocumentationResult(id uint64, result Documentation) DocumentationResult {
 	return DocumentationResult{
 		Vertex: Vertex{
@@ -102,9 +110,9 @@ const (
 // label or detail strings, which are "documentationString" vertices.
 type DocumentationStringEdge struct {
 	Edge
-	
+
 	// The "documentationResult" vertex ID.
-	InV  uint64 `json:"inV"`
+	InV uint64 `json:"inV"`
 
 	// The "documentationString" vertex ID.
 	OutV uint64 `json:"outV"`

--- a/enterprise/lib/codeintel/lsif/protocol/documentation.go
+++ b/enterprise/lib/codeintel/lsif/protocol/documentation.go
@@ -3,37 +3,76 @@ package protocol
 // Sourcegraph extension to LSIF: documentation.
 // See https://github.com/slimsag/language-server-protocol/pull/2
 
-// DocumentationEdge is an edge which connects a Documentation Vertex to a Project
-// Vertex.
-type DocumentationEdge struct {
+// A "documentationResult" edge connects a "project" or "resultSet" vertex to a
+// "documentationResult" vertex.
+//
+// It allows one to attach extensive documentation to a project, range (via being attached to a
+// "resultSet" vertex) or another "documentationResult" for representing hierarchical documentation
+// like:
+//
+// "project" (e.g. an HTTP library)
+// -> "documentationResult" (e.g. "HTTP library" library documentation)
+//   -> "documentationResult" (e.g. docs for the "Server" class in the HTTP library)
+//     -> "documentationResult" (e.g. docs for the "Listen" method on the "Server" class)
+//
+type DocumentationResultEdge struct {
 	Edge
+	
+	// A "project" or "resultSet" vertex ID.
 	InV  uint64 `json:"inV"`
+
+	// The "sourcegraph:documentationResult" vertex ID.
 	OutV uint64 `json:"outV"`
 }
 
-func NewDocumentationEdge(id, inV, outV uint64) DocumentationEdge {
-	return DocumentationEdge{
+func NewDocumentationResultEdge(id, inV, outV uint64) DocumentationResultEdge {
+	return DocumentationResultEdge{
 		Edge: Edge{
 			Element: Element{
 				ID:   id,
 				Type: ElementEdge,
 			},
-			Label: EdgeDocumentation,
+			Label: EdgeSourcegraphDocumentationResult,
 		},
 		OutV: outV,
 		InV:  inV,
 	}
 }
 
-// A Documentation vertex describes hierarchial project-wide documentation.
-// It represents documentation for a programming construct (variable, function, etc.) or group of
-// programming constructs in a workspace (library, package, crate, module, etc.)
+// A "documentationResult" vertex 
+type DocumentationResult struct {
+	Vertex
+	Result Documentation `json:"result"`
+}
+
+// NewDocumentationResult creates a new "sourcegraph:documentationResult" vertex.
+func NewDocumentationResult(id uint64, result Documentation) DocumentationResult {
+	return DocumentationResult{
+		Vertex: Vertex{
+			Element: Element{
+				ID:   id,
+				Type: ElementVertex,
+			},
+			Label: VertexSourcegraphDocumentationResult,
+		},
+		Result: result,
+	}
+}
+
+// A "documentationResult" vertex describes hierarchial project-wide documentation. It represents
+// documentation for a programming construct (variable, function, etc.) or group of programming
+// constructs in a workspace (library, package, crate, module, etc.)
 //
 // The exact structure of the documentation depends on what makes sense for the specific language
 // and concepts being described.
+//
+// Attached to this vertex MUST be two "documentationString" vertices:
+//
+// 1. The {type: "label"} string, a one-line label or this section of documentation.
+// 1. The {type: "detail"} string, a multi-line detailed string for this section of documentation.
+//
+// They can be attached using a "documentationStringEdge".
 type Documentation struct {
-	Vertex
-
 	// A human-readable URL slug identifier for this documentation. It should be unique relative to
 	// sibling Documentation.
 	Slug string `json:"slug"`
@@ -42,64 +81,8 @@ type Documentation struct {
 	// its children should be e.g. displayed on their own dedicate page.
 	NewPage bool `json:"newPage"`
 
-	// A single-line label to display for this documentation in e.g. the index of a book. For
-	// example, the name of a group of documentation, the name of a library, the signature of a
-	// function or class, etc.
-	Title InteractiveMarkupContent `json:"title"`
-
-	// A detailed multi-line string that contains detailed documentation for the section described by
-	// the title.
-	Detail InteractiveMarkupContent `json:"detail"`
-
 	// Tags about the type of content this documentation contains.
 	Tags []DocumentationTag `json:"tags"`
-
-	// Documentation that should be logically nested below this documentation itself, expressed as
-	// "documentation" vertex IDs. For example, this documentation may describe a class and have
-	// children describing each method of the class.
-	Children []uint64 `json:"children"`
-}
-
-// NewDocumentation initializes a "documentation" vertex with the given ID. The caller should then
-// populate the required fields.
-func NewDocumentation(id uint64) Documentation {
-	return Documentation{
-		Vertex: Vertex{
-			Element: Element{
-				ID:   id,
-				Type: ElementVertex,
-			},
-			Label: VertexDocumentation,
-		},
-	}
-}
-
-type InteractiveMarkupContent struct {
-	// The actual content which should be considered interactive.
-	Content MarkupContent `json:"content"`
-
-	// Ranges in the `content` string mapping to an associated "documentation" vertex ID, allowing
-	// for text in one piece of documentation to link to another.
-	Documentation map[Range]uint64 `json:"documentation"`
-
-	// Ranges in the `content` string mapping to an associated "hoverResult" vertex ID, allowing
-	// for text in one piece of documentation to include a hover result.
-	//
-	// The hover result could be specific to the documentation itself, or e.g. part of a type
-	// signature being hovered over.
-	Hover map[Range]uint64 `json:"hover"`
-
-	// Ranges in the `content` string mapping to an associated "definitionResult" vertex ID,
-	// allowing for text in one piece of documentation to include a definition result.
-	//
-	// This enables users to e.g. go-to-definition on a type signature inside documentation.
-	Definition map[Range]uint64 `json:"definition"`
-
-	// Ranges in the `content` string mapping to an associated "referenceResult" vertex ID,
-	// allowing for text in one piece of documentation to include a definition result.
-	//
-	// This enables users to e.g. find-references on a type signature inside documentation.
-	References map[Range]uint64 `json:"references"`
 }
 
 type DocumentationTag string
@@ -114,3 +97,79 @@ const (
 	// The documentation describes a concept that is deprecated.
 	DocumentationDeprecated DocumentationTag = "deprecated"
 )
+
+// A "documentationStringEdge" is an edge which connects a "documentationResult" vertex to its
+// label or detail strings, which are "documentationString" vertices.
+type DocumentationStringEdge struct {
+	Edge
+	
+	// The "documentationResult" vertex ID.
+	InV  uint64 `json:"inV"`
+
+	// The "documentationString" vertex ID.
+	OutV uint64 `json:"outV"`
+
+	// Whether this links the "label"" or "detail" string of the documentation.
+	Type DocumentationStringType `json:"type"`
+}
+
+type DocumentationStringType string
+
+const (
+	// A single-line label to display for this documentation in e.g. the index of a book. For
+	// example, the name of a group of documentation, the name of a library, the signature of a
+	// function or class, etc.
+	DocumentationStringTypeLabel DocumentationStringType = "label"
+
+	// A detailed multi-line string that contains detailed documentation for the section described by
+	// the title.
+	DocumentationStringTypeDetail DocumentationStringType = "detail"
+)
+
+func NewDocumentationStringEdge(id, inV, outV uint64) DocumentationStringEdge {
+	return DocumentationStringEdge{
+		Edge: Edge{
+			Element: Element{
+				ID:   id,
+				Type: ElementEdge,
+			},
+			Label: EdgeSourcegraphDocumentationString,
+		},
+		OutV: outV,
+		InV:  inV,
+	}
+}
+
+// A "documentationString" vertex is referred to by a "documentationResult" vertex using a
+// "documentationString" edge. It represents the actual string of content for the documentation's
+// label (a one-line string) or detail (a multi-line string).
+//
+// A "documentationString" vertex can itself be linked to "range" vertices (which describe a range
+// in the documentation string's markup content itself) using a ??????WHAT EDGE??????. This enables
+// ranges within a documentation string to have:
+//
+// * "hoverResult"s (e.g. you can hover over a type signature in the documentation string and get info)
+// * "definitionResult" and "referenceResults"
+// * "documentationResult" itself - allowing a range of text in one documentation to link to another
+//   documentation section (e.g. in the same way a hyperlink works in HTML.)
+// * "moniker" to link to another project's hover/definition/documentation results, across
+//   repositories.
+//
+type DocumentationString struct {
+	Vertex
+	Result MarkupContent `json:"result"`
+}
+
+// NewDocumentationString creates a new "documentationString" vertex.
+func NewDocumentationString(id uint64, result MarkupContent) DocumentationString {
+	return DocumentationString{
+		Vertex: Vertex{
+			Element: Element{
+				ID:   id,
+				Type: ElementVertex,
+			},
+			Label: VertexSourcegraphDocumentationString,
+		},
+		Result: result,
+	}
+}

--- a/enterprise/lib/codeintel/lsif/protocol/element.go
+++ b/enterprise/lib/codeintel/lsif/protocol/element.go
@@ -38,6 +38,9 @@ const (
 	VertexHoverResult          VertexLabel = "hoverResult"
 	VertexReferenceResult      VertexLabel = "referenceResult"
 	VertexImplementationResult VertexLabel = "implementationResult"
+
+	// Sourcegraph extensions
+	VertexDocumentation VertexLabel = "documentation"
 )
 
 type Edge struct {
@@ -64,4 +67,7 @@ const (
 	EdgeTextDocumentHover          EdgeLabel = "textDocument/hover"
 	EdgeTextDocumentReferences     EdgeLabel = "textDocument/references"
 	EdgeTextDocumentImplementation EdgeLabel = "textDocument/implementation"
+
+	// Sourcegraph extensions
+	EdgeDocumentation EdgeLabel = "documentation"
 )

--- a/enterprise/lib/codeintel/lsif/protocol/element.go
+++ b/enterprise/lib/codeintel/lsif/protocol/element.go
@@ -70,6 +70,7 @@ const (
 	EdgeTextDocumentImplementation EdgeLabel = "textDocument/implementation"
 
 	// Sourcegraph extensions
-	EdgeSourcegraphDocumentationResult EdgeLabel = "sourcegraph:documentationResult"
-	EdgeSourcegraphDocumentationString EdgeLabel = "sourcegraph:documentationString"
+	EdgeSourcegraphDocumentationResult         EdgeLabel = "sourcegraph:documentationResult"
+	EdgeSourcegraphDocumentationResultChildren EdgeLabel = "sourcegraph:documentationResultChildren"
+	EdgeSourcegraphDocumentationString         EdgeLabel = "sourcegraph:documentationString"
 )

--- a/enterprise/lib/codeintel/lsif/protocol/element.go
+++ b/enterprise/lib/codeintel/lsif/protocol/element.go
@@ -70,7 +70,7 @@ const (
 	EdgeTextDocumentImplementation EdgeLabel = "textDocument/implementation"
 
 	// Sourcegraph extensions
-	EdgeSourcegraphDocumentationResult         EdgeLabel = "sourcegraph:documentationResult"
-	EdgeSourcegraphDocumentationResultChildren EdgeLabel = "sourcegraph:documentationResultChildren"
-	EdgeSourcegraphDocumentationString         EdgeLabel = "sourcegraph:documentationString"
+	EdgeSourcegraphDocumentationResult   EdgeLabel = "sourcegraph:documentationResult"
+	EdgeSourcegraphDocumentationChildren EdgeLabel = "sourcegraph:documentationChildren"
+	EdgeSourcegraphDocumentationString   EdgeLabel = "sourcegraph:documentationString"
 )

--- a/enterprise/lib/codeintel/lsif/protocol/element.go
+++ b/enterprise/lib/codeintel/lsif/protocol/element.go
@@ -40,7 +40,8 @@ const (
 	VertexImplementationResult VertexLabel = "implementationResult"
 
 	// Sourcegraph extensions
-	VertexDocumentation VertexLabel = "documentation"
+	VertexSourcegraphDocumentationResult VertexLabel = "sourcegraph:documentationResult"
+	VertexSourcegraphDocumentationString VertexLabel = "sourcegraph:documentationString"
 )
 
 type Edge struct {
@@ -69,5 +70,6 @@ const (
 	EdgeTextDocumentImplementation EdgeLabel = "textDocument/implementation"
 
 	// Sourcegraph extensions
-	EdgeDocumentation EdgeLabel = "documentation"
+	EdgeSourcegraphDocumentationResult EdgeLabel = "sourcegraph:documentationResult"
+	EdgeSourcegraphDocumentationString EdgeLabel = "sourcegraph:documentationString"
 )

--- a/enterprise/lib/codeintel/lsif/protocol/hover.go
+++ b/enterprise/lib/codeintel/lsif/protocol/hover.go
@@ -57,6 +57,18 @@ func (m MarkedString) MarshalJSON() ([]byte, error) {
 	return marshaller.Marshal((markedString)(m))
 }
 
+type MarkupKind string
+
+const (
+	PlainText MarkupKind = "plaintext"
+	Markdown  MarkupKind = "markdown"
+)
+
+type MarkupContent struct {
+	Kind  MarkupKind
+	Value string
+}
+
 type TextDocumentHover struct {
 	Edge
 	OutV uint64 `json:"outV"`


### PR DESCRIPTION
This is a Go protocol implementation of the proposed documentation extension for LSIF:

https://github.com/slimsag/language-server-protocol/pull/2

Helps sourcegraph/sourcegraph#19389

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>