### PR TITLE
search redesign: sticky search sidebar that scrolls with content

### DIFF
--- a/client/web/src/search/results/streaming/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.module.scss
@@ -5,5 +5,13 @@
 
     :global(.theme-redesign) & {
         flex-direction: row;
+        height: min-content;
+    }
+
+    &-container {
+        :global(.theme-redesign) & {
+            overflow-y: visible;
+            overflow-x: hidden;
+        }
     }
 }

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -205,7 +205,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
             ) : (
                 <StreamingSearchResultsFilterBars {...props} results={results} />
             )}
-            <div className="search-results-list">
+            <div className={classNames('search-results-list', styles.streamingSearchResultsContainer)}>
                 <div className="d-lg-flex mb-2 align-items-end flex-wrap">
                     {!isRedesignEnabled && (
                         <SearchResultTypeTabs

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.module.scss
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.module.scss
@@ -2,5 +2,4 @@
     padding: 0.5rem 1rem;
     width: 17.5rem;
     flex-shrink: 0;
-    overflow-y: auto;
 }

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
@@ -44,17 +44,19 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
 
     return (
         <div className={styles.searchSidebar}>
-            <SearchSidebarSection header="Search types">{getSearchTypeLinks(props)}</SearchSidebarSection>
-            <SearchSidebarSection header="Dynamic filters">
-                {getDynamicFilterLinks(props.filters, onFilterClicked)}
-            </SearchSidebarSection>
-            <SearchSidebarSection header="Repositories" showSearch={true}>
-                {getRepoFilterLinks(props.filters, onFilterClicked)}
-            </SearchSidebarSection>
-            <SearchSidebarSection header="Search snippets">
-                {getSearchScopeLinks(props.settingsCascade, onFilterClicked)}
-            </SearchSidebarSection>
-            <SearchSidebarSection header="Quicklinks">{getQuickLinks(props.settingsCascade)}</SearchSidebarSection>
+            <div>
+                <SearchSidebarSection header="Search types">{getSearchTypeLinks(props)}</SearchSidebarSection>
+                <SearchSidebarSection header="Dynamic filters">
+                    {getDynamicFilterLinks(props.filters, onFilterClicked)}
+                </SearchSidebarSection>
+                <SearchSidebarSection header="Repositories" showSearch={true}>
+                    {getRepoFilterLinks(props.filters, onFilterClicked)}
+                </SearchSidebarSection>
+                <SearchSidebarSection header="Search snippets">
+                    {getSearchScopeLinks(props.settingsCascade, onFilterClicked)}
+                </SearchSidebarSection>
+                <SearchSidebarSection header="Quicklinks">{getQuickLinks(props.settingsCascade)}</SearchSidebarSection>
+            </div>
         </div>
     )
 }

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react'
 import { useHistory } from 'react-router'
+import StickyBox from 'react-sticky-box'
 
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -44,7 +45,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
 
     return (
         <div className={styles.searchSidebar}>
-            <div>
+            <StickyBox offsetTop={8} offsetBottom={8}>
                 <SearchSidebarSection header="Search types">{getSearchTypeLinks(props)}</SearchSidebarSection>
                 <SearchSidebarSection header="Dynamic filters">
                     {getDynamicFilterLinks(props.filters, onFilterClicked)}
@@ -56,7 +57,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
                     {getSearchScopeLinks(props.settingsCascade, onFilterClicked)}
                 </SearchSidebarSection>
                 <SearchSidebarSection header="Quicklinks">{getQuickLinks(props.settingsCascade)}</SearchSidebarSection>
-            </div>
+            </StickyBox>
         </div>
     )
 }

--- a/package.json
+++ b/package.json
@@ -344,6 +344,7 @@
     "react-grid-layout": "^0.18.3",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
+    "react-sticky-box": "^0.9.3",
     "react-stripe-elements": "^6.1.2",
     "react-textarea-autosize": "^8.3.0",
     "react-visibility-sensor": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1269,14 +1269,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
-  version "7.13.17"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
-  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.1.5":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.1.5", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.0", "@babel/runtime@^7.13.10", "@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.14.0"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
   integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1276,6 +1276,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.1.5":
+  version "7.14.0"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.13", "@babel/template@^7.3.3", "@babel/template@^7.7.4":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
@@ -18815,6 +18822,14 @@ react-spring@^9.0.0:
     "@react-spring/three" "^9.0.0"
     "@react-spring/web" "^9.0.0"
     "@react-spring/zdog" "^9.0.0"
+
+react-sticky-box@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.npmjs.org/react-sticky-box/-/react-sticky-box-0.9.3.tgz#8450d4cef8e4fdd7b0351520365bc98c97da11af"
+  integrity sha512-Y/qO7vTqAvXuRR6G6ZCW4fX2Bz0GZRwiiLTVeZN5CVz9wzs37ev0Xj3KSKF/PzF0jifwATivI4t24qXG8rSz4Q==
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    resize-observer-polyfill "^1.5.1"
 
 react-stripe-elements@^6.1.2:
   version "6.1.2"


### PR DESCRIPTION
- Search sidebar now scrolls with content instead of being scrollable on its own
- Sidebar is now sticky using [react-sticky-box](https://react-sticky-box.codecks.io/)

Fixes #20596

https://user-images.githubusercontent.com/206864/117067978-8ab90d80-acdf-11eb-9679-9ac5c5189a87.mov



