### PR TITLE
sg: No need to panic, it's just a little nil

### DIFF
--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -57,7 +57,6 @@ var (
 	rootFlagSet         = flag.NewFlagSet("sg", flag.ExitOnError)
 	configFlag          = rootFlagSet.String("config", "sg.config.yaml", "configuration file")
 	overwriteConfigFlag = rootFlagSet.String("overwrite", "sg.config.overwrite.yaml", "configuration overwrites file that is gitignored and can be used to, for example, add credentials")
-	conf                *Config
 
 	rootCommand = &ffcli.Command{
 		ShortUsage:  "sg [flags] <subcommand>",
@@ -71,26 +70,43 @@ func main() {
 		os.Exit(1)
 	}
 
-	var err error
-	conf, err = ParseConfigFile(*configFlag)
-	if err != nil {
-		out.WriteLine(output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s\n", output.StyleBold, *configFlag, output.StyleReset, output.StyleWarning, output.StyleReset, err))
+	ok, errLine := parseConf(*configFlag, *overwriteConfigFlag)
+	if !ok {
+		out.WriteLine(errLine)
 		os.Exit(1)
-	}
-
-	if ok, _ := fileExists(*overwriteConfigFlag); ok {
-		overwriteConf, err := ParseConfigFile(*overwriteConfigFlag)
-		if err != nil {
-			out.WriteLine(output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s\n", output.StyleBold, *overwriteConfigFlag, output.StyleReset, output.StyleWarning, output.StyleReset, err))
-			os.Exit(1)
-		}
-		conf.Merge(overwriteConf)
 	}
 
 	if err := rootCommand.Run(context.Background()); err != nil {
 		fmt.Printf("error: %s\n", err)
 		os.Exit(1)
 	}
+}
+
+var conf *Config
+
+// parseConf parses the config file and the optional overwrite file.
+// If the conf
+// has already been parsed it's a noop.
+func parseConf(confFile, overwriteFile string) (bool, output.FancyLine) {
+	if conf != nil {
+		return true, output.FancyLine{}
+	}
+
+	var err error
+	conf, err = ParseConfigFile(confFile)
+	if err != nil {
+		return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as configuration file:%s\n%s\n", output.StyleBold, confFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
+	}
+
+	if ok, _ := fileExists(overwriteFile); ok {
+		overwriteConf, err := ParseConfigFile(overwriteFile)
+		if err != nil {
+			return false, output.Linef("", output.StyleWarning, "Failed to parse %s%s%s%s as overwrites configuration file:%s\n%s\n", output.StyleBold, overwriteFile, output.StyleReset, output.StyleWarning, output.StyleReset, err)
+		}
+		conf.Merge(overwriteConf)
+	}
+
+	return true, output.FancyLine{}
 }
 
 func runSetExec(ctx context.Context, args []string) error {
@@ -177,11 +193,18 @@ func runUsage(c *ffcli.Command) string {
 
 	fmt.Fprintf(&out, "USAGE\n")
 	fmt.Fprintf(&out, "  sg %s <command>\n", c.Name)
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE COMMANDS IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
 
-	for name := range conf.Commands {
-		fmt.Fprintf(&out, "  %s\n", name)
+	// Attempt to parse config to list available commands, but don't fail on
+	// error, because we should never error when the user wants --help output.
+	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
+
+	if conf != nil {
+		fmt.Fprintf(&out, "\n")
+		fmt.Fprintf(&out, "AVAILABLE COMMANDS IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
+
+		for name := range conf.Commands {
+			fmt.Fprintf(&out, "  %s\n", name)
+		}
 	}
 
 	return out.String()
@@ -192,11 +215,18 @@ func testUsage(c *ffcli.Command) string {
 
 	fmt.Fprintf(&out, "USAGE\n")
 	fmt.Fprintf(&out, "  sg %s <test suite>\n", c.Name)
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE TESTSUITES IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
 
-	for name := range conf.Tests {
-		fmt.Fprintf(&out, "  %s\n", name)
+	// Attempt to parse config so we can list test suites, but don't fail on
+	// error, because we should never error when the user wants --help output.
+	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
+
+	if conf != nil {
+		fmt.Fprintf(&out, "\n")
+		fmt.Fprintf(&out, "AVAILABLE TESTSUITES IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
+
+		for name := range conf.Tests {
+			fmt.Fprintf(&out, "  %s\n", name)
+		}
 	}
 
 	return out.String()
@@ -207,11 +237,17 @@ func runSetUsage(c *ffcli.Command) string {
 
 	fmt.Fprintf(&out, "USAGE\n")
 	fmt.Fprintf(&out, "  sg %s <commandset>\n", c.Name)
-	fmt.Fprintf(&out, "\n")
-	fmt.Fprintf(&out, "AVAILABLE COMMANDSETS IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
 
-	for name := range conf.Commandsets {
-		fmt.Fprintf(&out, "  %s\n", name)
+	// Attempt to parse config so we can list available sets, but don't fail on
+	// error, because we should never error when the user wants --help output.
+	_, _ = parseConf(*configFlag, *overwriteConfigFlag)
+	if conf != nil {
+		fmt.Fprintf(&out, "\n")
+		fmt.Fprintf(&out, "AVAILABLE COMMANDSETS IN %s%s%s\n", output.StyleBold, *configFlag, output.StyleReset)
+
+		for name := range conf.Commandsets {
+			fmt.Fprintf(&out, "  %s\n", name)
+		}
 	}
 
 	return out.String()


### PR DESCRIPTION
This fixes the nil-panic that @muratsu reported when running `sg test --help`.