### PR TITLE
web: add new info, warning, danger colors for notices and alerts

### DIFF
--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -66,22 +66,30 @@ $theme-colors-redesign: (
 
 .theme-light.theme-redesign {
     --primary-2: #a3d0ff;
+    --primary-4: #e1f0ff;
     --secondary: #{$redesign-gray-04};
     --secondary-2: #eef1f7;
     --secondary-3: #c6cfe1;
+    --secondary-4: #f1f4f9;
     --success-3: #319e44;
+    --success-4: #ebfaee;
     --info-2: #a8dbe2;
     --info-3: #0bb3ca;
+    --info-4: #eafafc;
     --warning-3: #e09200;
+    --warning-4: #fff7e1;
     --danger-3: #b52626;
+    --danger-4: #fbeaea;
     --body-color: #{$redesign-gray-08};
     --body-bg: #{$redesign-gray-01};
     --color-bg-1: #{$white};
     --color-bg-2: #{$redesign-gray-03};
     --color-bg-3: #{$redesign-gray-04};
     --mark-bg: rgba(255, 218, 30, 0.5);
+    --merged-4: #eee9fd;
     --text-muted: #{$redesign-gray-07};
     --link-color: var(--primary);
+    --link-color-2: #0766cc;
     --link-active-color: #0c7bf0;
     --link-hover-color: #0c7bf0;
     --border-color: #{$redesign-gray-03};
@@ -105,22 +113,30 @@ $theme-colors-redesign: (
 
 .theme-dark.theme-redesign {
     --primary-2: #0f59aa;
+    --primary-4: #03284f;
     --secondary: #{$redesign-gray-08};
     --secondary-2: #242936;
     --secondary-3: #1f232e;
+    --secondary-4: #545967;
     --success-3: #237332;
+    --success-4: #054410;
     --info-2: #b8e3e8;
     --info-3: #005766;
+    --info-4: #025762;
     --warning-3: #9c6500;
+    --warning-4: #3d2904;
     --danger-3: #801b1b;
+    --danger-4: #3d0a0a;
     --body-color: #{$redesign-gray-04};
     --body-bg: #{$redesign-gray-12};
     --color-bg-1: #{$redesign-gray-11};
     --color-bg-2: #{$redesign-gray-10};
     --color-bg-3: #{$redesign-gray-08};
     --mark-bg: rgba(16, 104, 2, 0.5);
+    --merged-4: #1f0a5c;
     --text-muted: #{$redesign-gray-05};
     --link-color: #4393e7;
+    --link-color-2: #70b0f3;
     --link-active-color: #489ffa;
     --link-hover-color: #489ffa;
     --border-color: #{$redesign-gray-09};


### PR DESCRIPTION
Add new info, warning, danger colors required for [notices, and alerts redesign update](#19662).

Closes #20233.