### PR TITLE
Fix Postgres exporter config

### DIFF
--- a/docker-images/postgres_exporter/build.sh
+++ b/docker-images/postgres_exporter/build.sh
@@ -16,7 +16,7 @@ CODEINTEL_OUTPUT_FILE="${OUTPUT}/code_intel_queries.yaml"
 for source in ./config/*.yaml; do
   {
     if [[ "$source" == *"codeintel"* ]]; then
-      echo "Skipping $source"
+      echo "# skipping $source"
       continue
     fi
     echo "# source: ${source}"
@@ -28,7 +28,7 @@ done
 for source in ./config/*.yaml; do
   {
     if [[ "$source" == *"standard"* ]]; then
-      echo "Skipping $source"
+      echo "# skipping $source"
       continue
     fi
     echo "# source: ${source}"


### PR DESCRIPTION
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
The config files for Postgres exporter were outputting comments without prefixing them with '#'
This was causing the exporter to fail to start