### PR TITLE
Adding troubleshooting for rate limit

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -109,7 +109,10 @@ GitHub connections support the following configuration options, which are specif
 
 ## Troubleshooting
 
-### RepositoryQuery returns first 1000 results only
+### Hitting GitHub Search API rate limit with repositoryQuery
+Sometimes when Sourcegraph is synching many repositories via `repositoryQuery` githubs search rate limit will surpassed displaying an error like `failed to list GitHub repositories for search: page=..., searchString=\"...\"` to work around this try setting `repoListUpdateInterval` in your Sourcegraph [site config] (https://docs.sourcegraph.com/admin/config/site_config). `repositoryQuery` is the only repo syncing method that consumes GitHub search API quota, so if setting `repoListUpdateInterval` doesn't work consider switching your synching method to use another option, like `orgs`.
+
+### repositoryQuery returns first 1000 results only
 
 GitHub's [Search API](https://developer.github.com/v3/search/) only returns the first 1000 results. Therefore a `repositoryQuery` (other than the three pre-defined options) needs to return a 1000 results or less otherwise Sourcegraph will not synchronize some repositories. To workaround this limitation you can split your query into multiple queries, each returning less than a 1000 results. For example if your query is `org:Microsoft fork:no` you can adjust your query to:
 

--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -110,7 +110,11 @@ GitHub connections support the following configuration options, which are specif
 ## Troubleshooting
 
 ### Hitting GitHub Search API rate limit with repositoryQuery
-Sometimes when Sourcegraph is synching many repositories via `repositoryQuery` githubs search rate limit will surpassed displaying an error like `failed to list GitHub repositories for search: page=..., searchString=\"...\"` to work around this try setting `repoListUpdateInterval` in your Sourcegraph [site config] (https://docs.sourcegraph.com/admin/config/site_config). `repositoryQuery` is the only repo syncing method that consumes GitHub search API quota, so if setting `repoListUpdateInterval` doesn't work consider switching your synching method to use another option, like `orgs`.
+When Sourcegraph syncs repositories configured  via `repositoryQuery`, it consumes GitHub API search rate limit, which is lower than the normal rate limit. The `affiliated`, `public` and `none` special values, however, trigger normal API requests instead of search API requests.
+
+When the search rate limit quota is exhausted, an error like `failed to list GitHub repositories for search: page=..., searchString=\"...\"` can be found in logs. To work around this try reducing the frequency with which repository syncing happens by setting a higher value (in minutes) of `repoListUpdateInterval` in your Sourcegraph [site config] (https://docs.sourcegraph.com/admin/config/site_config).
+
+`repositoryQuery` is the only repo syncing method that consumes GitHub search API quota, so if setting `repoListUpdateInterval` doesn't work consider switching your synching method to use another option, like `orgs`, or using one of the special values described above.
 
 ### repositoryQuery returns first 1000 results only
 


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
This is an addition to the GitHub repo syncing docs to cover hitting the rate limit for the search API while using the repositoryQuery option