### PR TITLE
search: `contains` predicate respects repo parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Pushing batch changes to Bitbucket Server code hosts over SSH was broken in 3.27.0, and has been fixed. [#20324](https://github.com/sourcegraph/sourcegraph/issues/20324)
+- Indexed search failed when the `master` branch needed indexing but was not the default. [#20260](https://github.com/sourcegraph/sourcegraph/pull/20260)
+- `repo:contains(...)` built-in did not respect parameters that affect repo filtering (e.g., `repogroup`, `fork`). It now respects these. [#20339](https://github.com/sourcegraph/sourcegraph/pull/20339)
 
 ### Removed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1017,6 +1017,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Repo: 0},
 			},
 			{
+				`repo contains respects parameters that affect repo search (fork)`,
+				`repo:sgtest/mux fork:yes repo:contains.file(README)`,
+				counts{Repo: 1},
+			},
+			{
 				name:   `commit results without repo filter`,
 				query:  `type:commit LSIF`,
 				counts: counts{Commit: 9},

--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -239,21 +239,32 @@ func (f *RepoContainsCommitAfterPredicate) Plan(parent Basic) (Plan, error) {
 	return ToPlan(Dnf(nodes))
 }
 
-// nonPredicateRepos returns the repo nodes in a query that aren't predicates
+// nonPredicateRepos returns the repo nodes in a query that aren't predicates,
+// respecting parameters that determine repo results.
 func nonPredicateRepos(q Basic) []Node {
 	var res []Node
-	VisitField(q.ToParseTree(), FieldRepo, func(value string, negated bool, ann Annotation) {
+	VisitParameter(q.ToParseTree(), func(field, value string, negated bool, ann Annotation) {
 		if ann.Labels.IsSet(IsPredicate) {
 			// Skip predicates
 			return
 		}
-
-		res = append(res, Parameter{
-			Field:      FieldRepo,
-			Value:      value,
-			Negated:    negated,
-			Annotation: ann,
-		})
+		switch field {
+		case
+			FieldRepo,
+			FieldContext,
+			FieldRepoGroup,
+			FieldIndex,
+			FieldFork,
+			FieldArchived,
+			FieldVisibility,
+			FieldCase:
+			res = append(res, Parameter{
+				Field:      field,
+				Value:      value,
+				Negated:    negated,
+				Annotation: ann,
+			})
+		}
 	})
 	return res
 }


### PR DESCRIPTION
`contains` predicate should respect filters that affect repos. Noticed this when I was trying to combine it with `repogroup`. [This list](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/search_repositories.go#L36-53) is a good summary of which ones we should support, but we don't need all of them. 



