### PR TITLE
search: prevent possible nil panic in results

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -849,10 +849,12 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 		endpoint := r.stream
 		r.stream = nil // Disables streaming: backends may not use the endpoint.
 		srr, err := r.resultsBatch(ctx)
-		endpoint.Send(SearchEvent{
-			Results: srr.SearchResults,
-			Stats:   srr.Stats,
-		})
+		if srr != nil {
+			endpoint.Send(SearchEvent{
+				Results: srr.SearchResults,
+				Stats:   srr.Stats,
+			})
+		}
 		return srr, err
 	}
 	return r.resultsRecursive(ctx, r.Plan)


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/20480 introduced this code: https://github.com/sourcegraph/sourcegraph/blob/f6c4d3a59037250e7b3e57fb075553b985e49374/cmd/frontend/graphqlbackend/search_results.go#L851-L856

But `srr` can be nil on l853. A rare case in our logic requires triggering it, based on https://github.com/sourcegraph/sourcegraph/pull/20479#issuecomment-829027025. I'm not sure how, I will investigate our call stack tomorrow. This is a defensive change to prevent any nil deref here.

