### PR TITLE
Design Refresh: Update `<Toggle />` styles

### DIFF
--- a/client/branded/src/components/Toggle.scss
+++ b/client/branded/src/components/Toggle.scss
@@ -2,6 +2,7 @@ $toggle-width: 2rem;
 
 .toggle {
     --toggle-bar-bg: var(--text-muted);
+    --toggle-bar-bg-on: var(--primary);
     --toggle-knob-bg: var(--text-muted);
     --toggle-knob-bg-on: var(--primary);
     --toggle-bar-opacity: 0.2;
@@ -11,12 +12,13 @@ $toggle-width: 2rem;
 
     .theme-redesign & {
         --toggle-bar-bg: var(--icon-color);
+        --toggle-bar-bg-on: var(--primary);
         --toggle-knob-bg: var(--body-bg);
         --toggle-knob-bg-on: var(--body-bg);
         --toggle-bar-opacity: 1;
         --toggle-bar-focus-opacity: 1;
         --toggle-knob-disabled-opacity: 1;
-        --toggle-bar-focus-box-shadow: var(--input-focus-box-shadow);
+        --toggle-bar-focus-box-shadow: var(--focus-box-shadow);
     }
 
     background: none;
@@ -27,7 +29,17 @@ $toggle-width: 2rem;
     position: relative;
     width: $toggle-width;
 
+    &:focus-visible {
+        // Move focus to rounded bar
+        box-shadow: none;
+    }
+
+    &:focus-visible &__bar {
+        box-shadow: var(--toggle-bar-focus-box-shadow);
+    }
+
     &__bar {
+        border: 1px solid var(--body-bg);
         border-radius: 1rem;
         left: 0;
         height: 1rem;
@@ -41,7 +53,7 @@ $toggle-width: 2rem;
         transition-property: opacity;
 
         &--on {
-            background-color: var(--primary);
+            background-color: var(--toggle-bar-bg-on);
         }
     }
 
@@ -68,7 +80,18 @@ $toggle-width: 2rem;
         opacity: var(--toggle-bar-focus-opacity);
     }
 
+    .theme-redesign &:disabled {
+        --toggle-knob-bg: var(--icon-color);
+        --toggle-knob-bg-on: var(--icon-color);
+        --toggle-bar-bg: var(--input-disabled-bg);
+        --toggle-bar-bg-on: var(--input-disabled-bg);
+    }
+
     &:disabled &__knob {
-        opacity: var(--toggle-bar-focus-opacity);
+        opacity: var(--toggle-bar-opacity);
+    }
+
+    &:disabled &__bar {
+        opacity: var(--toggle-bar-opacity);
     }
 }

