### PR TITLE
database: fix scanRepo not initialize metadata for Perforce

### DIFF
--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitolite"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/perforce"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -346,6 +347,8 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 		r.Metadata = new(awscodecommit.Repository)
 	case extsvc.TypeGitolite:
 		r.Metadata = new(gitolite.Repo)
+	case extsvc.TypePerforce:
+		r.Metadata = new(perforce.Depot)
 	default:
 		return nil
 	}

--- a/internal/types/clone_url.go
+++ b/internal/types/clone_url.go
@@ -66,9 +66,9 @@ func RepoCloneURL(kind, config string, repo *Repo) (string, error) {
 	case *schema.OtherExternalServiceConnection:
 		return otherCloneURL(repo, t)
 	default:
-		return "", fmt.Errorf("unknown external service kind %q", kind)
+		return "", errors.Errorf("unknown external service kind %q for repo %d", kind, repo.ID)
 	}
-	return "", fmt.Errorf("unknown repo.Metadata type %T", repo.Metadata)
+	return "", errors.Errorf("unknown repo.Metadata type %T for repo %d", repo.Metadata, repo.ID)
 }
 
 func awsCodeCloneURL(repo *awscodecommit.Repository, cfg *schema.AWSCodeCommitConnection) string {


### PR DESCRIPTION
Also improved logging a bit for `RepoCloneURL` to print repo ID.