### PR TITLE
search: determineRepos directly returns alert

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -142,7 +142,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		return nil, err
 	}
 	if alertResult != nil {
-		return alertResult, nil
+		return &SearchResultsResolver{db: r.db, alert: alertResult}, nil
 	}
 
 	q, err := query.ToBasicQuery(r.Query)

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1255,8 +1255,8 @@ func (r *searchResolver) determineResultTypes(args search.TextParameters, forceT
 	return rts
 }
 
-func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (resolved searchrepos.Resolved, res *SearchResultsResolver, err error) {
-	resolved, err = r.resolveRepositories(ctx, nil)
+func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (searchrepos.Resolved, *SearchResultsResolver, error) {
+	resolved, err := r.resolveRepositories(ctx, nil)
 	if err != nil {
 		if errors.Is(err, authz.ErrStalePermissions{}) {
 			log15.Debug("searchResolver.determineRepos", "err", err)


### PR DESCRIPTION
We don't need to return a results resolver. This is one step closer to extracting this logic out of graphqlbackend.

Also included are two other refactoring commits related to this code. You can review commit by commit.
