### PR TITLE
Add MatchSender

### DIFF
--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
 
@@ -17,10 +18,24 @@ type SearchEvent struct {
 	Stats   streaming.Stats
 }
 
+// SearchMatchEvent is a temporary struct that takes matches rather than
+// SearchResultResolvers. Once the transition is complete, this will replace SearchEvent.
+type SearchMatchEvent struct {
+	Results []result.Match
+	Stats   streaming.Stats
+}
+
 // Sender is the interface that wraps the basic Send method. Send must not
 // mutate the event.
 type Sender interface {
 	Send(SearchEvent)
+}
+
+// MatchSender is a temporary interface that adds the SendMatches method to the
+// Sender interface. Eventually, Sender.Send() will be replaced with MatchSender.SendMatches
+type MatchSender interface {
+	Sender
+	SendMatches(SearchMatchEvent)
 }
 
 type limitStream struct {


### PR DESCRIPTION
This adds a temporary interface `MatchSender`, which will be used to
migrate the Sender interface to accept `[]result.Match` rather than
`[]SearchResultResolver`.

This should help make it easier to not convert _every_ call to `Sender.Send()` 
in a single PR since we can convert `SearchResultResolver` to `result.Match`
automatically, and vice versa with a reference to a db. 

As soon as we've converted all the call sites to use `MatchSender.SendMatches()`
instead of `Sender.Send()`, we can rename: 
- `MatchSender` -> `Sender`
- `MatchSender.SendMatches` -> `Sender.Send`
- `SearchMatchEvent` -> `SearchEvent`


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
