### PR TITLE
extensibility: fix large diffs on GitHub

### DIFF
--- a/client/browser/src/shared/code-hosts/github/codeHost.ts
+++ b/client/browser/src/shared/code-hosts/github/codeHost.ts
@@ -16,7 +16,7 @@ import {
 } from '@sourcegraph/shared/src/util/url'
 
 import { fetchBlobContentLines } from '../../repo/backend'
-import { querySelectorOrSelf } from '../../util/dom'
+import { querySelectorAllOrSelf, querySelectorOrSelf } from '../../util/dom'
 import { CodeHost, MountGetter } from '../shared/codeHost'
 import { CodeView, toCodeViewResolver } from '../shared/codeViews'
 import { NativeTooltip } from '../shared/nativeTooltips'
@@ -204,7 +204,31 @@ export const fileLineContainerResolver: ViewResolver<CodeView> = {
 }
 
 const genericCodeViewResolver: ViewResolver<CodeView> = {
-    selector: '.file',
+    selector: target => {
+        const codeViews: HTMLElement[] = []
+
+        // Logic to support large diffs that are loaded asynchronously:
+        // https://github.com/sourcegraph/sourcegraph/issues/18337
+        // - Don't return `.file` elements that have yet to be loaded (loading is triggered by user)
+        // - When the user triggers diff loading, the mutation observer will tell us about
+        // .js-blob-wrapper, since the actual '.file' has been in the DOM the whole time. Return
+        // the closest ancestor '.file'
+
+        for (const file of querySelectorAllOrSelf<HTMLElement>(target, '.file')) {
+            if (file.querySelectorAll('.js-diff-load-container').length === 0) {
+                codeViews.push(file)
+            }
+        }
+
+        for (const blobWrapper of querySelectorAllOrSelf(target, '.js-blob-wrapper')) {
+            const file = blobWrapper.closest('.file')
+            if (file instanceof HTMLElement) {
+                codeViews.push(file)
+            }
+        }
+
+        return codeViews
+    },
     resolveView: (element: HTMLElement): CodeView | null => {
         if (element.querySelector('article.markdown-body')) {
             // This code view is rendered markdown, we shouldn't add code intelligence

--- a/client/browser/src/shared/code-hosts/github/domFunctions.ts
+++ b/client/browser/src/shared/code-hosts/github/domFunctions.ts
@@ -76,10 +76,6 @@ const getDiffCodeCellFromLineNumber = (
     line: number,
     part?: DiffPart
 ): HTMLTableCellElement | null => {
-    if (codeView.querySelector('.js-diff-load-container')) {
-        // Diff is collapsed
-        return null
-    }
     const isSplitDiff = isDomSplitDiff(codeView)
     const nthChild = getLineNumberElementIndex(part!, isSplitDiff) + 1 // nth-child() is 1-indexed
     const lineNumberCell = codeView.querySelector<HTMLTableCellElement>(


### PR DESCRIPTION
Fix #18337. We previously injected extension features to all diff code views, but many of them (very large diffs) aren't loaded initially. Now, we discard code views that haven't loaded yet, and inject functionality into large diffs on load.