--- a/client/branded/src/components/Toggle.scss
+++ b/client/branded/src/components/Toggle.scss
@@ -1,6 +1,24 @@
 $toggle-width: 2rem;
 
 .toggle {
+    --toggle-bar-bg: var(--text-muted);
+    --toggle-knob-bg: var(--text-muted);
+    --toggle-knob-bg-on: var(--primary);
+    --toggle-bar-opacity: 0.2;
+    --toggle-bar-focus-opacity: 0.5;
+    --toggle-knob-disabled-opacity: 0.2;
+    --toggle-bar-focus-box-shadow: 0 0 0 0.1875rem var(--primary);
+
+    .theme-redesign & {
+        --toggle-bar-bg: var(--icon-color);
+        --toggle-knob-bg: var(--body-bg);
+        --toggle-knob-bg-on: var(--body-bg);
+        --toggle-bar-opacity: 1;
+        --toggle-bar-focus-opacity: 1;
+        --toggle-knob-disabled-opacity: 1;
+        --toggle-bar-focus-box-shadow: var(--input-focus-box-shadow);
+    }
+
     background: none;
     border: none;
     display: inline-block;
@@ -9,19 +27,16 @@ $toggle-width: 2rem;
     position: relative;
     width: $toggle-width;
 
-    &__bar,
-    &__bar-shadow {
+    &__bar {
         border-radius: 1rem;
-        top: 2px;
         left: 0;
         height: 1rem;
         width: 100%;
         position: absolute;
-    }
 
-    &__bar {
-        opacity: 0.2;
-        background-color: var(--text-muted);
+        opacity: var(--toggle-bar-opacity);
+        background-color: var(--toggle-bar-bg);
+
         transition: all 0.3s;
         transition-property: opacity;
 
@@ -30,52 +45,30 @@ $toggle-width: 2rem;
         }
     }
 
-    &:hover:enabled &__bar {
-        opacity: 0.5;
-    }
-
-    &:focus-visible &__bar {
-        opacity: 0.5;
-        background-color: var(--text-muted);
-
-        &--on {
-            background-color: var(--primary);
-        }
-    }
-
-    &__bar-shadow {
-        background-color: transparent;
-    }
-
-    &:focus-visible &__bar-shadow {
-        opacity: 0.2;
-        box-shadow: 0 0 0 0.1875rem var(--text-muted);
-
-        &--on {
-            box-shadow: 0 0 0 0.1875rem var(--primary);
-        }
-    }
-
     &__knob {
-        background-color: var(--text-muted);
+        background-color: var(--toggle-knob-bg);
 
         border-radius: 0.375rem;
         display: block;
 
         height: 0.75rem;
         width: 0.75rem;
-        margin-top: 0.25rem;
+        margin-top: 0.125rem;
         left: 0.125rem;
 
         position: relative;
 
         &--on {
-            background-color: var(--primary);
+            background-color: var(--toggle-knob-bg-on);
             transform: translate3d(1rem, 0, 0);
         }
     }
 
+    &:hover:enabled &__bar {
+        opacity: var(--toggle-bar-focus-opacity);
+    }
+
     &:disabled &__knob {
-        opacity: 0.2;
+        opacity: var(--toggle-bar-focus-opacity);
     }
 }

--- a/client/branded/src/components/Toggle.scss
+++ b/client/branded/src/components/Toggle.scss
@@ -1,4 +1,5 @@
 $toggle-width: 2rem;
+$box-shadow-spacing: 0 0 0 1px var(--body-bg);
 
 .toggle {
     --toggle-bar-bg: var(--text-muted);
@@ -8,7 +9,7 @@ $toggle-width: 2rem;
     --toggle-bar-opacity: 0.2;
     --toggle-bar-focus-opacity: 0.5;
     --toggle-knob-disabled-opacity: 0.2;
-    --toggle-bar-focus-box-shadow: 0 0 0 0.1875rem var(--primary);
+    --toggle-bar-focus-box-shadow: #{$box-shadow-spacing}, 0 0 0 0.1875rem var(--primary);
 
     .theme-redesign & {
         --toggle-bar-bg: var(--icon-color);
@@ -18,7 +19,7 @@ $toggle-width: 2rem;
         --toggle-bar-opacity: 1;
         --toggle-bar-focus-opacity: 1;
         --toggle-knob-disabled-opacity: 1;
-        --toggle-bar-focus-box-shadow: var(--focus-box-shadow);
+        --toggle-bar-focus-box-shadow: #{$box-shadow-spacing}, 0 0 0 0.1875rem var(--primary-2);
     }
 
     background: none;
@@ -30,7 +31,7 @@ $toggle-width: 2rem;
     width: $toggle-width;
 
     &:focus-visible {
-        // Move focus to rounded bar
+        // Move focus style to the rounded bar
         box-shadow: none;
     }
 
@@ -39,8 +40,8 @@ $toggle-width: 2rem;
     }
 
     &__bar {
-        border: 1px solid var(--body-bg);
         border-radius: 1rem;
+        top: 2px;
         left: 0;
         height: 1rem;
         width: 100%;
@@ -65,7 +66,7 @@ $toggle-width: 2rem;
 
         height: 0.75rem;
         width: 0.75rem;
-        margin-top: 0.125rem;
+        margin-top: 0.25rem;
         left: 0.125rem;
 
         position: relative;
@@ -88,10 +89,6 @@ $toggle-width: 2rem;
     }
 
     &:disabled &__knob {
-        opacity: var(--toggle-bar-opacity);
-    }
-
-    &:disabled &__bar {
-        opacity: var(--toggle-bar-opacity);
+        opacity: var(--toggle-knob-disabled-opacity);
     }
 }

