### PR TITLE
Revert "fix: clone url building of other code hosts"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
-- Fixed a regression that caused "other" code hosts urls to not be built correctly which prevents code to be cloned / updated in 3.27.0. [#20258](https://github.com/sourcegraph/sourcegraph/pull/20258)
+-
 
 ### Removed
 

--- a/internal/types/clone_url.go
+++ b/internal/types/clone_url.go
@@ -3,12 +3,11 @@ package types
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/conf/reposource"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
@@ -65,7 +64,7 @@ func RepoCloneURL(kind, config string, repo *Repo) (string, error) {
 			return phabricatorCloneURL(r, t), nil
 		}
 	case *schema.OtherExternalServiceConnection:
-		return otherCloneURL(&repo.ExternalRepo), nil
+		return otherCloneURL(repo, t)
 	default:
 		return "", errors.Errorf("unknown external service kind %q for repo %d", kind, repo.ID)
 	}
@@ -243,14 +242,38 @@ func phabricatorCloneURL(repo *phabricator.Repo, _ *schema.PhabricatorConnection
 	return cloneURL
 }
 
-func otherCloneURL(spec *api.ExternalRepoSpec) string {
-	base, path := spec.ServiceID, spec.ID
-	base = strings.TrimRight(base, "/")
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
+func otherCloneURL(repo *Repo, cfg *schema.OtherExternalServiceConnection) (string, error) {
+	if cfg.Url == "" {
+		return repo.URI, nil
 	}
 
-	return base + path
+	pattern := cfg.RepositoryPathPattern
+	if pattern == "" {
+		pattern = "{base}/{repo}"
+	}
+
+	base, err := url.Parse(cfg.Url)
+	if err != nil {
+		return "", err
+	}
+
+	for _, name := range cfg.Repos {
+		// normalize the repo name for comparison with the unescaped repo.Name
+		uName, err := url.Parse(name)
+		if err != nil {
+			return "", err
+		}
+
+		if reposource.OtherRepoName(pattern, cfg.Url, uName.Path) == string(repo.Name) {
+			u, err := base.Parse(uName.Path)
+			if err != nil {
+				return "", err
+			}
+			return u.String(), nil
+		}
+	}
+
+	return repo.URI, nil
 }
 
 // setUserinfoBestEffort adds the username and password to rawurl. If user is

--- a/internal/types/clone_url_test.go
+++ b/internal/types/clone_url_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -231,25 +230,6 @@ func TestPerforceCloneURL(t *testing.T) {
 
 	got := perforceCloneURL(repo, &cfg)
 	want := "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Sourcegraph/"
-	if got != want {
-		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
-	}
-}
-
-func TestOtherCloneURL(t *testing.T) {
-	got := otherCloneURL(&api.ExternalRepoSpec{
-		ID:        "my/repo",
-		ServiceID: "https://github-enterprise.example.com/",
-	})
-	want := "https://github-enterprise.example.com/my/repo"
-	if got != want {
-		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
-	}
-	got = otherCloneURL(&api.ExternalRepoSpec{
-		ID:        "/my/repo",
-		ServiceID: "https://github-enterprise.example.com/",
-	})
-	want = "https://github-enterprise.example.com/my/repo"
 	if got != want {
 		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
 	}


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#20258 as it only deals with `src-expose` repos and not all other git repos.