### PR TITLE
search: support select:commit.diff.added and select:commit.diff.removed

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1094,6 +1094,16 @@ func testSearchClient(t *testing.T, client searchClient) {
 				query:  `repo:go-diff patterntype:literal type:symbol HunkNoChunksize select:symbol`,
 				counts: counts{Symbol: 1},
 			},
+			{
+				name:   `select diffs with added lines containing pattern`,
+				query:  `repo:go-diff patterntype:literal type:diff select:commit.diff.added sample_binary_inline`,
+				counts: counts{Commit: 1},
+			},
+			{
+				name:   `select diffs with removed lines containing pattern`,
+				query:  `repo:go-diff patterntype:literal type:diff select:commit.diff.removed sample_binary_inline`,
+				counts: counts{Commit: 0},
+			},
 		}
 
 		for _, test := range tests {

--- a/internal/search/filter/select.go
+++ b/internal/search/filter/select.go
@@ -30,7 +30,12 @@ type Object map[string]interface{}
 var empty = struct{}{}
 
 var validSelectors = map[SelectType]Object{
-	Commit:     {},
+	Commit: {
+		"diff": Object{
+			"added":   empty,
+			"removed": empty,
+		},
+	},
 	Content:    {},
 	File:       {},
 	Repository: {},


### PR DESCRIPTION
`select:commit.diff.added` will return diff results only where a pattern exists in an added line. Respectively, `select:commit.diff.removed`. This functionality checks a prefix `+` (resp., `-`) for modified lines that have highlighting ranges (i.e., which imply a match for a pattern). When there is no pattern, it checks that the diff has _some_ modified lines containing the respective prefix.

This is only backend, frontend part to come, which will accompany changelog entry.

![Screen Shot 2021-04-22 at 1 47 55 PM](https://user-images.githubusercontent.com/888624/115787841-aafbda80-a377-11eb-84cf-a9533babbc0b.png)

Implementation notes: This was supposed to be a quick 2 hour thing and took a day instead. I'm still happy to be able to add this. I think it adds a lot of potential value for code monitors despite not doing anything fancy perf-wise. My intent is to have this functionality supported in the query syntax, and some rudimentary ways to do this in the backend, so that the day we have efficient/indexed commits, this interface will already just work.

For better future maintenance: 

- We should parse diff output into a unified diff data structure so that I'm not casing out on markdown content to figure stuff out
- It is crazy that we have two highlighting data structures (that must be kept in sync). Strictly speaking I think we only need `c.Body` values for this logic, but I don't know in what context the different highlighting data structures are used, so I keep them in sync.
- I don't know what's going on with this https://github.com/sourcegraph/sourcegraph/issues/20286 It's also crazy.