### PR TITLE
executor: Add execution time limit

### DIFF
--- a/enterprise/cmd/executor/config.go
+++ b/enterprise/cmd/executor/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	FirecrackerDiskSpace string
 	ImageArchivesPath    string
 	DisableHealthServer  bool
+	MaximumRuntimePerJob time.Duration
 }
 
 func (c *Config) Load() {
@@ -47,17 +48,19 @@ func (c *Config) Load() {
 	c.FirecrackerDiskSpace = c.Get("EXECUTOR_FIRECRACKER_DISK_SPACE", "20G", "How much disk space to allocate to each virtual machine or container.")
 	c.ImageArchivesPath = c.Get("EXECUTOR_IMAGE_ARCHIVE_PATH", "", "Where to store tar archives of docker images shared by virtual machines.")
 	c.DisableHealthServer = c.GetBool("EXECUTOR_DISABLE_HEALTHSERVER", "false", "Whether or not to disable the health server.")
+	c.MaximumRuntimePerJob = c.GetInterval("EXECUTOR_MAXIMUM_RUNTIME_PER_JOB", "30m", "The maximum wall time that can be spent on a single job.")
 }
 
 func (c *Config) APIWorkerOptions(transport http.RoundTripper) apiworker.Options {
 	return apiworker.Options{
-		QueueName:          c.QueueName,
-		HeartbeatInterval:  c.HeartbeatInterval,
-		WorkerOptions:      c.WorkerOptions(),
-		FirecrackerOptions: c.FirecrackerOptions(),
-		ResourceOptions:    c.ResourceOptions(),
-		GitServicePath:     "/.executors/git",
-		ClientOptions:      c.ClientOptions(transport),
+		QueueName:            c.QueueName,
+		HeartbeatInterval:    c.HeartbeatInterval,
+		WorkerOptions:        c.WorkerOptions(),
+		FirecrackerOptions:   c.FirecrackerOptions(),
+		ResourceOptions:      c.ResourceOptions(),
+		MaximumRuntimePerJob: c.MaximumRuntimePerJob,
+		GitServicePath:       "/.executors/git",
+		ClientOptions:        c.ClientOptions(transport),
 		RedactedValues: map[string]string{
 			// 🚨 SECURITY: Catch uses of the shared frontend token used to clone
 			// git repositories that make it into commands or stdout/stderr streams.

--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -86,6 +86,10 @@ func runCommand(ctx context.Context, command command, logger *Logger) (err error
 		return err
 	}
 	if exitCode != 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		return errors.New("command failed")
 	}
 	return nil

--- a/enterprise/cmd/executor/internal/command/run.go
+++ b/enterprise/cmd/executor/internal/command/run.go
@@ -43,6 +43,31 @@ func runCommand(ctx context.Context, command command, logger *Logger) (err error
 		return err
 	}
 
+	go func() {
+		// There is a deadlock condition due the following strange decisions:
+		//
+		// 1. The pipes attached to a command are not closed if the context
+		//    attached to the command is canceled. The pipes are only closed
+		//    after Wait has been called.
+		// 2. According to the docs, we are not meant to call cmd.Wait() until
+		//    we have complete read the pipes attached to the command.
+		//
+		// Since we're following the expected usage, we block on a wait group
+		// tracking the consumption of stdout and stderr pipes in two separate
+		// goroutines between calls to Start and Wait. This means that if there
+		// is a reason the command is abandoned but the pipes are not closed
+		// (such as context cancellation), we will hang indefinitely.
+		//
+		// To be defensive, we'll forcibly close both pipes when the context has
+		// finished. These may return an ErrClosed condition, but we don't really
+		// care: the command package doesn't surface errors when closing the pipes
+		// either.
+
+		<-ctx.Done()
+		stdout.Close()
+		stderr.Close()
+	}()
+
 	startTime := time.Now()
 	pipeContents, pipeReaderWaitGroup := readProcessPipes(stdout, stderr)
 	exitCode, err := monitorCommand(cmd, pipeReaderWaitGroup)
@@ -89,7 +114,7 @@ func validateCommand(command []string) error {
 	return ErrIllegalCommand
 }
 
-func prepCommand(ctx context.Context, command command) (cmd *exec.Cmd, stdout io.Reader, stderr io.Reader, err error) {
+func prepCommand(ctx context.Context, command command) (cmd *exec.Cmd, stdout, stderr io.ReadCloser, err error) {
 	cmd = exec.CommandContext(ctx, command.Command[0], command.Command[1:]...)
 	cmd.Dir = command.Dir
 	cmd.Env = command.Env

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
@@ -32,8 +33,7 @@ var _ workerutil.Handler = &handler{}
 // fresh docker container, and uploads the results to the external frontend API.
 func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workerutil.Record) error {
 	job := record.(executor.Job)
-
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(h.options.MaximumRuntimePerJob))
 	defer cancel()
 
 	h.idSet.Add(job.ID)

--- a/enterprise/cmd/executor/internal/worker/worker.go
+++ b/enterprise/cmd/executor/internal/worker/worker.go
@@ -48,6 +48,9 @@ type Options struct {
 	// ResourceOptions configures the resource limits of docker container and Firecracker
 	// virtual machines running on the executor.
 	ResourceOptions command.ResourceOptions
+
+	// MaximumRuntimePerJob is the maximum wall time that can be spent on a single job.
+	MaximumRuntimePerJob time.Duration
 }
 
 // NewWorker creates a worker that polls a remote job queue API for work. The returned


### PR DESCRIPTION
This adds a configurable maximum time (default of 30m) to each executor job. The handler context is canceled after this deadline, which causes the current command to be abandoned and the workspace to be cleaned up.

<img width="1053" alt="Screen Shot 2021-04-27 at 3 49 08 PM" src="https://user-images.githubusercontent.com/103087/116310853-255d9d80-a770-11eb-9284-5621dd56389d.png">