### PR TITLE
Remove error from CanonicalURL

### DIFF
--- a/cmd/frontend/graphqlbackend/file.go
+++ b/cmd/frontend/graphqlbackend/file.go
@@ -18,7 +18,7 @@ type FileResolver interface {
 	Binary(ctx context.Context) (bool, error)
 	RichHTML(ctx context.Context) (string, error)
 	URL(ctx context.Context) (string, error)
-	CanonicalURL() (string, error)
+	CanonicalURL() string
 	ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error)
 	Highlight(ctx context.Context, args *HighlightArgs) (*highlightedFileResolver, error)
 

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -318,7 +318,7 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 // given. This is because the convention in the frontend is for repo-rev URLs to omit the "@rev"
 // portion (unlike for commit page URLs, which must include some revspec in
 // "/REPO/-/commit/REVSPEC").
-func (r *GitCommitResolver) repoRevURL() (string, error) {
+func (r *GitCommitResolver) repoRevURL() string {
 	url := r.repoResolver.URL()
 	var rev string
 	if r.inputRev != nil {
@@ -327,9 +327,9 @@ func (r *GitCommitResolver) repoRevURL() (string, error) {
 		rev = string(r.oid)
 	}
 	if rev != "" {
-		return url + "@" + escapePathForURL(rev), nil
+		return url + "@" + escapePathForURL(rev)
 	}
-	return url, nil
+	return url
 }
 
 func (r *GitCommitResolver) canonicalRepoRevURL() string {

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -3,6 +3,7 @@ package graphqlbackend
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
@@ -318,8 +319,8 @@ func (r *GitCommitResolver) inputRevOrImmutableRev() string {
 // given. This is because the convention in the frontend is for repo-rev URLs to omit the "@rev"
 // portion (unlike for commit page URLs, which must include some revspec in
 // "/REPO/-/commit/REVSPEC").
-func (r *GitCommitResolver) repoRevURL() string {
-	url := r.repoResolver.URL()
+func (r *GitCommitResolver) repoRevURL() *url.URL {
+	url := r.repoResolver.RepoMatch.URL()
 	var rev string
 	if r.inputRev != nil {
 		rev = *r.inputRev // use the original input rev from the user
@@ -327,11 +328,13 @@ func (r *GitCommitResolver) repoRevURL() string {
 		rev = string(r.oid)
 	}
 	if rev != "" {
-		return url + "@" + escapePathForURL(rev)
+		url.RawPath += "@" + escapePathForURL(rev)
 	}
 	return url
 }
 
-func (r *GitCommitResolver) canonicalRepoRevURL() string {
-	return r.repoResolver.URL() + "@" + string(r.oid)
+func (r *GitCommitResolver) canonicalRepoRevURL() *url.URL {
+	url := r.repoResolver.RepoMatch.URL()
+	url.RawPath += "@" + string(r.oid)
+	return url
 }

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -332,6 +332,6 @@ func (r *GitCommitResolver) repoRevURL() (string, error) {
 	return url, nil
 }
 
-func (r *GitCommitResolver) canonicalRepoRevURL() (string, error) {
-	return r.repoResolver.URL() + "@" + string(r.oid), nil
+func (r *GitCommitResolver) canonicalRepoRevURL() string {
+	return r.repoResolver.URL() + "@" + string(r.oid)
 }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -131,10 +131,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 		}
 		return "/" + repoName + "@" + submodule.Commit(), nil
 	}
-	url, err := r.commit.repoRevURL()
-	if err != nil {
-		return "", err
-	}
+	url := r.commit.repoRevURL()
 	return r.urlPath(url)
 }
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -139,10 +139,7 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 }
 
 func (r *GitTreeEntryResolver) CanonicalURL() (string, error) {
-	url, err := r.commit.canonicalRepoRevURL()
-	if err != nil {
-		return "", err
-	}
+	url := r.commit.canonicalRepoRevURL()
 	return r.urlPath(url)
 }
 

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -132,12 +132,12 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 		return "/" + repoName + "@" + submodule.Commit(), nil
 	}
 	url := r.commit.repoRevURL()
-	return r.urlPath(url)
+	return r.urlPath(url.String())
 }
 
 func (r *GitTreeEntryResolver) CanonicalURL() (string, error) {
 	url := r.commit.canonicalRepoRevURL()
-	return r.urlPath(url)
+	return r.urlPath(url.String())
 }
 
 func (r *GitTreeEntryResolver) urlPath(prefix string) (string, error) {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -2,6 +2,7 @@ package graphqlbackend
 
 import (
 	"context"
+	"net/url"
 	neturl "net/url"
 	"os"
 	"path"
@@ -132,22 +133,17 @@ func (r *GitTreeEntryResolver) URL(ctx context.Context) (string, error) {
 		return "/" + repoName + "@" + submodule.Commit(), nil
 	}
 	url := r.commit.repoRevURL()
-	return r.urlPath(url.String())
+	return r.urlPath(url).String(), nil
 }
 
-func (r *GitTreeEntryResolver) CanonicalURL() (string, error) {
+func (r *GitTreeEntryResolver) CanonicalURL() string {
 	url := r.commit.canonicalRepoRevURL()
-	return r.urlPath(url.String())
+	return r.urlPath(url).String()
 }
 
-func (r *GitTreeEntryResolver) urlPath(prefix string) (string, error) {
+func (r *GitTreeEntryResolver) urlPath(prefix *url.URL) *url.URL {
 	if r.IsRoot() {
-		return prefix, nil
-	}
-
-	u, err := neturl.Parse(prefix)
-	if err != nil {
-		return "", err
+		return prefix
 	}
 
 	typ := "blob"
@@ -155,8 +151,8 @@ func (r *GitTreeEntryResolver) urlPath(prefix string) (string, error) {
 		typ = "tree"
 	}
 
-	u.Path = path.Join(u.Path, "-", typ, r.Path())
-	return u.String(), nil
+	prefix.RawPath = path.Join(prefix.RawPath, "-", typ, r.Path())
+	return prefix
 }
 
 func (r *GitTreeEntryResolver) IsDirectory() bool { return r.stat.Mode().IsDir() }

--- a/cmd/frontend/graphqlbackend/location.go
+++ b/cmd/frontend/graphqlbackend/location.go
@@ -12,7 +12,7 @@ type LocationResolver interface {
 	Resource() *GitTreeEntryResolver
 	Range() *rangeResolver
 	URL(ctx context.Context) (string, error)
-	CanonicalURL() (string, error)
+	CanonicalURL() string
 }
 
 type locationResolver struct {
@@ -46,9 +46,9 @@ func (r *locationResolver) URL(ctx context.Context) (string, error) {
 	return r.urlPath(url), nil
 }
 
-func (r *locationResolver) CanonicalURL() (string, error) {
+func (r *locationResolver) CanonicalURL() string {
 	url := r.resource.CanonicalURL()
-	return r.urlPath(url), nil
+	return r.urlPath(url)
 }
 
 func (r *locationResolver) urlPath(prefix string) string {

--- a/cmd/frontend/graphqlbackend/location.go
+++ b/cmd/frontend/graphqlbackend/location.go
@@ -47,10 +47,7 @@ func (r *locationResolver) URL(ctx context.Context) (string, error) {
 }
 
 func (r *locationResolver) CanonicalURL() (string, error) {
-	url, err := r.resource.CanonicalURL()
-	if err != nil {
-		return "", err
-	}
+	url := r.resource.CanonicalURL()
 	return r.urlPath(url), nil
 }
 

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -275,11 +275,7 @@ func (r *RepositoryResolver) UpdatedAt() *DateTime {
 }
 
 func (r *RepositoryResolver) URL() string {
-	url := "/" + escapePathForURL(r.Name())
-	if r.Rev() != "" {
-		url += "@" + escapePathForURL(r.Rev())
-	}
-	return url
+	return r.RepoMatch.URL().String()
 }
 
 func (r *RepositoryResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -224,20 +224,14 @@ func TestRepositoryComparison(t *testing.T) {
 			if mostRelevant == nil {
 				t.Fatalf("MostRelevantFile is nil")
 			}
-			relevantURL, err := mostRelevant.CanonicalURL()
-			if err != nil {
-				t.Fatal(err)
-			}
+			relevantURL := mostRelevant.CanonicalURL()
 
 			wantRelevantURL := fmt.Sprintf("/%s@%s/-/blob/%s", repo.Name, wantHeadRevision, "INSTALL.md")
 			if relevantURL != wantRelevantURL {
 				t.Fatalf("MostRelevantFile.CanonicalURL() is wrong. have=%q, want=%q", relevantURL, wantRelevantURL)
 			}
 
-			newFileURL, err := newFile.CanonicalURL()
-			if err != nil {
-				t.Fatal(err)
-			}
+			newFileURL := newFile.CanonicalURL()
 			// NewFile should be the most relevant file
 			if newFileURL != wantRelevantURL {
 				t.Fatalf(
@@ -629,8 +623,8 @@ func (d *dummyFileResolver) URL(ctx context.Context) (string, error) {
 	return d.url, nil
 }
 
-func (d *dummyFileResolver) CanonicalURL() (string, error) {
-	return d.canonicalURL, nil
+func (d *dummyFileResolver) CanonicalURL() string {
+	return d.canonicalURL
 }
 
 func (d *dummyFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -116,10 +116,9 @@ func (s symbolSuggestionResolver) Label() string {
 }
 func (s symbolSuggestionResolver) ToSymbol() (*symbolResolver, bool) { return &s.symbol, true }
 func (s symbolSuggestionResolver) Key() suggestionKey {
-	url, _ := s.symbol.CanonicalURL() // err always nil
 	return suggestionKey{
 		symbol: s.symbol.Symbol.Name + s.symbol.Symbol.Parent,
-		url:    url,
+		url:    s.symbol.CanonicalURL(),
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -296,6 +296,6 @@ func (r symbolResolver) Location() *locationResolver {
 
 func (r symbolResolver) URL(ctx context.Context) (string, error) { return r.Location().URL(ctx) }
 
-func (r symbolResolver) CanonicalURL() (string, error) { return r.Location().CanonicalURL() }
+func (r symbolResolver) CanonicalURL() string { return r.Location().CanonicalURL() }
 
 func (r symbolResolver) FileLocal() bool { return r.Symbol.FileLimited }

--- a/cmd/frontend/graphqlbackend/virtual_file.go
+++ b/cmd/frontend/graphqlbackend/virtual_file.go
@@ -42,9 +42,9 @@ func (r *virtualFileResolver) URL(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-func (r *virtualFileResolver) CanonicalURL() (string, error) {
+func (r *virtualFileResolver) CanonicalURL() string {
 	// Todo: allow viewing arbitrary files in the webapp.
-	return "", nil
+	return ""
 }
 
 func (r *virtualFileResolver) ExternalURLs(ctx context.Context) ([]*externallink.Resolver, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/locations_test.go
@@ -272,13 +272,13 @@ func TestResolveLocations(t *testing.T) {
 	if len(locations) != 3 {
 		t.Fatalf("unexpected length. want=%d have=%d", 3, len(locations))
 	}
-	if url, _ := locations[0].CanonicalURL(); url != "/repo50@deadbeef1/-/tree/p1#L12:13-14:15" {
+	if url := locations[0].CanonicalURL(); url != "/repo50@deadbeef1/-/tree/p1#L12:13-14:15" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo50@deadbeef1/-/tree/p1#L12:13-14:15", url)
 	}
-	if url, _ := locations[1].CanonicalURL(); url != "/repo51@deadbeef2/-/tree/p2#L22:23-24:25" {
+	if url := locations[1].CanonicalURL(); url != "/repo51@deadbeef2/-/tree/p2#L22:23-24:25" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo51@deadbeef2/-/tree/p2#L22:23-24:25", url)
 	}
-	if url, _ := locations[2].CanonicalURL(); url != "/repo53@deadbeef4/-/tree/p4#L42:43-44:45" {
+	if url := locations[2].CanonicalURL(); url != "/repo53@deadbeef4/-/tree/p4#L42:43-44:45" {
 		t.Errorf("unexpected canonical url. want=%s have=%s", "/repo53@deadbeef4/-/tree/p4#L42:43-44:45", url)
 	}
 }

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -1,6 +1,9 @@
 package result
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -38,4 +41,20 @@ func (r *RepoMatch) Select(path filter.SelectPath) Match {
 	return nil
 }
 
+func (r *RepoMatch) URL() *url.URL {
+	rawPath := "/" + escapePathForURL(string(r.Name))
+	if r.Rev != "" {
+		rawPath += "@" + escapePathForURL(r.Rev)
+	}
+	return &url.URL{RawPath: rawPath}
+}
+
 func (r *RepoMatch) searchResultMarker() {}
+
+// TODO(camdencheek): put this in a proper shared place outside of graphqlbackend
+// escapePathForURL escapes path (e.g. repository name, revspec) for use in a Sourcegraph URL.
+// For niceness/readability, we do NOT escape slashes but we do escape other characters like '#'
+// that are necessary for correctness.
+func escapePathForURL(path string) string {
+	return strings.ReplaceAll(url.PathEscape(path), "%2F", "/")
+}


### PR DESCRIPTION
`CanonicalURL()` can never fail, but we were propagating an error because we making a URL then parsing it, which can theoretically fail. By passing around `*url.URL` structs instead, we can ensure there is never a parse failure. Additionally, this will be useful for adding fragments and query params to URLs further down the line. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
