### PR TITLE
github: Request 'repo' OAuth scope (#20251)

### DIFF
--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dghubble/gologin/github"
 	"golang.org/x/oauth2"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -70,10 +69,7 @@ func validateClientIDAndSecret(clientIDOrSecret string) (valid bool) {
 }
 
 func requestedScopes(p *schema.GitHubAuthProvider) []string {
-	scopes := []string{"user:email"}
-	if !envvar.SourcegraphDotComMode() {
-		scopes = append(scopes, "repo")
-	}
+	scopes := []string{"user:email", "repo"}
 
 	// Needs extra scope to check organization membership
 	if len(p.AllowOrgs) > 0 {

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/provider_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/provider_test.go
@@ -38,14 +38,14 @@ func TestRequestedScopes(t *testing.T) {
 			schema: &schema.GitHubAuthProvider{
 				AllowOrgs: nil,
 			},
-			expScopes: []string{"user:email"},
+			expScopes: []string{"repo", "user:email"},
 		},
 		{
 			dotComMode: true,
 			schema: &schema.GitHubAuthProvider{
 				AllowOrgs: []string{"myorg"},
 			},
-			expScopes: []string{"read:org", "user:email"},
+			expScopes: []string{"read:org", "repo", "user:email"},
 		},
 	}
 	for _, test := range tests {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -57,7 +57,7 @@ func ExternalServices(db dbutil.DB) *ExternalServiceStore {
 	return &ExternalServiceStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
 }
 
-// NewExternalServicesStoreWithDB instantiates and returns a new ExternalServicesStore with prepared statements.
+// ExternalServicesWith instantiates and returns a new ExternalServicesStore with prepared statements.
 func ExternalServicesWith(other basestore.ShareableStore) *ExternalServiceStore {
 	return &ExternalServiceStore{Store: basestore.NewWithHandle(other.Handle())}
 }
@@ -501,8 +501,8 @@ func (e *ExternalServiceStore) Create(ctx context.Context, confGet func() *conf.
 	}
 
 	// NOTE: For GitHub and GitLab user code host connections on Sourcegraph Cloud,
-	//  we always want to enforce repository permissions using OAuth to prevent
-	//  unexpected resource leaking.
+	// we always want to enforce repository permissions using OAuth to prevent
+	// unexpected resource leaking.
 	if envvar.SourcegraphDotComMode() && es.NamespaceUserID != 0 {
 		switch es.Kind {
 		case extsvc.KindGitHub:

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -710,8 +710,9 @@ func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.Code
 			done = true
 		}
 		for _, repo := range repos {
-			// the github user repositories API doesn't support query strings, so we'll have to filter here 😬
-			// this does make pagination more awkward though, as we won't paginate futher if you don't match anything
+			// the github user repositories API doesn't support query strings, so we'll have
+			// to filter here 😬 this does make pagination more awkward though, as we won't
+			// paginate further if you don't match anything
 			out = append(out, types.CodeHostRepository{
 				Name:       repo.NameWithOwner,
 				Private:    repo.IsPrivate,


### PR DESCRIPTION
This will allow us to more easily enable private code in future.

Sorry for the revert noise. This actually *is* working as expected since there
is a special case when adding a repo on Cloud. I was testing locally *without*
the Cloud ennvironment variable which meant that my external service was
created without the `authorization` setting.