### PR TITLE
search redesign: quicklinks in sidebar

### DIFF
--- a/client/web/src/search/results/streaming/sidebar/QuickLink.tsx
+++ b/client/web/src/search/results/streaming/sidebar/QuickLink.tsx
@@ -1,0 +1,25 @@
+import LinkIcon from 'mdi-react/LinkIcon'
+import React from 'react'
+
+import { Link } from '@sourcegraph/shared/src/components/Link'
+import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+
+import { Settings } from '../../../../schema/settings.schema'
+
+import styles from './SearchSidebarSection.module.scss'
+
+export const getQuickLinks = (settingsCascade: SettingsCascadeProps['settingsCascade']): React.ReactElement[] => {
+    const quickLinks = (isSettingsValid<Settings>(settingsCascade) && settingsCascade.final.quicklinks) || []
+
+    return quickLinks.map((quickLink, index) => (
+        <Link
+            key={index}
+            to={quickLink.url}
+            data-tooltip={quickLink.description}
+            className={styles.sidebarSectionListItem}
+        >
+            <LinkIcon className="icon-inline pr-1" />
+            {quickLink.name}
+        </Link>
+    ))
+}

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.story.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.story.tsx
@@ -1,8 +1,11 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
+import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/settings'
+
 import { WebStory } from '../../../../components/WebStory'
 import { SearchPatternType } from '../../../../graphql-operations'
+import { QuickLink, SearchScope } from '../../../../schema/settings.schema'
 
 import { SearchSidebar, SearchSidebarProps } from './SearchSidebar'
 
@@ -19,6 +22,18 @@ const defaultProps: SearchSidebarProps = {
     versionContext: undefined,
     selectedSearchContextSpec: 'global',
     query: '',
+    settingsCascade: EMPTY_SETTINGS_CASCADE,
 }
 
+const quicklinks: QuickLink[] = [
+    { name: 'Home', url: '/' },
+    { name: 'Example', url: 'http://example.com', description: 'Example QuickLink' },
+]
+
 add('empty sidebar', () => <WebStory>{() => <SearchSidebar {...defaultProps} />}</WebStory>)
+
+add('with quicklinks', () => (
+    <WebStory>
+        {() => <SearchSidebar {...defaultProps} settingsCascade={{ subjects: [], final: { quicklinks } }} />}
+    </WebStory>
+))

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.story.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.story.tsx
@@ -5,7 +5,7 @@ import { EMPTY_SETTINGS_CASCADE } from '@sourcegraph/shared/src/settings/setting
 
 import { WebStory } from '../../../../components/WebStory'
 import { SearchPatternType } from '../../../../graphql-operations'
-import { QuickLink, SearchScope } from '../../../../schema/settings.schema'
+import { QuickLink } from '../../../../schema/settings.schema'
 
 import { SearchSidebar, SearchSidebarProps } from './SearchSidebar'
 

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
+import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 
 import { CaseSensitivityProps, PatternTypeProps, SearchContextProps } from '../../..'
 
+import { getQuickLinks } from './QuickLink'
 import styles from './SearchSidebar.module.scss'
 import { SearchSidebarSection } from './SearchSidebarSection'
 import { getSearchTypeLinks } from './SearchTypeLink'
@@ -12,7 +14,8 @@ export interface SearchSidebarProps
     extends Omit<PatternTypeProps, 'setPatternType'>,
         Omit<CaseSensitivityProps, 'setCaseSensitivity'>,
         VersionContextProps,
