### PR TITLE
Use SearchMatchEvent in streamHandler.startSearch()

### DIFF
--- a/cmd/frontend/graphqlbackend/search_filters.go
+++ b/cmd/frontend/graphqlbackend/search_filters.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
+	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 )
 
@@ -66,19 +68,18 @@ var commonFileFilters = []struct {
 }
 
 // Update internal state for the results in event.
-func (s *SearchFilters) Update(event SearchEvent) {
+func (s *SearchFilters) Update(event SearchMatchEvent) {
 	// Initialize state on first call.
 	if s.filters == nil {
 		s.filters = make(streaming.Filters)
 	}
 
-	addRepoFilter := func(repo *RepositoryResolver, rev string, lineMatchCount int32) {
-		uri := repo.Name()
+	addRepoFilter := func(repoName api.RepoName, repoID api.RepoID, rev string, lineMatchCount int32) {
 		var filter string
 		if s.Globbing {
-			filter = fmt.Sprintf(`repo:%s`, uri)
+			filter = fmt.Sprintf(`repo:%s`, repoName)
 		} else {
-			filter = fmt.Sprintf(`repo:^%s$`, regexp.QuoteMeta(uri))
+			filter = fmt.Sprintf(`repo:^%s$`, regexp.QuoteMeta(string(repoName)))
 		}
 
 		if rev != "" {
@@ -86,8 +87,8 @@ func (s *SearchFilters) Update(event SearchEvent) {
 			// are @ and :, both of which are disallowed in git refs
 			filter = filter + fmt.Sprintf(`@%s`, rev)
 		}
-		limitHit := event.Stats.Status.Get(repo.IDInt32())&search.RepoStatusLimitHit != 0
-		s.filters.Add(filter, uri, lineMatchCount, limitHit, "repo")
+		limitHit := event.Stats.Status.Get(repoID)&search.RepoStatusLimitHit != 0
+		s.filters.Add(filter, string(repoName), lineMatchCount, limitHit, "repo")
 	}
 
 	addFileFilter := func(fileMatchPath string, lineMatchCount int32, limitHit bool) {
@@ -130,25 +131,26 @@ func (s *SearchFilters) Update(event SearchEvent) {
 		s.filters.MarkImportant("archived:yes")
 	}
 
-	for _, result := range event.Results {
-		if fm, ok := result.ToFileMatch(); ok {
+	for _, match := range event.Results {
+		switch v := match.(type) {
+		case *result.FileMatch:
 			rev := ""
-			if fm.InputRev != nil {
-				rev = *fm.InputRev
+			if v.InputRev != nil {
+				rev = *v.InputRev
 			}
-			lines := fm.ResultCount()
-			addRepoFilter(fm.RepoResolver, rev, lines)
-			addLangFilter(fm.path(), lines, fm.LimitHit())
-			addFileFilter(fm.path(), lines, fm.LimitHit())
+			lines := int32(v.ResultCount())
+			addRepoFilter(v.Repo.Name, v.Repo.ID, rev, lines)
+			addLangFilter(v.Path, lines, v.LimitHit)
+			addFileFilter(v.Path, lines, v.LimitHit)
 
-			if len(fm.FileMatch.Symbols) > 0 {
-				s.filters.Add("type:symbol", "type:symbol", 1, fm.LimitHit(), "symbol")
+			if len(v.Symbols) > 0 {
+				s.filters.Add("type:symbol", "type:symbol", 1, v.LimitHit, "symbol")
 			}
-		} else if r, ok := result.ToRepository(); ok {
+		case *result.RepoMatch:
 			// It should be fine to leave this blank since revision specifiers
 			// can only be used with the 'repo:' scope. In that case,
 			// we shouldn't be getting any repositoy name matches back.
-			addRepoFilter(r, "", 1)
+			addRepoFilter(v.Name, v.ID, "", 1)
 		}
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -183,10 +183,10 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 	filters := SearchFilters{
 		Globbing: globbing,
 	}
-	filters.Update(SearchEvent{
+	filters.Update(SearchEventToSearchMatchEvent(SearchEvent{
 		Results: sr.SearchResults,
 		Stats:   sr.Stats,
-	})
+	}))
 
 	var resolvers []*searchFilterResolver
 	for _, f := range filters.Compute() {

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -203,3 +203,13 @@ func collectStream(search func(Sender) error) ([]SearchResultResolver, streaming
 
 	return results, stats, err
 }
+
+type MatchStreamFunc func(SearchMatchEvent)
+
+func (f MatchStreamFunc) Send(se SearchEvent) {
+	f(SearchEventToSearchMatchEvent(se))
+}
+
+func (f MatchStreamFunc) SendMatch(sme SearchMatchEvent) {
+	f(sme)
+}

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -23,21 +23,15 @@ type progressAggregator struct {
 	Dirty bool
 }
 
-func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
+func (p *progressAggregator) Update(event graphqlbackend.SearchMatchEvent) {
 	if len(event.Results) == 0 && event.Stats.Zero() {
 		return
 	}
 
 	p.Dirty = true
 	p.Stats.Update(&event.Stats)
-	for _, result := range event.Results {
-		// We use a different result count in streaming than graphql. We don't
-		// want to break existing graphql clients like saved searches.
-		if crs, ok := result.ToCommitSearchResult(); ok {
-			p.MatchCount += crs.CommitMatch.ResultCount()
-			continue
-		}
-		p.MatchCount += int(result.ResultCount())
+	for _, match := range event.Results {
+		p.MatchCount += match.ResultCount()
 	}
 
 	if p.MatchCount > p.Limit {


### PR DESCRIPTION
This converts startSearch to use match events rather than resolver
events, then fixes all the type errors caused by it.

Opened in favor of #20612 (so it's run through integration tests)



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
