### PR TITLE
web: fix breakpoints mixins import

### DIFF
--- a/client/branded/src/global-styles/breakpoints.scss
+++ b/client/branded/src/global-styles/breakpoints.scss
@@ -12,4 +12,4 @@ $grid-breakpoints: (
     xl: 1200px,
 );
 
-@import '~bootstrap/scss/mixins/breakpoints';
+@import 'bootstrap/scss/mixins/breakpoints';

--- a/doc/dev/background-information/web/styling.md
+++ b/doc/dev/background-information/web/styling.md
@@ -76,8 +76,8 @@ import styles from './PageSelector.module.scss'
 To use mixins/functions provided by Bootstrap in CSS modules use explicit imports to the required module.
 
 ```scss
-@import '~bootstrap/scss/functions';
-@import '~bootstrap/scss/mixins/caret';
+@import 'bootstrap/scss/functions';
+@import 'bootstrap/scss/mixins/caret';
 ```
 
 It's not safe to import all global Bootstrap helpers and variables into the CSS module because we redefine many Bootstrap variables on our side.


### PR DESCRIPTION
CSS modules types generator fails to understand the `~` prefix on SCSS imports. This PR fixes this import.