### PR TITLE
info on archived for repositoryQuery

### DIFF
--- a/doc/admin/external_service/github.md
+++ b/doc/admin/external_service/github.md
@@ -116,6 +116,27 @@ When the search rate limit quota is exhausted, an error like `failed to list Git
 
 `repositoryQuery` is the only repo syncing method that consumes GitHub search API quota, so if setting `repoListUpdateInterval` doesn't work consider switching your synching method to use another option, like `orgs`, or using one of the special values described above.
 
+### "repositoryQuery": ["public"] does not return archieved status of a repo
+
+The  `repositoryQuery` option `"public"` is valuable in that it allows sourcegraph to sync all public repositories, however, it does not return whether or not a repo is archived. This can result in archieved repos appearing in normal search. You can see an example of what is returned by the GitHub API for a query to "public" [here](https://docs.github.com/en/rest/reference/repos#list-public-repositories).
+
+If you would like to sync all public repositories while omitting archived repos, consider generating a GitHub token with access to only public repositories, then use `respositoryQuery` with option `affiliated` and an `exclude` argument with option `public` as seen in the example below:
+```
+{
+    "url": "https://github.example.com",
+    "gitURLType": "http",
+    "repositoryPathPattern": "devs/{nameWithOwner}",
+    "repositoryQuery": [
+        "affiliated"
+    ],
+    "token": "TOKEN_WITH_PUBLIC_ACCESS",
+    "exclude": [
+        {
+            "archived": true
+        }
+    ]
+}
+```
 ### repositoryQuery returns first 1000 results only
 
 GitHub's [Search API](https://developer.github.com/v3/search/) only returns the first 1000 results. Therefore a `repositoryQuery` (other than the three pre-defined options) needs to return a 1000 results or less otherwise Sourcegraph will not synchronize some repositories. To workaround this limitation you can split your query into multiple queries, each returning less than a 1000 results. For example if your query is `org:Microsoft fork:no` you can adjust your query to:


### PR DESCRIPTION
This is to address the bug where archived repos are displayed in regular search via the synching method repositoryQuery Public



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
