### PR TITLE
Add update API for search contexts

### DIFF
--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -603,6 +603,24 @@ type Mutation {
     (experimental) Delete search context.
     """
     deleteSearchContext(id: ID!): EmptyResponse!
+
+    """
+    (experimental) Update search context.
+    """
+    updateSearchContext(
+        """
+        Search context ID.
+        """
+        id: ID!
+        """
+        Search context input.
+        """
+        searchContext: SearchContextEditInput!
+        """
+        List of search context repository revisions.
+        """
+        repositories: [SearchContextRepositoryRevisionsInput!]!
+    ): SearchContext!
 }
 
 """
@@ -2464,6 +2482,31 @@ input SearchContextInput {
     Namespace of the search context (user or org). If not set, search context is considered instance-level.
     """
     namespace: ID
+}
+
+"""
+Input for editing an existing search context.
+"""
+input SearchContextEditInput {
+    """
+    Search context name. Not the same as the search context spec. Search context namespace and search context name
+    are used to construct the fully-qualified search context spec.
+    Example mappings from search context spec to search context name: global -> global, @user -> user, @org -> org,
+    @user/ctx1 -> ctx1, @org/ctxs/ctx -> ctxs/ctx.
+    """
+    name: String!
+    """
+    Search context description.
+    """
+    description: String!
+    """
+    Public property controls the visibility of the search context. Public search context is available to
+    any user on the instance. If a public search context contains private repositories, those are filtered out
+    for unauthorized users. Private search contexts are only available to their owners. Private user search context
+    is available only to the user, private org search context is available only to the members of the org, and private
+    instance-level search contexts are available only to site-admins.
+    """
+    public: Boolean!
 }
 
 """

--- a/cmd/frontend/internal/search/searchcontexts/search_contexts.go
+++ b/cmd/frontend/internal/search/searchcontexts/search_contexts.go
@@ -186,6 +186,38 @@ func CreateSearchContextWithRepositoryRevisions(ctx context.Context, db dbutil.D
 	return searchContext, nil
 }
 
+func UpdateSearchContextWithRepositoryRevisions(ctx context.Context, db dbutil.DB, searchContext *types.SearchContext, repositoryRevisions []*types.SearchContextRepositoryRevisions) (*types.SearchContext, error) {
+	if IsGlobalSearchContext(searchContext) {
+		return nil, errors.New("cannot update global search context")
+	}
+
+	err := validateSearchContextWriteAccessForCurrentUser(ctx, db, searchContext.NamespaceUserID, searchContext.NamespaceOrgID, searchContext.Public)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateSearchContextName(searchContext.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateSearchContextDescription(searchContext.Description)
+	if err != nil {
+		return nil, err
+	}
+
+	err = validateSearchContextRepositoryRevisions(repositoryRevisions)
+	if err != nil {
+		return nil, err
+	}
+
+	searchContext, err = database.SearchContexts(db).UpdateSearchContextWithRepositoryRevisions(ctx, searchContext, repositoryRevisions)
+	if err != nil {
+		return nil, err
+	}
+	return searchContext, nil
+}
+
 func DeleteSearchContext(ctx context.Context, db dbutil.DB, searchContext *types.SearchContext) error {
 	if IsAutoDefinedSearchContext(searchContext) {
 		return errors.New("cannot delete auto-defined search context")

--- a/internal/database/search_contexts_test.go
+++ b/internal/database/search_contexts_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -70,6 +71,75 @@ func TestSearchContexts_Get(t *testing.T) {
 			}
 			if !reflect.DeepEqual(tt.want, searchContext) {
 				t.Fatalf("wanted %v search contexts, got %v", tt.want, searchContext)
+			}
+		})
+	}
+}
+
+func TestSearchContexts_Update(t *testing.T) {
+	db := dbtesting.GetDB(t)
+	ctx := actor.WithInternalActor(context.Background())
+	u := Users(db)
+	o := Orgs(db)
+	sc := SearchContexts(db)
+
+	user, err := u.Create(ctx, NewUser{Username: "u", Password: "p"})
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+	displayName := "My Org"
+	org, err := o.Create(ctx, "myorg", &displayName)
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+
+	created, err := createSearchContexts(ctx, sc, []*types.SearchContext{
+		{Name: "instance", Description: "instance level", Public: true},
+		{Name: "user", Description: "user level", Public: true, NamespaceUserID: user.ID},
+		{Name: "org", Description: "org level", Public: true, NamespaceOrgID: org.ID},
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %s", err)
+	}
+
+	instanceSC := created[0]
+	userSC := created[1]
+	orgSC := created[2]
+
+	set := func(sc *types.SearchContext, f func(*types.SearchContext)) *types.SearchContext {
+		copied := *sc
+		f(&copied)
+		return &copied
+	}
+
+	tests := []struct {
+		name    string
+		updated *types.SearchContext
+		revs    []*types.SearchContextRepositoryRevisions
+	}{
+		{
+			name:    "update public",
+			updated: set(instanceSC, func(sc *types.SearchContext) { sc.Public = false }),
+		},
+		{
+			name:    "update description",
+			updated: set(userSC, func(sc *types.SearchContext) { sc.Description = "testdescription" }),
+		},
+		{
+			name:    "update name",
+			updated: set(orgSC, func(sc *types.SearchContext) { sc.Name = "testname" }),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			updated, err := sc.UpdateSearchContextWithRepositoryRevisions(ctx, tt.updated, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if diff := cmp.Diff(tt.updated, updated); diff != "" {
+				t.Fatalf("unexpected result: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Does not include an integration test because I think we could expand those in general, and it seems like that should go in a separate PR. 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
