### PR TITLE
Document site-credentials in Batch Changes

### DIFF
--- a/doc/_resources/assets/redirects
+++ b/doc/_resources/assets/redirects
@@ -225,3 +225,5 @@
 /cli/references/campaigns/repositories /cli/references/batch/repositories 308
 /cli/references/campaigns/validate /cli/references/batch/validate 308
 /cli/references/campaigns /cli/references/batch 308
+
+/batch_changes/how-tos/configuring_user_credentials /batch_changes/how-tos/configuring_credentials 308

--- a/doc/batch_changes/explanations/permissions_in_batch_changes.md
+++ b/doc/batch_changes/explanations/permissions_in_batch_changes.md
@@ -49,7 +49,7 @@ Interactions with the code host are performed by Sourcegraph with your personal 
 - Updating a changeset
 - Closing a changeset
 
-For instructions on adding and managing your code host access tokens, please refer to "[Configuring user credentials](../how-tos/configuring_user_credentials.md)".
+For instructions on adding and managing your code host access tokens, please refer to "[Configuring credentials](../how-tos/configuring_credentials.md)".
 
 See these code host specific pages for which permissions and scopes the tokens require:
 
@@ -62,6 +62,8 @@ See these code host specific pages for which permissions and scopes the tokens r
 Site admins will fall back to using the Sourcegraph token for the code host if they have not added a personal access token. This makes it easier to try out Batch Changes, but be aware that this may result in changesets being created or changed with different permissions to your normal code host user.
 
 Non-admin users are unable to apply batch changes without configuring access tokens.
+
+**NOTE** that this fallback has been deprecated in Sourcegraph 3.27 and is due to be removed in Sourcegraph 3.29.
 
 ## Repository permissions for Batch Changes
 

--- a/doc/batch_changes/explanations/permissions_in_batch_changes.md
+++ b/doc/batch_changes/explanations/permissions_in_batch_changes.md
@@ -63,7 +63,7 @@ Site admins will fall back to using the Sourcegraph token for the code host if t
 
 Non-admin users are unable to apply batch changes without configuring access tokens.
 
-**NOTE** that this fallback has been deprecated in Sourcegraph 3.27 and is due to be removed in Sourcegraph 3.29.
+> WARNING: This fallback has been deprecated in Sourcegraph 3.27 and is due to be removed in Sourcegraph 3.29.
 
 ## Repository permissions for Batch Changes
 

--- a/doc/batch_changes/how-tos/configuring_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_credentials.md
@@ -1,8 +1,8 @@
-# Configuring user credentials
+# Configuring credentials
 
 > NOTE: This page describes functionality added in Sourcegraph 3.22. Older Sourcegraph versions only allow batch changes to be applied and managed by site admins.
 
-In order to [publish changesets with Batch Changes](publishing_changesets.md), you need to add a personal access token for each code host that your batch change interact with. These tokens are used by Sourcegraph to create and manage changesets as you, and with your specific permissions, on the code host.
+In order to [publish changesets with Batch Changes](publishing_changesets.md), you need to add a personal access token for each code host that your batch change interacts with. These tokens are used by Sourcegraph to create and manage changesets on behalf of yourself, and with your specific permissions, on the code host. Since Sourcegraph 3.27, it is also possible to configure a global service account per code host to be used, when the user doesn't have credentials configured.
 
 ## Requirements
 
@@ -10,13 +10,29 @@ In order to [publish changesets with Batch Changes](publishing_changesets.md), y
 
 ## Adding a personal access token
 
-Adding personal access tokens is done through the the Batch Changes section of your user settings:
+Access tokens can be configured either for your user account, or globally, if you're a site admin of the Sourcegraph instance.
+
+### For yourself
+
+Adding personal access tokens is done through the Batch Changes section of your user settings:
 
 1. From any Sourcegraph page, click on your avatar at the top right of the page.
 1. Select **Settings** from the dropdown menu.
 1. Click **Batch Changes** on the sidebar menu.
 
