### PR TITLE
search frontend: hover information for `contains` predicate

### DIFF
--- a/client/shared/src/search/query/decoratedToken.ts
+++ b/client/shared/src/search/query/decoratedToken.ts
@@ -189,7 +189,9 @@ export enum MetaPredicateKind {
 export interface MetaPredicate {
     type: 'metaPredicate'
     range: CharacterRange
+    groupRange?: CharacterRange
     kind: MetaPredicateKind
+    value: Predicate
 }
 
 /**
@@ -957,12 +959,16 @@ const decoratePredicate = (predicate: Predicate, range: CharacterRange): Decorat
             type: 'metaPredicate',
             kind: MetaPredicateKind.NameAccess,
             range: { start: offset, end: offset + nameAccess.length },
+            groupRange: range,
+            value: predicate,
         })
         offset = offset + nameAccess.length
         decorated.push({
             type: 'metaPredicate',
             kind: MetaPredicateKind.Dot,
             range: { start: offset, end: offset + 1 },
+            groupRange: range,
+            value: predicate,
         })
         offset = offset + 1
     }
@@ -973,6 +979,8 @@ const decoratePredicate = (predicate: Predicate, range: CharacterRange): Decorat
         type: 'metaPredicate',
         kind: MetaPredicateKind.Parenthesis,
         range: { start: offset, end: offset + 1 },
+        groupRange: range,
+        value: predicate,
     })
     offset = offset + 1
     decorated.push(...decoratePredicateBody(predicate.path, body, offset))
@@ -981,6 +989,8 @@ const decoratePredicate = (predicate: Predicate, range: CharacterRange): Decorat
         type: 'metaPredicate',
         kind: MetaPredicateKind.Parenthesis,
         range: { start: offset, end: offset + 1 },
+        groupRange: range,
+        value: predicate,
     })
     return decorated
 }

--- a/client/shared/src/search/query/hover.test.ts
+++ b/client/shared/src/search/query/hover.test.ts
@@ -612,3 +612,23 @@ test('returns hover contents for select', () => {
         }
     `)
 })
+
+test('returns repo:contains hovers', () => {
+    const scannedQuery = toSuccess(scanSearchQuery('repo:contains.file(foo)', false, SearchPatternType.literal))
+
+    expect(getHoverResult(scannedQuery, { column: 8 }, true)).toMatchInlineSnapshot(`
+        {
+          "contents": [
+            {
+              "value": "**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`foo\`."
+            }
+          ],
+          "range": {
+            "startLineNumber": 1,
+            "endLineNumber": 1,
+            "startColumn": 6,
+            "endColumn": 24
+          }
+        }
+    `)
+})

--- a/client/shared/src/search/query/hover.ts
+++ b/client/shared/src/search/query/hover.ts
@@ -13,6 +13,7 @@ import {
     MetaStructuralKind,
     MetaSelector,
     MetaSelectorKind,
+    MetaPredicate,
 } from './decoratedToken'
 import { resolveFilter } from './filters'
 import { Token } from './token'
@@ -154,6 +155,21 @@ const toSelectorHover = (token: MetaSelector): string => {
     }
 }
 
+const toContainsHover = (token: MetaPredicate): string => {
+    const parameters = token.value.parameters.slice(1, -1)
+    switch (token.value.path.join('.')) {
+        case 'contains':
+            return '**Built-in predicate**. Search only inside repositories that satisfy the specified `file:` and `content:` filters. `file:` and `content:` filters should be regular expressions.'
+        case 'contains.file':
+            return `**Built-in predicate**. Search only inside repositories that contain a **file path** matching the regular expression \`${parameters}\`.`
+        case 'contains.content':
+            return `**Built-in predicate**. Search only inside repositories that contain **file content** matching the regular expression \`${parameters}\`.`
+        case 'contains.commit.after':
+            return `**Built-in predicate**. Search only inside repositories that have been committed to since \`${parameters}\`.`
+    }
+    return ''
+}
+
 const toHover = (token: DecoratedToken): string => {
     switch (token.type) {
         case 'pattern': {
@@ -170,6 +186,9 @@ const toHover = (token: DecoratedToken): string => {
             return toSelectorHover(token)
         case 'metaStructural':
             return toStructuralHover(token)
+        case 'metaPredicate': {
+            return toContainsHover(token)
+        }
     }
     return ''
 }
@@ -229,12 +248,11 @@ export const getHoverResult = (
                 range = toMonacoRange(token.range)
                 break
             case 'metaRegexp':
+            case 'metaStructural':
+            case 'metaPredicate':
                 values.push(toHover(token))
                 range = toMonacoRange(token.groupRange ? token.groupRange : token.range)
                 break
-            case 'metaStructural':
-                values.push(toHover(token))
-                range = toMonacoRange(token.groupRange ? token.groupRange : token.range)
         }
     })
     return {


### PR DESCRIPTION
Stacked on #20181. 

Adds hovers for various `contains(...)` filter predicates. 

<img width="767" alt="Screen Shot 2021-04-19 at 9 57 52 PM" src="https://user-images.githubusercontent.com/888624/115339817-5fb8b080-a15a-11eb-8e2a-bcad8e8479c7.png">

Implementation details: For highlighting, we want to treat subparts of the syntax separately, but for hovers, it's beneficial to group them together. To avoid repeating work filtering and parsing values, I've decided to associate the full predicate value with each subpart of decoration tokens so that it's easier to access in the hover logic. This adds redundant values but heavily cuts down on repeated work and control flow complexity. I'll think about trying to remove this redundancy but preserve clarity at some point.