### PR TITLE
batches: store key ID alongside credentials, take two

### DIFF
--- a/enterprise/internal/batches/background/migrations.go
+++ b/enterprise/internal/batches/background/migrations.go
@@ -1,6 +1,7 @@
 package background
 
 import (
+	"os"
 	"time"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -26,10 +27,18 @@ const (
 // RegisterMigrations registers all currently implemented out of band migrations
 // by batch changes with the migration runner.
 func RegisterMigrations(cstore *store.Store, outOfBandMigrationRunner *oobmigration.Runner) error {
+	allowDecrypt := os.Getenv("ALLOW_DECRYPT_MIGRATION") == "true"
+
 	migrations := map[int]oobmigration.Migrator{
-		BatchChangesSSHMigrationID:            &sshMigrator{store: cstore},
-		BatchChangesUserCredentialMigrationID: &userCredentialMigrator{store: cstore},
-		BatchChangesSiteCredentialMigrationID: &siteCredentialMigrator{store: cstore},
+		BatchChangesSSHMigrationID: &sshMigrator{store: cstore},
+		BatchChangesUserCredentialMigrationID: &userCredentialMigrator{
+			store:        cstore,
+			allowDecrypt: allowDecrypt,
+		},
+		BatchChangesSiteCredentialMigrationID: &siteCredentialMigrator{
+			store:        cstore,
+			allowDecrypt: allowDecrypt,
+		},
 	}
 
 	for id, migrator := range migrations {

--- a/enterprise/internal/batches/background/site_credential_migrator.go
+++ b/enterprise/internal/batches/background/site_credential_migrator.go
@@ -3,11 +3,13 @@ package background
 import (
 	"context"
 
+	"github.com/inconshreveable/log15"
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
@@ -15,7 +17,8 @@ import (
 const siteCredentialMigrationCountPerRun = 5
 
 type siteCredentialMigrator struct {
-	store *store.Store
+	store        *store.Store
+	allowDecrypt bool
 }
 
 var _ oobmigration.Migrator = &siteCredentialMigrator{}
@@ -51,6 +54,7 @@ func (m *siteCredentialMigrator) Up(ctx context.Context) error {
 		credentials, _, err := tx.ListSiteCredentials(ctx, store.ListSiteCredentialsOpts{
 			LimitOpts:         store.LimitOpts{Limit: siteCredentialMigrationCountPerRun},
 			RequiresMigration: true,
+			ForUpdate:         true,
 		})
 		if err != nil {
 			return errors.Wrap(err, "listing site credentials")
@@ -76,5 +80,44 @@ func (m *siteCredentialMigrator) Up(ctx context.Context) error {
 }
 
 func (m *siteCredentialMigrator) Down(ctx context.Context) error {
-	return errors.New("down migration is not supported for encrypting site credentials")
+	if !m.allowDecrypt {
+		log15.Warn("cannot run siteCredentialMigrator.Down when decryption isn't allowed")
+		return nil
+	}
+
+	tx, err := m.store.Transact(ctx)
+	if err != nil {
+		return errors.Wrap(err, "starting transaction")
+	}
+
+	f := func() error {
+		credentials, _, err := tx.ListSiteCredentials(ctx, store.ListSiteCredentialsOpts{
+			LimitOpts:     store.LimitOpts{Limit: siteCredentialMigrationCountPerRun},
+			OnlyEncrypted: true,
+			ForUpdate:     true,
+		})
+		if err != nil {
+			return errors.Wrap(err, "listing user credentials")
+		}
+		for _, cred := range credentials {
+			a, err := cred.Authenticator(ctx)
+			if err != nil {
+				return errors.Wrapf(err, "retrieving authenticator for ID %d", cred.ID)
+			}
+
+			raw, err := database.EncryptAuthenticator(ctx, nil, a)
+			if err != nil {
+				return errors.Wrapf(err, "marshalling authenticator without an encrypter")
+			}
+
+			cred.EncryptedCredential = raw
+			cred.EncryptionKeyID = ""
+			if err := tx.UpdateSiteCredential(ctx, cred); err != nil {
+				return errors.Wrapf(err, "upserting user credential %d", cred.ID)
+			}
+		}
+
+		return nil
+	}
+	return tx.Done(f())
 }

--- a/enterprise/internal/batches/background/site_credential_migrator_test.go
+++ b/enterprise/internal/batches/background/site_credential_migrator_test.go
@@ -22,7 +22,7 @@ func TestSiteCredentialMigrator(t *testing.T) {
 
 	cstore := store.New(db, et.TestKey{})
 
-	migrator := &siteCredentialMigrator{cstore}
+	migrator := &siteCredentialMigrator{cstore, true}
 	a := &auth.BasicAuth{Username: "foo", Password: "bar"}
 
 	t.Run("no user credentials", func(t *testing.T) {
@@ -106,8 +106,7 @@ func TestSiteCredentialMigrator(t *testing.T) {
 			}
 		}
 
-		// Let's get down into the weeds and verify that there are no non-NULL
-		// credential fields.
+		// Finally, let's ensure there's nothing left to be migrated.
 		if creds, _, err := cstore.ListSiteCredentials(ctx, store.ListSiteCredentialsOpts{
 			RequiresMigration: true,
 		}); err != nil {
@@ -117,9 +116,56 @@ func TestSiteCredentialMigrator(t *testing.T) {
 		}
 	})
 
-	t.Run("down", func(t *testing.T) {
-		if err := migrator.Down(ctx); err == nil {
-			t.Error("unexpected nil error as down migrations are unsupported")
+	t.Run("migrate down without allowing", func(t *testing.T) {
+		migrator.allowDecrypt = false
+		t.Cleanup(func() { migrator.allowDecrypt = true })
+
+		if err := migrator.Down(ctx); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		// Nothing should have changed.
+		assertProgress(t, ctx, 1.0, migrator)
+	})
+
+	t.Run("first migrate down", func(t *testing.T) {
+		if err := migrator.Down(ctx); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		assertProgress(t, ctx, 0.5, migrator)
+	})
+
+	t.Run("second migrate down", func(t *testing.T) {
+		if err := migrator.Down(ctx); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		assertProgress(t, ctx, 0.0, migrator)
+	})
+
+	t.Run("check credentials", func(t *testing.T) {
+		credentials, _, err := cstore.ListSiteCredentials(ctx, store.ListSiteCredentialsOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, cred := range credentials {
+			have, err := cred.Authenticator(ctx)
+			if err != nil {
+				t.Logf("cred: %+v", cred)
+				t.Errorf("cannot get authenticator: %v", err)
+			}
+
+			if diff := cmp.Diff(have, a); diff != "" {
+				t.Errorf("unexpected authenticator (-have +want):\n%s", diff)
+			}
+		}
+
+		// Finally, let's ensure there's nothing left to be migrated.
+		if creds, _, err := cstore.ListSiteCredentials(ctx, store.ListSiteCredentialsOpts{
+			RequiresMigration: true,
+		}); err != nil {
+			t.Fatal(err)
+		} else if want := siteCredentialMigrationCountPerRun * 2; len(creds) != want {
+			t.Errorf("unexpected number of unencrypted credentials: have=%d want=%d", len(creds), want)
 		}
 	})
 }

--- a/enterprise/internal/batches/background/user_credential_migrator.go
+++ b/enterprise/internal/batches/background/user_credential_migrator.go
@@ -12,10 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
 )
 
-const (
-	userCredentialMigrationCountPerRun      = 5
-	userCredentialMigrationPlaceholderKeyID = "previously-migrated"
-)
+const userCredentialMigrationCountPerRun = 5
 
 type userCredentialMigrator struct {
 	store *store.Store
@@ -35,7 +32,7 @@ func (m *userCredentialMigrator) Progress(ctx context.Context) (float64, error) 
 		m.store.Query(ctx, sqlf.Sprintf(
 			userCredentialMigratorProgressQuery,
 			database.UserCredentialDomainBatches,
-			userCredentialMigrationPlaceholderKeyID,
+			database.UserCredentialPlaceholderEncryptionKeyID,
 			database.UserCredentialDomainBatches,
 		)))
 	if err != nil {

--- a/enterprise/internal/batches/store/integration_test.go
+++ b/enterprise/internal/batches/store/integration_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 )
 
 func TestIntegration(t *testing.T) {
@@ -16,21 +18,29 @@ func TestIntegration(t *testing.T) {
 	db := dbtesting.GetDB(t)
 
 	t.Run("Store", func(t *testing.T) {
-		t.Run("BatchChanges", storeTest(db, testStoreBatchChanges))
-		t.Run("Changesets", storeTest(db, testStoreChangesets))
-		t.Run("ChangesetEvents", storeTest(db, testStoreChangesetEvents))
-		t.Run("ChangesetScheduling", storeTest(db, testStoreChangesetScheduling))
-		t.Run("ListChangesetSyncData", storeTest(db, testStoreListChangesetSyncData))
-		t.Run("ListChangesetsTextSearch", storeTest(db, testStoreListChangesetsTextSearch))
-		t.Run("BatchSpecs", storeTest(db, testStoreBatchSpecs))
-		t.Run("ChangesetSpecs", storeTest(db, testStoreChangesetSpecs))
-		t.Run("ChangesetSpecsCurrentState", storeTest(db, testStoreChangesetSpecsCurrentState))
-		t.Run("ChangesetSpecsCurrentStateAndTextSearch", storeTest(db, testStoreChangesetSpecsCurrentStateAndTextSearch))
-		t.Run("ChangesetSpecsTextSearch", storeTest(db, testStoreChangesetSpecsTextSearch))
-		t.Run("CodeHosts", storeTest(db, testStoreCodeHost))
-		t.Run("UserDeleteCascades", storeTest(db, testUserDeleteCascades))
-		t.Run("SiteCredentials", storeTest(db, testStoreSiteCredentials))
-		t.Run("ChangesetJobs", storeTest(db, testStoreChangesetJobs))
-		t.Run("BulkOperations", storeTest(db, testStoreBulkOperations))
+		t.Run("BatchChanges", storeTest(db, nil, testStoreBatchChanges))
+		t.Run("Changesets", storeTest(db, nil, testStoreChangesets))
+		t.Run("ChangesetEvents", storeTest(db, nil, testStoreChangesetEvents))
+		t.Run("ChangesetScheduling", storeTest(db, nil, testStoreChangesetScheduling))
+		t.Run("ListChangesetSyncData", storeTest(db, nil, testStoreListChangesetSyncData))
+		t.Run("ListChangesetsTextSearch", storeTest(db, nil, testStoreListChangesetsTextSearch))
+		t.Run("BatchSpecs", storeTest(db, nil, testStoreBatchSpecs))
+		t.Run("ChangesetSpecs", storeTest(db, nil, testStoreChangesetSpecs))
+		t.Run("ChangesetSpecsCurrentState", storeTest(db, nil, testStoreChangesetSpecsCurrentState))
+		t.Run("ChangesetSpecsCurrentStateAndTextSearch", storeTest(db, nil, testStoreChangesetSpecsCurrentStateAndTextSearch))
+		t.Run("ChangesetSpecsTextSearch", storeTest(db, nil, testStoreChangesetSpecsTextSearch))
+		t.Run("CodeHosts", storeTest(db, nil, testStoreCodeHost))
+		t.Run("UserDeleteCascades", storeTest(db, nil, testUserDeleteCascades))
+		t.Run("ChangesetJobs", storeTest(db, nil, testStoreChangesetJobs))
+		t.Run("BulkOperations", storeTest(db, nil, testStoreBulkOperations))
+
+		for name, key := range map[string]encryption.Key{
+			"no key":   nil,
+			"test key": &et.TestKey{},
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Run("SiteCredentials", storeTest(db, key, testStoreSiteCredentials))
+			})
+		}
 	})
 }

--- a/enterprise/internal/batches/store/site_credentials.go
+++ b/enterprise/internal/batches/store/site_credentials.go
@@ -6,7 +6,6 @@ import (
 	"github.com/keegancsmith/sqlf"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
-	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
@@ -37,25 +36,22 @@ INSERT INTO	batch_changes_site_credentials (
 	external_service_type,
 	external_service_id,
 	credential,
-	credential_enc,
 	encryption_key_id,
 	created_at,
 	updated_at
 )
 VALUES
-	(%s, %s, %s, %s, %s, %s, %s)
+	(%s, %s, %s, %s, %s, %s)
 RETURNING
 	%s
 `
 
 func createSiteCredentialQuery(c *btypes.SiteCredential) *sqlf.Query {
-	unencrypted, encrypted := c.GetRawCredential()
 	return sqlf.Sprintf(
 		createSiteCredentialQueryFmtstr,
 		c.ExternalServiceType,
 		c.ExternalServiceID,
-		&database.NullAuthenticator{A: &unencrypted},
-		encrypted,
+		c.EncryptedCredential,
 		c.EncryptionKeyID,
 		c.CreatedAt,
 		c.UpdatedAt,
@@ -148,7 +144,7 @@ type ListSiteCredentialsOpts struct {
 
 	// TODO(batch-changes-site-credential-encryption): remove when no longer
 	// needed.
-	OnlyUnencrypted bool
+	RequiresMigration bool
 }
 
 func (s *Store) ListSiteCredentials(ctx context.Context, opts ListSiteCredentialsOpts) (cs []*btypes.SiteCredential, next int64, err error) {
@@ -183,8 +179,8 @@ ORDER BY external_service_type ASC, external_service_id ASC
 
 func listSiteCredentialsQuery(opts ListSiteCredentialsOpts) *sqlf.Query {
 	preds := []*sqlf.Query{sqlf.Sprintf("TRUE")}
-	if opts.OnlyUnencrypted {
-		preds = append(preds, sqlf.Sprintf("credential_enc IS NULL"))
+	if opts.RequiresMigration {
+		preds = append(preds, sqlf.Sprintf("encryption_key_id IN ('', %s)", btypes.SiteCredentialPlaceholderEncryptionKeyID))
 	}
 
 	return sqlf.Sprintf(
@@ -220,7 +216,6 @@ SET
 	external_service_type = %s,
 	external_service_id = %s,
 	credential = %s,
-	credential_enc = %s,
 	encryption_key_id = %s,
 	created_at = %s,
 	updated_at = %s
@@ -231,13 +226,11 @@ RETURNING
 `
 
 func (s *Store) updateSiteCredentialQuery(c *btypes.SiteCredential) *sqlf.Query {
-	unencrypted, encrypted := c.GetRawCredential()
 	return sqlf.Sprintf(
 		updateSiteCredentialQueryFmtstr,
 		c.ExternalServiceType,
 		c.ExternalServiceID,
-		&database.NullAuthenticator{A: &unencrypted},
-		encrypted,
+		c.EncryptedCredential,
 		c.EncryptionKeyID,
 		c.CreatedAt,
 		c.UpdatedAt,
@@ -251,32 +244,19 @@ var siteCredentialColumns = []*sqlf.Query{
 	sqlf.Sprintf("external_service_type"),
 	sqlf.Sprintf("external_service_id"),
 	sqlf.Sprintf("credential"),
-	sqlf.Sprintf("credential_enc"),
 	sqlf.Sprintf("encryption_key_id"),
 	sqlf.Sprintf("created_at"),
 	sqlf.Sprintf("updated_at"),
 }
 
 func scanSiteCredential(c *btypes.SiteCredential, sc scanner) error {
-	var (
-		encrypted   []byte
-		unencrypted auth.Authenticator
-	)
-	na := database.NullAuthenticator{A: &unencrypted}
-
-	if err := sc.Scan(
+	return sc.Scan(
 		&c.ID,
 		&c.ExternalServiceType,
 		&c.ExternalServiceID,
-		&na,
-		&encrypted,
+		&c.EncryptedCredential,
 		&c.EncryptionKeyID,
 		&dbutil.NullTime{Time: &c.CreatedAt},
 		&dbutil.NullTime{Time: &c.UpdatedAt},
-	); err != nil {
-		return err
-	}
-
-	c.SetRawCredential(unencrypted, encrypted)
-	return nil
+	)
 }

--- a/enterprise/internal/batches/store/store_test.go
+++ b/enterprise/internal/batches/store/store_test.go
@@ -7,6 +7,7 @@ import (
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -14,7 +15,7 @@ type storeTestFunc func(*testing.T, context.Context, *Store, ct.Clock)
 
 // storeTest converts a storeTestFunc into a func(*testing.T) in which all
 // dependencies are set up and injected into the storeTestFunc.
-func storeTest(db *sql.DB, f storeTestFunc) func(*testing.T) {
+func storeTest(db *sql.DB, key encryption.Key, f storeTestFunc) func(*testing.T) {
 	return func(t *testing.T) {
 		c := &ct.TestClock{Time: timeutil.Now()}
 
@@ -23,7 +24,7 @@ func storeTest(db *sql.DB, f storeTestFunc) func(*testing.T) {
 		// don't need to insert a lot of dependencies into the DB (users,
 		// repos, ...) to setup the tests.
 		tx := dbtest.NewTx(t, db)
-		s := NewWithClock(tx, nil, c.Now)
+		s := NewWithClock(tx, key, c.Now)
 
 		f(t, context.Background(), s, c)
 	}

--- a/enterprise/internal/batches/types/site_credential.go
+++ b/enterprise/internal/batches/types/site_credential.go
@@ -15,41 +15,30 @@ type SiteCredential struct {
 	ID                  int64
 	ExternalServiceType string
 	ExternalServiceID   string
+	EncryptedCredential []byte
 	EncryptionKeyID     string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
 
-	// TODO(batch-changes-site-credential-encryption): once we're through the
-	// migration period, this should be simplified back to a single, exported
-	// EncryptedCredential []byte field.
-	credential          auth.Authenticator
-	encryptedCredential []byte
-
 	Key encryption.Key
 }
+
+const SiteCredentialPlaceholderEncryptionKeyID = "previously-migrated"
 
 // Authenticator decrypts and creates the authenticator associated with the site
 // credential.
 func (sc *SiteCredential) Authenticator(ctx context.Context) (auth.Authenticator, error) {
-	if sc.credential != nil {
-		return sc.credential, nil
-	}
-
-	if sc.encryptedCredential == nil {
-		return nil, errors.New("no unencrypted or encrypted credential found")
-	}
-
 	// The record includes a field indicating the encryption key ID. We don't
 	// really have a way to look up a key by ID right now, so this is used as a
 	// marker of whether we should expect a key or not.
 	if sc.EncryptionKeyID == "" {
-		return database.UnmarshalAuthenticator(string(sc.encryptedCredential))
+		return database.UnmarshalAuthenticator(string(sc.EncryptedCredential))
 	}
 	if sc.Key == nil {
 		return nil, errors.New("user credential is encrypted, but no key is available to decrypt it")
 	}
 
-	secret, err := sc.Key.Decrypt(ctx, sc.encryptedCredential)
+	secret, err := sc.Key.Decrypt(ctx, sc.EncryptedCredential)
 	if err != nil {
 		return nil, errors.Wrap(err, "decrypting credential")
 	}
@@ -78,30 +67,10 @@ func (sc *SiteCredential) SetAuthenticator(ctx context.Context, a auth.Authentic
 		return err
 	}
 
-	// We must set credential to nil here: if we're in the middle of migrating
-	// when this is called, we don't want the unencrypted credential to remain.
-	sc.credential = nil
-	sc.encryptedCredential = secret
+	sc.EncryptedCredential = secret
 	sc.EncryptionKeyID = id
 
 	return nil
-}
-
-// GetRawCredential gets the raw fields within the SiteCredential instance. This
-// must only be called from the batches store when updating a site credential;
-// all other users must use Authenticator() and SetAuthenticator() to access and
-// mutate the credential state.
-func (sc *SiteCredential) GetRawCredential() (auth.Authenticator, []byte) {
-	return sc.credential, sc.encryptedCredential
-}
-
-// SetRawCredential sets the raw fields within the SiteCredential instance. This
-// must only be called from the batches store when scanning a site credential;
-// all other users must use Authenticator() and SetAuthenticator() to access and
-// mutate the credential state.
-func (sc *SiteCredential) SetRawCredential(credential auth.Authenticator, encryptedCredential []byte) {
-	sc.credential = credential
-	sc.encryptedCredential = encryptedCredential
 }
 
 func keyID(ctx context.Context, key encryption.Key) (string, error) {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -65,17 +65,14 @@ Triggers:
  id                    | bigint                   |           | not null | nextval('batch_changes_site_credentials_id_seq'::regclass)
  external_service_type | text                     |           | not null | 
  external_service_id   | text                     |           | not null | 
- credential            | text                     |           |          | 
  created_at            | timestamp with time zone |           | not null | now()
  updated_at            | timestamp with time zone |           | not null | now()
- credential_enc        | bytea                    |           |          | 
+ credential            | bytea                    |           | not null | 
  encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
     "batch_changes_site_credentials_pkey" PRIMARY KEY, btree (id)
     "batch_changes_site_credentials_unique" UNIQUE, btree (external_service_type, external_service_id)
-    "batch_changes_site_credentials_credential_enc_idx" btree ((credential_enc IS NULL))
-Check constraints:
-    "batch_changes_site_credentials_there_can_be_only_one" CHECK (num_nonnulls(credential, credential_enc) = 1)
+    "batch_changes_site_credentials_credential_idx" btree ((encryption_key_id = ANY (ARRAY[''::text, 'previously-migrated'::text])))
 
 ```
 
@@ -1489,18 +1486,15 @@ Foreign-key constraints:
  user_id               | integer                  |           | not null | 
  external_service_type | text                     |           | not null | 
  external_service_id   | text                     |           | not null | 
- credential            | text                     |           |          | 
  created_at            | timestamp with time zone |           | not null | now()
  updated_at            | timestamp with time zone |           | not null | now()
- credential_enc        | bytea                    |           |          | 
+ credential            | bytea                    |           | not null | 
  ssh_migration_applied | boolean                  |           | not null | false
  encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
     "user_credentials_pkey" PRIMARY KEY, btree (id)
     "user_credentials_domain_user_id_external_service_type_exter_key" UNIQUE CONSTRAINT, btree (domain, user_id, external_service_type, external_service_id)
-    "user_credentials_credential_enc_idx" btree ((credential_enc IS NULL))
-Check constraints:
-    "user_credentials_there_can_be_only_one" CHECK (num_nonnulls(credential, credential_enc) = 1)
+    "user_credentials_credential_idx" btree ((encryption_key_id = ANY (ARRAY[''::text, 'previously-migrated'::text])))
 Foreign-key constraints:
     "user_credentials_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE DEFERRABLE
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -69,6 +69,7 @@ Triggers:
  created_at            | timestamp with time zone |           | not null | now()
  updated_at            | timestamp with time zone |           | not null | now()
  credential_enc        | bytea                    |           |          | 
+ encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
     "batch_changes_site_credentials_pkey" PRIMARY KEY, btree (id)
     "batch_changes_site_credentials_unique" UNIQUE, btree (external_service_type, external_service_id)
@@ -1493,6 +1494,7 @@ Foreign-key constraints:
  updated_at            | timestamp with time zone |           | not null | now()
  credential_enc        | bytea                    |           |          | 
  ssh_migration_applied | boolean                  |           | not null | false
+ encryption_key_id     | text                     |           | not null | ''::text
 Indexes:
     "user_credentials_pkey" PRIMARY KEY, btree (id)
     "user_credentials_domain_user_id_external_service_type_exter_key" UNIQUE CONSTRAINT, btree (domain, user_id, external_service_type, external_service_id)

--- a/internal/database/user_credentials.go
+++ b/internal/database/user_credentials.go
@@ -83,9 +83,10 @@ func (uc *UserCredential) SetAuthenticator(ctx context.Context, a auth.Authentic
 	return nil
 }
 
-// This const block contains the valid domain values for user credentials.
 const (
-	UserCredentialDomainBatches              = "batches"
+	// Valid domain values for user credentials.
+	UserCredentialDomainBatches = "batches"
+
 	UserCredentialPlaceholderEncryptionKeyID = "previously-migrated"
 )
 

--- a/internal/database/user_credentials.go
+++ b/internal/database/user_credentials.go
@@ -299,6 +299,10 @@ type UserCredentialsListOpts struct {
 	// TODO(batch-change-credential-encryption): this should be removed once the
 	// OOB user credential migration is removed.
 	RequiresMigration bool
+
+	// TODO(batch-change-credential-encryption): this should be removed once the
+	// OOB user credential migration is removed.
+	OnlyEncrypted bool
 }
 
 // sql overrides LimitOffset.SQL() to give a LIMIT clause with one extra value
@@ -330,15 +334,16 @@ func (s *UserCredentialsStore) List(ctx context.Context, opts UserCredentialsLis
 	if opts.Scope.ExternalServiceID != "" {
 		preds = append(preds, sqlf.Sprintf("external_service_id = %s", opts.Scope.ExternalServiceID))
 	}
-	// TODO(batch-change-credential-encryption): remove once the OOB SSH
-	// migration is removed.
+	// TODO(batch-change-credential-encryption): remove the remaining predicates
+	// once the OOB SSH migration is removed.
 	if opts.SSHMigrationApplied != nil {
 		preds = append(preds, sqlf.Sprintf("ssh_migration_applied = %s", *opts.SSHMigrationApplied))
 	}
-	// TODO(batch-change-credential-encryption): remove once the OOB user
-	// credential migration is removed.
 	if opts.RequiresMigration {
 		preds = append(preds, sqlf.Sprintf("encryption_key_id IN ('', %s)", UserCredentialPlaceholderEncryptionKeyID))
+	}
+	if opts.OnlyEncrypted {
+		preds = append(preds, sqlf.Sprintf("encryption_key_id <> ''"))
 	}
 
 	if len(preds) == 0 {

--- a/internal/database/user_credentials.go
+++ b/internal/database/user_credentials.go
@@ -85,7 +85,8 @@ func (uc *UserCredential) SetAuthenticator(ctx context.Context, a auth.Authentic
 
 // This const block contains the valid domain values for user credentials.
 const (
-	UserCredentialDomainBatches = "batches"
+	UserCredentialDomainBatches              = "batches"
+	UserCredentialPlaceholderEncryptionKeyID = "previously-migrated"
 )
 
 // UserCredentialNotFoundErr is returned when a credential cannot be found from
@@ -336,7 +337,7 @@ func (s *UserCredentialsStore) List(ctx context.Context, opts UserCredentialsLis
 	// TODO(batch-change-credential-encryption): remove once the OOB user
 	// credential migration is removed.
 	if opts.RequiresMigration {
-		preds = append(preds, sqlf.Sprintf("encryption_key_id IN ('', 'previously-migrated')"))
+		preds = append(preds, sqlf.Sprintf("encryption_key_id IN ('', %s)", UserCredentialPlaceholderEncryptionKeyID))
 	}
 
 	if len(preds) == 0 {

--- a/migrations/frontend/1528395822_track_encryption_key.down.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.down.sql
@@ -1,5 +1,81 @@
 BEGIN;
 
+-- Where we're going, we don't need indexes. (Yet.)
+
+DROP INDEX IF EXISTS
+    batch_changes_site_credentials_credential_enc_idx,
+    batch_changes_site_credentials_credential_idx,
+    user_credentials_credential_enc_idx,
+    user_credentials_credential_idx;
+
+-- Reinstate the old credential field.
+
+ALTER TABLE
+    batch_changes_site_credentials
+RENAME COLUMN
+    credential TO credential_enc;
+
+ALTER TABLE
+    batch_changes_site_credentials
+ADD COLUMN IF NOT EXISTS
+    credential TEXT NULL DEFAULT NULL,
+ALTER COLUMN
+    credential_enc DROP NOT NULL,
+DROP CONSTRAINT IF EXISTS
+    batch_changes_site_credentials_there_can_be_only_one,
+ADD CONSTRAINT
+    batch_changes_site_credentials_there_can_be_only_one
+    CHECK
+    (num_nonnulls(credential, credential_enc) = 1);
+
+ALTER TABLE
+    user_credentials
+RENAME COLUMN
+    credential TO credential_enc;
+
+ALTER TABLE
+    user_credentials
+ADD COLUMN IF NOT EXISTS
+    credential TEXT NULL DEFAULT NULL,
+ALTER COLUMN
+    credential_enc DROP NOT NULL,
+DROP CONSTRAINT IF EXISTS
+    user_credentials_there_can_be_only_one,
+ADD CONSTRAINT
+    user_credentials_there_can_be_only_one
+    CHECK
+    (num_nonnulls(credential, credential_enc) = 1);
+
+UPDATE
+    batch_changes_site_credentials
+SET
+    credential = ENCODE(credential_enc, 'escape'),
+    credential_enc = NULL
+WHERE
+    encryption_key_id = '';
+
+UPDATE
+    user_credentials
+SET
+    credential = ENCODE(credential_enc, 'escape'),
+    credential_enc = NULL
+WHERE
+    encryption_key_id = '';
+
+-- Put the indexes back.
+
+CREATE INDEX IF NOT EXISTS
+    user_credentials_credential_enc_idx
+ON
+    user_credentials ((credential_enc IS NULL));
+
+CREATE INDEX IF NOT EXISTS
+    batch_changes_site_credentials_credential_enc_idx
+ON
+    batch_changes_site_credentials ((credential_enc IS NULL));
+
+-- Get rid of the new encryption_key_id field.
+
 ALTER TABLE
     batch_changes_site_credentials
 DROP COLUMN IF EXISTS

--- a/migrations/frontend/1528395822_track_encryption_key.down.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE
+    batch_changes_site_credentials
+DROP COLUMN IF EXISTS
+    encryption_key_id;
+
+ALTER TABLE
+    user_credentials
+DROP COLUMN IF EXISTS
+    encryption_key_id;
+
+COMMIT;

--- a/migrations/frontend/1528395822_track_encryption_key.up.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.up.sql
@@ -1,13 +1,99 @@
 BEGIN;
 
+-- We're going to unify the credential columns here. This means that we need to
+-- preserve the value in credential if the OOB migrator hasn't run since the
+-- previous credential migrations.
+--
+-- Since this will break the constraint we added previously, first we have to
+-- drop that.
+
 ALTER TABLE
     batch_changes_site_credentials
 ADD COLUMN IF NOT EXISTS
-    encryption_key_id TEXT NOT NULL DEFAULT '';
+    encryption_key_id TEXT NOT NULL DEFAULT '',
+DROP CONSTRAINT IF EXISTS
+    batch_changes_site_credentials_there_can_be_only_one;
 
 ALTER TABLE
     user_credentials
 ADD COLUMN IF NOT EXISTS
-    encryption_key_id TEXT NOT NULL DEFAULT '';
+    encryption_key_id TEXT NOT NULL DEFAULT '',
+DROP CONSTRAINT IF EXISTS
+    user_credentials_there_can_be_only_one;
+
+-- Previously upgraded credentials need a placeholder encryption ID so that we
+-- can replace it with a real one later in the OOB migrator.
+
+UPDATE
+    batch_changes_site_credentials
+SET
+    encryption_key_id = 'previously-migrated'
+WHERE
+    credential_enc IS NOT NULL;
+
+UPDATE
+    user_credentials
+SET
+    encryption_key_id = 'previously-migrated'
+WHERE
+    credential_enc IS NOT NULL;
+
+-- Now we shift credentials into the new field.
+
+UPDATE
+    batch_changes_site_credentials
+SET
+    credential_enc = CONVERT_TO(credential, 'UTF8')
+WHERE
+    credential_enc IS NULL;
+
+UPDATE
+    user_credentials
+SET
+    credential_enc = CONVERT_TO(credential, 'UTF8')
+WHERE
+    credential_enc IS NULL;
+
+-- And finally we can rename the field and update the indexes on the tables.
+
+DROP INDEX IF EXISTS
+    batch_changes_site_credentials_credential_enc_idx,
+    batch_changes_site_credentials_credential_idx,
+    user_credentials_credential_enc_idx,
+    user_credentials_credential_idx;
+
+ALTER TABLE
+    batch_changes_site_credentials
+DROP COLUMN IF EXISTS
+    credential,
+ALTER COLUMN
+    credential_enc SET NOT NULL;
+
+ALTER TABLE
+    batch_changes_site_credentials
+RENAME COLUMN
+    credential_enc TO credential;
+
+ALTER TABLE
+    user_credentials
+DROP COLUMN IF EXISTS
+    credential,
+ALTER COLUMN
+    credential_enc SET NOT NULL;
+
+ALTER TABLE
+    user_credentials
+RENAME COLUMN
+    credential_enc TO credential;
+
+CREATE INDEX IF NOT EXISTS
+    batch_changes_site_credentials_credential_idx
+ON
+    batch_changes_site_credentials ((encryption_key_id IN ('', 'previously-migrated')));
+
+CREATE INDEX IF NOT EXISTS
+    user_credentials_credential_idx
+ON
+    user_credentials ((encryption_key_id IN ('', 'previously-migrated')));
 
 COMMIT;

--- a/migrations/frontend/1528395822_track_encryption_key.up.sql
+++ b/migrations/frontend/1528395822_track_encryption_key.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE
+    batch_changes_site_credentials
+ADD COLUMN IF NOT EXISTS
+    encryption_key_id TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE
+    user_credentials
+ADD COLUMN IF NOT EXISTS
+    encryption_key_id TEXT NOT NULL DEFAULT '';
+
+COMMIT;


### PR DESCRIPTION
This is a funkier version of #20689. Like that PR, it stores the key ID next to the encrypted data for site and user credentials. Unlike that PR, it reunifies the `credential` and `credential_enc` fields into a single field, performing the required SQL hackery to make this work regardless of the previous state.

To finish making this align with other encryption users, I've extended the OOB migrations to support down migrations under the same conditions as they do. I'll update the documentation PR tomorrow once we've (hopefully) landed this.

