### PR TITLE
frontend: Separate default repos scope

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
@@ -154,7 +156,8 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 	return s.store.List(ctx, opt)
 }
 
-// ListDefault calls database.DefaultRepos.List, with tracing.
+// ListDefault calls database.DefaultRepos.List, with tracing. It lists ALL
+// default repos which could include private user added repos.
 func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err error) {
 	ctx, done := trace(ctx, "Repos", "ListDefault", nil, &err)
 	defer func() {
@@ -165,6 +168,39 @@ func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err er
 		done()
 	}()
 	return database.GlobalDefaultRepos.List(ctx)
+}
+
+// ListDefaultPublicAndUser calls database.DefaultRepos.ListPublic, with tracing.
+// It lists all public default repos and also any private repos added by the
+// current user.
+func (s *repos) ListDefaultPublicAndUser(ctx context.Context) (repos []types.RepoName, err error) {
+	ctx, done := trace(ctx, "Repos", "ListDefaultPublic", nil, &err)
+	defer func() {
+		if err == nil {
+			span := opentracing.SpanFromContext(ctx)
+			span.LogFields(otlog.Int("result.len", len(repos)))
+		}
+		done()
+	}()
+
+	repos, err = database.GlobalDefaultRepos.ListPublic(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "listing default public repos")
+	}
+
+	// For authenticated users we also want to include any private repos they may have added
+	if a := actor.FromContext(ctx); a.IsAuthenticated() {
+		privateRepos, err := database.GlobalRepos.ListRepoNames(ctx, database.ReposListOptions{
+			UserID:      a.UID,
+			OnlyPrivate: true,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "getting user private repos")
+		}
+		repos = append(repos, privateRepos...)
+	}
+
+	return repos, nil
 }
 
 func (s *repos) GetInventory(ctx context.Context, repo *types.Repo, commitID api.CommitID, forceEnhancedLanguageDetection bool) (res *inventory.Inventory, err error) {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -424,7 +424,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 	repositoryResolver := &searchrepos.Resolver{
 		DB:               r.db,
 		Zoekt:            r.zoekt,
-		DefaultReposFunc: backend.Repos.ListDefault,
+		DefaultReposFunc: backend.Repos.ListDefaultPublicAndUser,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	tr.LazyPrintf("resolveRepositories - done")

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -20,7 +20,6 @@ import (
 	searchrepos "github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/search/searchcontexts"
 	"github.com/sourcegraph/sourcegraph/internal/comby"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/search"
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
@@ -119,7 +118,7 @@ func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Opt
 	repositoryResolver := &searchrepos.Resolver{
 		DB:               r.db,
 		Zoekt:            r.zoekt,
-		DefaultReposFunc: database.DefaultRepos(r.db).List,
+		DefaultReposFunc: backend.Repos.ListDefaultPublicAndUser,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -441,7 +441,8 @@ func resolveVersionContext(versionContext string) (*schema.VersionContext, error
 // Cf. golang/go/src/regexp/syntax/parse.go.
 const regexpFlags = regexpsyntax.ClassNL | regexpsyntax.PerlX | regexpsyntax.UnicodeGroups
 
-// A type that counts how many repos with a certain label were excluded from search results.
+// ExcludedRepos s a type that counts how many repos with a certain label were
+// excluded from search results.
 type ExcludedRepos struct {
 	Forks    int
 	Archived int
@@ -590,8 +591,8 @@ func findPatternRevs(includePatterns []string) (includePatternRevs []patternRevs
 
 type defaultReposFunc func(ctx context.Context) ([]types.RepoName, error)
 
-// defaultRepositories returns the intersection of default repos (db) and indexed
-// repos (zoekt), minus repos matching excludePatterns.
+// defaultRepositories returns the intersection of default public repos (db) and
+// indexed repos (zoekt), minus repos matching excludePatterns.
 func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFunc, z *searchbackend.Zoekt, excludePatterns []string) (_ []types.RepoName, err error) {
 	tr, ctx := trace.New(ctx, "defaultRepositories", "")
 	defer func() {

--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -450,9 +450,13 @@ func syncScheduler(ctx context.Context, sched scheduler, gitserverClient *gitser
 			return
 		}
 
-		// Fetch all default repos that are NOT cloned so that we can add them to the
+		// Fetch ALL default repos that are NOT cloned so that we can add them to the
 		// scheduler
-		if u, err := baseRepoStore.ListDefaultRepos(ctx, database.ListDefaultReposOptions{OnlyUncloned: true}); err != nil {
+		opts := database.ListDefaultReposOptions{
+			OnlyUncloned:   true,
+			IncludePrivate: true,
+		}
+		if u, err := baseRepoStore.ListDefaultRepos(ctx, opts); err != nil {
 			log15.Error("Listing default repos", "error", err)
 			return
 		} else {


### PR DESCRIPTION
Before, fetching default repos would list ALL default repos. These
include anything in the default_repos table, user added repos (both
public and private) as well as any repos added to the user_public_repos
table.

This query was used both for sending the list of repos that Zoekt should
index as well as the repos we include when performing a default indexed
search.

Since it's used for search, private repos added by any user would appear
in search results (although the contents would at least be hidden).

Now, we've split it into two:

1. ListDefault which list all default repos as before.

2. ListDefaultPublicAndUser which lists all public default repos and any
private repos added by the current user.

1 will be used by when sending repos to Zoekt for indexing.
2 will be used when performing searches.

Closes: https://github.com/sourcegraph/sourcegraph/issues/20254

TODO:
- [ ] Tests
