### PR TITLE
authtest: to be run within backend integration test suite

### DIFF
--- a/dev/authtest/code_intel_test.go
+++ b/dev/authtest/code_intel_test.go
@@ -3,7 +3,6 @@ package authtest
 import (
 	"bytes"
 	"io"
-	"net/http"
 	"testing"
 	"time"
 
@@ -121,8 +120,8 @@ func TestCodeIntelEndpoints(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode != http.StatusUnauthorized {
-			t.Fatalf(`Want status code %d error but got %d`, http.StatusUnauthorized, resp.StatusCode)
+		if resp.StatusCode/100 != 4 {
+			t.Fatalf(`Want status code 4xx error but got %d`, resp.StatusCode)
 		}
 	})
 }

--- a/dev/authtest/repository_test.go
+++ b/dev/authtest/repository_test.go
@@ -28,8 +28,9 @@ func TestRepository(t *testing.T) {
 						"sgtest/go-diff",
 						"sgtest/private", // Private
 					},
-					Token: *githubToken,
-					Url:   "https://github.com/",
+					RepositoryPathPattern: "github.com/{nameWithOwner}",
+					Token:                 *githubToken,
+					Url:                   "https://ghe.sgdev.org/",
 				},
 			),
 		},

--- a/dev/authtest/repository_test.go
+++ b/dev/authtest/repository_test.go
@@ -54,6 +54,16 @@ func TestRepository(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Proactively schedule a permissions syncing.
+	repo, err := client.Repository(privateRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.ScheduleRepositoryPermissionsSync(repo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// Wait up to 30 seconds for the private repository to have permissions synced
 	// from the code host at least once.
 	err = gqltestutil.Retry(30*time.Second, func() error {
@@ -68,7 +78,7 @@ func TestRepository(t *testing.T) {
 		return gqltestutil.ErrContinueRetry
 	})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("Waiting for repository permissions to be synced:", err)
 	}
 
 	// Create a test user (authtest-user-repository) which is not a site admin, the

--- a/dev/authtest/repository_test.go
+++ b/dev/authtest/repository_test.go
@@ -62,7 +62,7 @@ func TestRepository(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !permsInfo.SyncedAt.IsZero() {
+		if permsInfo != nil && !permsInfo.SyncedAt.IsZero() {
 			return nil
 		}
 		return gqltestutil.ErrContinueRetry

--- a/dev/authtest/site_admin_test.go
+++ b/dev/authtest/site_admin_test.go
@@ -92,69 +92,6 @@ mutation {
 	}
 }`,
 			}, {
-				name: "dotcom.productLicenses",
-				query: `
-{
-	dotcom {
-		productLicenses {
-			__typename
-		}
-	}
-}`,
-			}, {
-				name: "dotcom.createProductSubscription",
-				query: `
-mutation {
-	dotcom {
-		createProductSubscription(accountID: "VXNlcjox") {
-			id
-		}
-	}
-}`,
-			}, {
-				name: "dotcom.setProductSubscriptionBilling",
-				query: `
-mutation {
-	dotcom {
-		setProductSubscriptionBilling(id: "VXNlcjox") {
-			alwaysNil
-		}
-	}
-}`,
-			}, {
-				name: "dotcom.archiveProductSubscription",
-				query: `
-mutation {
-	dotcom {
-		archiveProductSubscription(id: "VXNlcjox") {
-			alwaysNil
-		}
-	}
-}`,
-			}, {
-				name: "dotcom.generateProductLicenseForSubscription",
-				query: `
-mutation {
-	dotcom {
-		generateProductLicenseForSubscription(
-			productSubscriptionID: "UHJvZHVjdFN1YnNjcmlwdGlvbjox"
-			license: {tags: [], userCount: 1, expiresAt: 1}
-		) {
-			id
-		}
-	}
-}`,
-			}, {
-				name: "dotcom.setUserBilling",
-				query: `
-mutation {
-	dotcom {
-		setUserBilling(user: "VXNlcjox", billingCustomerID: "404") {
-			alwaysNil
-		}
-	}
-}`,
-			}, {
 				name: "updateMirrorRepository",
 				query: `
 mutation {
@@ -426,6 +363,75 @@ mutation {
 	}
 }
 `,
+				},
+				gqlTest{
+					name: "dotcom.productLicenses",
+					query: `
+{
+	dotcom {
+		productLicenses {
+			__typename
+		}
+	}
+}`,
+				},
+				gqlTest{
+					name: "dotcom.createProductSubscription",
+					query: `
+mutation {
+	dotcom {
+		createProductSubscription(accountID: "VXNlcjox") {
+			id
+		}
+	}
+}`,
+				},
+				gqlTest{
+					name: "dotcom.setProductSubscriptionBilling",
+					query: `
+mutation {
+	dotcom {
+		setProductSubscriptionBilling(id: "VXNlcjox") {
+			alwaysNil
+		}
+	}
+}`,
+				},
+				gqlTest{
+					name: "dotcom.archiveProductSubscription",
+					query: `
+mutation {
+	dotcom {
+		archiveProductSubscription(id: "VXNlcjox") {
+			alwaysNil
+		}
+	}
+}`,
+				},
+				gqlTest{
+					name: "dotcom.generateProductLicenseForSubscription",
+					query: `
+mutation {
+	dotcom {
+		generateProductLicenseForSubscription(
+			productSubscriptionID: "UHJvZHVjdFN1YnNjcmlwdGlvbjox"
+			license: {tags: [], userCount: 1, expiresAt: 1}
+		) {
+			id
+		}
+	}
+}`,
+				},
+				gqlTest{
+					name: "dotcom.setUserBilling",
+					query: `
+mutation {
+	dotcom {
+		setUserBilling(user: "VXNlcjox", billingCustomerID: "404") {
+			alwaysNil
+		}
+	}
+}`,
 				},
 			)
 		}

--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -65,3 +65,6 @@ echo "Waiting for $URL... done"
 
 echo '--- go test ./dev/gqltest -long'
 go test ./dev/gqltest -long
+
+echo '--- go test ./dev/authtest -long'
+go test ./dev/authtest -long -email "gqltest@sourcegraph.com" -username "gqltest-admin"

--- a/dev/ci/backend-integration.sh
+++ b/dev/ci/backend-integration.sh
@@ -66,5 +66,8 @@ echo "Waiting for $URL... done"
 echo '--- go test ./dev/gqltest -long'
 go test ./dev/gqltest -long
 
+echo '--- sleep 5s to wait for site configuration to be restored from gqltest'
+sleep 5
+
 echo '--- go test ./dev/authtest -long'
 go test ./dev/authtest -long -email "gqltest@sourcegraph.com" -username "gqltest-admin"

--- a/internal/gqltestutil/client.go
+++ b/internal/gqltestutil/client.go
@@ -246,7 +246,7 @@ func (c *Client) GraphQL(token, query string, variables map[string]interface{}, 
 		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
 	} else {
 		// NOTE: We use this header to protect from CSRF attacks of HTTP API,
-		// see https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/cli/http.go#L41-42
+		// see https://sourcegraph.com/github.com/sourcegraph/sourcegraph@0cf1f0ca7f64e44728ab122e3f7562da7b6b5042/-/blob/cmd/frontend/internal/cli/http.go#L41-42
 		req.Header.Set("X-Requested-With", "Sourcegraph")
 		req.AddCookie(c.csrfCookie)
 		req.AddCookie(c.sessionCookie)

--- a/internal/gqltestutil/permissions.go
+++ b/internal/gqltestutil/permissions.go
@@ -1,0 +1,23 @@
+package gqltestutil
+
+import "github.com/pkg/errors"
+
+// ScheduleRepositoryPermissionsSync schedules a permissions syncing request for
+// the given repository.
+func (c *Client) ScheduleRepositoryPermissionsSync(id string) error {
+	const query = `
+mutation ScheduleRepositoryPermissionsSync($repository: ID!) {
+	scheduleRepositoryPermissionsSync(repository: $repository) {
+		alwaysNil
+	}
+}
+`
+	variables := map[string]interface{}{
+		"repository": id,
+	}
+	err := c.GraphQL("", query, variables, nil)
+	if err != nil {
+		return errors.Wrap(err, "request GraphQL")
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds authtest suite to be ran after the gqltest within our current backend integration test suite.

The `sleep 5` exists because 1) this is temporarily stop-gap and 2) our site config change is eventually consistent and we need to wait (for changes to be restored from gqltest side effects).

_This is not a complete solution to close <no> #19763 but I think this is a good stop-gap to wrap up RFC 266 for the June 4th launch._