### PR TITLE
fix: Incorrect padding on global alerts

### DIFF
--- a/client/web/src/global/GlobalAlerts.scss
+++ b/client/web/src/global/GlobalAlerts.scss
@@ -4,8 +4,8 @@
 
     &__alert {
         width: 100%;
-        padding: 0.5rem !important;
-        margin-bottom: 0 !important;
+        padding: 0.5rem;
+        margin-bottom: 0;
 
         border-radius: 0;
         border-width: 0 0 1px 0;


### PR DESCRIPTION
Fix incorrect padding on global alerts due to `!important` in the `.global-alerts` styles. Also remove it on `margin-bottom` since it doesn't seem to be required.

![Frame 1 (1)](https://user-images.githubusercontent.com/17293/117445196-b552d280-af3a-11eb-9d6c-2746c0123009.png)
