### PR TITLE
Do not require GITHUB_TOKEN in batch changes tests

### DIFF
--- a/enterprise/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_counts_test.go
@@ -82,19 +82,23 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	repoStore := database.Repos(db)
 	esStore := database.ExternalServices(db)
 
+	gitHubToken := os.Getenv("GITHUB_TOKEN")
+	if gitHubToken == "" {
+		gitHubToken = "no-GITHUB_TOKEN-set"
+	}
 	githubExtSvc := &types.ExternalService{
 		Kind:        extsvc.KindGitHub,
 		DisplayName: "GitHub",
 		Config: ct.MarshalJSON(t, &schema.GitHubConnection{
 			Url:   "https://github.com",
-			Token: os.Getenv("GITHUB_TOKEN"),
+			Token: gitHubToken,
 			Repos: []string{"sourcegraph/sourcegraph"},
 		}),
 	}
 
 	err := esStore.Upsert(ctx, githubExtSvc)
 	if err != nil {
-		t.Fatal(t)
+		t.Fatalf("Failed to Upsert external service: %s", err)
 	}
 
 	githubSrc, err := repos.NewGithubSource(githubExtSvc, cf)
@@ -168,7 +172,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 
 		src, err := sourcer.ForRepo(ctx, cstore, githubRepo)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to build source for repo: %s", err)
 		}
 		if err := syncer.SyncChangeset(ctx, cstore, src, githubRepo, c); err != nil {
 			t.Fatal(err)

--- a/enterprise/internal/batches/webhooks/github_test.go
+++ b/enterprise/internal/batches/webhooks/github_test.go
@@ -51,6 +51,10 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 		defer save()
 
 		secret := "secret"
+		token := os.Getenv("GITHUB_TOKEN")
+		if token == "" {
+			token = "no-GITHUB_TOKEN-set"
+		}
 		repoStore := database.Repos(db)
 		esStore := database.ExternalServices(db)
 		extSvc := &types.ExternalService{
@@ -58,7 +62,7 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 			DisplayName: "GitHub",
 			Config: ct.MarshalJSON(t, &schema.GitHubConnection{
 				Url:      "https://github.com",
-				Token:    os.Getenv("GITHUB_TOKEN"),
+				Token:    token,
 				Repos:    []string{"sourcegraph/sourcegraph"},
 				Webhooks: []*schema.GitHubWebhook{{Org: "sourcegraph", Secret: secret}},
 			}),


### PR DESCRIPTION
Co-authored with @eseliger 