### PR TITLE
codeintel: Only update committed_at on records that don't already have it set

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
@@ -92,7 +92,6 @@ SELECT repository_id, commit
 FROM lsif_uploads
 WHERE state = 'completed' AND committed_at IS NULL
 GROUP BY repository_id, commit
-ORDER BY repository_id, commit
 LIMIT %s
 `
 

--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
@@ -149,7 +149,7 @@ func (m *committedAtMigrator) processBatch(ctx context.Context, tx *dbstore.Stor
 
 const committedAtProcessBatchQuery = `
 -- source: enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go:ProcessBatch
-UPDATE lsif_uploads SET committed_at = %s WHERE repository_id = %s AND commit = %s
+UPDATE lsif_uploads SET committed_at = %s WHERE state = 'completed' AND repository_id = %s AND commit = %s AND committed_at IS NULL
 `
 
 // Down runs a batch of the migration in reverse. This method simply sets the committed_at column


### PR DESCRIPTION
This should run into fewer records that are locked. We may have been a bit slow before due to lock contention around _incomplete_ upload records. There's no system that holds a lock on a completed upload for too long (but the worker can hold processing upload records for minutes).