### PR TITLE
FileMatch URL refactor

### DIFF
--- a/cmd/frontend/graphqlbackend/result_deduper.go
+++ b/cmd/frontend/graphqlbackend/result_deduper.go
@@ -1,71 +1,73 @@
 package graphqlbackend
 
+import "github.com/sourcegraph/sourcegraph/internal/search/result"
+
 type searchResultDeduper struct {
-	seenFileMatches   map[string]*FileMatchResolver
-	seenRepoMatches   map[string]*RepositoryResolver
-	seenCommitMatches map[string]*CommitSearchResultResolver
-	seenDiffMatches   map[string]*CommitSearchResultResolver
+	seenFileMatches   map[result.Key]*FileMatchResolver
+	seenRepoMatches   map[result.Key]*RepositoryResolver
+	seenCommitMatches map[result.Key]*CommitSearchResultResolver
+	seenDiffMatches   map[result.Key]*CommitSearchResultResolver
 }
 
 func NewDeduper() *searchResultDeduper {
 	return &searchResultDeduper{
-		seenFileMatches:   make(map[string]*FileMatchResolver),
-		seenRepoMatches:   make(map[string]*RepositoryResolver),
-		seenCommitMatches: make(map[string]*CommitSearchResultResolver),
-		seenDiffMatches:   make(map[string]*CommitSearchResultResolver),
+		seenFileMatches:   make(map[result.Key]*FileMatchResolver),
+		seenRepoMatches:   make(map[result.Key]*RepositoryResolver),
+		seenCommitMatches: make(map[result.Key]*CommitSearchResultResolver),
+		seenDiffMatches:   make(map[result.Key]*CommitSearchResultResolver),
 	}
 }
 
 // Add adds a SearchResultResolver to the deduper, merging it into
