### PR TITLE
Make streaming search independent of CommitSearchResultResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -107,18 +107,11 @@ func (r *CommitSearchResultResolver) Icon() string {
 }
 
 func (r *CommitSearchResultResolver) Label() Markdown {
-	message := r.CommitMatch.Commit.Message.Subject()
-	author := r.CommitMatch.Commit.Author.Name
-	repoName := displayRepoName(r.Commit().Repository().Name())
-	repoURL := r.Commit().Repository().URL()
-	url := r.Commit().URL()
-
-	label := fmt.Sprintf("[%s](%s) › [%s](%s): [%s](%s)", repoName, repoURL, author, url, message, url)
-	return Markdown(label)
+	return Markdown(r.CommitMatch.Label())
 }
 
 func (r *CommitSearchResultResolver) URL() string {
-	return r.Commit().URL()
+	return r.CommitMatch.URL().String()
 }
 
 func (r *CommitSearchResultResolver) Detail() Markdown {
@@ -466,14 +459,6 @@ func cleanDiffPreview(highlights []result.HighlightedRange, rawDiffResult string
 
 	body := fmt.Sprintf("```diff\n%v```", strings.Join(finalLines, "\n"))
 	return body, highlights
-}
-
-func displayRepoName(repoPath string) string {
-	parts := strings.Split(repoPath, "/")
-	if len(parts) >= 3 && strings.Contains(parts[0], ".") {
-		parts = parts[1:] // remove hostname from repo path (reduce visual noise)
-	}
-	return strings.Join(parts, "/")
 }
 
 func highlightMatches(pattern *regexp.Regexp, data []byte) *result.HighlightedString {

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -12,7 +12,6 @@ import (
 	"unicode/utf8"
 
 	otlog "github.com/opentracing/opentracing-go/log"
-	"github.com/xeonx/timeago"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pkg/errors"
@@ -115,10 +114,7 @@ func (r *CommitSearchResultResolver) URL() string {
 }
 
 func (r *CommitSearchResultResolver) Detail() Markdown {
-	commitHash := r.CommitMatch.Commit.ID.Short()
-	timeagoConfig := timeago.NoMax(timeago.English)
-	detail := fmt.Sprintf("[`%v` %v](%v)", commitHash, timeagoConfig.Format(r.CommitMatch.Commit.Author.Date), r.Commit().URL())
-	return Markdown(detail)
+	return Markdown(r.CommitMatch.Detail())
 }
 
 func (r *CommitSearchResultResolver) Matches() []*searchResultMatchResolver {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -1111,28 +1112,24 @@ func TestSearchContext(t *testing.T) {
 	}
 }
 
-func commitResult(urlKey string) *CommitSearchResultResolver {
+func commitResult(repo, commit string) *CommitSearchResultResolver {
 	return &CommitSearchResultResolver{
-		gitCommitResolver: &GitCommitResolver{
-			repoResolver: &RepositoryResolver{
-				RepoMatch: result.RepoMatch{
-					Name: api.RepoName(urlKey),
-				},
+		CommitMatch: result.CommitMatch{
+			RepoName: types.RepoName{Name: api.RepoName(repo)},
+			Commit: git.Commit{
+				ID: api.CommitID(commit),
 			},
 		},
 	}
 }
 
-func diffResult(urlKey string) *CommitSearchResultResolver {
+func diffResult(repo, commit string) *CommitSearchResultResolver {
 	return &CommitSearchResultResolver{
 		CommitMatch: result.CommitMatch{
 			DiffPreview: &result.HighlightedString{},
-		},
-		gitCommitResolver: &GitCommitResolver{
-			repoResolver: &RepositoryResolver{
-				RepoMatch: result.RepoMatch{
-					Name: api.RepoName(urlKey),
-				},
+			RepoName:    types.RepoName{Name: api.RepoName(repo)},
+			Commit: git.Commit{
+				ID: api.CommitID(commit),
 			},
 		},
 	}
@@ -1203,46 +1200,46 @@ func TestUnionMerge(t *testing.T) {
 			left: SearchResultsResolver{
 				db: db,
 				SearchResults: []SearchResultResolver{
-					diffResult("a"),
-					commitResult("a"),
+					diffResult("a", "a"),
+					commitResult("a", "a"),
 					repoResult(db, "a"),
 					fileResult(db, "a", nil, nil),
 				},
 			},
 			right: SearchResultsResolver{db: db},
-			want:  autogold.Want("LeftOnly", "Commit:/a/-/commit/, Diff:/a/-/commit/, File{url:a/,symbols:[],lineMatches:[]}, Repo:/a"),
+			want:  autogold.Want("LeftOnly", "Commit:/a/-/commit/a, Diff:/a/-/commit/a, File{url:a/,symbols:[],lineMatches:[]}, Repo:/a"),
 		},
 		{
 			left: SearchResultsResolver{db: db},
 			right: SearchResultsResolver{
 				db: db,
 				SearchResults: []SearchResultResolver{
-					diffResult("a"),
-					commitResult("a"),
+					diffResult("a", "a"),
+					commitResult("a", "a"),
 					repoResult(db, "a"),
 					fileResult(db, "a", nil, nil),
 				},
 			},
-			want: autogold.Want("RightOnly", "Commit:/a/-/commit/, Diff:/a/-/commit/, File{url:a/,symbols:[],lineMatches:[]}, Repo:/a"),
+			want: autogold.Want("RightOnly", "Commit:/a/-/commit/a, Diff:/a/-/commit/a, File{url:a/,symbols:[],lineMatches:[]}, Repo:/a"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					diffResult("a"),
-					commitResult("a"),
+					diffResult("a", "a"),
+					commitResult("a", "a"),
 					repoResult(db, "a"),
 					fileResult(db, "a", nil, nil),
 				},
 			},
 			right: SearchResultsResolver{db: db,
 				SearchResults: []SearchResultResolver{
-					diffResult("b"),
-					commitResult("b"),
+					diffResult("b", "b"),
+					commitResult("b", "b"),
 					repoResult(db, "b"),
 					fileResult(db, "b", nil, nil),
 				},
 			},
-			want: autogold.Want("MergeAllDifferent", "Commit:/a/-/commit/, Diff:/a/-/commit/, File{url:a/,symbols:[],lineMatches:[]}, File{url:b/,symbols:[],lineMatches:[]}, Repo:/a, Repo:/b"),
+			want: autogold.Want("MergeAllDifferent", "Commit:/a/-/commit/a, Commit:/b/-/commit/b, Diff:/a/-/commit/a, Diff:/b/-/commit/b, File{url:a/,symbols:[],lineMatches:[]}, File{url:b/,symbols:[],lineMatches:[]}, Repo:/a, Repo:/b"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
@@ -1324,28 +1321,28 @@ func TestSearchResultDeduper(t *testing.T) {
 			autogold.Want("Empty", ""),
 		},
 		{
-			[]SearchResultResolver{commitResult("a")},
-			autogold.Want("SingleCommit", "Commit:/a/-/commit/"),
+			[]SearchResultResolver{commitResult("a", "b")},
+			autogold.Want("SingleCommit", "Commit:/a/-/commit/b"),
 		},
 		{
-			[]SearchResultResolver{commitResult("a"), commitResult("a")},
-			autogold.Want("DuplicateCommits", "Commit:/a/-/commit/"),
+			[]SearchResultResolver{commitResult("a", "b"), commitResult("a", "b")},
+			autogold.Want("DuplicateCommits", "Commit:/a/-/commit/b"),
 		},
 		{
-			[]SearchResultResolver{commitResult("a"), diffResult("a")},
-			autogold.Want("SharedURLCommitDiff", "Commit:/a/-/commit/, Diff:/a/-/commit/"),
+			[]SearchResultResolver{commitResult("a", "b"), diffResult("a", "b")},
+			autogold.Want("SharedURLCommitDiff", "Commit:/a/-/commit/b, Diff:/a/-/commit/b"),
 		},
 		{
-			[]SearchResultResolver{commitResult("a"), diffResult("b")},
-			autogold.Want("DifferentURLCommitDiff", "Commit:/a/-/commit/, Diff:/b/-/commit/"),
+			[]SearchResultResolver{commitResult("a", "a"), diffResult("b", "b")},
+			autogold.Want("DifferentURLCommitDiff", "Commit:/a/-/commit/a, Diff:/b/-/commit/b"),
 		},
 		{
-			[]SearchResultResolver{commitResult("a"), diffResult("a"), repoResult(db, "a"), fileResult(db, "a", nil, nil)},
-			autogold.Want("EachTypeSameURL", "Commit:/a/-/commit/, Diff:/a/-/commit/, File{url:a/,symbols:[],lineMatches:[]}, Repo:/a"),
+			[]SearchResultResolver{commitResult("a", "a"), diffResult("a", "a"), repoResult(db, "a"), fileResult(db, "a", nil, nil)},
+			autogold.Want("EachTypeSameURL", "Commit:/a/-/commit/a, Diff:/a/-/commit/a, File{url:a/,symbols:[],lineMatches:[]}, Repo:/a"),
 		},
 		{
-			[]SearchResultResolver{commitResult("a"), commitResult("b"), commitResult("a"), commitResult("b")},
-			autogold.Want("FourCommitsTwoURLs", "Commit:/a/-/commit/"),
+			[]SearchResultResolver{commitResult("a", "a"), commitResult("b", "b"), commitResult("a", "a"), commitResult("b", "b")},
+			autogold.Want("FourCommitsTwoURLs", "Commit:/a/-/commit/a, Commit:/b/-/commit/b"),
 		},
 	}
 

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -214,7 +214,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if commit, ok := result.ToCommitSearchResult(); ok {
 				display = commit.Limit(display)
 
-				matchesAppend(fromCommit(commit))
+				matchesAppend(fromCommit(&commit.CommitMatch))
 			}
 		}
 
@@ -461,10 +461,10 @@ func fromRepository(rm result.RepoMatch) *streamhttp.EventRepoMatch {
 	}
 }
 
-func fromCommit(commit *graphqlbackend.CommitSearchResultResolver) *streamhttp.EventCommitMatch {
-	content := commit.CommitMatch.Body.Value
+func fromCommit(commit *result.CommitMatch) *streamhttp.EventCommitMatch {
+	content := commit.Body.Value
 
-	highlights := commit.CommitMatch.Body.Highlights
+	highlights := commit.Body.Highlights
 	ranges := make([][3]int32, len(highlights))
 	for i, h := range highlights {
 		ranges[i] = [3]int32{h.Line, h.Character, h.Length}
@@ -472,9 +472,9 @@ func fromCommit(commit *graphqlbackend.CommitSearchResultResolver) *streamhttp.E
 
 	return &streamhttp.EventCommitMatch{
 		Type:    streamhttp.CommitMatchType,
-		Label:   commit.CommitMatch.Label(),
-		URL:     commit.CommitMatch.URL().String(),
-		Detail:  commit.CommitMatch.Detail(),
+		Label:   commit.Label(),
+		URL:     commit.URL().String(),
+		Detail:  commit.Detail(),
 		Content: content,
 		Ranges:  ranges,
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -462,17 +462,14 @@ func fromRepository(rm result.RepoMatch) *streamhttp.EventRepoMatch {
 }
 
 func fromCommit(commit *graphqlbackend.CommitSearchResultResolver) *streamhttp.EventCommitMatch {
-	var content string
-	var ranges [][3]int32
-	if matches := commit.Matches(); len(matches) == 1 {
-		match := matches[0]
-		content = match.Body().Text()
-		highlights := match.Highlights()
-		ranges = make([][3]int32, len(highlights))
-		for i, h := range highlights {
-			ranges[i] = [3]int32{h.Line(), h.Character(), h.Length()}
-		}
+	content := commit.CommitMatch.Body.Value
+
+	highlights := commit.CommitMatch.Body.Highlights
+	ranges := make([][3]int32, len(highlights))
+	for i, h := range highlights {
+		ranges[i] = [3]int32{h.Line, h.Character, h.Length}
 	}
+
 	return &streamhttp.EventCommitMatch{
 		Type:    streamhttp.CommitMatchType,
 		Label:   commit.CommitMatch.Label(),

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -477,7 +477,7 @@ func fromCommit(commit *graphqlbackend.CommitSearchResultResolver) *streamhttp.E
 		Type:    streamhttp.CommitMatchType,
 		Label:   commit.CommitMatch.Label(),
 		URL:     commit.CommitMatch.URL().String(),
-		Detail:  commit.Detail().Text(),
+		Detail:  commit.CommitMatch.Detail(),
 		Content: content,
 		Ranges:  ranges,
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -475,8 +475,8 @@ func fromCommit(commit *graphqlbackend.CommitSearchResultResolver) *streamhttp.E
 	}
 	return &streamhttp.EventCommitMatch{
 		Type:    streamhttp.CommitMatchType,
-		Label:   commit.Label().Text(),
-		URL:     commit.URL(),
+		Label:   commit.CommitMatch.Label(),
+		URL:     commit.CommitMatch.URL().String(),
 		Detail:  commit.Detail().Text(),
 		Content: content,
 		Ranges:  ranges,

--- a/internal/search/result/commit.go
+++ b/internal/search/result/commit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
+	"github.com/xeonx/timeago"
 )
 
 type CommitMatch struct {
@@ -90,6 +91,12 @@ func (r *CommitMatch) Label() string {
 	commitURL := r.URL().String()
 
 	return fmt.Sprintf("[%s](%s) › [%s](%s): [%s](%s)", repoName, repoURL, author, commitURL, message, commitURL)
+}
+
+func (r *CommitMatch) Detail() string {
+	commitHash := r.Commit.ID.Short()
+	timeagoConfig := timeago.NoMax(timeago.English)
+	return fmt.Sprintf("[`%v` %v](%v)", commitHash, timeagoConfig.Format(r.Commit.Author.Date), r.URL())
 }
 
 func (r *CommitMatch) URL() *url.URL {


### PR DESCRIPTION
This PR removes any data dependencies of streaming search on `CommitSearchResultResolver`. It does this by moving a couple of methods from `CommitSearchResultResolver` to `CommitMatch`. 

This is the last set of data dependencies of streaming search on resolvers. Next up: change the interface to take matches. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
