### PR TITLE
Disable flaky browser extension e2e tests

### DIFF
--- a/client/browser/src/end-to-end/github.test.ts
+++ b/client/browser/src/end-to-end/github.test.ts
@@ -69,7 +69,9 @@ describe('Sourcegraph browser extension on github.com', function () {
         },
     }
 
-    describe('Pull request pages', () => {
+    // Replace these unstable tests with integration tests with stubs:
+    // https://github.com/sourcegraph/sourcegraph/pull/20520#issuecomment-829726482
+    describe.skip('Pull request pages', () => {
         for (const diffType of ['unified', 'split']) {
             describe(`${startCase(diffType)} view`, () => {
                 for (const side of ['base', 'head'] as const) {


### PR DESCRIPTION
We [originally patched this test](https://github.com/sourcegraph/sourcegraph/pull/20520) by allowing multiple valid go to definition URLs to pass, but sourcegraph.com now returns incorrect go to definition URLs [at times](https://buildkite.com/sourcegraph/browser-extension-nightly-e2e/builds/386#a7de828e-b668-4ee5-866a-9146d54492d5/49-360). We should replace these tests with integration tests that do not assert/rely on code intelligence.