### PR TITLE
ci: set 60 min timeout for all steps

### DIFF
--- a/enterprise/dev/ci/internal/buildkite/buildkite.go
+++ b/enterprise/dev/ci/internal/buildkite/buildkite.go
@@ -28,6 +28,7 @@ type BuildOptions struct {
 type Step struct {
 	Label            string                 `json:"label"`
 	Command          []string               `json:"command,omitempty"`
+	TimeoutInMinutes string                 `json:"timeout_in_minutes,omitempty"`
 	Trigger          string                 `json:"trigger,omitempty"`
 	Async            bool                   `json:"async,omitempty"`
 	Build            *BuildOptions          `json:"build,omitempty"`

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -38,6 +38,21 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		env["PERCY_TARGET_BRANCH"] = c.branch
 	}
 
+	// Make all command steps timeout after 60 minutes in case a buildkite agent
+	// got stuck / died.
+	bk.AfterEveryStepOpts = append(bk.AfterEveryStepOpts, func(s *bk.Step) {
+
+		// bk.Step is a union containing fields across all the different step types.
+		// However, "timeout_in_minutes" only applies to the "command" step type.
+		//
+		// Testing the length of the "Command" field seems to be the most reliable way
+		// of differentiating "command" steps from other step types without refactoring
+		// everything.
+		if len(s.Command) > 0 {
+			s.TimeoutInMinutes = "60"
+		}
+	})
+
 	if c.profilingEnabled {
 		bk.AfterEveryStepOpts = append(bk.AfterEveryStepOpts, func(s *bk.Step) {
 			// wrap "time -v" around each command for CPU/RAM utilization information

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -49,7 +49,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 		// of differentiating "command" steps from other step types without refactoring
 		// everything.
 		if len(s.Command) > 0 {
-			s.TimeoutInMinutes = "60"
+			if s.TimeoutInMinutes == "" {
+
+				// Set the default value iff someone else hasn't set a custom one.
+				s.TimeoutInMinutes = "60"
+			}
 		}
 	})
 


### PR DESCRIPTION
This morning, I noticed that there was a [step in a particular build](https://buildkite.com/sourcegraph/sourcegraph/builds/93469#a5af79ab-fc89-452a-ba8f-f039f314a1d5) that was taking 2+ hrs. It had clearly died, but buildkite hadn't detected that for whatever reason. This had the unfortunate effect of backing up the entire image updater pipeline (since its concurrency group logic relies on all the previous steps to pass). 

This PR adds a sanity setting (`timeout_in_minutes`) to make any build step fail if it takes longer than 60 minutes to run. This check isn't meant to be overly aggressive. However, it does avoid other builds being endlessly blocked on a build that has clearly died for whatever reason. 

See https://buildkite.com/docs/pipelines/command-step#command-step-attributes for more info.