### PR TITLE
Return `SymbolMatch` rather than `FileMatchResolver`

### DIFF
--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -89,12 +89,7 @@ func (fm *FileMatchResolver) Resource() string {
 }
 
 func (fm *FileMatchResolver) Symbols() []symbolResolver {
-	commit := fm.Commit()
-	symbols := make([]symbolResolver, len(fm.FileMatch.Symbols))
-	for i, s := range fm.FileMatch.Symbols {
-		symbols[i] = toSymbolResolver(fm.db, commit, s)
-	}
-	return symbols
+	return symbolResultsToResolvers(fm.db, fm.Commit(), fm.FileMatch.Symbols)
 }
 
 func (fm *FileMatchResolver) LineMatches() []lineMatchResolver {


### PR DESCRIPTION
This refactors `searchZoektSymbols` and `computeSymbols` to 
return `[]*result.SymbolMatch` instead of `[]symbolResolver`. This
helps make them independent of GraphQL resolvers so the search logic
can be split out of `graphqlbackend`. 

There are 3 commits, each small and independent:
- First refactors `searchZoektSymbols`
- Second refactors `computeSymbols`, which uses `searchZoektSymbols`
- Third modifies `FileMatchResolver` to use a helper function added for this PR
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
