### PR TITLE
Update codeintel-db postgres image

### DIFF
--- a/docker-images/codeintel-db/build.sh
+++ b/docker-images/codeintel-db/build.sh
@@ -7,5 +7,5 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
-docker pull index.docker.io/sourcegraph/postgres-12.6:91442_2021-03-30_82db2f6@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982
-docker tag index.docker.io/sourcegraph/postgres-12.6:91442_2021-03-30_82db2f6@sha256:aa937c1c8ab20f3c809f04480d5a73791b05be59d3183726fd499ae0a123e982 "$IMAGE"
+docker pull index.docker.io/sourcegraph/postgres-12.6:95244_2021-05-06_2c1f77e@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778
+docker tag index.docker.io/sourcegraph/postgres-12.6:95244_2021-05-06_2c1f77e@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778 "$IMAGE"

--- a/docker-images/codeintel-db/build.sh
+++ b/docker-images/codeintel-db/build.sh
@@ -4,7 +4,7 @@ set -ex
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 # This merely re-tags the image to match our official versioning scheme. The
-# actual image currently lives here: https://github.com/sourcegraph/infrastructure/tree/master/docker-images
+# actual image currently lives here: https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/codeintel-db/build.sh
 #
 # TODO: Move the image to this directory so it is open-source and built in CI automatically.
 docker pull index.docker.io/sourcegraph/postgres-12.6:95244_2021-05-06_2c1f77e@sha256:35040317490324a15e1259c9023a726eb27c694530f6f8877e87d337c7b97778


### PR DESCRIPTION
This update patches CVE-2021-3449.

Note: our postgres image is now open-sourced: https://github.com/sourcegraph/sourcegraph/blob/main/docker-images/codeintel-db/build.sh. Seems related to the `TODO` comment.


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
