### PR TITLE
authtest: add tests for access repositories

### DIFF
--- a/dev/authtest/main_test.go
+++ b/dev/authtest/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
 )
@@ -68,4 +69,12 @@ func TestMain(m *testing.M) {
 		log15.Root().SetHandler(log15.DiscardHandler())
 	}
 	os.Exit(m.Run())
+}
+
+func mustMarshalJSONString(v interface{}) string {
+	str, err := jsoniter.MarshalToString(v)
+	if err != nil {
+		panic(err)
+	}
+	return str
 }

--- a/dev/authtest/repository_test.go
+++ b/dev/authtest/repository_test.go
@@ -1,0 +1,138 @@
+package authtest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestRepository(t *testing.T) {
+	if len(*githubToken) == 0 {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	// Set up external service
+	esID, err := client.AddExternalService(
+		gqltestutil.AddExternalServiceInput{
+			Kind:        extsvc.KindGitHub,
+			DisplayName: "authtest-github-repository",
+			Config: mustMarshalJSONString(
+				&schema.GitHubConnection{
+					Authorization: &schema.GitHubAuthorization{},
+					Repos: []string{
+						"sgtest/go-diff",
+						"sgtest/private", // Private
+					},
+					Token: *githubToken,
+					Url:   "https://github.com/",
+				},
+			),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := client.DeleteExternalService(esID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	const privateRepo = "github.com/sgtest/private"
+	err = client.WaitForReposToBeCloned(
+		"github.com/sgtest/go-diff",
+		privateRepo,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait up to 30 seconds for the private repository to have permissions synced
+	// from the code host at least once.
+	timeout := 30 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out in %s when waiting for permissions to be synced for %q", timeout, privateRepo)
+		default:
+		}
+
+		permsInfo, err := client.RepositoryPermissionsInfo(privateRepo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !permsInfo.SyncedAt.IsZero() {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Create a test user (authtest-user-repository) which is not a site admin, the
+	// user should only have access to non-private repositories.
+	const testUsername = "authtest-user-repository"
+	userClient, err := gqltestutil.SignUp(*baseURL, testUsername+"@sourcegraph.com", testUsername, "mysecurepassword")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := client.DeleteUser(userClient.AuthenticatedUserID(), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	t.Run("access repositories", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			repo    string
+			wantNil bool
+		}{
+			{
+				name:    "public repository",
+				repo:    "github.com/sgtest/go-diff",
+				wantNil: false,
+			},
+			{
+				name:    "private repository",
+				repo:    privateRepo,
+				wantNil: true,
+			},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				repo, err := userClient.Repository(test.repo)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if diff := cmp.Diff(test.wantNil, repo == nil); diff != "" {
+					t.Fatalf("Mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+
+	t.Run("search repositories", func(t *testing.T) {
+		results, err := userClient.SearchRepositories("type:repo sgtest")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := results.Exists(privateRepo)
+		want := []string{privateRepo}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("Missing mismatch (-want +got):\n%s", diff)
+		}
+	})
+}

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -36,7 +36,7 @@ func TestSearch(t *testing.T) {
 				"sgtest/go-diff",
 				"sgtest/appdash",
 				"sgtest/sourcegraph-typescript",
-				"sgtest/private",
+				"sgtest/private",  // Private
 				"sgtest/mux",      // Fork
 				"sgtest/archived", // Archived
 			},
@@ -59,7 +59,7 @@ func TestSearch(t *testing.T) {
 		"github.com/sgtest/go-diff",
 		"github.com/sgtest/appdash",
 		"github.com/sgtest/sourcegraph-typescript",
-		"github.com/sgtest/private",
+		"github.com/sgtest/private",  // Private
 		"github.com/sgtest/mux",      // Fork
 		"github.com/sgtest/archived", // Archived
 	)

--- a/internal/gqltestutil/repository.go
+++ b/internal/gqltestutil/repository.go
@@ -201,3 +201,43 @@ query Repository($name: String!) {
 
 	return resp.Data.Repository, nil
 }
+
+// PermissionsInfo contains permissions information of a repository from
+// GraphQL.
+type PermissionsInfo struct {
+	SyncedAt time.Time
+}
+
+// RepositoryPermissionsInfo returns permissions information of the given
+// repository.
+//
+// This method requires the authenticated user to be a site admin.
+func (c *Client) RepositoryPermissionsInfo(name string) (*PermissionsInfo, error) {
+	const query = `
+query RepositoryPermissionsInfo($name: String!) {
+	repository(name: $name) {
+		permissionsInfo {
+			syncedAt
+			updatedAt
+			permissions
+		}
+	}
+}
+`
+	variables := map[string]interface{}{
+		"name": name,
+	}
+	var resp struct {
+		Data struct {
+			Repository struct {
+				*PermissionsInfo `json:"permissionsInfo"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	err := c.GraphQL("", query, variables, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "request GraphQL")
+	}
+
+	return resp.Data.Repository.PermissionsInfo, nil
+}


### PR DESCRIPTION
This PR adds end-to-end tests for accessing repositories using GraphQL queries in the case of a user does not have access to the repository.

Fixes #19810, fixes #19812