### PR TITLE
add cached encryption.Key implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,6 +95,7 @@ require (
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-retryablehttp v0.6.7 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hexops/autogold v1.3.0
 	github.com/honeycombio/libhoney-go v1.14.0
 	github.com/imdario/mergo v0.3.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -760,6 +760,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -962,6 +963,7 @@ github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkB
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1141,6 +1143,7 @@ github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtb
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1327,15 +1330,19 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.1.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1348,6 +1355,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
+github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
@@ -1371,6 +1379,7 @@ github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPr
 github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -1956,6 +1965,7 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=

--- a/internal/encryption/cache/cache.go
+++ b/internal/encryption/cache/cache.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"context"
 
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 )

--- a/internal/encryption/cache/cache.go
+++ b/internal/encryption/cache/cache.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"context"
+
+	"github.com/hashicorp/golang-lru"
+
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+)
+
+func New(k encryption.Key, size int) (*Key, error) {
+	c, err := lru.New(size)
+	if err != nil {
+		return nil, err
+	}
+	return &Key{
+		Key:   k,
+		cache: c,
+	}, nil
+}
+
+type Key struct {
+	encryption.Key
+
+	cache *lru.Cache
+}
+
+func (k *Key) Decrypt(ctx context.Context, ciphertext []byte) (*encryption.Secret, error) {
+	v, found := k.cache.Get(string(ciphertext))
+	s, ok := v.(encryption.Secret)
+	if !ok || !found {
+		s, err := k.Key.Decrypt(ctx, ciphertext)
+		if err != nil {
+			return nil, err
+		}
+		k.cache.Add(string(ciphertext), *s)
+		return s, err
+	}
+	return &s, nil
+}

--- a/internal/encryption/cache/cache_test.go
+++ b/internal/encryption/cache/cache_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/sourcegraph/sourcegraph/internal/encryption"

--- a/internal/encryption/cache/cache_test.go
+++ b/internal/encryption/cache/cache_test.go
@@ -1,0 +1,57 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/sourcegraph/sourcegraph/internal/encryption"
+)
+
+func TestCacheKey(t *testing.T) {
+	m := make(map[string]int)
+	k := &testKey{
+		Key: &encryption.NoopKey{},
+		fn: func(b []byte) {
+			m[string(b)] = m[string(b)] + 1
+		},
+	}
+
+	cached, err := New(k, 10)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// first call, decrypt value
+	_, err = cached.Decrypt(ctx, []byte("foobar"))
+	require.NoError(t, err)
+
+	// second call, hit cache
+	_, err = cached.Decrypt(ctx, []byte("foobar"))
+	require.NoError(t, err)
+
+	// first call, decrypt value
+	_, err = cached.Decrypt(ctx, []byte("foobaz"))
+	require.NoError(t, err)
+
+	// second call, hit cache
+	_, err = cached.Decrypt(ctx, []byte("foobaz"))
+	require.NoError(t, err)
+
+	// each key will have only been decrypted once, and returned from the cache the second time
+	assert.Equal(t, m["foobar"], 1)
+	assert.Equal(t, m["foobaz"], 1)
+}
+
+type testKey struct {
+	encryption.Key
+	fn func([]byte)
+}
+
+func (k *testKey) Decrypt(ctx context.Context, ciphertext []byte) (*encryption.Secret, error) {
+	k.fn(ciphertext)
+	return k.Key.Decrypt(ctx, ciphertext)
+}

