### PR TITLE
docs: add `repo:contains`

### DIFF
--- a/doc/code_search/how-to/opengrok.md
+++ b/doc/code_search/how-to/opengrok.md
@@ -23,9 +23,9 @@ Sourcegraph, [provides full regular expression search](../reference/queries.md#r
 
 Oracle OpenGrok provides a multi-select dropdown box to allow users to select which repositories to include in a search. This scope is stored across sessions, until the user changes it.
 
-Sourcegraph provides a search keyword (`repo:`) that supports regexp and partial matches for selecting repositories. As examples: 
+Sourcegraph provides a search keyword (`repo:`) that supports regexp and partial matches for selecting repositories. As examples:
 
-- To search for the string "pattern" in all repositories in the github.com/org org, search for `pattern repo:github.com/org`. 
+- To search for the string "pattern" in all repositories in the github.com/org org, search for `pattern repo:github.com/org`.
 - To search in a distinct list of repositories, you can use a `|` character as a regexp OR operator: `pattern repo:github.com/org/repository1|github.com/org/repository2`.
   - Note this query could be simplified further using more advanced regexp matching if the two repos share part of their names, such as: `pattern repo:github.com/org/repository(1|2)`.
 
@@ -59,21 +59,22 @@ Sourcegraph also provides [`AND`, `OR`, and `NOT` operators](../reference/querie
 
 Both Sourcegraph and OpenGrok allow users to add keywords for scoping searches. Below is a mapping from OpenGrok syntax to Sourcegraph.
 
-| | OpenGrok | Sourcegraph |
-|-------------------|------------|--------|
-| Search text | `full:pattern` | `pattern` |
-| Search symbol definitions | `def:pattern` | `pattern type:symbol` |
-| Search symbol references | `def:pattern` | Available through hover tooltips and `Find references` panels on code pages |
-| Search for repository names | Not supported | `pattern type:repo` |
-| Search for file names | `file:pattern` | `file:pattern` |
-| Search commit messages | `hist:pattern` | `pattern type:commit` |
-| Search code changes (diff search) | Not supported | `pattern type:diff` |
-| Scope searches to a language | `pattern type:c` | `pattern lang:c` |
-| Case sensitivity | Not supported | `case:yes` or `case:no` |
-| Scope searches to forked repositories | Supported through the repository selector | `fork:yes`, `fork:no`, or `fork:only` |
-| Scope searches to archived repositories | Supported through the repository selector | `archived:yes`, `archived:no`, or `archived:only` |
-| Scope searches to repositories that contain a file | Not supported | `pattern repohasfile:foo` |
-| Scope searches to recently updated repositories | Not supported | `pattern repohascommitafter:"3 months"` or `pattern repohascommitafter:"june 25 2017"` |
+|                                                          | OpenGrok                                  | Sourcegraph                                                                                          |
+|----------------------------------------------------------|-------------------------------------------|------------------------------------------------------------------------------------------------------|
+| Search text                                              | `full:pattern`                            | `pattern`                                                                                            |
+| Search symbol definitions                                | `def:pattern`                             | `pattern type:symbol`                                                                                |
+| Search symbol references                                 | `def:pattern`                             | Available through hover tooltips and `Find references` panels on code pages                          |
+| Search for repository names                              | Not supported                             | `pattern type:repo`                                                                                  |
+| Search for file names                                    | `file:pattern`                            | `file:pattern`                                                                                       |
+| Search commit messages                                   | `hist:pattern`                            | `pattern type:commit`                                                                                |
+| Search code changes (diff search)                        | Not supported                             | `pattern type:diff`                                                                                  |
+| Scope searches to a language                             | `pattern type:c`                          | `pattern lang:c`                                                                                     |
+| Case sensitivity                                         | Not supported                             | `case:yes` or `case:no`                                                                              |
+| Scope searches to forked repositories                    | Supported through the repository selector | `fork:yes`, `fork:no`, or `fork:only`                                                                |
+| Scope searches to archived repositories                  | Supported through the repository selector | `archived:yes`, `archived:no`, or `archived:only`                                                    |
+| Scope searches to repositories that contain a file       | Not supported                             | `pattern repo:contains.file(README)`                                                                 |
+| Scope searches to repositories that contain file content | Not supported                             | `pattern repo:contains.content(TODO)`                                                                |
+| Scope searches to recently updated repositories          | Not supported                             | `pattern repo:contains.commit.after(3 months)` or `pattern repo:contains.commit.after(june 25 2017)` |
 
 Sourcegraph also provides keywords to [scope commit message and diff searches](../reference/queries.md#keywords-diff-and-commit-searches-only) to specific authors or timeframes in which a change was made.
 

--- a/doc/code_search/reference/language.md
+++ b/doc/code_search/reference/language.md
@@ -196,31 +196,33 @@ Search parameters allow you to filter search results or modify search behavior.
 
 <script>
 ComplexDiagram(
-    Choice(0,
-        Skip(),
-        Terminal("-"),
-        Sequence(
-            Terminal("NOT"),
-            Terminal("space", {href: "#whitespace"}))),
-    Choice(0,
-        Terminal("repo:"),
-        Terminal("r:")),
-        Terminal("regex", {href: "#regular-expression"}),
-    Choice(0,
-        Skip(),
-        Sequence(
-            Terminal("@"),
-            Terminal("revision", {href: "#revision"})),
-        Sequence(
-            Terminal("space", {href: "#whitespace"}),
-            Terminal("rev:"),
-            Terminal("revision", {href: "#revision"})))).addTo();
+		Choice(0,
+			Skip(),
+			Terminal("-"),
+			Sequence(
+				Terminal("NOT"),
+				Terminal("space", {href: "#whitespace"}))),
+		Choice(0,
+			Terminal("repo:"),
+			Terminal("r:")),
+		Choice(0,
+            Terminal("regex", {href: "#regular-expression"}),
+            Terminal("built-in", {href: "#built-in-predicate"})),
+   	    Choice(0,
+		    Skip(),
+		    Sequence(
+			    Terminal("@"),
+			    Terminal("revision", {href: "#revision"})),
+            Sequence(
+			    Terminal("space", {href: "#whitespace"}),
+			    Terminal("rev:"),
+			    Terminal("revision", {href: "#revision"})))).addTo();
 </script>
 
-Search repositories that match the regular expression.
-A `-` before `repo` excludes the repository. By default
-the repository will be searched at the `HEAD` commit of the default
-branch. You can optionally change the [revision](#revision).
+Search repositories that match the regular expression. A `-` before `repo`
+excludes the repository. By default the repository will be searched at the
+`HEAD` commit of the default branch. You can optionally change the
+[revision](#revision).
 
 **Example:** `repo:gorilla/mux testroute` [↗](https://sourcegraph.com/search?q=repo:gorilla/mux+testroute&patternType=regexp) `-repo:gorilla/mux testroute` [↗](https://sourcegraph.com/search?q=-repo:gorilla/mux+testroute&patternType=regexp)
 
@@ -501,7 +503,7 @@ ComplexDiagram(
     Terminal("regular expression", {href: "#regular-expression"})).addTo();
 </script>
 
-Only include results from repositories that contain a matching file. This
+_Deprecated. Prefer [Repo contains file](#repo-contains-file)._ Only include results from repositories that contain a matching file. This
 keyword is a pure filter, so it requires at least one other search term in the
 query. Note: this filter currently only works on text matches and file path
 matches.
@@ -516,8 +518,9 @@ ComplexDiagram(
     Terminal("quoted string", {href: "#quoted-string"})).addTo();
 </script>
 
-Filter out stale repositories that don’t contain commits past the specified time
-frame. This parameter is experimental.
+_Deprecated. Prefer [Repo contains commit
+after](#repo-contains-commit-after)._ Filter out stale repositories that don’t
+contain commits past the specified time frame. This parameter is experimental.
 
 **Example:** `repo:github\.com/sourcegraph repohascommitafter:"1 week ago"` [↗](https://sourcegraph.com/search?q=context:global+repo:github%5C.com/sourcegraph+repohascommitafter:%221+week+ago%22&patternType=literal)
 
@@ -598,6 +601,78 @@ ComplexDiagram(
 </script>
 
 A string that is interpreted as a <a href="https://golang.org/s/re2syntax">RE2</a> regular expression.
+
+## Built-in predicate
+
+<script>
+ComplexDiagram(
+    Choice(0,
+        Terminal("contains.content(...)", {href: "#repo-contains-content"}),
+        Terminal("contains.file(...)", {href: "#contains-file"}),
+        Terminal("contains(...)", {href: "#contains"}),
+        Terminal("contains.commit.after(...)", {href: "#contains-commit-after"}))).addTo();
+</script>
+
+### Repo contains file
+
+<script>
+ComplexDiagram(
+    Terminal("contains.file"),
+    Terminal("("),
+    Terminal("regexp", {href: "#regexp"}),
+    Terminal(")")).addTo();
+</script>
+
+Search only inside repositories that contain a file path matching the regular expression.
+
+**Example:** `repo:contains.file(README)` [↗](https://sourcegraph.com/search?q=repo:contains%28file:README%29&patternType=literal)
+
+### Repo contains content
+
+<script>
+ComplexDiagram(
+    Terminal("contains.content"),
+    Terminal("("),
+    Terminal("regexp", {href: "#regular-expression"}),
+    Terminal(")")).addTo();
+</script>
+
+Search only inside repositories that contain file content matching the regular expression.
+
+**Example:** `repo:contains.content(TODO)` [↗](https://sourcegraph.com/search?q=repo:contains.content%28TODO%29&patternType=literal)
+
+### Repo contains file and content
+
+<script>
+ComplexDiagram(
+    Terminal("contains"),
+    Terminal("("),
+    Stack(
+        Sequence(Terminal("file:"), Terminal("regexp", {href: "#regular-expression"}), Terminal("space", {href: "#whitespace"})),
+        Sequence(Terminal("content:"),Terminal("regexp", {href: "#regular-expression"}))),
+    Terminal(")")).addTo();
+</script>
+
+Search only inside repositories that contain a file matching the `file:` with `content:` filters.
+
+**Example:** `repo:contains(file:CHANGELOG content:fix)` [↗](https://sourcegraph.com/search?q=repo:contains%28file:CHANGELOG+content:fix%29&patternType=literal)
+
+### Repo contains commit after
+
+<script>
+ComplexDiagram(
+    Terminal("contains.commit.after"),
+    Terminal("("),
+    Terminal("string", {href: "#string"}),
+    Terminal(")")).addTo();
+</script>
+
+Search only inside repositories that contain a a commit after some specified
+time. See [git date formats](https://github.com/git/git/blob/master/Documentation/date-formats.txt)
+for accepted formats. Use this to filter out stale repositories that don’t contain
+commits past the specified time frame. This parameter is experimental.
+
+**Example:** `repo:contains.commit.after(1 month ago)` [↗](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph+repo:contains.commit.after%281+month+ago%29&patternType=literal)
 
 ## String
 

--- a/doc/code_search/reference/language.md
+++ b/doc/code_search/reference/language.md
@@ -196,27 +196,27 @@ Search parameters allow you to filter search results or modify search behavior.
 
 <script>
 ComplexDiagram(
-		Choice(0,
-			Skip(),
-			Terminal("-"),
-			Sequence(
-				Terminal("NOT"),
-				Terminal("space", {href: "#whitespace"}))),
-		Choice(0,
-			Terminal("repo:"),
-			Terminal("r:")),
-		Choice(0,
-            Terminal("regex", {href: "#regular-expression"}),
-            Terminal("built-in", {href: "#built-in-predicate"})),
-   	    Choice(0,
-		    Skip(),
-		    Sequence(
-			    Terminal("@"),
-			    Terminal("revision", {href: "#revision"})),
-            Sequence(
-			    Terminal("space", {href: "#whitespace"}),
-			    Terminal("rev:"),
-			    Terminal("revision", {href: "#revision"})))).addTo();
+    Choice(0,
+        Skip(),
+        Terminal("-"),
+        Sequence(
+            Terminal("NOT"),
+            Terminal("space", {href: "#whitespace"}))),
+    Choice(0,
+        Terminal("repo:"),
+        Terminal("r:")),
+    Choice(0,
+        Terminal("regex", {href: "#regular-expression"}),
+        Terminal("built-in", {href: "#built-in-predicate"})),
+    Choice(0,
+        Skip(),
+        Sequence(
+            Terminal("@"),
+            Terminal("revision", {href: "#revision"})),
+        Sequence(
+            Terminal("space", {href: "#whitespace"}),
+            Terminal("rev:"),
+            Terminal("revision", {href: "#revision"})))).addTo();
 </script>
 
 Search repositories that match the regular expression. A `-` before `repo`
@@ -518,8 +518,7 @@ ComplexDiagram(
     Terminal("quoted string", {href: "#quoted-string"})).addTo();
 </script>
 
-_Deprecated. Prefer [Repo contains commit
-after](#repo-contains-commit-after)._ Filter out stale repositories that don’t
+_Deprecated. Prefer [Repo contains commit after](#repo-contains-commit-after)._ Filter out stale repositories that don’t
 contain commits past the specified time frame. This parameter is experimental.
 
 **Example:** `repo:github\.com/sourcegraph repohascommitafter:"1 week ago"` [↗](https://sourcegraph.com/search?q=context:global+repo:github%5C.com/sourcegraph+repohascommitafter:%221+week+ago%22&patternType=literal)
@@ -591,26 +590,15 @@ or a structural search pattern. This parameter is available as a command-line an
 accessibility option, and synonymous with the visual [search pattern](#search-pattern) toggles.
 in [search pattern](#search-pattern).
 
-## Regular expression
-
-<script>
-ComplexDiagram(
-    Choice(0,
-        Terminal("string", {href: "#string"}),
-        Terminal("quoted string", {href: "#quoted-string"}))).addTo();
-</script>
-
-A string that is interpreted as a <a href="https://golang.org/s/re2syntax">RE2</a> regular expression.
-
 ## Built-in predicate
 
 <script>
 ComplexDiagram(
     Choice(0,
         Terminal("contains.content(...)", {href: "#repo-contains-content"}),
-        Terminal("contains.file(...)", {href: "#contains-file"}),
-        Terminal("contains(...)", {href: "#contains"}),
-        Terminal("contains.commit.after(...)", {href: "#contains-commit-after"}))).addTo();
+        Terminal("contains.file(...)", {href: "#repo-contains-file"}),
+        Terminal("contains(...)", {href: "#repo-contains-file-and-content"}),
+        Terminal("contains.commit.after(...)", {href: "#repo-contains-commit-after"}))).addTo();
 </script>
 
 ### Repo contains file
@@ -673,6 +661,17 @@ for accepted formats. Use this to filter out stale repositories that don’t con
 commits past the specified time frame. This parameter is experimental.
 
 **Example:** `repo:contains.commit.after(1 month ago)` [↗](https://sourcegraph.com/search?q=repo:github%5C.com/sourcegraph+repo:contains.commit.after%281+month+ago%29&patternType=literal)
+
+## Regular expression
+
+<script>
+ComplexDiagram(
+    Choice(0,
+        Terminal("string", {href: "#string"}),
+        Terminal("quoted string", {href: "#quoted-string"}))).addTo();
+</script>
+
+A string that is interpreted as a <a href="https://golang.org/s/re2syntax">RE2</a> regular expression.
 
 ## String
 


### PR DESCRIPTION
This updates the language doc, and OpenGrok doc. 

Updates look a bit out of place in the the tabular search query docs, because we don't support negation. Will see if I can PR something like that soon and will update then. The partial update here is good enough to ship.

 I will also remove the Deprecated note one iteration from now.
