### PR TITLE
ranking: store github metadata and compute a simple repo priority

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1576,6 +1576,10 @@ type Repository struct {
 	// This field will always be blank on repos stored in our database because the value will be different
 	// depending on which token was used to fetch it
 	ViewerPermission string // ADMIN, WRITE, READ, or empty if unknown. Only the graphql api populates this. https://developer.github.com/v4/enum/repositorypermission/
+
+	// Metadata retained for ranking
+	StargazerCount int `json:"omitempty"`
+	ForkCount      int `json:"omitempty"`
 }
 
 func ownerNameCacheKey(owner, name string) string       { return "0:" + owner + "/" + name }
@@ -1645,6 +1649,8 @@ type restRepository struct {
 	Locked      bool                      `json:"locked"`
 	Disabled    bool                      `json:"disabled"`
 	Permissions restRepositoryPermissions `json:"permissions"`
+	Stars       int                       `json:"stargazers_count"`
+	Forks       int                       `json:"forks_count"`
 }
 
 // getRepositoryFromAPI attempts to fetch a repository from the GitHub API without use of the redis cache.
@@ -1678,6 +1684,8 @@ func convertRestRepo(restRepo restRepository) *Repository {
 		IsLocked:         restRepo.Locked,
 		IsDisabled:       restRepo.Disabled,
 		ViewerPermission: convertRestRepoPermissions(restRepo.Permissions),
+		StargazerCount:   restRepo.Stars,
+		ForkCount:        restRepo.Forks,
 	}
 }
 

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1578,8 +1578,8 @@ type Repository struct {
 	ViewerPermission string // ADMIN, WRITE, READ, or empty if unknown. Only the graphql api populates this. https://developer.github.com/v4/enum/repositorypermission/
 
 	// Metadata retained for ranking
-	StargazerCount int `json:"omitempty"`
-	ForkCount      int `json:"omitempty"`
+	StargazerCount int `json:",omitempty"`
+	ForkCount      int `json:",omitempty"`
 }
 
 func ownerNameCacheKey(owner, name string) string       { return "0:" + owner + "/" + name }

--- a/internal/extsvc/github/common_test.go
+++ b/internal/extsvc/github/common_test.go
@@ -83,18 +83,23 @@ func TestClient_GetRepository(t *testing.T) {
 	"full_name": "o/r",
 	"description": "d",
 	"html_url": "https://github.example.com/o/r",
-	"fork": true
+	"fork": true,
+	"stargazers_count": 30,
+	"watchers_count": 20,
+	"forks_count": 5
 }
 `,
 	}
 	c := newTestClient(t, &mock)
 
 	want := Repository{
-		ID:            "i",
-		NameWithOwner: "o/r",
-		Description:   "d",
-		URL:           "https://github.example.com/o/r",
-		IsFork:        true,
+		ID:             "i",
+		NameWithOwner:  "o/r",
+		Description:    "d",
+		URL:            "https://github.example.com/o/r",
+		IsFork:         true,
+		StargazerCount: 30,
+		ForkCount:      5,
 	}
 
 	repo, err := c.GetRepository(context.Background(), "owner", "repo")

--- a/internal/extsvc/github/common_test.go
+++ b/internal/extsvc/github/common_test.go
@@ -128,7 +128,7 @@ func TestClient_GetRepository(t *testing.T) {
 		t.Errorf("mock.count == %d, expected to hit cache", mock.count)
 	}
 	if !reflect.DeepEqual(repo, &want) {
-		t.Errorf("got repository %+v, want %+v", repo, &want)
+		t.Errorf("got cached repository %+v, want %+v", repo, &want)
 	}
 }
 

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -446,6 +446,8 @@ fragment RepositoryFields on Repository {
 	isLocked
 	isDisabled
 	viewerPermission
+	stargazerCount
+	forkCount
 }
 	`
 	}