--- a/internal/encryption/keyring/ring.go
+++ b/internal/encryption/keyring/ring.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/sourcegraph/sourcegraph/internal/encryption/cache"
-
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
+	"github.com/sourcegraph/sourcegraph/internal/encryption/cache"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/cloudkms"
 	"github.com/sourcegraph/sourcegraph/internal/encryption/mounted"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -81,47 +80,26 @@ func NewRing(ctx context.Context, keyConfig *schema.EncryptionKeys) (*Ring, erro
 	var (
 		r   Ring
 		err error
-
-		enableCache = keyConfig.EnableCache
-		cacheSize   = keyConfig.CacheSize
 	)
 
 	if keyConfig.BatchChangesCredentialKey != nil {
-		r.BatchChangesCredentialKey, err = NewKey(ctx, keyConfig.BatchChangesCredentialKey)
+		r.BatchChangesCredentialKey, err = NewKey(ctx, keyConfig.BatchChangesCredentialKey, keyConfig)
 		if err != nil {
 			return nil, err
-		}
-		if enableCache {
-			r.BatchChangesCredentialKey, err = cache.New(r.BatchChangesCredentialKey, cacheSize)
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 
 	if keyConfig.ExternalServiceKey != nil {
-		r.ExternalServiceKey, err = NewKey(ctx, keyConfig.ExternalServiceKey)
+		r.ExternalServiceKey, err = NewKey(ctx, keyConfig.ExternalServiceKey, keyConfig)
 		if err != nil {
 			return nil, err
-		}
-		if enableCache {
-			r.ExternalServiceKey, err = cache.New(r.ExternalServiceKey, cacheSize)
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 
 	if keyConfig.UserExternalAccountKey != nil {
-		r.UserExternalAccountKey, err = NewKey(ctx, keyConfig.UserExternalAccountKey)
+		r.UserExternalAccountKey, err = NewKey(ctx, keyConfig.UserExternalAccountKey, keyConfig)
 		if err != nil {
 			return nil, err
-		}
-		if enableCache {
-			r.UserExternalAccountKey, err = cache.New(r.UserExternalAccountKey, cacheSize)
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -134,18 +112,30 @@ type Ring struct {
 	UserExternalAccountKey    encryption.Key
 }
 
-func NewKey(ctx context.Context, k *schema.EncryptionKey) (encryption.Key, error) {
+func NewKey(ctx context.Context, k *schema.EncryptionKey, config *schema.EncryptionKeys) (encryption.Key, error) {
 	if k == nil {
 		return nil, fmt.Errorf("cannot configure nil key")
 	}
+	var (
+		key encryption.Key
+		err error
+	)
 	switch {
 	case k.Cloudkms != nil:
-		return cloudkms.NewKey(ctx, *k.Cloudkms)
+		key, err = cloudkms.NewKey(ctx, *k.Cloudkms)
 	case k.Mounted != nil:
-		return mounted.NewKey(ctx, *k.Mounted)
+		key, err = mounted.NewKey(ctx, *k.Mounted)
 	case k.Noop != nil:
-		return &encryption.NoopKey{}, nil
+		key = &encryption.NoopKey{}
 	default:
 		return nil, fmt.Errorf("couldn't configure key: %v", *k)
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	if config.EnableCache {
+		key, err = cache.New(key, config.CacheSize)
+	}
+	return key, err
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -441,8 +441,12 @@ func (v *EncryptionKey) UnmarshalJSON(data []byte) error {
 // EncryptionKeys description: Configuration for encryption keys used to encrypt data at rest in the database.
 type EncryptionKeys struct {
 	BatchChangesCredentialKey *EncryptionKey `json:"batchChangesCredentialKey,omitempty"`
-	ExternalServiceKey        *EncryptionKey `json:"externalServiceKey,omitempty"`
-	UserExternalAccountKey    *EncryptionKey `json:"userExternalAccountKey,omitempty"`
+	// CacheSize description: number of values to keep in LRU cache
+	CacheSize int `json:"cacheSize,omitempty"`
+	// EnableCache description: enable LRU cache for decryption APIs
+	EnableCache            bool           `json:"enableCache,omitempty"`
+	ExternalServiceKey     *EncryptionKey `json:"externalServiceKey,omitempty"`
+	UserExternalAccountKey *EncryptionKey `json:"userExternalAccountKey,omitempty"`
 }
 type ExcludedAWSCodeCommitRepo struct {
 	// Id description: The ID of an AWS Code Commit repository (as returned by the AWS API) to exclude from mirroring. Use this to exclude the repository, even if renamed, or to differentiate between repositories with the same name in multiple regions.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -981,6 +981,16 @@
       "description": "Configuration for encryption keys used to encrypt data at rest in the database.",
       "type": "object",
       "properties": {
+        "enableCache": {
+          "description": "enable LRU cache for decryption APIs",
+          "type": "boolean",
+          "default": false
+        },
+        "cacheSize": {
+          "description": "number of values to keep in LRU cache",
+          "type": "integer",
+          "default": 2048
+        },
         "batchChangesCredentialKey": {
           "$ref": "#/definitions/EncryptionKey"
         },


### PR DESCRIPTION
https://sourcegraph.slack.com/archives/CMBA8F926/p1620256574316400

we noticed that we were starting to hit our quota limits on cloud KMS, the way we decrypt data means we waste a lot of time decrypting the same data over and over again so i added this cache.Key implementation. It wraps any key you give it with an LRU cache provided by github.com/hashicorp/golang-lru. it is configurable with the `enableCache` and `cacheSize` options in site config encryption.keys

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
