### PR TITLE
search redesign: infobar styling

### DIFF
--- a/client/branded/src/global-styles/buttons-redesign.scss
+++ b/client/branded/src/global-styles/buttons-redesign.scss
@@ -43,6 +43,19 @@
         }
     }
 
+    .show > .btn-#{$name}.dropdown-toggle {
+        color: $text-color;
+        background-color: $base-color;
+        border-color: var(--body-bg);
+
+        @at-root #{selector-append('.theme-light', &)} {
+            box-shadow: 0 0 0 2px $light-color-variant;
+        }
+        @at-root #{selector-append('.theme-dark', &)} {
+            box-shadow: 0 0 0 2px $dark-color-variant;
+        }
+    }
+
     .btn-outline-#{$name} {
         color: var(--body-color);
         border-color: $base-color;
@@ -92,6 +105,18 @@
                     box-shadow: 0 0 0 2px $dark-color-variant;
                 }
             }
+        }
+    }
+
+    .show > .btn-outline-#{$name}.dropdown-toggle {
+        color: var(--body-color);
+        border-color: var(--body-bg);
+        background-color: var(--body-bg);
+        @at-root #{selector-append('.theme-light', &)} {
+            box-shadow: 0 0 0 2px $light-color-variant;
+        }
+        @at-root #{selector-append('.theme-dark', &)} {
+            box-shadow: 0 0 0 2px $dark-color-variant;
         }
     }
 }
@@ -186,6 +211,10 @@
         &:not(:disabled):not(.disabled) {
             &:hover:not(.focus):not(:focus) {
                 color: var(--body-color);
+
+                svg {
+                    fill: var(--body-color);
+                }
             }
 
             &:focus,

--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -34,6 +34,14 @@
         height: 1rem;
         border-right: 1px solid var(--border-color);
         margin: 0 0.5rem;
+
+        .theme-redesign & {
+            margin-left: 0;
+
+            &:first-child {
+                display: none;
+            }
+        }
     }
 
     .theme-redesign & {

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -74,6 +74,9 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => {
+    const [isRedesignEnabled] = useRedesignToggle()
+    const buttonClass = isRedesignEnabled ? 'btn-outline-secondary mr-2' : 'btn-link'
+
     const createCodeMonitorButton = useMemo(() => {
         if (!props.enableCodeMonitoring || !props.query || !props.authenticatedUser) {
             return null
@@ -96,14 +99,21 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 <ButtonLink
                     disabled={!canCreateMonitorFromQuery}
                     to={toURL}
-                    className="btn btn-sm btn-link nav-link text-decoration-none"
+                    className={classNames('btn btn-sm nav-link text-decoration-none', buttonClass)}
                 >
                     <CodeMonitoringLogo className="icon-inline mr-1" />
                     Monitor
                 </ButtonLink>
             </li>
         )
-    }, [props.enableCodeMonitoring, props.query, props.authenticatedUser, props.location.search, props.patternType])
+    }, [
+        buttonClass,
+        props.enableCodeMonitoring,
+        props.query,
+        props.authenticatedUser,
+        props.location.search,
+        props.patternType,
+    ])
 
     const saveSearchButton = useMemo(() => {
         if (props.showSavedQueryButton === false || !props.authenticatedUser) {
@@ -115,23 +125,23 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 <button
                     type="button"
                     onClick={props.onSaveQueryClick}
-                    className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
+                    className={classNames(
+                        'btn btn-sm nav-link text-decoration-none test-save-search-link',
+                        buttonClass
+                    )}
                 >
                     <DownloadIcon className="icon-inline mr-1" />
                     Save search
                 </button>
             </li>
         )
-    }, [props.authenticatedUser, props.onSaveQueryClick, props.showSavedQueryButton])
+    }, [buttonClass, props.authenticatedUser, props.onSaveQueryClick, props.showSavedQueryButton])
 
     const extraContext = useMemo(() => ({ searchQuery: props.query || null }), [props.query])
 
