### PR TITLE
codeintel: Stop infinitely processing the same batch of unknown commits

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/uploads_test.go
@@ -773,6 +773,10 @@ func TestGetOldestCommitDate(t *testing.T) {
 		Upload{ID: 8, State: "completed", RepositoryID: 51},
 	)
 
+	if _, err := dbconn.Global.Exec("UPDATE lsif_uploads SET committed_at = '-infinity' WHERE id = 3"); err != nil {
+		t.Fatalf("unexpected error updating commit date %s", err)
+	}
+
 	for uploadID, commitDate := range map[int]time.Time{
 		1: t3,
 		2: t4,


### PR DESCRIPTION
Ok so this is obvious in retrospect. This is actually the same class of [bug I reported in the Go runtime](https://eric-fritz.com/articles/found-a-golang-bug/). 🤦

We keep processing a batch of (repository_id, commits) that are ALL unknown to gitserver because we don't mark any of them as being processed. We now insert a sentinel value of '-infinity' (which is a valid time in Postgres!) and skip that on the reading side.