-You should now see a list of the code hosts that are configured on Sourcegraph. Code hosts with tokens configured are indicated by a green tick, while code hosts without tokens have an empty red circle next to them.
+You should now see a list of the code hosts that are configured on Sourcegraph. Code hosts with tokens configured are indicated by a green tick, while code hosts without tokens have an empty red circle next to them. If a global access token has been configured, it is not required (but you can still do it, to create the changesets under your name) to do this. The UI will inform you if that's the case.
+
+### Global service account
+
+Configuring a global service account is done through the Batch Changes section of the site admin area: _(Site admins only)_
+
+1. From any Sourcegraph page, click on your avatar at the top right of the page.
+1. Select **Site admin** from the dropdown menu.
+1. Click **Batch Changes** on the sidebar menu.
+
+You should now see a list of the code hosts that are configured on Sourcegraph. Code hosts with tokens configured are indicated by a green tick, while code hosts without tokens have an empty red circle next to them. Credentials that are configured here will be usable by all users of the Sourcegraph instance for publishing and updating changesets on the code host.
+
+### Configuring a code host
 
 <video width="1920" height="1080" autoplay loop muted playsinline controls style="width: 100%; height: auto; max-width: 50rem">
   <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/user-tokens.webm" type="video/webm">
@@ -67,7 +83,6 @@ Sourcegraph requires the access token to have the `write` permission on both pro
 
 ## Removing a personal access token
 
-
 Removing personal access tokens is done through the the Batch Changes section of your user settings. To access this page, follow these instructions (also shown in the video below):
 
 1. From any Sourcegraph page, click on your avatar at the top right of the page.
@@ -78,7 +93,7 @@ You should now see a list of the code hosts that are configured on Sourcegraph. 
 
 <video width="1920" height="1080" autoplay loop muted playsinline controls style="width: 100%; height: auto; max-width: 50rem">
   <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/removing-user-token.webm" type="video/webm">
-  <sourec src="https://sourcegraphstatic.com/docs/videos/batch_changes/removing-user-token.mp4" type="video/mp4">
+  <source src="https://sourcegraphstatic.com/docs/videos/batch_changes/removing-user-token.mp4" type="video/mp4">
 </video>
 
 To remove a personal access token for a code host, click **Remove** next to that code host. The code host's indicator will change to an empty red circle to indicate that no token is configured for that code host:

--- a/doc/batch_changes/how-tos/configuring_credentials.md
+++ b/doc/batch_changes/how-tos/configuring_credentials.md
@@ -2,7 +2,7 @@
 
 > NOTE: This page describes functionality added in Sourcegraph 3.22. Older Sourcegraph versions only allow batch changes to be applied and managed by site admins.
 
-In order to [publish changesets with Batch Changes](publishing_changesets.md), you need to add a personal access token for each code host that your batch change interacts with. These tokens are used by Sourcegraph to create and manage changesets on behalf of yourself, and with your specific permissions, on the code host. Since Sourcegraph 3.27, it is also possible to configure a global service account per code host to be used, when the user doesn't have credentials configured.
+In order to [publish changesets with Batch Changes](publishing_changesets.md), you need to add a personal access token for each code host that your batch change interacts with. These tokens are used by Sourcegraph to create and manage changesets on behalf of yourself, and with your specific permissions, on the code host. Since Sourcegraph 3.27, it is also possible to configure a global service account per code host to be used when the user doesn't have credentials configured.
 
 ## Requirements
 

