### PR TITLE
Design refresh: Update outline Button focus styles

### DIFF
--- a/client/branded/src/global-styles/buttons-redesign.scss
+++ b/client/branded/src/global-styles/buttons-redesign.scss
@@ -20,7 +20,7 @@
         }
 
         &:not(:disabled):not(.disabled) {
-            &:hover {
+            &:hover:not(.focus):not(:focus) {
                 color: $text-color;
                 background-color: $dark-color-variant;
             }
@@ -61,7 +61,7 @@
                 fill: $base-color;
             }
 
-            &:hover {
+            &:hover:not(.focus):not(:focus) {
                 background-color: var(--body-bg);
                 @at-root #{selector-append('.theme-light', &)} {
                     color: $dark-color-variant;
@@ -81,6 +81,8 @@
             &.focus,
             &:active,
             &.active {
+                border-color: var(--body-bg);
+                background-color: var(--body-bg);
                 @at-root #{selector-append('.theme-light', &)} {
                     box-shadow: 0 0 0 2px $light-color-variant;
                 }
@@ -180,7 +182,7 @@
         }
 
         &:not(:disabled):not(.disabled) {
-            &:hover {
+            &:hover:not(.focus):not(:focus) {
                 color: var(--body-color);
             }
 


### PR DESCRIPTION
Fixes bug where `hover` styles were being applied when the button was `focus`. We want to ensure the states are separated.

