### PR TITLE
web: add Bootstrap breakpoints mixins entry-point for CSS modules

### DIFF
--- a/client/branded/src/global-styles/breakpoints.scss
+++ b/client/branded/src/global-styles/breakpoints.scss
@@ -2,7 +2,8 @@
 // @import 'branded/src/global-styles/breakpoints';
 
 // `$grid-breakpoints` is copied from `~bootstrap/scss/variables` because we cannot import a single variable from SCSS file
-// and we don't want to expose all Bootstrap SCSS variables ('bootstrap/scss/variables') to our CSS modules. CSS variables should be used instead.
+// and we don't want to expose all Bootstrap SCSS variables ('bootstrap/scss/variables') to our CSS modules.
+// If possible, prefer CSS variables to SCSS variables.
 $grid-breakpoints: (
     xs: 0,
     sm: 576px,

--- a/client/branded/src/global-styles/breakpoints.scss
+++ b/client/branded/src/global-styles/breakpoints.scss
@@ -1,0 +1,14 @@
+// To use breakpoints mixins in CSS modules import this file via:
+// @import 'branded/src/global-styles/breakpoints';
+
+// `$grid-breakpoints` is copied from `~bootstrap/scss/variables` because we cannot import a single variable from SCSS file
+// and we don't want to expose all Bootstrap SCSS variables ('bootstrap/scss/variables') to our CSS modules. CSS variables should be used instead.
+$grid-breakpoints: (
+    xs: 0,
+    sm: 576px,
+    md: 768px,
+    lg: 992px,
+    xl: 1200px,
+) !default;
+
+@import '~bootstrap/scss/mixins/breakpoints';

--- a/client/branded/src/global-styles/breakpoints.scss
+++ b/client/branded/src/global-styles/breakpoints.scss
@@ -9,6 +9,6 @@ $grid-breakpoints: (
     md: 768px,
     lg: 992px,
     xl: 1200px,
-) !default;
+);
 
 @import '~bootstrap/scss/mixins/breakpoints';

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -99,7 +99,7 @@ $collapsible-expand-btn-width: 1.25rem;
 $hr-border-color: var(--border-color);
 $hr-margin-y: 0.25rem;
 
-// Exposes breakpoints mixins to CSS modules
+// './breakpoints' defines $grid-breakpoints for global CSS and exposes breakpoints mixins to CSS modules
 @import './breakpoints';
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -1,9 +1,3 @@
-// Media breakpoints
-$media-sm: 576px;
-$media-md: 768px;
-$media-lg: 992px;
-$media-xl: 1200px;
-
 @import './colors.scss';
 
 // Bootstrap configuration before Bootstrap is imported
@@ -105,6 +99,8 @@ $collapsible-expand-btn-width: 1.25rem;
 $hr-border-color: var(--border-color);
 $hr-margin-y: 0.25rem;
 
+// Exposes breakpoints mixins to CSS modules
+@import './breakpoints';
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins';

--- a/client/browser/config/webpack/base.config.ts
+++ b/client/browser/config/webpack/base.config.ts
@@ -21,6 +21,7 @@ const babelLoader = {
 }
 
 const extensionHostWorker = /main\.worker\.ts$/
+const rootPath = path.resolve(__dirname, '../../../../')
 
 const getCSSLoaders = (...loaders: webpack.RuleSetUseItem[]): webpack.RuleSetUse => [
     MiniCssExtractPlugin.loader,
@@ -32,7 +33,7 @@ const getCSSLoaders = (...loaders: webpack.RuleSetUseItem[]): webpack.RuleSetUse
         loader: 'sass-loader',
         options: {
             sassOptions: {
-                includePaths: [path.resolve(__dirname, '../../../node_modules')],
+                includePaths: [path.resolve(rootPath, 'node_modules'), path.resolve(rootPath, 'client')],
             },
         },
     },

--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -7,12 +7,6 @@ $border-radius-lg: 4px;
 $font-size-base: 0.875rem;
 $line-height-base: (20/14);
 
