### PR TITLE
sg: Make sg-in-PATH check more robust in install.sh script

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -67,13 +67,13 @@ set +e # Don't fail if it the check fails
 sg_in_path=$(command -v sg)
 set -e
 
-red_bg="\033[41m"
-white_fg="\033[37;1m"
-reset="\033[0m"
+red_bg=$'\033[41m'
+white_fg=$'\033[37;1m'
+reset=$'\033[0m'
 if [ "$sg_in_path" != "$GOBIN/sg" ]; then
   echo
-  printf "  ${red_bg}${white_fg}NOTE: this is NOT on your \$PATH.${reset}"
-  if [ ! -z $sg_in_path ]; then
+  printf "  %s%sNOTE: this is NOT on your \$PATH.%s" "$red_bg" "$white_fg" "$reset"
+  if [ -n "${sg_in_path}" ]; then
     echo "  running sg will run '$sg_in_path' instead."
   fi
   echo

--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -35,10 +35,6 @@ if [ ! -x "$GOBIN/sg" ]; then
   exit 1
 fi
 
-# We can now compare this to the output of which sg, and make suggestions
-# accordingly in terms of usage.
-global_sg="$(which sg)"
-
 echo "          _____                    _____          "
 echo "         /\    \                  /\    \         "
 echo "        /::\    \                /::\    \        "
@@ -63,13 +59,25 @@ echo "         \/____/                                  "
 echo "                                                  "
 echo "                                                  "
 echo "  sg installed to $GOBIN/sg."
-if [ "$global_sg" != "$GOBIN/sg" ]; then
+
+# We can now check whether `sg` is in the $PATH and make suggestions
+# accordingly in terms of usage.
+
+set +e # Don't fail if it the check fails
+sg_in_path=$(command -v sg)
+set -e
+
+if [ "$sg_in_path" != "$GOBIN/sg" ]; then
   echo
-  echo "  Note that this is NOT on your \$PATH; running sg"
-  echo "  will run $global_sg instead."
+  echo "  Note that this is NOT on your \$PATH."
+
+  if [ ! -z $sg_in_path ]; then
+    echo "  running sg will run '$sg_in_path' instead."
+  fi
   echo
   echo "  Consider adding $GOBIN to your \$PATH for easier"
   echo "  sg-ing!"
 fi
+
 echo "                                                  "
 echo "                  Happy hacking!"

--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -67,10 +67,12 @@ set +e # Don't fail if it the check fails
 sg_in_path=$(command -v sg)
 set -e
 
+red_bg="\033[41m"
+white_fg="\033[37;1m"
+reset="\033[0m"
 if [ "$sg_in_path" != "$GOBIN/sg" ]; then
   echo
-  echo -e "  \u001b[41m\u001b[37;1mNOTE: this is NOT on your \$PATH. \u001b[0m \u001b[0m"
-
+  printf "  ${red_bg}${white_fg}NOTE: this is NOT on your \$PATH.${reset}"
   if [ ! -z $sg_in_path ]; then
     echo "  running sg will run '$sg_in_path' instead."
   fi

--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -69,7 +69,7 @@ set -e
 
 if [ "$sg_in_path" != "$GOBIN/sg" ]; then
   echo
-  echo "  Note that this is NOT on your \$PATH."
+  echo -e "  \u001b[41m\u001b[37;1mNOTE: this is NOT on your \$PATH. \u001b[0m \u001b[0m"
 
   if [ ! -z $sg_in_path ]; then
     echo "  running sg will run '$sg_in_path' instead."


### PR DESCRIPTION
Turns out that if we do `set -e` at the beginning then `global_sg=$(which sg)` will silently fail if `sg` is no in the `$PATH`