### PR TITLE
search: fall back to batch processing for search expressions

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1138,7 +1138,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				if test.name == "or statement merges file" || test.name == "select symbol" {
+				if test.name == "select symbol" {
 					t.Skip("streaming not supported yet")
 				}
 

--- a/internal/search/query/validate.go
+++ b/internal/search/query/validate.go
@@ -34,6 +34,32 @@ func IsPatternAtom(b Basic) bool {
 	return false
 }
 
+// IsStreamingCompatible returns whether a backend search process may
+// immediately send results over a streaming interface. A query is streaming
+// compatible if a streaming search engine component (like git-powered commit
+// search or Zoekt) may assume that it's processing just one logical search
+// expression which is not subject to additional merge/deduplication processing,
+// which are otherwise required by `and` and `or` expressions in the Sourcegraph
+// query evaluation routine. A single logical search expression is represented
+// by a single Basic query which contains either no pattern node, or a single
+// pattern node.
+func IsStreamingCompatible(p Plan) bool {
+	if len(p) == 1 {
+		if p[0].Pattern == nil {
+			return true
+		}
+		switch node := p[0].Pattern.(type) {
+		case Operator:
+			if len(node.Operands) == 1 {
+				return true
+			}
+		case Pattern:
+			return true
+		}
+	}
+	return false
+}
+
 // exists traverses every node in nodes and returns early as soon as fn is satisfied.
 func exists(nodes []Node, fn func(node Node) bool) bool {
 	found := false


### PR DESCRIPTION
Stacked on https://github.com/sourcegraph/sourcegraph/pull/20479.

Fixes https://github.com/sourcegraph/sourcegraph/issues/18203. This is the simple stopgap that disables streaming for complex search expressions. This while I work towards translating sourcegraph search expressions to a native representation for Zoekt, to allow streaming `and/or` expressions from Zoekt directly.