### PR TITLE
Make searchResolver.stream a MatchSender

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -335,7 +335,7 @@ func (r *RepositoryResolver) hydrate(ctx context.Context) error {
 	r.hydration.Do(func() {
 		// Repositories with an empty creation date were created using RepoName.ToRepo(),
 		// they only contain ID and name information.
-		if !r.innerRepo.CreatedAt.IsZero() {
+		if r.innerRepo != nil && !r.innerRepo.CreatedAt.IsZero() {
 			return
 		}
 

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -252,7 +252,7 @@ type searchResolver struct {
 	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating search subexpressions.
 
 	// stream if non-nil will send all search events we receive down it.
-	stream Sender
+	stream MatchSender
 
 	// Cached resolveRepositories results. We use a pointer to the mutex so that we
 	// can copy the resolver, while sharing the mutex. If we didn't use a pointer,

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -708,7 +708,7 @@ type alertObserver struct {
 }
 
 // Update AlertObserver's state based on event.
-func (o *alertObserver) Update(event SearchEvent) {
+func (o *alertObserver) Update(event SearchMatchEvent) {
 	if len(event.Results) > 0 {
 		o.hasResults = true
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -20,7 +20,7 @@ var mockSearchRepositories func(args *search.TextParameters) ([]SearchResultReso
 //
 // For a repository to match a query, the repository's name must match all of the repo: patterns AND the
 // default patterns (i.e., the patterns that are not prefixed with any search field).
-func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32, stream Sender) error {
+func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32, stream MatchSender) error {
 	if mockSearchRepositories != nil {
 		results, stats, err := mockSearchRepositories(args)
 		stream.Send(SearchEvent{

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -128,7 +128,7 @@ func TestSearchRepositories(t *testing.T) {
 }
 
 func searchRepositoriesBatch(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32) ([]SearchResultResolver, streaming.Stats, error) {
-	return collectStream(func(stream Sender) error {
+	return collectMatchStream(db, func(stream MatchSender) error {
 		return searchRepositories(ctx, db, args, limit, stream)
 	})
 }

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/filter"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 // SearchEvent is an event on a search stream. It contains fields which can be
@@ -73,7 +72,7 @@ func MatchesToResolvers(db dbutil.DB, matches []result.Match) []SearchResultReso
 			})
 		case *result.RepoMatch:
 			resolvers = append(resolvers, &RepositoryResolver{
-				db: db,
+				db:        db,
 				RepoMatch: *v,
 			})
 		case *result.CommitMatch:

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -71,10 +71,10 @@ func MatchesToResolvers(db dbutil.DB, matches []result.Match) []SearchResultReso
 				RepoResolver: NewRepositoryResolver(db, v.Repo.ToRepo()),
 			})
 		case *result.RepoMatch:
-			resolvers = append(resolvers, &RepositoryResolver{
-				db:        db,
-				RepoMatch: *v,
-			})
+			repoName := v.RepoName()
+			resolver := NewRepositoryResolver(db, repoName.ToRepo())
+			resolver.RepoMatch.Rev = v.Rev // preserve the rev
+			resolvers = append(resolvers, resolver)
 		case *result.CommitMatch:
 			resolvers = append(resolvers, &CommitSearchResultResolver{
 				db:          db,

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -368,7 +368,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		fileMatches, _, err := collectStream(func(stream Sender) error {
+		fileMatches, _, err := collectMatchStream(r.db, func(stream MatchSender) error {
 			return searchSymbols(ctx, r.db, &search.TextParameters{
 				PatternInfo:  p,
 				RepoPromise:  (&search.Promise{}).Resolve(resolved.RepoRevs),

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -27,7 +27,7 @@ var mockSearchSymbols func(ctx context.Context, args *search.TextParameters, lim
 // it can be used for both search suggestions and search results
 //
 // May return partial results and an error
-func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int, stream Sender) (err error) {
+func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int, stream MatchSender) (err error) {
 	if mockSearchSymbols != nil {
 		results, stats, err := mockSearchSymbols(ctx, args, limit)
 		stream.Send(SearchEvent{

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -310,7 +310,7 @@ func searchResultsToFileMatchResults(resolvers []SearchResultResolver) ([]*FileM
 // searchFilesInRepoBatch is a convenience function around searchFilesInRepos
 // which collects the results from the stream.
 func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.TextParameters) ([]*FileMatchResolver, streaming.Stats, error) {
-	results, stats, err := collectStream(func(stream Sender) error {
+	results, stats, err := collectMatchStream(db, func(stream MatchSender) error {
 		return searchFilesInRepos(ctx, db, args, stream)
 	})
 	fms, fmErr := searchResultsToFileMatchResults(results)
@@ -321,7 +321,7 @@ func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.Tex
 }
 
 // searchFilesInRepos searches a set of repos for a pattern.
-func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream Sender) (err error) {
+func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream MatchSender) (err error) {
 	if mockSearchFilesInRepos != nil {
 		results, mockStats, err := mockSearchFilesInRepos(args)
 		stream.Send(SearchEvent{


### PR DESCRIPTION
This makes searchResolver.stream a MatchSender, and fixes all downstream
errors, implementing MatchSender for things like aggregator and
WithLimit.

The plan here is to convert all references of Sender to MatchSender, 
then from there, convert all references of MatchSender.Send to 
MatchSender.SendMatches. At that point, we can remove all these
duplicate functions and methods. 

Stacked on #20725 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
