### PR TITLE
Fix flaky scheduler.ticker test by checking channel is closed

### DIFF
--- a/enterprise/internal/batches/scheduler/ticker.go
+++ b/enterprise/internal/batches/scheduler/ticker.go
@@ -64,8 +64,6 @@ func newTicker(schedule *window.Schedule) *ticker {
 			} else if err != nil {
 				log15.Warn("error taking from schedule", "schedule", t.schedule, "err", err)
 				close(t.C)
-				// Ensure we drain done so that there isn't a panic if and when
-				// stop() is called.
 				return
 			}
 

--- a/enterprise/internal/batches/scheduler/ticker_test.go
+++ b/enterprise/internal/batches/scheduler/ticker_test.go
@@ -47,6 +47,10 @@ func TestTickerGoBrrr(t *testing.T) {
 
 	// Finally, let's stop the ticker and make sure that the channel is closed.
 	ticker.stop()
+	// Also read from the now-closed `done` to synchronize, since closing a
+	// channel is non-blocking.
+	<-ticker.done
+	// Now make sure that the channel is closed.
 	if c := <-ticker.C; c != nil {
 		t.Errorf("unexpected non-nil channel: %v", c)
 	}
@@ -76,8 +80,12 @@ func TestTickerRateLimited(t *testing.T) {
 	}
 	c <- time.Duration(0)
 
-	// Finally, let's stop the ticker and make sure that the channel is closed.
+	// Finally, let's stop the ticker
 	ticker.stop()
+	// Also read from the now-closed `done` to synchronize, since closing a
+	// channel is non-blocking.
+	<-ticker.done
+	// Now make sure that the channel is closed.
 	if c := <-ticker.C; c != nil {
 		t.Errorf("unexpected non-nil channel: %v", c)
 	}


### PR DESCRIPTION
This should fix #20350.

Since closing a channel (which is what's happening under the hood of
`ticket.stop()`) is *not* a blocking operation, it's possible that the
goroutine of the test closes the channel and then immediately reads from
`ticker.C`. The ticker goroutine then sees the read from `t.C` before
the closing of `done` first.

The fix here leaks a bit of internals by checking `ticker.done`
explicitly. Another way to make this non-flaky would be to always  make
two reads of `ticker.C` and only check the second value.