### PR TITLE
Add a private toMatch method to SearchResultResolver

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -91,6 +91,10 @@ func RepositoryByIDInt32(ctx context.Context, db dbutil.DB, repoID api.RepoID) (
 	return NewRepositoryResolver(db, repo), nil
 }
 
+func (r *RepositoryResolver) toMatch() result.Match {
+	return &r.RepoMatch
+}
+
 func (r *RepositoryResolver) ID() graphql.ID {
 	return MarshalRepositoryID(r.IDInt32())
 }

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -54,6 +54,10 @@ func (r *CommitSearchResultResolver) Select(path filter.SelectPath) SearchResult
 	return nil
 }
 
+func (r *CommitSearchResultResolver) toMatch() result.Match {
+	return &r.CommitMatch
+}
+
 func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {
 	r.gitCommitOnce.Do(func() {
 		if r.gitCommitResolver != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1772,6 +1772,7 @@ type SearchResultResolver interface {
 	ToRepository() (*RepositoryResolver, bool)
 	ToFileMatch() (*FileMatchResolver, bool)
 	ToCommitSearchResult() (*CommitSearchResultResolver, bool)
+	toMatch() result.Match
 
 	ResultCount() int32
 }

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -44,13 +44,7 @@ type MatchSender interface {
 func SearchEventToSearchMatchEvent(se SearchEvent) SearchMatchEvent {
 	matches := make([]result.Match, 0, len(se.Results))
 	for _, resolver := range se.Results {
-		if fmr, ok := resolver.ToFileMatch(); ok {
-			matches = append(matches, &fmr.FileMatch)
-		} else if rr, ok := resolver.ToRepository(); ok {
-			matches = append(matches, &rr.RepoMatch)
-		} else if csr, ok := resolver.ToCommitSearchResult(); ok {
-			matches = append(matches, &csr.CommitMatch)
-		}
+		matches = append(matches, resolver.toMatch())
 	}
 	return SearchMatchEvent{
 		Results: matches,

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -42,6 +42,10 @@ type FileMatchResolver struct {
 	db           dbutil.DB
 }
 
+func (fm *FileMatchResolver) toMatch() result.Match {
+	return &fm.FileMatch
+}
+
 // Equal provides custom comparison which is used by go-cmp
 func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 	return reflect.DeepEqual(fm, other)


### PR DESCRIPTION
This adds a little helper method to SearchResultResolver so we can
easily convert a resolver to a match without unwrapping it.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
