### PR TITLE
code-intel: make table rows scroll on overflow

### DIFF
--- a/client/web/src/enterprise/codeintel/detail/CodeIntelIndexTimeline.scss
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelIndexTimeline.scss
@@ -1,5 +1,10 @@
 .docker-command-spec {
+    display: flex;
+    flex-direction: row;
+    overflow: auto;
+
     &__header {
         width: 5rem;
+        flex-shrink: 0;
     }
 }

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelIndexTimeline.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelIndexTimeline.tsx
@@ -172,22 +172,22 @@ const ExecutionLogEntry: FunctionComponent<ExecutionLogEntryProps> = ({ logEntry
             </div>
 
             {meta && (
-                <table className="table mt-4 mb-0 docker-command-spec">
-                    <tr>
-                        <th className="docker-command-spec__header">Image</th>
-                        <td>{meta.image}</td>
-                    </tr>
-                    <tr>
-                        <th className="docker-command-spec__header">Commands</th>
-                        <td>
+                <div className="pt-3">
+                    <div className="docker-command-spec py-2 border-top pl-2">
+                        <strong className="docker-command-spec__header">Image</strong>
+                        <div>{meta.image}</div>
+                    </div>
+                    <div className="docker-command-spec py-2 border-top pl-2">
+                        <strong className="docker-command-spec__header">Commands</strong>
+                        <div>
                             <code>{meta.commands.join(' ')}</code>
-                        </td>
-                    </tr>
-                    <tr>
-                        <th className="docker-command-spec__header">Root</th>
-                        <td>/{meta.root}</td>
-                    </tr>
-                </table>
+                        </div>
+                    </div>
+                    <div className="docker-command-spec py-2 border-top pl-2">
+                        <strong className="docker-command-spec__header">Root</strong>
+                        <div>/{meta.root}</div>
+                    </div>
+                </div>
             )}
         </div>
 


### PR DESCRIPTION
I feel iffy about the `!important`, but Im not sure how else to fix the issue of double borders cc @sourcegraph/frontend-platform 

<details>
<summary>OLD</summary>

![image](https://user-images.githubusercontent.com/18282288/116723938-f0538400-a9d7-11eb-94fc-04f59128eb45.png)

</details>

<details>
<summary>NEW</summary>

![image](https://user-images.githubusercontent.com/18282288/118301755-58778f00-b4db-11eb-9296-852a269c3993.png)

</details>