### PR TITLE
Refactor licensing resolver to new schema

### DIFF
--- a/cmd/frontend/enterprise/enterprise.go
+++ b/cmd/frontend/enterprise/enterprise.go
@@ -46,7 +46,6 @@ func DefaultServices() Services {
 		AuthzResolver:             graphqlbackend.DefaultAuthzResolver,
 		InsightsResolver:          graphqlbackend.DefaultInsightsResolver,
 		CodeMonitorsResolver:      graphqlbackend.DefaultCodeMonitorsResolver,
-		LicenseResolver:           graphqlbackend.DefaultLicenseResolver,
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -371,6 +371,8 @@ func NewSchema(db dbutil.DB, batchChanges BatchChangesResolver, codeIntel CodeIn
 	if license != nil {
 		EnterpriseResolvers.licenseResolver = license
 		resolver.LicenseResolver = license
+		schemas = append(schemas, LicenseSchema)
+		// No NodeByID handlers currently.
 	}
 
 	if dotcom != nil {
@@ -417,7 +419,6 @@ func newSchemaResolver(db dbutil.DB) *schemaResolver {
 
 		AuthzResolver:    defaultAuthzResolver{},
 		InsightsResolver: defaultInsightsResolver{},
-		LicenseResolver:  defaultLicenseResolver{},
 	}
 
 	r.nodeByIDFns = map[string]NodeByIDFunc{
@@ -483,7 +484,6 @@ var EnterpriseResolvers = struct {
 }{
 	authzResolver:        defaultAuthzResolver{},
 	codeMonitorsResolver: defaultCodeMonitorsResolver{},
-	licenseResolver:      defaultLicenseResolver{},
 }
 
 // DEPRECATED

--- a/cmd/frontend/graphqlbackend/license.go
+++ b/cmd/frontend/graphqlbackend/license.go
@@ -9,13 +9,3 @@ type LicenseResolver interface {
 type EnterpriseLicenseHasFeatureArgs struct {
 	Feature string
 }
-
-type defaultLicenseResolver struct{}
-
-var DefaultLicenseResolver = defaultLicenseResolver{}
-
-func (defaultLicenseResolver) EnterpriseLicenseHasFeature(ctx context.Context, args *EnterpriseLicenseHasFeatureArgs) (bool, error) {
-	// By definition, no enterprise features are available in the open source
-	// version of Sourcegraph.
-	return false, nil
-}

--- a/cmd/frontend/graphqlbackend/license.graphql
+++ b/cmd/frontend/graphqlbackend/license.graphql
@@ -1,0 +1,6 @@
+extend type Query {
+    """
+    Checks whether the given feature is enabled on Sourcegraph.
+    """
+    enterpriseLicenseHasFeature(feature: String!): Boolean!
+}

--- a/cmd/frontend/graphqlbackend/schema.go
+++ b/cmd/frontend/graphqlbackend/schema.go
@@ -19,3 +19,7 @@ var CodeIntelSchema string
 // DotcomSchema is the Dotcom schema extension raw graqhql schema.
 //go:embed dotcom.graphql
 var DotcomSchema string
+
+// LicenseSchema is the Licensing raw graqhql schema.
+//go:embed license.graphql
+var LicenseSchema string

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1526,12 +1526,6 @@ type Query {
     affiliatedRepositories(user: ID!, codeHost: ID, query: String): CodeHostRepositoryConnection!
 
     """
-    Checks whether the given feature is enabled on Sourcegraph. Open source
-    installations will always return false for any feature.
-    """
-    enterpriseLicenseHasFeature(feature: String!): Boolean!
-
-    """
     Retrieve all registered out-of-band migrations.
     """
     outOfBandMigrations: [OutOfBandMigration!]!


### PR DESCRIPTION
This resolver still uses quite a few global assignments, but one step at a time.
