### PR TITLE
authtest: add tests for LSIF upload

### DIFF
--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -3,6 +3,7 @@ package authtest
 import (
 	"bytes"
 	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -71,6 +72,18 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		})
 		if err != nil {
 			t.Fatal(err, "lastBody:", lastBody)
+		}
+	})
+
+	t.Run("executor endpoints", func(t *testing.T) {
+		resp, err := userClient.Get(*baseURL + "/.executors/")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Fatalf(`Want status code %d error but got %d`, http.StatusUnauthorized, resp.StatusCode)
 		}
 	})
 }

--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -1,0 +1,76 @@
+package authtest
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/sourcegraph/sourcegraph/internal/gqltestutil"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+func TestCodeIntelEndpoints(t *testing.T) {
+	// Create a test user (authtest-user-code-intel) which is not a site admin, the
+	// user should receive access denied for LSIF endpoints of repositories the user
+	// does not have access to.
+	const testUsername = "authtest-user-code-intel"
+	userClient, err := gqltestutil.SignUp(*baseURL, testUsername+"@sourcegraph.com", testUsername, "mysecurepassword")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := client.DeleteUser(userClient.AuthenticatedUserID(), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	t.Run("LSIF upload", func(t *testing.T) {
+		// Update site configuration to enable "lsifEnforceAuth".
+		siteConfig, err := client.SiteConfiguration()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		oldSiteConfig := new(schema.SiteConfiguration)
+		*oldSiteConfig = *siteConfig
+		defer func() {
+			err = client.UpdateSiteConfiguration(oldSiteConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		siteConfig.LsifEnforceAuth = true
+		err = client.UpdateSiteConfiguration(siteConfig)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Retry because the configuration update endpoint is eventually consistent
+		var lastBody string
+		err = gqltestutil.Retry(5*time.Second, func() error {
+			resp, err := userClient.Post(*baseURL+"/.api/lsif/upload?commit=6ffc6072f5ed13d8e8782490705d9689cd2c546a&repository=github.com/sgtest/private", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if bytes.Contains(body, []byte("must provide github_token")) {
+				return nil
+			}
+
+			lastBody = string(body)
+			return gqltestutil.ErrContinueRetry
+		})
+		if err != nil {
+			t.Fatal(err, "lastBody:", lastBody)
+		}
+	})
+}

--- a/dev/gqltest/site_config_test.go
+++ b/dev/gqltest/site_config_test.go
@@ -51,7 +51,6 @@ func TestSiteConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		var lastErr error
 		// Retry because the configuration update endpoint is eventually consistent
 		err = gqltestutil.Retry(5*time.Second, func() error {
 			// Sign up a new user should fail.
@@ -72,7 +71,7 @@ func TestSiteConfig(t *testing.T) {
 			return gqltestutil.ErrContinueRetry
 		})
 		if err != nil {
-			t.Fatal(err, "lastErr:", lastErr)
+			t.Fatal(err)
 		}
 	})
 }

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -3,6 +3,7 @@ package gqltestutil
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 )
 
@@ -296,6 +298,18 @@ func (c *Client) GraphQL(token, query string, variables map[string]interface{}, 
 // Get performs a GET request to the URL with authenticated user.
 func (c *Client) Get(url string) (*http.Response, error) {
 	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c.addCookies(req)
+
+	return http.DefaultClient.Do(req)
+}
+
+// Post performs a POST request to the URL with authenticated user.
+func (c *Client) Post(url string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds tests for assuring LSIF upload endpoint is enforcing auth via GitHub token.

Fixes #19815, fixes #19816