### PR TITLE
batches: correctly set the Bitbucket Server authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Pushing batch changes to Bitbucket Server code hosts over SSH was broken in 3.27.0, and has been fixed. [#20324](https://github.com/sourcegraph/sourcegraph/issues/20324)
 
 ### Removed
 

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -80,10 +80,10 @@ func (s BitbucketServerSource) WithAuthenticator(a auth.Authenticator) (Changese
 		return nil, newUnsupportedAuthenticatorError("BitbucketServerSource", a)
 	}
 
-	sc := s
-	sc.client = sc.client.WithAuthenticator(a)
-
-	return &sc, nil
+	return &BitbucketServerSource{
+		client: s.client.WithAuthenticator(a),
+		au:     a,
+	}, nil
 }
 
 // AuthenticatedUsername uses the underlying bitbucketserver.Client to get the

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -518,6 +518,8 @@ func TestBitbucketServerSource_WithAuthenticator(t *testing.T) {
 					t.Error("cannot coerce Source into bbsSource")
 				} else if gs == nil {
 					t.Error("unexpected nil Source")
+				} else if gs.au != tc {
+					t.Errorf("incorrect authenticator: have=%v want=%v", gs.au, tc)
 				}
 			})
 		}


### PR DESCRIPTION
Fixes #20324. (See that issue for the writeup.)