--- a/client/branded/src/components/Toggle.story.tsx
+++ b/client/branded/src/components/Toggle.story.tsx
@@ -15,6 +15,18 @@ const { add } = storiesOf('branded/Toggle', module).addDecorator(story => (
     </>
 ))
 
+const ToggleExample: typeof Toggle = ({ value, disabled, onToggle }) => (
+    <div className="d-flex align-items-baseline mb-2">
+        <Toggle value={value} onToggle={onToggle} disabled={disabled} title="Hello" className="mr-2" />
+        <div>
+            <label className="mb-0">
+                {disabled ? 'Disabled ' : ''}Toggle {value ? 'on' : 'off'}
+            </label>
+            <small className="field-message mt-0">This is helper text as needed</small>
+        </div>
+    </div>
+)
+
 add(
     'Interactive',
     () => {
@@ -22,11 +34,7 @@ add(
 
         const onToggle = (value: boolean) => setValue(value)
 
-        return (
-            <div className="d-flex align-items-center">
-                <Toggle value={value} onToggle={onToggle} title="Hello" className="mr-2" /> Value is {String(value)}
-            </div>
-        )
+        return <ToggleExample value={value} onToggle={onToggle} />
     },
     {
         chromatic: {
@@ -35,10 +43,11 @@ add(
     }
 )
 
-add('On', () => <Toggle value={true} onToggle={onToggle} />)
-
-add('Off', () => <Toggle value={false} onToggle={onToggle} />)
-
-add('Disabled & on', () => <Toggle value={true} disabled={true} onToggle={onToggle} />)
-
-add('Disabled & off', () => <Toggle value={false} disabled={true} onToggle={onToggle} />)
+add('Variants', () => (
+    <>
+        <ToggleExample value={true} onToggle={onToggle} />
+        <ToggleExample value={false} onToggle={onToggle} />
+        <ToggleExample value={true} disabled={true} onToggle={onToggle} />
+        <ToggleExample value={false} disabled={true} onToggle={onToggle} />
+    </>
+))

--- a/client/branded/src/components/Toggle.tsx
+++ b/client/branded/src/components/Toggle.tsx
@@ -78,11 +78,6 @@ export const Toggle: React.FunctionComponent<Props> = ({
                 })}
             />
             <span
-                className={classnames('toggle__bar-shadow', {
-                    'toggle__bar-shadow--on': value,
-                })}
-            />
-            <span
                 className={classnames('toggle__knob', {
                     'toggle__knob--on': value,
                 })}

--- a/client/branded/src/components/__snapshots__/Toggle.test.tsx.snap
+++ b/client/branded/src/components/__snapshots__/Toggle.test.tsx.snap
@@ -20,9 +20,6 @@ exports[`Toggle aria 1`] = `
       className="toggle__bar"
     />
     <span
-      className="toggle__bar-shadow"
-    />
-    <span
       className="toggle__knob"
     />
   </button>
@@ -42,9 +39,6 @@ exports[`Toggle className 1`] = `
   >
     <span
       className="toggle__bar"
-    />
-    <span
-      className="toggle__bar-shadow"
     />
     <span
       className="toggle__knob"
@@ -70,9 +64,6 @@ exports[`Toggle disabled 1`] = `
       className="toggle__bar"
     />
     <span
-      className="toggle__bar-shadow"
-    />
-    <span
       className="toggle__knob"
     />
   </button>
@@ -95,9 +86,6 @@ exports[`Toggle value is false 1`] = `
       className="toggle__bar"
     />
     <span
-      className="toggle__bar-shadow"
-    />
-    <span
       className="toggle__knob"
     />
   </button>
@@ -118,9 +106,6 @@ exports[`Toggle value is true 1`] = `
   >
     <span
       className="toggle__bar toggle__bar--on"
-    />
-    <span
-      className="toggle__bar-shadow toggle__bar-shadow--on"
     />
     <span
       className="toggle__knob toggle__knob--on"

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -62,7 +62,7 @@ $theme-colors-redesign: (
     --tooltip-bg: #{$redesign-gray-08};
     // Assumption: Uses light-mode body-color, which matches current behavior
     --box-shadow: 0 0.25rem 0.5rem #{rgba($redesign-gray-08, 0.07)};
-    --focus-box-shadow: 0 0 0 2px var(--primary-2);
+    --focus-box-shadow: 0 0 0 0.125rem var(--primary-2);
     --btn-link-disabled-color: var(--primary-2);
 }
 

--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -87,7 +87,7 @@ $text-muted: var(--text-muted);
     --logo-purple: #{$logo-purple};
     --tooltip-bg: #{$gray-19};
     --box-shadow: 0 0.25rem 0.5rem #{rgba($gray-19, 0.07)};
-    --focus-box-shadow: 0 0 0 2px #{rgba($primary, 0.8)};
+    --focus-box-shadow: 0 0 0 0.125rem #{rgba($primary, 0.8)};
     // Matches Bootstrap colors, using variable to easily change for redesign
     --btn-link-disabled-color: #6c757d;
 }

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -598,9 +598,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -707,9 +704,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -820,9 +814,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -929,9 +920,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -1042,9 +1030,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -1151,9 +1136,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -1264,9 +1246,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -1373,9 +1352,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -1486,9 +1462,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -1595,9 +1568,6 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -2054,9 +2024,6 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -2165,9 +2132,6 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -2274,9 +2238,6 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -2967,9 +2928,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -3076,9 +3034,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -3189,9 +3144,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -3298,9 +3250,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -3411,9 +3360,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -3520,9 +3466,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -3633,9 +3576,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -3742,9 +3682,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -3855,9 +3792,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -3964,9 +3898,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"
@@ -4077,9 +4008,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                     className="toggle__bar toggle__bar--on"
                                   />
                                   <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
-                                  />
-                                  <span
                                     className="toggle__knob toggle__knob--on"
                                   />
                                 </button>
@@ -4186,9 +4114,6 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                                 >
                                   <span
                                     className="toggle__bar toggle__bar--on"
-                                  />
-                                  <span
-                                    className="toggle__bar-shadow toggle__bar-shadow--on"
                                   />
                                   <span
                                     className="toggle__knob toggle__knob--on"

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormActionArea.test.tsx.snap
@@ -115,9 +115,6 @@ exports[`FormActionArea Error is shown if code monitor has empty description 1`]
               className="toggle__bar toggle__bar--on"
             />
             <span
-              className="toggle__bar-shadow toggle__bar-shadow--on"
-            />
-            <span
               className="toggle__knob toggle__knob--on"
             />
           </button>

--- a/client/web/src/extensions/__snapshots__/ExtensionToggle.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionToggle.test.tsx.snap
@@ -15,9 +15,6 @@ exports[`ExtensionToggle extension disabled in settings 1`] = `
     className="toggle__bar"
   />
   <span
-    className="toggle__bar-shadow"
-  />
-  <span
     className="toggle__knob"
   />
 </button>
@@ -38,9 +35,6 @@ exports[`ExtensionToggle extension enabled in settings 1`] = `
     className="toggle__bar toggle__bar--on"
   />
   <span
-    className="toggle__bar-shadow toggle__bar-shadow--on"
-  />
-  <span
     className="toggle__knob toggle__knob--on"
   />
 </button>
@@ -59,9 +53,6 @@ exports[`ExtensionToggle extension not present in settings 1`] = `
 >
   <span
     className="toggle__bar"
-  />
-  <span
-    className="toggle__bar-shadow"
   />
   <span
     className="toggle__knob"


### PR DESCRIPTION
## Description

This PR updates our `<Toggle />` component to use the new refresh styles

### Screenshots
| BEFORE             |  AFTER |
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/9516420/116422353-91570900-a837-11eb-9548-99c9d664b1c5.png) | ![image](https://user-images.githubusercontent.com/9516420/116422403-9b790780-a837-11eb-9b7b-6de2e3ea1fe1.png)



[Branch deployment
](https://5f0f381c0e50750022dc6bf7-jkarqrlvau.chromatic.com/?path=/story/branded-toggle--variants)

### Note
1. We have a different component called `<ToggleBig />`, it's similar with some extra content and only used on the extensions registry. I want to refactor this to just be a prop, e.g. `<Toggle big={true} />` but first I think it's important to see if we actually want to use this component after the redesign has been finished. Figma discussion: https://www.figma.com/file/NIsN34NH7lPu04olBzddTw?node-id=908:1#77380728
