### PR TITLE
Add debug services for docker-compose

### DIFF
--- a/enterprise/dev/src-prof-services.json
+++ b/enterprise/dev/src-prof-services.json
@@ -1,9 +1,0 @@
-[
-  { "Name": "frontend", "Host": "127.0.0.1:6063" },
-  { "Name": "gitserver", "Host": "127.0.0.1:6068" },
-  { "Name": "searcher", "Host": "127.0.0.1:6069" },
-  { "Name": "symbols", "Host": "127.0.0.1:6071" },
-  { "Name": "repo-updater", "Host": "127.0.0.1:6074" },
-  { "Name": "query-runner", "Host": "127.0.0.1:6067" },
-  { "Name": "precise-code-intel-worker", "Host": "127.0.0.1:6088" }
-]

--- a/internal/debugserver/debug.go
+++ b/internal/debugserver/debug.go
@@ -27,7 +27,21 @@ func init() {
 		panic("failed to JSON unmarshal SRC_PROF_SERVICES: " + err.Error())
 	}
 
-	if addr == "" {
+	if os.Getenv("DEPLOY_TYPE") == "DOCKER_COMPOSE" && len(Services) == 0 {
+		Services = []Service{
+			{Name: "frontend", Host: "sourcegraph-frontend-0"},
+			{Name: "gitserver", Host: "gitserver-0"},
+			{Name: "searcher", Host: "searchers-0"},
+			{Name: "symbols", Host: "symbols-0"},
+			{Name: "repo-updater", Host: "repo-updater"},
+			{Name: "query-runner", Host: "query-runner"},
+			{Name: "precise-code-intel-worker", Host: "precise-code-intel-worker"},
+			{Name: "executor-queue", Host: "executor-queue"},
+			{Name: "executor", Host: "executor"},
+			{Name: "zoekt-indexserver-0", Host: "zoekt-indexserver-0"},
+			{Name: "zoekt-webserver-0", Host: "zoekt-webserver-0", DefaultPath: "/debug/requests/"},
+		}
+	} else if addr == "" {
 		// Look for our binname in the services list
 		name := filepath.Base(os.Args[0])
 		for _, svc := range Services {


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
In docker-compose deployments, the metric server doesn't currently come up. We can use the deployment type to infer the default DNS names of the services.

Fixes https://github.com/sourcegraph/sourcegraph/issues/20249 https://github.com/sourcegraph/sourcegraph/issues/40852