### PR TITLE
Fix localStorage integration test issue

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -685,7 +685,7 @@ describe('Search', () => {
                 }),
             })
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=context:%40test+test&patternType=regexp', {
-                waitUntil: 'networkidle2',
+                waitUntil: 'networkidle0',
             })
             await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
             expect(await getSelectedSearchContextSpec()).toStrictEqual('context:@test')
@@ -704,7 +704,7 @@ describe('Search', () => {
         test('Unavailable search context should remain in the query and disable the search context dropdown', async () => {
             await driver.page.goto(
                 driver.sourcegraphBaseUrl + '/search?q=context:%40unavailableCtx+test&patternType=regexp',
-                { waitUntil: 'networkidle2' }
+                { waitUntil: 'networkidle0' }
             )
             await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
             await driver.page.waitForSelector('#monaco-query-input')
@@ -736,7 +736,7 @@ describe('Search', () => {
             await driver.page.evaluate(() => localStorage.setItem('sg-last-search-context', 'doesnotexist'))
             // Visit the page again with localStorage initialized
             await driver.page.goto(driver.sourcegraphBaseUrl + '/search', {
-                waitUntil: 'networkidle2',
+                waitUntil: 'networkidle0',
             })
             await driver.page.waitForSelector('.test-selected-search-context-spec', { visible: true })
             expect(await getSelectedSearchContextSpec()).toStrictEqual('context:global')


### PR DESCRIPTION
Fixes #20379

Search contexts integration tests fail occasionally. I think this is because we aren't waiting until the page is done loading, so changing Puppeteer to wait until there are no network requests seems to fix the issue. This failure is not super common, but after running 6 builds I didn't see it, so hopefully this actually fixes it.

Build 1: https://buildkite.com/sourcegraph/sourcegraph/builds/94167
Build 2: https://buildkite.com/sourcegraph/sourcegraph/builds/94168
Build 3: https://buildkite.com/sourcegraph/sourcegraph/builds/94171
Build 4: https://buildkite.com/sourcegraph/sourcegraph/builds/94174
Build 5: https://buildkite.com/sourcegraph/sourcegraph/builds/94181
Build 6: https://buildkite.com/sourcegraph/sourcegraph/builds/94183