### PR TITLE
Attach default reviewers to bitbucket server PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - User credentials used in Batch Changes are now encrypted if encryption is enabled in the database with the `encryption.keys` config. [#19570](https://github.com/sourcegraph/sourcegraph/issues/19570)
+- Default reviewers are now added to Bitbucket Server PRs opened by Batch Changes. [#20551](https://github.com/sourcegraph/sourcegraph/pull/20551)
 
 ### Fixed
 

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -107,10 +107,12 @@ func (s BitbucketServerSource) CreateChangeset(ctx context.Context, c *Changeset
 	pr := &bitbucketserver.PullRequest{Title: c.Title, Description: c.Body}
 
 	pr.ToRef.Repository.Slug = repo.Slug
+	pr.ToRef.Repository.ID = repo.ID
 	pr.ToRef.Repository.Project.Key = repo.Project.Key
 	pr.ToRef.ID = git.EnsureRefPrefix(c.BaseRef)
 
 	pr.FromRef.Repository.Slug = repo.Slug
+	pr.FromRef.Repository.ID = repo.ID
 	pr.FromRef.Repository.Project.Key = repo.Project.Key
 	pr.FromRef.ID = git.EnsureRefPrefix(c.HeadRef)
 

--- a/enterprise/internal/batches/sources/bitbucketserver_test.go
+++ b/enterprise/internal/batches/sources/bitbucketserver_test.go
@@ -114,6 +114,7 @@ func TestBitbucketServerSource_CreateChangeset(t *testing.T) {
 
 	repo := &types.Repo{
 		Metadata: &bitbucketserver.Repo{
+			ID:      10070,
 			Slug:    "automation-testing",
 			Project: &bitbucketserver.Project{Key: "SOUR"},
 		},

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CreateChangeset_abbreviated refs
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CreateChangeset_abbreviated refs
@@ -1,13 +1,13 @@
 {
-  "id": 69,
+  "id": 138,
   "version": 0,
   "title": "This is a test PR",
   "description": "This is the body of a test PR",
   "state": "OPEN",
   "open": true,
   "closed": false,
-  "createdDate": 1585316944811,
-  "updatedDate": 1585316944811,
+  "createdDate": 1619783866159,
+  "updatedDate": 1619783866159,
   "fromRef": {
    "id": "refs/heads/test-pr-bbs-11",
    "repository": {
@@ -31,38 +31,54 @@
   "locked": false,
   "author": {
    "user": {
-    "name": "milton",
-    "emailAddress": "dev@sourcegraph.com",
-    "id": 1,
-    "displayName": "milton woof",
+    "name": "erik",
+    "emailAddress": "erik@sourcegraph.com",
+    "id": 152,
+    "displayName": "Erik Seliger",
     "active": true,
-    "slug": "milton",
+    "slug": "erik",
     "type": "NORMAL"
    },
    "role": "AUTHOR",
    "approved": false,
    "status": "UNAPPROVED"
   },
-  "reviewers": [],
+  "reviewers": [
+   {
+    "user": {
+     "name": "thorsten",
+     "emailAddress": "thorsten@sourcegraph.com",
+     "id": 104,
+     "displayName": "thorsten",
+     "active": true,
+     "slug": "thorsten",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
   "participants": [],
   "links": {
    "self": [
     {
-     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/69"
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/138"
     }
    ]
   },
   "activities": [
    {
-    "id": 2980,
-    "createdDate": 1585316944831,
+    "id": 3891,
+    "createdDate": 1619783866192,
     "user": {
-     "name": "milton",
-     "emailAddress": "dev@sourcegraph.com",
-     "id": 1,
-     "displayName": "milton woof",
+     "name": "erik",
+     "emailAddress": "erik@sourcegraph.com",
+     "id": 152,
+     "displayName": "Erik Seliger",
      "active": true,
-     "slug": "milton",
+     "slug": "erik",
      "type": "NORMAL"
     },
     "action": "OPENED"

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CreateChangeset_already exists
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CreateChangeset_already exists
@@ -1,13 +1,13 @@
 {
-  "id": 3,
-  "version": 4,
-  "title": "This testing PR is always open",
-  "description": "Ignore this. This is a testing PR that is always open.",
+  "id": 132,
+  "version": 0,
+  "title": "This is a test PR",
+  "description": "This is a test PR. Feel free to ignore.",
   "state": "OPEN",
   "open": true,
   "closed": false,
-  "createdDate": 1573644199945,
-  "updatedDate": 1573644199945,
+  "createdDate": 1618447968146,
+  "updatedDate": 1618447968146,
   "fromRef": {
    "id": "refs/heads/always-open-pr-bbs",
    "repository": {
@@ -31,12 +31,12 @@
   "locked": false,
   "author": {
    "user": {
-    "name": "thorsten",
-    "emailAddress": "thorsten@sourcegraph.com",
-    "id": 104,
-    "displayName": "thorsten",
+    "name": "erik",
+    "emailAddress": "erik@sourcegraph.com",
+    "id": 152,
+    "displayName": "Erik Seliger",
     "active": true,
-    "slug": "thorsten",
+    "slug": "erik",
     "type": "NORMAL"
    },
    "role": "AUTHOR",
@@ -48,21 +48,21 @@
   "links": {
    "self": [
     {
-     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/3"
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/132"
     }
    ]
   },
   "activities": [
    {
-    "id": 95,
-    "createdDate": 1573644199954,
+    "id": 3867,
+    "createdDate": 1618447968165,
     "user": {
-     "name": "thorsten",
-     "emailAddress": "thorsten@sourcegraph.com",
-     "id": 104,
-     "displayName": "thorsten",
+     "name": "erik",
+     "emailAddress": "erik@sourcegraph.com",
+     "id": 152,
+     "displayName": "Erik Seliger",
      "active": true,
-     "slug": "thorsten",
+     "slug": "erik",
      "type": "NORMAL"
     },
     "action": "OPENED"

--- a/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CreateChangeset_success
+++ b/enterprise/internal/batches/sources/testdata/golden/BitbucketServerSource_CreateChangeset_success
@@ -1,13 +1,13 @@
 {
-  "id": 68,
+  "id": 139,
   "version": 0,
   "title": "This is a test PR",
   "description": "This is the body of a test PR",
   "state": "OPEN",
   "open": true,
   "closed": false,
-  "createdDate": 1585316689302,
-  "updatedDate": 1585316689302,
+  "createdDate": 1619783866982,
+  "updatedDate": 1619783866982,
   "fromRef": {
    "id": "refs/heads/test-pr-bbs-12",
    "repository": {
@@ -31,38 +31,54 @@
   "locked": false,
   "author": {
    "user": {
-    "name": "milton",
-    "emailAddress": "dev@sourcegraph.com",
-    "id": 1,
-    "displayName": "milton woof",
+    "name": "erik",
+    "emailAddress": "erik@sourcegraph.com",
+    "id": 152,
+    "displayName": "Erik Seliger",
     "active": true,
-    "slug": "milton",
+    "slug": "erik",
     "type": "NORMAL"
    },
    "role": "AUTHOR",
    "approved": false,
    "status": "UNAPPROVED"
   },
-  "reviewers": [],
+  "reviewers": [
+   {
+    "user": {
+     "name": "thorsten",
+     "emailAddress": "thorsten@sourcegraph.com",
+     "id": 104,
+     "displayName": "thorsten",
+     "active": true,
+     "slug": "thorsten",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
   "participants": [],
   "links": {
    "self": [
     {
-     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/68"
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/139"
     }
    ]
   },
   "activities": [
    {
-    "id": 2979,
-    "createdDate": 1585316689324,
+    "id": 3892,
+    "createdDate": 1619783867010,
     "user": {
-     "name": "milton",
-     "emailAddress": "dev@sourcegraph.com",
-     "id": 1,
-     "displayName": "milton woof",
+     "name": "erik",
+     "emailAddress": "erik@sourcegraph.com",
+     "id": 152,
+     "displayName": "Erik Seliger",
      "active": true,
-     "slug": "milton",
+     "slug": "erik",
      "type": "NORMAL"
     },
     "action": "OPENED"

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateChangeset_abbreviated-refs.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateChangeset_abbreviated-refs.yaml
@@ -2,8 +2,46 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/default-reviewers/1.0/projects/SOUR/repos/automation-testing/reviewers?sourceRefId=refs%2Fheads%2Ftest-pr-bbs-11&sourceRepoId=10070&targetRefId=refs%2Fheads%2Fmaster&targetRepoId=10070
+    method: GET
+  response:
+    body: '[{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}}]'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Apr 2021 11:57:46 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TO58QJx717x103575x0'
+      X-Asessionid:
+      - 1jrjx9p
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: |
-      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-11","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-11","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false,"reviewers":[{"user":{"name":"erik"}},{"user":{"name":"thorsten"}}]}
     form: {}
     headers:
       Content-Type:
@@ -11,41 +49,33 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests
     method: POST
   response:
-    body: '{"id":69,"version":0,"title":"This is a test PR","description":"This is
-      the body of a test PR","state":"OPEN","open":true,"closed":false,"createdDate":1585316944811,"updatedDate":1585316944811,"fromRef":{"id":"refs/heads/test-pr-bbs-11","displayId":"test-pr-bbs-11","latestCommit":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"e833db3fe2bdbc28b58cd72def1b0078e77aa171","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
-      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/69"}]}}'
+    body: '{"id":138,"version":0,"title":"This is a test PR","description":"This is
+      the body of a test PR","state":"OPEN","open":true,"closed":false,"createdDate":1619783866159,"updatedDate":1619783866159,"fromRef":{"id":"refs/heads/test-pr-bbs-11","displayId":"test-pr-bbs-11","latestCommit":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"db0a6e3b7bcd9963cfaa69bd3f87e04a803900ac","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/138"}]}}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a99297ed6d4925-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 13:49:04 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:46 GMT
       Location:
-      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/69
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/138
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx829x451858x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103576x0'
       X-Asessionid:
-      - 1og0byl
+      - pd49u0
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 201 Created
@@ -57,41 +87,33 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/69/activities?limit=1000
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/138/activities?limit=1000
     method: GET
   response:
-    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"id":2980,"createdDate":1585316944831,"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
-      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"action":"OPENED"}],"start":0}'
+    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"id":3891,"createdDate":1619783866192,"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"action":"OPENED"}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a9929a69b74925-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 13:49:05 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:46 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx829x451859x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103577x0'
       X-Asessionid:
-      - 1c7a941
+      - drlyqh
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK
@@ -103,7 +125,7 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/69/commits?limit=1000
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/138/commits?limit=1000
     method: GET
   response:
     body: '{"values":[{"id":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","displayId":"c9324a86ac3","author":{"name":"Thorsten
@@ -114,32 +136,24 @@ interactions:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a9929cfe554925-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 13:49:05 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:46 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx829x451861x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103578x0'
       X-Asessionid:
-      - 9q7zvx
+      - 17pogju
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK
@@ -154,38 +168,30 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/build-status/1.0/commits/c9324a86ac324cdf48f3db3595d2dd013e43b56c?limit=1000
     method: GET
   response:
-    body: '{"size":1,"limit":100,"isLastPage":true,"values":[{"state":"INPROGRESS","key":"thekey","name":"thename","url":"http://example.com","description":"the
+    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"state":"INPROGRESS","key":"thekey","name":"thename","url":"http://example.com","description":"the
       description","dateAdded":1581510032840}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a9929f09cf4925-CPT
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Mar 2020 13:49:06 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:46 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx829x451862x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103581x0'
       X-Asessionid:
-      - h7tpa4
+      - 1343ogg
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateChangeset_already-exists.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateChangeset_already-exists.yaml
@@ -2,8 +2,46 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/default-reviewers/1.0/projects/SOUR/repos/automation-testing/reviewers?sourceRefId=refs%2Fheads%2Falways-open-pr-bbs&sourceRepoId=10070&targetRefId=refs%2Fheads%2Fmaster&targetRepoId=10070
+    method: GET
+  response:
+    body: '[{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}}]'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Apr 2021 11:57:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TO58QJx717x103587x0'
+      X-Asessionid:
+      - 1bolhxl
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: |
-      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/always-open-pr-bbs","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/always-open-pr-bbs","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false,"reviewers":[{"user":{"name":"erik"}},{"user":{"name":"thorsten"}}]}
     form: {}
     headers:
       Content-Type:
@@ -12,39 +50,31 @@ interactions:
     method: POST
   response:
     body: '{"errors":[{"context":null,"message":"Only one pull request may be open
-      for a given source and target branch","exceptionName":"com.atlassian.bitbucket.pull.DuplicatePullRequestException","existingPullRequest":{"id":3,"version":4,"title":"This
-      testing PR is always open","description":"Ignore this. This is a testing PR
-      that is always open.","state":"OPEN","open":true,"closed":false,"createdDate":1573644199945,"updatedDate":1573644199945,"fromRef":{"id":"refs/heads/always-open-pr-bbs","displayId":"always-open-pr-bbs","latestCommit":"b939ea0debe88e145c5409230b29e7dbbedcb9da","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"e833db3fe2bdbc28b58cd72def1b0078e77aa171","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/3"}]}}}]}'
+      for a given source and target branch","exceptionName":"com.atlassian.bitbucket.pull.DuplicatePullRequestException","existingPullRequest":{"id":132,"version":0,"title":"This
+      is a test PR","description":"This is a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"createdDate":1618447968146,"updatedDate":1618447968146,"fromRef":{"id":"refs/heads/always-open-pr-bbs","displayId":"always-open-pr-bbs","latestCommit":"b939ea0debe88e145c5409230b29e7dbbedcb9da","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"db0a6e3b7bcd9963cfaa69bd3f87e04a803900ac","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/132"}]}}}]}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57c281c9ceec4931-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 30 Mar 2020 14:26:41 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:47 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx866x614755x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103588x0'
       X-Asessionid:
-      - 1tekham
+      - 1vcto7r
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 409 Conflict
@@ -56,40 +86,33 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/3/activities?limit=1000
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/132/activities?limit=1000
     method: GET
   response:
-    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"id":95,"createdDate":1573644199954,"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"action":"OPENED"}],"start":0}'
+    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"id":3867,"createdDate":1618447968165,"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"action":"OPENED"}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57c281cffa914931-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 30 Mar 2020 14:26:41 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:47 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx866x614756x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103590x0'
       X-Asessionid:
-      - 15uqxat
+      - 1hj0gl5
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK
@@ -101,7 +124,7 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/3/commits?limit=1000
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/132/commits?limit=1000
     method: GET
   response:
     body: '{"values":[{"id":"b939ea0debe88e145c5409230b29e7dbbedcb9da","displayId":"b939ea0debe","author":{"name":"Thorsten
@@ -112,32 +135,24 @@ interactions:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57c281d28f5f4931-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 30 Mar 2020 14:26:42 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:48 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx866x614757x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103591x0'
       X-Asessionid:
-      - 10y5pmo
+      - 148wu5w
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK
@@ -152,37 +167,29 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/build-status/1.0/commits/b939ea0debe88e145c5409230b29e7dbbedcb9da?limit=1000
     method: GET
   response:
-    body: '{"size":0,"limit":100,"isLastPage":true,"values":[],"start":0}'
+    body: '{"size":0,"limit":500,"isLastPage":true,"values":[],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57c281d8fae04931-CPT
       Content-Type:
       - application/json
       Date:
-      - Mon, 30 Mar 2020 14:26:43 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:48 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx866x614758x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103592x0'
       X-Asessionid:
-      - 1624byt
+      - 1sibx0z
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK

--- a/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateChangeset_success.yaml
+++ b/enterprise/internal/batches/sources/testdata/sources/BitbucketServerSource_CreateChangeset_success.yaml
@@ -2,8 +2,46 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/default-reviewers/1.0/projects/SOUR/repos/automation-testing/reviewers?sourceRefId=refs%2Fheads%2Ftest-pr-bbs-12&sourceRepoId=10070&targetRefId=refs%2Fheads%2Fmaster&targetRepoId=10070
+    method: GET
+  response:
+    body: '[{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}}]'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Apr 2021 11:57:46 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TO58QJx717x103582x0'
+      X-Asessionid:
+      - m5ltrf
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: |
-      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-12","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+      {"title":"This is a test PR","description":"This is the body of a test PR","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-12","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false,"reviewers":[{"user":{"name":"erik"}},{"user":{"name":"thorsten"}}]}
     form: {}
     headers:
       Content-Type:
@@ -11,41 +49,33 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests
     method: POST
   response:
-    body: '{"id":68,"version":0,"title":"This is a test PR","description":"This is
-      the body of a test PR","state":"OPEN","open":true,"closed":false,"createdDate":1585316689302,"updatedDate":1585316689302,"fromRef":{"id":"refs/heads/test-pr-bbs-12","displayId":"test-pr-bbs-12","latestCommit":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"e833db3fe2bdbc28b58cd72def1b0078e77aa171","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
-      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/68"}]}}'
+    body: '{"id":139,"version":0,"title":"This is a test PR","description":"This is
+      the body of a test PR","state":"OPEN","open":true,"closed":false,"createdDate":1619783866982,"updatedDate":1619783866982,"fromRef":{"id":"refs/heads/test-pr-bbs-12","displayId":"test-pr-bbs-12","latestCommit":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"db0a6e3b7bcd9963cfaa69bd3f87e04a803900ac","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/139"}]}}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a98c5b0843803e-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 13:44:49 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:47 GMT
       Location:
-      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/68
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/139
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx824x451600x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103583x0'
       X-Asessionid:
-      - 1ls2oer
+      - 1ms0048
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 201 Created
@@ -57,41 +87,33 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/68/activities?limit=1000
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/139/activities?limit=1000
     method: GET
   response:
-    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"id":2979,"createdDate":1585316689324,"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
-      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"action":"OPENED"}],"start":0}'
+    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"id":3892,"createdDate":1619783867010,"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"action":"OPENED"}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a98c5d8969803e-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 13:44:49 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:47 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx824x451602x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103584x0'
       X-Asessionid:
-      - lkge7k
+      - 14801hl
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK
@@ -103,7 +125,7 @@ interactions:
     headers:
       Content-Type:
       - application/json; charset=utf-8
-    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/68/commits?limit=1000
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/139/commits?limit=1000
     method: GET
   response:
     body: '{"values":[{"id":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","displayId":"c9324a86ac3","author":{"name":"Thorsten
@@ -114,32 +136,24 @@ interactions:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a98c5faa41803e-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 27 Mar 2020 13:44:50 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:47 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx824x451603x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103585x0'
       X-Asessionid:
-      - 1225eet
+      - 1wrr2j8
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK
@@ -154,38 +168,30 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/build-status/1.0/commits/c9324a86ac324cdf48f3db3595d2dd013e43b56c?limit=1000
     method: GET
   response:
-    body: '{"size":1,"limit":100,"isLastPage":true,"values":[{"state":"INPROGRESS","key":"thekey","name":"thename","url":"http://example.com","description":"the
+    body: '{"size":1,"limit":500,"isLastPage":true,"values":[{"state":"INPROGRESS","key":"thekey","name":"thename","url":"http://example.com","description":"the
       description","dateAdded":1581510032840}],"start":0}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57a98c61bb32803e-CPT
       Content-Type:
       - application/json
       Date:
-      - Fri, 27 Mar 2020 13:44:50 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 11:57:47 GMT
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx824x451605x1'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx717x103586x0'
       X-Asessionid:
-      - 72gh1r
+      - 14mayqi
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 200 OK

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -619,7 +619,7 @@ func (c *Client) CreatePullRequest(ctx context.Context, pr *PullRequest) error {
 	return nil
 }
 
-// FetchDefaultReviewers loads the suggested default reviewers for the given pr.
+// FetchDefaultReviewers loads the suggested default reviewers for the given PR.
 func (c *Client) FetchDefaultReviewers(ctx context.Context, pr *PullRequest) ([]string, error) {
 	// Validate input.
 	for _, namedRef := range [...]struct {

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -435,9 +435,11 @@ func TestClient_CreatePullRequest(t *testing.T) {
 	pr := &PullRequest{}
 	pr.Title = "This is a test PR"
 	pr.Description = "This is a test PR. Feel free to ignore."
+	pr.ToRef.Repository.ID = 10070
 	pr.ToRef.Repository.Slug = "automation-testing"
 	pr.ToRef.Repository.Project.Key = "SOUR"
 	pr.ToRef.ID = "refs/heads/master"
+	pr.FromRef.Repository.ID = 10070
 	pr.FromRef.Repository.Slug = "automation-testing"
 	pr.FromRef.Repository.Project.Key = "SOUR"
 	pr.FromRef.ID = "refs/heads/test-pr-bbs-1"
@@ -452,7 +454,7 @@ func TestClient_CreatePullRequest(t *testing.T) {
 			name: "timeout",
 			pr:   func() *PullRequest { return pr },
 			ctx:  timeout,
-			err:  "context deadline exceeded",
+			err:  "fetching default reviewers: context deadline exceeded",
 		},
 		{
 			name: "ToRef repo not set",
@@ -562,6 +564,151 @@ func TestClient_CreatePullRequest(t *testing.T) {
 			}
 
 			checkGolden(t, name, pr)
+		})
+	}
+}
+
+func TestClient_FetchDefaultReviewers(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		instanceURL = "https://bitbucket.sgdev.org"
+	}
+
+	timeout, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	pr := &PullRequest{}
+	pr.Title = "This is a test PR"
+	pr.Description = "This is a test PR. Feel free to ignore."
+	pr.ToRef.Repository.ID = 10070
+	pr.ToRef.Repository.Slug = "automation-testing"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+	pr.ToRef.ID = "refs/heads/master"
+	pr.FromRef.Repository.ID = 10070
+	pr.FromRef.Repository.Slug = "automation-testing"
+	pr.FromRef.Repository.Project.Key = "SOUR"
+	pr.FromRef.ID = "refs/heads/test-pr-bbs-1"
+
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+		pr   func() *PullRequest
+		err  string
+	}{
+		{
+			name: "timeout",
+			pr:   func() *PullRequest { return pr },
+			ctx:  timeout,
+			err:  "context deadline exceeded",
+		},
+		{
+			name: "ToRef repo id not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ToRef.Repository.ID = 0
+				return &pr
+			},
+			err: "ToRef repository id empty",
+		},
+		{
+			name: "ToRef repo slug not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ToRef.Repository.Slug = ""
+				return &pr
+			},
+			err: "ToRef repository slug empty",
+		},
+		{
+			name: "ToRef project not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ToRef.Repository.Project.Key = ""
+				return &pr
+			},
+			err: "ToRef project key empty",
+		},
+		{
+			name: "ToRef ID not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ToRef.ID = ""
+				return &pr
+			},
+			err: "ToRef id empty",
+		},
+		{
+			name: "FromRef repo id not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.FromRef.Repository.ID = 0
+				return &pr
+			},
+			err: "FromRef repository id empty",
+		},
+		{
+			name: "FromRef repo slug not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.FromRef.Repository.Slug = ""
+				return &pr
+			},
+			err: "FromRef repository slug empty",
+		},
+		{
+			name: "FromRef project not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.FromRef.Repository.Project.Key = ""
+				return &pr
+			},
+			err: "FromRef project key empty",
+		},
+		{
+			name: "FromRef ID not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.FromRef.ID = ""
+				return &pr
+			},
+			err: "FromRef id empty",
+		},
+		{
+			name: "success",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.FromRef.ID = "refs/heads/test-pr-bbs-3"
+				return &pr
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			name := "FetchDefaultReviewers-" + strings.ReplaceAll(tc.name, " ", "-")
+
+			cli, save := NewTestClient(t, name, *update)
+			defer save()
+
+			if tc.ctx == nil {
+				tc.ctx = context.Background()
+			}
+
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			pr := tc.pr()
+			reviewers, err := cli.FetchDefaultReviewers(tc.ctx, pr)
+			if have, want := fmt.Sprint(err), tc.err; have != want {
+				t.Fatalf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil || tc.err != "<nil>" {
+				return
+			}
+
+			checkGolden(t, name, reviewers)
 		})
 	}
 }

--- a/internal/extsvc/bitbucketserver/testdata/golden/CreatePullRequest-description-includes-GFM-tasklist-items
+++ b/internal/extsvc/bitbucketserver/testdata/golden/CreatePullRequest-description-includes-GFM-tasklist-items
@@ -1,13 +1,13 @@
 {
-  "id": 70,
+  "id": 141,
   "version": 0,
   "title": "This is a test PR",
   "description": "- One\n- Two",
   "state": "OPEN",
   "open": true,
   "closed": false,
-  "createdDate": 1585577826322,
-  "updatedDate": 1585577826322,
+  "createdDate": 1619784752633,
+  "updatedDate": 1619784752633,
   "fromRef": {
    "id": "refs/heads/test-pr-bbs-17",
    "repository": {
@@ -31,24 +31,40 @@
   "locked": false,
   "author": {
    "user": {
-    "name": "milton",
-    "emailAddress": "dev@sourcegraph.com",
-    "id": 1,
-    "displayName": "milton woof",
+    "name": "erik",
+    "emailAddress": "erik@sourcegraph.com",
+    "id": 152,
+    "displayName": "Erik Seliger",
     "active": true,
-    "slug": "milton",
+    "slug": "erik",
     "type": "NORMAL"
    },
    "role": "AUTHOR",
    "approved": false,
    "status": "UNAPPROVED"
   },
-  "reviewers": [],
+  "reviewers": [
+   {
+    "user": {
+     "name": "thorsten",
+     "emailAddress": "thorsten@sourcegraph.com",
+     "id": 104,
+     "displayName": "thorsten",
+     "active": true,
+     "slug": "thorsten",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
   "participants": [],
   "links": {
    "self": [
     {
-     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/70"
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/141"
     }
    ]
   }

--- a/internal/extsvc/bitbucketserver/testdata/golden/CreatePullRequest-success
+++ b/internal/extsvc/bitbucketserver/testdata/golden/CreatePullRequest-success
@@ -1,13 +1,13 @@
 {
-  "id": 71,
+  "id": 140,
   "version": 0,
   "title": "This is a test PR",
   "description": "This is a test PR. Feel free to ignore.",
   "state": "OPEN",
   "open": true,
   "closed": false,
-  "createdDate": 1585577904728,
-  "updatedDate": 1585577904728,
+  "createdDate": 1619784741907,
+  "updatedDate": 1619784741907,
   "fromRef": {
    "id": "refs/heads/test-pr-bbs-3",
    "repository": {
@@ -31,24 +31,40 @@
   "locked": false,
   "author": {
    "user": {
-    "name": "milton",
-    "emailAddress": "dev@sourcegraph.com",
-    "id": 1,
-    "displayName": "milton woof",
+    "name": "erik",
+    "emailAddress": "erik@sourcegraph.com",
+    "id": 152,
+    "displayName": "Erik Seliger",
     "active": true,
-    "slug": "milton",
+    "slug": "erik",
     "type": "NORMAL"
    },
    "role": "AUTHOR",
    "approved": false,
    "status": "UNAPPROVED"
   },
-  "reviewers": [],
+  "reviewers": [
+   {
+    "user": {
+     "name": "thorsten",
+     "emailAddress": "thorsten@sourcegraph.com",
+     "id": 104,
+     "displayName": "thorsten",
+     "active": true,
+     "slug": "thorsten",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
   "participants": [],
   "links": {
    "self": [
     {
-     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/71"
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/140"
     }
    ]
   }

--- a/internal/extsvc/bitbucketserver/testdata/golden/FetchDefaultReviewers-success
+++ b/internal/extsvc/bitbucketserver/testdata/golden/FetchDefaultReviewers-success
@@ -1,0 +1,4 @@
+[
+  "erik",
+  "thorsten"
+ ]

--- a/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-description-includes-GFM-tasklist-items.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-description-includes-GFM-tasklist-items.yaml
@@ -2,8 +2,46 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/default-reviewers/1.0/projects/SOUR/repos/automation-testing/reviewers?sourceRefId=refs%2Fheads%2Ftest-pr-bbs-17&sourceRepoId=10070&targetRefId=refs%2Fheads%2Fmaster&targetRepoId=10070
+    method: GET
+  response:
+    body: '[{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}}]'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Apr 2021 12:12:31 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TO58QJx732x105053x0'
+      X-Asessionid:
+      - ww6fpk
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: |
-      {"title":"This is a test PR","description":"- One\n- Two\n","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-17","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+      {"title":"This is a test PR","description":"- One\n- Two\n","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-17","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false,"reviewers":[{"user":{"name":"erik"}},{"user":{"name":"thorsten"}}]}
     form: {}
     headers:
       Content-Type:
@@ -11,41 +49,33 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests
     method: POST
   response:
-    body: '{"id":70,"version":0,"title":"This is a test PR","description":"- One\n-
-      Two","state":"OPEN","open":true,"closed":false,"createdDate":1585577826322,"updatedDate":1585577826322,"fromRef":{"id":"refs/heads/test-pr-bbs-17","displayId":"test-pr-bbs-17","latestCommit":"91d3c74b68e068e0d19fbff2f6171ec71f2ecfab","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"e833db3fe2bdbc28b58cd72def1b0078e77aa171","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
-      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/70"}]}}'
+    body: '{"id":141,"version":0,"title":"This is a test PR","description":"- One\n-
+      Two","state":"OPEN","open":true,"closed":false,"createdDate":1619784752633,"updatedDate":1619784752633,"fromRef":{"id":"refs/heads/test-pr-bbs-17","displayId":"test-pr-bbs-17","latestCommit":"91d3c74b68e068e0d19fbff2f6171ec71f2ecfab","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"db0a6e3b7bcd9963cfaa69bd3f87e04a803900ac","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/141"}]}}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57c273c1aec6491a-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 30 Mar 2020 14:17:06 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 12:12:32 GMT
       Location:
-      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/70
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/141
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx857x614391x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx732x105054x0'
       X-Asessionid:
-      - mqpb94
+      - hge7u2
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 201 Created

--- a/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-pull-request-already-exists.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-pull-request-already-exists.yaml
@@ -2,8 +2,46 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/default-reviewers/1.0/projects/SOUR/repos/automation-testing/reviewers?sourceRefId=refs%2Fheads%2Falways-open-pr-bbs&sourceRepoId=10070&targetRefId=refs%2Fheads%2Fmaster&targetRepoId=10070
+    method: GET
+  response:
+    body: '[{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}}]'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Apr 2021 12:05:11 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TO58QJx725x104200x0'
+      X-Asessionid:
+      - 2yup3s
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: |
-      {"title":"This is a test PR","description":"This is a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/always-open-pr-bbs","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+      {"title":"This is a test PR","description":"This is a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/always-open-pr-bbs","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false,"reviewers":[{"user":{"name":"erik"}},{"user":{"name":"thorsten"}}]}
     form: {}
     headers:
       Content-Type:
@@ -12,9 +50,9 @@ interactions:
     method: POST
   response:
     body: '{"errors":[{"context":null,"message":"Only one pull request may be open
-      for a given source and target branch","exceptionName":"com.atlassian.bitbucket.pull.DuplicatePullRequestException","existingPullRequest":{"id":3,"version":0,"title":"This
-      testing PR is always open","description":"Ignore this. This is a testing PR
-      that is always open.","state":"OPEN","open":true,"closed":false,"createdDate":1573644199945,"updatedDate":1573644199945,"fromRef":{"id":"refs/heads/always-open-pr-bbs","displayId":"always-open-pr-bbs","latestCommit":"b939ea0debe88e145c5409230b29e7dbbedcb9da","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"c75943274b322ffef2230df8f8049de84ddf12c1","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/3"}]}}}]}'
+      for a given source and target branch","exceptionName":"com.atlassian.bitbucket.pull.DuplicatePullRequestException","existingPullRequest":{"id":132,"version":0,"title":"This
+      is a test PR","description":"This is a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"createdDate":1618447968146,"updatedDate":1618447968146,"fromRef":{"id":"refs/heads/always-open-pr-bbs","displayId":"always-open-pr-bbs","latestCommit":"b939ea0debe88e145c5409230b29e7dbbedcb9da","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"db0a6e3b7bcd9963cfaa69bd3f87e04a803900ac","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/132"}]}}}]}'
     headers:
       Cache-Control:
       - private, no-cache
@@ -22,23 +60,21 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 13 Nov 2019 11:24:37 GMT
+      - Fri, 30 Apr 2021 12:05:12 GMT
       Pragma:
       - no-cache
       Server:
       - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@1IK17DGx684x2504569x0'
-      X-Asen:
-      - SEN-L13789548
+      - '@TO58QJx725x104202x0'
       X-Asessionid:
-      - 1bk87qm
+      - e99w1n
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 409 Conflict

--- a/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-success.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequest-success.yaml
@@ -2,8 +2,46 @@
 version: 1
 interactions:
 - request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/default-reviewers/1.0/projects/SOUR/repos/automation-testing/reviewers?sourceRefId=refs%2Fheads%2Ftest-pr-bbs-3&sourceRepoId=10070&targetRefId=refs%2Fheads%2Fmaster&targetRepoId=10070
+    method: GET
+  response:
+    body: '[{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}}]'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Apr 2021 12:12:21 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TO58QJx732x105040x0'
+      X-Asessionid:
+      - 1qakpqf
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
     body: |
-      {"title":"This is a test PR","description":"This is a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-3","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":0,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false}
+      {"title":"This is a test PR","description":"This is a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"fromRef":{"id":"refs/heads/test-pr-bbs-3","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"toRef":{"id":"refs/heads/master","repository":{"id":10070,"slug":"automation-testing","project":{"key":"SOUR"}}},"locked":false,"reviewers":[{"user":{"name":"erik"}},{"user":{"name":"thorsten"}}]}
     form: {}
     headers:
       Content-Type:
@@ -11,41 +49,33 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests
     method: POST
   response:
-    body: '{"id":71,"version":0,"title":"This is a test PR","description":"This is
-      a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"createdDate":1585577904728,"updatedDate":1585577904728,"fromRef":{"id":"refs/heads/test-pr-bbs-3","displayId":"test-pr-bbs-3","latestCommit":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"e833db3fe2bdbc28b58cd72def1b0078e77aa171","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"milton","emailAddress":"dev@sourcegraph.com","id":1,"displayName":"milton
-      woof","active":true,"slug":"milton","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/milton"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/71"}]}}'
+    body: '{"id":140,"version":0,"title":"This is a test PR","description":"This is
+      a test PR. Feel free to ignore.","state":"OPEN","open":true,"closed":false,"createdDate":1619784741907,"updatedDate":1619784741907,"fromRef":{"id":"refs/heads/test-pr-bbs-3","displayId":"test-pr-bbs-3","latestCommit":"c9324a86ac324cdf48f3db3595d2dd013e43b56c","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"db0a6e3b7bcd9963cfaa69bd3f87e04a803900ac","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/140"}]}}'
     headers:
       Cache-Control:
       - private, no-cache
       - no-cache, no-transform
