### PR TITLE
batches: don't panic on unexpected GitHub PR action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - `repo:contains(...)` built-in did not respect parameters that affect repo filtering (e.g., `repogroup`, `fork`). It now respects these. [#20339](https://github.com/sourcegraph/sourcegraph/pull/20339)
 - An issue where duplicate results would render for certain `or`-expressions. [#20480](https://github.com/sourcegraph/sourcegraph/pull/20480)
 - Issue where the search query bar suggests that some `lang` values are not valid. [#20534](https://github.com/sourcegraph/sourcegraph/pull/20534)
+- Pull request event webhooks received from GitHub with unexpected actions no longer cause panics.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - `repo:contains(...)` built-in did not respect parameters that affect repo filtering (e.g., `repogroup`, `fork`). It now respects these. [#20339](https://github.com/sourcegraph/sourcegraph/pull/20339)
 - An issue where duplicate results would render for certain `or`-expressions. [#20480](https://github.com/sourcegraph/sourcegraph/pull/20480)
 - Issue where the search query bar suggests that some `lang` values are not valid. [#20534](https://github.com/sourcegraph/sourcegraph/pull/20534)
-- Pull request event webhooks received from GitHub with unexpected actions no longer cause panics.
+- Pull request event webhooks received from GitHub with unexpected actions no longer cause panics. [#20571](https://github.com/sourcegraph/sourcegraph/pull/20571)
 
 ### Removed
 

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -112,7 +112,11 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 		}
 	}
 
-	events := e.ch.Events()
+	events, err := e.ch.Events()
+	if err != nil {
+		log15.Error("Events", "err", err)
+		return err
+	}
 	state.SetDerivedState(ctx, e.tx.Repos(), e.ch, events)
 
 	if err := e.tx.UpsertChangesetEvents(ctx, events...); err != nil {

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -16,6 +16,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
@@ -115,7 +116,7 @@ func (e *executor) Run(ctx context.Context, plan *Plan) (err error) {
 	events, err := e.ch.Events()
 	if err != nil {
 		log15.Error("Events", "err", err)
-		return err
+		return errcode.MakeNonRetryable(err)
 	}
 	state.SetDerivedState(ctx, e.tx.Repos(), e.ch, events)
 

--- a/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
@@ -88,7 +88,10 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 	})
 
 	// Create ChangesetEvents from the timeline items in the metadata.
-	events := changeset.Events()
+	events, err := changeset.Events()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := cstore.UpsertChangesetEvents(ctx, events...); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_test.go
@@ -156,7 +156,10 @@ func TestChangesetResolver(t *testing.T) {
 			UpdatedAt: now,
 		},
 	})
-	events := syncedGitHubChangeset.Events()
+	events, err := syncedGitHubChangeset.Events()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := cstore.UpsertChangesetEvents(ctx, events...); err != nil {
 		t.Fatal(err)
 	}

--- a/enterprise/internal/batches/syncer/syncer.go
+++ b/enterprise/internal/batches/syncer/syncer.go
@@ -456,7 +456,10 @@ func SyncChangeset(ctx context.Context, syncStore SyncStore, source sources.Chan
 		}
 	}
 
-	events := c.Events()
+	events, err := c.Events()
+	if err != nil {
+		return err
+	}
 	state.SetDerivedState(ctx, syncStore.Repos(), c, events)
 
 	tx, err := syncStore.Transact(ctx)

--- a/enterprise/internal/batches/types/changeset_event.go
+++ b/enterprise/internal/batches/types/changeset_event.go
@@ -77,6 +77,8 @@ const (
 	ChangesetEventKindGitLabUnapproved           ChangesetEventKind = "gitlab:unapproved"
 	ChangesetEventKindGitLabMarkWorkInProgress   ChangesetEventKind = "gitlab:mark_wip"
 	ChangesetEventKindGitLabUnmarkWorkInProgress ChangesetEventKind = "gitlab:unmark_wip"
+
+	ChangesetEventKindInvalid ChangesetEventKind = "invalid"
 )
 
 // A ChangesetEvent is an event that happened in the lifetime

--- a/enterprise/internal/batches/types/changeset_event_test.go
+++ b/enterprise/internal/batches/types/changeset_event_test.go
@@ -307,7 +307,10 @@ func TestChangesetEvent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			have := tc.changeset.Events()
+			have, err := tc.changeset.Events()
+			if err != nil {
+				t.Fatal(err)
+			}
 			want := tc.events
 
 			if diff := cmp.Diff(have, want); diff != "" {

--- a/enterprise/internal/batches/webhooks/github_test.go
+++ b/enterprise/internal/batches/webhooks/github_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	gh "github.com/google/go-github/v28/github"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/webhooks"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources"
@@ -214,5 +215,24 @@ func testGitHubWebhook(db *sql.DB, userID int32) func(*testing.T) {
 				}
 			})
 		}
