### PR TITLE
extensibility: fix diff status bar keys

### DIFF
--- a/client/web/src/components/diff/FileDiffHunks.tsx
+++ b/client/web/src/components/diff/FileDiffHunks.tsx
@@ -146,8 +146,16 @@ export const FileDiffHunks: React.FunctionComponent<FileHunksProps> = ({
                 map(([baseStatusBarItems, headStatusBarItems]) => {
                     if (baseStatusBarItems && headStatusBarItems) {
                         return [
-                            ...baseStatusBarItems.map(({ text, ...rest }) => ({ text: `base: ${text}`, ...rest })),
-                            ...headStatusBarItems.map(({ text, ...rest }) => ({ text: `head: ${text}`, ...rest })),
+                            ...baseStatusBarItems.map(({ text, key, ...rest }) => ({
+                                text: `base: ${text}`,
+                                key: `base-${key}`,
+                                ...rest,
+                            })),
+                            ...headStatusBarItems.map(({ text, key, ...rest }) => ({
+                                text: `head: ${text}`,
+                                key: `head-${key}`,
+                                ...rest,
+                            })),
                         ]
                     }
 


### PR DESCRIPTION
We currently use duplicate keys when extensions set status bar items for both base and head