### PR TITLE
Introduce `disableAutoCodeHostSyncs` site config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Repositories that gitserver fails to clone or fetch are now gradually moved to the back of the background update queue instead of remaining at the front. [#20204](https://github.com/sourcegraph/sourcegraph/pull/20204)
+- The new `disableAutoCodeHostSyncs` setting allows site admins to disable any periodic background syncing of configured code host connections. That includes syncing of repository metadata (i.e. not git updates, use `disableAutoGitUpdates` for that), permissions and batch changes changesets, but may include other data we'd sync from the code host API in the future.
 
 ### Changed
 

--- a/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
+++ b/enterprise/cmd/repo-updater/internal/authz/perms_syncer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/licensing"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -757,13 +758,15 @@ func (s *PermsSyncer) schedule(ctx context.Context) (*schedule, error) {
 
 // isDisabled returns true if the background permissions syncing is not enabled.
 // It is not enabled if:
-// 	- Permissions user mapping is enabled
-// 	- No authz provider is configured
-//	- Not purchased with the current license
+//   - Permissions user mapping is enabled
+//   - No authz provider is configured
+//   - Not purchased with the current license
+//   - `disableAutoCodeHostSyncs` site setting is set to true
 func (s *PermsSyncer) isDisabled() bool {
 	return globals.PermissionsUserMapping().Enabled ||
 		len(s.providersByServiceID()) == 0 ||
-		(licensing.EnforceTiers && licensing.Check(licensing.FeatureACLs) != nil)
+		(licensing.EnforceTiers && licensing.Check(licensing.FeatureACLs) != nil) ||
+		conf.Get().DisableAutoCodeHostSyncs
 }
 
 func (s *PermsSyncer) runSchedule(ctx context.Context) {

--- a/enterprise/internal/batches/resolvers/changeset.go
+++ b/enterprise/internal/batches/resolvers/changeset.go
@@ -22,6 +22,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/config"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -194,6 +195,12 @@ func (r *changesetResolver) UpdatedAt() graphqlbackend.DateTime {
 }
 
 func (r *changesetResolver) NextSyncAt(ctx context.Context) (*graphqlbackend.DateTime, error) {
+	// If code host syncs are disabled, the syncer is not actively syncing
+	// changesets and the next sync time cannot be determined.
+	if conf.Get().DisableAutoCodeHostSyncs {
+		return nil, nil
+	}
+
 	nextSyncAt, err := r.computeNextSyncAt(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/repos/syncer.go
+++ b/internal/repos/syncer.go
@@ -98,8 +98,11 @@ func (s *Syncer) Run(ctx context.Context, db *sql.DB, store *Store, opts RunOpti
 	defer resetter.Stop()
 
 	for ctx.Err() == nil {
-		if err := store.EnqueueSyncJobs(ctx, opts.IsCloud); err != nil && s.Logger != nil {
-			s.Logger.Error("Enqueuing sync jobs", "error", err)
+		if !conf.Get().DisableAutoCodeHostSyncs {
+			err := store.EnqueueSyncJobs(ctx, opts.IsCloud)
+			if err != nil && s.Logger != nil {
+				s.Logger.Error("Enqueuing sync jobs", "error", err)
+			}
 		}
 		sleep(ctx, opts.EnqueueInterval())
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1363,6 +1363,8 @@ type SiteConfiguration struct {
 	CorsOrigin string `json:"corsOrigin,omitempty"`
 	// DebugSearchSymbolsParallelism description: (debug) controls the amount of symbol search parallelism. Defaults to 20. It is not recommended to change this outside of debugging scenarios. This option will be removed in a future version.
 	DebugSearchSymbolsParallelism int `json:"debug.search.symbolsParallelism,omitempty"`
+	// DisableAutoCodeHostSyncs description: Disable periodic syncs of configured code host connections (repository metadata, permissions, batch changes changesets, etc)
+	DisableAutoCodeHostSyncs bool `json:"disableAutoCodeHostSyncs,omitempty"`
 	// DisableAutoGitUpdates description: Disable periodically fetching git contents for existing repositories.
 	DisableAutoGitUpdates bool `json:"disableAutoGitUpdates,omitempty"`
 	// DisableBuiltInSearches description: Whether built-in searches should be hidden on the Searches page.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -363,6 +363,12 @@
       "default": false,
       "group": "External services"
     },
+    "disableAutoCodeHostSyncs": {
+      "description": "Disable periodic syncs of configured code host connections (repository metadata, permissions, batch changes changesets, etc)",
+      "type": "boolean",
+      "default": false,
+      "group": "External services"
+    },
     "gitUpdateInterval": {
       "description": "JSON array of repo name patterns and update intervals. If a repo matches a pattern, the associated interval will be used. If it matches no patterns a default backoff heuristic will be used. Pattern matches are attempted in the order they are provided.",
       "type": "array",


### PR DESCRIPTION
This PR introduces a `disableAutoCodeHostSyncs` setting that disables any periodic background syncs with configured code host connections, while still allowing interactive user requests to succeed.