### PR TITLE
Add env var to prevent down migrations decrypting tables, add encryption to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Added
 
--
+- Database encryption, external service config & user auth data can now be encrypted in the database using the `encryption.keys` config. See [the docs](https://docs.sourcegraph.com/admin/encryption) for more info.
 
 ### Changed
 

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -178,11 +178,13 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 
 	// Run a background job to handle encryption of external service configuration.
 	extsvcMigrator := database.NewExternalServiceConfigMigratorWithDB(db)
+	extsvcMigrator.AllowDecrypt = os.Getenv("ALLOW_DECRYPT_MIGRATION") == "true"
 	if err := outOfBandMigrationRunner.Register(extsvcMigrator.ID(), extsvcMigrator, oobmigration.MigratorOptions{Interval: 3 * time.Second}); err != nil {
 		log.Fatalf("failed to run external service encryption job: %v", err)
 	}
 	// Run a background job to handle encryption of external service configuration.
 	extAccMigrator := database.NewExternalAccountsMigratorWithDB(db)
+	extAccMigrator.AllowDecrypt = os.Getenv("ALLOW_DECRYPT_MIGRATION") == "true"
 	if err := outOfBandMigrationRunner.Register(extAccMigrator.ID(), extAccMigrator, oobmigration.MigratorOptions{Interval: 3 * time.Second}); err != nil {
 		log.Fatalf("failed to run user external account encryption job: %v", err)
 	}

--- a/doc/admin/config/encryption.md
+++ b/doc/admin/config/encryption.md
@@ -31,5 +31,22 @@ To enable encryption you must specify key config for each of the keys defined in
 ## Migration
 When you first enable encryption two migrations will begin in the UI (https://sourcegraph.example.com/site-admin/migrations) called 'Encrypt auth data' and 'Encrypt configuration'. These jobs watch the site config waiting for a key to be configured and then iterate over all data in the relevant tables & encrypt it. Once these two migrations reach 100% your data will be fully encrypted! You can still use sourcegraph whilst these migrations are progressing, any unencrypted data will be read as normal, and encrypted if you update it.
 
-## Key Rotation
+## Key rotation
 If you use the Google Cloud KMS backend (or other future API based encryption backend) key rotation will be handled for you by the API. Currently key rotation is not supported in the 'mounted key' backend.
+
+## Disabling encryption
+If you decide to disable encryption, or want to switch to a new key, you must first decrypt the database. In order to do this you have to do a few things:
+* set the env var `ALLOW_DECRYPT_MIGRATION` to `true` on the `frontent` service. this allows decryptions to run, and prevents arbitrary queries decrypting the database.
+* update the migration to run the decryption (see SQL below).
+* once the migrations are complete, remove the keys from site config.
+
+Bear in mind that any new writes during these migrations will still be encrypted, the migrations will automatically pick them up & decrypt them.
+
+In order to reverse the migration you should update the migrations to set `apply_reverse` to true:
+```sql
+    -- for the external_services migration
+    UPDATE out_of_band_migrations SET apply_reverse = true WHERE id = 3;
+
+    -- for the user_external_accounts migration
+    UPDATE out_of_band_migrations SET apply_reverse = true WHERE id = 6;
+``` 

--- a/doc/admin/config/encryption.md
+++ b/doc/admin/config/encryption.md
@@ -36,7 +36,7 @@ If you use the Google Cloud KMS backend (or other future API based encryption ba
 
 ## Disabling encryption
 If you decide to disable encryption, or want to switch to a new key, you must first decrypt the database. In order to do this you have to do a few things:
-* set the env var `ALLOW_DECRYPT_MIGRATION` to `true` on the `frontent` service. this allows decryptions to run, and prevents arbitrary queries decrypting the database.
+* set the env var `ALLOW_DECRYPT_MIGRATION` to `true` on the `frontend` service. this allows decryptions to run, and prevents arbitrary queries decrypting the database.
 * update the migration to run the decryption (see SQL below).
 * once the migrations are complete, remove the keys from site config.
 

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
+const AllowDecryptMigration = "ALLOW_DECRYPT_MIGRATION"
+
 // ExternalServiceConfigMigrator is a background job that encrypts
 // external services config on startup.
 // It periodically waits until a keyring is configured to determine
@@ -117,7 +119,7 @@ func (m *ExternalServiceConfigMigrator) Down(ctx context.Context) (err error) {
 		return nil
 	}
 
-	if os.Getenv("ALLOW_DECRYPT_MIGRATION") != "true" {
+	if os.Getenv(AllowDecryptMigration) != "true" {
 		return nil
 	}
 
@@ -317,7 +319,7 @@ func (m *ExternalAccountsMigrator) Down(ctx context.Context) (err error) {
 		return nil
 	}
 
-	if os.Getenv("ALLOW_DECRYPT_MIGRATION") != "true" {
+	if os.Getenv(AllowDecryptMigration) != "true" {
 		return nil
 	}
 

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"os"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
@@ -113,6 +114,10 @@ func (m *ExternalServiceConfigMigrator) Up(ctx context.Context) (err error) {
 func (m *ExternalServiceConfigMigrator) Down(ctx context.Context) (err error) {
 	key := keyring.Default().ExternalServiceKey
 	if key == nil {
+		return nil
+	}
+
+	if os.Getenv("ALLOW_DECRYPT_MIGRATION") != "true" {
 		return nil
 	}
 
@@ -309,6 +314,10 @@ func (m *ExternalAccountsMigrator) Up(ctx context.Context) (err error) {
 func (m *ExternalAccountsMigrator) Down(ctx context.Context) (err error) {
 	key := keyring.Default().UserExternalAccountKey
 	if key == nil {
+		return nil
+	}
+
+	if os.Getenv("ALLOW_DECRYPT_MIGRATION") != "true" {
 		return nil
 	}
 

--- a/internal/database/oob_migrate.go
+++ b/internal/database/oob_migrate.go
@@ -3,7 +3,6 @@ package database
 import (
 	"context"
 	"database/sql"
-	"os"
 
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
@@ -14,8 +13,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-const AllowDecryptMigration = "ALLOW_DECRYPT_MIGRATION"
-
 // ExternalServiceConfigMigrator is a background job that encrypts
 // external services config on startup.
 // It periodically waits until a keyring is configured to determine
@@ -24,8 +21,9 @@ const AllowDecryptMigration = "ALLOW_DECRYPT_MIGRATION"
 // migration package.
 // The migration is non destructive and can be reverted.
 type ExternalServiceConfigMigrator struct {
-	store     *basestore.Store
-	BatchSize int
+	store        *basestore.Store
+	BatchSize    int
+	AllowDecrypt bool
 }
 
 func NewExternalServiceConfigMigrator(store *basestore.Store) *ExternalServiceConfigMigrator {
@@ -119,7 +117,7 @@ func (m *ExternalServiceConfigMigrator) Down(ctx context.Context) (err error) {
 		return nil
 	}
 
-	if os.Getenv(AllowDecryptMigration) != "true" {
+	if !m.AllowDecrypt {
 		return nil
 	}
 
@@ -195,8 +193,9 @@ func (m *ExternalServiceConfigMigrator) listConfigsForUpdate(ctx context.Context
 // migration package.
 // The migration is non destructive and can be reverted.
 type ExternalAccountsMigrator struct {
-	store     *basestore.Store
-	BatchSize int
+	store        *basestore.Store
+	BatchSize    int
+	AllowDecrypt bool
 }
 
 func NewExternalAccountsMigrator(store *basestore.Store) *ExternalAccountsMigrator {
@@ -319,7 +318,7 @@ func (m *ExternalAccountsMigrator) Down(ctx context.Context) (err error) {
 		return nil
 	}
 
-	if os.Getenv(AllowDecryptMigration) != "true" {
+	if !m.AllowDecrypt {
 		return nil
 	}
 

--- a/internal/database/oob_migrate_test.go
+++ b/internal/database/oob_migrate_test.go
@@ -36,9 +36,9 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 		}
 	}
 
-	os.Setenv("ALLOW_DECRYPT_MIGRATION", "true")
+	os.Setenv(AllowDecryptMigration, "true")
 	t.Cleanup(func() {
-		os.Setenv("ALLOW_DECRYPT_MIGRATION", "")
+		os.Setenv(AllowDecryptMigration, "")
 	})
 
 	t.Run("Up/Down/Progress", func(t *testing.T) {
@@ -294,7 +294,7 @@ func TestExternalServiceConfigMigrator(t *testing.T) {
 			}
 		}
 
-		os.Setenv("ALLOW_DECRYPT_MIGRATION", "")
+		os.Setenv(AllowDecryptMigration, "")
 
 		// setup key after storing the services
 		defer setupKey()()
@@ -631,7 +631,7 @@ func TestExternalAccountsMigrator(t *testing.T) {
 		}
 
 		// disallow decryption
-		os.Setenv("ALLOW_DECRYPT_MIGRATION", "")
+		os.Setenv(AllowDecryptMigration, "")
 
 		// revert the migration
 		if err := migrator.Down(ctx); err != nil {


### PR DESCRIPTION
I realised that anyone with database access could just decrypt tables by setting apply_reverse = true on the table, @eseliger recommended a safety of an env var that must be set to enable this to happen.

https://sourcegraph.slack.com/archives/CHPC7UX16/p1618905663056700

i've also added to CHANGELOG

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
