### PR TITLE
Add missing import paths to css module typings generator

### DIFF
--- a/client/shared/dev/generateCssModulesTypes.js
+++ b/client/shared/dev/generateCssModulesTypes.js
@@ -4,7 +4,7 @@ const { spawn } = require('child_process')
 const path = require('path')
 
 const CSS_MODULES_GLOB = path.resolve(__dirname, '../../*/src/**/*.module.scss')
-const TSM_COMMAND = `yarn --silent --ignore-engines --ignore-scripts tsm --logLevel error ${CSS_MODULES_GLOB}`
+const TSM_COMMAND = `yarn --silent --ignore-engines --ignore-scripts tsm --logLevel error ${CSS_MODULES_GLOB} --includePaths node_modules client`
 const [BIN, ...ARGS] = TSM_COMMAND.split(' ')
 
 /**


### PR DESCRIPTION
Extracted from https://github.com/sourcegraph/sourcegraph/pull/20340