### PR TITLE
Revert "codeintel: Re-enable TestCommittedAtMigratorUnknownCommits (#…

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at.go
@@ -94,7 +94,6 @@ SELECT repository_id, commit
 FROM lsif_uploads
 WHERE state = 'completed' AND committed_at IS NULL
 GROUP BY repository_id, commit
-ORDER BY repository_id, commit
 LIMIT %s
 `
 

--- a/enterprise/internal/codeintel/stores/dbstore/migration/committed_at_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/migration/committed_at_test.go
@@ -207,9 +207,11 @@ func TestCommittedAtMigratorUnknownRepository(t *testing.T) {
 }
 
 func TestCommittedAtMigratorUnknownCommits(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	// if testing.Short() {
+	// TODO: This test was broken on main, to unblock CI, it has been disabled
+	// here: https://github.com/sourcegraph/sourcegraph/pull/20489.
+	t.Skip()
+	// }
 	dbtesting.SetupGlobalTestDB(t)
 	store := dbstore.NewWithDB(dbconn.Global, &observation.TestContext)
 	gitserverClient := NewMockGitserverClient()


### PR DESCRIPTION
…20517)"

This reverts commit 32d85ba8fcc94ee2543e7471ec34ac680c1e18a5.

This test is still flaky in CI, so enabling as requested by @efritz .