### PR TITLE
add stackstorm search page

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -225,6 +225,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
         '/react-hooks',
         '/android',
         '/stanford',
+        '/stackstorm',
         '/cncf',
     ]
     const isRepogroupPage = repogroupPages.includes(props.location.pathname)

--- a/client/web/src/repogroups/HomepageConfig.ts
+++ b/client/web/src/repogroups/HomepageConfig.ts
@@ -4,6 +4,7 @@ import { golang } from './Golang'
 import { kubernetes } from './Kubernetes'
 import { python2To3Metadata } from './Python2To3'
 import { reactHooks } from './ReactHooks'
+import { stackStorm } from './StackStorm'
 import { stanford } from './Stanford'
 import { RepogroupMetadata } from './types'
 
@@ -11,6 +12,7 @@ export const repogroupList: RepogroupMetadata[] = [
     cncf,
     python2To3Metadata,
     android,
+    stackStorm,
     kubernetes,
     golang,
     reactHooks,

--- a/client/web/src/repogroups/StackStorm.tsx
+++ b/client/web/src/repogroups/StackStorm.tsx
@@ -1,4 +1,5 @@
 import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+
 import { RepogroupMetadata } from './types'
 
 export const stackStorm: RepogroupMetadata = {

--- a/client/web/src/repogroups/StackStorm.tsx
+++ b/client/web/src/repogroups/StackStorm.tsx
@@ -1,0 +1,38 @@
+import { SearchPatternType } from '@sourcegraph/shared/src/graphql-operations'
+import { RepogroupMetadata } from './types'
+
+export const stackStorm: RepogroupMetadata = {
+    title: 'StackStorm',
+    name: 'stackstorm',
+    url: '/stackstorm',
+    description: '',
+    examples: [
+        {
+            title: 'Passive sensor examples',
+            patternType: SearchPatternType.literal,
+            query: 'from st2reactor.sensor.base import Sensor',
+        },
+        {
+            title: 'Polling sensor examples',
+            patternType: SearchPatternType.literal,
+            query: 'from st2reactor.sensor.base import PollingSensor',
+        },
+        {
+            title: 'Trigger examples in rules',
+            patternType: SearchPatternType.literal,
+            query: 'repo:Exchange trigger: file:.yaml$',
+        },
+        {
+            title: 'Actions that use the Orquesta runner',
+            patternType: SearchPatternType.regexp,
+            query: 'repo:Exchange runner_type:\\s*"orquesta"',
+        },
+        {
+            title: 'All instances where a trigger is injected with an explicit payload',
+            patternType: SearchPatternType.structural,
+            query: 'repo:Exchange sensor_service.dispatch(:[1], payload=:[2])',
+        },
+    ],
+    homepageDescription: 'Search within the StackStorm and StackStorm Exchange community.',
+    homepageIcon: 'https://avatars.githubusercontent.com/u/4969009?s=200&v=4',
+}

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -13,11 +13,11 @@ import { kubernetes } from './repogroups/Kubernetes'
 import { python2To3Metadata } from './repogroups/Python2To3'
 import { reactHooks } from './repogroups/ReactHooks'
 import { RepogroupPage } from './repogroups/RepogroupPage'
+import { stackStorm } from './repogroups/StackStorm'
 import { stanford } from './repogroups/Stanford'
 import { StreamingSearchResults } from './search/results/streaming/StreamingSearchResults'
 import { isMacPlatform, UserRepositoriesUpdateProps } from './util'
 import { lazyComponent } from './util/lazyComponent'
-import { stackStorm } from './repogroups/StackStorm'
 
 const SearchPage = lazyComponent(() => import('./search/input/SearchPage'), 'SearchPage')
 const SearchResults = lazyComponent(() => import('./search/results/SearchResults'), 'SearchResults')

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -17,6 +17,7 @@ import { stanford } from './repogroups/Stanford'
 import { StreamingSearchResults } from './search/results/streaming/StreamingSearchResults'
 import { isMacPlatform, UserRepositoriesUpdateProps } from './util'
 import { lazyComponent } from './util/lazyComponent'
+import { stackStorm } from './repogroups/StackStorm'
 
 const SearchPage = lazyComponent(() => import('./search/input/SearchPage'), 'SearchPage')
 const SearchResults = lazyComponent(() => import('./search/results/SearchResults'), 'SearchResults')
@@ -226,6 +227,11 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     {
         path: '/kubernetes',
         render: props => <RepogroupPage {...props} repogroupMetadata={kubernetes} />,
+        condition: ({ isSourcegraphDotCom }) => isSourcegraphDotCom,
+    },
+    {
+        path: '/stackstorm',
+        render: props => <RepogroupPage {...props} repogroupMetadata={stackStorm} />,
         condition: ({ isSourcegraphDotCom }) => isSourcegraphDotCom,
     },
     {

--- a/client/web/src/search/panels/__snapshots__/RepogroupPanel.test.tsx.snap
+++ b/client/web/src/search/panels/__snapshots__/RepogroupPanel.test.tsx.snap
@@ -82,6 +82,26 @@ exports[`RepogroupPanel renders correctly 1`] = `
           <img
             alt=""
             className="repogroup-panel__repogroup-icon mr-4"
+            src="https://avatars.githubusercontent.com/u/4969009?s=200&v=4"
+          />
+          <div
+            className="d-flex flex-column"
+          >
+            <AnchorLink
+              className="mb-1"
+              onClick={[Function]}
+              to="/stackstorm"
+            >
+              StackStorm
+            </AnchorLink>
+          </div>
+        </div>
+        <div
+          className="d-flex align-items-center mb-4 col-xl-6 col-lg-12 col-sm-6"
+        >
+          <img
+            alt=""
+            className="repogroup-panel__repogroup-icon mr-4"
             src="https://code.benco.io/icon-collection/logos/kubernetes.svg"
           />
           <div
@@ -256,6 +276,33 @@ exports[`RepogroupPanel renders correctly 1`] = `
                   onClick={[Function]}
                 >
                   Android
+                </a>
+              </AnchorLink>
+            </div>
+          </div>
+          <div
+            className="d-flex align-items-center mb-4 col-xl-6 col-lg-12 col-sm-6"
+            key="stackstorm"
+          >
+            <img
+              alt=""
+              className="repogroup-panel__repogroup-icon mr-4"
+              src="https://avatars.githubusercontent.com/u/4969009?s=200&v=4"
+            />
+            <div
+              className="d-flex flex-column"
+            >
+              <AnchorLink
+                className="mb-1"
+                onClick={[Function]}
+                to="/stackstorm"
+              >
+                <a
+                  className="mb-1"
+                  href="/stackstorm"
+                  onClick={[Function]}
+                >
+                  StackStorm
                 </a>
               </AnchorLink>
             </div>

--- a/cmd/frontend/internal/app/ui/router.go
+++ b/cmd/frontend/internal/app/ui/router.go
@@ -163,7 +163,7 @@ func newRouter() *mux.Router {
 
 	// Repogroup pages. Must mirror web/src/Layout.tsx
 	if envvar.SourcegraphDotComMode() {
-		repogroups := []string{"refactor-python2-to-3", "kubernetes", "golang", "react-hooks", "android", "stanford"}
+		repogroups := []string{"refactor-python2-to-3", "kubernetes", "golang", "react-hooks", "android", "stanford", "stackstorm"}
 		r.Path("/{Path:(?:" + strings.Join(repogroups, "|") + ")}").Methods("GET").Name(routeRepoGroups)
 		r.Path("/cncf").Methods("GET").Name(routeCncf)
 	}


### PR DESCRIPTION
Adds a landing page for the StackStorm community similar to what we have for Kubernetes and Android.

![image](https://user-images.githubusercontent.com/1646931/116166784-91c69700-a6b3-11eb-9326-08340282194c.png)
