### PR TITLE
search frontend: don't warn about invalid languages when they're supported

### DIFF
--- a/client/shared/src/search/query/filters.ts
+++ b/client/shared/src/search/query/filters.ts
@@ -395,6 +395,12 @@ export const validateFilter = (
         // account for finite discrete values and exemption of checks.
         return { valid: true }
     }
+    if (typeAndDefinition.type === FilterType.lang) {
+        // Lang filter is exempt because our discrete completion values are only a subset of all valid
+        // language values, which are captured by a Go library. The backend takes care of returning an
+        // alert for invalid values.
+        return { valid: true }
+    }
     const { definition } = typeAndDefinition
     if (definition.discreteValues && (!value || !isValidDiscreteValue(definition, value, value.value))) {
         return {


### PR DESCRIPTION
We support a ton of languages to filter by file, but will warn if that language is not in a very small set of supported languages. Super misleading. This gets rid of the red squiggles on the `lang` filter--the backend will tell users if a language happens to not be supported.

<img width="562" alt="Screen Shot 2021-04-29 at 4 19 04 PM" src="https://user-images.githubusercontent.com/888624/116629692-a3ec4380-a906-11eb-8c8b-e18b2cb7ab79.png">

Closes https://github.com/sourcegraph/sourcegraph/issues/10148

Now, we simply won't show any squiggles:

<img width="98" alt="Screen Shot 2021-04-29 at 4 24 34 PM" src="https://user-images.githubusercontent.com/888624/116630049-6936db00-a907-11eb-8763-699ab931a0a6.png">


No test because I think this was an oversight in introducing too strict validation for our static suggestions.