### PR TITLE
search frontend: rename tree type to Access

### DIFF
--- a/client/shared/src/search/query/selectFilter.ts
+++ b/client/shared/src/search/query/selectFilter.ts
@@ -1,68 +1,68 @@
 import { Literal } from './token'
 
-interface Selector {
-    kind: string
-    fields?: Selector[]
+interface Access {
+    name: string
+    fields?: Access[]
 }
 
-export const SELECTORS: Selector[] = [
+export const SELECTORS: Access[] = [
     {
-        kind: 'repo',
+        name: 'repo',
     },
     {
-        kind: 'file',
+        name: 'file',
     },
     {
-        kind: 'content',
+        name: 'content',
     },
     {
-        kind: 'symbol',
+        name: 'symbol',
         fields: [
-            { kind: 'file' },
-            { kind: 'module' },
-            { kind: 'namespace' },
-            { kind: 'package' },
-            { kind: 'class' },
-            { kind: 'method' },
-            { kind: 'property' },
-            { kind: 'field' },
-            { kind: 'constructor' },
-            { kind: 'enum' },
-            { kind: 'interface' },
-            { kind: 'function' },
-            { kind: 'variable' },
-            { kind: 'constant' },
-            { kind: 'string' },
-            { kind: 'number' },
-            { kind: 'boolean' },
-            { kind: 'array' },
-            { kind: 'object' },
-            { kind: 'key' },
-            { kind: 'null' },
-            { kind: 'enum-member' },
-            { kind: 'struct' },
-            { kind: 'event' },
-            { kind: 'operator' },
-            { kind: 'type-parameter' },
+            { name: 'file' },
+            { name: 'module' },
+            { name: 'namespace' },
+            { name: 'package' },
+            { name: 'class' },
+            { name: 'method' },
+            { name: 'property' },
+            { name: 'field' },
+            { name: 'constructor' },
+            { name: 'enum' },
+            { name: 'interface' },
+            { name: 'function' },
+            { name: 'variable' },
+            { name: 'constant' },
+            { name: 'string' },
+            { name: 'number' },
+            { name: 'boolean' },
+            { name: 'array' },
+            { name: 'object' },
+            { name: 'key' },
+            { name: 'null' },
+            { name: 'enum-member' },
+            { name: 'struct' },
+            { name: 'event' },
+            { name: 'operator' },
+            { name: 'type-parameter' },
         ],
     },
     {
-        kind: 'commit',
+        name: 'commit',
     },
 ]
 
 /**
  * Returns all paths rooted at a {@link selector} up to {@param depth}.
  */
-export const selectDiscreteValues = (selectors: Selector[], depth: number): string[] => {
+export const selectDiscreteValues = (selectors: Access[], depth: number): string[] => {
     if (depth < 0) {
         return []
     }
     const paths: string[] = []
     for (const entry of selectors) {
-        paths.push(`${entry.kind}`)
+        paths.push(`${entry.name}`)
         if (entry.fields) {
-            paths.push(...selectDiscreteValues(entry.fields, depth - 1).map(value => `${entry.kind}.` + value))
+            paths.push(...selectDiscreteValues(entry.fields, depth - 1).map(value => `${entry.name}.` + value))
         }
     }
     return paths
@@ -77,7 +77,7 @@ export const selectorCompletion = (value: Literal | undefined): string[] => {
         // Resolve completions to greater depth for `foo.` if the value is `foo.` or `foo.bar`.
         const kind = value.value.split('.')[0]
         return selectDiscreteValues(
-            SELECTORS.filter(value => value.kind === kind),
+            SELECTORS.filter(value => value.name === kind),
             1
         )
     }


### PR DESCRIPTION
Just a rename of a type, to be consistent with the data structure I defined in `predicates.ts`