### PR TITLE
sg: Add ability to overwrite argument to tests

### DIFF
--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -30,6 +30,11 @@ func ParseConfigFile(name string) (*Config, error) {
 		conf.Commands[name] = cmd
 	}
 
+	for name, cmd := range conf.Tests {
+		cmd.Name = name
+		conf.Tests[name] = cmd
+	}
+
 	return &conf, nil
 }
 
@@ -43,6 +48,7 @@ type Command struct {
 	InstallDocLinux  string            `yaml:"installDoc.linux"`
 	IgnoreStdout     bool              `yaml:"ignoreStdout"`
 	IgnoreStderr     bool              `yaml:"ignoreStderr"`
+	DefaultArgs      string            `yaml:"defaultArgs"`
 }
 
 type Config struct {

--- a/dev/sg/main.go
+++ b/dev/sg/main.go
@@ -129,18 +129,13 @@ func testExec(ctx context.Context, args []string) error {
 		return flag.ErrHelp
 	}
 
-	if len(args) != 1 {
-		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: too many arguments\n"))
-		return flag.ErrHelp
-	}
-
 	cmd, ok := conf.Tests[args[0]]
 	if !ok {
 		out.WriteLine(output.Linef("", output.StyleWarning, "ERROR: test suite %q not found :(\n", args[0]))
 		return flag.ErrHelp
 	}
 
-	return runTest(ctx, cmd)
+	return runTest(ctx, cmd, args[1:])
 }
 
 func startExec(ctx context.Context, args []string) error {

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -351,7 +351,9 @@ commandsets:
 tests:
   # These can be run with `sg test [name]`
   backend:
-    cmd: go test ./...
+    cmd: go test
+    defaultArgs: ./...
+
   backend-integration:
     cmd: cd dev/gqltest && go test -long -base-url $BASE_URL -email $EMAIL -username $USERNAME -password $PASSWORD ./gqltest
     env:
@@ -360,8 +362,10 @@ tests:
       BASE_URL: "http://localhost:3080"
       EMAIL: "joe@sourcegraph.com"
       PASSWORD: "12345"
+
   frontend:
     cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook
+
   frontend-e2e:
     cmd: yarn run mocha ./client/web/src/end-to-end/end-to-end.test.ts
     env:


### PR DESCRIPTION
This allows you to run `sg test backend` (without args) and it will use the `defaultArgs` as defined in the `tests.backend` object in `sg.config.yaml`. _If_ you pass additional args those will get passed to the cmd instead: `sg test backend ./internal/my-folder` will then run the `tests.backend.cmd` with `./internal/my-folder` as arg.