### PR TITLE
storybook: fix CSS import order in WebStory

### DIFF
--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -13,7 +13,7 @@ export interface WebStoryProps extends MemoryRouterProps {
 }
 
 // Prepend global CSS styles to document head to keep them before CSS modules
-function prependCSSToDocumentHead(css: string): HTMLStyleElement {
+export function prependCSSToDocumentHead(css: string): HTMLStyleElement {
     const styleTag = document.createElement('style')
     styleTag.textContent = css
     document.head.prepend(styleTag)

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { MemoryRouter, MemoryRouterProps, RouteComponentProps, withRouter } from 'react-router'
 import { useDarkMode } from 'storybook-dark-mode'
 
@@ -28,11 +28,31 @@ export const WebStory: React.FunctionComponent<
     const isLightTheme = !useDarkMode()
     const breadcrumbSetters = useBreadcrumbs()
     const Children = useMemo(() => withRouter(children), [children])
+
+    useEffect(() => {
+        const webappCss = document.createElement('style')
+        webappCss.textContent = webStyles
+        webappCss.setAttribute('id', 'webapp-css')
+
+        const firstCss = document.head.querySelector('style')
+        document.head.insertBefore(webappCss, firstCss)
+
+        return () => {
+            const webappCss = document.querySelector('#webapp-css')
+            webappCss?.remove()
+        }
+    }, [webStyles])
+
     return (
-        <MemoryRouter {...memoryRouterProps}>
-            <Tooltip />
-            <Children {...breadcrumbSetters} isLightTheme={isLightTheme} telemetryService={NOOP_TELEMETRY_SERVICE} />
-            <style title="Webapp CSS">{webStyles}</style>
-        </MemoryRouter>
+        <>
+            <MemoryRouter {...memoryRouterProps}>
+                <Tooltip />
+                <Children
+                    {...breadcrumbSetters}
+                    isLightTheme={isLightTheme}
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                />
+            </MemoryRouter>
+        </>
     )
 }

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react'
 import { MemoryRouter, MemoryRouterProps, RouteComponentProps, withRouter } from 'react-router'
 import { useDarkMode } from 'storybook-dark-mode'
 
+import { prependCSSToDocumentHead } from '@sourcegraph/branded/src/components/BrandedStory'
 import { Tooltip } from '@sourcegraph/branded/src/components/tooltip/Tooltip'
 import { NOOP_TELEMETRY_SERVICE, TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
@@ -30,16 +31,10 @@ export const WebStory: React.FunctionComponent<
     const Children = useMemo(() => withRouter(children), [children])
 
     useEffect(() => {
-        const webappCss = document.createElement('style')
-        webappCss.textContent = webStyles
-        webappCss.setAttribute('id', 'webapp-css')
-
-        const firstCss = document.head.querySelector('style')
-        document.head.insertBefore(webappCss, firstCss)
+        const styleTag = prependCSSToDocumentHead(webStyles)
 
         return () => {
-            const webappCss = document.querySelector('#webapp-css')
-            webappCss?.remove()
+            styleTag.remove()
         }
     }, [webStyles])
 

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -44,15 +44,9 @@ export const WebStory: React.FunctionComponent<
     }, [webStyles])
 
     return (
-        <>
-            <MemoryRouter {...memoryRouterProps}>
-                <Tooltip />
-                <Children
-                    {...breadcrumbSetters}
-                    isLightTheme={isLightTheme}
-                    telemetryService={NOOP_TELEMETRY_SERVICE}
-                />
-            </MemoryRouter>
-        </>
+        <MemoryRouter {...memoryRouterProps}>
+            <Tooltip />
+            <Children {...breadcrumbSetters} isLightTheme={isLightTheme} telemetryService={NOOP_TELEMETRY_SERVICE} />
+        </MemoryRouter>
     )
 }


### PR DESCRIPTION
When creating a WebStory, add the CSS to the head before any other CSS. BrandedStory already does this so reusing the same technique from there.