### PR TITLE
web: fix TS constructor arguments shorthand

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -55,5 +55,7 @@ module.exports = api => {
       // Node 12 (released 2019 Apr 23) supports these natively, but there seem to be issues when used with TypeScript.
       ['@babel/plugin-proposal-class-properties', { loose: true }],
     ],
+    // Required for d3-array v1.2 (dependency of recharts). See https://github.com/babel/babel/issues/11038
+    ignore: [new RegExp('d3-array/src/cumsum.js')],
   }
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -50,7 +50,7 @@ module.exports = api => {
       '@babel/preset-react',
     ],
     plugins: [
-      '@babel/plugin-transform-typescript',
+      ['@babel/plugin-transform-typescript', { isTSX: true }],
       'babel-plugin-lodash',
       // Node 12 (released 2019 Apr 23) supports these natively, but there seem to be issues when used with TypeScript.
       ['@babel/plugin-proposal-class-properties', { loose: true }],

--- a/babel.config.js
+++ b/babel.config.js
@@ -50,6 +50,7 @@ module.exports = api => {
       '@babel/preset-react',
     ],
     plugins: [
+      '@babel/plugin-transform-typescript',
       'babel-plugin-lodash',
       // Node 12 (released 2019 Apr 23) supports these natively, but there seem to be issues when used with TypeScript.
       ['@babel/plugin-proposal-class-properties', { loose: true }],

--- a/package.json
+++ b/package.json
@@ -370,7 +370,6 @@
   "resolutions": {
     "history": "4.5.1",
     "cssnano": "4.1.10",
-    "@babel/traverse": "7.12.5",
-    "d3-array": "2.3.3"
+    "@babel/traverse": "7.12.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@babel/core": "^7.13.0",
     "@babel/plugin-proposal-class-properties": "^7.13.0",
     "@babel/plugin-proposal-decorators": "^7.13.0",
+    "@babel/plugin-transform-typescript": "^7.13.0",
     "@babel/preset-env": "^7.13.0",
     "@babel/preset-typescript": "^7.13.0",
     "@babel/runtime": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -370,6 +370,7 @@
   "resolutions": {
     "history": "4.5.1",
     "cssnano": "4.1.10",
-    "@babel/traverse": "7.12.5"
+    "@babel/traverse": "7.12.5",
+    "d3-array": "2.3.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8817,10 +8817,17 @@ cyclist@~0.2.2:
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-d3-array@2.3.3, d3-array@^1.2.0, d3-array@^2.3.0, d3-array@^2.6.0:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/d3-array/-/d3-array-2.3.3.tgz#e90c39fbaedccedf59fc30473092f99a0e14efa2"
-  integrity sha512-syv3wp0U5aB6toP2zb2OdBkhTy1MWDsCAaYk6OXJZv+G4u7bSWEmYgxLoFyc88RQUhZYGCebW9a9UD1gFi5+MQ==
+d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
+
+d3-array@^2.3.0, d3-array@^2.6.0:
+  version "2.12.1"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
+  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+  dependencies:
+    internmap "^1.0.0"
 
 d3-axis@^1.0.12:
   version "1.0.12"
@@ -13279,6 +13286,11 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
+
+internmap@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
+  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 interpret@^1.0.0, interpret@^1.1.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8817,17 +8817,10 @@ cyclist@~0.2.2:
   resolved "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
   integrity sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=
 
-d3-array@^1.2.0:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
-  integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
-
-d3-array@^2.3.0, d3-array@^2.6.0:
-  version "2.12.1"
-  resolved "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz#e20b41aafcdffdf5d50928004ececf815a465e81"
-  integrity sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
-  dependencies:
-    internmap "^1.0.0"
+d3-array@2.3.3, d3-array@^1.2.0, d3-array@^2.3.0, d3-array@^2.6.0:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-2.3.3.tgz#e90c39fbaedccedf59fc30473092f99a0e14efa2"
+  integrity sha512-syv3wp0U5aB6toP2zb2OdBkhTy1MWDsCAaYk6OXJZv+G4u7bSWEmYgxLoFyc88RQUhZYGCebW9a9UD1gFi5+MQ==
 
 d3-axis@^1.0.12:
   version "1.0.12"
@@ -13286,11 +13279,6 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
-
-internmap@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz#0017cc8a3b99605f0302f2b198d272e015e5df95"
-  integrity sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
 
 interpret@^1.0.0, interpret@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
The issue was caused by the Babel plugins order: https://github.com/babel/babel/issues/8752. It resulted in skipping constructor arguments assignments. That's why `this.key` in `LocalStorageSubject` was always `undefined`. This PR fixes the issue. Also discussed in Storybook repo: https://github.com/storybookjs/storybook/issues/13834.

Closes #20265.
