### PR TITLE
Implement auto-inference for Java.

### DIFF
--- a/enterprise/internal/codeintel/autoindex/inference/java.go
+++ b/enterprise/internal/codeintel/autoindex/inference/java.go
@@ -1,0 +1,68 @@
+package inference
+
+import (
+	"regexp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
+)
+
+type lsifJavaJobRecognizer struct{}
+
+func (r lsifJavaJobRecognizer) CanIndex(paths []string, gitserver GitserverClientWrapper) bool {
+	for _, path := range paths {
+		if r.canIndexPath(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r lsifJavaJobRecognizer) InferIndexJobs(paths []string, gitserver GitserverClientWrapper) (indexes []config.IndexJob) {
+	for _, path := range paths {
+		if !r.canIndexPath(path) {
+			continue
+		}
+		indexes = append(indexes, config.IndexJob{
+			Indexer: "gradle:7.0.0-jdk8",
+			LocalSteps: []string{
+				"apt-get update",
+				"apt-get install --yes maven",
+				"curl -fLo coursier https://git.io/coursier-cli",
+				"chmod +x coursier",
+			},
+			IndexerArgs: []string{
+				"./coursier launch --contrib lsif-java -- --packagehub=https://packagehub-ohcltxh6aq-uc.a.run.app index",
+			},
+			Outfile: "dump.lsif",
+			Root:    "",
+			Steps:   []config.DockerStep{},
+		})
+	}
+	return indexes
+}
+
+func (lsifJavaJobRecognizer) Patterns() []*regexp.Regexp {
+	var patterns []*regexp.Regexp
+	for _, filename := range supportedFilenames {
+		patterns = append(patterns, suffixPattern(filename))
+	}
+	return patterns
+}
+
+func (r lsifJavaJobRecognizer) canIndexPath(path string) bool {
+	for _, filename := range supportedFilenames {
+		if filename == path {
+			return true
+		}
+	}
+	return false
+}
+
+var supportedFilenames = []string{
+	"pom.xml",
+	"build.gradle",
+	"settings.gradle",
+	// The "lsif-java.json" file is used to index package repositories such as
+	// the JDK sources and published Java libraries.
+	"lsif-java.json",
+}

--- a/enterprise/internal/codeintel/autoindex/inference/java_test.go
+++ b/enterprise/internal/codeintel/autoindex/inference/java_test.go
@@ -1,0 +1,95 @@
+package inference
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/autoindex/config"
+)
+
+func TestLSIFJavaJobRecognizerCanIndex(t *testing.T) {
+	recognizer := lsifJavaJobRecognizer{}
+	testCases := []struct {
+		paths    []string
+		expected bool
+	}{
+		{paths: []string{"pom.xml"}, expected: true},
+		{paths: []string{"nested/pom.xml"}, expected: false},
+		{paths: []string{"build.gradle"}, expected: true},
+		{paths: []string{"nested/build.gradle"}, expected: false},
+		{paths: []string{"settings.gradle"}, expected: true},
+		{paths: []string{"nested/settings.gradle"}, expected: false},
+		{paths: []string{"lsif-java.json"}, expected: true},
+		{paths: []string{"nested/lsif-java.json"}, expected: false},
+		{paths: []string{"build.sbt"}, expected: false},
+		{paths: []string{"package.json"}, expected: false},
+		{paths: []string{"MyApp.java"}, expected: false},
+		{paths: []string{"MyApp.groovy"}, expected: false},
+		{paths: []string{"gradle.properties"}, expected: false},
+	}
+
+	for _, testCase := range testCases {
+		name := strings.Join(testCase.paths, ", ")
+
+		t.Run(name, func(t *testing.T) {
+			if value := recognizer.CanIndex(testCase.paths, NewMockGitserverClientWrapper()); value != testCase.expected {
+				t.Errorf("unexpected result from CanIndex. want=%v have=%v", testCase.expected, value)
+			}
+		})
+	}
+}
+
+func TestLsifJavaJobRecognizerInferIndexJobsTsConfigRoot(t *testing.T) {
+	recognizer := lsifJavaJobRecognizer{}
+	paths := []string{
+		"pom.xml",
+	}
+
+	expectedIndexJobs := []config.IndexJob{
+		{
+			Indexer: "gradle:7.0.0-jdk8",
+			LocalSteps: []string{
+				"apt-get update",
+				"apt-get install --yes maven",
+				"curl -fLo coursier https://git.io/coursier-cli",
+				"chmod +x coursier",
+			},
+			IndexerArgs: []string{
+				"./coursier launch --contrib lsif-java -- --packagehub=https://packagehub-ohcltxh6aq-uc.a.run.app index",
+			},
+			Outfile: "dump.lsif",
+			Root:    "",
+			Steps:   []config.DockerStep{},
+		},
+	}
+	if diff := cmp.Diff(expectedIndexJobs, recognizer.InferIndexJobs(paths, NewMockGitserverClientWrapper())); diff != "" {
+		t.Errorf("unexpected index jobs (-want +got):\n%s", diff)
+	}
+}
+
+func TestLSIFJavaJobRecognizerPatterns(t *testing.T) {
+	recognizer := lsifJavaJobRecognizer{}
+	paths := []string{
+		"lsif-java.json",
+		"settings.gradle",
+		"build.gradle",
+		"pom.xml",
+	}
+
+	for _, path := range paths {
+		match := false
+		for _, pattern := range recognizer.Patterns() {
+			if pattern.MatchString(path) {
+				match = true
+				break
+			}
+		}
+
+		if !match {
+			t.Error(fmt.Sprintf("failed to match %s", path))
+		}
+	}
+}

--- a/enterprise/internal/codeintel/autoindex/inference/recognizers.go
+++ b/enterprise/internal/codeintel/autoindex/inference/recognizers.go
@@ -25,6 +25,7 @@ type IndexJobRecognizer interface {
 
 // Recognizers is a list of registered index job recognizers.
 var Recognizers = map[string]IndexJobRecognizer{
-	"go":  lsifGoJobRecognizer{},
-	"tsc": lsifTscJobRecognizer{},
+	"go":   lsifGoJobRecognizer{},
+	"tsc":  lsifTscJobRecognizer{},
+	"java": lsifJavaJobRecognizer{},
 }


### PR DESCRIPTION
Previously, we had to manually add index configuration for Java
repositories. This commit adds auto-inference so that Sourcegraph can
automatically LSIF index a Java repository with lsif-java when it
detects a repo with a Gradle or Maven build tool.


Fixes https://github.com/sourcegraph/lsif-java/issues/153
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
