### PR TITLE
Revert "github: Request 'repo' OAuth scope (#20251)"

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dghubble/gologin/github"
 	"golang.org/x/oauth2"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -69,7 +70,10 @@ func validateClientIDAndSecret(clientIDOrSecret string) (valid bool) {
 }
 
 func requestedScopes(p *schema.GitHubAuthProvider) []string {
-	scopes := []string{"user:email", "repo"}
+	scopes := []string{"user:email"}
+	if !envvar.SourcegraphDotComMode() {
+		scopes = append(scopes, "repo")
+	}
 
 	// Needs extra scope to check organization membership
 	if len(p.AllowOrgs) > 0 {

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider_test.go
@@ -38,14 +38,14 @@ func TestRequestedScopes(t *testing.T) {
 			schema: &schema.GitHubAuthProvider{
 				AllowOrgs: nil,
 			},
-			expScopes: []string{"repo", "user:email"},
+			expScopes: []string{"user:email"},
 		},
 		{
 			dotComMode: true,
 			schema: &schema.GitHubAuthProvider{
 				AllowOrgs: []string{"myorg"},
 			},
-			expScopes: []string{"read:org", "repo", "user:email"},
+			expScopes: []string{"read:org", "user:email"},
 		},
 	}
 	for _, test := range tests {

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -710,9 +710,8 @@ func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.Code
 			done = true
 		}
 		for _, repo := range repos {
-			// the github user repositories API doesn't support query strings, so we'll have
-			// to filter here 😬 this does make pagination more awkward though, as we won't
-			// paginate further if you don't match anything
+			// the github user repositories API doesn't support query strings, so we'll have to filter here 😬
+			// this does make pagination more awkward though, as we won't paginate futher if you don't match anything
 			out = append(out, types.CodeHostRepository{
 				Name:       repo.NameWithOwner,
 				Private:    repo.IsPrivate,


### PR DESCRIPTION
We need to revert this so that we can ensure that external services added with `repo` scope
also have the `authorization` section added. If not, permissions are not checked. 

This reverts commit c4f17177b8cbf6fbc7f70709b67a0261234761bf.
