### PR TITLE
extensions: implement logging API

### DIFF
--- a/client/browser/src/shared.scss
+++ b/client/browser/src/shared.scss
@@ -9,7 +9,7 @@ $body-bg-color-light: #ffffff;
 @import '../../shared/src/actions/ActionsNavItems';
 @import '../../shared/src/commandPalette/CommandList';
 @import '../../shared/src/commandPalette/EmptyCommandList.scss';
-@import '../../shared/src/extensions/ExtensionStatus';
+@import '../../shared/src/extensions/devtools';
 @import '../../shared/src/notifications/NotificationItem';
 @import '../../shared/src/notifications/Notifications';
 

--- a/client/browser/src/shared/components/GlobalDebug.tsx
+++ b/client/browser/src/shared/components/GlobalDebug.tsx
@@ -2,7 +2,7 @@ import * as H from 'history'
 import * as React from 'react'
 
 import { Controller as ClientController } from '@sourcegraph/shared/src/extensions/controller'
-import { ExtensionDevToolsPopover } from '@sourcegraph/shared/src/extensions/devtools'
+import { ExtensionDevelopmentToolsPopover } from '@sourcegraph/shared/src/extensions/devtools'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 
 import { ShortcutProvider } from './ShortcutProvider'
@@ -27,7 +27,7 @@ export const GlobalDebug: React.FunctionComponent<Props> = props => (
         <div className="navbar-nav align-items-center">
             <div className="nav-item">
                 <ShortcutProvider>
-                    <ExtensionDevToolsPopover
+                    <ExtensionDevelopmentToolsPopover
                         extensionsController={props.extensionsController}
                         link={makeExtensionLink(props.sourcegraphURL)}
                         platformContext={props.platformContext}

--- a/client/browser/src/shared/components/GlobalDebug.tsx
+++ b/client/browser/src/shared/components/GlobalDebug.tsx
@@ -2,12 +2,12 @@ import * as H from 'history'
 import * as React from 'react'
 
 import { Controller as ClientController } from '@sourcegraph/shared/src/extensions/controller'
-import { ExtensionStatusPopover } from '@sourcegraph/shared/src/extensions/ExtensionStatus'
+import { ExtensionDevToolsPopover } from '@sourcegraph/shared/src/extensions/devtools'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 
 import { ShortcutProvider } from './ShortcutProvider'
 
-interface Props extends PlatformContextProps<'sideloadedExtensionURL'> {
+interface Props extends PlatformContextProps<'sideloadedExtensionURL' | 'settings'> {
     location: H.Location
     extensionsController: ClientController
     sourcegraphURL: string
@@ -27,7 +27,7 @@ export const GlobalDebug: React.FunctionComponent<Props> = props => (
         <div className="navbar-nav align-items-center">
             <div className="nav-item">
                 <ShortcutProvider>
-                    <ExtensionStatusPopover
+                    <ExtensionDevToolsPopover
                         extensionsController={props.extensionsController}
                         link={makeExtensionLink(props.sourcegraphURL)}
                         platformContext={props.platformContext}

--- a/client/extension-api/package.json
+++ b/client/extension-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcegraph",
-  "version": "25.2.0",
+  "version": "25.3.0",
   "license": "Apache-2.0",
   "description": "Sourcegraph extension API: build extensions that enhance reading and reviewing code in your existing tools",
   "author": "Sourcegraph",

--- a/client/extension-api/src/sourcegraph.d.ts
+++ b/client/extension-api/src/sourcegraph.d.ts
@@ -1165,6 +1165,9 @@ declare module 'sourcegraph' {
          * Log a message to the console if logs for the extension are enabled in user settings.
          *
          * Messages are automatically prefixed by the extension's ID.
+         *
+         * Note that messages may be transferred via the structured clone algorithm. Ensure that your messages are
+         * [cloneable](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#things_that_dont_work_with_structured_clone)
          */
         export function log(message?: any, ...optionalParams: any[]): void
     }

--- a/client/extension-api/src/sourcegraph.d.ts
+++ b/client/extension-api/src/sourcegraph.d.ts
@@ -1160,6 +1160,13 @@ declare module 'sourcegraph' {
          * Register a file decoration provider
          */
         export function registerFileDecorationProvider(provider: FileDecorationProvider): Unsubscribable
+
+        /**
+         * Log a message to the console if logs for the extension are enabled in user settings.
+         *
+         * Messages are automatically prefixed by the extension's ID.
+         */
+        export function log(message?: any, ...optionalParams: any[]): void
     }
 
     /**

--- a/client/shared/src/api/client/mainthread-api.ts
+++ b/client/shared/src/api/client/mainthread-api.ts
@@ -171,6 +171,7 @@ export const initMainThreadAPI = (
             return proxySubscribable(getEnabledExtensions(platformContext))
         },
         logEvent: (eventName, eventProperties) => platformContext.telemetryService?.log(eventName, eventProperties),
+        logExtensionMessage: (...data) => console.log(...data),
     }
 
     return { api, exposedToClient, subscription }

--- a/client/shared/src/api/contract.ts
+++ b/client/shared/src/api/contract.ts
@@ -208,4 +208,11 @@ export interface MainThreadAPI {
      * Log an event (by sending it to the server).
      */
     logEvent: (eventName: string, eventProperties?: any) => void
+
+    /**
+     * Log messages from extensions in the main thread. Makes it easier to debug extensions for applications
+     * in which extensions run in a different page from the main thread
+     * (e.g. browser extensions, where extensions run in the background page).
+     */
+    logExtensionMessage(message?: any, ...optionalParameters: any[]): void
 }

--- a/client/shared/src/api/extension/api/logging.ts
+++ b/client/shared/src/api/extension/api/logging.ts
@@ -28,5 +28,5 @@ export function getActiveLoggersFromSettings(settings: Settings): Set<string> {
         return new Set<string>()
     }
 
-    return new Set<string>([...activeLoggers])
+    return new Set<string>(activeLoggers)
 }

--- a/client/shared/src/api/extension/api/logging.ts
+++ b/client/shared/src/api/extension/api/logging.ts
@@ -1,0 +1,32 @@
+import { map } from 'rxjs/operators'
+import sourcegraph from 'sourcegraph'
+
+import { Settings } from '../../../settings/settings'
+import { ExtensionHostState } from '../extensionHostState'
+
+/**
+ * Sets active loggers extension host state based on user settings.
+ *
+ * @param state Extension host state
+ */
+export function setActiveLoggers(
+    state: Pick<ExtensionHostState, 'settings' | 'activeLoggers'>
+): sourcegraph.Unsubscribable {
+    const activeLoggers = state.settings.pipe(map(settings => getActiveLoggersFromSettings(settings.final)))
+
+    return activeLoggers.subscribe(activeLoggers => (state.activeLoggers = activeLoggers))
+}
+
+export function getActiveLoggersFromSettings(settings: Settings): Set<string> {
+    if (!settings || !settings['extensions.activeLoggers']) {
+        return new Set<string>()
+    }
+
+    const activeLoggers = settings['extensions.activeLoggers']
+
+    if (!Array.isArray(activeLoggers)) {
+        return new Set<string>()
+    }
+
+    return new Set<string>([...activeLoggers])
+}

--- a/client/shared/src/api/extension/extensionApi.ts
+++ b/client/shared/src/api/extension/extensionApi.ts
@@ -327,7 +327,11 @@ export function createExtensionAPIFactory(
                 log: (...data) => {
                     if (state.activeLoggers.has(extensionID)) {
                         // Use a light gray background to differentiate extension ID from the message
-                        console.log(`🧩 %c${extensionID}`, 'background-color: lightgrey;', ...data)
+                        clientAPI
+                            .logExtensionMessage(`🧩 %c${extensionID}`, 'background-color: lightgrey;', ...data)
+                            .catch(error => {
+                                console.error('Error sending extension message to main thread:', error)
+                            })
                     }
                 },
             },

--- a/client/shared/src/api/extension/extensionApi.ts
+++ b/client/shared/src/api/extension/extensionApi.ts
@@ -1,16 +1,20 @@
 import { proxy, Remote } from 'comlink'
-import { sortBy } from 'lodash'
+import { noop, sortBy } from 'lodash'
 import { BehaviorSubject, ReplaySubject } from 'rxjs'
 import { debounceTime, mapTo } from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
 
+import { Location, MarkupKind, Position, Range, Selection } from '@sourcegraph/extension-api-classes'
+
 import { asError } from '../../util/errors'
-import { MainThreadAPI } from '../contract'
+import { ClientAPI } from '../client/api/api'
 import { syncRemoteSubscription } from '../util'
 
 import { createStatusBarItemType } from './api/codeEditor'
 import { proxySubscribable } from './api/common'
 import { createDecorationType } from './api/decorations'
+import { DocumentHighlightKind } from './api/documentHighlights'
+import { InitData, updateContext } from './extensionHost'
 import { NotificationType, PanelViewData } from './extensionHostApi'
 import { ExtensionHostState } from './extensionHostState'
 import { addWithRollback } from './util'
@@ -31,7 +35,27 @@ export interface InitResult {
     app: typeof sourcegraph['app']
 }
 
-export function createExtensionAPI(state: ExtensionHostState, mainAPI: Remote<MainThreadAPI>): InitResult {
+/**
+ * Creates a factory function to create extension API objects. This factory function should be called
+ * when an extension is activated and the resulting extension API object should be passed to `replaceAPIRequire`.
+ *
+ * Methods shared between all API instances are implemented when the factory function is created.
+ * Methods scoped to an API instance (e.g. `sourcegraph.app.log`) are implemented when the factory function is called.
+ */
+export function createExtensionAPIFactory(
+    state: ExtensionHostState,
+    clientAPI: Remote<ClientAPI>,
+    initData: Pick<InitData, 'clientApplication' | 'sourcegraphURL'>
+): (
+    extensionID: string
+) => typeof sourcegraph & {
+    // Backcompat definitions that were removed from sourcegraph.d.ts but are still defined (as
+    // noops with a log message), to avoid completely breaking extensions that use them.
+    languages: {
+        registerTypeDefinitionProvider: any
+        registerImplementationProvider: any
+    }
+} {
     // Configuration
     const getConfiguration = <C extends object>(): sourcegraph.Configuration<C> => {
         const snapshot = state.settings.value.final as Readonly<C>
@@ -39,11 +63,14 @@ export function createExtensionAPI(state: ExtensionHostState, mainAPI: Remote<Ma
         const configuration: sourcegraph.Configuration<C> & { toJSON: any } = {
             value: snapshot,
             get: key => snapshot[key],
-            update: (key, value) => mainAPI.applySettingsEdit({ path: [key as string | number], value }),
+            update: (key, value) => clientAPI.applySettingsEdit({ path: [key as string | number], value }),
             toJSON: () => snapshot,
         }
         return configuration
     }
+    const configuration: typeof sourcegraph['configuration'] = Object.assign(state.settings.pipe(mapTo(undefined)), {
+        get: getConfiguration,
+    })
 
     // Workspace
     const workspace: typeof sourcegraph['workspace'] = {
@@ -134,8 +161,8 @@ export function createExtensionAPI(state: ExtensionHostState, mainAPI: Remote<Ma
         },
 
         showProgress: options => createProgressReporter(options),
-        showMessage: message => mainAPI.showMessage(message),
-        showInputBox: options => mainAPI.showInputBox(options),
+        showMessage: message => clientAPI.showMessage(message),
+        showInputBox: options => clientAPI.showInputBox(options),
     }
 
     const app: typeof sourcegraph['app'] = {
@@ -209,13 +236,15 @@ export function createExtensionAPI(state: ExtensionHostState, mainAPI: Remote<Ma
         },
         createDecorationType,
         createStatusBarItemType,
+        // `log` is implemented on extension activation
+        log: noop,
     }
 
     // Commands
     const commands: typeof sourcegraph['commands'] = {
-        executeCommand: (command, ...args) => mainAPI.executeCommand(command, args),
+        executeCommand: (command, ...args) => clientAPI.executeCommand(command, args),
         registerCommand: (command, callback) =>
-            syncRemoteSubscription(mainAPI.registerCommand(command, proxy(callback))),
+            syncRemoteSubscription(clientAPI.registerCommand(command, proxy(callback))),
     }
 
     // Search
@@ -269,7 +298,7 @@ export function createExtensionAPI(state: ExtensionHostState, mainAPI: Remote<Ma
 
     // GraphQL
     const graphQL: typeof sourcegraph['graphQL'] = {
-        execute: (query, variables) => mainAPI.requestGraphQL(query, variables),
+        execute: (query, variables) => clientAPI.requestGraphQL(query, variables),
     }
 
     // Content
@@ -278,16 +307,47 @@ export function createExtensionAPI(state: ExtensionHostState, mainAPI: Remote<Ma
             addWithRollback(state.linkPreviewProviders, { urlMatchPattern, provider }),
     }
 
-    return {
-        configuration: Object.assign(state.settings.pipe(mapTo(undefined)), {
-            get: getConfiguration,
-        }),
-        workspace,
-        commands,
-        search,
-        languages,
-        graphQL,
-        content,
-        app,
+    // For debugging/tests.
+    const sync = async (): Promise<void> => {
+        await clientAPI.ping()
+    }
+
+    return function extensionAPIFactory(extensionID) {
+        return {
+            URI: URL,
+            Position,
+            Range,
+            Selection,
+            Location,
+            MarkupKind,
+            NotificationType,
+            DocumentHighlightKind,
+            app: {
+                ...app,
+                log: (...data) => {
+                    if (state.activeLoggers.has(extensionID)) {
+                        // Use a light gray background to differentiate extension ID from the message
+                        console.log(`🧩 %c${extensionID}`, 'background-color: lightgrey;', ...data)
+                    }
+                },
+            },
+
+            workspace,
+            configuration,
+
+            languages,
+
+            search,
+            commands,
+            graphQL,
+            content,
+
+            internal: {
+                sync: () => sync(),
+                updateContext: (updates: sourcegraph.ContextValues) => updateContext(updates, state),
+                sourcegraphURL: new URL(initData.sourcegraphURL),
+                clientApplication: initData.clientApplication,
+            },
+        }
     }
 }

--- a/client/shared/src/api/extension/extensionHostState.ts
+++ b/client/shared/src/api/extension/extensionHostState.ts
@@ -42,7 +42,7 @@ export function createExtensionHostState(
         // Most extensions never call `configuration.get()` synchronously in `activate()` to get
         // the initial settings data, and instead only subscribe to configuration changes.
         // In order for these extensions to be able to access settings, make sure `configuration` emits on subscription.
-        settings: new BehaviorSubject<Readonly<SettingsCascade<object>>>(initData.initialSettings),
+        settings: new BehaviorSubject<Readonly<SettingsCascade>>(initData.initialSettings),
 
         queryTransformers: new BehaviorSubject<readonly sourcegraph.QueryTransformer[]>([]),
 
@@ -100,6 +100,7 @@ export function createExtensionHostState(
         >([]),
 
         activeExtensions,
+        activeLoggers: new Set<string>(),
     }
 }
 
@@ -166,4 +167,7 @@ export interface ExtensionHostState {
 
     // Extensions
     activeExtensions: Observable<(ConfiguredExtension | ExecutableExtension)[]>
+
+    /** Set of names of active loggers determined by user settings */
+    activeLoggers: Set<string>
 }

--- a/client/shared/src/api/extension/test/activation.test.ts
+++ b/client/shared/src/api/extension/test/activation.test.ts
@@ -1,6 +1,7 @@
 import { BehaviorSubject } from 'rxjs'
 import { filter, first } from 'rxjs/operators'
 import sinon from 'sinon'
+import sourcegraph from 'sourcegraph'
 
 import { SettingsCascade } from '../../../settings/settings'
 import { MainThreadAPI } from '../../contract'
@@ -43,7 +44,15 @@ describe('Extension activation', () => {
             // Noop for activation and deactivation
             const noopPromise = () => Promise.resolve()
 
-            activateExtensions(mockState, mockMain, noopPromise, noopPromise)
+            activateExtensions(
+                mockState,
+                mockMain,
+                function createExtensionAPI() {
+                    return {} as typeof sourcegraph
+                },
+                noopPromise,
+                noopPromise
+            )
 
             // Wait for extensions to load to check on the spy
             await haveInitialExtensionsLoaded

--- a/client/shared/src/api/extension/test/extensionHost.configuration.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.configuration.test.ts
@@ -2,8 +2,8 @@ import { proxy } from 'comlink'
 import { BehaviorSubject } from 'rxjs'
 
 import { SettingsCascade } from '../../../settings/settings'
+import { ClientAPI } from '../../client/api/api'
 import { SettingsEdit } from '../../client/services/settings'
-import { MainThreadAPI } from '../../contract'
 import { pretendRemote } from '../../util'
 import { proxySubscribable } from '../api/common'
 
@@ -21,8 +21,9 @@ describe('ExtensionHost: Configuration', () => {
                 {
                     initialSettings: initialSettings({ a: 'a' }),
                     clientApplication: 'sourcegraph',
+                    sourcegraphURL: 'https://example.com/',
                 },
-                pretendRemote<MainThreadAPI>({
+                pretendRemote<ClientAPI>({
                     getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
@@ -40,8 +41,9 @@ describe('ExtensionHost: Configuration', () => {
                 {
                     initialSettings: initialSettings({ a: 'a' }),
                     clientApplication: 'sourcegraph',
+                    sourcegraphURL: 'https://example.com/',
                 },
-                pretendRemote<MainThreadAPI>({
+                pretendRemote<ClientAPI>({
                     getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
@@ -57,8 +59,9 @@ describe('ExtensionHost: Configuration', () => {
                 {
                     initialSettings: initialSettings({ a: 'a' }),
                     clientApplication: 'sourcegraph',
+                    sourcegraphURL: 'https://example.com/',
                 },
-                pretendRemote<MainThreadAPI>({
+                pretendRemote<ClientAPI>({
                     getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
@@ -76,8 +79,9 @@ describe('ExtensionHost: Configuration', () => {
                 {
                     initialSettings: initialSettings({ a: 'b' }),
                     clientApplication: 'sourcegraph',
+                    sourcegraphURL: 'https://example.com/',
                 },
-                pretendRemote<MainThreadAPI>({
+                pretendRemote<ClientAPI>({
                     getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                 })
@@ -98,8 +102,9 @@ describe('ExtensionHost: Configuration', () => {
                 {
                     initialSettings: initialSettings({ a: 'b' }),
                     clientApplication: 'sourcegraph',
+                    sourcegraphURL: 'https://example.com/',
                 },
-                pretendRemote<MainThreadAPI>({
+                pretendRemote<ClientAPI>({
                     getScriptURLForExtension: proxy(() => undefined),
                     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
                     applySettingsEdit: edit =>

--- a/client/shared/src/api/extension/test/extensionHost.decorations.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.decorations.test.ts
@@ -2,7 +2,7 @@ import { ProxyMarked, proxyMarker, Remote } from 'comlink'
 import { Observer, of } from 'rxjs'
 
 import { SettingsCascade } from '../../../settings/settings'
-import { MainThreadAPI } from '../../contract'
+import { ClientAPI } from '../../client/api/api'
 import { pretendProxySubscribable, pretendRemote } from '../../util'
 import { FileDecorationsByPath } from '../extensionHostApi'
 
@@ -10,7 +10,7 @@ import { initializeExtensionHostTest } from './test-helpers'
 
 describe('extensionHostAPI.getFileDecorations()', () => {
     // integration(ish) tests for scenarios not covered by providers tests
-    const noopMain = pretendRemote<MainThreadAPI>({
+    const noopMain = pretendRemote<ClientAPI>({
         getEnabledExtensions: () => pretendProxySubscribable(of([])),
         getScriptURLForExtension: () => undefined,
     })
@@ -34,6 +34,7 @@ describe('extensionHostAPI.getFileDecorations()', () => {
             {
                 initialSettings: emptySettings,
                 clientApplication: 'sourcegraph',
+                sourcegraphURL: 'https://example.com/',
             },
             noopMain
         )

--- a/client/shared/src/api/extension/test/extensionHost.documentHighlights.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.documentHighlights.test.ts
@@ -5,7 +5,7 @@ import { DocumentHighlight } from 'sourcegraph'
 import { Range } from '@sourcegraph/extension-api-classes'
 
 import { SettingsCascade } from '../../../settings/settings'
-import { MainThreadAPI } from '../../contract'
+import { ClientAPI } from '../../client/api/api'
 import { pretendRemote } from '../../util'
 import { proxySubscribable } from '../api/common'
 
@@ -13,7 +13,7 @@ import { initializeExtensionHostTest } from './test-helpers'
 
 describe('getDocumentHighlights from ExtensionHost API, it aims to have more e2e feel', () => {
     // integration(ish) tests for scenarios not covered by providers tests
-    const noopMain = pretendRemote<MainThreadAPI>({
+    const noopMain = pretendRemote<ClientAPI>({
         getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
         getScriptURLForExtension: () => undefined,
     })
@@ -40,7 +40,7 @@ describe('getDocumentHighlights from ExtensionHost API, it aims to have more e2e
         const typescriptFileUri = 'file:///f.ts'
 
         const { extensionHostAPI, extensionAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
 

--- a/client/shared/src/api/extension/test/extensionHost.hover.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.hover.test.ts
@@ -6,15 +6,15 @@ import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { MarkupKind } from '@sourcegraph/extension-api-classes'
 
 import { SettingsCascade } from '../../../settings/settings'
+import { ClientAPI } from '../../client/api/api'
 import { HoverMerged } from '../../client/types/hover'
-import { MainThreadAPI } from '../../contract'
 import { pretendProxySubscribable, pretendRemote } from '../../util'
 
 import { initializeExtensionHostTest } from './test-helpers'
 
 describe('getHover from ExtensionHost API, it aims to have more e2e feel', () => {
     // integration(ish) tests for scenarios not covered by providers tests
-    const noopMain = pretendRemote<MainThreadAPI>({
+    const noopMain = pretendRemote<ClientAPI>({
         getEnabledExtensions: () => pretendProxySubscribable(of([])),
         getScriptURLForExtension: () => undefined,
     })
@@ -41,7 +41,7 @@ describe('getHover from ExtensionHost API, it aims to have more e2e feel', () =>
         const typescriptFileUri = 'file:///f.ts'
 
         const { extensionHostAPI, extensionAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
 

--- a/client/shared/src/api/extension/test/extensionHost.logging.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.logging.test.ts
@@ -10,6 +10,7 @@ import { initializeExtensionHostTest } from './test-helpers'
 const noopMain = pretendRemote<ClientAPI>({
     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
     getScriptURLForExtension: () => undefined,
+    logExtensionMessage: (...data) => console.log(...data),
 })
 
 describe('Extension logging', () => {

--- a/client/shared/src/api/extension/test/extensionHost.logging.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.logging.test.ts
@@ -1,0 +1,74 @@
+import { BehaviorSubject } from 'rxjs'
+import sinon from 'sinon'
+
+import { ClientAPI } from '../../client/api/api'
+import { pretendRemote } from '../../util'
+import { proxySubscribable } from '../api/common'
+
+import { initializeExtensionHostTest } from './test-helpers'
+
+const noopMain = pretendRemote<ClientAPI>({
+    getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
+    getScriptURLForExtension: () => undefined,
+})
+
+describe('Extension logging', () => {
+    let spy: sinon.SinonSpy
+    beforeEach(() => {
+        spy = sinon.spy(console, 'log')
+    })
+
+    afterEach(() => {
+        spy.restore()
+    })
+
+    it('does not log when extension ID is absent from settings', () => {
+        const extensionID = 'test/extension'
+
+        const { extensionAPI } = initializeExtensionHostTest(
+            {
+                initialSettings: {
+                    subjects: [],
+                    final: {
+                        'extensions.activeLoggers': [],
+                    },
+                },
+                clientApplication: 'sourcegraph',
+                sourcegraphURL: 'https://example.com/',
+            },
+            noopMain,
+            extensionID
+        )
+
+        extensionAPI.app.log('message from extension')
+
+        sinon.assert.notCalled(spy)
+    })
+    it('prefixes logs with extension ID', () => {
+        const extensionID = 'test/extension'
+
+        const { extensionAPI } = initializeExtensionHostTest(
+            {
+                initialSettings: {
+                    subjects: [],
+                    final: {
+                        'extensions.activeLoggers': [extensionID],
+                    },
+                },
+                clientApplication: 'sourcegraph',
+                sourcegraphURL: 'https://example.com/',
+            },
+            noopMain,
+            extensionID
+        )
+
+        extensionAPI.app.log('message from extension')
+
+        sinon.assert.calledOnceWithExactly(
+            spy,
+            `🧩 %c${extensionID}`,
+            'background-color: lightgrey;',
+            'message from extension'
+        )
+    })
+})

--- a/client/shared/src/api/extension/test/extensionHost.search.test.ts
+++ b/client/shared/src/api/extension/test/extensionHost.search.test.ts
@@ -2,13 +2,13 @@ import { ProxyMarked, proxyMarker, Remote } from 'comlink'
 import { BehaviorSubject, Observer } from 'rxjs'
 
 import { SettingsCascade } from '../../../settings/settings'
-import { MainThreadAPI } from '../../contract'
+import { ClientAPI } from '../../client/api/api'
 import { pretendRemote } from '../../util'
 import { proxySubscribable } from '../api/common'
 
 import { initializeExtensionHostTest } from './test-helpers'
 
-const noopMain = pretendRemote<MainThreadAPI>({
+const noopMain = pretendRemote<ClientAPI>({
     getEnabledExtensions: () => proxySubscribable(new BehaviorSubject([])),
     getScriptURLForExtension: () => undefined,
 })
@@ -27,7 +27,7 @@ const observe = (onValue: (value: string) => void): Remote<Observer<string> & Pr
 describe('QueryTransformers', () => {
     it('returns the same query with no registered transformers', () => {
         const { extensionHostAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
 
@@ -38,7 +38,7 @@ describe('QueryTransformers', () => {
 
     it('can work with Promise based transformers', async () => {
         const { extensionHostAPI, extensionAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
         extensionAPI.search.registerQueryTransformer({ transformQuery: query => Promise.resolve(query + '!') })
@@ -50,7 +50,7 @@ describe('QueryTransformers', () => {
 
     it('emits a new transformed value if there is a new transformer', () => {
         const { extensionHostAPI, extensionAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
 
@@ -64,7 +64,7 @@ describe('QueryTransformers', () => {
 
     it('emits new value if a transformer was removed', () => {
         const { extensionHostAPI, extensionAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
 
@@ -82,7 +82,7 @@ describe('QueryTransformers', () => {
 
     it('emits modified query if there are any transformers registered', () => {
         const { extensionHostAPI, extensionAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
 
@@ -95,7 +95,7 @@ describe('QueryTransformers', () => {
 
     it('cancels previous transformer chains', async () => {
         const { extensionHostAPI, extensionAPI } = initializeExtensionHostTest(
-            { initialSettings, clientApplication: 'sourcegraph' },
+            { initialSettings, clientApplication: 'sourcegraph', sourcegraphURL: 'https://example.com/' },
             noopMain
         )
 

--- a/client/shared/src/api/extension/test/test-helpers.ts
+++ b/client/shared/src/api/extension/test/test-helpers.ts
@@ -1,20 +1,26 @@
 import { Remote } from 'comlink'
 
-import { FlatExtensionHostAPI, MainThreadAPI } from '../../contract'
+import { ClientAPI } from '../../client/api/api'
+import { FlatExtensionHostAPI } from '../../contract'
 import { pretendRemote } from '../../util'
-import { createExtensionAPI } from '../extensionApi'
+import { setActiveLoggers } from '../api/logging'
+import { createExtensionAPIFactory } from '../extensionApi'
 import { InitData } from '../extensionHost'
 import { createExtensionHostAPI } from '../extensionHostApi'
 import { createExtensionHostState } from '../extensionHostState'
 
 export function initializeExtensionHostTest(
-    initData: Pick<InitData, 'initialSettings' | 'clientApplication'>,
-    mockMainThreadAPI: Remote<MainThreadAPI> = pretendRemote<MainThreadAPI>({})
-): { extensionHostAPI: FlatExtensionHostAPI; extensionAPI: ReturnType<typeof createExtensionAPI> } {
+    initData: InitData,
+    mockMainThreadAPI: Remote<ClientAPI> = pretendRemote<ClientAPI>({}),
+    extensionID: string = 'TEST'
+): { extensionHostAPI: FlatExtensionHostAPI; extensionAPI: ReturnType<ReturnType<typeof createExtensionAPIFactory>> } {
     const extensionHostState = createExtensionHostState(initData, mockMainThreadAPI)
 
     const extensionHostAPI = createExtensionHostAPI(extensionHostState)
-    const extensionAPI = createExtensionAPI(extensionHostState, mockMainThreadAPI)
+    const extensionAPIFactory = createExtensionAPIFactory(extensionHostState, mockMainThreadAPI, initData)
+    const extensionAPI = extensionAPIFactory(extensionID)
+
+    setActiveLoggers(extensionHostState)
 
     return {
         extensionHostAPI,

--- a/client/shared/src/extensions/ExtensionStatus.scss
+++ b/client/shared/src/extensions/ExtensionStatus.scss
@@ -1,4 +1,0 @@
-.extension-status {
-    min-width: 24vw;
-    max-width: 50vw;
-}

--- a/client/shared/src/extensions/devtools/ActiveExtensionsPanel.tsx
+++ b/client/shared/src/extensions/devtools/ActiveExtensionsPanel.tsx
@@ -1,24 +1,17 @@
-import MenuUpIcon from 'mdi-react/MenuUpIcon'
 import React, { useCallback, useMemo } from 'react'
-import { UncontrolledPopover } from 'reactstrap'
 import { from } from 'rxjs'
 import { catchError, switchMap } from 'rxjs/operators'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
-import { wrapRemoteObservable } from '../api/client/api/common'
-import { Link } from '../components/Link'
-import { PlatformContextProps } from '../platform/context'
-import { asError, isErrorLike } from '../util/errors'
-import { useObservable } from '../util/useObservable'
+import { wrapRemoteObservable } from '../../api/client/api/common'
+import { Link } from '../../components/Link'
+import { asError, isErrorLike } from '../../util/errors'
+import { useObservable } from '../../util/useObservable'
 
-import { ExtensionsControllerProps } from './controller'
+import { ExtensionsDevelopmentToolsProps } from '.'
 
-interface Props extends ExtensionsControllerProps, PlatformContextProps<'sideloadedExtensionURL'> {
-    link: React.ComponentType<{ id: string }>
-}
-
-const ExtensionStatus: React.FunctionComponent<Props> = props => {
+export const ActiveExtensionsPanel: React.FunctionComponent<ExtensionsDevelopmentToolsProps> = props => {
     const extensionsOrError = useObservable(
         useMemo(
             () =>
@@ -44,7 +37,7 @@ const ExtensionStatus: React.FunctionComponent<Props> = props => {
     ])
 
     return (
-        <div className="extension-status card border-0">
+        <>
             <div className="card-header">Active extensions (DEBUG)</div>
             {extensionsOrError ? (
                 isErrorLike(extensionsOrError) ? (
@@ -110,23 +103,6 @@ const ExtensionStatus: React.FunctionComponent<Props> = props => {
                     </div>
                 )}
             </div>
-        </div>
+        </>
     )
 }
-
-/** A button that toggles the visibility of the ExtensionStatus element in a popover. */
-export const ExtensionStatusPopover = React.memo<Props>(props => (
-    <>
-        <button type="button" id="extension-status-popover" className="btn btn-link text-decoration-none px-2">
-            <span className="text-muted">Ext</span> <MenuUpIcon className="icon-inline" />
-        </button>
-        <UncontrolledPopover
-            placement="auto-end"
-            target="extension-status-popover"
-            hideArrow={true}
-            popperClassName="border-0"
-        >
-            <ExtensionStatus {...props} />
-        </UncontrolledPopover>
-    </>
-))

--- a/client/shared/src/extensions/devtools/index.scss
+++ b/client/shared/src/extensions/devtools/index.scss
@@ -1,0 +1,7 @@
+.extension-status {
+    min-width: 24vw;
+    max-width: 50vw;
+
+    min-height: 27rem; // avoid jitter when only loading indicator is shown
+    max-height: 70vh;
+}

--- a/client/shared/src/extensions/devtools/index.tsx
+++ b/client/shared/src/extensions/devtools/index.tsx
@@ -27,7 +27,6 @@ interface ExtensionDevelopmentToolsTab {
 
 const TABS: ExtensionDevelopmentToolsTab[] = [
     { id: 'activeExtensions', label: 'Active extensions', component: ActiveExtensionsPanel },
-    // TODO(tj): tabs: activeExtensions, logging (all known/enabled exts, not just active), sideloaded extensions
 ]
 
 const ExtensionDevelopmentTools: React.FunctionComponent<ExtensionsDevelopmentToolsProps> = props => {
@@ -58,7 +57,7 @@ const ExtensionDevelopmentTools: React.FunctionComponent<ExtensionsDevelopmentTo
 }
 
 /** A button that toggles the visibility of the ExtensionDevTools element in a popover. */
-export const ExtensionDevToolsPopover = React.memo<ExtensionsDevelopmentToolsProps>(props => (
+export const ExtensionDevelopmentToolsPopover = React.memo<ExtensionsDevelopmentToolsProps>(props => (
     <>
         <button type="button" id="extension-status-popover" className="btn btn-link text-decoration-none px-2">
             <span className="text-muted">Ext</span> <MenuUpIcon className="icon-inline" />
@@ -69,7 +68,6 @@ export const ExtensionDevToolsPopover = React.memo<ExtensionsDevelopmentToolsPro
             hideArrow={true}
             popperClassName="border-0 rounded-0"
         >
-            {/* TODO(tj): Error boundary */}
             <ExtensionDevelopmentTools {...props} />
         </UncontrolledPopover>
     </>

--- a/client/shared/src/extensions/devtools/index.tsx
+++ b/client/shared/src/extensions/devtools/index.tsx
@@ -1,0 +1,76 @@
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@reach/tabs'
+import MenuUpIcon from 'mdi-react/MenuUpIcon'
+import React, { useCallback } from 'react'
+import { UncontrolledPopover } from 'reactstrap'
+
+import { PlatformContextProps } from '../../platform/context'
+import { useLocalStorage } from '../../util/useLocalStorage'
+import { ExtensionsControllerProps } from '../controller'
+
+import { ActiveExtensionsPanel } from './ActiveExtensionsPanel'
+
+export interface ExtensionsDevelopmentToolsProps
+    extends ExtensionsControllerProps,
+        PlatformContextProps<'sideloadedExtensionURL' | 'settings'> {
+    link: React.ComponentType<{ id: string }>
+}
+
+const LAST_TAB_STORAGE_KEY = 'ExtensionDevTools.lastTab'
+
+type ExtensionDevelopmentToolsTabID = 'activeExtensions' | 'loggers'
+
+interface ExtensionDevelopmentToolsTab {
+    id: ExtensionDevelopmentToolsTabID
+    label: string
+    component: React.ComponentType<ExtensionsDevelopmentToolsProps>
+}
+
+const TABS: ExtensionDevelopmentToolsTab[] = [
+    { id: 'activeExtensions', label: 'Active extensions', component: ActiveExtensionsPanel },
+    // TODO(tj): tabs: activeExtensions, logging (all known/enabled exts, not just active), sideloaded extensions
+]
+
+const ExtensionDevelopmentTools: React.FunctionComponent<ExtensionsDevelopmentToolsProps> = props => {
+    const [tabIndex, setTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
+    const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
+
+    return (
+        <Tabs defaultIndex={tabIndex} className="extension-status card border-0 rounded-0" onChange={handleTabsChange}>
+            <div className="tablist-wrapper w-100 align-items-center">
+                <TabList>
+                    {TABS.map(({ label, id }) => (
+                        <Tab className="d-flex flex-1 justify-content-around" key={id} data-test-tab={id}>
+                            {label}
+                        </Tab>
+                    ))}
+                </TabList>
+            </div>
+
+            <TabPanels>
+                {TABS.map(tab => (
+                    <TabPanel key={tab.id}>
+                        <tab.component {...props} />
+                    </TabPanel>
+                ))}
+            </TabPanels>
+        </Tabs>
+    )
+}
+
+/** A button that toggles the visibility of the ExtensionDevTools element in a popover. */
+export const ExtensionDevToolsPopover = React.memo<ExtensionsDevelopmentToolsProps>(props => (
+    <>
+        <button type="button" id="extension-status-popover" className="btn btn-link text-decoration-none px-2">
+            <span className="text-muted">Ext</span> <MenuUpIcon className="icon-inline" />
+        </button>
+        <UncontrolledPopover
+            placement="auto-end"
+            target="extension-status-popover"
+            hideArrow={true}
+            popperClassName="border-0 rounded-0"
+        >
+            {/* TODO(tj): Error boundary */}
+            <ExtensionDevelopmentTools {...props} />
+        </UncontrolledPopover>
+    </>
+))

--- a/client/shared/src/index.scss
+++ b/client/shared/src/index.scss
@@ -9,7 +9,7 @@
 @import './components/Markdown';
 @import './components/Resizable';
 @import './components/ResultContainer';
-@import './extensions/ExtensionStatus';
+@import './extensions/devtools';
 @import './hover/HoverOverlay';
 @import './notifications/NotificationItem';
 @import './notifications/Notifications';

--- a/client/web/src/global/GlobalDebug.tsx
+++ b/client/web/src/global/GlobalDebug.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { Link } from 'react-router-dom'
 
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { ExtensionStatusPopover } from '@sourcegraph/shared/src/extensions/ExtensionStatus'
+import { ExtensionDevToolsPopover } from '@sourcegraph/shared/src/extensions/devtools'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 
 interface Props extends ExtensionsControllerProps, PlatformContextProps {}
@@ -20,7 +20,7 @@ export const GlobalDebug: React.FunctionComponent<Props> = props =>
     SHOW_DEBUG ? (
         <ul className="global-debug nav">
             <li className="nav-item">
-                <ExtensionStatusPopover
+                <ExtensionDevToolsPopover
                     link={ExtensionLink}
                     extensionsController={props.extensionsController}
                     platformContext={props.platformContext}

--- a/client/web/src/global/GlobalDebug.tsx
+++ b/client/web/src/global/GlobalDebug.tsx
@@ -1,16 +1,25 @@
+import * as H from 'history'
 import * as React from 'react'
 import { Link } from 'react-router-dom'
 
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
-import { ExtensionDevToolsPopover } from '@sourcegraph/shared/src/extensions/devtools'
+import { ExtensionDevelopmentToolsPopover } from '@sourcegraph/shared/src/extensions/devtools'
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 
-interface Props extends ExtensionsControllerProps, PlatformContextProps {}
+import { ErrorBoundary } from '../components/ErrorBoundary'
+
+interface Props extends ExtensionsControllerProps, PlatformContextProps {
+    location: H.Location
+}
 
 const SHOW_DEBUG = localStorage.getItem('debug') !== null
 
 const ExtensionLink: React.FunctionComponent<{ id: string }> = props => (
     <Link to={`/extensions/${props.id}`}>{props.id}</Link>
+)
+
+const ExtensionDevelopmentToolsError = (error: Error): JSX.Element => (
+    <span>Error rendering extension development tools: {error.message}</span>
 )
 
 /**
@@ -20,11 +29,13 @@ export const GlobalDebug: React.FunctionComponent<Props> = props =>
     SHOW_DEBUG ? (
         <ul className="global-debug nav">
             <li className="nav-item">
-                <ExtensionDevToolsPopover
-                    link={ExtensionLink}
-                    extensionsController={props.extensionsController}
-                    platformContext={props.platformContext}
-                />
+                <ErrorBoundary location={props.location} render={ExtensionDevelopmentToolsError}>
+                    <ExtensionDevelopmentToolsPopover
+                        link={ExtensionLink}
+                        extensionsController={props.extensionsController}
+                        platformContext={props.platformContext}
+                    />
+                </ErrorBoundary>
             </li>
         </ul>
     ) : null

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1237,6 +1237,8 @@ type Settings struct {
 	ExperimentalFeatures *SettingsExperimentalFeatures `json:"experimentalFeatures,omitempty"`
 	// Extensions description: The Sourcegraph extensions to use. Enable an extension by adding a property `"my/extension": true` (where `my/extension` is the extension ID). Override a previously enabled extension and disable it by setting its value to `false`.
 	Extensions map[string]bool `json:"extensions,omitempty"`
+	// ExtensionsActiveLoggers description: The Sourcegraph extensions, by ID (e.g. `my/extension`), whose logs should be visible in the console.
+	ExtensionsActiveLoggers []string `json:"extensions.activeLoggers,omitempty"`
 	// Insights description: EXPERIMENTAL: Code Insights
 	Insights                            []*Insight `json:"insights,omitempty"`
 	InsightsDisplayLocationDirectory    *bool      `json:"insights.displayLocation.directory,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -306,6 +306,13 @@
         "description": "`true` to enable the extension, `false` to disable the extension (if it was previously enabled)"
       }
     },
+    "extensions.activeLoggers": {
+      "description": "The Sourcegraph extensions, by ID (e.g. `my/extension`), whose logs should be visible in the console.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "codeHost.useNativeTooltips": {
       "description": "Whether to use the code host's native hover tooltips when they exist (GitHub's jump-to-definition tooltips, for example).",
       "type": "boolean",


### PR DESCRIPTION
# Sourcegraph extensions logging API

Add `sourcegraph.app.log` to the extension API. Logs are automatically prefixed with the extension's ID. Closes #9694.

![example log](https://user-images.githubusercontent.com/37420160/117433825-ebbc2d80-aef9-11eb-9210-66e15a6ab661.png)

## Purpose

Allow extensions to freely log to the console to assist with debugging customer issues, while allowing end users to easily hide/show logs from specific extensions through settings. 

## API

https://github.com/sourcegraph/sourcegraph/blob/98f6c7eed4400435be7c9af619f7c90fa938f4a4/client/extension-api/src/sourcegraph.d.ts#L1164-L1169

### Settings

https://github.com/sourcegraph/sourcegraph/blob/98f6c7eed4400435be7c9af619f7c90fa938f4a4/schema/settings.schema.json#L309-L315

## Implementation details

Previously, we only created one instance of the extension API that was shared between all extensions. We had no way of knowing which extension called a method. Now, during extension host bootstrapping, we create a factory function that closes over all API methods shared between all API instances. When an extension is activated, we replace `global.require` with a function that returns a fresh API instance (result of calling the factory function) that implements extension specific methods. For example, `sourcegraph.app.log` is created on extension activation to enable it to automatically prefix logs with extension ID. 

## Explored alternatives

- Allowing extensions to create multiple "loggers" with custom prefixes. We would have to deal with potential prefix collisions, along with potential UX issues regarding prefix changes and enabled logger settings. Automatically using the extension ID as the log prefix forces stability and is easier for extension authors to use (fewer naming decisions to make).
- Deep proxying the extension API. We don't need to intercept the vast majority of methods, so it's better to explicitly override when necessary.

## Questions for API consumers

- Would you like the ability to create multiple "loggers"/"channels" for more granular filtering, or is that something you'd be happy implementing on a per-extension basis (e.g. with extension settings)?