### PR TITLE
codeintel: add explicit support for MarkupContent in lsif/protocol & optimize hover ingestion

### DIFF
--- a/enterprise/lib/codeintel/lsif/protocol/hover.go
+++ b/enterprise/lib/codeintel/lsif/protocol/hover.go
@@ -41,6 +41,13 @@ type MarkupContent struct {
 	Value string     `json:"value"`
 }
 
+func NewMarkupContent(s string, kind MarkupKind) MarkupContent {
+	return MarkupContent{
+		Kind:  kind,
+		Value: s,
+	}
+}
+
 func (mc MarkupContent) String() string {
 	return mc.Value
 }

--- a/enterprise/lib/codeintel/lsif/protocol/hover.go
+++ b/enterprise/lib/codeintel/lsif/protocol/hover.go
@@ -1,6 +1,9 @@
 package protocol
 
-import jsoniter "github.com/json-iterator/go"
+import (
+	"fmt"
+	"strings"
+)
 
 type HoverResult struct {
 	Vertex
@@ -8,10 +11,10 @@ type HoverResult struct {
 }
 
 type hoverResult struct {
-	Contents []MarkedString `json:"contents"`
+	Contents fmt.Stringer `json:"contents"`
 }
 
-func NewHoverResult(id uint64, contents []MarkedString) HoverResult {
+func NewHoverResult(id uint64, contents fmt.Stringer) HoverResult {
 	return HoverResult{
 		Vertex: Vertex{
 			Element: Element{
@@ -26,12 +29,41 @@ func NewHoverResult(id uint64, contents []MarkedString) HoverResult {
 	}
 }
 
-type MarkedString markedString
+type MarkupKind string
 
-type markedString struct {
-	Language    string `json:"language"`
-	Value       string `json:"value"`
-	isRawString bool
+const (
+	PlainText MarkupKind = "plaintext"
+	Markdown  MarkupKind = "markdown"
+)
+
+type MarkupContent struct {
+	Kind  MarkupKind `json:"kind"` // currently unused
+	Value string     `json:"value"`
+}
+
+func (mc MarkupContent) String() string {
+	return mc.Value
+}
+
+type MarkedStrings []MarkedString
+
+var (
+	hoverPartSeparator = "\n\n---\n\n"
+	codeFence          = "```"
+)
+
+func (ms MarkedStrings) String() string {
+	markedStrings := make([]string, 0, len(ms))
+	for _, marked := range ms {
+		markedStrings = append(markedStrings, marked.String())
+	}
+
+	return strings.Join(markedStrings, hoverPartSeparator)
+}
+
+type MarkedString struct {
+	Language string `json:"language"`
+	Value    string `json:"value"`
 }
 
 func NewMarkedString(s, languageID string) MarkedString {
@@ -41,20 +73,20 @@ func NewMarkedString(s, languageID string) MarkedString {
 	}
 }
 
-func RawMarkedString(s string) MarkedString {
-	return MarkedString{
-		Value:       s,
-		isRawString: true,
+func (ms MarkedString) String() string {
+	if ms.Language == "" {
+		return ms.Value
 	}
-}
+	var b strings.Builder
+	b.Grow(len(ms.Language) + len(ms.Value) + len(codeFence)*2 + 2)
+	b.WriteString(codeFence)
+	b.WriteString(ms.Language)
+	b.WriteRune('\n')
+	b.WriteString(ms.Value)
+	b.WriteRune('\n')
+	b.WriteString(codeFence)
 
-var marshaller = jsoniter.ConfigFastest
-
-func (m MarkedString) MarshalJSON() ([]byte, error) {
-	if m.isRawString {
-		return marshaller.Marshal(m.Value)
-	}
-	return marshaller.Marshal((markedString)(m))
+	return b.String()
 }
 
 type TextDocumentHover struct {

--- a/enterprise/lib/codeintel/lsif/protocol/reader/unmarshal.go
+++ b/enterprise/lib/codeintel/lsif/protocol/reader/unmarshal.go
@@ -290,18 +290,13 @@ func unmarshalHoverPart(raw json.RawMessage) (*string, error) {
 
 	// now check if MarkupContent
 	if m.Kind != "" {
-		markup := strings.TrimSpace(protocol.MarkupContent{
-			Kind:  protocol.MarkupKind(m.Kind), // TODO: validate possible values
-			Value: m.Value,
-		}.String())
+		// TODO: validate possible values
+		markup := strings.TrimSpace(protocol.NewMarkupContent(m.Value, protocol.MarkupKind(m.Kind)).String())
 		return &markup, nil
 	}
 
 	// else assume MarkedString
-	marked := strings.TrimSpace(protocol.MarkedString{
-		Language: m.Language,
-		Value:    m.Value,
-	}.String())
+	marked := strings.TrimSpace(protocol.NewMarkedString(m.Value, m.Language).String())
 
 	return &marked, nil
 }

--- a/enterprise/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
+++ b/enterprise/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
@@ -164,6 +164,18 @@ func TestUnmarshalRangeWithTag(t *testing.T) {
 	}
 }
 
+var result interface{}
+
+func BenchmarkUnmarshalHover(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var err error
+		result, err = unmarshalHover([]byte(`{"id": "16", "type": "vertex", "label": "hoverResult", "result": {"contents": [{"language": "go", "value": "text"}, {"language": "python", "value": "pext"}]}}`))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestUnmarshalHover(t *testing.T) {
 	testCases := []struct {
 		contents      string
@@ -183,10 +195,6 @@ func TestUnmarshalHover(t *testing.T) {
 		},
 		{
 			contents:      `[{"value": "text"}]`,
-			expectedHover: "text",
-		},
-		{
-			contents:      `[{"kind": "markdown", "value": "text"}]`,
 			expectedHover: "text",
 		},
 		{

--- a/enterprise/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
+++ b/enterprise/lib/codeintel/lsif/protocol/reader/unmarshal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/lsif/protocol"
 )
 
@@ -179,6 +180,18 @@ func TestUnmarshalHover(t *testing.T) {
 		{
 			contents:      `[{"language": "go", "value": "text"}]`,
 			expectedHover: "```go\ntext\n```",
+		},
+		{
+			contents:      `[{"value": "text"}]`,
+			expectedHover: "text",
+		},
+		{
+			contents:      `[{"kind": "markdown", "value": "text"}]`,
+			expectedHover: "text",
+		},
+		{
+			contents:      "[{\"kind\": \"markdown\", \"value\": \"asdf\\n```java\\ntest\\n```\"}]",
+			expectedHover: "asdf\n```java\ntest\n```",
 		},
 		{
 			contents:      `[{"language": "go", "value": "text"}, {"language": "python", "value": "pext"}]`,

--- a/enterprise/lib/codeintel/lsif/protocol/writer/emitter.go
+++ b/enterprise/lib/codeintel/lsif/protocol/writer/emitter.go
@@ -69,7 +69,7 @@ func (e *Emitter) EmitDocumentSymbolEdge(resultV, docV uint64) uint64 {
 
 func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewHoverResult(id, contents))
+	e.writer.Write(protocol.NewHoverResult(id, protocol.MarkedStrings(contents)))
 	return id
 }
 


### PR DESCRIPTION
This PR looks like it does a lot more than it actually does. Its mostly a minor reorganization, allowing for a nicer unmarshalling into either a `MarkedString` or `MarkupContent` (sum types when :crying_cat_face:).

As part of the reorganization, it has been made (almost) possible for lsif-go to also adopt `MarkupContent` instead, by changing `hoverResult` to take an `fmt.Stringer` and making the three types implement it (sum types/sealed types when :crying_cat_face:). The API which lsif-go currently uses to emit hovers still expects `MarkedStrings`, we can change that too in this PR if so desired.  

There are ramifications of course, if someone uses an indexer that emits `MarkupContent` but is on an older sourcegraph instance that was not `MarkupContent` aware. Im not sure how we can tackle that without never being able to move indexers away from `MarkedString`.

**Note**: this is a first draft and is a bit rough on the eyes in certain areas. Ill revisit again tomorrow to slap some makeup on it

Obligatory screenie:
![image](https://user-images.githubusercontent.com/18282288/115638817-004dd280-a30b-11eb-9a3e-18e5625cc368.png)
