### PR TITLE
github: Use the v3 API for listing affiliated repos

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 
 	"github.com/graph-gophers/graphql-go/gqltesting"
 	"github.com/inconshreveable/log15"
@@ -112,6 +113,7 @@ func TestMain(m *testing.M) {
 
 func TestAffiliatedRepositories(t *testing.T) {
 	resetMocks()
+	rcache.SetupForTest(t)
 	database.Mocks.Users.Tags = func(ctx context.Context, userID int32) (map[string]bool, error) {
 		return map[string]bool{}, nil
 	}
@@ -166,28 +168,34 @@ func TestAffiliatedRepositories(t *testing.T) {
 				buf := &bytes.Buffer{}
 				enc := json.NewEncoder(buf)
 				switch r.URL.Path {
-				case "/api/graphql": //github
-					enc.Encode(repoResponse{
-						Data: data{
-							Viewer: viewer{
-								Repositories: repositories{
-									Nodes: []githubRepository{
-										{
-											NameWithOwner: "test-user/test",
-											IsPrivate:     false,
-										},
-									},
-								},
+				case "/api/v3/user/repos": // github
+					page := r.URL.Query().Get("page")
+					if page == "1" {
+						if err := enc.Encode([]githubRepository{
+							{
+								FullName: "test-user/test",
+								Private:  false,
 							},
-						},
-					})
+						}); err != nil {
+							t.Fatal(err)
+						}
+					}
+					// Stop on the second page
+					if page == "2" {
+						if err := enc.Encode([]githubRepository{}); err != nil {
+							t.Fatal(err)
+						}
+					}
+
 				case "/api/v4/projects": //gitlab
-					enc.Encode([]gitlabRepository{
+					if err := enc.Encode([]gitlabRepository{
 						{
 							PathWithNamespace: "test-user2/test2",
 							Visibility:        "public",
 						},
-					})
+					}); err != nil {
+						t.Fatal(err)
+					}
 				default:
 					t.Fatalf("unexpected path: %s", r.URL.Path)
 				}
@@ -258,23 +266,8 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 
 // copied from the github client, just the fields we need
 type githubRepository struct {
-	NameWithOwner string
-	IsPrivate     bool
-}
-
-type repoResponse struct {
-	Data data `json:"data"`
-}
-type data struct {
-	Viewer viewer `json:"viewer"`
-}
-
-type viewer struct {
-	Repositories repositories `json:"repositories"`
-}
-
-type repositories struct {
-	Nodes []githubRepository `json:"nodes"`
+	FullName string `json:"full_name"`
+	Private  bool   `json:"private"`
 }
 
 type gitlabRepository struct {

--- a/internal/extsvc/github/repos.go
+++ b/internal/extsvc/github/repos.go
@@ -380,53 +380,6 @@ func (c *V3Client) ListAffiliatedRepositories(ctx context.Context, visibility Vi
 	return repos, len(repos) > 0, 1, err
 }
 
-type repoResponse struct {
-	Viewer struct {
-		Repositories struct {
-			Nodes    []*Repository `json:"nodes"`
-			PageInfo struct {
-				EndCursor string `json:"endCursor"`
-			} `json:"pageInfo"`
-		} `json:"repositories"`
-	} `json:"viewer"`
-}
-
-func (c *V4Client) ListAffiliatedRepositories(ctx context.Context, visibility Visibility, after string) (
-	repos []*Repository,
-	endCursor string,
-	rateLimitCost int,
-	err error) {
-	res := repoResponse{}
-	args := make(map[string]interface{})
-	if after != "" {
-		args["after"] = after
-	}
-	err = c.requestGraphQL(ctx, `query GetAffiliatedRepos($after: String) {
-		viewer {
-			repositories(
-				first: 100,
-				after: $after,
-				ownerAffiliations: [
-					OWNER,
-					COLLABORATOR,
-					ORGANIZATION_MEMBER
-				]) {
-				  nodes {
-					nameWithOwner
-					isPrivate
-				  }
-				  pageInfo {
-					endCursor
-				  }
-			}
-		}
-	}`,
-		args,
-		&res,
-	)
-	return res.Viewer.Repositories.Nodes, res.Viewer.Repositories.PageInfo.EndCursor, 1, err
-}
-
 // ListOrgRepositories lists GitHub repositories from the specified organization.
 // org is the name of the organization. page is the page of results to return.
 // Pages are 1-indexed (so the first call should be for page 1).

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -677,13 +677,12 @@ func exampleRepositoryQuerySplit(q string) string {
 
 func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.CodeHostRepository, error) {
 	var (
-		repos    []*github.Repository
-		nextPage string
-		done     bool
-		page     = 1
-		cost     int
-		err      error
+		repos []*github.Repository
+		page  = 1
+		cost  int
+		err   error
 	)
+	hasNextPage := true
 	defer func() {
 		remaining, reset, retry, _ := s.v3Client.RateLimitMonitor().Get()
 		log15.Debug(
@@ -695,24 +694,18 @@ func (s *GithubSource) AffiliatedRepositories(ctx context.Context) ([]types.Code
 			"retryAfter", retry,
 		)
 	}()
-	out := make([]types.CodeHostRepository, 0, len(repos))
-	for !done {
+	out := make([]types.CodeHostRepository, 0)
+	for hasNextPage {
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("context canceled")
 		default:
 		}
-		repos, nextPage, cost, err = s.v4Client.ListAffiliatedRepositories(ctx, github.VisibilityAll, nextPage)
+		repos, hasNextPage, _, err = s.v3Client.ListAffiliatedRepositories(ctx, github.VisibilityAll, page)
 		if err != nil {
 			return nil, err
 		}
-		if nextPage == "" {
-			done = true
-		}
 		for _, repo := range repos {
-			// the github user repositories API doesn't support query strings, so we'll have
-			// to filter here 😬 this does make pagination more awkward though, as we won't
-			// paginate further if you don't match anything
 			out = append(out, types.CodeHostRepository{
 				Name:       repo.NameWithOwner,
 				Private:    repo.IsPrivate,


### PR DESCRIPTION
When syncing affiliated repos we use the v3 API, we should also use it
when listing affiliated repos via our GraphQL API so that the results
are consistent.
