### PR TITLE
Start using `StreamMatchEvent` in `startSearch()`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -183,10 +183,10 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 	filters := SearchFilters{
 		Globbing: globbing,
 	}
-	filters.Update(SearchEvent{
+	filters.Update(SearchEventToSearchMatchEvent(SearchEvent{
 		Results: sr.SearchResults,
 		Stats:   sr.Stats,
-	})
+	}))
 
 	var resolvers []*searchFilterResolver
 	for _, f := range filters.Compute() {

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -203,3 +203,13 @@ func collectStream(search func(Sender) error) ([]SearchResultResolver, streaming
 
 	return results, stats, err
 }
+
+type MatchStreamFunc func(SearchMatchEvent)
+
+func (f MatchStreamFunc) Send(se SearchEvent) {
+	f(SearchEventToSearchMatchEvent(se))
+}
+
+func (f MatchStreamFunc) SendMatch(sme SearchMatchEvent) {
+	f(sme)
+}

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -23,21 +23,15 @@ type progressAggregator struct {
 	Dirty bool
 }
 
-func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
+func (p *progressAggregator) Update(event graphqlbackend.SearchMatchEvent) {
 	if len(event.Results) == 0 && event.Stats.Zero() {
 		return
 	}
 
 	p.Dirty = true
 	p.Stats.Update(&event.Stats)
-	for _, result := range event.Results {
-		// We use a different result count in streaming than graphql. We don't
-		// want to break existing graphql clients like saved searches.
-		if crs, ok := result.ToCommitSearchResult(); ok {
-			p.MatchCount += crs.CommitMatch.ResultCount()
-			continue
-		}
-		p.MatchCount += int(result.ResultCount())
+	for _, match := range event.Results {
+		p.MatchCount += match.ResultCount()
 	}
 
 	if p.MatchCount > p.Limit {


### PR DESCRIPTION
This converts startSearch to use match events rather than resolver
events, then fixes all the type errors caused by it.

~Currently in draft state because it depends on commits from both #20610 and #20609, so I can't make a clean PR until at least one of those is merged. I'll update this PR once that happens, but until then, you can get an idea of the direction this is going by looking at the last commit.~
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
