### PR TITLE
Resolver-free Symbol URL

### DIFF
--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/go-langserver/pkg/lsp"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -177,19 +176,6 @@ func TestLimitingSymbolResults(t *testing.T) {
 					t.Error(cmp.Diff(res2, tc.want))
 				}
 			})
-		}
-	})
-}
-
-func TestSymbolRange(t *testing.T) {
-	t.Run("unescaped pattern", func(t *testing.T) {
-		want := lsp.Range{
-			Start: lsp.Position{Line: 0, Character: 37},
-			End:   lsp.Position{Line: 0, Character: 40},
-		}
-		got := symbolRange(result.Symbol{Line: 1, Name: "baz", Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`})
-		if diff := cmp.Diff(want, got); diff != "" {
-			t.Fatal(diff)
 		}
 	})
 }

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -287,7 +287,7 @@ func (r symbolResolver) Language() string { return r.Symbol.Language }
 
 func (r symbolResolver) Location() *locationResolver {
 	stat := CreateFileInfo(r.Symbol.Path, false)
-	sr := symbolRange(r.Symbol)
+	sr := r.Symbol.Range()
 	return &locationResolver{
 		resource: NewGitTreeEntryResolver(r.commit, r.db, stat),
 		lspRange: &sr,

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -186,16 +186,10 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				display = fm.Limit(display)
 
 				if syms := fm.Symbols(); len(syms) > 0 {
-					// Inlining to avoid exporting a bunch of stuff from
-					// graphqlbackend
 					symbols := make([]streamhttp.Symbol, 0, len(syms))
 					for _, sym := range syms {
-						u, err := sym.URL(ctx)
-						if err != nil {
-							continue
-						}
 						symbols = append(symbols, streamhttp.Symbol{
-							URL:           u,
+							URL:           sym.SymbolMatch.URL().String(),
 							Name:          sym.Name(),
 							ContainerName: fromStrPtr(sym.ContainerName()),
 							Kind:          sym.Kind(),

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -1,6 +1,9 @@
 package result
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -15,6 +18,20 @@ type File struct {
 	Repo     types.RepoName `json:"-"`
 	CommitID api.CommitID   `json:"-"`
 	Path     string
+}
+
+func (f *File) URL() *url.URL {
+	var path strings.Builder
+	path.Grow(len("/@/-/blob/") + len(f.Repo.Name) + len(f.Path) + 20)
+	path.WriteRune('/')
+	path.WriteString(string(f.Repo.Name))
+	if f.InputRev != nil {
+		path.WriteRune('@')
+		path.WriteString(*f.InputRev)
+	}
+	path.WriteString("/-/blob/")
+	path.WriteString(f.Path)
+	return &url.URL{Path: path.String()}
 }
 
 // FileMatch represents either:

--- a/internal/search/result/file.go
+++ b/internal/search/result/file.go
@@ -25,7 +25,7 @@ func (f *File) URL() *url.URL {
 	path.Grow(len("/@/-/blob/") + len(f.Repo.Name) + len(f.Path) + 20)
 	path.WriteRune('/')
 	path.WriteString(string(f.Repo.Name))
-	if f.InputRev != nil {
+	if f.InputRev != nil && len(*f.InputRev) > 0 {
 		path.WriteRune('@')
 		path.WriteString(*f.InputRev)
 	}

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -33,7 +33,7 @@ type Symbol struct {
 // data member that currently exposes line content: the symbols Pattern member,
 // which has the form /^ ... $/. We find the offset of the symbol name in this
 // line, after escaping the Pattern.
-func (s Symbol) offset() int {
+func (s *Symbol) offset() int {
 	if s.Pattern == "" {
 		return 0
 	}

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -1,12 +1,22 @@
 package result
 
 import (
+	"fmt"
+	"net/url"
+	"strconv"
 	"strings"
+	"unicode/utf8"
+
+	"github.com/sourcegraph/go-lsp"
 )
 
 // Symbol is a code symbol.
 type Symbol struct {
-	Name       string
+	Name string
+
+	// TODO (@camdencheek): remove path since it's duplicated
+	// in the file reference of symbol match. Alternatively,
+	// merge Symbol and SymbolMatch.
 	Path       string
 	Line       int
 	Kind       string
@@ -19,6 +29,60 @@ type Symbol struct {
 	FileLimited bool
 }
 
+// offset calculates a symbol offset based on the the only Symbol
+// data member that currently exposes line content: the symbols Pattern member,
+// which has the form /^ ... $/. We find the offset of the symbol name in this
+// line, after escaping the Pattern.
+func (s Symbol) offset() int {
+	if s.Pattern == "" {
+		return 0
+	}
+	i := strings.Index(unescapePattern(s.Pattern), s.Name)
+	if i >= 0 {
+		return i
+	}
+	return 0
+}
+
+// unescapePattern expects a regexp pattern of the form /^ ... $/ and unescapes
+// the pattern inside it.
+func unescapePattern(pattern string) string {
+	pattern = strings.TrimSuffix(strings.TrimPrefix(pattern, "/^"), "$/")
+	var start int
+	var r rune
+	var escaped []rune
+	buf := []byte(pattern)
+
+	next := func() rune {
+		r, start := utf8.DecodeRune(buf)
+		buf = buf[start:]
+		return r
+	}
+
+	for len(buf) > 0 {
+		r = next()
+		if r == '\\' && len(buf[start:]) > 0 {
+			r = next()
+			if r == '/' || r == '\\' {
+				escaped = append(escaped, r)
+				continue
+			}
+			escaped = append(escaped, '\\', r)
+			continue
+		}
+		escaped = append(escaped, r)
+	}
+	return string(escaped)
+}
+
+func (s Symbol) Range() lsp.Range {
+	offset := s.offset()
+	return lsp.Range{
+		Start: lsp.Position{Line: s.Line - 1, Character: offset},
+		End:   lsp.Position{Line: s.Line - 1, Character: offset + len(s.Name)},
+	}
+}
+
 // Symbols is the result of a search on the symbols service.
 type Symbols = []Symbol
 
@@ -26,6 +90,28 @@ type Symbols = []Symbol
 type SymbolMatch struct {
 	Symbol Symbol
 	File   *File
+}
+
+func (s *SymbolMatch) URL() *url.URL {
+	base := s.File.URL()
+	base.Fragment = urlFragmentFromRange(s.Symbol.Range())
+	return base
+}
+
+func urlFragmentFromRange(lspRange lsp.Range) string {
+	if lspRange.Start == lspRange.End {
+		return "L" + lineSpecFromPosition(lspRange.Start, false)
+	}
+
+	hasCharacter := lspRange.Start.Character != 0 || lspRange.End.Character != 0
+	return "L" + lineSpecFromPosition(lspRange.Start, hasCharacter) + "-" + lineSpecFromPosition(lspRange.End, hasCharacter)
+}
+
+func lineSpecFromPosition(pos lsp.Position, forceIncludeCharacter bool) string {
+	if !forceIncludeCharacter && pos.Character == 0 {
+		return strconv.Itoa(pos.Line + 1)
+	}
+	return fmt.Sprintf("%d:%d", pos.Line+1, pos.Character+1)
 }
 
 // toSelectKind maps an internal symbol kind (cf. ctagsKind) to a corresponding

--- a/internal/search/result/symbol_test.go
+++ b/internal/search/result/symbol_test.go
@@ -1,0 +1,69 @@
+package result
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sourcegraph/go-lsp"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSymbolRange(t *testing.T) {
+	t.Run("unescaped pattern", func(t *testing.T) {
+		want := lsp.Range{
+			Start: lsp.Position{Line: 0, Character: 37},
+			End:   lsp.Position{Line: 0, Character: 40},
+		}
+		got := Symbol{Line: 1, Name: "baz", Pattern: `/^bar() { var regex = \/.*\\\/\/; function baz() { }  } $/`}.Range()
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+}
+
+func TestSymbolURL(t *testing.T) {
+	repoA := types.RepoName{Name: "repo/A", ID: 1}
+	fileAA := File{Repo: repoA, Path: "A"}
+
+	rev := "testrev"
+	fileAB := File{Repo: repoA, Path: "B", InputRev: &rev}
+
+	cases := []struct {
+		name   string
+		symbol SymbolMatch
+		url    string
+	}{
+		{
+			name: "simple",
+			symbol: SymbolMatch{
+				File: &fileAA,
+				Symbol: Symbol{
+					Name:    "testsymbol",
+					Line:    3,
+					Pattern: `/^abc testsymbol def$/`,
+				},
+			},
+			url: "/repo/A/-/blob/A#L3:5-3:15",
+		},
+		{
+			name: "with rev",
+			symbol: SymbolMatch{
+				File: &fileAB,
+				Symbol: Symbol{
+					Name:    "testsymbol",
+					Line:    3,
+					Pattern: `/^abc testsymbol def$/`,
+				},
+			},
+			url: "/repo/A@testrev/-/blob/B#L3:5-3:15",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := tc.symbol.URL().String()
+			require.Equal(t, tc.url, u)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a `URL()` method to both `result.File` and `result.SymbolMatch`. This allows us to use this method instead of `LocationResolver` to build the URL to the symbol. This is required for using result types for streaming search. 

Stacked on #20538 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