-    const [isRedesignEnabled] = useRedesignToggle()
-    const Container = isRedesignEnabled ? 'div' : 'small'
-
     return (
         <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
-            <Container className="search-results-info-bar__row">
+            <div className="search-results-info-bar__row">
                 {props.stats}
                 <QuotesInterpretedLiterallyNotice {...props} />
 
@@ -142,7 +152,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         menu={ContributableMenu.SearchResultsToolbar}
                         wrapInList={false}
                         showLoadingSpinnerDuringExecution={true}
-                        actionItemClass="btn btn-sm btn-link nav-link text-decoration-none"
+                        actionItemClass={classNames('btn nav-link text-decoration-none btn-sm', buttonClass)}
                     />
 
                     {(createCodeMonitorButton || saveSearchButton) && (
@@ -158,7 +168,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                                 <button
                                     type="button"
                                     onClick={props.onExpandAllResultsToggle}
-                                    className="btn btn-sm btn-link nav-link text-decoration-none"
+                                    className={classNames('btn btn-sm nav-link text-decoration-none', buttonClass)}
                                     data-tooltip={`${props.allExpanded ? 'Hide' : 'Show'} more matches on all results`}
                                 >
                                     {props.allExpanded ? (
@@ -171,7 +181,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         </>
                     )}
                 </ul>
-            </Container>
+            </div>
         </div>
     )
 }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -12,6 +12,7 @@ import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/co
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/validate'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { PatternTypeProps } from '..'
 import { AuthenticatedUser } from '../../auth'
@@ -125,9 +126,12 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
 
     const extraContext = useMemo(() => ({ searchQuery: props.query || null }), [props.query])
 
+    const [isRedesignEnabled] = useRedesignToggle()
+    const Container = isRedesignEnabled ? 'div' : 'small'
+
     return (
         <div className={classNames(props.className, 'search-results-info-bar')} data-testid="results-info-bar">
-            <small className="search-results-info-bar__row">
+            <Container className="search-results-info-bar__row">
                 {props.stats}
                 <QuotesInterpretedLiterallyNotice {...props} />
 
@@ -167,7 +171,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                         </>
                     )}
                 </ul>
