### PR TITLE
Implement AWS KMS secret encryption backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,13 +14,14 @@ require (
 	github.com/aphistic/sweet-junit v0.2.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
 	github.com/avelino/slugify v0.0.0-20180501145920-855f152bd774
-	github.com/aws/aws-sdk-go-v2 v1.2.1
+	github.com/aws/aws-sdk-go-v2 v1.3.2
 	github.com/aws/aws-sdk-go-v2/config v1.1.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.1.2
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.0.3
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.1.2
+	github.com/aws/aws-sdk-go-v2/service/kms v1.2.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.2.1
-	github.com/aws/smithy-go v1.2.0
+	github.com/aws/smithy-go v1.3.1
 	github.com/beevik/etree v1.1.0
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff
 	github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/aws/aws-sdk-go v1.29.15/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTg
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.2.1 h1:055XAi+MtmhyYX161p+jWRibkCb9YpI2ymXZiW1dwVY=
 github.com/aws/aws-sdk-go-v2 v1.2.1/go.mod h1:hTQc/9pYq5bfFACIUY9tc/2SYWd9Vnmw+testmuQeRY=
+github.com/aws/aws-sdk-go-v2 v1.3.2 h1:RQj8l98yKUm0UV2Wd3w/Ms+TXV9Rs1E6Kr5tRRMfyU4=
+github.com/aws/aws-sdk-go-v2 v1.3.2/go.mod h1:7OaACgj2SX3XGWnrIjGlJM22h6yD6MEWKvm7levnnM8=
 github.com/aws/aws-sdk-go-v2/config v1.1.2 h1:H2r6cwMvvINFpEC55Y7jcNaR/oc7zYIChrG2497wmBI=
 github.com/aws/aws-sdk-go-v2/config v1.1.2/go.mod h1:77yIk+qmCS/94JlxbwV1d+YEyu6Z8FBlCGcSz3TdM6A=
 github.com/aws/aws-sdk-go-v2/credentials v1.1.2 h1:YoNqfhxAJGZI+lStIbqgx30UcCqQ86fr7FjTLUvrFOc=
@@ -158,6 +160,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.3 h1:dST4y8pZKZ
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.3/go.mod h1:C50Z41fJaJ7WgaeeCulOGAU3q4+4se4B3uOPFdhBi2I=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.1.1 h1:+WCVceRPiUsrui55mDByXOVremK1n3Hm8GnB4ZD3eco=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.1.1/go.mod h1:B+fb+BFbja6obFOHYmYE4iUMdej9aM2VGSpgdU1pn0M=
+github.com/aws/aws-sdk-go-v2/service/kms v1.2.2 h1:9CJBrElBVX699f4ugbwsD2EPyHYWEdf9rGZZJwDzPSU=
+github.com/aws/aws-sdk-go-v2/service/kms v1.2.2/go.mod h1:aDkYNnoS4NikbSA7AiTomko1eJIZgrIG0ZE0yPJRn+w=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.2.1 h1:3qn6YVXpOCK9seQ8ZilDyMrhpEUaZNaJG8SXNiCvk+c=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.2.1/go.mod h1:3xGOyhtPPD/WXJUljmb5+ZXhNyHa4h6wgL6mWOF6S0c=
 github.com/aws/aws-sdk-go-v2/service/sso v1.1.2 h1:9BnjX/ALn5uLo2DbgkwMpUkPL1VLQVBXcjZxqJBhf44=
@@ -166,6 +170,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.1.2 h1:7Kxqov7uQeP8WUEO0iHz3j9Bh0E1r
 github.com/aws/aws-sdk-go-v2/service/sts v1.1.2/go.mod h1:zu7rotIY9P4Aoc6ytqLP9jeYrECDHUODB5Gbp+BSHl8=
 github.com/aws/smithy-go v1.2.0 h1:0PoGBWXkXDIyVdPaZW9gMhaGzj3UOAgTdiVoHuuZAFA=
 github.com/aws/smithy-go v1.2.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
+github.com/aws/smithy-go v1.3.1 h1:xJFO4pK0y9J8fCl34uGsSJX5KNnGbdARDlA5BPhXnwE=
+github.com/aws/smithy-go v1.3.1/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/internal/encryption/README.md
+++ b/internal/encryption/README.md
@@ -42,5 +42,6 @@ The `encryption.Key` interface was built to be simple, and intended to be extend
 ### Implementations
 
 - Cloud KMS
+- AWS KMS
 - Mounted Key
 - No Op

--- a/internal/encryption/awskms/aws_kms.go
+++ b/internal/encryption/awskms/aws_kms.go
@@ -1,0 +1,98 @@
+package awskms
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func NewKey(ctx context.Context, keyConfig schema.AWSKMSEncryptionKey) (encryption.Key, error) {
+	config, err := config.LoadDefaultConfig(ctx, awsConfigOptsForKeyConfig(keyConfig)...)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading config for aws KMS")
+	}
+	return newKey(ctx, keyConfig, config)
+}
+
+func newKey(ctx context.Context, keyConfig schema.AWSKMSEncryptionKey, config aws.Config) (encryption.Key, error) {
+	k := &Key{
+		keyID:  keyConfig.KeyId,
+		client: kms.NewFromConfig(config),
+	}
+	// Test client connection.
+	_, err := k.Version(ctx)
+	return k, err
+}
+
+func awsConfigOptsForKeyConfig(keyConfig schema.AWSKMSEncryptionKey) []func(*config.LoadOptions) error {
+	configOpts := []func(*config.LoadOptions) error{}
+	if keyConfig.Region != "" {
+		configOpts = append(configOpts, config.WithRegion(keyConfig.Region))
+	}
+	if keyConfig.CredentialsFile != "" {
+		configOpts = append(configOpts, config.WithSharedCredentialsFiles([]string{keyConfig.CredentialsFile}))
+	}
+	return configOpts
+}
+
+type Key struct {
+	keyID  string
+	client *kms.Client
+}
+
+func (k *Key) Version(ctx context.Context) (encryption.KeyVersion, error) {
+	key, err := k.client.DescribeKey(ctx, &kms.DescribeKeyInput{
+		KeyId: &k.keyID,
+	})
+	if err != nil {
+		return encryption.KeyVersion{}, errors.Wrap(err, "getting key version")
+	}
+	return encryption.KeyVersion{
+		Type:    "awskms",
+		Version: *key.KeyMetadata.Arn,
+		Name:    *key.KeyMetadata.KeyId,
+	}, nil
+}
+
+// Decrypt a secret, it must have been encrypted with the same Key.
+// Encrypted secrets are a base64 encoded string containing the original content.
+func (k *Key) Decrypt(ctx context.Context, cipherText []byte) (*encryption.Secret, error) {
+	buf, err := base64.StdEncoding.DecodeString(string(cipherText))
+	if err != nil {
+		return nil, err
+	}
+
+	// Decrypt ciphertext.
+	res, err := k.client.Decrypt(ctx, &kms.DecryptInput{
+		KeyId:          &k.keyID,
+		CiphertextBlob: buf,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s := encryption.NewSecret(string(res.Plaintext))
+	return &s, nil
+}
+
+// Encrypt a secret, storing it as a base64 encoded string.
+func (k *Key) Encrypt(ctx context.Context, plaintext []byte) ([]byte, error) {
+	// Encrypt plaintext.
+	res, err := k.client.Encrypt(ctx, &kms.EncryptInput{
+		KeyId:     &k.keyID,
+		Plaintext: plaintext,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	buf := base64.StdEncoding.EncodeToString(res.CiphertextBlob)
+	return []byte(buf), err
+}

--- a/internal/encryption/awskms/aws_kms_test.go
+++ b/internal/encryption/awskms/aws_kms_test.go
@@ -1,0 +1,117 @@
+package awskms
+
+import (
+	"context"
+	"flag"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/recorder"
+
+	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// testKeyID is the ID of a key defined here:
+// https://us-west-2.console.aws.amazon.com/kms/home?region=us-west-2#/kms/keys/4b739277-5a93-4551-b71c-99608c9c805d
+// If you want to update this test, feel free to replace the key ID used here.
+const testKeyID = "4b739277-5a93-4551-b71c-99608c9c805d"
+
+func TestRoundtrip(t *testing.T) {
+	ctx := context.Background()
+	testString := "test1234"
+	keyConfig := schema.AWSKMSEncryptionKey{
+		KeyId:  testKeyID,
+		Region: "us-west-2",
+		Type:   "awskms",
+	}
+
+	cf, save := newClientFactory(t, "awskms")
+	defer save(t)
+
+	// Create http cli with aws defaults.
+	cli, err := cf.Doer(func(c *http.Client) error {
+		c.Transport = awshttp.NewBuildableClient().GetTransport()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Build config options for aws config.
+	configOpts := awsConfigOptsForKeyConfig(keyConfig)
+	configOpts = append(configOpts, config.WithHTTPClient(cli))
+	configOpts = append(configOpts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+		readEnvFallback("AWS_ACCESS_KEY_ID", "test"),
+		readEnvFallback("AWS_SECRET_ACCESS_KEY", "test"),
+		readEnvFallback("AWS_SESSION_TOKEN", "test"),
+	)))
+	config, err := config.LoadDefaultConfig(ctx, configOpts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k, err := newKey(ctx, keyConfig, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ct, err := k.Encrypt(ctx, []byte(testString))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := k.Decrypt(ctx, ct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Secret() != testString {
+		t.Fatalf("expected %s, got %s", testString, res.Secret())
+	}
+}
+
+var shouldUpdate = flag.Bool("update", false, "Update testdata")
+
+func newClientFactory(t testing.TB, name string, mws ...httpcli.Middleware) (*httpcli.Factory, func(testing.TB)) {
+	t.Helper()
+	cassete := filepath.Join("testdata", strings.ReplaceAll(name, " ", "-"))
+	rec := newRecorder(t, cassete, *shouldUpdate)
+	mw := httpcli.NewMiddleware(mws...)
+	return httpcli.NewFactory(mw, httptestutil.NewRecorderOpt(rec)),
+		func(t testing.TB) { save(t, rec) }
+}
+
+func newRecorder(t testing.TB, file string, record bool) *recorder.Recorder {
+	t.Helper()
+	rec, err := httptestutil.NewRecorder(file, record, func(i *cassette.Interaction) error {
+		i.Request.Headers.Del("Amz-Sdk-Invocation-Id")
+		i.Request.Headers.Del("X-Amz-Date")
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rec
+}
+
+func save(t testing.TB, rec *recorder.Recorder) {
+	t.Helper()
+	if err := rec.Stop(); err != nil {
+		t.Errorf("failed to update test data: %s", err)
+	}
+}
+
+func readEnvFallback(key, fallback string) string {
+	if val := os.Getenv(key); val == "" {
+		return fallback
+	} else {
+		return val
+	}
+}

--- a/internal/encryption/awskms/aws_kms_test.go
+++ b/internal/encryption/awskms/aws_kms_test.go
@@ -27,7 +27,8 @@ const testKeyID = "4b739277-5a93-4551-b71c-99608c9c805d"
 
 func TestRoundtrip(t *testing.T) {
 	ctx := context.Background()
-	testString := "test1234"
+	// Validate that we successfully worked around the 4096 bytes restriction.
+	testString := strings.Repeat("test1234", 4096)
 	keyConfig := schema.AWSKMSEncryptionKey{
 		KeyId:  testKeyID,
 		Region: "us-west-2",
@@ -51,7 +52,7 @@ func TestRoundtrip(t *testing.T) {
 	configOpts = append(configOpts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
 		readEnvFallback("AWS_ACCESS_KEY_ID", "test"),
 		readEnvFallback("AWS_SECRET_ACCESS_KEY", "test"),
-		readEnvFallback("AWS_SESSION_TOKEN", "test"),
+		"",
 	)))
 	config, err := config.LoadDefaultConfig(ctx, configOpts...)
 	if err != nil {

--- a/internal/encryption/awskms/testdata/awskms.yaml
+++ b/internal/encryption/awskms/testdata/awskms.yaml
@@ -1,0 +1,111 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"KeyId":"4b739277-5a93-4551-b71c-99608c9c805d"}'
+    form: {}
+    headers:
+      Amz-Sdk-Request:
+      - attempt=1; max=3
+      Content-Type:
+      - application/x-amz-json-1.1
+      User-Agent:
+      - aws-sdk-go-v2/1.3.2
+      X-Amz-Target:
+      - TrentService.DescribeKey
+      X-Amz-User-Agent:
+      - aws-sdk-go-v2/1.3.2 os/other lang/go/1.16.3 md/GOOS/darwin md/GOARCH/amd64
+    url: https://kms.us-west-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{"KeyMetadata":{"AWSAccountId":"185007729374","Arn":"arn:aws:kms:us-west-2:185007729374:key/4b739277-5a93-4551-b71c-99608c9c805d","CreationDate":1.619445087217E9,"CustomerMasterKeySpec":"SYMMETRIC_DEFAULT","Description":"","Enabled":true,"EncryptionAlgorithms":["SYMMETRIC_DEFAULT"],"KeyId":"4b739277-5a93-4551-b71c-99608c9c805d","KeyManager":"CUSTOMER","KeySpec":"SYMMETRIC_DEFAULT","KeyState":"Enabled","KeyUsage":"ENCRYPT_DECRYPT","Origin":"AWS_KMS"}}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Content-Length:
+      - "454"
+      Content-Type:
+      - application/x-amz-json-1.1
+      Date:
+      - Mon, 26 Apr 2021 14:57:19 GMT
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      X-Amzn-Requestid:
+      - 783d9478-5c7c-4dba-a733-dc6aa024fe10
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"KeyId":"4b739277-5a93-4551-b71c-99608c9c805d","Plaintext":"dGVzdDEyMzQ="}'
+    form: {}
+    headers:
+      Amz-Sdk-Request:
+      - attempt=1; max=3
+      Content-Type:
+      - application/x-amz-json-1.1
+      User-Agent:
+      - aws-sdk-go-v2/1.3.2
+      X-Amz-Target:
+      - TrentService.Encrypt
+      X-Amz-User-Agent:
+      - aws-sdk-go-v2/1.3.2 os/other lang/go/1.16.3 md/GOOS/darwin md/GOARCH/amd64
+    url: https://kms.us-west-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{"CiphertextBlob":"AQICAHgVKhdyNRw2H1EOImj+ZiPtPzBL/QnBteec2v9iergqpAHno5Lq1fzeO4zidWNdIFbpAAAAZjBkBgkqhkiG9w0BBwagVzBVAgEAMFAGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNTfwc8cE8LolSuhSAgEQgCMrsASJScKkt+04Z1Z9T5wSWS5sV1pPu6LRbFDNa/KzMHmu4Q==","EncryptionAlgorithm":"SYMMETRIC_DEFAULT","KeyId":"arn:aws:kms:us-west-2:185007729374:key/4b739277-5a93-4551-b71c-99608c9c805d"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Content-Length:
+      - "365"
+      Content-Type:
+      - application/x-amz-json-1.1
+      Date:
+      - Mon, 26 Apr 2021 14:57:20 GMT
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      X-Amzn-Requestid:
+      - a1629618-c2aa-4074-bef9-720670174522
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"CiphertextBlob":"AQICAHgVKhdyNRw2H1EOImj+ZiPtPzBL/QnBteec2v9iergqpAHno5Lq1fzeO4zidWNdIFbpAAAAZjBkBgkqhkiG9w0BBwagVzBVAgEAMFAGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNTfwc8cE8LolSuhSAgEQgCMrsASJScKkt+04Z1Z9T5wSWS5sV1pPu6LRbFDNa/KzMHmu4Q==","KeyId":"4b739277-5a93-4551-b71c-99608c9c805d"}'
+    form: {}
+    headers:
+      Amz-Sdk-Request:
+      - attempt=1; max=3
+      Content-Type:
+      - application/x-amz-json-1.1
+      User-Agent:
+      - aws-sdk-go-v2/1.3.2
+      X-Amz-Target:
+      - TrentService.Decrypt
+      X-Amz-User-Agent:
+      - aws-sdk-go-v2/1.3.2 os/other lang/go/1.16.3 md/GOOS/darwin md/GOARCH/amd64
+    url: https://kms.us-west-2.amazonaws.com/
+    method: POST
+  response:
+    body: '{"EncryptionAlgorithm":"SYMMETRIC_DEFAULT","KeyId":"arn:aws:kms:us-west-2:185007729374:key/4b739277-5a93-4551-b71c-99608c9c805d","Plaintext":"dGVzdDEyMzQ="}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, private
+      Content-Length:
+      - "156"
+      Content-Type:
+      - application/x-amz-json-1.1
+      Date:
+      - Mon, 26 Apr 2021 14:57:20 GMT
+      Expires:
+      - "0"
+      Pragma:
+      - no-cache
+      X-Amzn-Requestid:
+      - 1726a5ed-c9e6-4cb5-aad3-564a76abe1cc
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/encryption/awskms/testdata/awskms.yaml
+++ b/internal/encryption/awskms/testdata/awskms.yaml
@@ -27,18 +27,18 @@ interactions:
       Content-Type:
       - application/x-amz-json-1.1
       Date:
-      - Mon, 26 Apr 2021 14:57:19 GMT
+      - Wed, 19 May 2021 18:18:16 GMT
       Expires:
       - "0"
       Pragma:
       - no-cache
       X-Amzn-Requestid:
-      - 783d9478-5c7c-4dba-a733-dc6aa024fe10
+      - a1f235ec-4e7d-4306-838f-914c582123f2
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"KeyId":"4b739277-5a93-4551-b71c-99608c9c805d","Plaintext":"dGVzdDEyMzQ="}'
+    body: '{"KeyId":"4b739277-5a93-4551-b71c-99608c9c805d","KeySpec":"AES_256"}'
     form: {}
     headers:
       Amz-Sdk-Request:
@@ -48,33 +48,33 @@ interactions:
       User-Agent:
       - aws-sdk-go-v2/1.3.2
       X-Amz-Target:
-      - TrentService.Encrypt
+      - TrentService.GenerateDataKey
       X-Amz-User-Agent:
       - aws-sdk-go-v2/1.3.2 os/other lang/go/1.16.3 md/GOOS/darwin md/GOARCH/amd64
     url: https://kms.us-west-2.amazonaws.com/
     method: POST
   response:
-    body: '{"CiphertextBlob":"AQICAHgVKhdyNRw2H1EOImj+ZiPtPzBL/QnBteec2v9iergqpAHno5Lq1fzeO4zidWNdIFbpAAAAZjBkBgkqhkiG9w0BBwagVzBVAgEAMFAGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNTfwc8cE8LolSuhSAgEQgCMrsASJScKkt+04Z1Z9T5wSWS5sV1pPu6LRbFDNa/KzMHmu4Q==","EncryptionAlgorithm":"SYMMETRIC_DEFAULT","KeyId":"arn:aws:kms:us-west-2:185007729374:key/4b739277-5a93-4551-b71c-99608c9c805d"}'
+    body: '{"CiphertextBlob":"AQIDAHgVKhdyNRw2H1EOImj+ZiPtPzBL/QnBteec2v9iergqpAE1T8ohbUu9/ML5cGkdZqWjAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM4gx3vKEbMij95UIkAgEQgDu7NxS3T7Vcm4rNtzT8JXu7z8o+IXmporkXsRhJQmjOL4D/tS22/7XJGeegY5nI17/U0drejAJTgRq8kg==","KeyId":"arn:aws:kms:us-west-2:185007729374:key/4b739277-5a93-4551-b71c-99608c9c805d","Plaintext":"+zne20Pvs2NZcA25YwfcqaIbdjIn36JDgp6cOTQ14XA="}'
     headers:
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Content-Length:
-      - "365"
+      - "414"
       Content-Type:
       - application/x-amz-json-1.1
       Date:
-      - Mon, 26 Apr 2021 14:57:20 GMT
+      - Wed, 19 May 2021 18:18:17 GMT
       Expires:
       - "0"
       Pragma:
       - no-cache
       X-Amzn-Requestid:
-      - a1629618-c2aa-4074-bef9-720670174522
+      - 52133c7f-1fa4-4b95-9ca2-dac230f40b83
     status: 200 OK
     code: 200
     duration: ""
 - request:
-    body: '{"CiphertextBlob":"AQICAHgVKhdyNRw2H1EOImj+ZiPtPzBL/QnBteec2v9iergqpAHno5Lq1fzeO4zidWNdIFbpAAAAZjBkBgkqhkiG9w0BBwagVzBVAgEAMFAGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNTfwc8cE8LolSuhSAgEQgCMrsASJScKkt+04Z1Z9T5wSWS5sV1pPu6LRbFDNa/KzMHmu4Q==","KeyId":"4b739277-5a93-4551-b71c-99608c9c805d"}'
+    body: '{"CiphertextBlob":"AQIDAHgVKhdyNRw2H1EOImj+ZiPtPzBL/QnBteec2v9iergqpAE1T8ohbUu9/ML5cGkdZqWjAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM4gx3vKEbMij95UIkAgEQgDu7NxS3T7Vcm4rNtzT8JXu7z8o+IXmporkXsRhJQmjOL4D/tS22/7XJGeegY5nI17/U0drejAJTgRq8kg==","KeyId":"4b739277-5a93-4551-b71c-99608c9c805d"}'
     form: {}
     headers:
       Amz-Sdk-Request:
@@ -90,22 +90,22 @@ interactions:
     url: https://kms.us-west-2.amazonaws.com/
     method: POST
   response:
-    body: '{"EncryptionAlgorithm":"SYMMETRIC_DEFAULT","KeyId":"arn:aws:kms:us-west-2:185007729374:key/4b739277-5a93-4551-b71c-99608c9c805d","Plaintext":"dGVzdDEyMzQ="}'
+    body: '{"EncryptionAlgorithm":"SYMMETRIC_DEFAULT","KeyId":"arn:aws:kms:us-west-2:185007729374:key/4b739277-5a93-4551-b71c-99608c9c805d","Plaintext":"+zne20Pvs2NZcA25YwfcqaIbdjIn36JDgp6cOTQ14XA="}'
     headers:
       Cache-Control:
       - no-cache, no-store, must-revalidate, private
       Content-Length:
-      - "156"
+      - "188"
       Content-Type:
       - application/x-amz-json-1.1
       Date:
-      - Mon, 26 Apr 2021 14:57:20 GMT
+      - Wed, 19 May 2021 18:18:17 GMT
       Expires:
       - "0"
       Pragma:
       - no-cache
       X-Amzn-Requestid:
-      - 1726a5ed-c9e6-4cb5-aad3-564a76abe1cc
+      - 0d5a4806-f4f3-4f2f-be1d-ca93e4c3d966
     status: 200 OK
     code: 200
     duration: ""

--- a/internal/encryption/keyring/ring.go
+++ b/internal/encryption/keyring/ring.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/awskms"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/cache"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/cloudkms"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/mounted"
@@ -123,6 +124,8 @@ func NewKey(ctx context.Context, k *schema.EncryptionKey, config *schema.Encrypt
 	switch {
 	case k.Cloudkms != nil:
 		key, err = cloudkms.NewKey(ctx, *k.Cloudkms)
+	case k.Awskms != nil:
+		key, err = awskms.NewKey(ctx, *k.Awskms)
 	case k.Mounted != nil:
 		key, err = mounted.NewKey(ctx, *k.Mounted)
 	case k.Noop != nil:

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -45,6 +45,14 @@ type AWSCodeCommitGitCredentials struct {
 	// Username description: The Git username
 	Username string `json:"username"`
 }
+
+// AWSKMSEncryptionKey description: AWS KMS Encryption Key, used to encrypt data in AWS environments
+type AWSKMSEncryptionKey struct {
+	CredentialsFile string `json:"credentialsFile,omitempty"`
+	KeyId           string `json:"keyId"`
+	Region          string `json:"region,omitempty"`
+	Type            string `json:"type"`
+}
 type AdditionalProperties struct {
 	// Format description: The expected format of the output. If set, the output is being parsed in that format before being stored in the var. If not set, 'text' is assumed to the format.
 	Format string `json:"format,omitempty"`
@@ -404,6 +412,7 @@ type Dotcom struct {
 // EncryptionKey description: Config for a key
 type EncryptionKey struct {
 	Cloudkms *CloudKMSEncryptionKey
+	Awskms   *AWSKMSEncryptionKey
 	Mounted  *MountedEncryptionKey
 	Noop     *NoOpEncryptionKey
 }
@@ -411,6 +420,9 @@ type EncryptionKey struct {
 func (v EncryptionKey) MarshalJSON() ([]byte, error) {
 	if v.Cloudkms != nil {
 		return json.Marshal(v.Cloudkms)
+	}
+	if v.Awskms != nil {
+		return json.Marshal(v.Awskms)
 	}
 	if v.Mounted != nil {
 		return json.Marshal(v.Mounted)
@@ -428,6 +440,8 @@ func (v *EncryptionKey) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	switch d.DiscriminantProperty {
+	case "awskms":
+		return json.Unmarshal(data, &v.Awskms)
 	case "cloudkms":
 		return json.Unmarshal(data, &v.Cloudkms)
 	case "mounted":
@@ -435,7 +449,7 @@ func (v *EncryptionKey) UnmarshalJSON(data []byte) error {
 	case "noop":
 		return json.Unmarshal(data, &v.Noop)
 	}
-	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"cloudkms", "mounted", "noop"})
+	return fmt.Errorf("tagged union type must have a %q property whose value is one of %s", "type", []string{"cloudkms", "awskms", "mounted", "noop"})
 }
 
 // EncryptionKeys description: Configuration for encryption keys used to encrypt data at rest in the database.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -1436,12 +1436,15 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["cloudkms", "mounted", "noop"]
+          "enum": ["cloudkms", "awskms", "mounted", "noop"]
         }
       },
       "oneOf": [
         {
           "$ref": "#/definitions/CloudKMSEncryptionKey"
+        },
+        {
+          "$ref": "#/definitions/AWSKMSEncryptionKey"
         },
         {
           "$ref": "#/definitions/MountedEncryptionKey"
@@ -1464,6 +1467,26 @@
           "const": "cloudkms"
         },
         "keyname": {
+          "type": "string"
+        },
+        "credentialsFile": {
+          "type": "string"
+        }
+      }
+    },
+    "AWSKMSEncryptionKey": {
+      "description": "AWS KMS Encryption Key, used to encrypt data in AWS environments",
+      "type": "object",
+      "required": ["type", "keyId"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "awskms"
+        },
+        "keyId": {
+          "type": "string"
+        },
+        "region": {
           "type": "string"
         },
         "credentialsFile": {


### PR DESCRIPTION
I've followed [the guide here](https://github.com/sourcegraph/sourcegraph/blob/main/internal/encryption/README.md) for implementing a new encryption backend and 
AWS doesn't seem to have a CRC32 checksum to test against, and there are no real "versions" of encryption keys(they can rotate in the background but as far as I understood it that's opaque to the API consumer), so I think the version function is not super useful here, but that's how far I got and understood the code. Can someone please check if this makes sense and tell me if something is missing here? 

Closes https://github.com/sourcegraph/sourcegraph/issues/19983