### PR TITLE
Return FileMatch from searchFilesInRepo

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -169,9 +169,9 @@ func (lm lineMatchResolver) LimitHit() bool {
 	return lm.LineMatch.LimitHit
 }
 
-var mockSearchFilesInRepo func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
+var mockSearchFilesInRepo func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.FileMatch, limitHit bool, err error)
 
-func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint.Map, repo types.RepoName, gitserverRepo api.RepoName, rev string, index bool, info *search.TextPatternInfo, fetchTimeout time.Duration) ([]*FileMatchResolver, bool, error) {
+func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo types.RepoName, gitserverRepo api.RepoName, rev string, index bool, info *search.TextPatternInfo, fetchTimeout time.Duration) ([]result.FileMatch, bool, error) {
 	if mockSearchFilesInRepo != nil {
 		return mockSearchFilesInRepo(ctx, repo, gitserverRepo, rev, info, fetchTimeout)
 	}
@@ -208,8 +208,7 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 		return nil, false, err
 	}
 
-	repoResolver := NewRepositoryResolver(db, repo.ToRepo())
-	resolvers := make([]*FileMatchResolver, 0, len(matches))
+	resolvers := make([]result.FileMatch, 0, len(matches))
 	for _, fm := range matches {
 		lineMatches := make([]*result.LineMatch, 0, len(fm.LineMatches))
 		for _, lm := range fm.LineMatches {
@@ -225,17 +224,13 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 			})
 		}
 
-		resolvers = append(resolvers, &FileMatchResolver{
-			db: db,
-			FileMatch: result.FileMatch{
-				Path:        fm.Path,
-				LineMatches: lineMatches,
-				LimitHit:    fm.LimitHit,
-				Repo:        repo,
-				CommitID:    commit,
-				InputRev:    &rev,
-			},
-			RepoResolver: repoResolver,
+		resolvers = append(resolvers, result.FileMatch{
+			Path:        fm.Path,
+			LineMatches: lineMatches,
+			LimitHit:    fm.LimitHit,
+			Repo:        repo,
+			CommitID:    commit,
+			InputRev:    &rev,
 		})
 	}
 
@@ -479,7 +474,7 @@ func callSearcherOverRepos(
 					ctx, done := limitCtx, limitDone
 					defer done()
 
-					matches, repoLimitHit, err := searchFilesInRepo(ctx, db, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), repoRev.RevSpecs()[0], index, args.PatternInfo, fetchTimeout)
+					matches, repoLimitHit, err := searchFilesInRepo(ctx, args.SearcherURLs, repoRev.Repo, repoRev.GitserverRepo(), repoRev.RevSpecs()[0], index, args.PatternInfo, fetchTimeout)
 					if err != nil {
 						tr.LogFields(otlog.String("repo", string(repoRev.Repo.Name)), otlog.Error(err), otlog.Bool("timeout", errcode.IsTimeout(err)), otlog.Bool("temporary", errcode.IsTemporary(err)))
 						log15.Warn("searchFilesInRepo failed", "error", err, "repo", repoRev.Repo.Name)
@@ -487,7 +482,7 @@ func callSearcherOverRepos(
 					// non-diff search reports timeout through err, so pass false for timedOut
 					stats, err := handleRepoSearchResult(repoRev, repoLimitHit, false, err)
 					stream.Send(SearchEvent{
-						Results: fileMatchResolversToSearchResults(matches),
+						Results: fileMatchesToSearchResults(db, matches),
 						Stats:   stats,
 					})
 					return err

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -208,7 +208,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 		return nil, false, err
 	}
 
-	resolvers := make([]result.FileMatch, 0, len(matches))
+	fileMatches := make([]result.FileMatch, 0, len(matches))
 	for _, fm := range matches {
 		lineMatches := make([]*result.LineMatch, 0, len(fm.LineMatches))
 		for _, lm := range fm.LineMatches {
@@ -224,7 +224,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 			})
 		}
 
-		resolvers = append(resolvers, result.FileMatch{
+		fileMatches = append(fileMatches, result.FileMatch{
 			Path:        fm.Path,
 			LineMatches: lineMatches,
 			LimitHit:    fm.LimitHit,
@@ -234,7 +234,7 @@ func searchFilesInRepo(ctx context.Context, searcherURLs *endpoint.Map, repo typ
 		})
 	}
 
-	return resolvers, limitHit, err
+	return fileMatches, limitHit, err
 }
 
 // repoShouldBeSearched determines whether a repository should be searched in, based on whether the repository

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -39,21 +39,21 @@ import (
 func TestSearchFilesInRepos(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.FileMatch, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
+			return []result.FileMatch{{
 				Repo:     repo,
 				InputRev: &rev,
 				Path:     "main.go",
-			})}, false, nil
+			}}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
+			return []result.FileMatch{{
 				Repo:     repo,
 				InputRev: &rev,
 				Path:     "main.go",
-			})}, false, nil
+			}}, false, nil
 		case "foo/empty":
 			return nil, false, nil
 		case "foo/cloning":
@@ -132,27 +132,27 @@ func TestSearchFilesInRepos(t *testing.T) {
 func TestSearchFilesInReposStream(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.FileMatch, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
+			return []result.FileMatch{{
 				Repo:     repo,
 				InputRev: &rev,
 				Path:     "main.go",
-			})}, false, nil
+			}}, false, nil
 		case "foo/two":
-			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
+			return []result.FileMatch{{
 				Repo:     repo,
 				InputRev: &rev,
 				Path:     "main.go",
-			})}, false, nil
+			}}, false, nil
 		case "foo/three":
-			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
+			return []result.FileMatch{{
 				Repo:     repo,
 				InputRev: &rev,
 				Path:     "main.go",
-			})}, false, nil
+			}}, false, nil
 		default:
 			return nil, false, errors.New("Unexpected repo")
 		}
@@ -212,15 +212,15 @@ func mkStatusMap(m map[string]search.RepoStatus) search.RepoStatusMap {
 func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.FileMatch, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
-			return []*FileMatchResolver{mkFileMatchResolver(db, result.FileMatch{
+			return []result.FileMatch{{
 				Repo:     repo,
 				InputRev: &rev,
 				Path:     "main.go",
-			})}, false, nil
+			}}, false, nil
 		default:
 			panic("unexpected repo")
 		}


### PR DESCRIPTION
This decouples searchFilesInRepo from GraphQL resolvers, helping
progress the decoupling of search logic from graphqlbackend.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
