### PR TITLE
batches: build clone url on demand

### DIFF
--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -143,7 +143,7 @@ func (e *executor) pushChangesetPatch(ctx context.Context) (err error) {
 	// Figure out which authenticator we should use to modify the changeset.
 	// au is nil if we want to use the global credentials stored in the external
 	// service configuration.
-	pushConf, err := e.css.GitserverPushConfig(e.repo)
+	pushConf, err := e.css.GitserverPushConfig(ctx, e.tx.ExternalServices(), e.repo)
 	if err != nil {
 		return err
 	}

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -806,19 +806,15 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 
 	rs, gitHubExtSvc := ct.CreateTestRepos(t, ctx, db, 1)
 	gitHubRepo := rs[0]
-	gitHubRepoCloneURL := gitHubRepo.Sources[gitHubExtSvc.URN()].CloneURL
 
 	gitLabRepos, gitLabExtSvc := ct.CreateGitlabTestRepos(t, ctx, db, 1)
 	gitLabRepo := gitLabRepos[0]
-	gitLabRepoCloneURL := gitLabRepo.Sources[gitLabExtSvc.URN()].CloneURL
 
 	bbsRepos, bbsExtSvc := ct.CreateBbsTestRepos(t, ctx, db, 1)
 	bbsRepo := bbsRepos[0]
-	bbsRepoCloneURL := bbsRepo.Sources[bbsExtSvc.URN()].CloneURL
 
 	bbsSSHRepos, bbsSSHExtsvc := ct.CreateBbsSSHTestRepos(t, ctx, db, 1)
 	bbsSSHRepo := bbsSSHRepos[0]
-	bbsSSHRepoCloneURL := bbsSSHRepo.Sources[bbsSSHExtsvc.URN()].CloneURL
 
 	plan := &Plan{}
 	plan.AddOp(btypes.ReconcilerOperationPush)
@@ -839,7 +835,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			repo:        gitHubRepo,
 			credentials: &auth.OAuthBearerToken{Token: "my-secret-github-token"},
 			wantPushConfig: &gitprotocol.PushConfig{
-				RemoteURL: "https://my-secret-github-token@github.com/" + string(gitHubRepo.Name),
+				RemoteURL: "https://my-secret-github-token@github.com/sourcegraph/" + string(gitHubRepo.Name),
 			},
 		},
 		{
@@ -855,7 +851,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			repo:   gitHubRepo,
 			user:   admin,
 			wantPushConfig: &gitprotocol.PushConfig{
-				RemoteURL: gitHubRepoCloneURL,
+				RemoteURL: "https://SECRETTOKEN@github.com/sourcegraph/" + string(gitHubRepo.Name),
 			},
 		},
 		{
@@ -865,7 +861,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			repo:        gitLabRepo,
 			credentials: &auth.OAuthBearerToken{Token: "my-secret-gitlab-token"},
 			wantPushConfig: &gitprotocol.PushConfig{
-				RemoteURL: "https://git:my-secret-gitlab-token@gitlab.com/" + string(gitLabRepo.Name),
+				RemoteURL: "https://git:my-secret-gitlab-token@gitlab.com/sourcegraph/" + string(gitLabRepo.Name),
 			},
 		},
 		{
@@ -881,7 +877,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			extSvc: gitLabExtSvc,
 			repo:   gitLabRepo,
 			wantPushConfig: &gitprotocol.PushConfig{
-				RemoteURL: gitLabRepoCloneURL,
+				RemoteURL: "https://git:SECRETTOKEN@gitlab.com/sourcegraph/" + string(gitLabRepo.Name),
 			},
 		},
 		{
@@ -907,7 +903,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			extSvc: bbsExtSvc,
 			repo:   bbsRepo,
 			wantPushConfig: &gitprotocol.PushConfig{
-				RemoteURL: bbsRepoCloneURL,
+				RemoteURL: "https://bbs-user:bbs-token@bitbucket.sourcegraph.com/scm/" + string(bbsRepo.Name),
 			},
 		},
 		{
@@ -923,7 +919,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 			extSvc: bbsSSHExtsvc,
 			repo:   bbsSSHRepo,
 			wantPushConfig: &gitprotocol.PushConfig{
-				RemoteURL: bbsSSHRepoCloneURL,
+				RemoteURL: "ssh://git@bitbucket.sgdev.org:7999/" + string(bbsSSHRepo.Name),
 			},
 		},
 		{
@@ -938,7 +934,7 @@ func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 				Passphrase:       "passphrase",
 			},
 			wantPushConfig: &gitprotocol.PushConfig{
-				RemoteURL:  bbsSSHRepoCloneURL,
+				RemoteURL:  "ssh://git@bitbucket.sgdev.org:7999/" + string(bbsSSHRepo.Name),
 				PrivateKey: "private key",
 				Passphrase: "passphrase",
 			},

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -8,6 +8,7 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
@@ -62,8 +63,8 @@ func newBitbucketServerSource(c *schema.BitbucketServerConnection, cf *httpcli.F
 	}, nil
 }
 