--- a/doc/batch_changes/how-tos/creating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/creating_a_batch_change.md
@@ -6,7 +6,7 @@ Batch changes are created by writing a [batch spec](../references/batch_spec_yam
 
 - Sourcegraph instance with repositories in it. See the "[Quickstart](../../index.md#quickstart)" guide on how to setup a Sourcegraph instance.
 - Installed and configured [Sourcegraph CLI](https://github.com/sourcegraph/src-cli) (see "[Install the Sourcegraph CLI](../quickstart.md#install-the-sourcegraph-cli)" in the Batch Changes quickstart for detailed instructions).
-- Configured user credentials for the code host(s) that you'll be creating changesets on. See "[Configuring user credentials](configuring_user_credentials.md)" for a guide on how to add and manage your user credentials.
+- Configured credentials for the code host(s) that you'll be creating changesets on. See "[Configuring user credentials](configuring_credentials.md)" for a guide on how to add and manage credentials.
 
 ## Writing a batch spec
 

--- a/doc/batch_changes/how-tos/handling_errored_changesets.md
+++ b/doc/batch_changes/how-tos/handling_errored_changesets.md
@@ -23,7 +23,7 @@ Examples of errors that can be fixed by [automatically retrying](#automatic-retr
 
 Examples of errors that requires [manual retrying](#manual-retrying-by-re-applying-the-batch-change-spec):
 
-- No [Batch Changes credentials](configuring_user_credentials.md) have been setup for the affected code host
+- No [Batch Changes credentials](configuring_credentials.md) have been setup for the affected code host
 - The configured code host connection needs a different type of credentials (e.g. with SSH keys)
 - A pull request for the specified branch already exists in another batch change
 - ...

--- a/doc/batch_changes/how-tos/index.md
+++ b/doc/batch_changes/how-tos/index.md
@@ -9,7 +9,7 @@ The following is a list of how-tos that show how to use [Sourcegraph Batch Chang
 - [Tracking existing changesets](tracking_existing_changesets.md)
 - [Closing or deleting a batch change](closing_or_deleting_a_batch_change.md)
 - [Site admin configuration for Batch Changes](site_admin_configuration.md)
-- [Configuring user credentials for Batch Changes](configuring_user_credentials.md)
+- [Configuring credentials for Batch Changes](configuring_credentials.md)
 - [Handling errored changesets](handling_errored_changesets.md)
 - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
 - [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)

--- a/doc/batch_changes/how-tos/publishing_changesets.md
+++ b/doc/batch_changes/how-tos/publishing_changesets.md
@@ -12,7 +12,7 @@ To publish a changeset, you need:
 
 1. [admin permissions for the batch change](../explanations/permissions_in_batch_changes.md#permission-levels-for-batch-changes),
 1. write access to the changeset's repository (on the code host), and
-1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_user_credentials.md).  
+1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_credentials.md).  
 
 For more information, see "[Code host interactions in Batch Changes](../explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes)".
 [Forking the repository](../explanations/introduction_to_batch_changes.md#known-issues) is not yet supported.

--- a/doc/batch_changes/how-tos/site_admin_configuration.md
+++ b/doc/batch_changes/how-tos/site_admin_configuration.md
@@ -8,3 +8,4 @@ Site admins can also:
 - [Control the rate at which Batch Changes will create changesets](../../../admin/config/batch_changes.md#rollout-windows).
 - [Disable Batch Changes](../explanations/permissions_in_batch_changes.md#disabling-batch-changes).
 - [Disable Batch Changes for non-site-admin users](../explanations/permissions_in_batch_changes.md#disabling-batch-changes-for-non-site-admin-users).
+- [Configure global credentials](configuring_credentials.md) for pushing and updating changesets.

--- a/doc/batch_changes/how-tos/updating_a_batch_change.md
+++ b/doc/batch_changes/how-tos/updating_a_batch_change.md
@@ -12,7 +12,7 @@ To update a changeset, you need:
 
 1. [admin permissions for the batch change](../explanations/permissions_in_batch_changes.md#permission-levels-for-batch-changes),
 1. write access to the changeset's repository (on the code host), and
-1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_user_credentials.md).
+1. a personal access token [configured in Sourcegraph for your code host(s)](configuring_credentials.md).
 
 For more information, see [Code host interactions in Batch Changes](../explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes).
 

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -86,7 +86,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Tracking existing changesets](how-tos/tracking_existing_changesets.md)
 - [Closing or deleting a batch change](how-tos/closing_or_deleting_a_batch_change.md)
 - [Site admin configuration for batch changes](how-tos/site_admin_configuration.md)
-- [Configuring user credentials for Batch Changes](how-tos/configuring_user_credentials.md)
+- [Configuring credentials for Batch Changes](how-tos/configuring_credentials.md)
 - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
 - [Handling errored changesets](how-tos/handling_errored_changesets.md)
 - [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -101,7 +101,7 @@ _You probably don't want to publish these toy "Hello World" changesets to active
 
 ### Configure code host credentials
 
-Since Batch Changes need write permissions to open changesets, you might need to add a personal access token for each code host you'll be publishing changesets on. This is a one time operation that you don't need to do for each batch change. Administrators of your Sourcegraph instance can also [configure global credentials](how-tos/configuring_credentials.md), so you don't need to go through this process. The UI for configuring the tokens will tell you when there is a global token configured.
+Since Batch Changes need write permissions to open changesets, you might need to add a personal access token for each code host you'll be publishing changesets on. This is a one time operation that you don't need to do for each batch change. Administrators of your Sourcegraph instance can also [configure global credentials](how-tos/configuring_credentials.md#global_service_account), so you don't need to go through this process. The UI for configuring the tokens will tell you when there is a global token configured.
 
 See "[Configuring user credentials](how-tos/configuring_credentials.md)" for more detail on adding and removing user tokens beyond the quickstart below, or ["Code host interactions in Batch Changes"](explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes) for details on what the permissions are used for.
 

--- a/doc/batch_changes/quickstart.md
+++ b/doc/batch_changes/quickstart.md
@@ -101,9 +101,9 @@ _You probably don't want to publish these toy "Hello World" changesets to active
 
 ### Configure code host credentials
 
-Since Batch Changes need write permissions to open changesets, you'll need to add a personal access token for each code host you'll be publishing changesets on. This is a one time operation that you don't need to do for each batch change.
+Since Batch Changes need write permissions to open changesets, you might need to add a personal access token for each code host you'll be publishing changesets on. This is a one time operation that you don't need to do for each batch change. Administrators of your Sourcegraph instance can also [configure global credentials](how-tos/configuring_credentials.md), so you don't need to go through this process. The UI for configuring the tokens will tell you when there is a global token configured.
 
-See "[Configuring user credentials](how-tos/configuring_user_credentials.md)" for more detail on adding and removing user tokens beyond the quickstart below, or ["Code host interactions in Batch Changes"](explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes) for details on what the permissions are used for.
+See "[Configuring user credentials](how-tos/configuring_credentials.md)" for more detail on adding and removing user tokens beyond the quickstart below, or ["Code host interactions in Batch Changes"](explanations/permissions_in_batch_changes.md#code-host-interactions-in-batch-changes) for details on what the permissions are used for.
 
 To add a personal access token:
 
@@ -111,7 +111,7 @@ To add a personal access token:
 1. Select **Settings** from the dropdown menu.
 1. Click **Batch Changes** on the sidebar menu.
 1. Click **Add token** next to the code host you want to configure.
-1. Go to the code host and create a personal access token with the exact scopes or permissions required, which are noted below the token text field. For more provider-specific detail, please refer to "[GitHub](how-tos/configuring_user_credentials.md#github)", "[GitLab](how-tos/configuring_user_credentials.md#gitlab)", or "[Bitbucket Server](how-tos/configuring_user_credentials.md#bitbucket-server)".
+1. Go to the code host and create a personal access token with the exact scopes or permissions required, which are noted below the token text field. For more provider-specific detail, please refer to "[GitHub](how-tos/configuring_credentials.md#github)", "[GitLab](how-tos/configuring_credentials.md#gitlab)", or "[Bitbucket Server](how-tos/configuring_credentials.md#bitbucket-server)".
 1. Click **Add token** to save the token.
 
 The red circle next to the code host will now change to a green tick. Sourcegraph has everything it needs to publish changesets to that code host!

--- a/doc/batch_changes/references/troubleshooting.md
+++ b/doc/batch_changes/references/troubleshooting.md
@@ -144,4 +144,4 @@ Make sure that you put your `steps.run` command in `/tmp-script` (or any other l
 
 ### Do you have the right credentials?
 
-When publishing changesets fails, make sure that the credentials you use have the correct credentials to create changesets on the code host: "[Configuring user credentials](../how-tos/configuring_user_credentials.md)"
+When publishing changesets fails, make sure that the credentials you use have the correct credentials to create changesets on the code host: "[Configuring credentials](../how-tos/configuring_credentials.md)"


### PR DESCRIPTION
This adds documentation pages for site credentials in Batch Changes.

Closes https://github.com/sourcegraph/sourcegraph/issues/19571