### PR TITLE
Fix panic when highlighting commits with multiple trailing newlines

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -522,11 +522,22 @@ func (r *DiffHunk) Highlight(ctx context.Context, args *HighlightArgs) (*highlig
 	if err != nil {
 		return nil, err
 	}
+
 	hunkLines := strings.Split(string(r.hunk.Body), "\n")
+
 	// Remove final empty line on files that end with a newline, as most code hosts do.
 	if hunkLines[len(hunkLines)-1] == "" {
 		hunkLines = hunkLines[:len(hunkLines)-1]
 	}
+
+	// Trim a trailing empty line to match the behavior of highlight.Code
+	// If this isn't done, it causes the length of highlightedHead to be
+	// different than the length of hunkLines, which leads to out-of-bounds
+	// errors like https://github.com/sourcegraph/sourcegraph/issues/20405
+	if hunkLines[len(hunkLines)-1] == "+" {
+		hunkLines = hunkLines[:len(hunkLines)-1]
+	}
+
 	highlightedDiffHunkLineResolvers := make([]*highlightedDiffHunkLineResolver, len(hunkLines))
 	// Lines in highlightedBase and highlightedHead are 0-indexed.
 	baseLine := r.hunk.OrigStartLine - 1


### PR DESCRIPTION
We were hitting a panic when highlighting commits that have multiple
trailing newlines because gosyntect.Code trims a trailing empty line
before highlighting, but the diff parsing does not. This would lead to
out-of-bounds panics when attempting to get the line that matches the
diff line.

See [here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/highlight/highlight.go?subtree=true#L137-145) for the related code. 

Fixes #20405 for real. I'd found another case that could panic that was
caused by the new CSS highlighting changes, so I thought that's what
was causing #20405, but it turns out this issue was completely unrelated
to the CSS highlighting changes. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
