### PR TITLE
add link to examples repo

### DIFF
--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -98,6 +98,7 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Updating Go import statements using Comby](tutorials/updating_go_import_statements.md)
 - [Update base images in Dockerfiles](tutorials/update_base_images_in_dockerfiles.md)
 - [Search and replace specific terms](tutorials/search_and_replace_specific_terms.md)
+- [Examples repository](https://github.com/sourcegraph/batch-change-examples)
 
 ## References
 

--- a/doc/batch_changes/tutorials/index.md
+++ b/doc/batch_changes/tutorials/index.md
@@ -6,3 +6,4 @@ The following is a list of tutorials that show how to use [Sourcegraph Batch Cha
 - [Updating Go import statements using Comby](updating_go_import_statements.md)
 - [Update base images in Dockerfiles](update_base_images_in_dockerfiles.md)
 - [Search and replace specific terms](search_and_replace_specific_terms.md)
+- [Examples repository](https://github.com/sourcegraph/batch-change-examples)

--- a/doc/batch_changes/tutorials/index.md
+++ b/doc/batch_changes/tutorials/index.md
@@ -6,4 +6,6 @@ The following is a list of tutorials that show how to use [Sourcegraph Batch Cha
 - [Updating Go import statements using Comby](updating_go_import_statements.md)
 - [Update base images in Dockerfiles](update_base_images_in_dockerfiles.md)
 - [Search and replace specific terms](search_and_replace_specific_terms.md)
-- [Examples repository](https://github.com/sourcegraph/batch-change-examples)
+
+
+Take a look at our [examples repository](https://github.com/sourcegraph/batch-change-examples) for a collection of ready-to-be-executed batch specs.


### PR DESCRIPTION
From CE feedback, Batch Changes examples are helpful, but nor really discoverable.
Although we will have a better fix soon-ish when we link to an example registry website from the GUI, I propose this as a quick fix.