-      Cf-Cache-Status:
-      - DYNAMIC
-      Cf-Ray:
-      - 57c275abbe66806e-CPT
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 30 Mar 2020 14:18:24 GMT
-      Expect-Ct:
-      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      - Fri, 30 Apr 2021 12:12:21 GMT
       Location:
-      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/71
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/140
       Pragma:
       - no-cache
       Server:
-      - cloudflare
+      - Caddy
       Vary:
-      - X-AUSERNAME,Accept-Encoding
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@MWNSEUx858x614463x0'
-      X-Asen:
-      - SEN-11363689
+      - '@TO58QJx732x105041x0'
       X-Asessionid:
-      - 1aonnlu
+      - t12wmw
       X-Auserid:
-      - "1"
+      - "152"
       X-Ausername:
-      - milton
+      - erik
       X-Content-Type-Options:
       - nosniff
     status: 201 Created

--- a/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequestComment-success.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/CreatePullRequestComment-success.yaml
@@ -11,23 +11,28 @@ interactions:
     url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/63/comments?version=2
     method: POST
   response:
-    body: '{"properties":{"repositoryId":10070},"id":2790,"version":0,"text":"test_comment","author":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
-      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"createdDate":1618447968919,"updatedDate":1618447968919,"comments":[],"tasks":[],"severity":"NORMAL","state":"OPEN","permittedOperations":{"editable":true,"transitionable":true,"deletable":true}}'
+    body: '{"properties":{"repositoryId":10070},"id":2810,"version":0,"text":"test_comment","author":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"createdDate":1619784742091,"updatedDate":1619784742091,"comments":[],"tasks":[],"severity":"NORMAL","state":"OPEN","permittedOperations":{"editable":true,"transitionable":true,"deletable":true}}'
     headers:
       Cache-Control:
