### PR TITLE
Fix out-of-bounds panic for highlighted diffs with trailing delete line

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -538,6 +538,21 @@ func (r *DiffHunk) Highlight(ctx context.Context, args *HighlightArgs) (*highlig
 		hunkLines = hunkLines[:len(hunkLines)-1]
 	}
 
+	// Now do the same thing for trailing "-" lines. But only if they're not
+	// followed by an "unchanged" line.
+	var lastMinus int = -1
+	for i, hunkLine := range hunkLines {
+		if hunkLine == " " {
+			lastMinus = -1
+		} else if hunkLine == "-" {
+			lastMinus = i
+		}
+	}
+	// Empty "-" line that's not followed by an unchanged line, so cut it out
+	if lastMinus > -1 {
+		hunkLines = append(hunkLines[:lastMinus], hunkLines[lastMinus+1:]...)
+	}
+
 	highlightedDiffHunkLineResolvers := make([]*highlightedDiffHunkLineResolver, len(hunkLines))
 	// Lines in highlightedBase and highlightedHead are 0-indexed.
 	baseLine := r.hunk.OrigStartLine - 1


### PR DESCRIPTION
This is the mirror PR to https://github.com/sourcegraph/sourcegraph/pull/20505 and fixes the same issue for trailing "-" lines.

The added complication here is that we can't assume that trailing lines
are always the last lines in a hunk. So we need to do an additional loop
to detect where the last delete-line is that's not followed by another
"unchanged" line.

Happy to give this PR away though, but we wanted to fix the panic we ran
into :)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
