### PR TITLE
Rename `MatchSender` to `Sender`

### DIFF
--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -48,7 +48,7 @@ type SearchArgs struct {
 	// allow us to stream out things like dynamic filters or take into account
 	// AND/OR. However, streaming is behind a feature flag for now, so this is
 	// to make it visible in the browser.
-	Stream MatchSender
+	Stream Sender
 
 	// For tests
 	Settings *schema.Settings
@@ -252,7 +252,7 @@ type searchResolver struct {
 	invalidateRepoCache bool // if true, invalidates the repo cache when evaluating search subexpressions.
 
 	// stream if non-nil will send all search events we receive down it.
-	stream MatchSender
+	stream Sender
 
 	// Cached resolveRepositories results. We use a pointer to the mutex so that we
 	// can copy the resolver, while sharing the mutex. If we didn't use a pointer,

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -708,7 +708,7 @@ type alertObserver struct {
 }
 
 // Update AlertObserver's state based on event.
-func (o *alertObserver) Update(event SearchMatchEvent) {
+func (o *alertObserver) Update(event SearchEvent) {
 	if len(event.Results) > 0 {
 		o.hasResults = true
 	}

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -318,7 +318,7 @@ func searchCommitsInRepoStream(ctx context.Context, db dbutil.DB, op search.Comm
 
 		// Only send if we have something to report back.
 		if len(results) > 0 || !stats.Zero() {
-			s.SendMatches(SearchMatchEvent{
+			s.SendMatches(SearchEvent{
 				Results: commitMatchesToMatches(results),
 				Stats:   stats,
 			})

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -266,7 +266,7 @@ func commitParametersToDiffParameters(ctx context.Context, db dbutil.DB, op *sea
 }
 
 // searchCommitsInRepoStream searches for commits based on op.
-func searchCommitsInRepoStream(ctx context.Context, db dbutil.DB, op search.CommitParameters, s MatchSender) (err error) {
+func searchCommitsInRepoStream(ctx context.Context, db dbutil.DB, op search.CommitParameters, s Sender) (err error) {
 	var timedOut, limitHit bool
 	resultCount := 0
 	tr, ctx := trace.New(ctx, "searchCommitsInRepo", fmt.Sprintf("repoRevs: %v, pattern %+v", op.RepoRevs, op.PatternInfo))
@@ -511,7 +511,7 @@ type searchCommitsInReposParameters struct {
 	// with the RepoRevs field set.
 	CommitParams search.CommitParameters
 
-	ResultChannel MatchSender
+	ResultChannel Sender
 }
 
 func searchCommitsInRepos(ctx context.Context, db dbutil.DB, args *search.TextParametersForCommitParameters, params searchCommitsInReposParameters) (err error) {
@@ -547,7 +547,7 @@ func searchCommitsInRepos(ctx context.Context, db dbutil.DB, args *search.TextPa
 }
 
 // searchCommitDiffsInRepos searches a set of repos for matching commit diffs.
-func searchCommitDiffsInRepos(ctx context.Context, db dbutil.DB, args *search.TextParametersForCommitParameters, resultChannel MatchSender) error {
+func searchCommitDiffsInRepos(ctx context.Context, db dbutil.DB, args *search.TextParametersForCommitParameters, resultChannel Sender) error {
 	return searchCommitsInRepos(ctx, db, args, searchCommitsInReposParameters{
 		TraceName:     "searchCommitDiffsInRepos",
 		ResultChannel: resultChannel,
@@ -560,7 +560,7 @@ func searchCommitDiffsInRepos(ctx context.Context, db dbutil.DB, args *search.Te
 }
 
 // searchCommitLogInRepos searches a set of repos for matching commits.
-func searchCommitLogInRepos(ctx context.Context, db dbutil.DB, args *search.TextParametersForCommitParameters, resultChannel MatchSender) error {
+func searchCommitLogInRepos(ctx context.Context, db dbutil.DB, args *search.TextParametersForCommitParameters, resultChannel Sender) error {
 	var terms []string
 	if args.PatternInfo.Pattern != "" {
 		terms = append(terms, args.PatternInfo.Pattern)

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -318,7 +318,7 @@ func searchCommitsInRepoStream(ctx context.Context, db dbutil.DB, op search.Comm
 
 		// Only send if we have something to report back.
 		if len(results) > 0 || !stats.Zero() {
-			s.SendMatches(SearchEvent{
+			s.Send(SearchEvent{
 				Results: commitMatchesToMatches(results),
 				Stats:   stats,
 			})

--- a/cmd/frontend/graphqlbackend/search_commits_test.go
+++ b/cmd/frontend/graphqlbackend/search_commits_test.go
@@ -305,7 +305,7 @@ func Benchmark_highlightMatches(b *testing.B) {
 // searchCommitsInRepo is a blocking version of searchCommitsInRepoStream.
 func searchCommitsInRepo(ctx context.Context, db dbutil.DB, op search.CommitParameters) (results []*CommitSearchResultResolver, limitHit, timedOut bool, err error) {
 	var matches []result.Match
-	err = searchCommitsInRepoStream(ctx, db, op, MatchStreamFunc(func(event SearchMatchEvent) {
+	err = searchCommitsInRepoStream(ctx, db, op, MatchStreamFunc(func(event SearchEvent) {
 		matches = append(matches, event.Results...)
 		timedOut = timedOut || event.Stats.Status.Any(search.RepoStatusTimedout)
 		limitHit = limitHit || event.Stats.Status.Any(search.RepoStatusLimitHit)

--- a/cmd/frontend/graphqlbackend/search_filters.go
+++ b/cmd/frontend/graphqlbackend/search_filters.go
@@ -68,7 +68,7 @@ var commonFileFilters = []struct {
 }
 
 // Update internal state for the results in event.
-func (s *SearchFilters) Update(event SearchMatchEvent) {
+func (s *SearchFilters) Update(event SearchEvent) {
 	// Initialize state on first call.
 	if s.filters == nil {
 		s.filters = make(streaming.Filters)

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -21,7 +21,7 @@ var mockSearchRepositories func(args *search.TextParameters) ([]result.Match, *s
 //
 // For a repository to match a query, the repository's name must match all of the repo: patterns AND the
 // default patterns (i.e., the patterns that are not prefixed with any search field).
-func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32, stream MatchSender) error {
+func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32, stream Sender) error {
 	if mockSearchRepositories != nil {
 		results, stats, err := mockSearchRepositories(args)
 		stream.SendMatches(SearchEvent{

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -24,7 +24,7 @@ var mockSearchRepositories func(args *search.TextParameters) ([]result.Match, *s
 func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32, stream MatchSender) error {
 	if mockSearchRepositories != nil {
 		results, stats, err := mockSearchRepositories(args)
-		stream.SendMatches(SearchMatchEvent{
+		stream.SendMatches(SearchEvent{
 			Results: results,
 			Stats:   statsDeref(stats),
 		})
@@ -93,14 +93,14 @@ func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextPara
 		if err != nil {
 			return err
 		}
-		stream.SendMatches(SearchMatchEvent{
+		stream.SendMatches(SearchEvent{
 			Results: repoRevsToRepoMatches(ctx, repos),
 		})
 		return nil
 	}
 
 	for repos := range results {
-		stream.SendMatches(SearchMatchEvent{
+		stream.SendMatches(SearchEvent{
 			Results: repoRevsToRepoMatches(ctx, repos),
 		})
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories.go
+++ b/cmd/frontend/graphqlbackend/search_repositories.go
@@ -24,7 +24,7 @@ var mockSearchRepositories func(args *search.TextParameters) ([]result.Match, *s
 func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32, stream Sender) error {
 	if mockSearchRepositories != nil {
 		results, stats, err := mockSearchRepositories(args)
-		stream.SendMatches(SearchEvent{
+		stream.Send(SearchEvent{
 			Results: results,
 			Stats:   statsDeref(stats),
 		})
@@ -93,14 +93,14 @@ func searchRepositories(ctx context.Context, db dbutil.DB, args *search.TextPara
 		if err != nil {
 			return err
 		}
-		stream.SendMatches(SearchEvent{
+		stream.Send(SearchEvent{
 			Results: repoRevsToRepoMatches(ctx, repos),
 		})
 		return nil
 	}
 
 	for repos := range results {
-		stream.SendMatches(SearchEvent{
+		stream.Send(SearchEvent{
 			Results: repoRevsToRepoMatches(ctx, repos),
 		})
 	}

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -128,7 +128,7 @@ func TestSearchRepositories(t *testing.T) {
 }
 
 func searchRepositoriesBatch(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32) ([]SearchResultResolver, streaming.Stats, error) {
-	return collectMatchStream(db, func(stream MatchSender) error {
+	return collectMatchStream(db, func(stream Sender) error {
 		return searchRepositories(ctx, db, args, limit, stream)
 	})
 }

--- a/cmd/frontend/graphqlbackend/search_repositories_test.go
+++ b/cmd/frontend/graphqlbackend/search_repositories_test.go
@@ -128,7 +128,7 @@ func TestSearchRepositories(t *testing.T) {
 }
 
 func searchRepositoriesBatch(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int32) ([]SearchResultResolver, streaming.Stats, error) {
-	return collectMatchStream(db, func(stream Sender) error {
+	return collectStream(db, func(stream Sender) error {
 		return searchRepositories(ctx, db, args, limit, stream)
 	})
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -468,7 +468,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 			result.Stats.IsLimitHit = true
 		}
 		if r.stream != nil {
-			r.stream.SendMatches(SearchEvent{
+			r.stream.Send(SearchEvent{
 				Results: ResolversToMatches(result.SearchResults),
 				Stats:   result.Stats,
 			})
@@ -853,7 +853,7 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 		r.stream = nil // Disables streaming: backends may not use the endpoint.
 		srr, err := r.resultsBatch(ctx)
 		if srr != nil {
-			endpoint.SendMatches(SearchEvent{
+			endpoint.Send(SearchEvent{
 				Results: ResolversToMatches(srr.SearchResults),
 				Stats:   srr.Stats,
 			})
@@ -1364,9 +1364,9 @@ func (a *aggregator) get() ([]SearchResultResolver, streaming.Stats, *searchAler
 	return MatchesToResolvers(a.db, a.results), a.stats, alert, err
 }
 
-func (a *aggregator) SendMatches(event SearchEvent) {
+func (a *aggregator) Send(event SearchEvent) {
 	if a.parentStream != nil {
-		a.parentStream.SendMatches(event)
+		a.parentStream.Send(event)
 	}
 
 	a.mu.Lock()
@@ -1446,7 +1446,7 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 		}
 	}
 
-	a.SendMatches(SearchEvent{
+	a.Send(SearchEvent{
 		Results: fileMatchResolversToMatches(fileResults),
 		Stats:   stats,
 	})
@@ -1659,7 +1659,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 			repos[repoRev.Repo.ID] = repoRev.Repo
 		}
 
-		agg.SendMatches(SearchEvent{
+		agg.Send(SearchEvent{
 			Stats: streaming.Stats{
 				Repos:            repos,
 				ExcludedForks:    resolved.ExcludedRepos.Forks,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -183,10 +183,10 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 	filters := SearchFilters{
 		Globbing: globbing,
 	}
-	filters.Update(SearchEventToSearchMatchEvent(SearchEvent{
-		Results: sr.SearchResults,
+	filters.Update(SearchMatchEvent{
+		Results: ResolversToMatches(sr.SearchResults),
 		Stats:   sr.Stats,
-	}))
+	})
 
 	var resolvers []*searchFilterResolver
 	for _, f := range filters.Compute() {
@@ -1379,10 +1379,6 @@ func (a *aggregator) SendMatches(event SearchMatchEvent) {
 
 	a.alert.Update(event)
 	a.stats.Update(&event.Stats)
-}
-
-func (a *aggregator) Send(event SearchEvent) {
-	a.SendMatches(SearchEventToSearchMatchEvent(event))
 }
 
 func (a *aggregator) error(ctx context.Context, err error) {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1334,7 +1334,7 @@ func checkDiffCommitSearchLimits(ctx context.Context, args *search.TextParameter
 	return nil
 }
 
-func newAggregator(db dbutil.DB, stream MatchSender, inputs *SearchInputs) *aggregator {
+func newAggregator(db dbutil.DB, stream Sender, inputs *SearchInputs) *aggregator {
 	return &aggregator{
 		db:           db,
 		parentStream: stream,
@@ -1345,7 +1345,7 @@ func newAggregator(db dbutil.DB, stream MatchSender, inputs *SearchInputs) *aggr
 }
 
 type aggregator struct {
-	parentStream MatchSender
+	parentStream Sender
 	db           dbutil.DB
 
 	mu      sync.Mutex

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -183,7 +183,7 @@ func (sr *SearchResultsResolver) DynamicFilters(ctx context.Context) []*searchFi
 	filters := SearchFilters{
 		Globbing: globbing,
 	}
-	filters.Update(SearchMatchEvent{
+	filters.Update(SearchEvent{
 		Results: ResolversToMatches(sr.SearchResults),
 		Stats:   sr.Stats,
 	})
@@ -468,7 +468,7 @@ func (r *searchResolver) evaluateLeaf(ctx context.Context) (_ *SearchResultsReso
 			result.Stats.IsLimitHit = true
 		}
 		if r.stream != nil {
-			r.stream.SendMatches(SearchMatchEvent{
+			r.stream.SendMatches(SearchEvent{
 				Results: ResolversToMatches(result.SearchResults),
 				Stats:   result.Stats,
 			})
@@ -853,7 +853,7 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 		r.stream = nil // Disables streaming: backends may not use the endpoint.
 		srr, err := r.resultsBatch(ctx)
 		if srr != nil {
-			endpoint.SendMatches(SearchMatchEvent{
+			endpoint.SendMatches(SearchEvent{
 				Results: ResolversToMatches(srr.SearchResults),
 				Stats:   srr.Stats,
 			})
@@ -1364,7 +1364,7 @@ func (a *aggregator) get() ([]SearchResultResolver, streaming.Stats, *searchAler
 	return MatchesToResolvers(a.db, a.results), a.stats, alert, err
 }
 
-func (a *aggregator) SendMatches(event SearchMatchEvent) {
+func (a *aggregator) SendMatches(event SearchEvent) {
 	if a.parentStream != nil {
 		a.parentStream.SendMatches(event)
 	}
@@ -1446,7 +1446,7 @@ func (a *aggregator) doFilePathSearch(ctx context.Context, args *search.TextPara
 		}
 	}
 
-	a.SendMatches(SearchMatchEvent{
+	a.SendMatches(SearchEvent{
 		Results: fileMatchResolversToMatches(fileResults),
 		Stats:   stats,
 	})
@@ -1659,7 +1659,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 			repos[repoRev.Repo.ID] = repoRev.Repo
 		}
 
-		agg.SendMatches(SearchMatchEvent{
+		agg.SendMatches(SearchEvent{
 			Stats: streaming.Stats{
 				Repos:            repos,
 				ExcludedForks:    resolved.ExcludedRepos.Forks,

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -144,9 +144,9 @@ func (f MatchStreamFunc) Send(se SearchEvent) {
 	f(se)
 }
 
-// collectMatchStream will call search and aggregates all events it sends. It then
+// collectStream will call search and aggregates all events it sends. It then
 // returns the aggregate event and any error it returns.
-func collectMatchStream(db dbutil.DB, search func(Sender) error) ([]SearchResultResolver, streaming.Stats, error) {
+func collectStream(db dbutil.DB, search func(Sender) error) ([]SearchResultResolver, streaming.Stats, error) {
 	var (
 		mu      sync.Mutex
 		results []result.Match

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -368,7 +368,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		fileMatches, _, err := collectMatchStream(r.db, func(stream Sender) error {
+		fileMatches, _, err := collectStream(r.db, func(stream Sender) error {
 			return searchSymbols(ctx, r.db, &search.TextParameters{
 				PatternInfo:  p,
 				RepoPromise:  (&search.Promise{}).Resolve(resolved.RepoRevs),

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -368,7 +368,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		fileMatches, _, err := collectMatchStream(r.db, func(stream MatchSender) error {
+		fileMatches, _, err := collectMatchStream(r.db, func(stream Sender) error {
 			return searchSymbols(ctx, r.db, &search.TextParameters{
 				PatternInfo:  p,
 				RepoPromise:  (&search.Promise{}).Resolve(resolved.RepoRevs),

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -30,7 +30,7 @@ var mockSearchSymbols func(ctx context.Context, args *search.TextParameters, lim
 func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int, stream Sender) (err error) {
 	if mockSearchSymbols != nil {
 		results, stats, err := mockSearchSymbols(ctx, args, limit)
-		stream.SendMatches(SearchEvent{
+		stream.Send(SearchEvent{
 			Results: fileMatchResolversToMatches(results),
 			Stats:   statsDeref(stats),
 		})
@@ -91,7 +91,7 @@ func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameter
 
 			matches, err := searchSymbolsInRepo(ctx, repoRevs, args.PatternInfo, limit)
 			stats, err := handleRepoSearchResult(repoRevs, len(matches) > limit, false, err)
-			stream.SendMatches(SearchEvent{
+			stream.Send(SearchEvent{
 				Results: fileMatchesToMatches(matches),
 				Stats:   stats,
 			})

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -27,7 +27,7 @@ var mockSearchSymbols func(ctx context.Context, args *search.TextParameters, lim
 // it can be used for both search suggestions and search results
 //
 // May return partial results and an error
-func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int, stream MatchSender) (err error) {
+func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int, stream Sender) (err error) {
 	if mockSearchSymbols != nil {
 		results, stats, err := mockSearchSymbols(ctx, args, limit)
 		stream.SendMatches(SearchEvent{

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -30,7 +30,7 @@ var mockSearchSymbols func(ctx context.Context, args *search.TextParameters, lim
 func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameters, limit int, stream MatchSender) (err error) {
 	if mockSearchSymbols != nil {
 		results, stats, err := mockSearchSymbols(ctx, args, limit)
-		stream.SendMatches(SearchMatchEvent{
+		stream.SendMatches(SearchEvent{
 			Results: fileMatchResolversToMatches(results),
 			Stats:   statsDeref(stats),
 		})
@@ -91,7 +91,7 @@ func searchSymbols(ctx context.Context, db dbutil.DB, args *search.TextParameter
 
 			matches, err := searchSymbolsInRepo(ctx, repoRevs, args.PatternInfo, limit)
 			stats, err := handleRepoSearchResult(repoRevs, len(matches) > limit, false, err)
-			stream.SendMatches(SearchMatchEvent{
+			stream.SendMatches(SearchEvent{
 				Results: fileMatchesToMatches(matches),
 				Stats:   stats,
 			})

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -306,7 +306,7 @@ func searchResultsToFileMatchResults(resolvers []SearchResultResolver) ([]*FileM
 // searchFilesInRepoBatch is a convenience function around searchFilesInRepos
 // which collects the results from the stream.
 func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.TextParameters) ([]*FileMatchResolver, streaming.Stats, error) {
-	results, stats, err := collectMatchStream(db, func(stream Sender) error {
+	results, stats, err := collectStream(db, func(stream Sender) error {
 		return searchFilesInRepos(ctx, db, args, stream)
 	})
 	fms, fmErr := searchResultsToFileMatchResults(results)

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -320,7 +320,7 @@ func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.Tex
 func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream MatchSender) (err error) {
 	if mockSearchFilesInRepos != nil {
 		results, mockStats, err := mockSearchFilesInRepos(args)
-		stream.SendMatches(SearchMatchEvent{
+		stream.SendMatches(SearchEvent{
 			Results: fileMatchResolversToMatches(results),
 			Stats:   statsDeref(mockStats),
 		})
@@ -473,7 +473,7 @@ func callSearcherOverRepos(
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
 					stats, err := handleRepoSearchResult(repoRev, repoLimitHit, false, err)
-					stream.SendMatches(SearchMatchEvent{
+					stream.SendMatches(SearchEvent{
 						Results: fileMatchesToMatches(matches),
 						Stats:   stats,
 					})

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -306,7 +306,7 @@ func searchResultsToFileMatchResults(resolvers []SearchResultResolver) ([]*FileM
 // searchFilesInRepoBatch is a convenience function around searchFilesInRepos
 // which collects the results from the stream.
 func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.TextParameters) ([]*FileMatchResolver, streaming.Stats, error) {
-	results, stats, err := collectMatchStream(db, func(stream MatchSender) error {
+	results, stats, err := collectMatchStream(db, func(stream Sender) error {
 		return searchFilesInRepos(ctx, db, args, stream)
 	})
 	fms, fmErr := searchResultsToFileMatchResults(results)
@@ -317,7 +317,7 @@ func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.Tex
 }
 
 // searchFilesInRepos searches a set of repos for a pattern.
-func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream MatchSender) (err error) {
+func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream Sender) (err error) {
 	if mockSearchFilesInRepos != nil {
 		results, mockStats, err := mockSearchFilesInRepos(args)
 		stream.SendMatches(SearchEvent{
@@ -398,7 +398,7 @@ func callSearcherOverRepos(
 	ctx context.Context,
 	db dbutil.DB,
 	args *search.TextParameters,
-	stream MatchSender,
+	stream Sender,
 	searcherRepos []*search.RepositoryRevisions,
 	index bool,
 ) (err error) {

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -320,7 +320,7 @@ func searchFilesInReposBatch(ctx context.Context, db dbutil.DB, args *search.Tex
 func searchFilesInRepos(ctx context.Context, db dbutil.DB, args *search.TextParameters, stream Sender) (err error) {
 	if mockSearchFilesInRepos != nil {
 		results, mockStats, err := mockSearchFilesInRepos(args)
-		stream.SendMatches(SearchEvent{
+		stream.Send(SearchEvent{
 			Results: fileMatchResolversToMatches(results),
 			Stats:   statsDeref(mockStats),
 		})
@@ -473,7 +473,7 @@ func callSearcherOverRepos(
 					}
 					// non-diff search reports timeout through err, so pass false for timedOut
 					stats, err := handleRepoSearchResult(repoRev, repoLimitHit, false, err)
-					stream.SendMatches(SearchEvent{
+					stream.Send(SearchEvent{
 						Results: fileMatchesToMatches(matches),
 						Stats:   stats,
 					})

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -314,7 +314,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 			limitHit := event.FilesSkipped+event.ShardsSkipped > 0
 
 			if len(files) == 0 {
-				c.SendMatches(SearchEvent{
+				c.Send(SearchEvent{
 					Stats: streaming.Stats{IsLimitHit: limitHit},
 				})
 				return
@@ -381,7 +381,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 				}
 			}
 
-			c.SendMatches(SearchEvent{
+			c.Send(SearchEvent{
 				Results: ResolversToMatches(matches),
 				Stats: streaming.Stats{
 					IsLimitHit: limitHit,
@@ -406,7 +406,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 	}
 
 	if !foundResults.Load() && since(t0) >= searchOpts.MaxWallTime {
-		c.SendMatches(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
+		c.Send(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
 		return nil
 	}
 	return nil
@@ -460,7 +460,7 @@ func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoek
 		resolvers = append(resolvers, NewRepositoryResolver(db, &types.Repo{Name: rev.Repo.Name, ID: rev.Repo.ID}))
 	}
 
-	c.SendMatches(SearchEvent{
+	c.Send(SearchEvent{
 		Results: ResolversToMatches(resolvers),
 		Stats:   streaming.Stats{}, // TODO
 	})
@@ -840,7 +840,7 @@ func limitUnindexedRepos(unindexed []*search.RepositoryRevisions, limit int, str
 		for _, r := range missing {
 			status.Update(r.Repo.ID, search.RepoStatusMissing)
 		}
-		stream.SendMatches(SearchEvent{
+		stream.Send(SearchEvent{
 			Stats: streaming.Stats{
 				Status: status,
 			},

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -72,7 +72,7 @@ type indexedSearchRequest struct {
 	db dbutil.DB
 }
 
-func newIndexedSearchRequest(ctx context.Context, db dbutil.DB, args *search.TextParameters, typ indexedRequestType, stream MatchSender) (_ *indexedSearchRequest, err error) {
+func newIndexedSearchRequest(ctx context.Context, db dbutil.DB, args *search.TextParameters, typ indexedRequestType, stream Sender) (_ *indexedSearchRequest, err error) {
 	tr, ctx := trace.New(ctx, "newIndexedSearchRequest", string(typ))
 	tr.LogFields(trace.Stringer("global_search_mode", args.Mode))
 	defer func() {
@@ -182,7 +182,7 @@ func (s *indexedSearchRequest) Repos() map[string]*search.RepositoryRevisions {
 }
 
 // Search streams 0 or more events to c.
-func (s *indexedSearchRequest) Search(ctx context.Context, c MatchSender) error {
+func (s *indexedSearchRequest) Search(ctx context.Context, c Sender) error {
 	if s.args == nil {
 		return nil
 	}
@@ -203,7 +203,7 @@ func (s *indexedSearchRequest) Search(ctx context.Context, c MatchSender) error 
 // Timeouts are reported through the context, and as a special case errNoResultsInTimeout
 // is returned if no results are found in the given timeout (instead of the more common
 // case of finding partial or full results in the given timeout).
-func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration, c MatchSender) error {
+func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters, repos *indexedRepoRevs, typ indexedRequestType, since func(t time.Time) time.Duration, c Sender) error {
 	if args == nil {
 		return nil
 	}
@@ -439,7 +439,7 @@ func bufferedSender(cap int, sender zoekt.Sender) (zoekt.Sender, func()) {
 // zoektSearchReposOnly is used when select:repo is set, in which case we can ask zoekt
 // only for the repos that contain matches for the query. This is a performance optimization,
 // and not required for proper function of select:repo.
-func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoektquery.Q, db dbutil.DB, c MatchSender, getRepoRevMap func() map[string]*search.RepositoryRevisions) error {
+func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoektquery.Q, db dbutil.DB, c Sender, getRepoRevMap func() map[string]*search.RepositoryRevisions) error {
 	repoList, err := client.List(ctx, query)
 	if err != nil {
 		return err
@@ -823,7 +823,7 @@ func (rb *indexedRepoRevs) GetRepoInputRev(file *zoekt.FileMatch) (repo types.Re
 // excluded.
 //
 // A slice to the input list is returned, it is not copied.
-func limitUnindexedRepos(unindexed []*search.RepositoryRevisions, limit int, stream MatchSender) []*search.RepositoryRevisions {
+func limitUnindexedRepos(unindexed []*search.RepositoryRevisions, limit int, stream Sender) []*search.RepositoryRevisions {
 	var missing []*search.RepositoryRevisions
 
 	for i, repoRevs := range unindexed {

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -314,7 +314,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 			limitHit := event.FilesSkipped+event.ShardsSkipped > 0
 
 			if len(files) == 0 {
-				c.SendMatches(SearchMatchEvent{
+				c.SendMatches(SearchEvent{
 					Stats: streaming.Stats{IsLimitHit: limitHit},
 				})
 				return
@@ -381,7 +381,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 				}
 			}
 
-			c.SendMatches(SearchMatchEvent{
+			c.SendMatches(SearchEvent{
 				Results: ResolversToMatches(matches),
 				Stats: streaming.Stats{
 					IsLimitHit: limitHit,
@@ -406,7 +406,7 @@ func zoektSearch(ctx context.Context, db dbutil.DB, args *search.TextParameters,
 	}
 
 	if !foundResults.Load() && since(t0) >= searchOpts.MaxWallTime {
-		c.SendMatches(SearchMatchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
+		c.SendMatches(SearchEvent{Stats: streaming.Stats{Status: mkStatusMap(search.RepoStatusTimedout)}})
 		return nil
 	}
 	return nil
@@ -460,7 +460,7 @@ func zoektSearchReposOnly(ctx context.Context, client zoekt.Streamer, query zoek
 		resolvers = append(resolvers, NewRepositoryResolver(db, &types.Repo{Name: rev.Repo.Name, ID: rev.Repo.ID}))
 	}
 
-	c.SendMatches(SearchMatchEvent{
+	c.SendMatches(SearchEvent{
 		Results: ResolversToMatches(resolvers),
 		Stats:   streaming.Stats{}, // TODO
 	})
@@ -840,7 +840,7 @@ func limitUnindexedRepos(unindexed []*search.RepositoryRevisions, limit int, str
 		for _, r := range missing {
 			status.Update(r.Repo.ID, search.RepoStatusMissing)
 		}
-		stream.SendMatches(SearchMatchEvent{
+		stream.SendMatches(SearchEvent{
 			Stats: streaming.Stats{
 				Status: status,
 			},

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -296,7 +296,7 @@ func TestIndexedSearch(t *testing.T) {
 			// This is a quick fix which will break once we enable the zoekt client for true streaming.
 			// Once we return more than one event we have to account for the proper order of results
 			// in the tests.
-			gotResults, gotCommon, err := collectMatchStream(db, func(stream Sender) error {
+			gotResults, gotCommon, err := collectStream(db, func(stream Sender) error {
 				return indexed.Search(tt.args.ctx, stream)
 			})
 			if (err != nil) != tt.wantErr {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -296,7 +296,7 @@ func TestIndexedSearch(t *testing.T) {
 			// This is a quick fix which will break once we enable the zoekt client for true streaming.
 			// Once we return more than one event we have to account for the proper order of results
 			// in the tests.
-			gotResults, gotCommon, err := collectMatchStream(db, func(stream MatchSender) error {
+			gotResults, gotCommon, err := collectMatchStream(db, func(stream Sender) error {
 				return indexed.Search(tt.args.ctx, stream)
 			})
 			if (err != nil) != tt.wantErr {

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -282,7 +282,7 @@ func TestIndexedSearch(t *testing.T) {
 				},
 			}
 
-			indexed, err := newIndexedSearchRequest(context.Background(), db, args, textRequest, MatchStreamFunc(func(SearchMatchEvent) {}))
+			indexed, err := newIndexedSearchRequest(context.Background(), db, args, textRequest, MatchStreamFunc(func(SearchEvent) {}))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/cmd/frontend/internal/search/progress.go
+++ b/cmd/frontend/internal/search/progress.go
@@ -23,7 +23,7 @@ type progressAggregator struct {
 	Dirty bool
 }
 
-func (p *progressAggregator) Update(event graphqlbackend.SearchMatchEvent) {
+func (p *progressAggregator) Update(event graphqlbackend.SearchEvent) {
 	if len(event.Results) == 0 && event.Stats.Zero() {
 		return
 	}

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -158,7 +158,7 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	first := true
 
 	for {
-		var event graphqlbackend.SearchMatchEvent
+		var event graphqlbackend.SearchEvent
 		var ok bool
 		select {
 		case event, ok = <-events:
@@ -276,8 +276,8 @@ func (h *streamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // startSearch will start a search. It returns the events channel which
 // streams out search events. Once events is closed you can call results which
 // will return the results resolver and error.
-func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan graphqlbackend.SearchMatchEvent, inputs graphqlbackend.SearchInputs, results func() (*graphqlbackend.SearchResultsResolver, error)) {
-	eventsC := make(chan graphqlbackend.SearchMatchEvent)
+func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan graphqlbackend.SearchEvent, inputs graphqlbackend.SearchInputs, results func() (*graphqlbackend.SearchResultsResolver, error)) {
+	eventsC := make(chan graphqlbackend.SearchEvent)
 
 	search, err := h.newSearchResolver(ctx, h.db, &graphqlbackend.SearchArgs{
 		Query:          a.Query,
@@ -285,7 +285,7 @@ func (h *streamHandler) startSearch(ctx context.Context, a *args) (events <-chan
 		PatternType:    strPtr(a.PatternType),
 		VersionContext: strPtr(a.VersionContext),
 
-		Stream: graphqlbackend.MatchStreamFunc(func(event graphqlbackend.SearchMatchEvent) {
+		Stream: graphqlbackend.MatchStreamFunc(func(event graphqlbackend.SearchEvent) {
 			eventsC <- event
 		}),
 	})

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -173,7 +173,7 @@ func TestDisplayLimit(t *testing.T) {
 			})
 
 			// Send 2 repository matches.
-			mock.c.SendMatches(graphqlbackend.SearchEvent{
+			mock.c.Send(graphqlbackend.SearchEvent{
 				Results: graphqlbackend.ResolversToMatches([]graphqlbackend.SearchResultResolver{mkRepoResolver(1), mkRepoResolver(2)}),
 			})
 			mock.Close()
@@ -224,7 +224,7 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 }
 
 func (h *mockSearchResolver) Send(r []graphqlbackend.SearchResultResolver) {
-	h.c.SendMatches(graphqlbackend.SearchEvent{Results: graphqlbackend.ResolversToMatches(r)})
+	h.c.Send(graphqlbackend.SearchEvent{Results: graphqlbackend.ResolversToMatches(r)})
 }
 
 func (h *mockSearchResolver) Close() {

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -173,7 +173,7 @@ func TestDisplayLimit(t *testing.T) {
 			})
 
 			// Send 2 repository matches.
-			mock.c.SendMatches(graphqlbackend.SearchMatchEvent{
+			mock.c.SendMatches(graphqlbackend.SearchEvent{
 				Results: graphqlbackend.ResolversToMatches([]graphqlbackend.SearchResultResolver{mkRepoResolver(1), mkRepoResolver(2)}),
 			})
 			mock.Close()
@@ -224,7 +224,7 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 }
 
 func (h *mockSearchResolver) Send(r []graphqlbackend.SearchResultResolver) {
-	h.c.SendMatches(graphqlbackend.SearchMatchEvent{Results: graphqlbackend.ResolversToMatches(r)})
+	h.c.SendMatches(graphqlbackend.SearchEvent{Results: graphqlbackend.ResolversToMatches(r)})
 }
 
 func (h *mockSearchResolver) Close() {

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -208,7 +208,7 @@ func mkRepoResolver(id int) *graphqlbackend.RepositoryResolver {
 
 type mockSearchResolver struct {
 	done   chan struct{}
-	c      graphqlbackend.MatchSender
+	c      graphqlbackend.Sender
 	inputs *graphqlbackend.SearchInputs
 }
 


### PR DESCRIPTION
And `SendMatches` to `Send`
And `SearchMatchEvent` to `SearchEvent`
And `collectMatchStream` to `collectStream`
And remove now-unneeded conversion functions and old sender types.

Stacked on #20744 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
