### PR TITLE
gitserver: Cleanups spotted while investigating an issue

### DIFF
--- a/cmd/gitserver/server/cleanup_test.go
+++ b/cmd/gitserver/server/cleanup_test.go
@@ -247,7 +247,7 @@ func TestCleanupExpired(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if err := gitConfigSet(GitDir(repoCorrupt), "sourcegraph.maybeCorruptRepo", "1"); err != nil {
+	if err := gitConfigSet(GitDir(repoCorrupt), gitConfigMaybeCorrupt, "1"); err != nil {
 		t.Fatal(err)
 	}
 	if err := setRepositoryType(GitDir(repoPerforce), "perforce"); err != nil {


### PR DESCRIPTION
We were looking into whether bad repos would be cloned over and over in
our "old repos" cleanup job. We confirmed that we already have backoff
logic in place.

During the investigation, spotted a few small cleanup opportunities.
