### PR TITLE
Use pre-exisitng env var

### DIFF
--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -273,8 +273,8 @@ describe('e2e test suite', () => {
 
         const awsAccessKeyID = process.env.AWS_ACCESS_KEY_ID
         const awsSecretAccessKey = process.env.AWS_SECRET_ACCESS_KEY
-        const awsCodeCommitUsername = process.env.AWS_CODE_COMMIT_GIT_USERNAME
-        const awsCodeCommitPassword = process.env.AWS_CODE_COMMIT_GIT_PASSWORD
+        const awsCodeCommitUsername = process.env.AWS_CODE_COMMIT_USERNAME
+        const awsCodeCommitPassword = process.env.AWS_CODE_COMMIT_PASSWORD
 
         const testIfAwsCredentialsSet =
             awsSecretAccessKey && awsAccessKeyID && awsCodeCommitUsername && awsCodeCommitPassword


### PR DESCRIPTION
We have several AWS env vars, this standardizes it

https://k8s.sgdev.org/search?q=context:global+AWS_CODE_COMMIT_GIT_PASSWORD&patternType=literal
https://k8s.sgdev.org/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+AWS_CODE_COMMIT_USERNAME&patternType=literal

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
