### PR TITLE
search frontend: highlight contains `content:` field as regex

### DIFF
--- a/client/shared/src/search/query/decoratedToken.test.ts
+++ b/client/shared/src/search/query/decoratedToken.test.ts
@@ -1283,7 +1283,7 @@ describe('getMonacoTokens()', () => {
     })
 
     test('highlight recognized predicate with multiple fields', () => {
-        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains(file:README.md content:fix)')), true))
+        expect(getMonacoTokens(toSuccess(scanSearchQuery('repo:contains(file:README.md content:^fix$)')), true))
             .toMatchInlineSnapshot(`
             [
               {
@@ -1324,10 +1324,18 @@ describe('getMonacoTokens()', () => {
               },
               {
                 "startIndex": 37,
+                "scopes": "metaRegexpAssertion"
+              },
+              {
+                "startIndex": 38,
                 "scopes": "identifier"
               },
               {
-                "startIndex": 40,
+                "startIndex": 41,
+                "scopes": "metaRegexpAssertion"
+              },
+              {
+                "startIndex": 42,
                 "scopes": "metaPredicateParenthesis"
               }
             ]


### PR DESCRIPTION
This handles a last special highlighting case, where regex values of like `content:^potentially.*regex$` are highlighted. 

<img width="375" alt="Screen Shot 2021-04-16 at 6 46 46 PM" src="https://user-images.githubusercontent.com/888624/115098437-fda34580-9ee4-11eb-9f50-fcb6eff01e0d.png">

Note currently, `contains` values are all interpreted as regular expressions. This is unlike the top level query and `content`, which may be literal or regex, depending on toggle state/`patterntype`. I wanted to do a separate refactor that would make the change of handling this special case smaller, but I have to temper my desires with looming release cut :-) 



