### PR TITLE
batches: store encryption key "ID" alongside credentials

### DIFF
--- a/enterprise/internal/batches/store/integration_test.go
+++ b/enterprise/internal/batches/store/integration_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 )
 
 func TestIntegration(t *testing.T) {
@@ -16,21 +18,29 @@ func TestIntegration(t *testing.T) {
 	db := dbtesting.GetDB(t)
 
 	t.Run("Store", func(t *testing.T) {
-		t.Run("BatchChanges", storeTest(db, testStoreBatchChanges))
-		t.Run("Changesets", storeTest(db, testStoreChangesets))
-		t.Run("ChangesetEvents", storeTest(db, testStoreChangesetEvents))
-		t.Run("ChangesetScheduling", storeTest(db, testStoreChangesetScheduling))
-		t.Run("ListChangesetSyncData", storeTest(db, testStoreListChangesetSyncData))
-		t.Run("ListChangesetsTextSearch", storeTest(db, testStoreListChangesetsTextSearch))
-		t.Run("BatchSpecs", storeTest(db, testStoreBatchSpecs))
-		t.Run("ChangesetSpecs", storeTest(db, testStoreChangesetSpecs))
-		t.Run("ChangesetSpecsCurrentState", storeTest(db, testStoreChangesetSpecsCurrentState))
-		t.Run("ChangesetSpecsCurrentStateAndTextSearch", storeTest(db, testStoreChangesetSpecsCurrentStateAndTextSearch))
-		t.Run("ChangesetSpecsTextSearch", storeTest(db, testStoreChangesetSpecsTextSearch))
-		t.Run("CodeHosts", storeTest(db, testStoreCodeHost))
-		t.Run("UserDeleteCascades", storeTest(db, testUserDeleteCascades))
-		t.Run("SiteCredentials", storeTest(db, testStoreSiteCredentials))
-		t.Run("ChangesetJobs", storeTest(db, testStoreChangesetJobs))
-		t.Run("BulkOperations", storeTest(db, testStoreBulkOperations))
+		t.Run("BatchChanges", storeTest(db, nil, testStoreBatchChanges))
+		t.Run("Changesets", storeTest(db, nil, testStoreChangesets))
+		t.Run("ChangesetEvents", storeTest(db, nil, testStoreChangesetEvents))
+		t.Run("ChangesetScheduling", storeTest(db, nil, testStoreChangesetScheduling))
+		t.Run("ListChangesetSyncData", storeTest(db, nil, testStoreListChangesetSyncData))
+		t.Run("ListChangesetsTextSearch", storeTest(db, nil, testStoreListChangesetsTextSearch))
+		t.Run("BatchSpecs", storeTest(db, nil, testStoreBatchSpecs))
+		t.Run("ChangesetSpecs", storeTest(db, nil, testStoreChangesetSpecs))
+		t.Run("ChangesetSpecsCurrentState", storeTest(db, nil, testStoreChangesetSpecsCurrentState))
+		t.Run("ChangesetSpecsCurrentStateAndTextSearch", storeTest(db, nil, testStoreChangesetSpecsCurrentStateAndTextSearch))
+		t.Run("ChangesetSpecsTextSearch", storeTest(db, nil, testStoreChangesetSpecsTextSearch))
+		t.Run("CodeHosts", storeTest(db, nil, testStoreCodeHost))
+		t.Run("UserDeleteCascades", storeTest(db, nil, testUserDeleteCascades))
+		t.Run("ChangesetJobs", storeTest(db, nil, testStoreChangesetJobs))
+		t.Run("BulkOperations", storeTest(db, nil, testStoreBulkOperations))
+
+		for name, key := range map[string]encryption.Key{
+			"no key":   nil,
+			"test key": &et.TestKey{},
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Run("SiteCredentials", storeTest(db, key, testStoreSiteCredentials))
+			})
+		}
 	})
 }

--- a/enterprise/internal/batches/store/site_credentials.go
+++ b/enterprise/internal/batches/store/site_credentials.go
@@ -33,7 +33,7 @@ func (s *Store) CreateSiteCredential(ctx context.Context, c *btypes.SiteCredenti
 
 var createSiteCredentialQueryFmtstr = `
 -- source: enterprise/internal/batches/store/site_credentials.go:CreateSiteCredential
-INSERT INTO	batch_changes_site_credentials (
+INSERT INTO batch_changes_site_credentials (
 	external_service_type,
 	external_service_id,
 	credential,

--- a/enterprise/internal/batches/store/store_test.go
+++ b/enterprise/internal/batches/store/store_test.go
@@ -7,6 +7,7 @@ import (
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -14,7 +15,7 @@ type storeTestFunc func(*testing.T, context.Context, *Store, ct.Clock)
 
 // storeTest converts a storeTestFunc into a func(*testing.T) in which all
 // dependencies are set up and injected into the storeTestFunc.
-func storeTest(db *sql.DB, f storeTestFunc) func(*testing.T) {
+func storeTest(db *sql.DB, key encryption.Key, f storeTestFunc) func(*testing.T) {
 	return func(t *testing.T) {
 		c := &ct.TestClock{Time: timeutil.Now()}
 
@@ -23,7 +24,7 @@ func storeTest(db *sql.DB, f storeTestFunc) func(*testing.T) {
 		// don't need to insert a lot of dependencies into the DB (users,
 		// repos, ...) to setup the tests.
 		tx := dbtest.NewTx(t, db)
-		s := NewWithClock(tx, nil, c.Now)
+		s := NewWithClock(tx, key, c.Now)
 
 		f(t, context.Background(), s, c)
 	}

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -69,6 +69,7 @@ Triggers:
  created_at            | timestamp with time zone |           | not null | now()
  updated_at            | timestamp with time zone |           | not null | now()
  credential_enc        | bytea                    |           |          | 
+ encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
     "batch_changes_site_credentials_pkey" PRIMARY KEY, btree (id)
     "batch_changes_site_credentials_unique" UNIQUE, btree (external_service_type, external_service_id)
@@ -1493,6 +1494,7 @@ Foreign-key constraints:
  updated_at            | timestamp with time zone |           | not null | now()
  credential_enc        | bytea                    |           |          | 
  ssh_migration_applied | boolean                  |           | not null | false
+ encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
     "user_credentials_pkey" PRIMARY KEY, btree (id)
     "user_credentials_domain_user_id_external_service_type_exter_key" UNIQUE CONSTRAINT, btree (domain, user_id, external_service_type, external_service_id)

--- a/migrations/frontend/1528395822_track_encryption_key.down.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE
+    batch_changes_site_credentials
+DROP COLUMN IF EXISTS
+    encryption_key_id;
+
+ALTER TABLE
+    user_credentials
+DROP COLUMN IF EXISTS
+    encryption_key_id;
+
+COMMIT;

--- a/migrations/frontend/1528395822_track_encryption_key.up.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE
+    batch_changes_site_credentials
+ADD COLUMN IF NOT EXISTS
+    encryption_key_id TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE
+    user_credentials
+ADD COLUMN IF NOT EXISTS
+    encryption_key_id TEXT NOT NULL DEFAULT '';
+
+COMMIT;


### PR DESCRIPTION
This is essentially what we do for `external_accounts`, and is required to handle the plaintext to encrypted upgrade scenario.

@eseliger, I think you're the only person who'll be affected by this in practice: you _may_ need to delete and recreate your local credentials. Sorry.