### PR TITLE
Remove symbol resolver dependencies

### DIFF
--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -395,7 +395,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 				if len(sr.Symbol.Name) < 12 {
 					score++
 				}
-				switch ctagsKindToLSPSymbolKind(sr.Symbol.Kind) {
+				switch sr.Symbol.LSPKind() {
 				case lsp.SKFunction, lsp.SKMethod:
 					score += 2
 				case lsp.SKClass:

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 
-	"github.com/inconshreveable/log15"
 	"github.com/neelance/parallel"
 	"github.com/opentracing/opentracing-go/ext"
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/sourcegraph/go-lsp"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -215,64 +212,4 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 		return fileMatches[i].Path < fileMatches[j].Path
 	})
 	return fileMatches, err
-}
-
-func ctagsKindToLSPSymbolKind(kind string) lsp.SymbolKind {
-	// Ctags kinds are determined by the parser and do not (in general) match LSP symbol kinds.
-	switch strings.ToLower(kind) {
-	case "file":
-		return lsp.SKFile
-	case "module":
-		return lsp.SKModule
-	case "namespace":
-		return lsp.SKNamespace
-	case "package", "packagename", "subprogspec":
-		return lsp.SKPackage
-	case "class", "type", "service", "typedef", "union", "section", "subtype", "component":
-		return lsp.SKClass
-	case "method", "methodspec":
-		return lsp.SKMethod
-	case "property":
-		return lsp.SKProperty
-	case "field", "member", "anonmember", "recordfield":
-		return lsp.SKField
-	case "constructor":
-		return lsp.SKConstructor
-	case "enum", "enumerator":
-		return lsp.SKEnum
-	case "interface":
-		return lsp.SKInterface
-	case "function", "func", "subroutine", "macro", "subprogram", "procedure", "command", "singletonmethod":
-		return lsp.SKFunction
-	case "variable", "var", "functionvar", "define", "alias", "val":
-		return lsp.SKVariable
-	case "constant", "const":
-		return lsp.SKConstant
-	case "string", "message", "heredoc":
-		return lsp.SKString
-	case "number":
-		return lsp.SKNumber
-	case "bool", "boolean":
-		return lsp.SKBoolean
-	case "array":
-		return lsp.SKArray
-	case "object", "literal", "map":
-		return lsp.SKObject
-	case "key", "label", "target", "selector", "id", "tag":
-		return lsp.SKKey
-	case "null":
-		return lsp.SKNull
-	case "enum member", "enumconstant":
-		return lsp.SKEnumMember
-	case "struct":
-		return lsp.SKStruct
-	case "event":
-		return lsp.SKEvent
-	case "operator":
-		return lsp.SKOperator
-	case "type parameter", "annotation":
-		return lsp.SKTypeParameter
-	}
-	log15.Debug("Unknown ctags kind", "kind", kind)
-	return 0
 }

