### PR TITLE
search redesign: initial sidebar and infobar styling

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -35,4 +35,8 @@
         border-right: 1px solid var(--border-color);
         margin: 0 0.5rem;
     }
+
+    .theme-redesign & {
+        padding-left: 0;
+    }
 }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -127,7 +127,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
 
     return (
         <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
-            <div className="search-results-info-bar__row">
+            <small className="search-results-info-bar__row">
                 {props.stats}
                 <QuotesInterpretedLiterallyNotice {...props} />
 
@@ -167,7 +167,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         </>
                     )}
                 </ul>
-            </div>
+            </small>
         </div>
     )
 }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -127,7 +127,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
 
     return (
         <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
-            <small className="search-results-info-bar__row">
+            <div className="search-results-info-bar__row">
                 {props.stats}
                 <QuotesInterpretedLiterallyNotice {...props} />
 
@@ -167,7 +167,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         </>
                     )}
                 </ul>
-            </small>
+            </div>
         </div>
     )
 }

--- a/client/web/src/search/results/streaming/SearchSidebar.module.scss
+++ b/client/web/src/search/results/streaming/SearchSidebar.module.scss
@@ -1,0 +1,6 @@
+.search-sidebar {
+    margin: 0 1rem;
+    padding-top: 0.5rem;
+    width: 15.5rem;
+    flex-shrink: 0;
+}

--- a/client/web/src/search/results/streaming/SearchSidebar.story.tsx
+++ b/client/web/src/search/results/streaming/SearchSidebar.story.tsx
@@ -1,0 +1,15 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { WebStory } from '../../../components/WebStory'
+
+import { SearchSidebar } from './SearchSidebar'
+
+const { add } = storiesOf('web/search/results/streaming/SearchSidebar', module).addParameters({
+    design: {
+        type: 'figma',
+        url: 'https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/?node-id=1018%3A13883',
+    },
+})
+
+add('empty sidebar', () => <WebStory>{() => <SearchSidebar />}</WebStory>)

--- a/client/web/src/search/results/streaming/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/SearchSidebar.tsx
@@ -1,3 +1,13 @@
 import React from 'react'
 
-export const SearchSidebar: React.FunctionComponent<{}> = props => <div>Sidebar goes here</div>
+import styles from './SearchSidebar.module.scss'
+
+export const SearchSidebar: React.FunctionComponent<{}> = props => (
+    <div className={styles.searchSidebar}>
+        <h5>Result types</h5>
+        <h5>Dynamic filters</h5>
+        <h5>Repositories</h5>
+        <h5>Search snippets</h5>
+        <h5>Quicklinks</h5>
+    </div>
+)

--- a/client/web/src/search/results/streaming/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.module.scss
@@ -1,0 +1,9 @@
+.streaming-search-results {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    :global(.theme-redesign) & {
+        flex-direction: row;
+    }
+}

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -38,6 +38,7 @@ import { VersionContextWarning } from '../VersionContextWarning'
 
 import { StreamingProgress } from './progress/StreamingProgress'
 import { SearchSidebar } from './SearchSidebar'
+import styles from './StreamingSearchResults.module.scss'
 import { StreamingSearchResultsFilterBars } from './StreamingSearchResultsFilterBars'
 import { StreamingSearchResultsList } from './StreamingSearchResultsList'
 
@@ -196,12 +197,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
     const [isRedesignEnabled] = useRedesignToggle()
 
     return (
-        <div
-            className={classNames(
-                'test-search-results search-results d-flex w-100',
-                isRedesignEnabled ? 'flex-row' : 'flex-column'
-            )}
-        >
+        <div className={classNames('test-search-results search-results', styles.streamingSearchResults)}>
             <PageTitle key="page-title" title={query} />
 
             {isRedesignEnabled ? <SearchSidebar /> : <StreamingSearchResultsFilterBars {...props} results={results} />}
@@ -219,7 +215,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
                         {...props}
                         query={query}
                         resultsFound={results ? results.results.length > 0 : false}
-                        className="border-bottom flex-grow-1"
+                        className={classNames('flex-grow-1', { 'border-bottom': !isRedesignEnabled })}
                         allExpanded={allExpanded}
                         onExpandAllResultsToggle={onExpandAllResultsToggle}
                         onSaveQueryClick={onSaveQueryClick}

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -11,7 +11,6 @@
     &__count {
         padding: 0.375rem 0.75rem; // Match padding for .btn (but this is not a button)
         color: var(--link-color);
-        font-size: 0.75rem;
 
         .theme-redesign & {
             color: inherit;

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -11,6 +11,17 @@
     &__count {
         padding: 0.375rem 0.75rem; // Match padding for .btn (but this is not a button)
         color: var(--link-color);
+        font-size: 0.75rem;
+
+        .theme-redesign & {
+            color: inherit;
+            padding-left: 0.5rem;
+            padding-right: 0.5rem;
+
+            &--in-progress {
+                color: var(--link-color);
+            }
+        }
 
         &--in-progress {
             background-color: var(--color-bg-2);
@@ -35,6 +46,10 @@
             width: 20rem;
             padding: 0;
         }
+    }
+
+    .theme-redesign & {
+        flex-grow: 1;
     }
 }
 


### PR DESCRIPTION
Fixes #20101

Some initial work to get the sidebar sizing right and the infobar looking closer to the final design. Only enabled if the redesign theme is enabled.

![image](https://user-images.githubusercontent.com/206864/115628144-087b2300-a2b5-11eb-87a2-ddb1d9ba6f7f.png)
