### PR TITLE
Improve error handling for code host errors

### DIFF
--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -97,16 +97,14 @@ const isLoading = (status: initialFetchingReposState): boolean => {
 }
 
 const displayWarning = (warning: string, hint?: JSX.Element): JSX.Element => (
-    <div className="alert alert-warning mt-3" role="alert">
-        <AlertCircleIcon key={warning} className="icon icon-inline" /> {warning}. {hint}{' '}
-        {hint ? 'for more details' : null}
+    <div key={warning} className="alert alert-warning mt-3" role="alert">
+        <AlertCircleIcon className="icon icon-inline" /> {warning}. {hint} {hint ? 'for more details' : null}
     </div>
 )
 
 const displayError = (error: ErrorLike, hint?: JSX.Element): JSX.Element => (
-    <div className="alert alert-danger mt-3" role="alert">
-        <AlertCircleIcon key={error.message} className="icon icon-inline" /> {error.message}. {hint}{' '}
-        {hint ? 'for more details' : null}
+    <div key={error.message} className="alert alert-danger mt-3" role="alert">
+        <AlertCircleIcon className="icon icon-inline" /> {error.message}. {hint} {hint ? 'for more details' : null}
     </div>
 )
 
@@ -123,7 +121,7 @@ const displayAffiliateRepoProblems = (
     }
 
     if (Array.isArray(problem)) {
-        return displayAffiliateRepoProblems(problem)
+        return <>{problem.map(prob => displayAffiliateRepoProblems(prob, hint))}</>
     }
 
     return null


### PR DESCRIPTION

### Description

Fixes how the code host errors are displayed at "Manage repositories" page

### Demo

![Screen Shot 2021-04-22 at 1 32 19 AM](https://user-images.githubusercontent.com/1319181/115660855-99c8b480-a30a-11eb-9168-a3ef9e32a127.png)
