### PR TITLE
Fix file start anchor for diff search

### DIFF
--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1125,6 +1125,11 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Symbol: 1},
 			},
 			{
+				name:   `search diffs with file start anchor`,
+				query:  `repo:go-diff patterntype:literal type:diff file:^README.md$ sourcegraph.com`,
+				counts: counts{Commit: 1},
+			},
+			{
 				name:   `select diffs with added lines containing pattern`,
 				query:  `repo:go-diff patterntype:literal type:diff select:commit.diff.added sample_binary_inline`,
 				counts: counts{Commit: 1},

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1126,7 +1126,7 @@ func testSearchClient(t *testing.T, client searchClient) {
 			},
 			{
 				name:   `search diffs with file start anchor`,
-				query:  `repo:go-diff patterntype:literal type:diff file:^README.md$ sourcegraph.com`,
+				query:  `repo:go-diff patterntype:literal type:diff file:^README.md$ installing`,
 				counts: counts{Commit: 1},
 			},
 			{

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -361,7 +361,8 @@ func rawShowSearch(ctx context.Context, repo api.RepoName, opt RawLogDiffSearchO
 		commitOIDs[i] = c.sha1
 	}
 	showArgs := append([]string{}, "show")
-	showArgs = append(showArgs, "--no-patch") // will be overridden if opt.FormatArgs has --patch
+	showArgs = append(showArgs, "--no-patch")  // will be overridden if opt.FormatArgs has --patch
+	showArgs = append(showArgs, "--no-prefix") // do not prefix file names with a/ and b/
 	showArgs = append(showArgs, opt.FormatArgs...)
 	showArgs = append(showArgs, commitOIDs...)
 	// Need --patch (TODO(sqs): or just --raw, which is smaller) if we are filtering by file paths,

--- a/internal/vcs/git/diff_search_test.go
+++ b/internal/vcs/git/diff_search_test.go
@@ -67,7 +67,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			},
 			Refs:       []string{"refs/heads/branch1"},
 			SourceRefs: []string{"refs/heads/branch2"},
-			Diff:       &RawDiff{Raw: "diff --git a/f b/f\nindex d8649da..1193ff4 100644\n--- a/f\n+++ b/f\n@@ -1,1 +1,1 @@\n-root\n+branch1\n"},
+			Diff:       &RawDiff{Raw: "diff --git f f\nindex d8649da..1193ff4 100644\n--- f\n+++ f\n@@ -1,1 +1,1 @@\n-root\n+branch1\n"},
 		}, {
 			Commit: Commit{
 				ID:        "ce72ece27fd5c8180cfbc1c412021d32fd1cda0d",
@@ -77,7 +77,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
 			SourceRefs: []string{"refs/heads/branch2"},
-			Diff:       &RawDiff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
+			Diff:       &RawDiff{Raw: "diff --git f f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ f\n@@ -0,0 +1,1 @@\n+root\n"},
 		}},
 	}, {
 		name: "refglob",
@@ -95,7 +95,7 @@ func TestRepository_RawLogDiffSearch(t *testing.T) {
 			},
 			Refs:       []string{"refs/heads/master", "refs/tags/mytag"},
 			SourceRefs: []string{"refs/tags/mytag"},
-			Diff:       &RawDiff{Raw: "diff --git a/f b/f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ b/f\n@@ -0,0 +1,1 @@\n+root\n"},
+			Diff:       &RawDiff{Raw: "diff --git f f\nnew file mode 100644\nindex 0000000..d8649da\n--- /dev/null\n+++ f\n@@ -0,0 +1,1 @@\n+root\n"},
 		}},
 	}, {
 		name: "empty-query",


### PR DESCRIPTION
This fixes an issue where specifying a file start anchor for a diff
search like `file:^CHANGELOG.md$` would cause the search to return no
matches because we removed the `--no-prefix` flag from the `git show`
command. This adds that flag back, so file names are in the form
`CHANGELOG.md` rather than `a/CHANGELOG.md`.

Fixes #20664 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
