### PR TITLE
Better disabled message for code insights

### DIFF
--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -37,7 +37,11 @@ func IsEnabled() bool {
 // Init initializes the given enterpriseServices to include the required resolvers for insights.
 func Init(ctx context.Context, postgres dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services) error {
 	if !IsEnabled() {
-		enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver()
+		if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
+			enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver("code insights is not available on single-container deployments")
+		} else {
+			enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver("code insights has been disabled")
+		}
 		return nil
 	}
 	timescale, err := InitializeCodeInsightsDB()

--- a/enterprise/internal/insights/insights.go
+++ b/enterprise/internal/insights/insights.go
@@ -38,7 +38,7 @@ func IsEnabled() bool {
 func Init(ctx context.Context, postgres dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services) error {
 	if !IsEnabled() {
 		if conf.IsDeployTypeSingleDockerContainer(conf.DeployType()) {
-			enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver("code insights is not available on single-container deployments")
+			enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver("backend-run code insights are not available on single-container deployments")
 		} else {
 			enterpriseServices.InsightsResolver = resolvers.NewDisabledResolver("code insights has been disabled")
 		}

--- a/enterprise/internal/insights/resolvers/resolver.go
+++ b/enterprise/internal/insights/resolvers/resolver.go
@@ -46,14 +46,14 @@ func (r *Resolver) Insights(ctx context.Context) (graphqlbackend.InsightConnecti
 	}, nil
 }
 
-type disabledResolver struct{}
-
-func NewDisabledResolver() graphqlbackend.InsightsResolver {
-	return &disabledResolver{}
+type disabledResolver struct {
+	reason string
 }
 
-var ErrCodeInsightsDisabled = errors.New("code insights has been disabled")
+func NewDisabledResolver(reason string) graphqlbackend.InsightsResolver {
+	return &disabledResolver{reason}
+}
 
 func (r *disabledResolver) Insights(ctx context.Context) (graphqlbackend.InsightConnectionResolver, error) {
-	return nil, ErrCodeInsightsDisabled
+	return nil, errors.New(r.reason)
 }


### PR DESCRIPTION
When the deploy type is single container, the error message should be more descriptive.
After a [recent refactor](https://github.com/sourcegraph/sourcegraph/pull/20241), disabled is now properly shown and in this PR we add an additional case for single docker container.

New error messages
Single docker deployment
![image](https://user-images.githubusercontent.com/19534377/115631941-0d68c280-a307-11eb-9483-3740d0d40814.png)
Disabled via env var
![image](https://user-images.githubusercontent.com/19534377/115632021-338e6280-a307-11eb-9d05-12bb7d8bd8f2.png)

Part of https://github.com/sourcegraph/sourcegraph/issues/17223