### PR TITLE
Fix repo rev deduplication

### DIFF
--- a/internal/search/result/match.go
+++ b/internal/search/result/match.go
@@ -42,6 +42,9 @@ type Key struct {
 	// Repo is the name of the repo the match belongs to
 	Repo api.RepoName
 
+	// Rev is the revision associated with the repo if it exists
+	Rev string
+
 	// Commit is the commit hash of the commit the match belongs to.
 	// Empty if there is no commit associated with the match (e.g. RepoMatch)
 	Commit api.CommitID
@@ -58,6 +61,10 @@ type Key struct {
 func (k Key) Less(other Key) bool {
 	if k.Repo != other.Repo {
 		return k.Repo < other.Repo
+	}
+
+	if k.Rev != other.Rev {
+		return k.Rev < other.Rev
 	}
 
 	if k.Commit != other.Commit {

--- a/internal/search/result/repo.go
+++ b/internal/search/result/repo.go
@@ -52,6 +52,7 @@ func (r *RepoMatch) Key() Key {
 	return Key{
 		TypeRank: rankRepoMatch,
 		Repo:     r.Name,
+		Rev:      r.Rev,
 	}
 }
 


### PR DESCRIPTION
The repo key did not include the repo rev, so repos with different revs were being merged. Will merge without review if it passes backend integration tests since this is currently breaking main builds. 

Introduced by #20538 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
