### PR TITLE
web: skip asking for accountData in listing external accounts

### DIFF
--- a/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
+++ b/client/web/src/user/settings/auth/UserSettingsSecurityPage.tsx
@@ -69,7 +69,6 @@ const fetchUserExternalAccountsByType = async (username: string): Promise<MinExt
                                 id
                                 serviceID
                                 serviceType
-                                accountData
                             }
                         }
                     }


### PR DESCRIPTION
`accountData` is only available to site admins, and the info is not needed in the purpose of just getting list of external accounts.

This fixes users from not able to use the "Settings > Account security" page entirely on Cloud.

<img width="929" alt="CleanShot 2021-04-22 at 11 51 30@2x" src="https://user-images.githubusercontent.com/2946214/115653087-18e8d780-a361-11eb-90e7-7cc9f8231ee6.png">
