### PR TITLE
Remove `LimitHit` from `LineMatch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to Sourcegraph are documented in this file.
   - Added a new checklist UI to make it more intuitive to create code monitor trigger queries.
 - Deprecated the GraphQL `icon` field on `GenericSearchResultInterface`. It will be removed in a future release. [#20028](https://github.com/sourcegraph/sourcegraph/pull/20028/files)
 - Creating changesets through Batch Changes as a site-admin without configured Batch Changes credentials has been deprecated. Please configure user or global credentials before Sourcegraph 3.29 to not experience any interruptions in changeset creation. [#20143](https://github.com/sourcegraph/sourcegraph/pull/20143)
+- Deprecated the GraphQL `limitHit` field on `LineMatch`. It will be removed in a future release. [#20164](https://github.com/sourcegraph/sourcegraph/pull/20164)
 
 ### Fixed
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5104,7 +5104,7 @@ type LineMatch {
     """
     Whether or not the limit was hit.
     """
-    limitHit: Boolean!
+    limitHit: Boolean! @deprecated(reason: "will always be false")
 }
 
 """

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -141,7 +141,6 @@ var testSearchGQLQuery = `
 				preview
 				lineNumber
 				offsetAndLengths
-				limitHit
 			}
 		}
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -166,7 +166,7 @@ func (lm lineMatchResolver) OffsetAndLengths() [][]int32 {
 }
 
 func (lm lineMatchResolver) LimitHit() bool {
-	return lm.LineMatch.LimitHit
+	return false
 }
 
 var mockSearchFilesInRepo func(ctx context.Context, repo *types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*FileMatchResolver, limitHit bool, err error)
@@ -221,7 +221,6 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 				Preview:          lm.Preview,
 				OffsetAndLengths: ranges,
 				LineNumber:       int32(lm.LineNumber),
-				LimitHit:         false,
 			})
 		}
 

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -221,7 +221,7 @@ func searchFilesInRepo(ctx context.Context, db dbutil.DB, searcherURLs *endpoint
 				Preview:          lm.Preview,
 				OffsetAndLengths: ranges,
 				LineNumber:       int32(lm.LineNumber),
-				LimitHit:         lm.LimitHit,
+				LimitHit:         false,
 			})
 		}
 

--- a/cmd/searcher/protocol/searcher.go
+++ b/cmd/searcher/protocol/searcher.go
@@ -214,7 +214,4 @@ type LineMatch struct {
 	// representing each match on a line.
 	// Offsets and lengths are measured in characters, not bytes.
 	OffsetAndLengths [][2]int
-
-	// LimitHit is true if OffsetAndLengths may not include all OffsetAndLengths.
-	LimitHit bool
 }

--- a/cmd/searcher/search/search_regex.go
+++ b/cmd/searcher/search/search_regex.go
@@ -269,7 +269,6 @@ func appendMatches(matches []protocol.LineMatch, fileBuf []byte, matchLineBuf []
 			Preview:          string(fileBuf[:limit]),
 			LineNumber:       lineNumber,
 			OffsetAndLengths: [][2]int{{offset, length}},
-			LimitHit:         false, // We will always return false for this field since we no longer limit the number of offsets per line.
 		})
 
 		if eol >= 0 {

--- a/internal/cmd/search-blitz/query.go
+++ b/internal/cmd/search-blitz/query.go
@@ -16,7 +16,6 @@ var graphQLQuery = `fragment FileMatchFields on FileMatch {
 					preview
 					lineNumber
 					offsetAndLengths
-					limitHit
 				}
 			}
 

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -132,5 +132,4 @@ type LineMatch struct {
 	Preview          string
 	OffsetAndLengths [][2]int32
 	LineNumber       int32
-	LimitHit         bool
 }


### PR DESCRIPTION
`LimitHit` is always false because we never limit the number of matches for a single line, so we can safely remove the field. 

Thoughts on whether we should deprecate the graphql field? Or just leave it as always returning false?
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
