### PR TITLE
Fix stale diff stat of unpublished changesets

### DIFF
--- a/enterprise/internal/batches/rewirer/rewirer.go
+++ b/enterprise/internal/batches/rewirer/rewirer.go
@@ -94,14 +94,11 @@ func (r *ChangesetRewirer) createChangesetForSpec(repo *types.Repo, spec *btypes
 
 		BatchChanges:         []btypes.BatchChangeAssoc{{BatchChangeID: r.batchChangeID}},
 		OwnedByBatchChangeID: r.batchChangeID,
-		CurrentSpecID:        spec.ID,
 
 		PublicationState: btypes.ChangesetPublicationStateUnpublished,
 	}
 
-	// Copy over diff stat from the spec.
-	diffStat := spec.DiffStat()
-	newChangeset.SetDiffStat(&diffStat)
+	newChangeset.SetCurrentSpec(spec)
 
 	// Set up the initial queue state of the changeset.
 	newChangeset.ResetReconcilerState(global.DefaultReconcilerEnqueueState())
@@ -113,7 +110,8 @@ func (r *ChangesetRewirer) updateChangesetToNewSpec(c *btypes.Changeset, spec *b
 	if c.ReconcilerState == btypes.ReconcilerStateCompleted {
 		c.PreviousSpecID = c.CurrentSpecID
 	}
-	c.CurrentSpecID = spec.ID
+
+	c.SetCurrentSpec(spec)
 
 	// Ensure that the changeset is attached to the batch change
 	c.Attach(r.batchChangeID)

--- a/enterprise/internal/batches/rewirer/rewirer_test.go
+++ b/enterprise/internal/batches/rewirer/rewirer_test.go
@@ -388,6 +388,8 @@ func TestRewirer_Rewire(t *testing.T) {
 				CurrentSpec:        testChangesetSpecID + 1,
 				// The changeset was reconciled successfully before, so the previous spec should have been recorded.
 				PreviousSpec: testChangesetSpecID,
+				// Diff stat is copied over from changeset spec
+				DiffStat: ct.TestChangsetSpecDiffStat,
 			})},
 		},
 		{
@@ -420,6 +422,8 @@ func TestRewirer_Rewire(t *testing.T) {
 				CurrentSpec:        testChangesetSpecID + 1,
 				// The changeset was not reconciled successfully before, so the previous spec should have remained unset.
 				PreviousSpec: 0,
+				// Diff stat is copied over from changeset spec
+				DiffStat: ct.TestChangsetSpecDiffStat,
 			})},
 		},
 		// END CHANGESET SPEC AND CHANGESET

--- a/enterprise/internal/batches/state/state.go
+++ b/enterprise/internal/batches/state/state.go
@@ -53,7 +53,7 @@ func SetDerivedState(ctx context.Context, repoStore *database.RepoStore, c *btyp
 	// synced, and it's still complete, then we don't need to do any further
 	// work: the diffstat should still be correct, and this way we don't need to
 	// rely on gitserver having the head OID still available.
-	if c.SyncState.IsComplete && c.ExternalState != btypes.ChangesetExternalStateOpen {
+	if c.SyncState.IsComplete && c.Complete() {
 		return
 	}
 
@@ -584,7 +584,7 @@ func computeSyncState(ctx context.Context, c *btypes.Changeset, repo api.RepoNam
 	return &btypes.ChangesetSyncState{
 		BaseRefOid: base,
 		HeadRefOid: head,
-		IsComplete: c.ExternalState != btypes.ChangesetExternalStateOpen,
+		IsComplete: c.Complete(),
 	}, nil
 }
 

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -271,6 +271,13 @@ func (c *Changeset) Closeable() bool {
 		c.ExternalState != ChangesetExternalStateMerged
 }
 
+// Complete returns whether the Changeset has been published and its
+// ExternalState is in a final state.
+func (c *Changeset) Complete() bool {
+	return c.Published() && c.ExternalState != ChangesetExternalStateOpen &&
+		c.ExternalState != ChangesetExternalStateDraft
+}
+
 // Published returns whether the Changeset's PublicationState is Published.
 func (c *Changeset) Published() bool { return c.PublicationState.Published() }
 
@@ -279,6 +286,15 @@ func (c *Changeset) Unpublished() bool { return c.PublicationState.Unpublished()
 
 // IsImporting returns whether the Changeset is being imported but it's not finished yet.
 func (c *Changeset) IsImporting() bool { return c.Unpublished() && c.CurrentSpecID == 0 }
+
+// SetCurrentSpec sets the CurrentSpecID field and copies the diff stat over from the spec.
+func (c *Changeset) SetCurrentSpec(spec *ChangesetSpec) {
+	c.CurrentSpecID = spec.ID
+
+	// Copy over diff stat from the spec.
+	diffStat := spec.DiffStat()
+	c.SetDiffStat(&diffStat)
+}
 
 // DiffStat returns a *diff.Stat if DiffStatAdded, DiffStatChanged, and
 // DiffStatDeleted are set, or nil if one or more is not.


### PR DESCRIPTION
Before this change the diff stat of changesets wasn't updated when a new
changeset spec was attached.

While investigating this we also found out that when checking whether
the derived state of a changeset needs to be updated we assume that
"Open" is the only non-final state a changeset can be in. But "draft" is
the other one.

So we also updated that.