### PR TITLE
Change #feedback to feedback

### DIFF
--- a/.github/ISSUE_TEMPLATE/customer_feedback.md
+++ b/.github/ISSUE_TEMPLATE/customer_feedback.md
@@ -2,7 +2,7 @@
 name: 'Customer #feedback'
 about: 'Customer #feedback via an internal Sourcegraph teammate'
 title: ''
-labels: '#feedback'
+labels: 'feedback'
 assignees: ''
 
 ---


### PR DESCRIPTION
Thought I was clever that github handled #feedback but alas, the slack integration can't handle the hashtag.