-            </small>
+            </Container>
         </div>
     )
 }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -58,7 +58,7 @@ export interface SearchResultsInfoBarProps
  */
 const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInfoBarProps> = props =>
     props.patternType === SearchPatternType.literal && props.query && props.query.includes('"') ? (
-        <div
+        <small
             className="search-results-info-bar__notice"
             data-tooltip="Your search query is interpreted literally, including the quotes. Use the .* toggle to switch between literal and regular expression search."
         >
@@ -66,7 +66,7 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
                 <FormatQuoteOpenIcon className="icon-inline" />
                 Searching literally <strong>(including quotes)</strong>
             </span>
-        </div>
+        </small>
     ) : null
 
 /**

--- a/client/web/src/search/results/SearchResultsStats.tsx
+++ b/client/web/src/search/results/SearchResultsStats.tsx
@@ -21,13 +21,13 @@ export const SearchResultsStats: React.FunctionComponent<{
     return (
         <>
             <div className="search-results-info-bar__notice test-search-results-stats">
-                <span>
+                <small>
                     <CalculatorIcon className="icon-inline" /> {results.approximateResultCount}{' '}
                     {pluralize('result', results.matchCount)} in {(results.elapsedMilliseconds / 1000).toFixed(2)}{' '}
                     seconds
                     {results.indexUnavailable && ' (index unavailable)'}
                     {results.limitHit && String.fromCharCode(160)}
-                </span>
+                </small>
 
                 {results.limitHit && onShowMoreResultsClick && (
                     <button type="button" className="btn btn-link btn-sm p-0" onClick={onShowMoreResultsClick}>
@@ -38,19 +38,19 @@ export const SearchResultsStats: React.FunctionComponent<{
 
             {excludedForksCount > 0 && (
                 <div className="search-results-info-bar__notice" data-tooltip="add fork:yes to include forks">
-                    <span>
+                    <small>
                         <AlertCircleIcon className="icon-inline" /> {excludedForksCount} forked{' '}
                         {pluralize('repository', excludedForksCount, 'repositories')} excluded
-                    </span>
+                    </small>
                 </div>
             )}
 
             {excludedArchivedCount > 0 && (
                 <div className="search-results-info-bar__notice" data-tooltip="add archived:yes to include archives">
-                    <span>
+                    <small>
                         <AlertCircleIcon className="icon-inline" /> {excludedArchivedCount} archived{' '}
                         {pluralize('repository', excludedArchivedCount, 'repositories')} excluded
-                    </span>
+                    </small>
                 </div>
             )}
 
@@ -59,10 +59,10 @@ export const SearchResultsStats: React.FunctionComponent<{
                     className="search-results-info-bar__notice"
                     data-tooltip={results.missing.map(repo => repo.name).join('\n')}
                 >
-                    <span>
+                    <small>
                         <MapSearchIcon className="icon-inline" /> {results.missing.length}{' '}
                         {pluralize('repository', results.missing.length, 'repositories')} not found
-                    </span>
+                    </small>
                 </div>
             )}
 
@@ -71,11 +71,11 @@ export const SearchResultsStats: React.FunctionComponent<{
                     className="search-results-info-bar__notice"
                     data-tooltip={results.timedout.map(repo => repo.name).join('\n')}
                 >
-                    <span>
+                    <small>
                         <TimerSandIcon className="icon-inline" /> {results.timedout.length}{' '}
                         {pluralize('repository', results.timedout.length, 'repositories')} timed out (reload to try
                         again, or specify a longer "timeout:" in your query)
-                    </span>
+                    </small>
                 </div>
             )}
 
@@ -84,10 +84,10 @@ export const SearchResultsStats: React.FunctionComponent<{
                     className="search-results-info-bar__notice"
                     data-tooltip={results.cloning.map(repo => repo.name).join('\n')}
                 >
-                    <span>
+                    <small>
                         <CloudDownloadIcon className="icon-inline" /> {results.cloning.length}{' '}
                         {pluralize('repository', results.cloning.length, 'repositories')} cloning (reload to try again)
-                    </span>
+                    </small>
                 </div>
             )}
         </>

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
   className="search-results-info-bar"
   data-testid="results-info-bar"
 >
-  <small
+  <div
     className="search-results-info-bar__row"
   >
     <div />
@@ -20,7 +20,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
         className="nav-item"
       >
         <button
-          className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
+          className="btn btn-sm nav-link text-decoration-none test-save-search-link btn-link"
           onClick={[Function]}
           type="button"
         >
@@ -46,7 +46,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
         className="nav-item"
       >
         <button
-          className="btn btn-sm btn-link nav-link text-decoration-none"
+          className="btn btn-sm nav-link text-decoration-none btn-link"
           data-tooltip="Hide more matches on all results"
           onClick={[Function]}
           type="button"
@@ -65,7 +65,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
         </button>
       </li>
     </ul>
-  </small>
+  </div>
 </div>
 `;
 
@@ -74,7 +74,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
   className="search-results-info-bar"
   data-testid="results-info-bar"
 >
-  <small
+  <div
     className="search-results-info-bar__row"
   >
     <div />
@@ -89,7 +89,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         className="nav-item"
       >
         <a
-          className="btn btn-sm btn-link nav-link text-decoration-none"
+          className="btn btn-sm nav-link text-decoration-none btn-link"
           href="/code-monitoring/new?trigger-query=foo+type%3Adiff+patterntype%3Aliteral"
           onClick={[Function]}
           onKeyPress={[Function]}
@@ -116,7 +116,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         className="nav-item"
       >
         <button
-          className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
+          className="btn btn-sm nav-link text-decoration-none test-save-search-link btn-link"
           onClick={[Function]}
           type="button"
         >
@@ -142,7 +142,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         className="nav-item"
       >
         <button
-          className="btn btn-sm btn-link nav-link text-decoration-none"
+          className="btn btn-sm nav-link text-decoration-none btn-link"
           data-tooltip="Hide more matches on all results"
           onClick={[Function]}
           type="button"
@@ -161,7 +161,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         </button>
       </li>
     </ul>
-  </small>
+  </div>
 </div>
 `;
 
@@ -170,7 +170,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
   className="search-results-info-bar"
   data-testid="results-info-bar"
 >
-  <small
+  <div
     className="search-results-info-bar__row"
   >
     <div />
@@ -185,7 +185,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         className="nav-item"
       >
         <button
-          className="btn btn-sm btn-link nav-link text-decoration-none"
+          className="btn btn-sm nav-link text-decoration-none btn-link"
           data-tooltip="Hide more matches on all results"
           onClick={[Function]}
           type="button"
@@ -204,7 +204,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
         </button>
       </li>
     </ul>
-  </small>
+  </div>
 </div>
 `;
 
@@ -213,7 +213,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
   className="search-results-info-bar"
   data-testid="results-info-bar"
 >
-  <small
+  <div
     className="search-results-info-bar__row"
   >
     <div />
@@ -229,7 +229,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         data-tooltip="Code monitors only support type:diff or type:commit searches."
       >
         <a
-          className="btn btn-sm btn-link nav-link text-decoration-none disabled"
+          className="btn btn-sm nav-link text-decoration-none btn-link disabled"
           href=""
           onAuxClick={[Function]}
           onClick={[Function]}
@@ -258,7 +258,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         className="nav-item"
       >
         <button
-          className="btn btn-sm btn-link nav-link text-decoration-none test-save-search-link"
+          className="btn btn-sm nav-link text-decoration-none test-save-search-link btn-link"
           onClick={[Function]}
           type="button"
         >
@@ -284,7 +284,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         className="nav-item"
       >
         <button
-          className="btn btn-sm btn-link nav-link text-decoration-none"
+          className="btn btn-sm nav-link text-decoration-none btn-link"
           data-tooltip="Hide more matches on all results"
           onClick={[Function]}
           type="button"
@@ -303,6 +303,6 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
         </button>
       </li>
     </ul>
-  </small>
+  </div>
 </div>
 `;

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -62,9 +62,14 @@
     &__button {
         &:disabled {
             opacity: 1;
+
+            .theme-redesign & {
+                color: var(--body-color);
+            }
         }
     }
 
+    // Not needed once .theme-redesign is removed
     &__icon {
         color: var(--primary);
     }
@@ -102,6 +107,7 @@
     }
 
     &--warn {
+        // Not needed once .theme-redesign is removed
         .streaming-skipped-item__icon {
             color: var(--danger);
         }

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -13,7 +13,7 @@
         color: var(--link-color);
 
         .theme-redesign & {
-            color: inherit;
+            color: var(--body-color);
             padding-left: 0.5rem;
             padding-right: 0.5rem;
 
@@ -34,6 +34,12 @@
         }
     }
 
+    &__count-icon {
+        .theme-redesign & {
+            display: none;
+        }
+    }
+
     &__skipped {
         margin-left: 0.25rem;
 
@@ -44,6 +50,10 @@
         &-popover {
             width: 20rem;
             padding: 0;
+        }
+
+        .theme-redesign & {
+            font-size: 0.75rem;
         }
     }
 

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -106,6 +106,10 @@
         margin-right: 0.75rem;
     }
 
+    &__chevron {
+        fill: currentColor !important;
+    }
+
     &--warn {
         // Not needed once .theme-redesign is removed
         .streaming-skipped-item__icon {

--- a/client/web/src/search/results/streaming/progress/StreamingProgress.scss
+++ b/client/web/src/search/results/streaming/progress/StreamingProgress.scss
@@ -51,10 +51,6 @@
             width: 20rem;
             padding: 0;
         }
-
-        .theme-redesign & {
-            font-size: 0.75rem;
-        }
     }
 
     .theme-redesign & {

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -28,7 +28,7 @@ export const StreamingProgressCount: React.FunctionComponent<
     Pick<StreamingProgressProps, 'progress' | 'state' | 'showTrace'> & { className?: string }
 > = ({ progress, state, showTrace, className = '' }) => (
     <>
-        <div
+        <small
             className={classNames(className, 'streaming-progress__count d-flex align-items-center', {
                 'streaming-progress__count--in-progress': state === 'loading',
             })}
@@ -44,14 +44,14 @@ export const StreamingProgressCount: React.FunctionComponent<
                     {pluralize('repository', progress.repositoriesCount, 'repositories')}
                 </>
             )}
-        </div>
+        </small>
         {showTrace && progress.trace && (
-            <div className="d-flex">
+            <small className="d-flex">
                 <a href={progress.trace}>
                     <ClipboardPulseOutlineIcon className="mr-2 icon-inline" />
                     View trace
                 </a>
-            </div>
+            </small>
         )}
     </>
 )

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -33,7 +33,7 @@ export const StreamingProgressCount: React.FunctionComponent<
                 'streaming-progress__count--in-progress': state === 'loading',
             })}
         >
-            <CalculatorIcon className="mr-2 icon-inline" />
+            <CalculatorIcon className="mr-2 icon-inline streaming-progress__count-icon" />
             {abbreviateNumber(progress.matchCount)}
             {limitHit(progress) ? '+' : ''} {pluralize('result', progress.matchCount)} in{' '}
             {(progress.durationMs / 1000).toFixed(2)}s

--- a/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressCount.tsx
@@ -46,7 +46,7 @@ export const StreamingProgressCount: React.FunctionComponent<
             )}
         </small>
         {showTrace && progress.trace && (
-            <small className="d-flex">
+            <small className="d-flex ml-2">
                 <a href={progress.trace}>
                     <ClipboardPulseOutlineIcon className="mr-2 icon-inline" />
                     View trace

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -4,6 +4,8 @@ import InformationOutlineIcon from 'mdi-react/InformationOutlineIcon'
 import React, { useCallback, useMemo, useState } from 'react'
 import { ButtonDropdown, DropdownMenu, DropdownToggle } from 'reactstrap'
 
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+
 import { StreamingProgressProps } from './StreamingProgress'
 import { StreamingProgressSkippedPopover } from './StreamingProgressSkippedPopover'
 
@@ -26,19 +28,28 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
         [setIsOpen, onSearchAgain]
     )
 
+    const [isRedesignEnabled] = useRedesignToggle()
+
     return (
         <>
             {progress.skipped.length > 0 && (
                 <ButtonDropdown isOpen={isOpen} toggle={toggleOpen}>
                     <DropdownToggle
                         className={classNames(
-                            'streaming-progress__skipped mb-0 ml-2 d-flex align-items-center text-decoration-none btn-sm',
+                            'streaming-progress__skipped mb-0 ml-2 d-flex align-items-center text-decoration-none',
                             {
-                                'streaming-progress__skipped--warning': skippedWithWarningOrError,
+                                'streaming-progress__skipped--warning': !isRedesignEnabled && skippedWithWarningOrError,
+                                'btn-sm': !isRedesignEnabled,
                             }
                         )}
                         caret={true}
-                        color="link"
+                        color={
+                            isRedesignEnabled
+                                ? skippedWithWarningOrError
+                                    ? 'outline-danger'
+                                    : 'outline-secondary'
+                                : 'link'
+                        }
                     >
                         {skippedWithWarningOrError ? (
                             <AlertCircleIcon className="mr-2 icon-inline" />

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedButton.tsx
@@ -36,10 +36,9 @@ export const StreamingProgressSkippedButton: React.FunctionComponent<
                 <ButtonDropdown isOpen={isOpen} toggle={toggleOpen}>
                     <DropdownToggle
                         className={classNames(
-                            'streaming-progress__skipped mb-0 ml-2 d-flex align-items-center text-decoration-none',
+                            'streaming-progress__skipped mb-0 ml-2 d-flex align-items-center text-decoration-none btn-sm',
                             {
                                 'streaming-progress__skipped--warning': !isRedesignEnabled && skippedWithWarningOrError,
-                                'btn-sm': !isRedesignEnabled,
                             }
                         )}
                         caret={true}

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -84,9 +84,9 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
 
                     {skipped.message &&
                         (isOpen ? (
-                            <ChevronDownIcon className="icon-inline flex-shrink-0" />
+                            <ChevronDownIcon className="icon-inline flex-shrink-0 streaming-skipped-item__chevron" />
                         ) : (
-                            <ChevronLeftIcon className="icon-inline flex-shrink-0" />
+                            <ChevronLeftIcon className="icon-inline flex-shrink-0 streaming-skipped-item__chevron" />
                         ))}
                 </h4>
             </Button>

--- a/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
+++ b/client/web/src/search/results/streaming/progress/StreamingProgressSkippedPopover.tsx
@@ -10,6 +10,7 @@ import { Button, Collapse, Form, FormGroup, Input, Label } from 'reactstrap'
 
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { SyntaxHighlightedSearchQuery } from '../../../../components/SyntaxHighlightedSearchQuery'
 import { Skipped } from '../../../stream'
@@ -52,6 +53,8 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
         }
     }, [])
 
+    const [isRedesignEnabled] = useRedesignToggle()
+
     return (
         <div
             className={classNames('streaming-skipped-item pt-2 w-100', {
@@ -63,6 +66,13 @@ const SkippedMessage: React.FunctionComponent<{ skipped: Skipped; history: H.His
                 onClick={toggleIsOpen}
                 onKeyDown={onKeyDown}
                 disabled={!skipped.message}
+                color={
+                    !isRedesignEnabled
+                        ? 'secondary'
+                        : skipped.severity !== 'info'
+                        ? 'outline-danger'
+                        : 'outline-primary'
+                }
             >
                 <h4 className="d-flex align-items-center mb-0 w-100">
                     {skipped.severity === 'info' ? (

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressCount.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`StreamingProgressCount should not render a trace link when not opted in
   }
   state="loading"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     0
      
@@ -25,7 +25,7 @@ exports[`StreamingProgressCount should not render a trace link when not opted in
      
     0.00
     s
-  </div>
+  </small>
 </StreamingProgressCount>
 `;
 
@@ -40,11 +40,11 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
   }
   state="loading"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     0
      
@@ -53,7 +53,7 @@ exports[`StreamingProgressCount should render correctly for 0 items in progress 
      
     0.00
     s
-  </div>
+  </small>
 </StreamingProgressCount>
 `;
 
@@ -69,11 +69,11 @@ exports[`StreamingProgressCount should render correctly for 0 repositories 1`] =
   }
   state="loading"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     0
      
@@ -87,7 +87,7 @@ exports[`StreamingProgressCount should render correctly for 0 repositories 1`] =
     0
      
     repositories
-  </div>
+  </small>
 </StreamingProgressCount>
 `;
 
@@ -103,11 +103,11 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
   }
   state="complete"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     1
      
@@ -121,7 +121,7 @@ exports[`StreamingProgressCount should render correctly for 1 item complete 1`] 
     1
      
     repository
-  </div>
+  </small>
 </StreamingProgressCount>
 `;
 
@@ -137,11 +137,11 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
   }
   state="complete"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     123
      
@@ -155,7 +155,7 @@ exports[`StreamingProgressCount should render correctly for 123 items complete 1
     500
      
     repositories
-  </div>
+  </small>
 </StreamingProgressCount>
 `;
 
@@ -171,11 +171,11 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
   }
   state="complete"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     1.2m
      
@@ -189,7 +189,7 @@ exports[`StreamingProgressCount should render correctly for big numbers complete
     8.9k
      
     repositories
-  </div>
+  </small>
 </StreamingProgressCount>
 `;
 
@@ -212,11 +212,11 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
   }
   state="complete"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     123
     +
@@ -231,7 +231,7 @@ exports[`StreamingProgressCount should render correctly for limithit 1`] = `
     500
      
     repositories
-  </div>
+  </small>
 </StreamingProgressCount>
 `;
 
@@ -248,11 +248,11 @@ exports[`StreamingProgressCount should render correctly when a trace url is prov
   showTrace={true}
   state="loading"
 >
-  <div
+  <small
     className="streaming-progress__count d-flex align-items-center streaming-progress__count--in-progress"
   >
     <Memo(CalculatorIcon)
-      className="mr-2 icon-inline"
+      className="mr-2 icon-inline streaming-progress__count-icon"
     />
     0
      
@@ -261,9 +261,9 @@ exports[`StreamingProgressCount should render correctly when a trace url is prov
      
     0.00
     s
-  </div>
-  <div
-    className="d-flex"
+  </small>
+  <small
+    className="d-flex ml-2"
   >
     <a
       href="https://sourcegraph.test:3443/-/debug/jaeger/trace/abcdefg"
@@ -273,6 +273,6 @@ exports[`StreamingProgressCount should render correctly when a trace url is prov
       />
       View trace
     </a>
-  </div>
+  </small>
 </StreamingProgressCount>
 `;

--- a/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
+++ b/client/web/src/search/results/streaming/progress/__snapshots__/StreamingProgressSkippedPopover.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
               Error loading results
             </span>
             <Memo(ChevronDownIcon)
-              className="icon-inline flex-shrink-0"
+              className="icon-inline flex-shrink-0 streaming-skipped-item__chevron"
             />
           </h4>
         </button>
@@ -218,7 +218,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
               Search timed out
             </span>
             <Memo(ChevronLeftIcon)
-              className="icon-inline flex-shrink-0"
+              className="icon-inline flex-shrink-0 streaming-skipped-item__chevron"
             />
           </h4>
         </button>
@@ -332,7 +332,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
               10k forked repositories excluded
             </span>
             <Memo(ChevronLeftIcon)
-              className="icon-inline flex-shrink-0"
+              className="icon-inline flex-shrink-0 streaming-skipped-item__chevron"
             />
           </h4>
         </button>
@@ -446,7 +446,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
               60k archived repositories excluded
             </span>
             <Memo(ChevronLeftIcon)
-              className="icon-inline flex-shrink-0"
+              className="icon-inline flex-shrink-0 streaming-skipped-item__chevron"
             />
           </h4>
         </button>
@@ -560,7 +560,7 @@ exports[`StreamingProgressSkippedPopover should render correctly 1`] = `
               1 archived
             </span>
             <Memo(ChevronLeftIcon)
-              className="icon-inline flex-shrink-0"
+              className="icon-inline flex-shrink-0 streaming-skipped-item__chevron"
             />
           </h4>
         </button>


### PR DESCRIPTION
- Global fixes for redesign theme (fyi @sourcegraph/frontend-platform):
  - Fixes background colors for dropdown toggle buttons
  - Fixes icon hover colors inside `.btn-secondary` and `.btn-outline-secondary`
- Infobar is no longer wrapped in a `<small>`; instead items inside use `<small>` or `.btn-sm` directly
- When redesign theme is enabled:
  - Buttons in the infobar are now `.btn-outline-secondary` instead of `.btn-link`
  - Calculator icon no longer displayed on count
  - Icons inside buttons are now colored automatically by the button's type (eg. `outline-danger`). However, this required overriding so chevrons inside the skipped results popover would not also be colored.
  
 
![image](https://user-images.githubusercontent.com/206864/117214300-7a716300-adb1-11eb-9dac-c4e8f0545974.png)

![image](https://user-images.githubusercontent.com/206864/117214362-8e1cc980-adb1-11eb-8e71-bb91724098ae.png)

Fixes #20648