-// a previously added SearchResultResolver if the URL has already been seen
+// a previously added SearchResultResolver if the result key has already been seen
 func (d *searchResultDeduper) Add(r SearchResultResolver) {
 	if fileMatch, ok := r.ToFileMatch(); ok {
-		if prev, seen := d.seenFileMatches[fileMatch.URL()]; seen {
+		if prev, seen := d.seenFileMatches[fileMatch.FileMatch.Key()]; seen {
 			prev.appendMatches(fileMatch)
 			return
 		}
-		d.seenFileMatches[fileMatch.URL()] = fileMatch
+		d.seenFileMatches[fileMatch.FileMatch.Key()] = fileMatch
 		return
 	}
 
 	if repoMatch, ok := r.ToRepository(); ok {
-		if _, seen := d.seenRepoMatches[repoMatch.URL()]; seen {
+		if _, seen := d.seenRepoMatches[repoMatch.Key()]; seen {
 			return
 		}
-		d.seenRepoMatches[repoMatch.URL()] = repoMatch
+		d.seenRepoMatches[repoMatch.Key()] = repoMatch
 		return
 	}
 
 	if commitMatch, ok := r.ToCommitSearchResult(); ok {
 		if commitMatch.DiffPreview() != nil {
-			if _, seen := d.seenDiffMatches[commitMatch.URL()]; seen {
+			if _, seen := d.seenDiffMatches[commitMatch.Key()]; seen {
 				return
 			}
-			d.seenDiffMatches[commitMatch.URL()] = commitMatch
+			d.seenDiffMatches[commitMatch.Key()] = commitMatch
 			return
 		}
 
-		if _, seen := d.seenCommitMatches[commitMatch.URL()]; seen {
+		if _, seen := d.seenCommitMatches[commitMatch.Key()]; seen {
 			return
 		}
-		d.seenCommitMatches[commitMatch.URL()] = commitMatch
+		d.seenCommitMatches[commitMatch.Key()] = commitMatch
 		return
 	}
 }
 
-// Seen returns whether the given url exists for a file type in the deduper without
+// Seen returns whether the given result key exists for a file type in the deduper without
 // modifying the contents of the deduper
 func (d *searchResultDeduper) Seen(r SearchResultResolver) (ok bool) {
 	switch v := r.(type) {
 	case *FileMatchResolver:
-		_, ok = d.seenFileMatches[v.URL()]
+		_, ok = d.seenFileMatches[v.FileMatch.Key()]
 	case *RepositoryResolver:
-		_, ok = d.seenRepoMatches[v.URL()]
+		_, ok = d.seenRepoMatches[v.Key()]
 	case *CommitSearchResultResolver:
 		if v.DiffPreview() != nil {
-			_, ok = d.seenDiffMatches[v.URL()]
+			_, ok = d.seenDiffMatches[v.Key()]
 		} else {
-			_, ok = d.seenCommitMatches[v.URL()]
+			_, ok = d.seenCommitMatches[v.Key()]
 		}
 	}
 

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -268,7 +268,7 @@ func paginatedSearchFilesInRepos(ctx context.Context, db dbutil.DB, args *search
 		// fileResults is not sorted so we must sort it now. fileCommon may or
 		// may not be sorted, but we do not rely on its order.
 		sort.Slice(fileResults, func(i, j int) bool {
-			return fileResults[i].URL() < fileResults[j].URL()
+			return fileResults[i].FileMatch.Key().Less(fileResults[j].FileMatch.Key())
 		})
 		results := make([]SearchResultResolver, 0, len(fileResults))
 		for _, r := range fileResults {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -520,10 +520,10 @@ func union(left, right *SearchResultsResolver) *SearchResultsResolver {
 // intersectMerge performs a merge of file match results, merging line matches
 // for files contained in both result sets, and updating counts.
 func intersectMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
-	rightFileMatches := make(map[string]*FileMatchResolver)
+	rightFileMatches := make(map[result.Key]*FileMatchResolver)
 	for _, r := range right.SearchResults {
 		if fileMatch, ok := r.ToFileMatch(); ok {
-			rightFileMatches[fileMatch.URL()] = fileMatch
+			rightFileMatches[fileMatch.FileMatch.Key()] = fileMatch
 		}
 	}
 
@@ -534,7 +534,7 @@ func intersectMerge(left, right *SearchResultsResolver) *SearchResultsResolver {
 			continue
 		}
 
-		rightFileMatch := rightFileMatches[leftFileMatch.URL()]
+		rightFileMatch := rightFileMatches[leftFileMatch.FileMatch.Key()]
 		if rightFileMatch == nil {
 			continue
 		}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -48,7 +48,7 @@ func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 }
 
 func (fm *FileMatchResolver) Key() string {
-	return fmt.Sprintf("%#v", fm.Key())
+	return fmt.Sprintf("%#v", fm.FileMatch.Key())
 }
 
 func (fm *FileMatchResolver) File() *GitTreeEntryResolver {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -48,7 +48,7 @@ func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 }
 
 func (fm *FileMatchResolver) Key() string {
-	return fm.URL()
+	return fmt.Sprintf("%#v", fm.Key())
 }
 
 func (fm *FileMatchResolver) File() *GitTreeEntryResolver {

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -229,7 +229,7 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 			return []result.FileMatch{{
 				File: result.File{
 					Repo:     repo,
-					InputRev: &rev,
+					CommitID: api.CommitID(rev),
 					Path:     "main.go",
 				},
 			}}, false, nil
@@ -270,20 +270,20 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resultURIs := make([]string, len(results))
+	resultKeys := make([]result.Key, len(results))
 	for i, result := range results {
-		resultURIs[i] = result.URL()
+		resultKeys[i] = result.FileMatch.Key()
 	}
-	sort.Strings(resultURIs)
+	sort.Slice(resultKeys, func(i, j int) bool { return resultKeys[i].Less(resultKeys[j]) })
 
-	wantResultURIs := []string{
-		"git://foo?branch3#main.go",
-		"git://foo?branch4#main.go",
-		"git://foo?master#main.go",
-		"git://foo?mybranch#main.go",
+	wantResultKeys := []result.Key{
+		{Repo: "foo", Commit: "branch3", Path: "main.go"},
+		{Repo: "foo", Commit: "branch4", Path: "main.go"},
+		{Repo: "foo", Commit: "master", Path: "main.go"},
+		{Repo: "foo", Commit: "mybranch", Path: "main.go"},
 	}
-	if !reflect.DeepEqual(resultURIs, wantResultURIs) {
-		t.Errorf("got %v, want %v", resultURIs, wantResultURIs)
+	if !reflect.DeepEqual(resultKeys, wantResultKeys) {
+		t.Errorf("got %v, want %v", resultKeys, wantResultKeys)
 	}
 }
 

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -67,6 +67,19 @@ func (r *CommitMatch) Select(path filter.SelectPath) Match {
 	return nil
 }
 
+// Key implements Match interface's Key() method
+func (r *CommitMatch) Key() Key {
+	typeRank := 1
+	if r.DiffPreview != nil {
+		typeRank = 2
+	}
+	return Key{
+		TypeRank: typeRank,
+		Repo:     string(r.RepoName.Name),
+		Commit:   string(r.Commit.ID),
+	}
+}
+
 // selectModifiedLines extracts the highlight ranges that correspond to lines
 // that have a `+` or `-` prefix (corresponding to additions resp. removals).
 func selectModifiedLines(lines []string, highlights []HighlightedRange, prefix string, offset int32) []HighlightedRange {

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -69,9 +69,9 @@ func (r *CommitMatch) Select(path filter.SelectPath) Match {
 
 // Key implements Match interface's Key() method
 func (r *CommitMatch) Key() Key {
-	typeRank := CommitMatchRank
+	typeRank := rankCommitMatch
 	if r.DiffPreview != nil {
-		typeRank = DiffMatchRank
+		typeRank = rankDiffMatch
 	}
 	return Key{
 		TypeRank: typeRank,

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -69,9 +69,9 @@ func (r *CommitMatch) Select(path filter.SelectPath) Match {
 
 // Key implements Match interface's Key() method
 func (r *CommitMatch) Key() Key {
-	typeRank := 1
+	typeRank := CommitMatchRank
 	if r.DiffPreview != nil {
-		typeRank = 2
+		typeRank = DiffMatchRank
 	}
 	return Key{
 		TypeRank: typeRank,

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -75,8 +75,8 @@ func (r *CommitMatch) Key() Key {
 	}
 	return Key{
 		TypeRank: typeRank,
-		Repo:     string(r.RepoName.Name),
-		Commit:   string(r.Commit.ID),
+		Repo:     r.RepoName.Name,
+		Commit:   r.Commit.ID,
 	}
 }
 

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -138,6 +138,15 @@ func (fm *FileMatch) Limit(limit int) int {
 	return 0
 }
 
+func (fm *FileMatch) Key() Key {
+	return Key{
+		TypeRank: 0,
+		Repo:     string(fm.Repo.Name),
+		Commit:   string(fm.CommitID),
+		Path:     fm.Path,
+	}
+}
+
 // LineMatch is the struct used by vscode to receive search results for a line
 type LineMatch struct {
 	Preview          string

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -1,9 +1,6 @@
 package result
 
 import (
-	"net/url"
-	"strings"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -18,26 +15,6 @@ type File struct {
 	Repo     types.RepoName `json:"-"`
 	CommitID api.CommitID   `json:"-"`
 	Path     string
-}
-
-// URL generates a git URL for the file. This seems to currently only be used
-// as a unique key for the File, and may be removed in the future.
-func (fm *File) URL() string {
-	var b strings.Builder
-	var ref string
-	if fm.InputRev != nil {
-		ref = url.QueryEscape(*fm.InputRev)
-	}
-	b.Grow(len(fm.Repo.Name) + len(ref) + len(fm.Path) + len("git://?#"))
-	b.WriteString("git://")
-	b.WriteString(string(fm.Repo.Name))
-	if ref != "" {
-		b.WriteByte('?')
-		b.WriteString(ref)
-	}
-	b.WriteByte('#')
-	b.WriteString(fm.Path)
-	return b.String()
 }
 
 // FileMatch represents either:

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -117,7 +117,7 @@ func (fm *FileMatch) Limit(limit int) int {
 
 func (fm *FileMatch) Key() Key {
 	return Key{
-		TypeRank: FileMatchRank,
+		TypeRank: rankFileMatch,
 		Repo:     fm.Repo.Name,
 		Commit:   fm.CommitID,
 		Path:     fm.Path,

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -118,8 +118,8 @@ func (fm *FileMatch) Limit(limit int) int {
 func (fm *FileMatch) Key() Key {
 	return Key{
 		TypeRank: FileMatchRank,
-		Repo:     string(fm.Repo.Name),
-		Commit:   string(fm.CommitID),
+		Repo:     fm.Repo.Name,
+		Commit:   fm.CommitID,
 		Path:     fm.Path,
 	}
 }

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -117,7 +117,7 @@ func (fm *FileMatch) Limit(limit int) int {
 
 func (fm *FileMatch) Key() Key {
 	return Key{
-		TypeRank: 0,
+		TypeRank: FileMatchRank,
 		Repo:     string(fm.Repo.Name),
 		Commit:   string(fm.CommitID),
 		Path:     fm.Path,

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -8,6 +8,7 @@ type Match interface {
 	ResultCount() int
 	Limit(int) int
 	Select(filter.SelectPath) Match
+	Key() Key
 
 	// ensure only types in this package can be a Match.
 	searchResultMarker()
@@ -16,3 +17,32 @@ type Match interface {
 var _ Match = (*FileMatch)(nil)
 var _ Match = (*RepoMatch)(nil)
 var _ Match = (*CommitMatch)(nil)
+
+type MatchSlice []Match
+
+func (m MatchSlice) Len() int           { return len(m) }
+func (m MatchSlice) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+func (m MatchSlice) Less(i, j int) bool { return m[i].Key().Less(m[j].Key()) }
+
+type Key struct {
+	TypeRank int
+	Repo     string
+	Commit   string
+	Path     string
+}
+
+func (k Key) Less(other Key) bool {
+	if k.TypeRank != other.TypeRank {
+		return k.TypeRank < other.TypeRank
+	}
+
+	if k.Repo != other.Repo {
+		return k.Repo < other.Repo
+	}
+
+	if k.Commit != other.Commit {
+		return k.Commit < other.Commit
+	}
+
+	return k.Path < other.Path
+}

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -8,6 +8,8 @@ type Match interface {
 	ResultCount() int
 	Limit(int) int
 	Select(filter.SelectPath) Match
+
+	// Key returns a key which uniquely identifies this match.
 	Key() Key
 
 	// ensure only types in this package can be a Match.
@@ -18,19 +20,29 @@ var _ Match = (*FileMatch)(nil)
 var _ Match = (*RepoMatch)(nil)
 var _ Match = (*CommitMatch)(nil)
 
-type MatchSlice []Match
-
-func (m MatchSlice) Len() int           { return len(m) }
-func (m MatchSlice) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
-func (m MatchSlice) Less(i, j int) bool { return m[i].Key().Less(m[j].Key()) }
-
+// Key is a sorting or deduplicating key for a Match.
+// It contains all the identifying information for the Match.
 type Key struct {
+	// TypeRank is the sorting rank of the type this key belongs to.
+	// FileMatch = 0
+	// CommitMatch (Commit) = 1
+	// CommitMatch (Diff) = 2
+	// RepoMatch = 3
 	TypeRank int
-	Repo     string
-	Commit   string
-	Path     string
+
+	// Repo is the name of the repo the match belongs to
+	Repo string
+
+	// Commit is the commit hash of the commit the match belongs to.
+	// Empty if there is no commit associated with the match (e.g. RepoMatch)
+	Commit string
+
+	// Path is the path of the file the match belongs to.
+	// Empty if there is no file associated with the match (e.g. RepoMatch or CommitMatch)
+	Path string
 }
 
+// Less compares one key to another for sorting
 func (k Key) Less(other Key) bool {
 	if k.TypeRank != other.TypeRank {
 		return k.TypeRank < other.TypeRank

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -1,6 +1,9 @@
 package result
 
-import "github.com/sourcegraph/sourcegraph/internal/search/filter"
+import (
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+)
 
 // Match is *FileMatch | *RepoMatch | *CommitMatch. We have a private method
 // to ensure only those types implement Match.
@@ -40,11 +43,11 @@ type Key struct {
 	TypeRank int
 
 	// Repo is the name of the repo the match belongs to
-	Repo string
+	Repo api.RepoName
 
 	// Commit is the commit hash of the commit the match belongs to.
 	// Empty if there is no commit associated with the match (e.g. RepoMatch)
-	Commit string
+	Commit api.CommitID
 
 	// Path is the path of the file the match belongs to.
 	// Empty if there is no file associated with the match (e.g. RepoMatch or CommitMatch)

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -16,18 +16,27 @@ type Match interface {
 	searchResultMarker()
 }
 
-var _ Match = (*FileMatch)(nil)
-var _ Match = (*RepoMatch)(nil)
-var _ Match = (*CommitMatch)(nil)
+// Guard to ensure all match types implement the interface
+var (
+	_ Match = (*FileMatch)(nil)
+	_ Match = (*RepoMatch)(nil)
+	_ Match = (*CommitMatch)(nil)
+)
+
+// Match ranks are used for sorting the different match types.
+// Match types with lower ranks will be sorted before match types
+// with higher ranks.
+const (
+	FileMatchRank   = 0
+	CommitMatchRank = 1
+	DiffMatchRank   = 2
+	RepoMatchRank   = 3
+)
 
 // Key is a sorting or deduplicating key for a Match.
 // It contains all the identifying information for the Match.
 type Key struct {
 	// TypeRank is the sorting rank of the type this key belongs to.
-	// FileMatch = 0
-	// CommitMatch (Commit) = 1
-	// CommitMatch (Diff) = 2
-	// RepoMatch = 3
 	TypeRank int
 
 	// Repo is the name of the repo the match belongs to

--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -30,18 +30,15 @@ var (
 // Match types with lower ranks will be sorted before match types
 // with higher ranks.
 const (
-	FileMatchRank   = 0
-	CommitMatchRank = 1
-	DiffMatchRank   = 2
-	RepoMatchRank   = 3
+	rankFileMatch   = 0
+	rankCommitMatch = 1
+	rankDiffMatch   = 2
+	rankRepoMatch   = 3
 )
 
 // Key is a sorting or deduplicating key for a Match.
 // It contains all the identifying information for the Match.
 type Key struct {
-	// TypeRank is the sorting rank of the type this key belongs to.
-	TypeRank int
-
 	// Repo is the name of the repo the match belongs to
 	Repo api.RepoName
 
@@ -52,14 +49,13 @@ type Key struct {
 	// Path is the path of the file the match belongs to.
 	// Empty if there is no file associated with the match (e.g. RepoMatch or CommitMatch)
 	Path string
+
+	// TypeRank is the sorting rank of the type this key belongs to.
+	TypeRank int
 }
 
 // Less compares one key to another for sorting
 func (k Key) Less(other Key) bool {
-	if k.TypeRank != other.TypeRank {
-		return k.TypeRank < other.TypeRank
-	}
-
 	if k.Repo != other.Repo {
 		return k.Repo < other.Repo
 	}
@@ -68,5 +64,9 @@ func (k Key) Less(other Key) bool {
 		return k.Commit < other.Commit
 	}
 
-	return k.Path < other.Path
+	if k.Path != other.Path {
+		return k.Path < other.Path
+	}
+
+	return k.TypeRank < other.TypeRank
 }

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -48,4 +48,11 @@ func (r *RepoMatch) URL() *url.URL {
 	return &url.URL{Path: path}
 }
 
+func (r *RepoMatch) Key() Key {
+	return Key{
+		TypeRank: 2,
+		Repo:     string(r.Name),
+	}
+}
+
 func (r *RepoMatch) searchResultMarker() {}

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -51,7 +51,7 @@ func (r *RepoMatch) URL() *url.URL {
 func (r *RepoMatch) Key() Key {
 	return Key{
 		TypeRank: RepoMatchRank,
-		Repo:     string(r.Name),
+		Repo:     r.Name,
 	}
 }
 

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -50,7 +50,7 @@ func (r *RepoMatch) URL() *url.URL {
 
 func (r *RepoMatch) Key() Key {
 	return Key{
-		TypeRank: 2,
+		TypeRank: RepoMatchRank,
 		Repo:     string(r.Name),
 	}
 }

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -50,7 +50,7 @@ func (r *RepoMatch) URL() *url.URL {
 
 func (r *RepoMatch) Key() Key {
 	return Key{
-		TypeRank: RepoMatchRank,
+		TypeRank: rankRepoMatch,
 		Repo:     r.Name,
 	}
 }


### PR DESCRIPTION
### What is this?

This PR removes the `URL()` method from `result.File`. 

Stacked on #20552

### Why would you do that?

Throughout the codebase, we use `URL()` method for sorting, for deduplicating, and for checking test values. It's never used as a URL except for in `Resource()` which is removed by #20552

This is confusing since I expect something called URL to actually be a useful URL, but it's not even in the right format to use it for accessing the file as a URL. 

Additionally, I would like to add an _actual_ URL method to FileMatch so that we can use URLs without being attached to resolvers. This is required for splitting up the `Symbol` result type from resolvers. 

### Why `Key()` then? 

Since URL was being used as a unique key and a sorting key, it felt more natural to call it a key. Additionally, with a `result.Key` type, we will be able to sort and deduplicate all result types generically. This PR can't yet convert everything to use `Match` sorting because we still use resolvers all over the place. As I push result types up the stack, I'll replace our manual sorts with the generic sort for `MatchSlice`. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
