### PR TITLE
Remove credentials from repo clone urls

### DIFF
--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -121,16 +121,18 @@ func (s BitbucketCloudSource) makeRepo(r *bitbucketcloud.Repo) *types.Repo {
 		Sources: map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,
-				CloneURL: s.authenticatedRemoteURL(r),
+				CloneURL: s.remoteURL(r),
 			},
 		},
 		Metadata: r,
 	}
 }
 
-// authenticatedRemoteURL returns the repository's Git remote URL with the configured
-// Bitbucket Cloud app password inserted in the URL userinfo.
-func (s *BitbucketCloudSource) authenticatedRemoteURL(repo *bitbucketcloud.Repo) string {
+// remoteURL returns the repository's Git remote URL
+//
+// note: this used to contain credentials but that is no longer the case
+// if you need to get an authenticated clone url use types.RepoCloneURL
+func (s *BitbucketCloudSource) remoteURL(repo *bitbucketcloud.Repo) string {
 	if s.config.GitURLType == "ssh" {
 		return fmt.Sprintf("git@%s:%s.git", s.config.Url, repo.FullName)
 	}
@@ -146,14 +148,7 @@ func (s *BitbucketCloudSource) authenticatedRemoteURL(repo *bitbucketcloud.Repo)
 		log15.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", "url", repo.Links.Clone, "error", err)
 		return fallbackURL
 	}
-	u, err := url.Parse(httpsURL)
-	if err != nil {
-		log15.Warn("Error adding authentication to Bitbucket Cloud repository Git remote URL.", "url", httpsURL, "error", err)
-		return fallbackURL
-	}
-
-	u.User = url.UserPassword(s.config.Username, s.config.AppPassword)
-	return u.String()
+	return httpsURL
 }
 
 func (s *BitbucketCloudSource) excludes(r *bitbucketcloud.Repo) bool {

--- a/internal/repos/bitbucketserver.go
+++ b/internal/repos/bitbucketserver.go
@@ -135,13 +135,7 @@ func (s BitbucketServerSource) makeRepo(repo *bitbucketserver.Repo, isArchived b
 			break
 		}
 		if l.Name == "http" {
-			var password string
-			if s.config.Token != "" {
-				password = s.config.Token // prefer personal access token
-			} else {
-				password = s.config.Password
-			}
-			cloneURL = setUserinfoBestEffort(l.Href, s.config.Username, password)
+			cloneURL = setUserinfoBestEffort(l.Href, s.config.Username, "")
 			// No break, so that we fallback to http in case of ssh missing
 			// with GitURLType == "ssh"
 		}

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -254,31 +254,24 @@ func (s GithubSource) makeRepo(r *github.Repository) *types.Repo {
 		Sources: map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,
-				CloneURL: s.authenticatedRemoteURL(r),
+				CloneURL: s.remoteURL(r),
 			},
 		},
 		Metadata: r,
 	}
 }
 
