### PR TITLE
search redesign: inline search for repo sidebar section

### DIFF
--- a/client/web/src/search/results/streaming/sidebar/FilterLink.tsx
+++ b/client/web/src/search/results/streaming/sidebar/FilterLink.tsx
@@ -9,7 +9,7 @@ import { Filter } from '../../../stream'
 
 import styles from './SearchSidebarSection.module.scss'
 
-interface FilterLinkProps {
+export interface FilterLinkProps {
     label: string
     value: string
     count?: number
@@ -17,7 +17,13 @@ interface FilterLinkProps {
     onFilterChosen: (value: string) => void
 }
 
-const FilterLink: React.FunctionComponent<FilterLinkProps> = ({ label, value, count, limitHit, onFilterChosen }) => (
+export const FilterLink: React.FunctionComponent<FilterLinkProps> = ({
+    label,
+    value,
+    count,
+    limitHit,
+    onFilterChosen,
+}) => (
     <button
         type="button"
         className={classNames('test-sidebar-filter-link btn btn-link', styles.sidebarSectionListItem)}

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.story.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.story.tsx
@@ -73,6 +73,7 @@ const filters: Filter[] = [
         limitHit: false,
         kind: 'lang',
     },
+
     {
         label: '-file:_test\\.go$',
         value: '-file:_test\\.go$',
@@ -80,6 +81,14 @@ const filters: Filter[] = [
         limitHit: false,
         kind: 'file',
     },
+
+    ...['typescript', 'javascript', 'c++', 'c', 'c#', 'python', 'ruby', 'haskell', 'java'].map(lang => ({
+        label: `lang:${lang}`,
+        value: `lang:${lang}`,
+        count: 10,
+        limitHit: true,
+        kind: 'lang',
+    })),
 ]
 
 add('empty sidebar', () => <WebStory>{() => <SearchSidebar {...defaultProps} />}</WebStory>)

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
@@ -45,7 +45,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     return (
         <div className={styles.searchSidebar}>
             <SearchSidebarSection header="Search types">{getSearchTypeLinks(props)}</SearchSidebarSection>
-            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+            <SearchSidebarSection header="Dynamic filters">
                 {getDynamicFilterLinks(props.filters, onFilterClicked)}
             </SearchSidebarSection>
             <SearchSidebarSection header="Repositories" showSearch={true}>

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
@@ -45,10 +45,10 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
     return (
         <div className={styles.searchSidebar}>
             <SearchSidebarSection header="Search types">{getSearchTypeLinks(props)}</SearchSidebarSection>
-            <SearchSidebarSection header="Dynamic filters">
+            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
                 {getDynamicFilterLinks(props.filters, onFilterClicked)}
             </SearchSidebarSection>
-            <SearchSidebarSection header="Repositories">
+            <SearchSidebarSection header="Repositories" showSearch={true}>
                 {getRepoFilterLinks(props.filters, onFilterClicked)}
             </SearchSidebarSection>
             <SearchSidebarSection header="Search snippets">

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
@@ -3,6 +3,8 @@
         list-style-type: none;
         padding: 0;
         margin-top: 0.5rem;
+        max-height: 15.5rem;
+        overflow: auto;
     }
 
     &__search-box {

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
@@ -5,6 +5,10 @@
         margin-top: 0.5rem;
     }
 
+    &__search-box {
+        display: block;
+    }
+
     &__list-item {
         display: flex;
         font-size: 0.75rem;
@@ -22,5 +26,10 @@
         &:active {
             background-color: var(--color-bg-3);
         }
+    }
+
+    &__no-results {
+        font-size: 0.75rem;
+        padding: 0.25rem 0.5rem;
     }
 }

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.test.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.test.tsx
@@ -1,0 +1,101 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import sinon from 'sinon'
+
+import { Filter } from '../../../stream'
+
+import { FilterLink, getDynamicFilterLinks } from './FilterLink'
+import { SearchSidebarSection } from './SearchSidebarSection'
+
+describe('SearchSidebarSection', () => {
+    const filters: Filter[] = ['typescript', 'JavaScript', 'c++', 'c', 'c#', 'python', 'ruby', 'haskell', 'java'].map(
+        lang => ({
+            label: `lang:${lang}`,
+            value: `lang:${lang}`,
+            count: 10,
+            limitHit: true,
+            kind: 'lang',
+        })
+    )
+
+    const onFilterChosen = sinon.stub()
+
+    it('should render all items initially', () => {
+        const element = mount(
+            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+                {getDynamicFilterLinks(filters, onFilterChosen)}
+            </SearchSidebarSection>
+        )
+
+        const items = element.find(FilterLink)
+        expect(items.length).toBe(9)
+
+        const searchbox = element.find('.test-sidebar-section-search-box')
+        expect(searchbox.length).toBe(1)
+    })
+
+    it('should filter items based on search', () => {
+        const element = mount(
+            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+                {getDynamicFilterLinks(filters, onFilterChosen)}
+            </SearchSidebarSection>
+        )
+
+        const searchbox = element.find('.test-sidebar-section-search-box')
+        searchbox.getDOMNode().setAttribute('value', 'Script')
+        searchbox.simulate('change', { currentTarget: searchbox })
+
+        const items = element.find(FilterLink)
+        expect(items.length).toBe(2)
+    })
+
+    it('should clear search when items change', () => {
+        const element = mount(
+            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+                {getDynamicFilterLinks(filters, onFilterChosen)}
+            </SearchSidebarSection>
+        )
+
+        let searchbox = element.find('.test-sidebar-section-search-box')
+        searchbox.getDOMNode().setAttribute('value', 'Script')
+        searchbox.simulate('change', { currentTarget: searchbox })
+
+        element.setProps({ children: getDynamicFilterLinks([filters[0], filters[5], filters[3]], onFilterChosen) })
+        element.update()
+
+        const items = element.find(FilterLink)
+        expect(items.length).toBe(3)
+
+        searchbox = element.find('.test-sidebar-section-search-box')
+        const searchFilter = searchbox.getDOMNode().getAttribute('value')
+        expect(searchFilter).toBe('')
+    })
+
+    it('should not show search if only one item in list', () => {
+        const element = mount(
+            <SearchSidebarSection header="Dynamic filters" showSearch={true}>
+                {getDynamicFilterLinks([filters[2]], onFilterChosen)}
+            </SearchSidebarSection>
+        )
+
+        const items = element.find(FilterLink)
+        expect(items.length).toBe(1)
+
+        const searchbox = element.find('.test-sidebar-section-search-box')
+        expect(searchbox.length).toBe(0)
+    })
+
+    it('should not show search if showSearch is false', () => {
+        const element = mount(
+            <SearchSidebarSection header="Dynamic filters">
+                {getDynamicFilterLinks(filters, onFilterChosen)}
+            </SearchSidebarSection>
+        )
+
+        const items = element.find(FilterLink)
+        expect(items.length).toBe(9)
+
+        const searchbox = element.find('.test-sidebar-section-search-box')
+        expect(searchbox.length).toBe(0)
+    })
+})

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.test.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.test.tsx
@@ -30,7 +30,7 @@ describe('SearchSidebarSection', () => {
         const items = element.find(FilterLink)
         expect(items.length).toBe(9)
 
-        const searchbox = element.find('.test-sidebar-section-search-box')
+        const searchbox = element.find('[data-testid="sidebar-section-search-box"]')
         expect(searchbox.length).toBe(1)
     })
 
@@ -41,7 +41,7 @@ describe('SearchSidebarSection', () => {
             </SearchSidebarSection>
         )
 
-        const searchbox = element.find('.test-sidebar-section-search-box')
+        const searchbox = element.find('[data-testid="sidebar-section-search-box"]')
         searchbox.getDOMNode().setAttribute('value', 'Script')
         searchbox.simulate('change', { currentTarget: searchbox })
 
@@ -56,7 +56,7 @@ describe('SearchSidebarSection', () => {
             </SearchSidebarSection>
         )
 
-        let searchbox = element.find('.test-sidebar-section-search-box')
+        let searchbox = element.find('[data-testid="sidebar-section-search-box"]')
         searchbox.getDOMNode().setAttribute('value', 'Script')
         searchbox.simulate('change', { currentTarget: searchbox })
 
@@ -66,7 +66,7 @@ describe('SearchSidebarSection', () => {
         const items = element.find(FilterLink)
         expect(items.length).toBe(3)
 
-        searchbox = element.find('.test-sidebar-section-search-box')
+        searchbox = element.find('[data-testid="sidebar-section-search-box"]')
         const searchFilter = searchbox.getDOMNode().getAttribute('value')
         expect(searchFilter).toBe('')
     })
@@ -81,7 +81,7 @@ describe('SearchSidebarSection', () => {
         const items = element.find(FilterLink)
         expect(items.length).toBe(1)
 
-        const searchbox = element.find('.test-sidebar-section-search-box')
+        const searchbox = element.find('[data-testid="sidebar-section-search-box"]')
         expect(searchbox.length).toBe(0)
     })
 
@@ -95,7 +95,7 @@ describe('SearchSidebarSection', () => {
         const items = element.find(FilterLink)
         expect(items.length).toBe(9)
 
-        const searchbox = element.find('.test-sidebar-section-search-box')
+        const searchbox = element.find('[data-testid="sidebar-section-search-box"]')
         expect(searchbox.length).toBe(0)
     })
 })

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -1,20 +1,60 @@
-import React from 'react'
+import classNames from 'classnames'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
+import { FilterLink, FilterLinkProps } from './FilterLink'
 import styles from './SearchSidebarSection.module.scss'
 
-export const SearchSidebarSection: React.FunctionComponent<{ header: string; children?: React.ReactElement[] }> = ({
-    header,
-    children = [],
-}) =>
-    children.length > 0 ? (
+export const SearchSidebarSection: React.FunctionComponent<{
+    header: string
+    children?: React.ReactElement[]
+    showSearch?: boolean // Search only works if children are FilterLink
+}> = ({ header, children = [], showSearch = false }) => {
+    const [filter, setFilter] = useState('')
+    const onFilterChanged = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
+        event => setFilter(event.currentTarget.value),
+        []
+    )
+
+    // Clear filter when children change
+    useEffect(() => {
+        setFilter('')
+    }, [children])
+
+    const filteredChildren = useMemo(
+        () =>
+            children.filter(child => {
+                if (child.type === FilterLink) {
+                    const props = child.props as FilterLinkProps
+                    return (
+                        (props?.label).includes(filter.toLowerCase()) || (props?.value).includes(filter.toLowerCase())
+                    )
+                }
+                return true
+            }),
+        [children, filter]
+    )
+
+    return children.length > 0 ? (
         <div>
-            <h5>{header}</h5>
-            <div>
-                <ul className={styles.sidebarSectionList}>
-                    {children.map((child, index) => (
-                        <li key={child.key || index}>{child}</li>
-                    ))}
-                </ul>
-            </div>
+            <h5 className="pb-2">{header}</h5>
+            {showSearch && children.length > 1 && (
+                <input
+                    type="search"
+                    placeholder="Find..."
+                    value={filter}
+                    onInput={onFilterChanged}
+                    className={classNames('form-control', styles.sidebarSectionSearchBox)}
+                />
+            )}
+
+            <ul className={styles.sidebarSectionList}>
+                {filteredChildren.map((child, index) => (
+                    <li key={child.key || index}>{child}</li>
+                ))}
+                {filteredChildren.length === 0 && (
+                    <li className={classNames('text-muted', styles.sidebarSectionNoResults)}>No results</li>
+                )}
+            </ul>
         </div>
     ) : null
+}

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -18,7 +18,7 @@ export const SearchSidebarSection: React.FunctionComponent<{
         () =>
             children.filter(child => {
                 if (child.type === FilterLink) {
-                    const props = child.props as FilterLinkProps
+                    const props: FilterLinkProps = child.props as FilterLinkProps
                     return (
                         (props?.label).toLowerCase().includes(filter.toLowerCase()) ||
                         (props?.value).toLowerCase().includes(filter.toLowerCase())

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -36,13 +36,11 @@ export const SearchSidebarSection: React.FunctionComponent<{
                 <input
                     type="search"
                     placeholder="Find..."
+                    aria-label="Find filters"
                     value={filter}
                     onChange={event => setFilter(event.currentTarget.value)}
-                    className={classNames(
-                        'form-control',
-                        styles.sidebarSectionSearchBox,
-                        'test-sidebar-section-search-box'
-                    )}
+                    data-testid="sidebar-section-search-box"
+                    className={classNames('form-control', styles.sidebarSectionSearchBox)}
                 />
             )}
 

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 
 import { FilterLink, FilterLinkProps } from './FilterLink'
 import styles from './SearchSidebarSection.module.scss'

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -10,15 +10,9 @@ export const SearchSidebarSection: React.FunctionComponent<{
     showSearch?: boolean // Search only works if children are FilterLink
 }> = ({ header, children = [], showSearch = false }) => {
     const [filter, setFilter] = useState('')
-    const onFilterChanged = useCallback<React.ChangeEventHandler<HTMLInputElement>>(
-        event => setFilter(event.currentTarget.value),
-        []
-    )
 
     // Clear filter when children change
-    useEffect(() => {
-        setFilter('')
-    }, [children])
+    useEffect(() => setFilter(''), [children])
 
     const filteredChildren = useMemo(
         () =>
@@ -26,7 +20,8 @@ export const SearchSidebarSection: React.FunctionComponent<{
                 if (child.type === FilterLink) {
                     const props = child.props as FilterLinkProps
                     return (
-                        (props?.label).includes(filter.toLowerCase()) || (props?.value).includes(filter.toLowerCase())
+                        (props?.label).toLowerCase().includes(filter.toLowerCase()) ||
+                        (props?.value).toLowerCase().includes(filter.toLowerCase())
                     )
                 }
                 return true
@@ -42,8 +37,12 @@ export const SearchSidebarSection: React.FunctionComponent<{
                     type="search"
                     placeholder="Find..."
                     value={filter}
-                    onInput={onFilterChanged}
-                    className={classNames('form-control', styles.sidebarSectionSearchBox)}
+                    onChange={event => setFilter(event.currentTarget.value)}
+                    className={classNames(
+                        'form-control',
+                        styles.sidebarSectionSearchBox,
+                        'test-sidebar-section-search-box'
+                    )}
                 />
             )}
 

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -35,7 +35,7 @@ export const SearchSidebarSection: React.FunctionComponent<{
     )
 
     return children.length > 0 ? (
-        <div>
+        <div className="mb-4">
             <h5 className="pb-2">{header}</h5>
             {showSearch && children.length > 1 && (
                 <input


### PR DESCRIPTION
Adds inline search for sidebar repos section. Search is naïve case-insensitive match for either the label or the filter.

Fixes #20411

![image](https://user-images.githubusercontent.com/206864/117031427-69dbc280-acb5-11eb-8494-6ef5ba00258d.png)