### PR TITLE
Increase go test timeout to 5m

### DIFF
--- a/dev/ci/go-test.sh
+++ b/dev/ci/go-test.sh
@@ -24,7 +24,7 @@ find . -name go.mod -exec dirname '{}' \; | while read -r d; do
   go mod download
 
   echo "--- $d go test"
-  go test -timeout 4m -coverprofile=coverage.txt -covermode=atomic -race ./...
+  go test -timeout 5m -coverprofile=coverage.txt -covermode=atomic -race ./...
 
   popd >/dev/null
 done


### PR DESCRIPTION
There's been a couple of CI runs recently that exceeded the 4min threshold, given that we constantly add new tests, I think this is the right thing to do. (Of course we can and should invest in making the existing tests faster, but this should fix it for the time being).

