### PR TITLE
frontend: Rename default repo related methods

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -156,10 +156,10 @@ func (s *repos) List(ctx context.Context, opt database.ReposListOptions) (repos 
 	return s.store.List(ctx, opt)
 }
 
-// ListDefault calls database.DefaultRepos.List, with tracing. It lists ALL
+// ListIndexable calls database.DefaultRepos.List, with tracing. It lists ALL
 // default repos which could include private user added repos.
-func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err error) {
-	ctx, done := trace(ctx, "Repos", "ListDefault", nil, &err)
+func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err error) {
+	ctx, done := trace(ctx, "Repos", "ListIndexable", nil, &err)
 	defer func() {
 		if err == nil {
 			span := opentracing.SpanFromContext(ctx)
@@ -170,10 +170,10 @@ func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err er
 	return database.GlobalDefaultRepos.List(ctx)
 }
 
-// ListDefaultPublicAndUser calls database.DefaultRepos.ListPublic, with tracing.
+// ListDefault calls database.DefaultRepos.ListPublic, with tracing.
 // It lists all public default repos and also any private repos added by the
 // current user.
-func (s *repos) ListDefaultPublicAndUser(ctx context.Context) (repos []types.RepoName, err error) {
+func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err error) {
 	ctx, done := trace(ctx, "Repos", "ListDefaultPublic", nil, &err)
 	defer func() {
 		if err == nil {

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -424,7 +424,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, effectiveRepoF
 	repositoryResolver := &searchrepos.Resolver{
 		DB:               r.db,
 		Zoekt:            r.zoekt,
-		DefaultReposFunc: backend.Repos.ListDefaultPublicAndUser,
+		DefaultReposFunc: backend.Repos.ListDefault,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	tr.LazyPrintf("resolveRepositories - done")

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -118,7 +118,7 @@ func (r *searchResolver) reposExist(ctx context.Context, options searchrepos.Opt
 	repositoryResolver := &searchrepos.Resolver{
 		DB:               r.db,
 		Zoekt:            r.zoekt,
-		DefaultReposFunc: backend.Repos.ListDefaultPublicAndUser,
+		DefaultReposFunc: backend.Repos.ListDefault,
 	}
 	resolved, err := repositoryResolver.Resolve(ctx, options)
 	return err == nil && len(resolved.RepoRevs) > 0

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -213,8 +213,8 @@ type reposListServer struct {
 	// Repos is the subset of backend.Repos methods we use. Declared as an
 	// interface for testing.
 	Repos interface {
-		// ListDefault returns the repositories to index on Sourcegraph.com
-		ListDefault(context.Context) ([]types.RepoName, error)
+		// ListIndexable returns the repositories to index on Sourcegraph.com
+		ListIndexable(context.Context) ([]types.RepoName, error)
 		// List returns a list of repositories
 		List(context.Context, database.ReposListOptions) ([]*types.Repo, error)
 	}
@@ -248,7 +248,7 @@ func (h *reposListServer) serveIndex(w http.ResponseWriter, r *http.Request) err
 
 	var names []string
 	if h.SourcegraphDotComMode {
-		res, err := h.Repos.ListDefault(r.Context())
+		res, err := h.Repos.ListIndexable(r.Context())
 		if err != nil {
 			return errors.Wrap(err, "listing repos")
 		}

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -149,7 +149,7 @@ type mockRepos struct {
 	repos        []string
 }
 
-func (r *mockRepos) ListDefault(context.Context) ([]types.RepoName, error) {
+func (r *mockRepos) ListIndexable(context.Context) ([]types.RepoName, error) {
 	var repos []types.RepoName
 	for _, name := range r.defaultRepos {
 		repos = append(repos, types.RepoName{

--- a/cmd/frontend/internal/search/repos/repos.go
+++ b/cmd/frontend/internal/search/repos/repos.go
@@ -591,8 +591,8 @@ func findPatternRevs(includePatterns []string) (includePatternRevs []patternRevs
 
 type defaultReposFunc func(ctx context.Context) ([]types.RepoName, error)
 
-// defaultRepositories returns the intersection of default public repos (db) and
-// indexed repos (zoekt), minus repos matching excludePatterns.
+// defaultRepositories returns the intersection of calling getRawDefaultRepos
+// (db) and indexed repos (zoekt), minus repos matching excludePatterns.
 func defaultRepositories(ctx context.Context, getRawDefaultRepos defaultReposFunc, z *searchbackend.Zoekt, excludePatterns []string) (_ []types.RepoName, err error) {
 	tr, ctx := trace.New(ctx, "defaultRepositories", "")
 	defer func() {


### PR DESCRIPTION
So that the naming more closely matches the intent.

Handles feedback from the post merge review on https://github.com/sourcegraph/sourcegraph/pull/20322