### PR TITLE
Remove file match resource

### DIFF
--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -219,7 +219,6 @@ function toGQLFileMatchBase(fileMatch: FileMatch | FileSymbolMatch): GQL.IFileMa
         file,
         repository,
         revSpec: revisionSpec,
-        resource: fileMatch.name,
         symbols: [],
         lineMatches: [],
         limitHit: false,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -4060,10 +4060,6 @@ type FileMatch {
     """
     revSpec: GitRevSpec
     """
-    The resource.
-    """
-    resource: String! @deprecated(reason: "use the file field instead")
-    """
     The symbols found in this file that match the query.
     """
     symbols: [Symbol!]!

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -84,10 +84,6 @@ func (fm *FileMatchResolver) RevSpec() *gitRevSpec {
 	}
 }
 
-func (fm *FileMatchResolver) Resource() string {
-	return fm.URL()
-}
-
 func (fm *FileMatchResolver) Symbols() []symbolResolver {
 	return symbolResultsToResolvers(fm.db, fm.Commit(), fm.FileMatch.Symbols)
 }

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -312,7 +312,7 @@ func TestIndexedSearch(t *testing.T) {
 			var gotMatchInputRevs []string
 			for _, m := range gotFm {
 				gotMatchCount += int(m.ResultCount())
-				gotMatchURLs = append(gotMatchURLs, m.Resource())
+				gotMatchURLs = append(gotMatchURLs, m.URL())
 				if m.InputRev != nil {
 					gotMatchInputRevs = append(gotMatchInputRevs, *m.InputRev)
 				}


### PR DESCRIPTION
The field has been deprecated since at least 2018, and it is the only
external-facing code using `FileMatch.URL()`.

Reopened from #20532 because of github weirdness

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
