### PR TITLE
On quickstart show that Postgres min version is 12

### DIFF
--- a/doc/dev/getting-started/quickstart_1_install_dependencies.md
+++ b/doc/dev/getting-started/quickstart_1_install_dependencies.md
@@ -9,7 +9,7 @@ Sourcegraph has the following dependencies:
 - [make](https://www.gnu.org/software/make/)
 - [Docker](https://docs.docker.com/engine/installation/) (v18 or higher)
   - For macOS we recommend using Docker for Mac instead of `docker-machine`
-- [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides) (v11 or higher)
+- [PostgreSQL](https://wiki.postgresql.org/wiki/Detailed_installation_guides) (v12 or higher)
 - [Redis](http://redis.io/) (v5.0.7 or higher)
 - [Yarn](https://yarnpkg.com) (v1.10.1 or higher)
 - [SQLite](https://www.sqlite.org/index.html) tools


### PR DESCRIPTION
In PR #19424 we bumped the minimum version of Postgres to be 12.  This small calls out that minimum version in our quickstart guide too for development.