@@ -464,6 +466,8 @@ fragment RepositoryFields on Repository {
 	isArchived
 	isLocked
 	isDisabled
+	stargazerCount
+	forkCount
 }
 	`
 }

--- a/internal/repos/github_test.go
+++ b/internal/repos/github_test.go
@@ -76,11 +76,13 @@ func TestGithubSource_GetRepo(t *testing.T) {
 						},
 					},
 					Metadata: &github.Repository{
-						ID:            "MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==",
-						DatabaseID:    41288708,
-						NameWithOwner: "sourcegraph/sourcegraph",
-						Description:   "Code search and navigation tool (self-hosted)",
-						URL:           "https://github.com/sourcegraph/sourcegraph",
+						ID:             "MDEwOlJlcG9zaXRvcnk0MTI4ODcwOA==",
+						DatabaseID:     41288708,
+						NameWithOwner:  "sourcegraph/sourcegraph",
+						Description:    "Code search and navigation tool (self-hosted)",
+						URL:            "https://github.com/sourcegraph/sourcegraph",
+						StargazerCount: 2220,
+						ForkCount:      164,
 					},
 				}
 

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -32,6 +32,9 @@ type zoektIndexOptions struct {
 
 	// Error if non-empty indicates the request failed for the repo.
 	Error string `json:",omitempty"`
+
+	// Priority indicates ranking in results, higher first.
+	Priority float64 `json:",omitempty"`
 }
 
 // RepoIndexOptions are the options used by GetIndexOptions for a specific
@@ -44,6 +47,9 @@ type RepoIndexOptions struct {
 	// error is encoded in the body. If the revision is missing, an empty
 	// string should be returned rather than an error.
 	GetVersion func(branch string) (string, error)
+
+	// GetPriority returns the suggested priority for the repo, or 0 if none exists.
+	GetPriority func() float64
 }
 
 // GetIndexOptions returns a json blob for consumption by
@@ -91,6 +97,10 @@ func getIndexOptions(
 		RepoID:     opts.RepoID,
 		LargeFiles: c.SearchLargeFiles,
 		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
+	}
+
+	if opts.GetPriority != nil {
+		o.Priority = opts.GetPriority()
 	}
 
 	// Set of branch names. Always index HEAD

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -168,6 +168,18 @@ func TestGetIndexOptions(t *testing.T) {
 				{Name: "rev2", Version: "!rev2"},
 			},
 		},
+	}, {
+		name: "with a priority value",
+		conf: schema.SiteConfiguration{},
+		repo: "priority",
+		want: zoektIndexOptions{
+			RepoID:  4,
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+			},
+			Priority: 10,
+		},
 	}}
 
 	{
@@ -197,17 +209,22 @@ func TestGetIndexOptions(t *testing.T) {
 
 	getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
 		repoID := int32(1)
-		for _, r := range []string{"repo", "foo", "not_in_version_context"} {
+		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority"} {
 			if r == repo {
 				break
 			}
 			repoID++
+		}
+		var getPriority func() float64 = nil
+		if repo == "priority" {
+			getPriority = func() float64 { return 10 }
 		}
 		return &RepoIndexOptions{
 			RepoID: repoID,
 			GetVersion: func(branch string) (string, error) {
 				return "!" + branch, nil
 			},
+			GetPriority: getPriority,
 		}, nil
 	}
 


### PR DESCRIPTION
zoekt hits this API for configuration, and it now includes a simple priority to hint at ranking:
```
$ curl -s --data-urlencode repo=github.com/sqs-test/my-sample-repo-1 http://localhost:3090/.internal/search/configuration | jq .
{
  "RepoID": 8,
  "LargeFiles": null,
  "Symbols": true,
  "Branches": [
    {
      "Name": "HEAD",
      "Version": "a9540eea4fd94c7b5db7b8c4e90fc5118e75b270"
    },
    {
      "Name": "master",
      "Version": "a9540eea4fd94c7b5db7b8c4e90fc5118e75b270"
    }
  ],
  "Priority": 1
}
```