+      - private, no-cache
       - no-cache, no-transform
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 15 Apr 2021 00:52:48 GMT
+      - Fri, 30 Apr 2021 12:12:21 GMT
       Location:
-      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/63/comments/2790?version=2
+      - https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/63/comments/2810?version=2
+      Pragma:
+      - no-cache
       Server:
       - Caddy
       Vary:
       - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
       X-Arequestid:
-      - '@1MUQQ7Jx52x452530x0'
+      - '@TO58QJx732x105042x0'
+      X-Asessionid:
+      - 191lb6e
       X-Auserid:
       - "152"
       X-Ausername:

--- a/internal/extsvc/bitbucketserver/testdata/vcr/FetchDefaultReviewers-success.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/FetchDefaultReviewers-success.yaml
@@ -1,0 +1,41 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/default-reviewers/1.0/projects/SOUR/repos/automation-testing/reviewers?sourceRefId=refs%2Fheads%2Ftest-pr-bbs-3&sourceRepoId=10070&targetRefId=refs%2Fheads%2Fmaster&targetRepoId=10070
+    method: GET
+  response:
+    body: '[{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}}]'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 30 Apr 2021 12:05:12 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TO58QJx725x104205x0'
+      X-Asessionid:
+      - 1tc7voa
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""


### PR DESCRIPTION
Since we deemed this an oversight and not an additional feature, I went ahead and implemented it as a "bug fix". It wasn't much effort to do and works alright, so I guess we _could_ merge it. Deferring to other engineers and product to make that decision.

Demo PR: https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/142/overview (user `thorsten` is assigned)

Closes https://github.com/sourcegraph/sourcegraph/issues/20472
Closes https://github.com/sourcegraph/sourcegraph/issues/14746