### PR TITLE
Replace remaining `MatchSender.Send()` with `MatchSender.SendMatches()`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -318,8 +318,8 @@ func searchCommitsInRepoStream(ctx context.Context, db dbutil.DB, op search.Comm
 
 		// Only send if we have something to report back.
 		if len(results) > 0 || !stats.Zero() {
-			s.Send(SearchEvent{
-				Results: commitMatchesToSearchResults(db, results),
+			s.SendMatches(SearchMatchEvent{
+				Results: commitMatchesToMatches(results),
 				Stats:   stats,
 			})
 		}
@@ -578,24 +578,21 @@ func searchCommitLogInRepos(ctx context.Context, db dbutil.DB, args *search.Text
 	})
 }
 
-func commitMatchesToSearchResults(db dbutil.DB, matches []*result.CommitMatch) []SearchResultResolver {
-	if len(matches) == 0 {
+func commitMatchesToMatches(commitMatches []*result.CommitMatch) []result.Match {
+	if len(commitMatches) == 0 {
 		return nil
 	}
 
 	// Show most recent commits first.
-	sort.Slice(matches, func(i, j int) bool {
-		return matches[i].Commit.Author.Date.After(matches[j].Commit.Author.Date)
+	sort.Slice(commitMatches, func(i, j int) bool {
+		return commitMatches[i].Commit.Author.Date.After(commitMatches[j].Commit.Author.Date)
 	})
 
-	resolvers := make([]SearchResultResolver, len(matches))
-	for i, result := range matches {
-		resolvers[i] = &CommitSearchResultResolver{
-			db:          db,
-			CommitMatch: *result,
-		}
+	matches := make([]result.Match, 0, len(commitMatches))
+	for _, result := range commitMatches {
+		matches = append(matches, result)
 	}
-	return resolvers
+	return matches
 }
 
 // expandUsernamesToEmails expands references to usernames to mention all possible (known and

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/search/query"
 )
 
-var mockSearchRepositories func(args *search.TextParameters) ([]SearchResultResolver, *streaming.Stats, error)
+var mockSearchRepositories func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error)
 
 // searchRepositories searches for repositories by name.
 //
@@ -24,7 +24,7 @@ var mockSearchRepositories func(args *search.TextParameters) ([]SearchResultReso
 func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32, stream MatchSender) error {
 	if mockSearchRepositories != nil {
 		results, stats, err := mockSearchRepositories(args)
-		stream.Send(SearchEvent{
+		stream.SendMatches(SearchMatchEvent{
 			Results: results,
 			Stats:   statsDeref(stats),
 		})

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1663,7 +1663,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 			repos[repoRev.Repo.ID] = repoRev.Repo
 		}
 
-		agg.Send(SearchEvent{
+		agg.SendMatches(SearchMatchEvent{
 			Stats: streaming.Stats{
 				Repos:            repos,
 				ExcludedForks:    resolved.ExcludedRepos.Forks,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1450,8 +1450,8 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 		}
 	}
 
-	a.Send(SearchEvent{
-		Results: fileMatchResolversToSearchResults(fileResults),
+	a.SendMatches(SearchMatchEvent{
+		Results: fileMatchResolversToMatches(fileResults),
 		Stats:   stats,
 	})
 	return err

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -468,7 +468,10 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 			result.Stats.IsLimitHit = true
 		}
 		if r.stream != nil {
-			r.stream.Send(SearchEvent{result.SearchResults, result.Stats})
+			r.stream.SendMatches(SearchMatchEvent{
+				Results: ResolversToMatches(result.SearchResults),
+				Stats:   result.Stats,
+			})
 		}
 		return result, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -853,8 +853,8 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 		r.stream = nil // Disables streaming: backends may not use the endpoint.
 		srr, err := r.resultsBatch(ctx)
 		if srr != nil {
-			endpoint.Send(SearchEvent{
-				Results: srr.SearchResults,
+			endpoint.SendMatches(SearchMatchEvent{
+				Results: ResolversToMatches(srr.SearchResults),
 				Stats:   srr.Stats,
 			})
 		}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -148,7 +148,7 @@ func TestSearchResults(t *testing.T) {
 		database.Mocks.Repos.Count = mockCount
 
 		calledSearchRepositories := false
-		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *streaming.Stats, error) {
+		mockSearchRepositories = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			calledSearchRepositories = true
 			return nil, &streaming.Stats{}, nil
 		}
@@ -213,7 +213,7 @@ func TestSearchResults(t *testing.T) {
 		database.Mocks.Repos.Count = mockCount
 
 		calledSearchRepositories := false
-		mockSearchRepositories = func(args *search.TextParameters) ([]SearchResultResolver, *streaming.Stats, error) {
+		mockSearchRepositories = func(args *search.TextParameters) ([]result.Match, *streaming.Stats, error) {
 			calledSearchRepositories = true
 			return nil, &streaming.Stats{}, nil
 		}

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -29,7 +29,6 @@ type SearchMatchEvent struct {
 // MatchSender is a temporary interface that adds the SendMatches method to the
 // Sender interface. Eventually, Sender.Send() will be replaced with MatchSender.SendMatches
 type MatchSender interface {
-	Send(SearchEvent)
 	SendMatches(SearchMatchEvent)
 }
 

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -35,14 +35,19 @@ type MatchSender interface {
 
 // Temporary conversion function from SearchEvent to SearchMatchEvent
 func SearchEventToSearchMatchEvent(se SearchEvent) SearchMatchEvent {
-	matches := make([]result.Match, 0, len(se.Results))
-	for _, resolver := range se.Results {
-		matches = append(matches, resolver.toMatch())
-	}
 	return SearchMatchEvent{
-		Results: matches,
+		Results: ResolversToMatches(se.Results),
 		Stats:   se.Stats,
 	}
+}
+
+// Temporary conversion function from []SearchResultResolver to []result.Match
+func ResolversToMatches(resolvers []SearchResultResolver) []result.Match {
+	matches := make([]result.Match, 0, len(resolvers))
+	for _, resolver := range resolvers {
+		matches = append(matches, resolver.toMatch())
+	}
+	return matches
 }
 
 // Temporary conversion function from SearchMatchEvent to SearchEvent

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -114,7 +114,7 @@ func (s *limitStream) SendMatches(event SearchMatchEvent) {
 	// multiple times, but this is fine. Want to avoid lots of noop events
 	// after the first IsLimitHit.
 	if old >= 0 && s.remaining.Load() < 0 {
-		s.s.Send(SearchEvent{Stats: streaming.Stats{IsLimitHit: true}})
+		s.s.SendMatches(SearchMatchEvent{Stats: streaming.Stats{IsLimitHit: true}})
 		s.cancel()
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -91,8 +91,8 @@ func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameter
 
 			matches, err := searchSymbolsInRepo(ctx, repoRevs, args.PatternInfo, limit)
 			stats, err := handleRepoSearchResult(repoRevs, len(matches) > limit, false, err)
-			stream.Send(SearchEvent{
-				Results: fileMatchesToSearchResults(db, matches),
+			stream.SendMatches(SearchMatchEvent{
+				Results: fileMatchesToMatches(matches),
 				Stats:   stats,
 			})
 			if err != nil {

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -30,8 +30,8 @@ var mockSearchSymbols func(ctx context.Context, args *search.TextParameters, lim
 func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int, stream MatchSender) (err error) {
 	if mockSearchSymbols != nil {
 		results, stats, err := mockSearchSymbols(ctx, args, limit)
-		stream.Send(SearchEvent{
-			Results: fileMatchResolversToSearchResults(results),
+		stream.SendMatches(SearchMatchEvent{
+			Results: fileMatchResolversToMatches(results),
 			Stats:   statsDeref(stats),
 		})
 		return err

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -276,7 +276,7 @@ func repoHasFilesWithNamesMatching(ctx context.Context, searcherURLs *endpoint.M
 var mockSearchFilesInRepos func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error)
 
 func fileMatchesToMatches(fms []result.FileMatch) []result.Match {
-	matches := make([]result.Match, len(fms))
+	matches := make([]result.Match, 0, len(fms))
 	for _, fm := range fms {
 		matches = append(matches, &fm)
 	}

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -283,14 +283,6 @@ func fileMatchesToMatches(fms []result.FileMatch) []result.Match {
 	return matches
 }
 
-func fileMatchResolversToSearchResults(resolvers []*FileMatchResolver) []SearchResultResolver {
-	results := make([]SearchResultResolver, len(resolvers))
-	for i, resolver := range resolvers {
-		results[i] = resolver
-	}
-	return results
-}
-
 func fileMatchResolversToMatches(resolvers []*FileMatchResolver) []result.Match {
 	matches := make([]result.Match, 0, len(resolvers))
 	for _, resolver := range resolvers {
@@ -328,8 +320,8 @@ func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.Tex
 func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream MatchSender) (err error) {
 	if mockSearchFilesInRepos != nil {
 		results, mockStats, err := mockSearchFilesInRepos(args)
-		stream.Send(SearchEvent{
-			Results: fileMatchResolversToSearchResults(results),
+		stream.SendMatches(SearchMatchEvent{
+			Results: fileMatchResolversToMatches(results),
 			Stats:   statsDeref(mockStats),
 		})
 		return err

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -295,6 +295,14 @@ func fileMatchResolversToSearchResults(resolvers []*FileMatchResolver) []SearchR
 	return results
 }
 
+func fileMatchResolversToMatches(resolvers []*FileMatchResolver) []result.Match {
+	matches := make([]result.Match, 0, len(resolvers))
+	for _, resolver := range resolvers {
+		matches = append(matches, resolver.toMatch())
+	}
+	return matches
+}
+
 func searchResultsToFileMatchResults(resolvers []SearchResultResolver) ([]*FileMatchResolver, error) {
 	results := make([]*FileMatchResolver, len(resolvers))
 	for i, resolver := range resolvers {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -287,6 +287,14 @@ func fileMatchesToSearchResults(db dbutil.DB, matches []result.FileMatch) []Sear
 	return results
 }
 
+func fileMatchesToMatches(fms []result.FileMatch) []result.Match {
+	matches := make([]result.Match, len(fms))
+	for _, fm := range fms {
+		matches = append(matches, &fm)
+	}
+	return matches
+}
+
 func fileMatchResolversToSearchResults(resolvers []*FileMatchResolver) []SearchResultResolver {
 	results := make([]SearchResultResolver, len(resolvers))
 	for i, resolver := range resolvers {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -275,18 +275,6 @@ func repoHasFilesWithNamesMatching(ctx context.Context, searcherURLs *endpoint.M
 
 var mockSearchFilesInRepos func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error)
 
-func fileMatchesToSearchResults(db dbutil.DB, matches []result.FileMatch) []SearchResultResolver {
-	results := make([]SearchResultResolver, len(matches))
-	for i, match := range matches {
-		results[i] = &FileMatchResolver{
-			FileMatch:    match,
-			RepoResolver: NewRepositoryResolver(db, match.Repo.ToRepo()),
-			db:           db,
-		}
-	}
-	return results
-}
-
 func fileMatchesToMatches(fms []result.FileMatch) []result.Match {
 	matches := make([]result.Match, len(fms))
 	for _, fm := range fms {
@@ -493,8 +481,8 @@ func callSearcherOverRepos(
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
 					stats, err := handleRepoSearchResult(repoRev, repoLimitHit, false, err)
-					stream.Send(SearchEvent{
-						Results: fileMatchesToSearchResults(db, matches),
+					stream.SendMatches(SearchMatchEvent{
+						Results: fileMatchesToMatches(matches),
 						Stats:   stats,
 					})
 					return err

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -314,7 +314,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 			limitHit := event.FilesSkipped+event.ShardsSkipped > 0
 
 			if len(files) == 0 {
-				c.Send(SearchEvent{
+				c.SendMatches(SearchMatchEvent{
 					Stats: streaming.Stats{IsLimitHit: limitHit},
 				})
 				return
@@ -381,8 +381,8 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 				}
 			}
 
-			c.Send(SearchEvent{
-				Results: matches,
+			c.SendMatches(SearchMatchEvent{
+				Results: ResolversToMatches(matches),
 				Stats: streaming.Stats{
 					IsLimitHit: limitHit,
 				},
@@ -406,7 +406,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 	}
 
 	if !foundResults.Load() && since(t0) >= searchOpts.MaxWallTime {
-		c.Send(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
+		c.SendMatches(SearchMatchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
 		return nil
 	}
 	return nil

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -840,7 +840,7 @@ func limitUnindexedRepos(unindexed []*search.RepositoryRevisions, limit int, str
 		for _, r := range missing {
 			status.Update(r.Repo.ID, search.RepoStatusMissing)
 		}
-		stream.Send(SearchEvent{
+		stream.SendMatches(SearchMatchEvent{
 			Stats: streaming.Stats{
 				Status: status,
 			},

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -460,8 +460,8 @@ func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoek
 		resolvers = append(resolvers, NewRepositoryResolver(db, &types.Repo{Name: rev.Repo.Name, ID: rev.Repo.ID}))
 	}
 
-	c.Send(SearchEvent{
-		Results: resolvers,
+	c.SendMatches(SearchMatchEvent{
+		Results: ResolversToMatches(resolvers),
 		Stats:   streaming.Stats{}, // TODO
 	})
 	return nil

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -173,8 +173,8 @@ func TestDisplayLimit(t *testing.T) {
 			})
 
 			// Send 2 repository matches.
-			mock.c.Send(graphqlbackend.SearchEvent{
-				Results: []graphqlbackend.SearchResultResolver{mkRepoResolver(1), mkRepoResolver(2)},
+			mock.c.SendMatches(graphqlbackend.SearchMatchEvent{
+				Results: graphqlbackend.ResolversToMatches([]graphqlbackend.SearchResultResolver{mkRepoResolver(1), mkRepoResolver(2)}),
 			})
 			mock.Close()
 			if err := g.Wait(); err != nil {
@@ -224,7 +224,7 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 }
 
 func (h *mockSearchResolver) Send(r []graphqlbackend.SearchResultResolver) {
-	h.c.Send(graphqlbackend.SearchEvent{Results: r})
+	h.c.SendMatches(graphqlbackend.SearchMatchEvent{Results: graphqlbackend.ResolversToMatches(r)})
 }
 
 func (h *mockSearchResolver) Close() {


### PR DESCRIPTION
This replaces the remaining calls to `MatchSender.Send()` with `MatchSender.SendMatches()`
and removes `MatchSender.Send()`. 

Next step is to remove now-unused implementations of `MatchSender.Send()`.

Stacked on #20744 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
