### PR TITLE
Update batch changes changelog for 3.27 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ All notable changes to Sourcegraph are documented in this file.
   - A `patternType` filter is no longer required. `patternType:literal` will be added to a code monitor query if not specified.
   - Added a new checklist UI to make it more intuitive to create code monitor trigger queries.
 - Deprecated the GraphQL `icon` field on `GenericSearchResultInterface`. It will be removed in a future release. [#20028](https://github.com/sourcegraph/sourcegraph/pull/20028/files)
+- Creating changesets through Batch Changes as a site-admin without configured Batch Changes credentials has been deprecated. Please configure user or global credentials before Sourcegraph 3.29 to not experience any interruptions in changeset creation. [#20143](https://github.com/sourcegraph/sourcegraph/pull/20143)
 
 ### Fixed
 

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -63,6 +63,12 @@ const BatchChangesChangelogAlert: React.FunctionComponent = () => (
                     </li>
                 </ul>
                 <ul className="text-muted mb-0 pl-3">
+                    <li>
+                        The site configuration now supports defining batch change rollout windows, which can be used to
+                        slow or disable pushing changesets at particular times of day or days of the week.
+                    </li>
+                </ul>
+                <ul className="text-muted mb-0 pl-3">
                     <li>Changesets will now be archived by default when not part of a batch change anymore.</li>
                 </ul>
                 <ul className="text-muted mb-0 pl-3">

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -59,7 +59,7 @@ const BatchChangesChangelogAlert: React.FunctionComponent = () => (
                 <ul className="text-muted mb-0 pl-3">
                     <li>
                         Site admins can now configure a global service account to be used when creating and updating
-                        changesets on code hosts.
+                        changesets on code hosts and the user has no credential configured.
                     </li>
                 </ul>
                 <ul className="text-muted mb-0 pl-3">

--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -1,4 +1,6 @@
+import WarningIcon from 'mdi-react/WarningIcon'
 import React from 'react'
+import { Link } from 'react-router-dom'
 
 import { SourcegraphIcon } from '../../../auth/icons'
 import { DismissibleAlert } from '../../../components/DismissibleAlert'
@@ -40,18 +42,40 @@ export const BatchChangesListIntro: React.FunctionComponent<BatchChangesListIntr
 const BatchChangesChangelogAlert: React.FunctionComponent = () => (
     <DismissibleAlert
         className="batch-changes-list-intro__alert"
-        partialStorageKey="batch-changes-list-intro-changelog-3.26"
+        partialStorageKey="batch-changes-list-intro-changelog-3.27"
     >
         <div className="batch-changes-list-intro__card card h-100 p-2">
             <div className="card-body">
-                <h4>New Batch Changes features in version 3.26</h4>
+                <h4>New Batch Changes features in version 3.27</h4>
                 <ul className="text-muted mb-0 pl-3">
-                    <li>Batch Changes now supports SSH cloned repos. Users can configure SSH access in settings.</li>
+                    <li>
+                        <WarningIcon className="icon-inline text-warning" /> <strong>Deprecation:</strong> Starting with
+                        Sourcegraph 3.29, we will stop using code host connection tokens for creating changesets. If a
+                        site-admin on your instance relied on the global configuration, please ask them to go add global
+                        credentials for Batch Changes in the <Link to="/site-admin/batch-changes">admin UI</Link> for
+                        uninterrupted Batch Changes usage.
+                    </li>
                 </ul>
                 <ul className="text-muted mb-0 pl-3">
                     <li>
-                        Burndown charts have been improved: changeset progress is now shown with greater resolution
-                        across the entire lifespan of the batch change.
+                        Site admins can now configure a global service account to be used when creating and updating
+                        changesets on code hosts.
+                    </li>
+                </ul>
+                <ul className="text-muted mb-0 pl-3">
+                    <li>Changesets will now be archived by default when not part of a batch change anymore.</li>
+                </ul>
+                <ul className="text-muted mb-0 pl-3">
+                    <li>
+                        Ignore repositories in batch changes with{' '}
+                        <a
+                            href="https://docs.sourcegraph.com/batch_changes/how-tos/opting_out_of_batch_changes"
+                            target="_blank"
+                            rel="noopener"
+                        >
+                            <span className="text-monospace">.batchignore</span>
+                        </a>{' '}
+                        files.
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
This PR updates the in-app changelog list for Batch Changes.

It also adds the deprecation notice for site-admin changesets being created with external service tokens. This is a very edge-case and a relict from earlier times, so I don't think we need to advertise it more prominently than we do here.

## What this deprecation means

When you created a Batch Change as a site admin before, and never configured user credentials, we fell back to using the code host connection tokens for backwards compatible with the early days of Batch Changes, where only site-admins were able to publish changesets. We ask you to configure a user credential if you haven't done so, or configure a global service account to be used with Batch Changes. All regular users of Batch Changes aren't affected by this deprecation at all.