### PR TITLE
Remove Link usage from code insights charts and use native links

### DIFF
--- a/client/web/src/views/ChartViewContent/ChartViewContent.tsx
+++ b/client/web/src/views/ChartViewContent/ChartViewContent.tsx
@@ -1,10 +1,13 @@
 import { ParentSize } from '@visx/responsive'
 import * as H from 'history'
-import React, { FunctionComponent, useCallback, useMemo } from 'react'
+import React, { FunctionComponent, useMemo } from 'react'
 import { ChartContent } from 'sourcegraph'
 
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { createProgrammaticLinkHandler } from '@sourcegraph/shared/src/util/link-click-handler/linkClickHandler'
+import {
+    createLinkClickHandler,
+    createProgrammaticLinkHandler
+} from '@sourcegraph/shared/src/util/link-click-handler/linkClickHandler'
 
 import { BarChart } from './charts/bar/BarChart'
 import { LineChart } from './charts/line/LineChart'
@@ -32,9 +35,14 @@ export interface ChartViewContentProps {
 export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props => {
     const { content, className = '', history, viewID, telemetryService } = props
 
-    const handleDatumLinkClick = useCallback(() => {
-        telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
-    }, [viewID, telemetryService])
+    const handleDatumLinkClick = useMemo(() => {
+        const nativeLinkHandler = createLinkClickHandler(history);
+
+        return (event: React.MouseEvent) => {
+            telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
+            nativeLinkHandler(event);
+        }
+    }, [viewID, telemetryService, history])
 
     // Click link-zone handler for line chart only. Catch click around point and redirect user by
     // link which we've got from nearest datum point to user cursor position. This allows user

--- a/client/web/src/views/ChartViewContent/ChartViewContent.tsx
+++ b/client/web/src/views/ChartViewContent/ChartViewContent.tsx
@@ -6,7 +6,7 @@ import { ChartContent } from 'sourcegraph'
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import {
     createLinkClickHandler,
-    createProgrammaticLinkHandler
+    createProgrammaticLinkHandler,
 } from '@sourcegraph/shared/src/util/link-click-handler/linkClickHandler'
 
 import { BarChart } from './charts/bar/BarChart'
@@ -36,11 +36,11 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
     const { content, className = '', history, viewID, telemetryService } = props
 
     const handleDatumLinkClick = useMemo(() => {
-        const nativeLinkHandler = createLinkClickHandler(history);
+        const nativeLinkHandler = createLinkClickHandler(history)
 
         return (event: React.MouseEvent) => {
             telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
-            nativeLinkHandler(event);
+            nativeLinkHandler(event)
         }
     }, [viewID, telemetryService, history])
 

--- a/client/web/src/views/ChartViewContent/charts/MaybeLink.tsx
+++ b/client/web/src/views/ChartViewContent/charts/MaybeLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-interface MaybeLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>{
-    to?: string;
+interface MaybeLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+    to?: string
 }
 
 /** Wraps the children in a link if to (link href) prop is passed. */

--- a/client/web/src/views/ChartViewContent/charts/MaybeLink.tsx
+++ b/client/web/src/views/ChartViewContent/charts/MaybeLink.tsx
@@ -1,17 +1,15 @@
-import * as H from 'history'
 import React from 'react'
-import { Link, LinkProps } from 'react-router-dom'
 
-interface MaybeLinkProps<S = H.LocationState> extends Omit<LinkProps<S>, 'to'> {
-    to?: H.LocationDescriptor<S> | ((location: H.Location<S>) => H.LocationDescriptor<S>)
+interface MaybeLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement>{
+    to?: string;
 }
 
 /** Wraps the children in a link if to (link href) prop is passed. */
 export const MaybeLink: React.FunctionComponent<MaybeLinkProps> = ({ children, to, ...props }) =>
     to ? (
-        <Link {...props} to={to}>
+        <a {...props} href={to}>
             {children}
-        </Link>
+        </a>
     ) : (
         (children as React.ReactElement)
     )


### PR DESCRIPTION
Just because `Link` component from `react-router-dom` package can't handle external and local links together we should't use them in the code insights charts. 

In case of global path `Link` component transforms `href` from `https:sourcegraph.com/search` to `/https:sourcegraph.com/search`, notice `/` at the beginning of the href path. This `/` makes redirect by link relative which lead us to a problem when after redirect by this link we have URL like this `https://sourcegraph/https://sourcegraph/search` which is just a bad link.

Possible solution here use native links with absolute paths and handle cmd+click and check external path. We already have this logic for handling markdown links - `createLinkClickHandler` 