### PR TITLE
Add additional docs for Postgres 12 upgrade

### DIFF
--- a/doc/admin/updates/kubernetes.md
+++ b/doc/admin/updates/kubernetes.md
@@ -19,23 +19,32 @@ and any manual migration steps you must perform.
 
 TODO
 
-*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.26).*
+*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling
+out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.26).*
 
 ## 3.26 -> 3.27
 
 > Warning: ⚠️ Sourcegraph 3.27 now requires **Postgres 12+**.
 
-If you are using an external database, [upgrade your database](https://docs.sourcegraph.com/admin/postgres#upgrading-external-postgresql-instances) to Postgres 12 or above prior to upgrading Sourcegraph. No action is required if you are using the supplied supplied database images.
+If you are using an external
+database, [upgrade your database](https://docs.sourcegraph.com/admin/postgres#upgrading-external-postgresql-instances)
+to Postgres 12 or above prior to upgrading Sourcegraph. No action is required if you are using the supplied database
+images.
+> **Note**: The Postgres 12 database migration scales with the size of your database, and the resources provided to the container.
+> Expect to have downtime relative to the size of your database. Additionally, you must ensure that have enough storage
+> space to accommodate the migration. A rough guide would be 2x the current on-disk database size
 
 > Warning: ⚠️ We have updated the default replicas for `sourcegraph-frontend` and `precise-code-intel-worker` to `2`. If you use a custom value, make sure you do not merge the replica change.
 
 Afterwards, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your deployment.
 
-*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.26).*
+*How smooth was this upgrade process for you? You can give us your feedback on this upgrade by filling
+out [this feedback form](https://share.hsforms.com/1aGeG7ALQQEGO6zyfauIiCA1n7ku?update_version=3.26).*
 
 ## 3.25 -> 3.26
 
-No manual migration required, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your deployment.
+No manual migration required, follow the [standard upgrade method](../install/kubernetes/update.md) to upgrade your
+deployment.
 
 > NOTE: ⚠️ From **3.27** onwards we will only support PostgreSQL versions **starting from 12**.
 


### PR DESCRIPTION
The Postgres 12 upgrade needs to be more clearly highlighted so customers are aware of the requirements and downtime.

Part of https://github.com/sourcegraph/sourcegraph/issues/20422



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