--- a/cmd/frontend/graphqlbackend/symbols.go
+++ b/cmd/frontend/graphqlbackend/symbols.go
@@ -276,7 +276,7 @@ func (r symbolResolver) ContainerName() *string {
 }
 
 func (r symbolResolver) Kind() string /* enum SymbolKind */ {
-	kind := ctagsKindToLSPSymbolKind(r.Symbol.Kind)
+	kind := r.Symbol.LSPKind()
 	if kind == 0 {
 		return "UNKNOWN"
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -188,11 +188,17 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				if syms := fm.Symbols(); len(syms) > 0 {
 					symbols := make([]streamhttp.Symbol, 0, len(syms))
 					for _, sym := range syms {
+						kind := sym.SymbolMatch.Symbol.LSPKind()
+						kindString := "UNKNOWN"
+						if kind != 0 {
+							kindString = strings.ToUpper(kind.String())
+						}
+
 						symbols = append(symbols, streamhttp.Symbol{
 							URL:           sym.SymbolMatch.URL().String(),
-							Name:          sym.Name(),
-							ContainerName: fromStrPtr(sym.ContainerName()),
-							Kind:          sym.Kind(),
+							Name:          sym.SymbolMatch.Symbol.Name,
+							ContainerName: sym.SymbolMatch.Symbol.Parent,
+							Kind:          kindString,
 						})
 					}
 					matchesAppend(fromSymbolMatch(fm, symbols))

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -185,19 +185,19 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if fm, ok := result.ToFileMatch(); ok {
 				display = fm.Limit(display)
 
-				if syms := fm.Symbols(); len(syms) > 0 {
+				if syms := fm.FileMatch.Symbols; len(syms) > 0 {
 					symbols := make([]streamhttp.Symbol, 0, len(syms))
 					for _, sym := range syms {
-						kind := sym.SymbolMatch.Symbol.LSPKind()
+						kind := sym.Symbol.LSPKind()
 						kindString := "UNKNOWN"
 						if kind != 0 {
 							kindString = strings.ToUpper(kind.String())
 						}
 
 						symbols = append(symbols, streamhttp.Symbol{
-							URL:           sym.SymbolMatch.URL().String(),
-							Name:          sym.SymbolMatch.Symbol.Name,
-							ContainerName: sym.SymbolMatch.Symbol.Parent,
+							URL:           sym.URL().String(),
+							Name:          sym.Symbol.Name,
+							ContainerName: sym.Symbol.Parent,
 							Kind:          kindString,
 						})
 					}

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/go-lsp"
 )
 
@@ -86,7 +85,6 @@ func (s Symbol) LSPKind() lsp.SymbolKind {
 	case "type parameter", "annotation":
 		return lsp.SKTypeParameter
 	}
-	log15.Debug("Unknown ctags kind", "kind", s.Kind)
 	return 0
 }
 

--- a/internal/search/result/symbol.go
+++ b/internal/search/result/symbol.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/go-lsp"
 )
 
@@ -27,6 +28,66 @@ type Symbol struct {
 	Pattern    string
 
 	FileLimited bool
+}
+
+func (s Symbol) LSPKind() lsp.SymbolKind {
+	// Ctags kinds are determined by the parser and do not (in general) match LSP symbol kinds.
+	switch strings.ToLower(s.Kind) {
+	case "file":
+		return lsp.SKFile
+	case "module":
+		return lsp.SKModule
+	case "namespace":
+		return lsp.SKNamespace
+	case "package", "packagename", "subprogspec":
+		return lsp.SKPackage
+	case "class", "type", "service", "typedef", "union", "section", "subtype", "component":
+		return lsp.SKClass
+	case "method", "methodspec":
+		return lsp.SKMethod
+	case "property":
+		return lsp.SKProperty
+	case "field", "member", "anonmember", "recordfield":
+		return lsp.SKField
+	case "constructor":
+		return lsp.SKConstructor
+	case "enum", "enumerator":
+		return lsp.SKEnum
+	case "interface":
+		return lsp.SKInterface
+	case "function", "func", "subroutine", "macro", "subprogram", "procedure", "command", "singletonmethod":
+		return lsp.SKFunction
+	case "variable", "var", "functionvar", "define", "alias", "val":
+		return lsp.SKVariable
+	case "constant", "const":
+		return lsp.SKConstant
+	case "string", "message", "heredoc":
+		return lsp.SKString
+	case "number":
+		return lsp.SKNumber
+	case "bool", "boolean":
+		return lsp.SKBoolean
+	case "array":
+		return lsp.SKArray
+	case "object", "literal", "map":
+		return lsp.SKObject
+	case "key", "label", "target", "selector", "id", "tag":
+		return lsp.SKKey
+	case "null":
+		return lsp.SKNull
+	case "enum member", "enumconstant":
+		return lsp.SKEnumMember
+	case "struct":
+		return lsp.SKStruct
+	case "event":
+		return lsp.SKEvent
+	case "operator":
+		return lsp.SKOperator
+	case "type parameter", "annotation":
+		return lsp.SKTypeParameter
+	}
+	log15.Debug("Unknown ctags kind", "kind", s.Kind)
+	return 0
 }
 
 // offset calculates a symbol offset based on the the only Symbol


### PR DESCRIPTION
This removes all remaining dependencies of streaming search on symbol resolver methods. 

It trivially changes a few resolver calls to field accesses, and moves ctags to LSP kind translation into onto the `result.Symbol` type. Additionally, it removes the call to `FileMatchResolver.Symbols()` entirely so we never create symbol resolvers for streaming.

Stacked on #20555 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