-// Media breakpoints
-$media-sm: 576px;
-$media-md: 768px;
-$media-lg: 992px;
-$media-xl: 1200px;
-
 :root {
     --border-color: rgba(0, 0, 0, 0.125);
     --mark-bg: #{$mark-bg-light};

--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -19,7 +19,7 @@ const getCSSLoaders = (...loaders: RuleSetUseItem[]): RuleSetUse => [
         loader: 'sass-loader',
         options: {
             sassOptions: {
-                includePaths: [path.resolve(rootPath, 'node_modules')],
+                includePaths: [path.resolve(rootPath, 'node_modules'), path.resolve(rootPath, 'client')],
             },
         },
     },

--- a/client/web/src/enterprise/productSubscription/TrueUpStatusSummary.scss
+++ b/client/web/src/enterprise/productSubscription/TrueUpStatusSummary.scss
@@ -7,7 +7,7 @@
 
     &__item {
         width: 32%;
-        @media (max-width: $media-md) {
+        @include media-breakpoint-up(md) {
             width: 100%;
             margin-bottom: 1rem;
         }

--- a/client/web/src/repo/tree/TreeEntriesSection.scss
+++ b/client/web/src/repo/tree/TreeEntriesSection.scss
@@ -11,13 +11,13 @@
         column-rule: 1px solid var(--border-color);
         border-right: solid 1px var(--border-color);
 
-        @media (max-width: $media-sm) {
+        @include media-breakpoint-up(sm) {
             column-count: 1;
         }
-        @media (max-width: $media-md) {
+        @include media-breakpoint-up(md) {
             column-count: 3;
         }
-        @media (min-width: $media-md) {
+        @include media-breakpoint-down(md) {
             column-count: 4;
         }
     }

--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -21,7 +21,7 @@
             margin-bottom: 0.125rem;
         }
 
-        max-width: $media-xl;
+        max-width: map-get($grid-breakpoints, xl);
 
         &-search {
             display: flex;

--- a/client/web/src/search/queryBuilder/QueryBuilder.scss
+++ b/client/web/src/search/queryBuilder/QueryBuilder.scss
@@ -38,7 +38,7 @@
         &-example {
             font-weight: bold;
 
-            @media (max-width: $media-md) {
+            @include media-breakpoint-up(md) {
                 display: none;
             }
         }
@@ -63,7 +63,7 @@
             display: flex;
             align-items: center;
 
-            @media (max-width: $media-md) {
+            @include media-breakpoint-up(md) {
                 width: 100%;
             }
         }

--- a/client/web/src/site-admin/SiteAdminSurveyResponsesPage.scss
+++ b/client/web/src/site-admin/SiteAdminSurveyResponsesPage.scss
@@ -7,7 +7,7 @@
 
     &__item {
         width: 32%;
-        @media (max-width: $media-md) {
+        @include media-breakpoint-up(md) {
             width: 100%;
             margin-bottom: 1rem;
         }

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -23,8 +23,8 @@ if (shouldAnalyze) {
   logger.info('Running bundle analyzer')
 }
 
-const rootDirectory = path.resolve(__dirname, '..', '..')
-const nodeModulesPath = path.resolve(rootDirectory, 'node_modules')
+const rootPath = path.resolve(__dirname, '..', '..')
+const nodeModulesPath = path.resolve(rootPath, 'node_modules')
 const monacoEditorPaths = [path.resolve(nodeModulesPath, 'monaco-editor')]
 
 const isEnterpriseBuild = !!process.env.ENTERPRISE
@@ -45,7 +45,7 @@ const extensionHostWorker = /main\.worker\.ts$/
  * Useful to ensure that we use the same configuration for shared loaders: postcss-loader, sass-loader, etc.
  *
  * @param {import('webpack').RuleSetUseItem[]} loaders additional CSS loaders
- * @returns {import('webpack').RuleSetUse} array of CSS loaders
+ * @returns {import('webpack').RuleSetUseItem[]} array of CSS loaders
  */
 const getCSSLoaders = (...loaders) => [
   // Use style-loader for local development as it is significantly faster.
@@ -57,7 +57,7 @@ const getCSSLoaders = (...loaders) => [
     options: {
       sassOptions: {
         implementation: require('sass'),
-        includePaths: [nodeModulesPath],
+        includePaths: [nodeModulesPath, path.resolve(rootPath, 'client')],
       },
     },
   },
@@ -103,7 +103,7 @@ const config = {
     'json.worker': 'monaco-editor/esm/vs/language/json/json.worker',
   },
   output: {
-    path: path.join(rootDirectory, 'ui', 'assets'),
+    path: path.join(rootPath, 'ui', 'assets'),
     // Do not [hash] for development -- see https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
     filename: mode === 'production' ? 'scripts/[name].[contenthash].bundle.js' : 'scripts/[name].bundle.js',
     chunkFilename: mode === 'production' ? 'scripts/[id]-[contenthash].chunk.js' : 'scripts/[id].chunk.js',
@@ -155,10 +155,7 @@ const config = {
     alias: {
       // react-visibility-sensor's main field points to a UMD bundle instead of ESM
       // https://github.com/joshwnj/react-visibility-sensor/issues/148
-      'react-visibility-sensor': path.resolve(
-        rootDirectory,
-        'node_modules/react-visibility-sensor/visibility-sensor.js'
-      ),
+      'react-visibility-sensor': path.resolve(rootPath, 'node_modules/react-visibility-sensor/visibility-sensor.js'),
     },
   },
   module: {

--- a/doc/dev/background-information/web/styling.md
+++ b/doc/dev/background-information/web/styling.md
@@ -73,6 +73,22 @@ import styles from './PageSelector.module.scss'
 <button className={styles.pageSelectorButton} />
 ```
 
+To use mixins/functions provided by Bootstrap in CSS modules use explicit imports to the required module.
+
+```scss
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/mixins/caret';
+```
+
+It's not safe to import all global Bootstrap helpers and variables into the CSS module because we redefine many Bootstrap variables on our side.
+If mixin relies on Bootstrap variables create an entry point for the target mixin which ensures that it uses correct SCSS variables.
+
+```scss
+@import 'branded/src/global-styles/breakpoints';
+```
+
+Do not use SCSS variables in CSS modules. Prefer CSS variables instead.
+
 #### BEM convention
 
 The older approach is the [BEM convention](http://getbem.com/naming/) (Block - Element - Modifier).

--- a/doc/dev/background-information/web/styling.md
+++ b/doc/dev/background-information/web/styling.md
@@ -81,13 +81,14 @@ To use mixins/functions provided by Bootstrap in CSS modules use explicit import
 ```
 
 It's not safe to import all global Bootstrap helpers and variables into the CSS module because we redefine many Bootstrap variables on our side.
-If mixin relies on Bootstrap variables create an entry point for the target mixin which ensures that it uses correct SCSS variables.
+If mixin relies on Bootstrap variables, create a separate SCSS file for the target mixin, ensuring that it uses correct SCSS variables.
+This file should not contain any real CSS rules so that it can be included in multiple CSS modules without additional overhead.
 
 ```scss
 @import 'branded/src/global-styles/breakpoints';
 ```
 
-Do not use SCSS variables in CSS modules. Prefer CSS variables instead.
+If possible, prefer CSS variables to SCSS variables.
 
 #### BEM convention
 


### PR DESCRIPTION
## Issue

It's impossible to use the global SCSS helpers provided by Bootstrap in CSS modules without importing them explicitly.
It's not safe to import all global Bootstrap helpers and variables into the CSS module because we redefine many Bootstrap variables before those imports. This slows down the adoption of CSS modules because we rely on some of the helpers. e.g. `@include media-breakpoint-x`.

## Solution

1. **[Explored]** Use [sass-resources-loader](https://github.com/shakacode/sass-resources-loader) to import our redefined variables and Bootstrap globals to each CSS module implicitly. This approach has issues:
   -  We have a mix of SCSS modules and CSS variables declarations. It's hard to separate one from another. That means that CSS variable declarations will be included in every CSS module.
   - It's implicit, and it's hard to track which helpers we are actually using in our CSS modules.
   - We don't want to expose all Bootstrap SCSS variables (`'bootstrap/scss/variables'`) to our CSS modules. CSS variables should be used instead. Apparently, `Stylelint` doesn't have any rules to limit SCSS variables usage 🤷‍♂️.

2. **[Adoped]** Use _explicit_ imports in CSS modules and create modular entry points for mixins if needed. It might require some duplication. For example, for breakpoints mixins, the `$grid-breakpoints` variable should be available. It's impossible to import it from Bootstrap without dragging everything else with it, so it's now copy-pasted to our stylesheet. This approach:
   - Exposes some Bootstrap helpers to smooth the migration to CSS modules.
   - Limits Bootstrap features usage in new components and CSS modules. 
   - Explicitly defines dependencies. Later it will allow us to implement this functionality internally to have full control over it if we need more flexibility than Bootstrap offers.

```scss
// In CSS module
@import 'branded/src/global-styles/breakpoints';

.list {
  @include media-breakpoint-down(xs) {
    magin: 0;
  }
}
```

## Changes

- Created entry point for Bootstrap breakpoints mixins.
- Added `/<rootPath>/client` to SASS loader option `includePaths` to allow absolute imports from our packages.
- Removed `$media-x` SCSS variables in favor of `$grid-breakpoints` used by Bootstrap mixins. Thanks, @vovakulikov, for noticing it.
- Updated `web/styling.md` to include guidelines on using Bootstrap helpers.

Closes #20137.