### PR TITLE
Refresh: update active button color

### DIFF
--- a/client/branded/src/global-styles/buttons-redesign.scss
+++ b/client/branded/src/global-styles/buttons-redesign.scss
@@ -29,6 +29,7 @@
             &.focus,
             &:active,
             &.active {
+                color: $text-color;
                 background-color: $base-color;
                 border-color: var(--body-bg);
 
@@ -81,6 +82,7 @@
             &.focus,
             &:active,
             &.active {
+                color: var(--body-color);
                 border-color: var(--body-bg);
                 background-color: var(--body-bg);
                 @at-root #{selector-append('.theme-light', &)} {


### PR DESCRIPTION
Bug I found after splitting out `focus/active` and `hover` styles. Some styles were being shared across states which led to some unexpected behavior