+
+		t.Run("unexpected payload", func(t *testing.T) {
+			// GitHub pull request events are processed based on the action
+			// embedded within them, but that action is just a string that could
+			// be anything. We need to ensure that this is hardened against
+			// unexpected input.
+			n := 10156
+			action := "this is a bad action"
+
+			if err := hook.handleGitHubWebhook(ctx, extSvc, &gh.PullRequestEvent{
+				Number: &n,
+				Repo: &gh.Repository{
+					NodeID: &githubRepo.ExternalRepo.ID,
+				},
+				Action: &action,
+			}); err == nil {
+				t.Error("unexpected nil error")
+			}
+		})
 	}
 }

--- a/enterprise/internal/batches/webhooks/webhooks.go
+++ b/enterprise/internal/batches/webhooks/webhooks.go
@@ -109,6 +109,11 @@ func (h Webhook) upsertChangesetEvent(
 		return nil
 	}
 
+	var kind btypes.ChangesetEventKind
+	if kind, err = btypes.ChangesetEventKindFor(ev); err != nil {
+		return err
+	}
+
 	cs, err := tx.GetChangeset(ctx, store.GetChangesetOpts{
 		RepoID:              r.ID,
 		ExternalID:          strconv.FormatInt(pr.ID, 10),
@@ -124,7 +129,7 @@ func (h Webhook) upsertChangesetEvent(
 	now := h.Store.Clock()()
 	event := &btypes.ChangesetEvent{
 		ChangesetID: cs.ID,
-		Kind:        btypes.ChangesetEventKindFor(ev),
+		Kind:        kind,
 		Key:         ev.Key(),
 		CreatedAt:   now,
 		UpdatedAt:   now,

--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -182,6 +182,15 @@ func IsNonRetryable(err error) bool {
 	})
 }
 
+// MakeNonRetryable makes any error non-retryable.
+func MakeNonRetryable(err error) error {
+	return nonRetryableError{err}
+}
+
+type nonRetryableError struct{ error }
+
+func (nonRetryableError) NonRetryable() bool { return true }
+
 // isErrorPredicate returns true if err or one of its causes returns true when
 // passed to p.
 func isErrorPredicate(err error, p func(err error) bool) bool {

--- a/internal/errcode/code_test.go
+++ b/internal/errcode/code_test.go
@@ -27,6 +27,17 @@ func TestHTTP(t *testing.T) {
 	}
 }
 
+func TestMakeNonRetryable(t *testing.T) {
+	err := errors.New("foo")
+	if errcode.IsNonRetryable(err) {
+		t.Errorf("unexpected non-retryable error: %+v", err)
+	}
+
+	if nrerr := errcode.MakeNonRetryable(err); !errcode.IsNonRetryable(nrerr) {
+		t.Errorf("unexpected retryable error: %+v", nrerr)
+	}
+}
+
 type notFoundErr struct{}
 
 func (e *notFoundErr) Error() string {


### PR DESCRIPTION
When converting a raw payload to changeset event kind, we need to be able to handle payloads of unexpected types, especially nil, since we don't control the inputs that come in via webhooks.

The specific case that triggered this was a GitHub pull request event that had an unknown action: this results in a nil event keyer being returned, and that caused a panic in ChangesetEventKindFor().