-        Pick<SearchContextProps, 'selectedSearchContextSpec'> {
+        Pick<SearchContextProps, 'selectedSearchContextSpec'>,
+        SettingsCascadeProps {
     query: string
 }
 
@@ -22,6 +25,6 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
         <SearchSidebarSection header="Dynamic filters" />
         <SearchSidebarSection header="Repositories" />
         <SearchSidebarSection header="Search snippets" />
-        <SearchSidebarSection header="Quicklinks" />
+        <SearchSidebarSection header="Quicklinks">{getQuickLinks(props.settingsCascade)}</SearchSidebarSection>
     </div>
 )

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -5,15 +5,16 @@ import styles from './SearchSidebarSection.module.scss'
 export const SearchSidebarSection: React.FunctionComponent<{ header: string; children?: React.ReactElement[] }> = ({
     header,
     children = [],
-}) => (
-    <div>
-        <h5>{header}</h5>
+}) =>
+    children.length > 0 ? (
         <div>
-            <ul className={styles.sidebarSectionList}>
-                {children.map((child, index) => (
-                    <li key={child.key || index}>{child}</li>
-                ))}
-            </ul>
+            <h5>{header}</h5>
+            <div>
+                <ul className={styles.sidebarSectionList}>
+                    {children.map((child, index) => (
+                        <li key={child.key || index}>{child}</li>
+                    ))}
+                </ul>
+            </div>
         </div>
-    </div>
-)
+    ) : null

--- a/client/web/src/search/results/streaming/sidebar/SearchTypeLink.test.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchTypeLink.test.tsx
@@ -6,7 +6,7 @@ import { SearchPatternType } from '../../../../graphql-operations'
 import { SearchSidebarProps } from './SearchSidebar'
 import { getSearchTypeLinks } from './SearchTypeLink'
 
-const defaultProps: SearchSidebarProps = {
+const defaultProps: Omit<SearchSidebarProps, 'settingsCascade'> = {
     caseSensitive: false,
     patternType: SearchPatternType.literal,
     versionContext: undefined,

--- a/client/web/src/search/results/streaming/sidebar/SearchTypeLink.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchTypeLink.tsx
@@ -9,7 +9,7 @@ import { SearchType } from '../../SearchResults'
 import { SearchSidebarProps } from './SearchSidebar'
 import styles from './SearchSidebarSection.module.scss'
 
-interface SearchTypeLinkProps extends Omit<SearchSidebarProps, 'settingsCascate'> {
+interface SearchTypeLinkProps extends Omit<SearchSidebarProps, 'settingsCascade'> {
     type: SearchType
 }
 
@@ -40,7 +40,7 @@ const SearchTypeLink: React.FunctionComponent<SearchTypeLinkProps> = ({
     )
 }
 
-export const getSearchTypeLinks = (props: Omit<SearchSidebarProps, 'settingsCascate'>): ReactElement[] => {
+export const getSearchTypeLinks = (props: Omit<SearchSidebarProps, 'settingsCascade'>): ReactElement[] => {
     const types: Exclude<SearchType, null>[] = ['file', 'repo', 'path', 'symbol', 'diff', 'commit']
     return types.map(type => <SearchTypeLink {...props} type={type} key={type} />)
 }

--- a/client/web/src/search/results/streaming/sidebar/SearchTypeLink.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchTypeLink.tsx
@@ -9,7 +9,7 @@ import { SearchType } from '../../SearchResults'
 import { SearchSidebarProps } from './SearchSidebar'
 import styles from './SearchSidebarSection.module.scss'
 
-interface SearchTypeLinkProps extends SearchSidebarProps {
+interface SearchTypeLinkProps extends Omit<SearchSidebarProps, 'settingsCascate'> {
     type: SearchType
 }
 
@@ -40,7 +40,7 @@ const SearchTypeLink: React.FunctionComponent<SearchTypeLinkProps> = ({
     )
 }
 
-export const getSearchTypeLinks = (props: SearchSidebarProps): ReactElement[] => {
+export const getSearchTypeLinks = (props: Omit<SearchSidebarProps, 'settingsCascate'>): ReactElement[] => {
     const types: Exclude<SearchType, null>[] = ['file', 'repo', 'path', 'symbol', 'diff', 'commit']
     return types.map(type => <SearchTypeLink {...props} type={type} key={type} />)
 }


### PR DESCRIPTION
Fixes #20330

- Adds quicklinks to sidebar
- Hides empty sidebar sections

![image](https://user-images.githubusercontent.com/206864/115788721-d7fcbd00-a378-11eb-9b7e-8d94ec907687.png)
