### PR TITLE
search: move fork and archived filter chips

### DIFF
--- a/cmd/frontend/graphqlbackend/search_filters.go
+++ b/cmd/frontend/graphqlbackend/search_filters.go
@@ -67,11 +67,6 @@ var commonFileFilters = []struct {
 
 // Update internal state for the results in event.
 func (s *SearchFilters) Update(event SearchEvent) {
-	// Avoid work if nothing to observe.
-	if len(event.Results) == 0 {
-		return
-	}
-
 	// Initialize state on first call.
 	if s.filters == nil {
 		s.filters = make(streaming.Filters)
@@ -127,13 +122,14 @@ func (s *SearchFilters) Update(event SearchEvent) {
 	}
 
 	if event.Stats.ExcludedForks > 0 {
-		s.filters.Add("fork:yes", "fork:yes", int32(event.Stats.ExcludedForks), event.Stats.IsLimitHit, "repo")
+		s.filters.Add("fork:yes", "fork:yes", int32(event.Stats.ExcludedForks), event.Stats.IsLimitHit, "dynamic")
 		s.filters.MarkImportant("fork:yes")
 	}
 	if event.Stats.ExcludedArchived > 0 {
-		s.filters.Add("archived:yes", "archived:yes", int32(event.Stats.ExcludedArchived), event.Stats.IsLimitHit, "repo")
+		s.filters.Add("archived:yes", "archived:yes", int32(event.Stats.ExcludedArchived), event.Stats.IsLimitHit, "dynamic")
 		s.filters.MarkImportant("archived:yes")
 	}
+
 	for _, result := range event.Results {
 		if fm, ok := result.ToFileMatch(); ok {
 			rev := ""


### PR DESCRIPTION
Closes #20655

This moves the filter chips `archived:yes` and `fork:yes` from the repo
carousel to the generic filters carousel.

Naming the new kind "dynamic" is arbitrary but fits the language of the re-design.

I removed the guard for `len(event.Results)` because it can happen that
we get events with relevant stats but without events

<img width="1375" alt="Screenshot 2021-05-06 at 08 54 42" src="https://user-images.githubusercontent.com/26413131/117257228-f5875780-ae4b-11eb-9576-5cf48d6dc635.png">




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