-func (s BitbucketServerSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(repo, s.au)
+func (s BitbucketServerSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
+	return gitserverPushConfig(ctx, store, repo, s.au)
 }
 
 func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -40,7 +41,7 @@ type DraftChangesetSource interface {
 type ChangesetSource interface {
 	// GitserverPushConfig returns an authenticated push config used for pushing
 	// commits to the code host.
-	GitserverPushConfig(*types.Repo) (*protocol.PushConfig, error)
+	GitserverPushConfig(context.Context, *database.ExternalServiceStore, *types.Repo) (*protocol.PushConfig, error)
 	// WithAuthenticator returns a copy of the original Source configured to use
 	// the given authenticator, provided that authenticator type is supported by
 	// the code host.

--- a/enterprise/internal/batches/sources/fake.go
+++ b/enterprise/internal/batches/sources/fake.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
@@ -256,8 +257,8 @@ func (s *FakeChangesetSource) CreateComment(ctx context.Context, c *Changeset, b
 	return s.Err
 }
 
-func (s *FakeChangesetSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(repo, s.CurrentAuthenticator)
+func (s *FakeChangesetSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
+	return gitserverPushConfig(ctx, store, repo, s.CurrentAuthenticator)
 }
 
 func (s *FakeChangesetSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -72,8 +73,8 @@ func newGithubSource(c *schema.GitHubConnection, cf *httpcli.Factory, au auth.Au
 	}, nil
 }
 
-func (s GithubSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(repo, s.au)
+func (s GithubSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
+	return gitserverPushConfig(ctx, store, repo, s.au)
 }
 
 func (s GithubSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
@@ -74,8 +75,8 @@ func newGitLabSource(c *schema.GitLabConnection, cf *httpcli.Factory, au auth.Au
 	}, nil
 }
 
-func (s GitLabSource) GitserverPushConfig(repo *types.Repo) (*protocol.PushConfig, error) {
-	return gitserverPushConfig(repo, s.au)
+func (s GitLabSource) GitserverPushConfig(ctx context.Context, store *database.ExternalServiceStore, repo *types.Repo) (*protocol.PushConfig, error) {
+	return gitserverPushConfig(ctx, store, repo, s.au)
 }
 
 func (s GitLabSource) WithAuthenticator(a auth.Authenticator) (ChangesetSource, error) {

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -19,8 +19,6 @@ import (
 )
 
 func TestExtractCloneURL(t *testing.T) {
-	t.Parallel()
-
 	tcs := []struct {
 		name            string
 		want            string
@@ -211,8 +209,6 @@ func TestLoadExternalService(t *testing.T) {
 }
 
 func TestGitserverPushConfig(t *testing.T) {
-	t.Parallel()
-
 	oauthHTTPSAuthenticator := auth.OAuthBearerToken{Token: "bearer-test"}
 	oauthSSHAuthenticator := auth.OAuthBearerTokenWithSSH{
 		OAuthBearerToken: oauthHTTPSAuthenticator,

--- a/enterprise/internal/batches/sources/sources_test.go
+++ b/enterprise/internal/batches/sources/sources_test.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,6 +11,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -18,60 +22,83 @@ func TestExtractCloneURL(t *testing.T) {
 	t.Parallel()
 
 	tcs := []struct {
-		name      string
-		want      string
-		cloneURLs []string
+		name            string
+		want            string
+		configs         []string
+		overrideRepoURL string
 	}{
 		{
-			name:      "https",
-			want:      "https://secrettoken@github.com/sourcegraph/sourcegraph",
-			cloneURLs: []string{"https://secrettoken@github.com/sourcegraph/sourcegraph"},
+			name: "https",
+			want: "https://secrettoken@github.com/sourcegraph/sourcegraph",
+			configs: []string{
+				`{"url": "https://github.com", "token": "secrettoken", "authorization": {}}`,
+			},
 		},
 		{
-			name:      "https user password",
-			want:      "https://git:secrettoken@github.com/sourcegraph/sourcegraph",
-			cloneURLs: []string{"https://git:secrettoken@github.com/sourcegraph/sourcegraph"},
+			name: "https user password",
+			want: "https://git:secrettoken@github.com/sourcegraph/sourcegraph",
+			configs: []string{
+				`{"url": "https://github.com", "authorization": {}}`,
+			},
+			overrideRepoURL: "https://git:secrettoken@github.com/sourcegraph/sourcegraph",
 		},
 		{
-			name:      "ssh no protocol specified",
-			want:      "ssh://git@github.com/sourcegraph/sourcegraph.git",
-			cloneURLs: []string{"git@github.com:sourcegraph/sourcegraph.git"},
-		},
-		{
-			name:      "ssh protocol specified",
-			want:      "ssh://git@github.com/sourcegraph/sourcegraph.git",
-			cloneURLs: []string{"ssh://git@github.com/sourcegraph/sourcegraph.git"},
+			name: "ssh",
+			want: "ssh://git@github.com/sourcegraph/sourcegraph.git",
+			configs: []string{
+				`{"url": "https://github.com", "gitURLType": "ssh", "authorization": {}}`,
+			},
 		},
 		{
 			name: "https and ssh, favoring https",
 			want: "https://secrettoken@github.com/sourcegraph/sourcegraph",
-			cloneURLs: []string{
-				"https://secrettoken@github.com/sourcegraph/sourcegraph",
-				"git@github.com:sourcegraph/sourcegraph.git",
-				"ssh://git@github.com/sourcegraph/sourcegraph.git",
+			configs: []string{
+				`{"url": "https://github.com", "token": "secrettoken", "authorization": {}}`,
+				`{"url": "https://github.com", "gitURLType": "ssh", "authorization": {}}`,
 			},
 		},
 		{
 			name: "https and ssh, favoring https different order",
 			want: "https://secrettoken@github.com/sourcegraph/sourcegraph",
-			cloneURLs: []string{
-				"git@github.com:sourcegraph/sourcegraph.git",
-				"ssh://git@github.com/sourcegraph/sourcegraph.git",
-				"https://secrettoken@github.com/sourcegraph/sourcegraph",
+			configs: []string{
+				`{"url": "https://github.com", "gitURLType": "ssh", "authorization": {}}`,
+				`{"url": "https://github.com", "token": "secrettoken", "authorization": {}}`,
 			},
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			repo := &types.Repo{
-				Sources: map[string]*types.SourceInfo{},
+				Name:    api.RepoName("github.com/sourcegraph/sourcegraph"),
+				URI:     "github.com/sourcegraph/sourcegraph",
+				Sources: make(map[string]*types.SourceInfo),
+				Metadata: &github.Repository{
+					NameWithOwner: "sourcegraph/sourcegraph",
+					URL:           "https://github.com/sourcegraph/sourcegraph",
+				},
 			}
-			for _, cloneURL := range tc.cloneURLs {
-				repo.Sources[cloneURL] = &types.SourceInfo{
-					CloneURL: cloneURL,
+			if tc.overrideRepoURL != "" {
+				repo.Metadata.(*github.Repository).URL = tc.overrideRepoURL
+			}
+
+			for idx := range tc.configs {
+				repo.Sources[fmt.Sprintf("%d", idx)] = &types.SourceInfo{
+					ID: fmt.Sprintf("::%d", idx), // see SourceInfo.ExternalServiceID
 				}
 			}
-			have, err := extractCloneURL(repo)
+
+			database.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
+				return &types.ExternalService{
+					ID:     id,
+					Kind:   extsvc.KindGitHub,
+					Config: tc.configs[int(id)],
+				}, nil
+			}
+			t.Cleanup(func() {
+				database.Mocks.ExternalServices.GetByID = nil
+			})
+
+			have, err := extractCloneURL(context.Background(), &database.ExternalServiceStore{}, repo)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -202,8 +229,11 @@ func TestGitserverPushConfig(t *testing.T) {
 	}
 	tcs := []struct {
 		name                string
+		repoName            string
 		externalServiceType string
-		cloneURL            string
+		config              string
+		repoMetadata        interface{}
+		overrideRepoURL     string
 		authenticator       auth.Authenticator
 		wantPushConfig      *protocol.PushConfig
 		wantErr             error
@@ -211,48 +241,84 @@ func TestGitserverPushConfig(t *testing.T) {
 		// Without authenticator:
 		{
 			name:                "GitHub HTTPS no token",
+			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
-			cloneURL:            "https://github.com/sourcegraph/sourcegraph",
+			config:              `{"url": "https://github.com", "authorization": {}}`,
+			repoMetadata: &github.Repository{
+				NameWithOwner: "sourcegraph/sourcegraph",
+				URL:           "https://github.com/sourcegraph/sourcegraph",
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://github.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitHub HTTPS token",
+			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
-			cloneURL:            "https://token@github.com/sourcegraph/sourcegraph",
+			config:              `{"url": "https://github.com", "token": "token", "authorization": {}}`,
+			repoMetadata: &github.Repository{
+				NameWithOwner: "sourcegraph/sourcegraph",
+				URL:           "https://github.com/sourcegraph/sourcegraph",
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://token@github.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitHub SSH",
+			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
-			cloneURL:            "git@github.com:sourcegraph/sourcegraph.git",
+			config:              `{"url": "https://github.com", "gitURLType": "ssh", "authorization": {}}`,
+			repoMetadata: &github.Repository{
+				NameWithOwner: "sourcegraph/sourcegraph",
+				URL:           "https://github.com/sourcegraph/sourcegraph",
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "ssh://git@github.com/sourcegraph/sourcegraph.git",
 			},
 		},
 		{
 			name:                "GitLab HTTPS no token",
+			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
-			cloneURL:            "https://gitlab.com/sourcegraph/sourcegraph",
+			config:              `{}`,
+			repoMetadata: &gitlab.Project{
+				ProjectCommon: gitlab.ProjectCommon{
+					ID:                1,
+					PathWithNamespace: "sourcegraph/sourcegraph",
+					HTTPURLToRepo:     "https://gitlab.com/sourcegraph/sourcegraph",
+				}},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://gitlab.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitLab HTTPS token",
+			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
-			cloneURL:            "https://git:token@gitlab.com/sourcegraph/sourcegraph",
+			config:              `{}`,
+			repoMetadata: &gitlab.Project{
+				ProjectCommon: gitlab.ProjectCommon{
+					ID:                1,
+					PathWithNamespace: "sourcegraph/sourcegraph",
+					HTTPURLToRepo:     "https://git:token@gitlab.com/sourcegraph/sourcegraph",
+				}},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://git:token@gitlab.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitLab SSH",
+			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
-			cloneURL:            "git@gitlab.com:sourcegraph/sourcegraph.git",
+			config:              `{"gitURLType": "ssh"}`,
+			repoMetadata: &gitlab.Project{
+				ProjectCommon: gitlab.ProjectCommon{
+					ID:                1,
+					PathWithNamespace: "sourcegraph/sourcegraph",
+					SSHURLToRepo:      "git@gitlab.com:sourcegraph/sourcegraph.git",
+				}},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "ssh://git@gitlab.com/sourcegraph/sourcegraph.git",
 			},
@@ -260,7 +326,30 @@ func TestGitserverPushConfig(t *testing.T) {
 		{
 			name:                "Bitbucket server HTTPS no token",
 			externalServiceType: extsvc.TypeBitbucketServer,
-			cloneURL:            "https://bitbucket.sgdev.org/sourcegraph/sourcegraph",
+			config:              `{}`,
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "http", Href: "https://bitbucket.sgdev.org/sourcegraph/sourcegraph"},
+					},
+				},
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://bitbucket.sgdev.org/sourcegraph/sourcegraph",
 			},
@@ -268,7 +357,30 @@ func TestGitserverPushConfig(t *testing.T) {
 		{
 			name:                "Bitbucket server HTTPS token",
 			externalServiceType: extsvc.TypeBitbucketServer,
-			cloneURL:            "https://token@bitbucket.sgdev.org/sourcegraph/sourcegraph",
+			config:              `{}`,
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "http", Href: "https://token@bitbucket.sgdev.org/sourcegraph/sourcegraph"},
+					},
+				},
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://token@bitbucket.sgdev.org/sourcegraph/sourcegraph",
 			},
@@ -276,7 +388,30 @@ func TestGitserverPushConfig(t *testing.T) {
 		{
 			name:                "Bitbucket server SSH",
 			externalServiceType: extsvc.TypeBitbucketServer,
-			cloneURL:            "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph",
+			config:              `{"gitURLType": "ssh"}`,
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "ssh", Href: "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph"},
+					},
+				},
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph",
 			},
@@ -284,27 +419,42 @@ func TestGitserverPushConfig(t *testing.T) {
 		// With authenticator:
 		{
 			name:                "GitHub HTTPS no token with authenticator",
+			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
-			cloneURL:            "https://github.com/sourcegraph/sourcegraph",
+			config:              `{"url": "https://github.com", "authorization": {}}`,
 			authenticator:       &oauthHTTPSAuthenticator,
+			repoMetadata: &github.Repository{
+				NameWithOwner: "sourcegraph/sourcegraph",
+				URL:           "https://github.com/sourcegraph/sourcegraph",
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://bearer-test@github.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitHub HTTPS token with authenticator",
+			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
-			cloneURL:            "https://token@github.com/sourcegraph/sourcegraph",
+			config:              `{"url": "https://github.com", "token": "token", "authorization": {}}`,
 			authenticator:       &oauthHTTPSAuthenticator,
+			repoMetadata: &github.Repository{
+				NameWithOwner: "sourcegraph/sourcegraph",
+				URL:           "https://github.com/sourcegraph/sourcegraph",
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://bearer-test@github.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitHub SSH with authenticator",
+			repoName:            "github.com/sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitHub,
-			cloneURL:            "git@github.com:sourcegraph/sourcegraph.git",
+			config:              `{"url": "https://github.com", "gitURLType": "ssh", "authorization": {}}`,
 			authenticator:       &oauthSSHAuthenticator,
+			repoMetadata: &github.Repository{
+				NameWithOwner: "sourcegraph/sourcegraph",
+				URL:           "https://github.com/sourcegraph/sourcegraph",
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL:  "ssh://git@github.com/sourcegraph/sourcegraph.git",
 				PrivateKey: "private-key",
@@ -313,27 +463,48 @@ func TestGitserverPushConfig(t *testing.T) {
 		},
 		{
 			name:                "GitLab HTTPS no token with authenticator",
+			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
-			cloneURL:            "https://gitlab.com/sourcegraph/sourcegraph",
+			config:              `{}`,
 			authenticator:       &oauthHTTPSAuthenticator,
+			repoMetadata: &gitlab.Project{
+				ProjectCommon: gitlab.ProjectCommon{
+					ID:                1,
+					PathWithNamespace: "sourcegraph/sourcegraph",
+					HTTPURLToRepo:     "https://gitlab.com/sourcegraph/sourcegraph",
+				}},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://git:bearer-test@gitlab.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitLab HTTPS token with authenticator",
+			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
-			cloneURL:            "https://git:token@gitlab.com/sourcegraph/sourcegraph",
+			config:              `{}`,
 			authenticator:       &oauthHTTPSAuthenticator,
+			repoMetadata: &gitlab.Project{
+				ProjectCommon: gitlab.ProjectCommon{
+					ID:                1,
+					PathWithNamespace: "sourcegraph/sourcegraph",
+					HTTPURLToRepo:     "https://git:token@gitlab.com/sourcegraph/sourcegraph",
+				}},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://git:bearer-test@gitlab.com/sourcegraph/sourcegraph",
 			},
 		},
 		{
 			name:                "GitLab SSH with authenticator",
+			repoName:            "sourcegraph/sourcegraph",
 			externalServiceType: extsvc.TypeGitLab,
-			cloneURL:            "git@gitlab.com:sourcegraph/sourcegraph.git",
+			config:              `{"gitURLType": "ssh"}`,
 			authenticator:       &oauthSSHAuthenticator,
+			repoMetadata: &gitlab.Project{
+				ProjectCommon: gitlab.ProjectCommon{
+					ID:                1,
+					PathWithNamespace: "sourcegraph/sourcegraph",
+					SSHURLToRepo:      "git@gitlab.com:sourcegraph/sourcegraph.git",
+				}},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL:  "ssh://git@gitlab.com/sourcegraph/sourcegraph.git",
 				PrivateKey: "private-key",
@@ -343,8 +514,31 @@ func TestGitserverPushConfig(t *testing.T) {
 		{
 			name:                "Bitbucket server HTTPS no token with authenticator",
 			externalServiceType: extsvc.TypeBitbucketServer,
-			cloneURL:            "https://bitbucket.sgdev.org/sourcegraph/sourcegraph",
+			config:              `{}`,
 			authenticator:       &basicHTTPSAuthenticator,
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "http", Href: "https://bitbucket.sgdev.org/sourcegraph/sourcegraph"},
+					},
+				},
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://basic:pw@bitbucket.sgdev.org/sourcegraph/sourcegraph",
 			},
@@ -352,8 +546,31 @@ func TestGitserverPushConfig(t *testing.T) {
 		{
 			name:                "Bitbucket server HTTPS token with authenticator",
 			externalServiceType: extsvc.TypeBitbucketServer,
-			cloneURL:            "https://token@bitbucket.sgdev.org/sourcegraph/sourcegraph",
+			config:              `{}`,
 			authenticator:       &basicHTTPSAuthenticator,
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "http", Href: "https://token@bitbucket.sgdev.org/sourcegraph/sourcegraph"},
+					},
+				},
+			},
 			wantPushConfig: &protocol.PushConfig{
 				RemoteURL: "https://basic:pw@bitbucket.sgdev.org/sourcegraph/sourcegraph",
 			},
@@ -361,10 +578,33 @@ func TestGitserverPushConfig(t *testing.T) {
 		{
 			name:                "Bitbucket server SSH with authenticator",
 			externalServiceType: extsvc.TypeBitbucketServer,
-			cloneURL:            "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph",
+			config:              `{"gitURLType": "ssh"}`,
 			authenticator:       &basicSSHAuthenticator,
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "ssh", Href: "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph.git"},
+					},
+				},
+			},
 			wantPushConfig: &protocol.PushConfig{
-				RemoteURL:  "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph",
+				RemoteURL:  "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph.git",
 				PrivateKey: "private-key",
 				Passphrase: "passphrase",
 			},
@@ -373,16 +613,62 @@ func TestGitserverPushConfig(t *testing.T) {
 		{
 			name:                "Bitbucket server SSH no keypair",
 			externalServiceType: extsvc.TypeBitbucketServer,
-			cloneURL:            "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph",
+			config:              `{"gitURLType": "ssh"}`,
 			authenticator:       &basicHTTPSAuthenticator,
-			wantErr:             ErrNoSSHCredential,
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "ssh", Href: "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph.git"},
+					},
+				},
+			},
+			wantErr: ErrNoSSHCredential,
 		},
 		{
 			name:                "Invalid credential type",
-			externalServiceType: extsvc.TypeGitHub,
-			cloneURL:            "https://github.com/sourcegraph/sourcegraph",
+			externalServiceType: extsvc.TypeBitbucketServer,
+			config:              `{}`,
 			authenticator:       &auth.OAuthClient{},
-			wantErr:             ErrNoPushCredentials{CredentialsType: "*auth.OAuthClient"},
+			repoMetadata: &bitbucketserver.Repo{
+				ID:   1,
+				Slug: "sourcegraph/sourcegraph",
+				Project: &bitbucketserver.Project{
+					Key: "sourcegraph/sourcegraph",
+				},
+				Links: struct {
+					Clone []struct {
+						Href string `json:"href"`
+						Name string `json:"name"`
+					} `json:"clone"`
+					Self []struct {
+						Href string `json:"href"`
+					} `json:"self"`
+				}{
+					Clone: []struct {
+						Href string "json:\"href\""
+						Name string "json:\"name\""
+					}{
+						{Name: "ssh", Href: "ssh://git@bitbucket.sgdev.org:7999/sourcegraph/sourcegraph.git"},
+					},
+				},
+			},
+			wantErr: ErrNoPushCredentials{CredentialsType: "*auth.OAuthClient"},
 		},
 	}
 	for _, tt := range tcs {
@@ -391,9 +677,28 @@ func TestGitserverPushConfig(t *testing.T) {
 				ExternalRepo: api.ExternalRepoSpec{
 					ServiceType: tt.externalServiceType,
 				},
-				Sources: map[string]*types.SourceInfo{tt.cloneURL: {CloneURL: tt.cloneURL}},
+				Name:     api.RepoName(tt.repoName),
+				URI:      tt.repoName,
+				Sources:  make(map[string]*types.SourceInfo),
+				Metadata: tt.repoMetadata,
 			}
-			havePushConfig, haveErr := gitserverPushConfig(repo, tt.authenticator)
+
+			repo.Sources["1"] = &types.SourceInfo{
+				ID: "::1", // see SourceInfo.ExternalServiceID
+			}
+
+			database.Mocks.ExternalServices.GetByID = func(id int64) (*types.ExternalService, error) {
+				return &types.ExternalService{
+					ID:     id,
+					Kind:   extsvc.TypeToKind(tt.externalServiceType),
+					Config: tt.config,
+				}, nil
+			}
+			t.Cleanup(func() {
+				database.Mocks.ExternalServices.GetByID = nil
+			})
+
+			havePushConfig, haveErr := gitserverPushConfig(context.Background(), &database.ExternalServiceStore{}, repo, tt.authenticator)
 			if haveErr != tt.wantErr {
 				t.Fatalf("invalid error returned, want=%v have=%v", tt.wantErr, haveErr)
 			}

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -39,7 +39,10 @@ func TestRepo(t *testing.T, store *database.ExternalServiceStore, serviceKind st
 		t.Fatalf("failed to insert external services: %v", err)
 	}
 
-	return TestRepoWithService(t, store, fmt.Sprintf("repo-%d", svc.ID), &svc)
+	repo := TestRepoWithService(t, store, fmt.Sprintf("repo-%d", svc.ID), &svc)
+
+	repo.Sources[svc.URN()].CloneURL = "https://secrettoken@github.com/sourcegraph/sourcegraph"
+	return repo
 }
 
 func TestRepoWithService(t *testing.T, store *database.ExternalServiceStore, name string, svc *types.ExternalService) *types.Repo {

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -90,7 +90,7 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db dbutil.DB, count int)
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d", i+1), ext)
+		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d-%d", ext.ID, i+1), ext)
 		r.Metadata = &github.Repository{
 			NameWithOwner: string(r.Name),
 			URL:           fmt.Sprintf("https://github.com/sourcegraph/%s", string(r.Name)),
@@ -127,7 +127,7 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count 
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d", i+1), ext)
+		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d-%d", ext.ID, i+1), ext)
 		r.Metadata = &gitlab.Project{
 			ProjectCommon: gitlab.ProjectCommon{
 				HTTPURLToRepo: fmt.Sprintf("https://gitlab.com/sourcegraph/%s", string(r.Name)),
@@ -223,7 +223,7 @@ func createBbsRepos(t *testing.T, ctx context.Context, db dbutil.DB, ext *types.
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d", i+1), ext)
+		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d-%d", ext.ID, i+1), ext)
 		var metadata bitbucketserver.Repo
 		urlType := "http"
 		if strings.HasPrefix(cloneBaseURL, "ssh") {

--- a/enterprise/internal/batches/testing/repos.go
+++ b/enterprise/internal/batches/testing/repos.go
@@ -39,18 +39,18 @@ func TestRepo(t *testing.T, store *database.ExternalServiceStore, serviceKind st
 		t.Fatalf("failed to insert external services: %v", err)
 	}
 
-	return TestRepoWithService(t, store, &svc)
+	return TestRepoWithService(t, store, fmt.Sprintf("repo-%d", svc.ID), &svc)
 }
 
-func TestRepoWithService(t *testing.T, store *database.ExternalServiceStore, svc *types.ExternalService) *types.Repo {
+func TestRepoWithService(t *testing.T, store *database.ExternalServiceStore, name string, svc *types.ExternalService) *types.Repo {
 	t.Helper()
 
 	return &types.Repo{
-		Name:    api.RepoName(fmt.Sprintf("repo-%d", svc.ID)),
-		URI:     fmt.Sprintf("repo-%d", svc.ID),
+		Name:    api.RepoName(name),
+		URI:     name,
 		Private: true,
 		ExternalRepo: api.ExternalRepoSpec{
-			ID:          fmt.Sprintf("external-id-%d", svc.ID),
+			ID:          fmt.Sprintf("external-id-%s", name),
 			ServiceType: extsvc.KindToType(svc.Kind),
 			ServiceID:   fmt.Sprintf("https://%s.com/", strings.ToLower(svc.Kind)),
 		},
@@ -90,7 +90,7 @@ func CreateTestRepos(t *testing.T, ctx context.Context, db dbutil.DB, count int)
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepoWithService(t, esStore, ext)
+		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d", i+1), ext)
 		r.Metadata = &github.Repository{
 			NameWithOwner: string(r.Name),
 			URL:           fmt.Sprintf("https://github.com/sourcegraph/%s", string(r.Name)),
@@ -127,7 +127,7 @@ func CreateGitlabTestRepos(t *testing.T, ctx context.Context, db *sql.DB, count 
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepoWithService(t, esStore, ext)
+		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d", i+1), ext)
 		r.Metadata = &gitlab.Project{
 			ProjectCommon: gitlab.ProjectCommon{
 				HTTPURLToRepo: fmt.Sprintf("https://gitlab.com/sourcegraph/%s", string(r.Name)),
@@ -223,7 +223,7 @@ func createBbsRepos(t *testing.T, ctx context.Context, db dbutil.DB, ext *types.
 
 	var rs []*types.Repo
 	for i := 0; i < count; i++ {
-		r := TestRepoWithService(t, esStore, ext)
+		r := TestRepoWithService(t, esStore, fmt.Sprintf("repo-%d", i+1), ext)
 		var metadata bitbucketserver.Repo
 		urlType := "http"
 		if strings.HasPrefix(cloneBaseURL, "ssh") {


### PR DESCRIPTION
This replaces usages of Sources.CloneURL in the batches/reconcilier package with building the url with the external service configuration.
This also changes the sources.ChangesetSource implementations, which now take a context and an external service store.