### PR TITLE
Implement actions on changeset lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Additional language autocompletions for the `lang:` filter in the search bar. [#20535](https://github.com/sourcegraph/sourcegraph/pull/20535)
 - Steps in batch specs can now have an `if:` attribute to enable conditional execution of different steps. [#20701](https://github.com/sourcegraph/sourcegraph/pull/20701)
 - Extensions can now log messages through `sourcegraph.app.log` to aid debugging user issues. [#20474](https://github.com/sourcegraph/sourcegraph/pull/20474)
+- Bulk comments on many changesets are now available in Batch Changes. [#20361](https://github.com/sourcegraph/sourcegraph/pull/20361)
 
 ### Changed
 

--- a/client/web/src/components/DismissibleAlert.tsx
+++ b/client/web/src/components/DismissibleAlert.tsx
@@ -14,9 +14,7 @@ interface Props {
  * again.
  */
 export const DismissibleAlert: React.FunctionComponent<Props> = ({ partialStorageKey, className, children }) => {
-    const [dismissed, setDismissed] = React.useState<boolean>(
-        localStorage.getItem(storageKeyForPartial(partialStorageKey)) === 'true'
-    )
+    const [dismissed, setDismissed] = React.useState<boolean>(isAlertDismissed(partialStorageKey))
 
     const onDismiss = React.useCallback(() => {
         dismissAlert(partialStorageKey)
@@ -38,6 +36,10 @@ export const DismissibleAlert: React.FunctionComponent<Props> = ({ partialStorag
 
 export function dismissAlert(key: string): void {
     localStorage.setItem(storageKeyForPartial(key), 'true')
+}
+
+export function isAlertDismissed(key: string): boolean {
+    return localStorage.getItem(storageKeyForPartial(key)) === 'true'
 }
 
 function storageKeyForPartial(partialStorageKey: string): string {

--- a/client/web/src/components/DismissibleAlert.tsx
+++ b/client/web/src/components/DismissibleAlert.tsx
@@ -14,13 +14,14 @@ interface Props {
  * again.
  */
 export const DismissibleAlert: React.FunctionComponent<Props> = ({ partialStorageKey, className, children }) => {
-    const key = `DismissibleAlert/${partialStorageKey}/dismissed`
-    const [dismissed, setDismissed] = React.useState<boolean>(localStorage.getItem(key) === 'true')
+    const [dismissed, setDismissed] = React.useState<boolean>(
+        localStorage.getItem(storageKeyForPartial(partialStorageKey)) === 'true'
+    )
 
     const onDismiss = React.useCallback(() => {
-        localStorage.setItem(key, 'true')
+        dismissAlert(partialStorageKey)
         setDismissed(true)
-    }, [key])
+    }, [partialStorageKey])
 
     if (dismissed) {
         return null
@@ -33,4 +34,12 @@ export const DismissibleAlert: React.FunctionComponent<Props> = ({ partialStorag
             </button>
         </div>
     )
+}
+
+export function dismissAlert(key: string): void {
+    localStorage.setItem(storageKeyForPartial(key), 'true')
+}
+
+function storageKeyForPartial(partialStorageKey: string): string {
+    return `DismissibleAlert/${partialStorageKey}/dismissed`
 }

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.story.tsx
@@ -69,6 +69,13 @@ const batchChangeDefaults: BatchChangeFields = {
         originalInput: 'name: awesome-batch-change\ndescription: somestring',
         supersedingBatchSpec: null,
     },
+    bulkOperations: {
+        totalCount: 0,
+    },
+    activeBulkOperations: {
+        totalCount: 0,
+        nodes: [],
+    },
 }
 
 const queryChangesets: typeof _queryChangesets = () =>

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
@@ -1,3 +1,4 @@
+import { subDays } from 'date-fns'
 import * as H from 'history'
 import AlertCircleIcon from 'mdi-react/AlertCircleIcon'
 import React, { useState, useMemo, useCallback } from 'react'
@@ -25,7 +26,6 @@ import { BatchChangeInfoByline } from '../detail/BatchChangeInfoByline'
 import { closeBatchChange as _closeBatchChange } from './backend'
 import { BatchChangeCloseAlert } from './BatchChangeCloseAlert'
 import { BatchChangeCloseChangesetsList } from './BatchChangeCloseChangesetsList'
-import { subDays } from 'date-fns'
 
 export interface BatchChangeClosePageProps
     extends ThemeProps,
@@ -71,9 +71,10 @@ export const BatchChangeClosePage: React.FunctionComponent<BatchChangeClosePageP
     const createdAfter = useMemo(() => subDays(new Date(), 3).toISOString(), [])
     const batchChange = useObservable(
         useMemo(() => fetchBatchChangeByNamespace(namespaceID, batchChangeName, createdAfter), [
+            fetchBatchChangeByNamespace,
             namespaceID,
             batchChangeName,
-            fetchBatchChangeByNamespace,
+            createdAfter,
         ])
     )
 

--- a/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
+++ b/client/web/src/enterprise/batches/close/BatchChangeClosePage.tsx
@@ -25,6 +25,7 @@ import { BatchChangeInfoByline } from '../detail/BatchChangeInfoByline'
 import { closeBatchChange as _closeBatchChange } from './backend'
 import { BatchChangeCloseAlert } from './BatchChangeCloseAlert'
 import { BatchChangeCloseChangesetsList } from './BatchChangeCloseChangesetsList'
+import { subDays } from 'date-fns'
 
 export interface BatchChangeClosePageProps
     extends ThemeProps,
@@ -67,8 +68,9 @@ export const BatchChangeClosePage: React.FunctionComponent<BatchChangeClosePageP
     closeBatchChange,
 }) => {
     const [closeChangesets, setCloseChangesets] = useState<boolean>(false)
+    const createdAfter = useMemo(() => subDays(new Date(), 3).toISOString(), [])
     const batchChange = useObservable(
-        useMemo(() => fetchBatchChangeByNamespace(namespaceID, batchChangeName), [
+        useMemo(() => fetchBatchChangeByNamespace(namespaceID, batchChangeName, createdAfter), [
             namespaceID,
             batchChangeName,
             fetchBatchChangeByNamespace,

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -75,6 +75,20 @@ const batchChangeDefaults: BatchChangeFields = {
     bulkOperations: {
         totalCount: 3,
     },
+    activeBulkOperations: {
+        totalCount: 1,
+        nodes: [
+            {
+                id: 'testid-123',
+                state: BulkOperationState.PROCESSING,
+                createdAt: subDays(now, 2).toISOString(),
+                finishedAt: null,
+                progress: 0.37,
+                errors: [],
+                type: BulkOperationType.COMMENT,
+            },
+        ],
+    },
     diffStat: { added: 1000, changed: 2000, deleted: 1000 },
 }
 
@@ -259,7 +273,7 @@ const queryBulkOperations: typeof _queryBulkOperations = () =>
                             },
                             title: 'Changeset title on code host',
                         },
-                        error: `Failed to create comment, cannot comment on a PR that is awesome.`,
+                        error: 'Failed to create comment, cannot comment on a PR that is awesome.',
                     },
                 ],
                 progress: 1,

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -81,26 +81,6 @@ const batchChangeDefaults: BatchChangeFields = {
             {
                 id: 'testid-123',
                 state: BulkOperationState.PROCESSING,
-                createdAt: subDays(now, 2).toISOString(),
-                finishedAt: null,
-                progress: 0.37,
-                errors: [
-                    {
-                        changeset: {
-                            __typename: 'ExternalChangeset',
-                            title: 'Changeset title',
-                            externalURL: { url: '/test' },
-                            repository: { name: 'sourcegraph/sourcegraph', url: '/github.com/sourcegraph/sourcegraph' },
-                        },
-                        error: 'Very bad error happening here',
-                    },
-                ],
-                type: BulkOperationType.COMMENT,
-                changesetCount: 100,
-                initiator: {
-                    url: '/users/alice',
-                    username: 'alice',
-                },
             },
         ],
     },

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -7,6 +7,8 @@ import { of } from 'rxjs'
 
 import {
     BatchChangeFields,
+    BulkOperationState,
+    BulkOperationType,
     ChangesetCheckState,
     ChangesetReviewState,
     ChangesetSpecType,
@@ -19,6 +21,7 @@ import {
     queryChangesets as _queryChangesets,
     queryExternalChangesetWithFileDiffs,
     queryChangesetCountsOverTime as _queryChangesetCountsOverTime,
+    queryBulkOperations as _queryBulkOperations,
 } from './backend'
 import { BatchChangeDetailsPage } from './BatchChangeDetailsPage'
 
@@ -68,6 +71,9 @@ const batchChangeDefaults: BatchChangeFields = {
     currentSpec: {
         originalInput: 'name: awesome-batch-changes\ndescription: somestring',
         supersedingBatchSpec: null,
+    },
+    bulkOperations: {
+        totalCount: 3,
     },
     diffStat: { added: 1000, changed: 2000, deleted: 1000 },
 }
@@ -210,6 +216,59 @@ const queryEmptyExternalChangesetWithFileDiffs: typeof queryExternalChangesetWit
         },
     })
 
+const queryBulkOperations: typeof _queryBulkOperations = () =>
+    of({
+        totalCount: 3,
+        pageInfo: {
+            endCursor: null,
+            hasNextPage: false,
+        },
+        nodes: [
+            {
+                id: 'id1',
+                type: BulkOperationType.COMMENT,
+                state: BulkOperationState.PROCESSING,
+                errors: [],
+                progress: 0.25,
+                createdAt: subDays(now, 5).toISOString(),
+                finishedAt: null,
+            },
+            {
+                id: 'id2',
+                type: BulkOperationType.COMMENT,
+                state: BulkOperationState.COMPLETED,
+                errors: [],
+                progress: 1,
+                createdAt: subDays(now, 5).toISOString(),
+                finishedAt: subDays(now, 4).toISOString(),
+            },
+            {
+                id: 'id3',
+                type: BulkOperationType.COMMENT,
+                state: BulkOperationState.FAILED,
+                errors: [
+                    {
+                        changeset: {
+                            __typename: 'ExternalChangeset',
+                            externalURL: {
+                                url: 'https://test.test/my/pr',
+                            },
+                            repository: {
+                                name: 'sourcegraph/sourcegraph',
+                                url: '/github.com/sourcegraph/sourcegraph',
+                            },
+                            title: 'Changeset title on code host',
+                        },
+                        error: `Failed to create comment, cannot comment on a PR that is awesome.`,
+                    },
+                ],
+                progress: 1,
+                createdAt: subDays(now, 5).toISOString(),
+                finishedAt: subDays(now, 4).toISOString(),
+            },
+        ],
+    })
+
 const queryChangesetCountsOverTime: typeof _queryChangesetCountsOverTime = () =>
     of([
         {
@@ -281,6 +340,7 @@ const stories: Record<string, { url: string; supersededBatchSpec?: boolean }> = 
     'Burndown chart': { url: '/users/alice/batch-changes/awesome-batch-change?tab=chart' },
     'Spec file': { url: '/users/alice/batch-changes/awesome-batch-change?tab=spec' },
     Archived: { url: '/users/alice/batch-changes/awesome-batch-change?tab=archived' },
+    'Bulk operations': { url: '/users/alice/batch-changes/awesome-batch-change?tab=bulkoperations' },
     'Superseded batch-spec': { url: '/users/alice/batch-changes/awesome-batch-change', supersededBatchSpec: true },
 }
 
@@ -320,6 +380,7 @@ for (const [name, { url, supersededBatchSpec }] of Object.entries(stories)) {
                         queryChangesetCountsOverTime={queryChangesetCountsOverTime}
                         queryExternalChangesetWithFileDiffs={queryEmptyExternalChangesetWithFileDiffs}
                         deleteBatchChange={deleteBatchChange}
+                        queryBulkOperations={queryBulkOperations}
                         extensionsController={{} as any}
                         platformContext={{} as any}
                     />

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -86,6 +86,11 @@ const batchChangeDefaults: BatchChangeFields = {
                 progress: 0.37,
                 errors: [],
                 type: BulkOperationType.COMMENT,
+                changesetCount: 100,
+                initiator: {
+                    url: '/users/alice',
+                    username: 'alice',
+                },
             },
         ],
     },
@@ -246,6 +251,11 @@ const queryBulkOperations: typeof _queryBulkOperations = () =>
                 progress: 0.25,
                 createdAt: subDays(now, 5).toISOString(),
                 finishedAt: null,
+                changesetCount: 100,
+                initiator: {
+                    url: '/users/alice',
+                    username: 'alice',
+                },
             },
             {
                 id: 'id2',
@@ -255,6 +265,11 @@ const queryBulkOperations: typeof _queryBulkOperations = () =>
                 progress: 1,
                 createdAt: subDays(now, 5).toISOString(),
                 finishedAt: subDays(now, 4).toISOString(),
+                changesetCount: 100,
+                initiator: {
+                    url: '/users/alice',
+                    username: 'alice',
+                },
             },
             {
                 id: 'id3',
@@ -279,6 +294,11 @@ const queryBulkOperations: typeof _queryBulkOperations = () =>
                 progress: 1,
                 createdAt: subDays(now, 5).toISOString(),
                 finishedAt: subDays(now, 4).toISOString(),
+                changesetCount: 100,
+                initiator: {
+                    url: '/users/alice',
+                    username: 'alice',
+                },
             },
         ],
     })

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -84,7 +84,17 @@ const batchChangeDefaults: BatchChangeFields = {
                 createdAt: subDays(now, 2).toISOString(),
                 finishedAt: null,
                 progress: 0.37,
-                errors: [],
+                errors: [
+                    {
+                        changeset: {
+                            __typename: 'ExternalChangeset',
+                            title: 'Changeset title',
+                            externalURL: { url: '/test' },
+                            repository: { name: 'sourcegraph/sourcegraph', url: '/github.com/sourcegraph/sourcegraph' },
+                        },
+                        error: 'Very bad error happening here',
+                    },
+                ],
                 type: BulkOperationType.COMMENT,
                 changesetCount: 100,
                 initiator: {

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -33,6 +33,7 @@ import { BatchChangeInfoByline } from './BatchChangeInfoByline'
 import { BatchChangeStatsCard } from './BatchChangeStatsCard'
 import { BatchChangeTabs } from './BatchChangeTabs'
 import { BulkOperationNode } from './bulk-operations/BulkOperationNode'
+import { BulkOperationsNotifications } from './BulkOperationsNotifications'
 import { ChangesetsArchivedNotice } from './ChangesetsArchivedNotice'
 import { ClosedNotice } from './ClosedNotice'
 import { SupersedingBatchSpecAlert } from './SupersedingBatchSpecAlert'
@@ -117,9 +118,6 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
         return <HeroPage icon={AlertCircleIcon} title="Batch change not found" />
     }
 
-    const parameters = new URLSearchParams(location.search)
-    const isBulkTabOpen = parameters.get('tab') === 'bulkoperations'
-
     return (
         <>
             <PageTitle title={batchChange.name} />
@@ -151,16 +149,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                 }
                 className="test-batch-change-details-page mb-3"
             />
-            {!isBulkTabOpen &&
-                batchChange.activeBulkOperations.nodes.map(node => (
-                    <DismissibleAlert
-                        key={node.id}
-                        className="alert alert-info"
-                        partialStorageKey={`bulkOperation-${node.id}`}
-                    >
-                        <BulkOperationNode node={node} key={node.id} />
-                    </DismissibleAlert>
-                ))}
+            <BulkOperationsNotifications location={location} bulkOperations={batchChange.activeBulkOperations} />
             <SupersedingBatchSpecAlert spec={batchChange.currentSpec.supersedingBatchSpec} />
             <ClosedNotice closedAt={batchChange.closedAt} className="mb-3" />
             <UnpublishedNotice

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -31,7 +31,7 @@ import { BatchChangeDetailsActionSection } from './BatchChangeDetailsActionSecti
 import { BatchChangeInfoByline } from './BatchChangeInfoByline'
 import { BatchChangeStatsCard } from './BatchChangeStatsCard'
 import { BatchChangeTabs } from './BatchChangeTabs'
-import { BulkOperationsNotifications } from './BulkOperationsNotifications'
+import { BulkOperationsAlerts } from './BulkOperationsAlerts'
 import { ChangesetsArchivedNotice } from './ChangesetsArchivedNotice'
 import { ClosedNotice } from './ClosedNotice'
 import { SupersedingBatchSpecAlert } from './SupersedingBatchSpecAlert'
@@ -146,7 +146,7 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
                 }
                 className="test-batch-change-details-page mb-3"
             />
-            <BulkOperationsNotifications location={location} bulkOperations={batchChange.activeBulkOperations} />
+            <BulkOperationsAlerts location={location} bulkOperations={batchChange.activeBulkOperations} />
             <SupersedingBatchSpecAlert spec={batchChange.currentSpec.supersedingBatchSpec} />
             <ClosedNotice closedAt={batchChange.closedAt} className="mb-3" />
             <UnpublishedNotice

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.tsx
@@ -14,7 +14,6 @@ import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 import { PageHeader } from '@sourcegraph/wildcard'
 
 import { BatchChangesIcon } from '../../../batches/icons'
-import { DismissibleAlert } from '../../../components/DismissibleAlert'
 import { HeroPage } from '../../../components/HeroPage'
 import { PageTitle } from '../../../components/PageTitle'
 import { BatchChangeFields, Scalars } from '../../../graphql-operations'
@@ -32,7 +31,6 @@ import { BatchChangeDetailsActionSection } from './BatchChangeDetailsActionSecti
 import { BatchChangeInfoByline } from './BatchChangeInfoByline'
 import { BatchChangeStatsCard } from './BatchChangeStatsCard'
 import { BatchChangeTabs } from './BatchChangeTabs'
-import { BulkOperationNode } from './bulk-operations/BulkOperationNode'
 import { BulkOperationsNotifications } from './BulkOperationsNotifications'
 import { ChangesetsArchivedNotice } from './ChangesetsArchivedNotice'
 import { ClosedNotice } from './ClosedNotice'
@@ -93,7 +91,6 @@ export const BatchChangeDetailsPage: React.FunctionComponent<BatchChangeDetailsP
     }, [telemetryService])
 
     const createdAfter = useMemo(() => subDays(new Date(), 3).toISOString(), [])
-
     const batchChange: BatchChangeFields | null | undefined = useObservable(
         useMemo(
             () =>

--- a/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
@@ -207,7 +207,6 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                     queryChangesets={queryChangesets}
                     queryExternalChangesetWithFileDiffs={queryExternalChangesetWithFileDiffs}
                     onlyArchived={true}
-                    enableSelect={true}
                 />
             )}
         </>

--- a/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeTabs.tsx
@@ -25,7 +25,13 @@ import { BatchSpecTab } from './BatchSpecTab'
 import { BulkOperationsTab } from './BulkOperationsTab'
 import { BatchChangeChangesets } from './changesets/BatchChangeChangesets'
 
-type SelectedTab = 'changesets' | 'chart' | 'spec' | 'archived' | 'bulkoperations'
+export enum BatchChangeTab {
+    CHANGESETS = 'changesets',
+    CHART = 'chart',
+    SPEC = 'spec',
+    ARCHIVED = 'archived',
+    BULK_OPERATIONS = 'bulkoperations',
+}
 
 export interface BatchChangeTabsProps
     extends ExtensionsControllerProps,
@@ -64,7 +70,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     queryExternalChangesetWithFileDiffs,
     queryBulkOperations,
 }) => {
-    const [selectedTab, setSelectedTab] = useState<SelectedTab>(selectedTabFromLocation(location.search))
+    const [selectedTab, setSelectedTab] = useState<BatchChangeTab>(selectedTabFromLocation(location.search))
     useEffect(() => {
         const newTab = selectedTabFromLocation(location.search)
         if (newTab !== selectedTab) {
@@ -75,7 +81,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     const onSelectChangesets = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()
-            setSelectedTab('changesets')
+            setSelectedTab(BatchChangeTab.CHANGESETS)
             const urlParameters = new URLSearchParams(location.search)
             urlParameters.delete('tab')
             removeConnectionParameters(urlParameters)
@@ -88,9 +94,9 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     const onSelectChart = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()
-            setSelectedTab('chart')
+            setSelectedTab(BatchChangeTab.CHART)
             const urlParameters = new URLSearchParams(location.search)
-            urlParameters.set('tab', 'chart')
+            urlParameters.set('tab', BatchChangeTab.CHART)
             removeConnectionParameters(urlParameters)
             if (location.search !== urlParameters.toString()) {
                 history.replace({ ...location, search: urlParameters.toString() })
@@ -101,9 +107,9 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     const onSelectSpec = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()
-            setSelectedTab('spec')
+            setSelectedTab(BatchChangeTab.SPEC)
             const urlParameters = new URLSearchParams(location.search)
-            urlParameters.set('tab', 'spec')
+            urlParameters.set('tab', BatchChangeTab.SPEC)
             removeConnectionParameters(urlParameters)
             if (location.search !== urlParameters.toString()) {
                 history.replace({ ...location, search: urlParameters.toString() })
@@ -114,9 +120,9 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     const onSelectArchived = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()
-            setSelectedTab('archived')
+            setSelectedTab(BatchChangeTab.ARCHIVED)
             const urlParameters = new URLSearchParams(location.search)
-            urlParameters.set('tab', 'archived')
+            urlParameters.set('tab', BatchChangeTab.ARCHIVED)
             removeConnectionParameters(urlParameters)
             if (location.search !== urlParameters.toString()) {
                 history.replace({ ...location, search: urlParameters.toString() })
@@ -127,9 +133,9 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     const onSelectBulkOperations = useCallback<React.MouseEventHandler>(
         event => {
             event.preventDefault()
-            setSelectedTab('bulkoperations')
+            setSelectedTab(BatchChangeTab.BULK_OPERATIONS)
             const urlParameters = new URLSearchParams(location.search)
-            urlParameters.set('tab', 'bulkoperations')
+            urlParameters.set('tab', BatchChangeTab.BULK_OPERATIONS)
             removeConnectionParameters(urlParameters)
             if (location.search !== urlParameters.toString()) {
                 history.replace({ ...location, search: urlParameters.toString() })
@@ -148,7 +154,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                             href=""
                             role="button"
                             onClick={onSelectChangesets}
-                            className={classNames('nav-link', selectedTab === 'changesets' && 'active')}
+                            className={classNames('nav-link', selectedTab === BatchChangeTab.CHANGESETS && 'active')}
                         >
                             <SourceBranchIcon className="icon-inline text-muted mr-1" />
                             Changesets <span className="badge badge-pill badge-secondary ml-1">{changesetsCount}</span>
@@ -160,7 +166,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                             href=""
                             role="button"
                             onClick={onSelectChart}
-                            className={classNames('nav-link', selectedTab === 'chart' && 'active')}
+                            className={classNames('nav-link', selectedTab === BatchChangeTab.CHART && 'active')}
                         >
                             <ChartLineVariantIcon className="icon-inline text-muted mr-1" /> Burndown chart
                         </a>
@@ -171,7 +177,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                             href=""
                             role="button"
                             onClick={onSelectSpec}
-                            className={classNames('nav-link', selectedTab === 'spec' && 'active')}
+                            className={classNames('nav-link', selectedTab === BatchChangeTab.SPEC && 'active')}
                         >
                             <FileDocumentIcon className="icon-inline text-muted mr-1" /> Spec
                         </a>
@@ -182,7 +188,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                             href=""
                             role="button"
                             onClick={onSelectArchived}
-                            className={classNames('nav-link', selectedTab === 'archived' && 'active')}
+                            className={classNames('nav-link', selectedTab === BatchChangeTab.ARCHIVED && 'active')}
                         >
                             <ArchiveIcon className="icon-inline text-muted mr-1" /> Archived{' '}
                             <span className="badge badge-pill badge-secondary ml-1">{archivedCount}</span>
@@ -194,7 +200,10 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                             href=""
                             role="button"
                             onClick={onSelectBulkOperations}
-                            className={classNames('nav-link', selectedTab === 'bulkoperations' && 'active')}
+                            className={classNames(
+                                'nav-link',
+                                selectedTab === BatchChangeTab.BULK_OPERATIONS && 'active'
+                            )}
                         >
                             <MonitorStarIcon className="icon-inline text-muted mr-1" /> Bulk operations{' '}
                             <span className="badge badge-pill badge-secondary ml-1">{bulkOperationsCount}</span>
@@ -202,14 +211,14 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                     </li>
                 </ul>
             </div>
-            {selectedTab === 'chart' && (
+            {selectedTab === BatchChangeTab.CHART && (
                 <BatchChangeBurndownChart
                     batchChangeID={batchChange.id}
                     queryChangesetCountsOverTime={queryChangesetCountsOverTime}
                     history={history}
                 />
             )}
-            {selectedTab === 'changesets' && (
+            {selectedTab === BatchChangeTab.CHANGESETS && (
                 <BatchChangeChangesets
                     batchChangeID={batchChange.id}
                     viewerCanAdminister={batchChange.viewerCanAdminister}
@@ -224,10 +233,10 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                     onlyArchived={false}
                 />
             )}
-            {selectedTab === 'spec' && (
+            {selectedTab === BatchChangeTab.SPEC && (
                 <BatchSpecTab batchChange={batchChange} originalInput={batchChange.currentSpec.originalInput} />
             )}
-            {selectedTab === 'archived' && (
+            {selectedTab === BatchChangeTab.ARCHIVED && (
                 <BatchChangeChangesets
                     batchChangeID={batchChange.id}
                     viewerCanAdminister={batchChange.viewerCanAdminister}
@@ -242,7 +251,7 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
                     onlyArchived={true}
                 />
             )}
-            {selectedTab === 'bulkoperations' && (
+            {selectedTab === BatchChangeTab.BULK_OPERATIONS && (
                 <BulkOperationsTab
                     batchChangeID={batchChange.id}
                     history={history}
@@ -254,21 +263,17 @@ export const BatchChangeTabs: React.FunctionComponent<BatchChangeTabsProps> = ({
     )
 }
 
-function selectedTabFromLocation(locationSearch: string): SelectedTab {
+function selectedTabFromLocation(locationSearch: string): BatchChangeTab {
     const urlParameters = new URLSearchParams(locationSearch)
-    if (urlParameters.get('tab') === 'chart') {
-        return 'chart'
+    const tabParameter = urlParameters.get('tab')
+    if (tabParameter && isValidTabParameter(tabParameter)) {
+        return tabParameter
     }
-    if (urlParameters.get('tab') === 'spec') {
-        return 'spec'
-    }
-    if (urlParameters.get('tab') === 'archived') {
-        return 'archived'
-    }
-    if (urlParameters.get('tab') === 'bulkoperations') {
-        return 'bulkoperations'
-    }
-    return 'changesets'
+    return BatchChangeTab.CHANGESETS
+}
+
+function isValidTabParameter(value: string): value is BatchChangeTab {
+    return Object.values<string>(BatchChangeTab).includes(value)
 }
 
 function removeConnectionParameters(parameters: URLSearchParams): void {

--- a/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.story.tsx
@@ -6,9 +6,9 @@ import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
 
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 
-import { BulkOperationsNotifications } from './BulkOperationsNotifications'
+import { BulkOperationsAlerts } from './BulkOperationsAlerts'
 
-const { add } = storiesOf('web/batches/details/BulkOperationsNotifications', module).addDecorator(story => (
+const { add } = storiesOf('web/batches/details/BulkOperationsAlerts', module).addDecorator(story => (
     <div className="p-3 container web-content">{story()}</div>
 ))
 
@@ -19,7 +19,7 @@ add('Processing', () => {
     )
     return (
         <EnterpriseWebStory>
-            {props => <BulkOperationsNotifications {...props} bulkOperations={bulkOperations} />}
+            {props => <BulkOperationsAlerts {...props} bulkOperations={bulkOperations} />}
         </EnterpriseWebStory>
     )
 })
@@ -30,7 +30,7 @@ add('Failed', () => {
     )
     return (
         <EnterpriseWebStory>
-            {props => <BulkOperationsNotifications {...props} bulkOperations={bulkOperations} />}
+            {props => <BulkOperationsAlerts {...props} bulkOperations={bulkOperations} />}
         </EnterpriseWebStory>
     )
 })
@@ -41,7 +41,7 @@ add('Completed', () => {
     )
     return (
         <EnterpriseWebStory>
-            {props => <BulkOperationsNotifications {...props} bulkOperations={bulkOperations} />}
+            {props => <BulkOperationsAlerts {...props} bulkOperations={bulkOperations} />}
         </EnterpriseWebStory>
     )
 })

--- a/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.tsx
@@ -7,6 +7,7 @@ import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { DismissibleAlert, isAlertDismissed } from '../../../components/DismissibleAlert'
 import { ActiveBulkOperationsConnectionFields } from '../../../graphql-operations'
+
 import { BatchChangeTab } from './BatchChangeTabs'
 
 export interface BulkOperationsAlertsProps {
@@ -16,7 +17,7 @@ export interface BulkOperationsAlertsProps {
 
 /**
  * Renders the alert bar at the top of the BatchChangeDetailsPage, when a bulk operation recently changed state or is processing.
- * The logic for this is rather complex (TODO). It takes a list of bulk operations, which returns at most the latest 3 entries and
+ * The logic for this is rather complex (TODO). It takes a list of bulk operations, which returns at most the latest 50 entries and
  * only entries that were created less than three days ago.
  * If there are any processing operations in that list, and the alerts have not been dismissed yet, a "in progress" alert is shown.
  * If not, and there are failed bulk operations in the list and the alert for that hasn't been dismissed yet, a "something failed"

--- a/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.tsx
@@ -14,6 +14,16 @@ export interface BulkOperationsAlertsProps {
     bulkOperations: ActiveBulkOperationsConnectionFields
 }
 
+/**
+ * Renders the alert bar at the top of the BatchChangeDetailsPage, when a bulk operation recently changed state or is processing.
+ * The logic for this is rather complex (TODO). It takes a list of bulk operations, which returns at most the latest 3 entries and
+ * only entries that were created less than three days ago.
+ * If there are any processing operations in that list, and the alerts have not been dismissed yet, a "in progress" alert is shown.
+ * If not, and there are failed bulk operations in the list and the alert for that hasn't been dismissed yet, a "something failed"
+ * alert is shown.
+ * If neither of the two above, and at least one completed operation is in the list and the alert has not yet been dismissed, a
+ * "something recently completed" alert is shown.
+ */
 export const BulkOperationsAlerts: React.FunctionComponent<BulkOperationsAlertsProps> = ({
     bulkOperations,
     location,

--- a/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsAlerts.tsx
@@ -9,12 +9,12 @@ import { DismissibleAlert, isAlertDismissed } from '../../../components/Dismissi
 import { ActiveBulkOperationsConnectionFields } from '../../../graphql-operations'
 import { BatchChangeTab } from './BatchChangeTabs'
 
-export interface BulkOperationsNotificationsProps {
+export interface BulkOperationsAlertsProps {
     location: H.Location
     bulkOperations: ActiveBulkOperationsConnectionFields
 }
 
-export const BulkOperationsNotifications: React.FunctionComponent<BulkOperationsNotificationsProps> = ({
+export const BulkOperationsAlerts: React.FunctionComponent<BulkOperationsAlertsProps> = ({
     bulkOperations,
     location,
 }) => {

--- a/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.story.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from '@storybook/addons'
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
+
+import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
+
+import { BulkOperationsNotifications } from './BulkOperationsNotifications'
+
+const { add } = storiesOf('web/batches/details/BulkOperationsNotifications', module).addDecorator(story => (
+    <div className="p-3 container web-content">{story()}</div>
+))
+
+add('Processing', () => {
+    const bulkOperations = useMemo(
+        () => ({ totalCount: 1, nodes: [{ id: '132', state: BulkOperationState.PROCESSING }] }),
+        []
+    )
+    return (
+        <EnterpriseWebStory>
+            {props => <BulkOperationsNotifications {...props} bulkOperations={bulkOperations} />}
+        </EnterpriseWebStory>
+    )
+})
+add('Failed', () => {
+    const bulkOperations = useMemo(
+        () => ({ totalCount: 1, nodes: [{ id: '132', state: BulkOperationState.FAILED }] }),
+        []
+    )
+    return (
+        <EnterpriseWebStory>
+            {props => <BulkOperationsNotifications {...props} bulkOperations={bulkOperations} />}
+        </EnterpriseWebStory>
+    )
+})
+add('Completed', () => {
+    const bulkOperations = useMemo(
+        () => ({ totalCount: 1, nodes: [{ id: '132', state: BulkOperationState.COMPLETED }] }),
+        []
+    )
+    return (
+        <EnterpriseWebStory>
+            {props => <BulkOperationsNotifications {...props} bulkOperations={bulkOperations} />}
+        </EnterpriseWebStory>
+    )
+})

--- a/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
@@ -7,6 +7,7 @@ import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { DismissibleAlert, isAlertDismissed } from '../../../components/DismissibleAlert'
 import { ActiveBulkOperationsConnectionFields } from '../../../graphql-operations'
+import { BatchChangeTab } from './BatchChangeTabs'
 
 export interface BulkOperationsNotificationsProps {
     location: H.Location
@@ -19,7 +20,7 @@ export const BulkOperationsNotifications: React.FunctionComponent<BulkOperations
 }) => {
     // Don't show the header banners if the bulkoperations tab is open.
     const parameters = new URLSearchParams(location.search)
-    if (parameters.get('tab') === 'bulkoperations') {
+    if (parameters.get('tab') === BatchChangeTab.BULK_OPERATIONS) {
         return null
     }
 

--- a/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
@@ -29,7 +29,7 @@ export const BulkOperationsNotifications: React.FunctionComponent<BulkOperations
                     className="alert alert-info"
                     partialStorageKey={`bulkOperation-${node.id}`}
                 >
-                    <BulkOperationNode node={node} key={node.id} />
+                    <BulkOperationNode node={node} key={node.id} showErrors={false} />
                 </DismissibleAlert>
             ))}
         </>

--- a/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
@@ -1,10 +1,12 @@
 import * as H from 'history'
 import React from 'react'
 
-import { DismissibleAlert } from '../../../components/DismissibleAlert'
-import { ActiveBulkOperationsConnectionFields } from '../../../graphql-operations'
+import { Link } from '@sourcegraph/shared/src/components/Link'
+import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
-import { BulkOperationNode } from './bulk-operations/BulkOperationNode'
+import { DismissibleAlert, isAlertDismissed } from '../../../components/DismissibleAlert'
+import { ActiveBulkOperationsConnectionFields } from '../../../graphql-operations'
 
 export interface BulkOperationsNotificationsProps {
     location: H.Location
@@ -21,17 +23,54 @@ export const BulkOperationsNotifications: React.FunctionComponent<BulkOperations
         return null
     }
 
-    return (
-        <>
-            {bulkOperations.nodes.map(node => (
-                <DismissibleAlert
-                    key={node.id}
-                    className="alert alert-info"
-                    partialStorageKey={`bulkOperation-${node.id}`}
-                >
-                    <BulkOperationNode node={node} key={node.id} showErrors={false} />
-                </DismissibleAlert>
-            ))}
-        </>
-    )
+    const latestProcessingNode = bulkOperations.nodes.find(node => node.state === BulkOperationState.PROCESSING)
+    if (latestProcessingNode && !isAlertDismissed(`bulkOperation-processing-${latestProcessingNode.id}`)) {
+        const processingCount = bulkOperations.nodes.filter(node => node.state === BulkOperationState.PROCESSING).length
+        return (
+            <DismissibleAlert
+                className="alert alert-info"
+                partialStorageKey={`bulkOperation-processing-${latestProcessingNode.id}`}
+            >
+                <span>
+                    {processingCount} bulk {pluralize('operation', processingCount)}{' '}
+                    {pluralize('is', processingCount, 'are')} currently running. Click the{' '}
+                </span>
+                <Link to="?tab=bulkoperations">bulk operations tab</Link> to view.
+            </DismissibleAlert>
+        )
+    }
+
+    const latestFailedNode = bulkOperations.nodes.find(node => node.state === BulkOperationState.FAILED)
+    if (latestFailedNode && !isAlertDismissed(`bulkOperation-failed-${latestFailedNode.id}`)) {
+        const failedCount = bulkOperations.nodes.filter(node => node.state === BulkOperationState.FAILED).length
+        return (
+            <DismissibleAlert
+                className="alert alert-info"
+                partialStorageKey={`bulkOperation-failed-${latestFailedNode.id}`}
+            >
+                <span>
+                    {failedCount} bulk {pluralize('operation', failedCount)} {pluralize('has', failedCount, 'have')}{' '}
+                    recently failed running. Click the <Link to="?tab=bulkoperations">bulk operations tab</Link> to
+                    view.
+                </span>
+            </DismissibleAlert>
+        )
+    }
+    const latestCompleteNode = bulkOperations.nodes.find(node => node.state === BulkOperationState.COMPLETED)
+    if (latestCompleteNode && !isAlertDismissed(`bulkOperation-completed-${latestCompleteNode.id}`)) {
+        const completeCount = bulkOperations.nodes.filter(node => node.state === BulkOperationState.COMPLETED).length
+        return (
+            <DismissibleAlert
+                className="alert alert-info"
+                partialStorageKey={`bulkOperation-completed-${latestCompleteNode.id}`}
+            >
+                <span>
+                    {completeCount} bulk {pluralize('operation', completeCount)}{' '}
+                    {pluralize('has', completeCount, 'have')} recently finished running. Click the{' '}
+                    <Link to="?tab=bulkoperations">bulk operations tab</Link> to view.
+                </span>
+            </DismissibleAlert>
+        )
+    }
+    return null
 }

--- a/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
@@ -34,8 +34,8 @@ export const BulkOperationsNotifications: React.FunctionComponent<BulkOperations
                 <span>
                     {processingCount} bulk {pluralize('operation', processingCount)}{' '}
                     {pluralize('is', processingCount, 'are')} currently running. Click the{' '}
+                    <Link to="?tab=bulkoperations">bulk operations tab</Link> to view.
                 </span>
-                <Link to="?tab=bulkoperations">bulk operations tab</Link> to view.
             </DismissibleAlert>
         )
     }

--- a/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsNotifications.tsx
@@ -1,0 +1,37 @@
+import * as H from 'history'
+import React from 'react'
+
+import { DismissibleAlert } from '../../../components/DismissibleAlert'
+import { ActiveBulkOperationsConnectionFields } from '../../../graphql-operations'
+
+import { BulkOperationNode } from './bulk-operations/BulkOperationNode'
+
+export interface BulkOperationsNotificationsProps {
+    location: H.Location
+    bulkOperations: ActiveBulkOperationsConnectionFields
+}
+
+export const BulkOperationsNotifications: React.FunctionComponent<BulkOperationsNotificationsProps> = ({
+    bulkOperations,
+    location,
+}) => {
+    // Don't show the header banners if the bulkoperations tab is open.
+    const parameters = new URLSearchParams(location.search)
+    if (parameters.get('tab') === 'bulkoperations') {
+        return null
+    }
+
+    return (
+        <>
+            {bulkOperations.nodes.map(node => (
+                <DismissibleAlert
+                    key={node.id}
+                    className="alert alert-info"
+                    partialStorageKey={`bulkOperation-${node.id}`}
+                >
+                    <BulkOperationNode node={node} key={node.id} />
+                </DismissibleAlert>
+            ))}
+        </>
+    )
+}

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -3,6 +3,8 @@ import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useCallback } from 'react'
 import { delay, repeatWhen, tap } from 'rxjs/operators'
 
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
+
 import { dismissAlert } from '../../../components/DismissibleAlert'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
 import { BulkOperationFields, Scalars } from '../../../graphql-operations'
@@ -68,4 +70,8 @@ export const EmptyBulkOperationsListElement: React.FunctionComponent<{}> = () =>
 
 export const BulkOperationsListHeadComponent: React.FunctionComponent<{ totalCount?: number | null }> = ({
     totalCount,
-}) => <h3 className="mt-4">{totalCount} changeset updates</h3>
+}) => (
+    <h3 className="mt-4">
+        {totalCount} changeset {pluralize('updates', totalCount ?? 0)}
+    </h3>
+)

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -1,0 +1,66 @@
+import * as H from 'history'
+import React, { useCallback } from 'react'
+import { delay, repeatWhen } from 'rxjs/operators'
+
+import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
+import { BulkOperationFields, Scalars } from '../../../graphql-operations'
+
+import { queryBulkOperations as _queryBulkOperations } from './backend'
+import { BulkOperationNode, BulkOperationNodeProps } from './bulk-operations/BulkOperationNode'
+
+export interface BulkOperationsTabProps {
+    batchChangeID: Scalars['ID']
+    history: H.History
+    location: H.Location
+
+    queryBulkOperations?: typeof _queryBulkOperations
+}
+
+export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> = ({
+    batchChangeID,
+    history,
+    location,
+    queryBulkOperations = _queryBulkOperations,
+}) => {
+    const query = useCallback(
+        ({ first, after }: FilteredConnectionQueryArguments) =>
+            queryBulkOperations({ batchChange: batchChangeID, after: after ?? null, first: first ?? null }).pipe(
+                repeatWhen(notifier => notifier.pipe(delay(5000)))
+            ),
+        [batchChangeID, queryBulkOperations]
+    )
+    return (
+        <FilteredConnection<BulkOperationFields, Omit<BulkOperationNodeProps, 'node'>>
+            className="mt-2"
+            nodeComponent={BulkOperationNode}
+            nodeComponentProps={{}}
+            queryConnection={query}
+            hideSearch={true}
+            defaultFirst={15}
+            noun="bulk operation"
+            pluralNoun="bulk operations"
+            history={history}
+            location={location}
+            useURLQuery={true}
+            listComponent="div"
+            // listClassName={classNames(styles.batchChangeChangesetsGridWithCheckboxes, 'mb-3')}
+            // headComponent={BatchChangeChangesetsHeader}
+            // headComponentProps={{
+            //     allSelected,
+            //     toggleSelectAll,
+            //     disabled: !(viewerCanAdminister && !isSubmittingSelected),
+            // }}
+            // Only show the empty element, if no filters are selected.
+            // emptyElement={
+            //     filtersSelected(changesetFilters) ? (
+            //         <EmptyChangesetSearchElement />
+            //     ) : onlyArchived ? (
+            //         <EmptyArchivedChangesetListElement />
+            //     ) : (
+            //         <EmptyChangesetListElement />
+            //     )
+            // }
+            noSummaryIfAllNodesVisible={true}
+        />
+    )
+}

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -41,7 +41,7 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
         <FilteredConnection<BulkOperationFields, Omit<BulkOperationNodeProps, 'node'>>
             className="mt-2"
             nodeComponent={BulkOperationNode}
-            nodeComponentProps={{}}
+            nodeComponentProps={{ showErrors: true }}
             queryConnection={query}
             hideSearch={true}
             defaultFirst={15}

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -1,8 +1,9 @@
 import * as H from 'history'
 import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useCallback } from 'react'
-import { delay, repeatWhen } from 'rxjs/operators'
+import { delay, repeatWhen, tap } from 'rxjs/operators'
 
+import { dismissAlert } from '../../../components/DismissibleAlert'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../../../components/FilteredConnection'
 import { BulkOperationFields, Scalars } from '../../../graphql-operations'
 
@@ -26,6 +27,12 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
     const query = useCallback(
         ({ first, after }: FilteredConnectionQueryArguments) =>
             queryBulkOperations({ batchChange: batchChangeID, after: after ?? null, first: first ?? null }).pipe(
+                tap(connection => {
+                    for (const node of connection.nodes) {
+                        // Hide alerts for bulk operations seen already.
+                        dismissAlert(`bulkOperation-${node.id}`)
+                    }
+                }),
                 repeatWhen(notifier => notifier.pipe(delay(2000)))
             ),
         [batchChangeID, queryBulkOperations]

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -51,7 +51,7 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
             location={location}
             useURLQuery={true}
             listComponent="div"
-            // listClassName={classNames(styles.batchChangeChangesetsGridWithCheckboxes, 'mb-3')}
+            listClassName="mb-3"
             emptyElement={<EmptyBulkOperationsListElement />}
             noSummaryIfAllNodesVisible={true}
         />

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -30,7 +30,7 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
                 tap(connection => {
                     for (const node of connection.nodes) {
                         // Hide alerts for bulk operations seen already.
-                        dismissAlert(`bulkOperation-${node.id}`)
+                        dismissAlert(`bulkOperation-${node.state.toLocaleLowerCase()}-${node.id}`)
                     }
                 }),
                 repeatWhen(notifier => notifier.pipe(delay(2000)))

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -54,6 +54,7 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
             listClassName="mb-3"
             emptyElement={<EmptyBulkOperationsListElement />}
             noSummaryIfAllNodesVisible={true}
+            headComponent={BulkOperationsListHeadComponent}
         />
     )
 }
@@ -66,3 +67,7 @@ export const EmptyBulkOperationsListElement: React.FunctionComponent<{}> = () =>
         </div>
     </div>
 )
+
+export const BulkOperationsListHeadComponent: React.FunctionComponent<{ totalCount?: number | null }> = ({
+    totalCount,
+}) => <h3 className="mt-4">{totalCount} changeset updates</h3>

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -60,11 +60,9 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
 }
 
 export const EmptyBulkOperationsListElement: React.FunctionComponent<{}> = () => (
-    <div className="text-muted mt-4 pt-4 mb-4 row">
-        <div className="col-12 text-center">
-            <MapSearchIcon className="icon" />
-            <div className="pt-2">No bulk operations have been run on this batch change.</div>
-        </div>
+    <div className="text-muted my-4 pt-4 text-center">
+        <MapSearchIcon className="icon" />
+        <div className="pt-2">No bulk operations have been run on this batch change.</div>
     </div>
 )
 

--- a/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
+++ b/client/web/src/enterprise/batches/detail/BulkOperationsTab.tsx
@@ -1,4 +1,5 @@
 import * as H from 'history'
+import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React, { useCallback } from 'react'
 import { delay, repeatWhen } from 'rxjs/operators'
 
@@ -25,7 +26,7 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
     const query = useCallback(
         ({ first, after }: FilteredConnectionQueryArguments) =>
             queryBulkOperations({ batchChange: batchChangeID, after: after ?? null, first: first ?? null }).pipe(
-                repeatWhen(notifier => notifier.pipe(delay(5000)))
+                repeatWhen(notifier => notifier.pipe(delay(2000)))
             ),
         [batchChangeID, queryBulkOperations]
     )
@@ -44,23 +45,17 @@ export const BulkOperationsTab: React.FunctionComponent<BulkOperationsTabProps> 
             useURLQuery={true}
             listComponent="div"
             // listClassName={classNames(styles.batchChangeChangesetsGridWithCheckboxes, 'mb-3')}
-            // headComponent={BatchChangeChangesetsHeader}
-            // headComponentProps={{
-            //     allSelected,
-            //     toggleSelectAll,
-            //     disabled: !(viewerCanAdminister && !isSubmittingSelected),
-            // }}
-            // Only show the empty element, if no filters are selected.
-            // emptyElement={
-            //     filtersSelected(changesetFilters) ? (
-            //         <EmptyChangesetSearchElement />
-            //     ) : onlyArchived ? (
-            //         <EmptyArchivedChangesetListElement />
-            //     ) : (
-            //         <EmptyChangesetListElement />
-            //     )
-            // }
+            emptyElement={<EmptyBulkOperationsListElement />}
             noSummaryIfAllNodesVisible={true}
         />
     )
 }
+
+export const EmptyBulkOperationsListElement: React.FunctionComponent<{}> = () => (
+    <div className="text-muted mt-4 pt-4 mb-4 row">
+        <div className="col-12 text-center">
+            <MapSearchIcon className="icon" />
+            <div className="pt-2">No bulk operations have been run on this batch change.</div>
+        </div>
+    </div>
+)

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -126,10 +126,7 @@ const batchChangeFragment = gql`
         }
 
         activeBulkOperations: bulkOperations(first: 3, createdAfter: $createdAfter) {
-            totalCount
-            nodes {
-                ...BulkOperationFields
-            }
+            ...ActiveBulkOperationsConnectionFields
         }
 
         currentSpec {
@@ -138,6 +135,13 @@ const batchChangeFragment = gql`
                 createdAt
                 applyURL
             }
+        }
+    }
+
+    fragment ActiveBulkOperationsConnectionFields on BulkOperationConnection {
+        totalCount
+        nodes {
+            ...BulkOperationFields
         }
     }
 

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -141,7 +141,7 @@ const batchChangeFragment = gql`
     fragment ActiveBulkOperationsConnectionFields on BulkOperationConnection {
         totalCount
         nodes {
-            ...BulkOperationFields
+            ...ActiveBulkOperationFields
         }
     }
 
@@ -149,7 +149,10 @@ const batchChangeFragment = gql`
 
     ${diffStatFields}
 
-    ${bulkOperationFragment}
+    fragment ActiveBulkOperationFields on BulkOperation {
+        id
+        state
+    }
 `
 
 const changesetLabelFragment = gql`

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -53,7 +53,7 @@ const changesetsStatsFragment = gql`
     }
 `
 
-const bulkOperationsFragment = gql`
+const bulkOperationFragment = gql`
     fragment BulkOperationFields on BulkOperation {
         id
         type
@@ -149,7 +149,7 @@ const batchChangeFragment = gql`
 
     ${diffStatFields}
 
-    ${bulkOperationsFragment}
+    ${bulkOperationFragment}
 `
 
 const changesetLabelFragment = gql`
@@ -678,7 +678,7 @@ export const queryBulkOperations = (
                 }
             }
 
-            ${bulkOperationsFragment}
+            ${bulkOperationFragment}
         `,
         args
     ).pipe(

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -125,7 +125,7 @@ const batchChangeFragment = gql`
             totalCount
         }
 
-        activeBulkOperations: bulkOperations(first: 3, createdAfter: $createdAfter) {
+        activeBulkOperations: bulkOperations(first: 50, createdAfter: $createdAfter) {
             ...ActiveBulkOperationsConnectionFields
         }
 

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -75,6 +75,11 @@ const bulkOperationsFragment = gql`
             }
             error
         }
+        initiator {
+            username
+            url
+        }
+        changesetCount
         createdAt
         finishedAt
     }
@@ -759,8 +764,10 @@ export const queryAllChangesetIDs = ({
     return request(null).pipe(
         expand(connection => (connection.pageInfo.hasNextPage ? request(connection.pageInfo.endCursor) : EMPTY)),
         reduce(
-            (prev, next) =>
-                prev.concat(next.nodes.filter(node => node.__typename === 'ExternalChangeset').map(node => node.id)),
+            (previous, next) =>
+                previous.concat(
+                    next.nodes.filter(node => node.__typename === 'ExternalChangeset').map(node => node.id)
+                ),
             [] as Scalars['ID'][]
         )
     )

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -38,6 +38,7 @@ import {
     BulkOperationConnectionFields,
     AllChangesetIDsResult,
     AllChangesetIDsVariables,
+    ChangesetIDConnectionFields,
 } from '../../../graphql-operations'
 
 const changesetsStatsFragment = gql`
@@ -706,7 +707,7 @@ export const queryAllChangesetIDs = ({
     search,
     onlyArchived,
 }: Omit<AllChangesetIDsVariables, 'after'>): Observable<Scalars['ID'][]> => {
-    const request = (after: string | null) =>
+    const request = (after: string | null): Observable<ChangesetIDConnectionFields> =>
         requestGraphQL<AllChangesetIDsResult, AllChangesetIDsVariables>(
             gql`
                 query AllChangesetIDs(
@@ -732,16 +733,20 @@ export const queryAllChangesetIDs = ({
                                 search: $search
                                 onlyArchived: $onlyArchived
                             ) {
-                                nodes {
-                                    __typename
-                                    id
-                                }
-                                pageInfo {
-                                    hasNextPage
-                                    endCursor
-                                }
+                                ...ChangesetIDConnectionFields
                             }
                         }
+                    }
+                }
+
+                fragment ChangesetIDConnectionFields on ChangesetConnection {
+                    nodes {
+                        __typename
+                        id
+                    }
+                    pageInfo {
+                        hasNextPage
+                        endCursor
                     }
                 }
             `,

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.module.scss
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.module.scss
@@ -1,0 +1,5 @@
+.bulk-operation-node {
+    &__progress-bar {
+        max-width: 200px;
+    }
+}

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.module.scss
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.module.scss
@@ -2,4 +2,16 @@
     &__progress-bar {
         max-width: 200px;
     }
+    &__divider {
+        border-left: 1px solid var(--border-color-2);
+        height: 2rem;
+    }
+    &__container {
+        + .bulk-operation-node__container {
+            border-top: 1px solid var(--border-color-2);
+        }
+    }
+    &__errors {
+        background-color: var(--body-bg);
+    }
 }

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -1,0 +1,49 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
+
+import { ErrorMessage } from '../../../../components/alerts'
+import { Timestamp } from '../../../../components/time/Timestamp'
+import { BulkOperationFields } from '../../../../graphql-operations'
+import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
+
+export interface BulkOperationNodeProps {
+    node: BulkOperationFields
+}
+
+export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> = ({ node }) => (
+    <div>
+        Ran type <span>{node.type}</span> <Timestamp date={node.createdAt} />
+        <p
+            className={classNames(
+                node.state === BulkOperationState.PROCESSING && 'text-info',
+                node.state === BulkOperationState.FAILED && 'text-danger',
+                node.state === BulkOperationState.COMPLETED && 'text-success'
+            )}
+        >
+            {node.state}
+        </p>
+        <div>
+            <progress value={node.progress} max={1} /> {Math.ceil(node.progress * 100)}%
+        </div>
+        {node.errors.map((error, index) => (
+            <div className="alert alert-danger" key={index}>
+                <p>
+                    Failed to run task for{' '}
+                    {error.changeset.__typename === 'HiddenExternalChangeset' ? (
+                        <span className="text-muted">hidden repository.</span>
+                    ) : (
+                        <>
+                            <a href={error.changeset.externalURL?.url}>
+                                {error.changeset.title} <ExternalLinkIcon className="icon-inline" />
+                            </a>{' '}
+                            on repo <a href={error.changeset.repository.url}>{error.changeset.repository.name}</a>.
+                        </>
+                    )}
+                </p>
+                <ErrorMessage error={'```\n' + error.error! + '\n```'} />
+            </div>
+        ))}
+    </div>
+)

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -4,16 +4,16 @@ import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { ErrorMessage } from '../../../../components/alerts'
+import { Collapsible } from '../../../../components/Collapsible'
 import { Timestamp } from '../../../../components/time/Timestamp'
 import { BulkOperationFields } from '../../../../graphql-operations'
 
 import styles from './BulkOperationNode.module.scss'
-import { Collapsible } from '../../../../components/Collapsible'
-import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 
 export interface BulkOperationNodeProps {
     node: BulkOperationFields

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -71,7 +71,7 @@ export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> 
                                         </LinkOrSpan>{' '}
                                         on{' '}
                                         <Link className="alert-link" to={error.changeset.repository.url}>
-                                            repo:{error.changeset.repository.name}
+                                            repository {error.changeset.repository.name}
                                         </Link>
                                         .
                                     </>

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -10,18 +10,21 @@ import { ErrorMessage } from '../../../../components/alerts'
 import { Timestamp } from '../../../../components/time/Timestamp'
 import { BulkOperationFields } from '../../../../graphql-operations'
 
+import styles from './BulkOperationNode.module.scss'
+
 export interface BulkOperationNodeProps {
     node: BulkOperationFields
+    showErrors: boolean
 }
 
-export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> = ({ node }) => (
+export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> = ({ node, showErrors }) => (
     <div className="card mb-3">
         <div className="card-body">
             <div className="d-flex justify-content-between">
                 <div>
-                    <Link to={node.initiator.url}>{node.initiator.username}</Link> ran type <span>{node.type}</span>{' '}
-                    over {node.changesetCount} {pluralize('changeset', node.changesetCount)}{' '}
-                    <Timestamp date={node.createdAt} />
+                    <Link to={node.initiator.url}>{node.initiator.username}</Link> ran type{' '}
+                    <span>{node.type.toLocaleLowerCase()}</span> over {node.changesetCount}{' '}
+                    {pluralize('changeset', node.changesetCount)} <Timestamp date={node.createdAt} />
                     <p
                         className={classNames(
                             node.state === BulkOperationState.PROCESSING && 'text-info',
@@ -29,34 +32,39 @@ export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> 
                             node.state === BulkOperationState.COMPLETED && 'text-success'
                         )}
                     >
-                        {node.state}
+                        {node.state.toLocaleLowerCase()}
                     </p>
+                    {!showErrors && node.errors.length > 0 && (
+                        <p className="text-danger">{node.errors.length} errors occurred while running.</p>
+                    )}
                 </div>
-                <div className="flex-grow-1 ml-3" style={{ maxWidth: '200px' }}>
+                <div className={classNames(styles.bulkOperationNodeProgressBar, 'flex-grow-1 ml-3')}>
                     <div>
                         <progress value={node.progress} className="w-100" max={1} />
                     </div>
                     <p className="text-center">{Math.ceil(node.progress * 100)}%</p>
                 </div>
             </div>
-            {node.errors.map((error, index) => (
-                <div className="alert alert-danger" key={index}>
-                    <p>
-                        Failed to run task for{' '}
-                        {error.changeset.__typename === 'HiddenExternalChangeset' ? (
-                            <span className="text-muted">hidden repository.</span>
-                        ) : (
-                            <>
-                                <a href={error.changeset.externalURL?.url}>
-                                    {error.changeset.title} <ExternalLinkIcon className="icon-inline" />
-                                </a>{' '}
-                                on repo <a href={error.changeset.repository.url}>{error.changeset.repository.name}</a>.
-                            </>
-                        )}
-                    </p>
-                    <ErrorMessage error={'```\n' + error.error! + '\n```'} />
-                </div>
-            ))}
+            {showErrors &&
+                node.errors.map((error, index) => (
+                    <div className="alert alert-danger" key={index}>
+                        <p>
+                            Failed to run task for{' '}
+                            {error.changeset.__typename === 'HiddenExternalChangeset' ? (
+                                <span className="text-muted">hidden repository.</span>
+                            ) : (
+                                <>
+                                    <a href={error.changeset.externalURL?.url}>
+                                        {error.changeset.title} <ExternalLinkIcon className="icon-inline" />
+                                    </a>{' '}
+                                    on repo{' '}
+                                    <a href={error.changeset.repository.url}>{error.changeset.repository.name}</a>.
+                                </>
+                            )}
+                        </p>
+                        {error.error && <ErrorMessage error={'```\n' + error.error + '\n```'} />}
+                    </div>
+                ))}
         </div>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -32,7 +32,7 @@ export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> 
                         {node.state}
                     </p>
                 </div>
-                <div className="flex-grow-1" style={{ maxWidth: '200px' }}>
+                <div className="flex-grow-1 ml-3" style={{ maxWidth: '200px' }}>
                     <div>
                         <progress value={node.progress} className="w-100" max={1} />
                     </div>

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -1,49 +1,62 @@
 import classNames from 'classnames'
+import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import React from 'react'
 
+import { Link } from '@sourcegraph/shared/src/components/Link'
 import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { ErrorMessage } from '../../../../components/alerts'
 import { Timestamp } from '../../../../components/time/Timestamp'
 import { BulkOperationFields } from '../../../../graphql-operations'
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 
 export interface BulkOperationNodeProps {
     node: BulkOperationFields
 }
 
 export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> = ({ node }) => (
-    <div>
-        Ran type <span>{node.type}</span> <Timestamp date={node.createdAt} />
-        <p
-            className={classNames(
-                node.state === BulkOperationState.PROCESSING && 'text-info',
-                node.state === BulkOperationState.FAILED && 'text-danger',
-                node.state === BulkOperationState.COMPLETED && 'text-success'
-            )}
-        >
-            {node.state}
-        </p>
-        <div>
-            <progress value={node.progress} max={1} /> {Math.ceil(node.progress * 100)}%
-        </div>
-        {node.errors.map((error, index) => (
-            <div className="alert alert-danger" key={index}>
-                <p>
-                    Failed to run task for{' '}
-                    {error.changeset.__typename === 'HiddenExternalChangeset' ? (
-                        <span className="text-muted">hidden repository.</span>
-                    ) : (
-                        <>
-                            <a href={error.changeset.externalURL?.url}>
-                                {error.changeset.title} <ExternalLinkIcon className="icon-inline" />
-                            </a>{' '}
-                            on repo <a href={error.changeset.repository.url}>{error.changeset.repository.name}</a>.
-                        </>
-                    )}
-                </p>
-                <ErrorMessage error={'```\n' + error.error! + '\n```'} />
+    <div className="card mb-3">
+        <div className="card-body">
+            <div className="d-flex justify-content-between">
+                <div>
+                    <Link to={node.initiator.url}>{node.initiator.username}</Link> ran type <span>{node.type}</span>{' '}
+                    over {node.changesetCount} {pluralize('changeset', node.changesetCount)}{' '}
+                    <Timestamp date={node.createdAt} />
+                    <p
+                        className={classNames(
+                            node.state === BulkOperationState.PROCESSING && 'text-info',
+                            node.state === BulkOperationState.FAILED && 'text-danger',
+                            node.state === BulkOperationState.COMPLETED && 'text-success'
+                        )}
+                    >
+                        {node.state}
+                    </p>
+                </div>
+                <div className="flex-grow-1" style={{ maxWidth: '200px' }}>
+                    <div>
+                        <progress value={node.progress} className="w-100" max={1} />
+                    </div>
+                    <p className="text-center">{Math.ceil(node.progress * 100)}%</p>
+                </div>
             </div>
-        ))}
+            {node.errors.map((error, index) => (
+                <div className="alert alert-danger" key={index}>
+                    <p>
+                        Failed to run task for{' '}
+                        {error.changeset.__typename === 'HiddenExternalChangeset' ? (
+                            <span className="text-muted">hidden repository.</span>
+                        ) : (
+                            <>
+                                <a href={error.changeset.externalURL?.url}>
+                                    {error.changeset.title} <ExternalLinkIcon className="icon-inline" />
+                                </a>{' '}
+                                on repo <a href={error.changeset.repository.url}>{error.changeset.repository.name}</a>.
+                            </>
+                        )}
+                    </p>
+                    <ErrorMessage error={'```\n' + error.error! + '\n```'} />
+                </div>
+            ))}
+        </div>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -42,9 +42,7 @@ export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> 
             </div>
             {node.state === BulkOperationState.PROCESSING && (
                 <div className={classNames(styles.bulkOperationNodeProgressBar, 'flex-grow-1 ml-3')}>
-                    <div>
-                        <meter value={node.progress} className="w-100" min={0} max={1} />
-                    </div>
+                    <meter value={node.progress} className="w-100" min={0} max={1} />
                     <p className="text-center mb-0">{Math.ceil(node.progress * 100)}%</p>
                 </div>
             )}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.module.scss
@@ -1,15 +1,7 @@
 .batch-change-changesets {
     &__grid {
         display: grid;
-        grid-template-columns: [caret] min-content [status] min-content [info] minmax(auto, 1fr) [checkstate] min-content [reviewstate] min-content [diffstat] min-content [end];
+        grid-template-columns: [checkbox] min-content [caret] min-content [status] min-content [info] minmax(auto, 1fr) [checkstate] min-content [reviewstate] min-content [diffstat] min-content [end];
         align-items: center;
-
-        &--with-checkboxes {
-            display: grid;
-            grid-template-columns:
-                [checkbox] min-content [caret] min-content [status] min-content [info] minmax(auto, 1fr)
-                [checkstate] min-content [reviewstate] min-content [diffstat] min-content [end];
-            align-items: center;
-        }
     }
 }

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -290,7 +290,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                     location={location}
                     useURLQuery={true}
                     listComponent="div"
-                    listClassName={classNames(styles.batchChangeChangesetsGridWithCheckboxes, 'mb-3')}
+                    listClassName={classNames(styles.batchChangeChangesetsGrid, 'mb-3')}
                     headComponent={BatchChangeChangesetsHeader}
                     headComponentProps={{
                         allSelected,

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -262,7 +262,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                     totalCount={totalChangesetCount}
                     isAllSelected={allSelected}
                     allAllSelected={allAllSelected}
-                    setAllSelected={onSelectAllAll}
+                    setAllAllSelected={onSelectAllAll}
                     queryArguments={queryArguments!}
                 />
             )}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -71,14 +71,14 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
     onlyArchived,
 }) => {
     // Whether all the changesets are selected, beyond the scope of what's on screen right now.
-    const [allAllSelected, setAllAllSelected] = useState<boolean>(false)
+    const [allSelected, setAllSelected] = useState<boolean>(false)
     // The overall amount of all changesets in the connection.
     const [totalChangesetCount, setTotalChangesetCount] = useState<number>(0)
     // All changesets that are currently in view and can be selected. That currently
     // just means they are visible.
     const [availableChangesets, setAvailableChangesets] = useState<Set<Scalars['ID']>>(new Set())
     // The list of all selected changesets. This list does not reflect the selection
-    // when `allAllSelected` is true.
+    // when `allSelected` is true.
     const [selectedChangesets, setSelectedChangesets] = useState<Set<Scalars['ID']>>(new Set())
 
     const onSelect = useCallback((id: string, selected: boolean): void => {
@@ -94,20 +94,20 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
             newSet.delete(id)
             return newSet
         })
-        setAllAllSelected(false)
+        setAllSelected(false)
     }, [])
 
     /**
-     * Whether the given changeset is currently selected. Returns always true, if `allAllSelected` is true.
+     * Whether the given changeset is currently selected. Returns always true, if `allSelected` is true.
      */
-    const changesetSelected = useCallback(
-        (id: Scalars['ID']): boolean => allAllSelected || selectedChangesets.has(id),
-        [allAllSelected, selectedChangesets]
-    )
+    const changesetSelected = useCallback((id: Scalars['ID']): boolean => allSelected || selectedChangesets.has(id), [
+        allSelected,
+        selectedChangesets,
+    ])
 
     const deselectAll = useCallback((): void => {
         setSelectedChangesets(new Set())
-        setAllAllSelected(false)
+        setAllSelected(false)
     }, [setSelectedChangesets])
 
     const selectAll = useCallback((): void => {
@@ -116,18 +116,18 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
 
     // True when all in the current list are selected. It ticks the header row
     // checkbox when true.
-    const allSelected = allAllSelected || selectedChangesets.size === availableChangesets.size
+    const allSelectedCheckboxChecked = allSelected || selectedChangesets.size === availableChangesets.size
 
     const toggleSelectAll = useCallback((): void => {
-        if (allSelected) {
+        if (allSelectedCheckboxChecked) {
             deselectAll()
         } else {
             selectAll()
         }
-    }, [allSelected, selectAll, deselectAll])
+    }, [allSelectedCheckboxChecked, selectAll, deselectAll])
 
-    const onSelectAllAll = useCallback(() => {
-        setAllAllSelected(true)
+    const onSelectAll = useCallback(() => {
+        setAllSelected(true)
     }, [])
 
     const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
@@ -254,16 +254,16 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                     onFiltersChange={setChangesetFiltersAndDeselectAll}
                 />
             )}
-            {showSelectRow && (
+            {showSelectRow && queryArguments && (
                 <ChangesetSelectRow
                     batchChangeID={batchChangeID}
                     selected={selectedChangesets}
                     onSubmit={deselectAll}
                     totalCount={totalChangesetCount}
-                    isAllSelected={allSelected}
-                    allAllSelected={allAllSelected}
-                    setAllAllSelected={onSelectAllAll}
-                    queryArguments={queryArguments!}
+                    allVisibleSelected={allSelectedCheckboxChecked}
+                    allSelected={allSelected}
+                    setAllSelected={onSelectAll}
+                    queryArguments={queryArguments}
                 />
             )}
             <div className="list-group position-relative" ref={nextContainerElement}>
@@ -293,7 +293,7 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
                     listClassName={classNames(styles.batchChangeChangesetsGrid, 'mb-3')}
                     headComponent={BatchChangeChangesetsHeader}
                     headComponentProps={{
-                        allSelected,
+                        allSelected: allSelectedCheckboxChecked,
                         toggleSelectAll,
                         disabled: !viewerCanAdminister,
                     }}

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesets.tsx
@@ -97,8 +97,9 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
         setAllAllSelected(false)
     }, [])
 
-    // Whether the given changeset is currently selected. Returns always true, if
-    // `allAllSelected` is true.
+    /**
+     * Whether the given changeset is currently selected. Returns always true, if `allAllSelected` is true.
+     */
     const changesetSelected = useCallback(
         (id: Scalars['ID']): boolean => allAllSelected || selectedChangesets.has(id),
         [allAllSelected, selectedChangesets]
@@ -125,6 +126,10 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
         }
     }, [allSelected, selectAll, deselectAll])
 
+    const onSelectAllAll = useCallback(() => {
+        setAllAllSelected(true)
+    }, [])
+
     const [changesetFilters, setChangesetFilters] = useState<ChangesetFilters>({
         checkState: null,
         state: null,
@@ -139,10 +144,6 @@ export const BatchChangeChangesets: React.FunctionComponent<Props> = ({
         },
         [deselectAll, setChangesetFilters]
     )
-
-    const onSelectAllAll = useCallback(() => {
-        setAllAllSelected(true)
-    }, [])
 
     const [queryArguments, setQueryArguments] = useState<Omit<AllChangesetIDsVariables, 'after'>>()
 

--- a/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/BatchChangeChangesetsHeader.tsx
@@ -1,21 +1,19 @@
 import React from 'react'
 
 export interface BatchChangeChangesetsHeaderProps {
-    enableSelect?: boolean
     allSelected?: boolean
     toggleSelectAll?: () => void
     disabled?: boolean
 }
 
 export const BatchChangeChangesetsHeader: React.FunctionComponent<BatchChangeChangesetsHeaderProps> = ({
-    enableSelect,
     allSelected,
     toggleSelectAll,
     disabled,
 }) => (
     <>
         <span className="d-none d-md-block" />
-        {enableSelect && toggleSelectAll && (
+        {toggleSelectAll && (
             <input
                 type="checkbox"
                 className="btn ml-2"

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetNode.tsx
@@ -20,7 +20,6 @@ export interface ChangesetNodeProps extends ThemeProps {
     viewerCanAdminister: boolean
     history: H.History
     location: H.Location
-    enableSelect?: boolean
     onSelect?: (id: string, selected: boolean) => void
     isSelected?: (id: string) => boolean
     extensionInfo?: {

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.module.scss
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.module.scss
@@ -1,0 +1,5 @@
+.changeset-select-row {
+    &__dropdown-item {
+        min-width: min(90vw, 350px);
+    }
+}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -22,7 +22,7 @@ add('all states', () => (
                     allAllSelected={false}
                     batchChangeID="test-123"
                     isAllSelected={false}
-                    setAllSelected={() => undefined}
+                    setAllAllSelected={() => undefined}
                     totalCount={100}
                     queryArguments={{
                         batchChange: 'test-123',
@@ -42,7 +42,7 @@ add('all states', () => (
                     allAllSelected={false}
                     batchChangeID="test-123"
                     isAllSelected={false}
-                    setAllSelected={() => undefined}
+                    setAllAllSelected={() => undefined}
                     totalCount={100}
                     queryArguments={{
                         batchChange: 'test-123',
@@ -62,7 +62,7 @@ add('all states', () => (
                     allAllSelected={false}
                     batchChangeID="test-123"
                     isAllSelected={false}
-                    setAllSelected={() => undefined}
+                    setAllAllSelected={() => undefined}
                     totalCount={100}
                     queryArguments={{
                         batchChange: 'test-123',

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -19,21 +19,60 @@ add('all states', () => (
                     {...props}
                     onSubmit={onSubmit}
                     selected={new Set(['id-1', 'id-2'])}
-                    isSubmitting={false}
+                    allAllSelected={false}
+                    batchChangeID="test-123"
+                    isAllSelected={false}
+                    setAllSelected={() => undefined}
+                    totalCount={100}
+                    queryArguments={{
+                        batchChange: 'test-123',
+                        checkState: null,
+                        onlyArchived: null,
+                        onlyPublishedByThisBatchChange: null,
+                        reviewState: null,
+                        search: null,
+                        state: null,
+                    }}
                 />
                 <hr />
                 <ChangesetSelectRow
                     {...props}
                     onSubmit={onSubmit}
                     selected={new Set(['id-1', 'id-2'])}
-                    isSubmitting={true}
+                    allAllSelected={false}
+                    batchChangeID="test-123"
+                    isAllSelected={false}
+                    setAllSelected={() => undefined}
+                    totalCount={100}
+                    queryArguments={{
+                        batchChange: 'test-123',
+                        checkState: null,
+                        onlyArchived: null,
+                        onlyPublishedByThisBatchChange: null,
+                        reviewState: null,
+                        search: null,
+                        state: null,
+                    }}
                 />
                 <hr />
                 <ChangesetSelectRow
                     {...props}
                     onSubmit={onSubmit}
                     selected={new Set(['id-1', 'id-2'])}
-                    isSubmitting={new Error('something went wrong with the backend :(')}
+                    allAllSelected={false}
+                    batchChangeID="test-123"
+                    isAllSelected={false}
+                    setAllSelected={() => undefined}
+                    totalCount={100}
+                    queryArguments={{
+                        batchChange: 'test-123',
+                        checkState: null,
+                        onlyArchived: null,
+                        onlyPublishedByThisBatchChange: null,
+                        reviewState: null,
+                        search: null,
+                        state: null,
+                    }}
                 />
             </>
         )}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.story.tsx
@@ -19,10 +19,10 @@ add('all states', () => (
                     {...props}
                     onSubmit={onSubmit}
                     selected={new Set(['id-1', 'id-2'])}
-                    allAllSelected={false}
+                    allSelected={false}
                     batchChangeID="test-123"
-                    isAllSelected={false}
-                    setAllAllSelected={() => undefined}
+                    allVisibleSelected={false}
+                    setAllSelected={() => undefined}
                     totalCount={100}
                     queryArguments={{
                         batchChange: 'test-123',
@@ -39,10 +39,10 @@ add('all states', () => (
                     {...props}
                     onSubmit={onSubmit}
                     selected={new Set(['id-1', 'id-2'])}
-                    allAllSelected={false}
+                    allSelected={false}
                     batchChangeID="test-123"
-                    isAllSelected={false}
-                    setAllAllSelected={() => undefined}
+                    allVisibleSelected={false}
+                    setAllSelected={() => undefined}
                     totalCount={100}
                     queryArguments={{
                         batchChange: 'test-123',
@@ -59,10 +59,10 @@ add('all states', () => (
                     {...props}
                     onSubmit={onSubmit}
                     selected={new Set(['id-1', 'id-2'])}
-                    allAllSelected={false}
+                    allSelected={false}
                     batchChangeID="test-123"
-                    isAllSelected={false}
-                    setAllAllSelected={() => undefined}
+                    allVisibleSelected={false}
+                    setAllSelected={() => undefined}
                     totalCount={100}
                     queryArguments={{
                         batchChange: 'test-123',
@@ -73,6 +73,67 @@ add('all states', () => (
                         search: null,
                         state: null,
                     }}
+                />
+                <hr />
+                <ChangesetSelectRow
+                    {...props}
+                    onSubmit={onSubmit}
+                    selected={new Set(['id-1', 'id-2'])}
+                    allSelected={false}
+                    batchChangeID="test-123"
+                    allVisibleSelected={true}
+                    setAllSelected={() => undefined}
+                    totalCount={100}
+                    queryArguments={{
+                        batchChange: 'test-123',
+                        checkState: null,
+                        onlyArchived: null,
+                        onlyPublishedByThisBatchChange: null,
+                        reviewState: null,
+                        search: null,
+                        state: null,
+                    }}
+                />
+                <hr />
+                <ChangesetSelectRow
+                    {...props}
+                    onSubmit={onSubmit}
+                    selected={new Set(['id-1', 'id-2'])}
+                    allSelected={true}
+                    batchChangeID="test-123"
+                    allVisibleSelected={true}
+                    setAllSelected={() => undefined}
+                    totalCount={100}
+                    queryArguments={{
+                        batchChange: 'test-123',
+                        checkState: null,
+                        onlyArchived: null,
+                        onlyPublishedByThisBatchChange: null,
+                        reviewState: null,
+                        search: null,
+                        state: null,
+                    }}
+                />
+                <hr />
+                <ChangesetSelectRow
+                    {...props}
+                    onSubmit={onSubmit}
+                    selected={new Set(['id-1', 'id-2'])}
+                    allSelected={false}
+                    batchChangeID="test-123"
+                    allVisibleSelected={false}
+                    setAllSelected={() => undefined}
+                    totalCount={100}
+                    queryArguments={{
+                        batchChange: 'test-123',
+                        checkState: null,
+                        onlyArchived: true,
+                        onlyPublishedByThisBatchChange: null,
+                        reviewState: null,
+                        search: null,
+                        state: null,
+                    }}
+                    dropDownInitiallyOpen={true}
                 />
             </>
         )}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -1,10 +1,53 @@
+import classNames from 'classnames'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { ErrorAlert } from '../../../../components/alerts'
+import { CreateCommentModal } from './CreateCommentModal'
+
+interface ChangesetListAction {
+    actionType: string
+    actionVerb: string
+    dropdownTitle: string
+    dropdownDescription: string
+    isAvailable: () => boolean
+    onTrigger: () => void | JSX.Element
+}
+
+const availableActions: ChangesetListAction[] = [
+    {
+        actionType: 'detach',
+        actionVerb: 'Detach changesets',
+        dropdownTitle: 'Detach changesets',
+        dropdownDescription:
+            "Removes the selected changesets from this batch change. Unlike archive, this can't be undone.",
+        isAvailable: () => true,
+        onTrigger: () => undefined,
+    },
+    {
+        actionType: 'commentatore',
+        actionVerb: 'Create comment',
+        dropdownTitle: 'Create comment',
+        dropdownDescription:
+            'Create a comment on all selected changesets to ask people for reviews, or give an update.',
+        isAvailable: () => true,
+        onTrigger: () => {
+            return <CreateCommentModal userID={'123'} afterCreate={() => undefined} onCancel={() => undefined} />
+        },
+    },
+    {
+        actionType: 'merge',
+        actionVerb: 'Merge changesets',
+        dropdownTitle: 'Merge changesets',
+        dropdownDescription:
+            "Merges all selected, currently open changesets on the code host. Some changesets may not be in a mergeable state, and hence won't be merged.",
+        isAvailable: () => true,
+        onTrigger: () => undefined,
+    },
+]
 
 export interface ChangesetSelectRowProps {
     selected: Set<string>
@@ -16,32 +59,101 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     selected,
     onSubmit,
     isSubmitting,
-}) => (
-    <>
-        <div className="row align-items-center no-gutters">
-            <div className="ml-2 col">
-                <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
-                Select changesets to detach them
-            </div>
-            <div className="w-100 d-block d-md-none" />
-            <div className="m-0 col col-md-auto">
-                <div className="row no-gutters">
-                    <div className="col my-2 ml-0 ml-sm-2">
-                        <button
-                            type="button"
-                            className="btn btn-secondary text-nowrap"
-                            onClick={onSubmit}
-                            disabled={selected.size === 0 || isSubmitting === true}
-                        >
-                            {selected.size > 0
-                                ? `Detach ${selected.size} ${pluralize('changeset', selected.size)}`
-                                : 'Detach changesets'}
-                        </button>
+}) => {
+    const [isOpen, setIsOpen] = useState<boolean>(false)
+    const toggleIsOpen = useCallback(() => setIsOpen(open => !open), [])
+    const [selectedType, setSelectedType] = useState<string | undefined>()
+    const onSelectedTypeSelect = useCallback((type: string) => {
+        setSelectedType(type)
+        setIsOpen(false)
+    }, [])
+    const [renderedElem, setRenderedElem] = useState<JSX.Element>()
+    const onTriggerAction = useCallback(() => {
+        const action = availableActions.find(action => action.actionType === selectedType)!
+        const elem = action.onTrigger()
+        if (elem !== undefined) {
+            setRenderedElem(elem)
+        }
+        // onSubmit()
+    }, [selectedType])
+    const buttonLabel =
+        selectedType === undefined
+            ? 'Select action'
+            : availableActions.find(action => action.actionType === selectedType)!.actionVerb
+    return (
+        <>
+            {renderedElem}
+            <div className="row align-items-center no-gutters">
+                <div className="ml-2 col">
+                    <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
+                    {selected.size} {pluralize('changeset', selected.size)} selected
+                </div>
+                <div className="w-100 d-block d-md-none" />
+                <div className="m-0 col col-md-auto">
+                    <div className="row no-gutters">
+                        <div className="col my-2 ml-0 ml-sm-2">
+                            <div className="btn-group">
+                                <button
+                                    type="button"
+                                    className="btn btn-primary text-nowrap"
+                                    onClick={onTriggerAction}
+                                    disabled={
+                                        selected.size === 0 || isSubmitting === true || selectedType === undefined
+                                    }
+                                >
+                                    {buttonLabel}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={toggleIsOpen}
+                                    className="btn btn-primary dropdown-toggle dropdown-toggle-split"
+                                />
+                                <div
+                                    className={classNames('dropdown-menu dropdown-menu-right', isOpen && 'show')}
+                                    style={{ minWidth: '350px' }}
+                                >
+                                    {availableActions.map((action, index) => (
+                                        <>
+                                            <ActionDropdownItem
+                                                action={action}
+                                                setSelectedType={onSelectedTypeSelect}
+                                            />
+                                            {index !== availableActions.length - 1 && (
+                                                <div className="dropdown-divider" />
+                                            )}
+                                        </>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
 
-        {isErrorLike(isSubmitting) && <ErrorAlert error={isSubmitting} />}
-    </>
-)
+            {isErrorLike(isSubmitting) && <ErrorAlert error={isSubmitting} />}
+        </>
+    )
+}
+
+const ActionDropdownItem: React.FunctionComponent<{
+    setSelectedType: (type: string) => void
+    action: ChangesetListAction
+}> = ({ action, setSelectedType }) => {
+    const onClick = useCallback<React.MouseEventHandler>(
+        event => {
+            event.preventDefault()
+            setSelectedType(action.actionType)
+        },
+        [setSelectedType, action.actionType]
+    )
+    return (
+        <div className="dropdown-item">
+            <a href="#" onClick={onClick}>
+                <h4 className="mb-1">{action.dropdownTitle}</h4>
+                <p className="text-wrap text-muted mb-0">
+                    <small>{action.dropdownDescription}</small>
+                </p>
+            </a>
+        </div>
+    )
+}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -84,6 +84,9 @@ export interface ChangesetSelectRowProps {
     allSelected: boolean
     setAllSelected: () => void
     queryArguments: Omit<AllChangesetIDsVariables, 'after'>
+
+    /** For testing only. */
+    dropDownInitiallyOpen?: boolean
 }
 
 /**
@@ -99,12 +102,13 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     allSelected,
     setAllSelected,
     queryArguments,
+    dropDownInitiallyOpen = false,
 }) => {
     const actions = useMemo(() => AVAILABLE_ACTIONS.filter(action => action.isAvailable(queryArguments)), [
         queryArguments,
     ])
     /* Whether the dropdown menu is expanded. */
-    const [isOpen, setIsOpen] = useState<boolean>(false)
+    const [isOpen, setIsOpen] = useState<boolean>(dropDownInitiallyOpen)
     /* Toggle the dropdown menu */
     const toggleIsOpen = useCallback(() => setIsOpen(open => !open), [])
     const [selectedAction, setSelectedAction] = useState<ChangesetListAction | undefined>(() => {

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -82,7 +82,7 @@ export interface ChangesetSelectRowProps {
     isAllSelected: boolean
     totalCount: number
     allAllSelected: boolean
-    setAllSelected: () => void
+    setAllAllSelected: () => void
     queryArguments: Omit<AllChangesetIDsVariables, 'after'>
 }
 
@@ -97,7 +97,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     isAllSelected,
     totalCount,
     allAllSelected,
-    setAllSelected,
+    setAllAllSelected: setAllSelected,
     queryArguments,
 }) => {
     const actions = useMemo(() => availableActions.filter(action => action.isAvailable(queryArguments)), [

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -79,10 +79,10 @@ export interface ChangesetSelectRowProps {
     selected: Set<Scalars['ID']>
     batchChangeID: Scalars['ID']
     onSubmit: () => void
-    isAllSelected: boolean
+    allVisibleSelected: boolean
     totalCount: number
-    allAllSelected: boolean
-    setAllAllSelected: () => void
+    allSelected: boolean
+    setAllSelected: () => void
     queryArguments: Omit<AllChangesetIDsVariables, 'after'>
 }
 
@@ -94,10 +94,10 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     selected,
     batchChangeID,
     onSubmit,
-    isAllSelected,
+    allVisibleSelected,
     totalCount,
-    allAllSelected,
-    setAllAllSelected: setAllSelected,
+    allSelected,
+    setAllSelected,
     queryArguments,
 }) => {
     const actions = useMemo(() => AVAILABLE_ACTIONS.filter(action => action.isAvailable(queryArguments)), [
@@ -129,7 +129,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
         // Depending on the selection, we need to construct a loader function for
         // the changeset IDs.
         let ids: () => Promise<Scalars['ID'][]>
-        if (allAllSelected) {
+        if (allSelected) {
             // We asynchronously fetch all the IDs for ALL all.
             ids = () => queryAllChangesetIDs(queryArguments).toPromise()
         } else {
@@ -148,12 +148,12 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
         if (element !== undefined) {
             setRenderedElement(element)
         }
-    }, [allAllSelected, batchChangeID, onSubmit, queryArguments, selected, selectedAction])
+    }, [allSelected, batchChangeID, onSubmit, queryArguments, selected, selectedAction])
 
     const buttonLabel = selectedAction === undefined ? 'Select action' : selectedAction.buttonLabel
 
     // If we have ALL all selected, we take the totalCount in the current connection, otherwise the count of selected changeset IDs.
-    const selectedAmount = allAllSelected ? totalCount : selected.size
+    const selectedAmount = allSelected ? totalCount : selected.size
 
     return (
         <>
@@ -162,7 +162,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                 <div className="ml-2 col d-flex align-items-center">
                     <InfoCircleOutlineIcon className="icon-inline text-muted mr-2" />
                     {selectedAmount} {pluralize('changeset', selectedAmount)} selected
-                    {isAllSelected && totalCount > selectedAmount && (
+                    {allVisibleSelected && totalCount > selectedAmount && (
                         <button type="button" className="btn btn-link py-0 px-1" onClick={setAllSelected}>
                             (Select all {totalCount})
                         </button>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
-import React, { Fragment, useCallback, useState } from 'react'
+import React, { Fragment, useCallback, useMemo, useState } from 'react'
 
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
@@ -8,15 +8,28 @@ import { AllChangesetIDsVariables, Scalars } from '../../../../graphql-operation
 import { eventLogger } from '../../../../tracking/eventLogger'
 import { queryAllChangesetIDs } from '../backend'
 
+import styles from './ChangesetSelectRow.module.scss'
 import { CreateCommentModal } from './CreateCommentModal'
 import { DetachChangesetsModal } from './DetachChangesetsModal'
 
+/**
+ * Describes a possible action on the changeset list.
+ */
 interface ChangesetListAction {
-    actionType: string
-    actionVerb: string
+    /* The type of action. Used internally. */
+    type: string
+    /* The button label for the action. */
+    buttonLabel: string
+    /* The title in the dropdown menu item. */
     dropdownTitle: string
+    /* The description in the dropdown menu item. */
     dropdownDescription: string
+    /* Conditionally display the action based on the given query arguments. */
     isAvailable: (queryArguments: Omit<AllChangesetIDsVariables, 'after'>) => boolean
+    /**
+     * Invoked when the action is triggered. Either onDone or onCancel need to be called
+     * eventually. Can return a JSX.Element to be rendered adacent to the button (i.e. a modal).
+     */
     onTrigger: (
         batchChangeID: Scalars['ID'],
         changesetIDs: () => Promise<Scalars['ID'][]>,
@@ -27,11 +40,12 @@ interface ChangesetListAction {
 
 const availableActions: ChangesetListAction[] = [
     {
-        actionType: 'detach',
-        actionVerb: 'Detach changesets',
+        type: 'detach',
+        buttonLabel: 'Detach changesets',
         dropdownTitle: 'Detach changesets',
         dropdownDescription:
             "Removes the selected changesets from this batch change. Unlike archive, this can't be undone.",
+        // Only show on the archived tab.
         isAvailable: ({ onlyArchived }) => !!onlyArchived,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
             <DetachChangesetsModal
@@ -44,8 +58,8 @@ const availableActions: ChangesetListAction[] = [
         ),
     },
     {
-        actionType: 'commentatore',
-        actionVerb: 'Create comment',
+        type: 'commentatore',
+        buttonLabel: 'Create comment',
         dropdownTitle: 'Create comment',
         dropdownDescription:
             'Create a comment on all selected changesets to ask people for reviews, or give an update.',
@@ -72,6 +86,10 @@ export interface ChangesetSelectRowProps {
     queryArguments: Omit<AllChangesetIDsVariables, 'after'>
 }
 
+/**
+ * Renders the top bar of the ChangesetList with the action buttons and the X selected
+ * label. Provides select ALL functionality.
+ */
 export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps> = ({
     selected,
     batchChangeID,
@@ -82,10 +100,15 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     setAllSelected,
     queryArguments,
 }) => {
-    const actions = availableActions.filter(action => action.isAvailable(queryArguments))
+    const actions = useMemo(() => availableActions.filter(action => action.isAvailable(queryArguments)), [
+        queryArguments,
+    ])
+    /* Whether the dropdown menu is expanded. */
     const [isOpen, setIsOpen] = useState<boolean>(false)
+    /* Toggle the dropdown menu */
     const toggleIsOpen = useCallback(() => setIsOpen(open => !open), [])
     const [selectedAction, setSelectedAction] = useState<ChangesetListAction | undefined>(() => {
+        // If there's only one available action, default select that one.
         if (actions.length === 1) {
             return actions[0]
         }
@@ -93,7 +116,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     })
     const onSelectedTypeSelect = useCallback(
         (type: string) => {
-            setSelectedAction(actions.find(action => action.actionType === type))
+            setSelectedAction(actions.find(action => action.type === type))
             setIsOpen(false)
         },
         [actions]
@@ -103,22 +126,33 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
         if (!selectedAction) {
             return
         }
+        // Depending on the selection, we need to construct a loader function for
+        // the changeset IDs.
         let ids: () => Promise<Scalars['ID'][]>
         if (allAllSelected) {
+            // We asynchronously fetch all the IDs for ALL all.
             ids = () => queryAllChangesetIDs(queryArguments).toPromise()
         } else {
+            // We can just pass down the IDs.
             ids = () => Promise.resolve([...selected])
         }
-        const element = selectedAction.onTrigger(batchChangeID, ids, onSubmit, () => {
-            setRenderedElement(undefined)
-        })
+        const element = selectedAction.onTrigger(
+            batchChangeID,
+            ids,
+            onSubmit,
+            // On cancel hide the rendered element.
+            () => {
+                setRenderedElement(undefined)
+            }
+        )
         if (element !== undefined) {
             setRenderedElement(element)
         }
     }, [allAllSelected, batchChangeID, onSubmit, queryArguments, selected, selectedAction])
 
-    const buttonLabel = selectedAction === undefined ? 'Select action' : selectedAction.actionVerb
+    const buttonLabel = selectedAction === undefined ? 'Select action' : selectedAction.buttonLabel
 
+    // If we have ALL all selected, we take the totalCount in the current connection, otherwise the count of selected changeset IDs.
     const selectedAmount = allAllSelected ? totalCount : selected.size
 
     return (
@@ -156,13 +190,13 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
                                         />
                                         <div
                                             className={classNames(
+                                                styles.changesetSelectRowDropdownItem,
                                                 'dropdown-menu dropdown-menu-right',
                                                 isOpen && 'show'
                                             )}
-                                            style={{ minWidth: '350px' }}
                                         >
                                             {actions.map((action, index) => (
-                                                <Fragment key={action.actionType}>
+                                                <Fragment key={action.type}>
                                                     <ActionDropdownItem
                                                         action={action}
                                                         setSelectedType={onSelectedTypeSelect}
@@ -184,17 +218,15 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     )
 }
 
-const ActionDropdownItem: React.FunctionComponent<{
+interface ActionDropdownItemProps {
     setSelectedType: (type: string) => void
     action: ChangesetListAction
-}> = ({ action, setSelectedType }) => {
-    const onClick = useCallback<React.MouseEventHandler>(
-        event => {
-            event.preventDefault()
-            setSelectedType(action.actionType)
-        },
-        [setSelectedType, action.actionType]
-    )
+}
+
+const ActionDropdownItem: React.FunctionComponent<ActionDropdownItemProps> = ({ action, setSelectedType }) => {
+    const onClick = useCallback<React.MouseEventHandler>(() => {
+        setSelectedType(action.type)
+    }, [setSelectedType, action.type])
     return (
         <div className="dropdown-item">
             <button type="button" className="btn text-left" onClick={onClick}>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -44,7 +44,7 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
         buttonLabel: 'Detach changesets',
         dropdownTitle: 'Detach changesets',
         dropdownDescription:
-            "Removes the selected changesets from this batch change. Unlike archive, this can't be undone.",
+            "Remove the selected changesets from this batch change. Unlike archive, this can't be undone.",
         // Only show on the archived tab.
         isAvailable: ({ onlyArchived }) => !!onlyArchived,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
@@ -62,7 +62,7 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
         buttonLabel: 'Create comment',
         dropdownTitle: 'Create comment',
         dropdownDescription:
-            'Create a comment on all selected changesets to ask people for reviews, or give an update.',
+            'Create a comment on all selected changesets. For example, you could ask people for reviews, give an update, or post a cat GIF.',
         isAvailable: () => true,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
             <CreateCommentModal

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -38,7 +38,7 @@ interface ChangesetListAction {
     ) => void | JSX.Element
 }
 
-const availableActions: ChangesetListAction[] = [
+const AVAILABLE_ACTIONS: ChangesetListAction[] = [
     {
         type: 'detach',
         buttonLabel: 'Detach changesets',
@@ -100,7 +100,7 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
     setAllAllSelected: setAllSelected,
     queryArguments,
 }) => {
-    const actions = useMemo(() => availableActions.filter(action => action.isAvailable(queryArguments)), [
+    const actions = useMemo(() => AVAILABLE_ACTIONS.filter(action => action.isAvailable(queryArguments)), [
         queryArguments,
     ])
     /* Whether the dropdown menu is expanded. */

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.story.tsx
@@ -1,0 +1,33 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+
+import { CreateCommentModal } from './CreateCommentModal'
+
+const { add } = storiesOf('web/batches/details/CreateCommentModal', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
+const createChangesetCommentsAction = () => {
+    action('CreateChangesetComments')
+    return Promise.resolve()
+}
+
+add('Confirmation', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CreateCommentModal
+                {...props}
+                afterCreate={noop}
+                batchChangeID="test-123"
+                changesetIDs={changesetIDsFunction}
+                onCancel={noop}
+                createChangesetComments={createChangesetCommentsAction}
+            />
+        )}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
@@ -1,0 +1,117 @@
+import Dialog from '@reach/dialog'
+import classNames from 'classnames'
+import React, { useCallback, useState } from 'react'
+
+import { Form } from '@sourcegraph/branded/src/components/Form'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { ErrorAlert } from '../../../../components/alerts'
+import { ExternalServiceKind, Scalars } from '../../../../graphql-operations'
+
+export interface CreateCommentModalProps {
+    onCancel: () => void
+    afterCreate: () => void
+    userID: Scalars['ID'] | null
+    // externalServiceKind: ExternalServiceKind
+    // externalServiceURL: string
+    // requiresSSH: boolean
+
+    /** For testing only. */
+    // createBatchChangesCredential?: typeof _createBatchChangesCredential
+}
+
+export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps> = ({
+    onCancel,
+    afterCreate,
+    userID,
+    // externalServiceKind,
+    // externalServiceURL,
+    // requiresSSH,
+    // createBatchChangesCredential = _createBatchChangesCredential,
+}) => {
+    const labelId = 'addCredential'
+    const [isLoading, setIsLoading] = useState<boolean | Error>(false)
+    const [credential, setCredential] = useState<string>('')
+
+    const onChangeCredential = useCallback<React.ChangeEventHandler<HTMLTextAreaElement>>(event => {
+        setCredential(event.target.value)
+    }, [])
+
+    const onSubmit = useCallback<React.FormEventHandler>(
+        async event => {
+            event.preventDefault()
+            setIsLoading(true)
+            try {
+                // const createdCredential = await createBatchChangesCredential({
+                //     user: userID,
+                //     credential,
+                //     externalServiceKind,
+                //     externalServiceURL,
+                // })
+                afterCreate()
+            } catch (error) {
+                setIsLoading(asError(error))
+            }
+        },
+        [
+            afterCreate,
+            userID,
+            credential,
+            // externalServiceKind,
+            // externalServiceURL,
+            // requiresSSH,
+            // createBatchChangesCredential,
+        ]
+    )
+
+    return (
+        <Dialog
+            className="modal-body modal-body--top-third p-4 rounded border"
+            onDismiss={onCancel}
+            aria-labelledby={labelId}
+        >
+            <div className="web-content test-add-credential-modal">
+                <h3>Post a bulk comment on changesets</h3>
+                <p className="mb-4">Use this feature to create a bulk comment on all the selected code hosts.</p>
+                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
+                <Form onSubmit={onSubmit}>
+                    <div className="form-group">
+                        <label htmlFor="token">Comment text</label>
+                        <textarea
+                            id="token"
+                            name="token"
+                            className="form-control test-add-credential-modal-input text-monospace"
+                            placeholder={`## Please review this
+
+This change is really important for us so please go review and merge this.`}
+                            required={true}
+                            rows={8}
+                            minLength={1}
+                            value={credential}
+                            onChange={onChangeCredential}
+                        />
+                    </div>
+                    <div className="d-flex justify-content-end">
+                        <button
+                            type="button"
+                            disabled={isLoading === true}
+                            className="btn btn-outline-secondary mr-2"
+                            onClick={onCancel}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isLoading === true || credential.length === 0}
+                            className="btn btn-primary test-add-credential-modal-submit"
+                        >
+                            {isLoading === true && <LoadingSpinner className="icon-inline" />}
+                            Post comments
+                        </button>
+                    </div>
+                </Form>
+            </div>
+        </Dialog>
+    )
+}

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
@@ -1,5 +1,4 @@
 import Dialog from '@reach/dialog'
-import classNames from 'classnames'
 import React, { useCallback, useState } from 'react'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
@@ -7,7 +6,7 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { ErrorAlert } from '../../../../components/alerts'
-import { ExternalServiceKind, Scalars } from '../../../../graphql-operations'
+import { Scalars } from '../../../../graphql-operations'
 import { createChangesetComments } from '../backend'
 
 export interface CreateCommentModalProps {

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
@@ -26,7 +26,6 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
     changesetIDs,
     createChangesetComments = _createChangesetComments,
 }) => {
-    const labelId = 'create-comment-modal-id'
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
     const [commentBody, setCommentBody] = useState<string>('')
 
@@ -53,10 +52,10 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
         <Dialog
             className="modal-body modal-body--top-third p-4 rounded border"
             onDismiss={onCancel}
-            aria-labelledby={labelId}
+            aria-labelledby={LABEL_ID}
         >
             <div className="web-content">
-                <h3 id={labelId}>Post a bulk comment on changesets</h3>
+                <h3 id={LABEL_ID}>Post a bulk comment on changesets</h3>
                 <p className="mb-4">Use this feature to create a bulk comment on all the selected code hosts.</p>
                 {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
                 <Form onSubmit={onSubmit}>
@@ -66,7 +65,7 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
                             id="token"
                             name="token"
                             className="form-control text-monospace"
-                            placeholder={placeholderComment}
+                            placeholder={PLACEHOLDER_COMMENT}
                             required={true}
                             rows={8}
                             minLength={1}
@@ -98,6 +97,8 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
     )
 }
 
-const placeholderComment = `## Please review this
+const LABEL_ID = 'create-comment-modal-id'
+
+const PLACEHOLDER_COMMENT = `## Please review this
 
 This change is really important for us so please go review and merge this.`

--- a/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/CreateCommentModal.tsx
@@ -64,7 +64,7 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
                         <textarea
                             id="token"
                             name="token"
-                            className="form-control text-monospace"
+                            className="form-control"
                             placeholder={PLACEHOLDER_COMMENT}
                             required={true}
                             rows={8}
@@ -99,6 +99,8 @@ export const CreateCommentModal: React.FunctionComponent<CreateCommentModalProps
 
 const LABEL_ID = 'create-comment-modal-id'
 
-const PLACEHOLDER_COMMENT = `## Please review this
+const PLACEHOLDER_COMMENT = `A comment that will be posted to all selected changesets.
 
-This change is really important for us so please go review and merge this.`
+You can use whatever formatting is available on your code host, such as _Markdown_!
+
+Use this to request a review, provide an update, or post your favorite emoji, like 🦡.`

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.story.tsx
@@ -1,0 +1,36 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
+import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+
+import { DetachChangesetsModal } from './DetachChangesetsModal'
+
+const { add } = storiesOf('web/batches/details/DetachChangesetsModal', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
+const detachAction = () => {
+    action('DetachChangesets')
+    return Promise.resolve()
+}
+
+add('Confirmation', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <DetachChangesetsModal
+                {...props}
+                afterCreate={noop}
+                batchChangeID="test-123"
+                changesetIDs={changesetIDsFunction}
+                onCancel={noop}
+                telemetryService={NOOP_TELEMETRY_SERVICE}
+                detachChangesets={detachAction}
+            />
+        )}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
@@ -1,0 +1,71 @@
+import Dialog from '@reach/dialog'
+import React, { useCallback, useState } from 'react'
+
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { ErrorAlert } from '../../../../components/alerts'
+import { Scalars } from '../../../../graphql-operations'
+import { detachChangesets } from '../backend'
+
+export interface DetachChangesetsModalProps extends TelemetryProps {
+    onCancel: () => void
+    afterCreate: () => void
+    batchChangeID: Scalars['ID']
+    changesetIDs: () => Promise<Scalars['ID'][]>
+
+    /** For testing only. */
+    // createBatchChangesCredential?: typeof _createBatchChangesCredential
+}
+
+export const DetachChangesetsModal: React.FunctionComponent<DetachChangesetsModalProps> = ({
+    onCancel,
+    afterCreate,
+    batchChangeID,
+    changesetIDs,
+    telemetryService,
+    // createBatchChangesCredential = _createBatchChangesCredential,
+}) => {
+    const [isLoading, setIsLoading] = useState<boolean | Error>(false)
+
+    const onSubmit = useCallback<React.FormEventHandler>(
+        async event => {
+            event.preventDefault()
+            setIsLoading(true)
+            try {
+                const ids = await changesetIDs()
+                await detachChangesets(batchChangeID, ids)
+                telemetryService.logViewEvent('BatchChangeDetailsPageDetachArchivedChangesets')
+                afterCreate()
+            } catch (error) {
+                setIsLoading(asError(error))
+            }
+        },
+        [changesetIDs, batchChangeID, telemetryService, afterCreate]
+    )
+
+    return (
+        <Dialog className="modal-body modal-body--top-third p-4 rounded border" onDismiss={onCancel}>
+            <div className="web-content">
+                <h3>Detach changesets</h3>
+                <p className="mb-4">Are you sure you want to detach the selected changesets?</p>
+                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
+                <div className="d-flex justify-content-end">
+                    <button
+                        type="button"
+                        disabled={isLoading === true}
+                        className="btn btn-outline-secondary mr-2"
+                        onClick={onCancel}
+                    >
+                        Cancel
+                    </button>
+                    <button type="button" onClick={onSubmit} disabled={isLoading === true} className="btn btn-primary">
+                        {isLoading === true && <LoadingSpinner className="icon-inline" />}
+                        Detach
+                    </button>
+                </div>
+            </div>
+        </Dialog>
+    )
+}

--- a/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/DetachChangesetsModal.tsx
@@ -7,7 +7,7 @@ import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { ErrorAlert } from '../../../../components/alerts'
 import { Scalars } from '../../../../graphql-operations'
-import { detachChangesets } from '../backend'
+import { detachChangesets as _detachChangesets } from '../backend'
 
 export interface DetachChangesetsModalProps extends TelemetryProps {
     onCancel: () => void
@@ -16,7 +16,7 @@ export interface DetachChangesetsModalProps extends TelemetryProps {
     changesetIDs: () => Promise<Scalars['ID'][]>
 
     /** For testing only. */
-    // createBatchChangesCredential?: typeof _createBatchChangesCredential
+    detachChangesets?: typeof _detachChangesets
 }
 
 export const DetachChangesetsModal: React.FunctionComponent<DetachChangesetsModalProps> = ({
@@ -25,30 +25,32 @@ export const DetachChangesetsModal: React.FunctionComponent<DetachChangesetsModa
     batchChangeID,
     changesetIDs,
     telemetryService,
-    // createBatchChangesCredential = _createBatchChangesCredential,
+    detachChangesets = _detachChangesets,
 }) => {
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
 
-    const onSubmit = useCallback<React.FormEventHandler>(
-        async event => {
-            event.preventDefault()
-            setIsLoading(true)
-            try {
-                const ids = await changesetIDs()
-                await detachChangesets(batchChangeID, ids)
-                telemetryService.logViewEvent('BatchChangeDetailsPageDetachArchivedChangesets')
-                afterCreate()
-            } catch (error) {
-                setIsLoading(asError(error))
-            }
-        },
-        [changesetIDs, batchChangeID, telemetryService, afterCreate]
-    )
+    const onSubmit = useCallback<React.FormEventHandler>(async () => {
+        setIsLoading(true)
+        try {
+            const ids = await changesetIDs()
+            await detachChangesets(batchChangeID, ids)
+            telemetryService.logViewEvent('BatchChangeDetailsPageDetachArchivedChangesets')
+            afterCreate()
+        } catch (error) {
+            setIsLoading(asError(error))
+        }
+    }, [changesetIDs, detachChangesets, batchChangeID, telemetryService, afterCreate])
+
+    const labelId = 'detach-changesets-modal-title'
 
     return (
-        <Dialog className="modal-body modal-body--top-third p-4 rounded border" onDismiss={onCancel}>
+        <Dialog
+            className="modal-body modal-body--top-third p-4 rounded border"
+            onDismiss={onCancel}
+            aria-labelledby={labelId}
+        >
             <div className="web-content">
-                <h3>Detach changesets</h3>
+                <h3 id={labelId}>Detach changesets</h3>
                 <p className="mb-4">Are you sure you want to detach the selected changesets?</p>
                 {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
                 <div className="d-flex justify-content-end">

--- a/client/web/src/enterprise/batches/detail/changesets/EmptyArchivedChangesetListElement.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/EmptyArchivedChangesetListElement.tsx
@@ -2,10 +2,8 @@ import ArchiveIcon from 'mdi-react/ArchiveIcon'
 import React from 'react'
 
 export const EmptyArchivedChangesetListElement: React.FunctionComponent<{}> = () => (
-    <div className="text-muted mt-4 pt-4 mb-4 row">
-        <div className="col-12 text-center">
-            <ArchiveIcon className="icon" />
-            <div className="pt-2">This batch change does not contain archived changesets.</div>
-        </div>
+    <div className="text-muted my-4 pt-4 text-center">
+        <ArchiveIcon className="icon" />
+        <div className="pt-2">This batch change does not contain archived changesets.</div>
     </div>
 )

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -101,7 +101,7 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                     checked={selected}
                     onChange={toggleSelected}
                     disabled={!viewerCanAdminister}
-                    data-tooltip="Click to select changeset for detaching from batch change"
+                    data-tooltip="Click to select changeset for bulk operation"
                 />
             </div>
             <ChangesetStatusCell

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.tsx
@@ -34,7 +34,6 @@ import styles from './ExternalChangesetNode.module.scss'
 export interface ExternalChangesetNodeProps extends ThemeProps {
     node: ExternalChangesetFields
     viewerCanAdminister: boolean
-    enableSelect?: boolean
     onSelect?: (id: string, selected: boolean) => void
     isSelected?: (id: string) => boolean
     history: H.History
@@ -51,7 +50,6 @@ export interface ExternalChangesetNodeProps extends ThemeProps {
 export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNodeProps> = ({
     node: initialNode,
     viewerCanAdminister,
-    enableSelect,
     onSelect,
     isSelected,
     isLightTheme,
@@ -95,19 +93,17 @@ export const ExternalChangesetNode: React.FunctionComponent<ExternalChangesetNod
                     <ChevronRightIcon className="icon-inline" aria-label="Expand section" />
                 )}
             </button>
-            {enableSelect && (
-                <div className="p-2">
-                    <input
-                        id={`select-changeset-${node.id}`}
-                        type="checkbox"
-                        className="btn"
-                        checked={selected}
-                        onChange={toggleSelected}
-                        disabled={!viewerCanAdminister}
-                        data-tooltip="Click to select changeset for detaching from batch change"
-                    />
-                </div>
-            )}
+            <div className="p-2">
+                <input
+                    id={`select-changeset-${node.id}`}
+                    type="checkbox"
+                    className="btn"
+                    checked={selected}
+                    onChange={toggleSelected}
+                    disabled={!viewerCanAdminister}
+                    data-tooltip="Click to select changeset for detaching from batch change"
+                />
+            </div>
             <ChangesetStatusCell
                 id={node.id}
                 state={node.state}

--- a/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
@@ -9,27 +9,21 @@ import styles from './HiddenExternalChangesetNode.module.scss'
 
 export interface HiddenExternalChangesetNodeProps {
     node: Pick<HiddenExternalChangesetFields, 'id' | 'nextSyncAt' | 'updatedAt' | 'state' | '__typename'>
-    enableSelect?: boolean
 }
 
-export const HiddenExternalChangesetNode: React.FunctionComponent<HiddenExternalChangesetNodeProps> = ({
-    node,
-    enableSelect = false,
-}) => (
+export const HiddenExternalChangesetNode: React.FunctionComponent<HiddenExternalChangesetNodeProps> = ({ node }) => (
     <>
         <span className="d-none d-sm-block" />
-        {enableSelect && (
-            <div className="p-2">
-                <input
-                    id={`select-changeset-${node.id}`}
-                    type="checkbox"
-                    className="btn"
-                    checked={false}
-                    disabled={true}
-                    data-tooltip="You do not have permission to detach this changeset"
-                />
-            </div>
-        )}
+        <div className="p-2">
+            <input
+                id={`select-changeset-${node.id}`}
+                type="checkbox"
+                className="btn"
+                checked={false}
+                disabled={true}
+                data-tooltip="You do not have permission to detach this changeset"
+            />
+        </div>
         <ChangesetStatusCell
             id={node.id}
             state={node.state}

--- a/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/HiddenExternalChangesetNode.tsx
@@ -21,7 +21,7 @@ export const HiddenExternalChangesetNode: React.FunctionComponent<HiddenExternal
                 className="btn"
                 checked={false}
                 disabled={true}
-                data-tooltip="You do not have permission to detach this changeset"
+                data-tooltip="You do not have permission to perform a bulk operation on this changeset"
             />
         </div>
         <ChangesetStatusCell

--- a/client/web/src/integration/batches.test.ts
+++ b/client/web/src/integration/batches.test.ts
@@ -298,6 +298,8 @@ function mockCommonGraphQLResponses(
                     originalInput: 'name: awesome-batch-change\ndescription: somesttring',
                     supersedingBatchSpec: null,
                 },
+                bulkOperations: { totalCount: 0 },
+                activeBulkOperations: { totalCount: 0, nodes: [] },
                 ...batchesOverrides,
             },
         }),

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -272,6 +272,8 @@ type BulkOperationResolver interface {
 	State() string
 	Progress() float64
 	Errors(ctx context.Context) ([]ChangesetJobErrorResolver, error)
+	Initiator(ctx context.Context) (*UserResolver, error)
+	ChangesetCount() int32
 	CreatedAt() DateTime
 	FinishedAt() *DateTime
 }

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -207,7 +207,6 @@ type DetachChangesetsArgs struct {
 type ListBatchChangeBulkOperationArgs struct {
 	First        int32
 	After        *string
-	State        *[]string
 	CreatedAfter *DateTime
 }
 

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -205,8 +205,10 @@ type DetachChangesetsArgs struct {
 }
 
 type ListBatchChangeBulkOperationArgs struct {
-	First int32
-	After *string
+	First        int32
+	After        *string
+	State        *[]string
+	CreatedAfter *DateTime
 }
 
 type CreateChangesetCommentsArgs struct {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2319,6 +2319,14 @@ type BatchChange implements Node {
         Opaque pagination cursor.
         """
         after: String
+        """
+        Filter by state.
+        """
+        state: [BulkOperationState!]
+        """
+        Filter by createdAt value.
+        """
+        createdAfter: DateTime
     ): BulkOperationConnection!
 }
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2320,10 +2320,6 @@ type BatchChange implements Node {
         """
         after: String
         """
-        Filter by state.
-        """
-        state: [BulkOperationState!]
-        """
         Filter by createdAt value.
         """
         createdAfter: DateTime

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2416,6 +2416,16 @@ type BulkOperation implements Node {
     when some operations are still processing.
     """
     finishedAt: DateTime
+
+    """
+    The user who triggered this bulk operation.
+    """
+    initiator: User!
+
+    """
+    The number of changesets involved in this bulk operation.
+    """
+    changesetCount: Int!
 }
 
 """

--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 	"sync"
@@ -275,16 +274,6 @@ func (r *batchChangeResolver) BulkOperations(
 			return nil, err
 		}
 		opts.Cursor = int64(id)
-	}
-
-	if args.State != nil {
-		for _, state := range *args.State {
-			boState := btypes.BulkOperationState(state)
-			if !boState.Valid() {
-				return nil, fmt.Errorf("invalid BulkOperationState %q", state)
-			}
-			opts.States = append(opts.States, boState)
-		}
 	}
 
 	if args.CreatedAfter != nil {

--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strconv"
 	"sync"
@@ -274,6 +275,20 @@ func (r *batchChangeResolver) BulkOperations(
 			return nil, err
 		}
 		opts.Cursor = int64(id)
+	}
+
+	if args.State != nil {
+		for _, state := range *args.State {
+			boState := btypes.BulkOperationState(state)
+			if !boState.Valid() {
+				return nil, fmt.Errorf("invalid BulkOperationState %q", state)
+			}
+			opts.States = append(opts.States, boState)
+		}
+	}
+
+	if args.CreatedAfter != nil {
+		opts.CreatedAfter = args.CreatedAfter.Time
 	}
 
 	return &bulkOperationConnectionResolver{

--- a/enterprise/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation.go
@@ -88,6 +88,14 @@ func (r *bulkOperationResolver) Errors(ctx context.Context) ([]graphqlbackend.Ch
 	return res, nil
 }
 
+func (r *bulkOperationResolver) Initiator(ctx context.Context) (*graphqlbackend.UserResolver, error) {
+	return graphqlbackend.UserByIDInt32(ctx, r.store.DB(), r.bulkOperation.UserID)
+}
+
+func (r *bulkOperationResolver) ChangesetCount() int32 {
+	return r.bulkOperation.ChangesetCount
+}
+
 func (r *bulkOperationResolver) CreatedAt() graphqlbackend.DateTime {
 	return graphqlbackend.DateTime{Time: r.bulkOperation.CreatedAt}
 }

--- a/enterprise/internal/batches/resolvers/bulk_operation_connection.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation_connection.go
@@ -28,6 +28,7 @@ var _ graphqlbackend.BulkOperationConnectionResolver = &bulkOperationConnectionR
 func (r *bulkOperationConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	count, err := r.store.CountBulkOperations(ctx, store.CountBulkOperationsOpts{
 		BatchChangeID: r.batchChangeID,
+		CreatedAfter:  r.opts.CreatedAfter,
 	})
 	if err != nil {
 		return 0, err

--- a/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -87,7 +87,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 
 	nodes := []apitest.BulkOperation{
 		{
-			ID:        string(marshalBulkOperationID("group-1")),
+			ID:        string(marshalBulkOperationID("group-3")),
 			Type:      "COMMENT",
 			State:     string(btypes.BulkOperationStateProcessing),
 			Errors:    []*apitest.ChangesetJobError{},
@@ -101,7 +101,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 			CreatedAt: marshalDateTime(t, now),
 		},
 		{
-			ID:        string(marshalBulkOperationID("group-3")),
+			ID:        string(marshalBulkOperationID("group-1")),
 			Type:      "COMMENT",
 			State:     string(btypes.BulkOperationStateProcessing),
 			Errors:    []*apitest.ChangesetJobError{},
@@ -117,7 +117,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 		wantNodes       []apitest.BulkOperation
 	}{
 		{firstParam: 1, wantHasNextPage: true, wantEndCursor: "2", wantTotalCount: 3, wantNodes: nodes[:1]},
-		{firstParam: 2, wantHasNextPage: true, wantEndCursor: "3", wantTotalCount: 3, wantNodes: nodes[:2]},
+		{firstParam: 2, wantHasNextPage: true, wantEndCursor: "1", wantTotalCount: 3, wantNodes: nodes[:2]},
 		{firstParam: 3, wantHasNextPage: false, wantTotalCount: 3, wantNodes: nodes[:3]},
 	}
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -671,10 +671,8 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 		BatchChangeID: batchChangeID,
 		// We can only run jobs on published changesets.
 		PublicationState: &published,
-		// TODO: Do we want to allow this on imported changesets?
-		// OwnedByBatchChangeID: batchChangeID,
+		// Also include archived changesets, we allow commenting on them as well.
 		IncludeArchived: true,
-
 		// We only want to allow changesets the user has access to.
 		EnforceAuthz: true,
 	})

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -673,6 +673,7 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 		PublicationState: &published,
 		// TODO: Do we want to allow this on imported changesets?
 		// OwnedByBatchChangeID: batchChangeID,
+		IncludeArchived: true,
 
 		// We only want to allow changesets the user has access to.
 		EnforceAuthz: true,

--- a/enterprise/internal/batches/store/bulk_operations.go
+++ b/enterprise/internal/batches/store/bulk_operations.go
@@ -33,6 +33,8 @@ END AS state`,
 		btypes.ChangesetJobStateCompleted.ToDB(),
 		btypes.ChangesetJobStateFailed.ToDB(),
 	),
+	sqlf.Sprintf("MIN(changeset_jobs.user_id) AS user_id"),
+	sqlf.Sprintf("COUNT(changeset_jobs.id) AS changeset_count"),
 	sqlf.Sprintf("MIN(changeset_jobs.created_at) AS created_at"),
 	sqlf.Sprintf(
 		"CASE WHEN (COUNT(*) FILTER (WHERE changeset_jobs.state IN (%s, %s)) / COUNT(*)) = 1.0 THEN MAX(changeset_jobs.finished_at) ELSE null END AS finished_at",
@@ -254,6 +256,8 @@ func scanBulkOperation(b *btypes.BulkOperation, s scanner) error {
 		&b.Type,
 		&b.State,
 		&b.Progress,
+		&b.UserID,
+		&b.ChangesetCount,
 		&b.CreatedAt,
 		&dbutil.NullTime{Time: &b.FinishedAt},
 	)

--- a/enterprise/internal/batches/store/bulk_operations.go
+++ b/enterprise/internal/batches/store/bulk_operations.go
@@ -148,7 +148,7 @@ func listBulkOperationsQuery(opts *ListBulkOperationsOpts) *sqlf.Query {
 	having := sqlf.Sprintf("")
 
 	if opts.Cursor > 0 {
-		preds = append(preds, sqlf.Sprintf("changeset_jobs.id >= %s", opts.Cursor))
+		preds = append(preds, sqlf.Sprintf("changeset_jobs.id <= %s", opts.Cursor))
 	}
 
 	if !opts.CreatedAfter.IsZero() {

--- a/enterprise/internal/batches/types/bulk_operation.go
+++ b/enterprise/internal/batches/types/bulk_operation.go
@@ -31,12 +31,14 @@ type BulkOperation struct {
 	ID string
 	// DBID is only used internally for pagination. Don't make any assumptions
 	// about this field.
-	DBID       int64
-	Type       ChangesetJobType
-	State      BulkOperationState
-	Progress   float64
-	CreatedAt  time.Time
-	FinishedAt time.Time
+	DBID           int64
+	Type           ChangesetJobType
+	State          BulkOperationState
+	Progress       float64
+	UserID         int32
+	ChangesetCount int32
+	CreatedAt      time.Time
+	FinishedAt     time.Time
 }
 
 // BulkOperationError represents an error on a changeset that occurred within a bulk


### PR DESCRIPTION
This PR implements the bulk operations tab and header notifications, and the UI element to trigger the create comment operation. Therefor, I made the checkboxes available on all list views and migrated the detach operation to just be another case of a bulk operation. I will convert it into a proper bulk operation in the backend in a follow-up PR.

This is 98% ready, so opening up for review.

## Walk through video

https://user-images.githubusercontent.com/19534377/118569236-ce008b00-b779-11eb-84fa-074a060c165c.mov