### PR TITLE
web: more precise typography letter-spacing

### DIFF
--- a/client/branded/src/global-styles/GlobalStylesStory/TextStory.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/TextStory.tsx
@@ -19,7 +19,7 @@ export const TextStory: React.FunctionComponent = () => (
                             </code>
                         </td>
                         <td>
-                            <Heading>This is an {Heading.toUpperCase()}</Heading>
+                            <Heading>This is {Heading}</Heading>
                         </td>
                     </tr>
                 ))}

--- a/client/branded/src/global-styles/GlobalStylesStory/TextStory.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/TextStory.tsx
@@ -19,7 +19,7 @@ export const TextStory: React.FunctionComponent = () => (
                             </code>
                         </td>
                         <td>
-                            <Heading>This is {Heading}</Heading>
+                            <Heading>This is an {Heading.toUpperCase()}</Heading>
                         </td>
                     </tr>
                 ))}

--- a/client/branded/src/global-styles/buttons-redesign.scss
+++ b/client/branded/src/global-styles/buttons-redesign.scss
@@ -187,6 +187,10 @@
         @extend %label-base;
     }
 
+    .btn.btn-sm {
+        @extend %label-base-small;
+    }
+
     // Label / Uppercase / Base
     .btn.text-uppercase {
         @extend %label-uppercase;
@@ -194,6 +198,7 @@
         // Label / Uppercase / Small
         &.btn-sm {
             font-size: 0.6875rem;
+            @extend %label-uppercase;
         }
     }
 }

--- a/client/branded/src/global-styles/typography-redesign.scss
+++ b/client/branded/src/global-styles/typography-redesign.scss
@@ -1,32 +1,32 @@
 .theme-redesign {
     h1 {
-        font-size: 1.625rem;
+        font-size: 1.625rem; // 26px
         font-weight: 600;
-        letter-spacing: -0.031em;
+        letter-spacing: (0.5/26) + em;
     }
 
     h2 {
-        font-size: 1.25rem;
+        font-size: 1.25rem; // 20px
         font-weight: 600;
-        letter-spacing: -0.016em;
+        letter-spacing: (0.25/20) + em;
     }
 
     h3 {
-        font-size: 1rem;
+        font-size: 1rem; // 16px
         font-weight: 600;
-        letter-spacing: -0.016em;
+        letter-spacing: (0.25/16) + em;
     }
 
     h4 {
-        font-size: 0.875rem;
+        font-size: 0.875rem; // 14px
         font-weight: 500;
-        letter-spacing: -0.016em;
+        letter-spacing: (0.25/14) + em;
     }
 
     h5 {
-        font-size: 0.625rem;
+        font-size: 0.625rem; // 10px
         font-weight: 600;
-        letter-spacing: 0.031em;
+        letter-spacing: (0.5/10) + em;
         text-transform: uppercase;
     }
 
@@ -67,13 +67,24 @@
     label,
     %label-base {
         font-weight: 500;
-        letter-spacing: -0.016em;
+        letter-spacing: -(0.1/14) + em;
+    }
+
+    label small,
+    %label-base-small {
+        letter-spacing: -(0.25/12) + em;
     }
 
     // Label / Uppercase
     label.text-uppercase,
     %label-uppercase {
         font-size: 0.75rem;
-        letter-spacing: 0.016em;
+        letter-spacing: (0.25/14) + em;
+    }
+
+    label.text-uppercase small,
+    %label-uppercase-small {
+        font-size: 0.75rem;
+        letter-spacing: -(0.25/12) + em;
     }
 }


### PR DESCRIPTION
## Description

CSS rules from Figma `Inspect` for `letter-spacing` are imprecise for some reason. 
This PR changes `letter-spacing` rules for typography redesign based on Pixel Perfect matching. 
Below are the resulting screenshots: text with opacity — screenshots from Figma at 100% zoom. 

### Headings

<img width="319" alt="headings" src="https://user-images.githubusercontent.com/3846380/117240519-959cab00-ae63-11eb-9be5-922dedd6734f.png">

### Label / Base

<img width="445" alt="label-base" src="https://user-images.githubusercontent.com/3846380/117240539-9df4e600-ae63-11eb-98f9-a8cb21bbab62.png">

### Label / Small

<img width="425" alt="label-small" src="https://user-images.githubusercontent.com/3846380/117240551-a6e5b780-ae63-11eb-9e7d-489bab7d7755.png">

### Label / Uppercase

<img width="492" alt="label-uppercase" src="https://user-images.githubusercontent.com/3846380/117240564-ae0cc580-ae63-11eb-92ca-9692ebf4f7ce.png">
