### PR TITLE
Fix regexp patterns in site schema to also work in JavaScript regexp

### DIFF
--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -322,7 +322,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^(mon(day)?|tue(s|sday)?|wed(nesday)?|thu(r|rs|rsday)?|fri(day)?|sat(urday)?|sun(day)?)$"
+              "pattern": "^([mM]on(day)?|[tT]ue(s|sday)?|[wW]ed(nesday)?|[tT]hu(r|rs|rsday)?|[fF]ri(day)?|[sS]at(urday)?|[sS]un(day)?)$"
             }
           }
         },

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -303,7 +303,7 @@
               { "type": "number", "minimum": 0, "maximum": 0 },
               {
                 "type": "string",
-                "pattern": "^(?i)(unlimited|[0-9]+/(sec|secs|second|seconds|min|mins|minute|minutes|hr|hrs|hour|hours))$"
+                "pattern": "^(unlimited|[0-9]+\\/(sec|secs|second|seconds|min|mins|minute|minutes|hr|hrs|hour|hours))$"
               }
             ]
           },
@@ -322,7 +322,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "pattern": "^(?i)(mon(day)?|tue(s|sday)?|wed(nesday)?|thu(r|rs|rsday)?|fri(day)?|sat(urday)?|sun(day)?)$"
+              "pattern": "^(mon(day)?|tue(s|sday)?|wed(nesday)?|thu(r|rs|rsday)?|fri(day)?|sat(urday)?|sun(day)?)$"
             }
           }
         },


### PR DESCRIPTION
The `/` needs to be escaped in JS regexp, and flags like `(?i)` are not allowed. This change causes it to be case-sensitive, but it's the best I could come up with in a short amount of time.
Better case-insensitive, than broken for the release, I guess.

Closes https://github.com/sourcegraph/sourcegraph/issues/20205