### PR TITLE
Remove unit from unsuccessful status rate

### DIFF
--- a/monitoring/definitions/frontend.go
+++ b/monitoring/definitions/frontend.go
@@ -907,7 +907,7 @@ func Frontend() *monitoring.Container {
 							Description: "unsuccessful status rate per 5m",
 							Query:       `sum(rate(src_graphql_search_response{source=~"searchblitz.*", status!="success"}[5m])) by (status)`,
 							NoAlert:     true,
-							Panel:       monitoring.Panel().LegendFormat("{{status}}").Unit(monitoring.Seconds),
+							Panel:       monitoring.Panel().LegendFormat("{{status}}"),
 							Owner:       monitoring.ObservableOwnerSearch,
 							Interpretation: `
 								- The rate of unsuccessful sentinel query, broken down by failure type


### PR DESCRIPTION
Removes the "seconds" unit from the unsuccessful status rate. Doesn't
add a rate unit because it's per 5 minutes. I'll probably change this in
the future, but per minute is too spiky to be useful for as few queries
as we're running



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
