### PR TITLE
Fix flaky test

### DIFF
--- a/internal/database/dbcache/main_test.go
+++ b/internal/database/dbcache/main_test.go
@@ -1,0 +1,9 @@
+package dbcache
+
+import (
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+)
+
+func init() {
+	dbtesting.DBNameSuffix = "internal-database-cache"
+}


### PR DESCRIPTION
Without this, tests would sometimes yield

```
dbtesting.go:77: Could not connect to DB dropdb --if-exists failed: exit status 1
    dropdb: error: database removal failed: ERROR:  database "sourcegraph-test-database" is being accessed by other users
    DETAIL:  There are 3 other sessions using the database.
```