-// authenticatedRemoteURL returns the repository's Git remote URL with the configured
-// GitHub personal access token inserted in the URL userinfo.
-func (s *GithubSource) authenticatedRemoteURL(repo *github.Repository) string {
+// remoteURL returns the repository's Git remote URL
+//
+// note: this used to contain credentials but that is no longer the case
+// if you need to get an authenticated clone url use types.RepoCloneURL
+func (s *GithubSource) remoteURL(repo *github.Repository) string {
 	if s.config.GitURLType == "ssh" {
 		url := fmt.Sprintf("git@%s:%s.git", s.originalHostname, repo.NameWithOwner)
 		return url
 	}
 
-	if s.config.Token == "" {
-		return repo.URL
-	}
-	u, err := url.Parse(repo.URL)
-	if err != nil {
-		log15.Warn("Error adding authentication to GitHub repository Git remote URL.", "url", repo.URL, "error", err)
-		return repo.URL
-	}
-	u.User = url.User(s.config.Token)
-	return u.String()
+	return repo.URL
 }
 
 func (s *GithubSource) excludes(r *github.Repository) bool {

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -199,30 +199,22 @@ func (s GitLabSource) makeRepo(proj *gitlab.Project) *types.Repo {
 		Sources: map[string]*types.SourceInfo{
 			urn: {
 				ID:       urn,
-				CloneURL: s.authenticatedRemoteURL(proj),
+				CloneURL: s.remoteURL(proj),
 			},
 		},
 		Metadata: proj,
 	}
 }
 
-// authenticatedRemoteURL returns the GitLab projects's Git remote URL with the
-// configured GitLab personal access token inserted in the URL userinfo.
-func (s *GitLabSource) authenticatedRemoteURL(proj *gitlab.Project) string {
+// remoteURL returns the GitLab projects's Git remote URL
+//
+// note: this used to contain credentials but that is no longer the case
+// if you need to get an authenticated clone url use types.RepoCloneURL
+func (s *GitLabSource) remoteURL(proj *gitlab.Project) string {
 	if s.config.GitURLType == "ssh" {
 		return proj.SSHURLToRepo // SSH authentication must be provided out-of-band
 	}
-	if s.config.Token == "" {
-		return proj.HTTPURLToRepo
-	}
-	u, err := url.Parse(proj.HTTPURLToRepo)
-	if err != nil {
-		log15.Warn("Error adding authentication to GitLab repository Git remote URL.", "url", proj.HTTPURLToRepo, "error", err)
-		return proj.HTTPURLToRepo
-	}
-	// Any username works; "git" is not special.
-	u.User = url.UserPassword("git", s.config.Token)
-	return u.String()
+	return proj.HTTPURLToRepo
 }
 
 func (s *GitLabSource) excludes(p *gitlab.Project) bool {

--- a/internal/repos/perforce.go
+++ b/internal/repos/perforce.go
@@ -49,11 +49,10 @@ func (s PerforceSource) ListRepos(ctx context.Context, results chan SourceResult
 
 // composePerforceCloneURL composes a clone URL for a Perforce depot based on
 // given information. e.g.
-// perforce://admin:password@ssl:111.222.333.444:1666//Sourcegraph/
-func composePerforceCloneURL(username, password, host, depot string) string {
+// perforce://ssl:111.222.333.444:1666//Sourcegraph/
+func composePerforceCloneURL(host, depot string) string {
 	cloneURL := url.URL{
 		Scheme: "perforce",
-		User:   url.UserPassword(username, password),
 		Host:   host,
 		Path:   depot,
 	}
@@ -67,7 +66,7 @@ func (s PerforceSource) makeRepo(depot string) *types.Repo {
 	name := strings.Trim(depot, "/")
 	urn := s.svc.URN()
 
-	cloneURL := composePerforceCloneURL(s.config.P4User, s.config.P4Passwd, s.config.P4Port, depot)
+	cloneURL := composePerforceCloneURL(s.config.P4Port, depot)
 
 	return &types.Repo{
 		Name: reposource.PerforceRepoName(

--- a/internal/repos/phabricator.go
+++ b/internal/repos/phabricator.go
@@ -113,10 +113,6 @@ func (s *PhabricatorSource) makeRepo(repo *phabricator.Repo) (*types.Repo, error
 	} {
 		if u, ok := builtin[alt.protocol+"+"+alt.identifier]; ok {
 			cloneURL = u.Effective
-			// TODO(tsenart): Authenticate the cloneURL with the user's
-			// VCS password once we have that setting in the config. The
-			// Conduit token can't be used for cloning.
-			// cloneURL = setUserinfoBestEffort(cloneURL, conn.VCSPassword, "")
 
 			if name == "" {
 				name = u.Normalized

--- a/internal/repos/sources_test.go
+++ b/internal/repos/sources_test.go
@@ -586,54 +586,6 @@ func TestSources_ListRepos(t *testing.T) {
 	{
 		svcs := types.ExternalServices{
 			{
-				Kind: extsvc.KindAWSCodeCommit,
-				Config: marshalJSON(t, &schema.AWSCodeCommitConnection{
-					AccessKeyID:     getAWSEnv("AWS_ACCESS_KEY_ID"),
-					SecretAccessKey: getAWSEnv("AWS_SECRET_ACCESS_KEY"),
-					Region:          "us-west-1",
-					GitCredentials: schema.AWSCodeCommitGitCredentials{
-						Username: "git-username",
-						Password: "git-password",
-					},
-				}),
-			},
-		}
-
-		testCases = append(testCases, testCase{
-			name: "yielded repos have authenticated CloneURLs",
-			svcs: svcs,
-			assert: func(s *types.ExternalService) types.ReposAssertion {
-				return func(t testing.TB, rs types.Repos) {
-					t.Helper()
-
-					urls := []string{}
-					for _, r := range rs {
-						urls = append(urls, r.CloneURLs()...)
-					}
-
-					switch s.Kind {
-					case extsvc.KindAWSCodeCommit:
-						want := []string{
-							"https://git-username:git-password@git-codecommit.us-west-1.amazonaws.com/v1/repos/empty-repo",
-							"https://git-username:git-password@git-codecommit.us-west-1.amazonaws.com/v1/repos/stripe-go",
-							"https://git-username:git-password@git-codecommit.us-west-1.amazonaws.com/v1/repos/test2",
-							"https://git-username:git-password@git-codecommit.us-west-1.amazonaws.com/v1/repos/__WARNING_DO_NOT_PUT_ANY_PRIVATE_CODE_IN_HERE",
-							"https://git-username:git-password@git-codecommit.us-west-1.amazonaws.com/v1/repos/test",
-						}
-
-						if have := urls; !reflect.DeepEqual(have, want) {
-							t.Error(cmp.Diff(have, want))
-						}
-					}
-				}
-			},
-			err: "<nil>",
-		})
-	}
-
-	{
-		svcs := types.ExternalServices{
-			{
 				Kind: extsvc.KindPhabricator,
 				Config: marshalJSON(t, &schema.PhabricatorConnection{
 					Url:   "https://secure.phabricator.com",

--- a/internal/repos/testdata/bitbucketserver-repos-path-pattern.golden
+++ b/internal/repos/testdata/bitbucketserver-repos-path-pattern.golden
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git"
     }
    },
    "Metadata": {
@@ -83,7 +83,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git"
     }
    },
    "Metadata": {
@@ -148,7 +148,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git"
     }
    },
    "Metadata": {
@@ -254,7 +254,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git"
     }
    },
    "Metadata": {

--- a/internal/repos/testdata/bitbucketserver-repos-simple.golden
+++ b/internal/repos/testdata/bitbucketserver-repos-simple.golden
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git"
     }
    },
    "Metadata": {
@@ -83,7 +83,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git"
     }
    },
    "Metadata": {
@@ -148,7 +148,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git"
     }
    },
    "Metadata": {
@@ -254,7 +254,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git"
     }
    },
    "Metadata": {

--- a/internal/repos/testdata/bitbucketserver-repos-username.golden
+++ b/internal/repos/testdata/bitbucketserver-repos-username.golden
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/go-langserver.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/go-langserver.git"
     }
    },
    "Metadata": {
@@ -83,7 +83,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/python-langserver.git"
     }
    },
    "Metadata": {
@@ -148,7 +148,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/sg/python-langserver-fork.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/sg/python-langserver-fork.git"
     }
    },
    "Metadata": {
@@ -254,7 +254,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://keegan:secret@bitbucket.example.com/scm/~keegan/rgp.git"
+     "CloneURL": "https://keegan@bitbucket.example.com/scm/~keegan/rgp.git"
     }
    },
    "Metadata": {
@@ -319,7 +319,7 @@
    "Sources": {
     "extsvc:bitbucketserver:1": {
      "ID": "extsvc:bitbucketserver:1",
-     "CloneURL": "https://foo:secret@bitbucket.example.com/scm/~keegan/rgp.git"
+     "CloneURL": "https://foo@bitbucket.example.com/scm/~keegan/rgp.git"
     }
    },
    "Metadata": {

--- a/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_path-pattern
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:bitbucketcloud:1": {
      "ID": "extsvc:bitbucketcloud:1",
-     "CloneURL": "https://alice:secret@bitbucket.org/sg/go-langserver.git"
+     "CloneURL": "https://jchen@bitbucket.org/sg/go-langserver.git"
     }
    },
    "Metadata": {
@@ -66,7 +66,7 @@
    "Sources": {
     "extsvc:bitbucketcloud:1": {
      "ID": "extsvc:bitbucketcloud:1",
-     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver.git"
+     "CloneURL": "https://jchen@bitbucket.org/sg/python-langserver.git"
     }
    },
    "Metadata": {
@@ -114,7 +114,7 @@
    "Sources": {
     "extsvc:bitbucketcloud:1": {
      "ID": "extsvc:bitbucketcloud:1",
-     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver-fork.git"
+     "CloneURL": "https://jchen@bitbucket.org/sg/python-langserver-fork.git"
     }
    },
    "Metadata": {

--- a/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/BitbucketCloudSource_makeRepo_simple
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:bitbucketcloud:1": {
      "ID": "extsvc:bitbucketcloud:1",
-     "CloneURL": "https://alice:secret@bitbucket.org/sg/go-langserver.git"
+     "CloneURL": "https://jchen@bitbucket.org/sg/go-langserver.git"
     }
    },
    "Metadata": {
@@ -66,7 +66,7 @@
    "Sources": {
     "extsvc:bitbucketcloud:1": {
      "ID": "extsvc:bitbucketcloud:1",
-     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver.git"
+     "CloneURL": "https://jchen@bitbucket.org/sg/python-langserver.git"
     }
    },
    "Metadata": {
@@ -114,7 +114,7 @@
    "Sources": {
     "extsvc:bitbucketcloud:1": {
      "ID": "extsvc:bitbucketcloud:1",
-     "CloneURL": "https://alice:secret@bitbucket.org/sg/python-langserver-fork.git"
+     "CloneURL": "https://jchen@bitbucket.org/sg/python-langserver-fork.git"
     }
    },
    "Metadata": {

--- a/internal/repos/testdata/golden/PerforceSource_makeRepo_path-pattern
+++ b/internal/repos/testdata/golden/PerforceSource_makeRepo_path-pattern
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:perforce:1": {
      "ID": "extsvc:perforce:1",
-     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Sourcegraph/"
+     "CloneURL": "perforce://ssl:111.222.333.444:1666//Sourcegraph/"
     }
    },
    "Metadata": {
@@ -44,7 +44,7 @@
    "Sources": {
     "extsvc:perforce:1": {
      "ID": "extsvc:perforce:1",
-     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Engineering/Cloud/"
+     "CloneURL": "perforce://ssl:111.222.333.444:1666//Engineering/Cloud/"
     }
    },
    "Metadata": {

--- a/internal/repos/testdata/golden/PerforceSource_makeRepo_simple
+++ b/internal/repos/testdata/golden/PerforceSource_makeRepo_simple
@@ -18,7 +18,7 @@
    "Sources": {
     "extsvc:perforce:1": {
      "ID": "extsvc:perforce:1",
-     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Sourcegraph/"
+     "CloneURL": "perforce://ssl:111.222.333.444:1666//Sourcegraph/"
     }
    },
    "Metadata": {
@@ -44,7 +44,7 @@
    "Sources": {
     "extsvc:perforce:1": {
      "ID": "extsvc:perforce:1",
-     "CloneURL": "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Engineering/Cloud/"
+     "CloneURL": "perforce://ssl:111.222.333.444:1666//Engineering/Cloud/"
     }
    },
    "Metadata": {


### PR DESCRIPTION
Originally we were going to drop this column, but the change is much simpler if we just remove the credentials from it instead.

There's a chance we can remove the batch changes dependency on this column, and then can drop the column without dependencies, so this work is a safety net for if we need to keep this around.

Originally i had planned to rename the field to RemoteURL but that broke far too many tests for me to spend time fixing today

https://sourcegraph.slack.com/archives/CHPC7UX16/p1618991621113500
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
