### PR TITLE
search frontend: recognize diff.{added,removed} selectors

### DIFF
--- a/client/shared/src/search/query/selectFilter.test.ts
+++ b/client/shared/src/search/query/selectFilter.test.ts
@@ -50,4 +50,13 @@ describe('selectorCompletion', () => {
             symbol.type-parameter
         `)
     })
+
+    test('suggest depth 2 commit.diff completions', () => {
+        expect(selectorCompletion(create('commit.diff.'))).toMatchInlineSnapshot(`
+            commit,
+            commit.diff,
+            commit.diff.added,
+            commit.diff.removed
+        `)
+    })
 })

--- a/client/shared/src/search/query/selectFilter.ts
+++ b/client/shared/src/search/query/selectFilter.ts
@@ -48,6 +48,7 @@ export const SELECTORS: Access[] = [
     },
     {
         name: 'commit',
+        fields: [{ name: 'diff', fields: [{ name: 'added' }, { name: 'removed' }] }],
     },
 ]
 
@@ -78,7 +79,7 @@ export const selectorCompletion = (value: Literal | undefined): string[] => {
         const kind = value.value.split('.')[0]
         return selectDiscreteValues(
             SELECTORS.filter(value => value.name === kind),
-            1
+            2
         )
     }
     return selectDiscreteValues(SELECTORS, 0)


### PR DESCRIPTION
Stacked on #20386.

Adds autocomplete for `select:commit.` and removes squiggles for valid values.

<img width="663" alt="Screen Shot 2021-04-23 at 6 27 01 PM" src="https://user-images.githubusercontent.com/888624/115942897-8aa84a80-a461-11eb-9cb5-130278f2f484.png">
