### PR TITLE
Return matches from collectStream

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -260,19 +260,23 @@ func paginatedSearchFilesInRepos(ctx context.Context, db dbutil.DB, args *search
 	return plan.execute(ctx, database.Repos(db), func(batch []*search.RepositoryRevisions) ([]SearchResultResolver, *streaming.Stats, error) {
 		batchArgs := *args
 		batchArgs.RepoPromise = (&search.Promise{}).Resolve(batch)
-		fileResults, fileCommon, err := searchFilesInReposBatch(ctx, db, &batchArgs)
+		fileMatches, fileCommon, err := searchFilesInReposBatch(ctx, db, &batchArgs)
 		// Timeouts are reported through Stats so don't report an error for them
 		if err != nil && !(err == context.DeadlineExceeded || err == context.Canceled) {
 			return nil, nil, err
 		}
 		// fileResults is not sorted so we must sort it now. fileCommon may or
 		// may not be sorted, but we do not rely on its order.
-		sort.Slice(fileResults, func(i, j int) bool {
-			return fileResults[i].FileMatch.Key().Less(fileResults[j].FileMatch.Key())
+		sort.Slice(fileMatches, func(i, j int) bool {
+			return fileMatches[i].Key().Less(fileMatches[j].Key())
 		})
-		results := make([]SearchResultResolver, 0, len(fileResults))
-		for _, r := range fileResults {
-			results = append(results, r)
+		results := make([]SearchResultResolver, 0, len(fileMatches))
+		for _, match := range fileMatches {
+			results = append(results, &FileMatchResolver{
+				FileMatch:    *match,
+				db:           db,
+				RepoResolver: NewRepositoryResolver(db, match.Repo.ToRepo()),
+			})
 		}
 		return results, &fileCommon, nil
 	})

--- a/cmd/frontend/graphqlbackend/search_stream.go
+++ b/cmd/frontend/graphqlbackend/search_stream.go
@@ -159,7 +159,7 @@ func (f MatchStreamFunc) Send(se SearchEvent) {
 
 // collectStream will call search and aggregates all events it sends. It then
 // returns the aggregate event and any error it returns.
-func collectStream(db dbutil.DB, search func(Sender) error) ([]SearchResultResolver, streaming.Stats, error) {
+func collectStream(search func(Sender) error) ([]result.Match, streaming.Stats, error) {
 	var (
 		mu      sync.Mutex
 		results []result.Match
@@ -173,5 +173,5 @@ func collectStream(db dbutil.DB, search func(Sender) error) ([]SearchResultResol
 		mu.Unlock()
 	}))
 
-	return MatchesToResolvers(db, results), stats, err
+	return results, stats, err
 }

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -368,7 +368,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 		defer cancel()
 
-		fileMatches, _, err := collectStream(r.db, func(stream Sender) error {
+		fileMatches, _, err := collectStream(func(stream Sender) error {
 			return searchSymbols(ctx, &search.TextParameters{
 				PatternInfo:  p,
 				RepoPromise:  (&search.Promise{}).Resolve(resolved.RepoRevs),
@@ -383,33 +383,42 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 
 		results = make([]SearchSuggestionResolver, 0)
 		for _, match := range fileMatches {
-			fileMatch, ok := match.ToFileMatch()
+			fileMatch, ok := match.(*result.FileMatch)
 			if !ok {
 				continue
 			}
-			for _, sr := range fileMatch.Symbols() {
+			for _, sm := range fileMatch.Symbols {
 				score := 20
-				if sr.Symbol.Parent == "" {
+				if sm.Symbol.Parent == "" {
 					score++
 				}
-				if len(sr.Symbol.Name) < 12 {
+				if len(sm.Symbol.Name) < 12 {
 					score++
 				}
-				switch sr.Symbol.LSPKind() {
+				switch sm.Symbol.LSPKind() {
 				case lsp.SKFunction, lsp.SKMethod:
 					score += 2
 				case lsp.SKClass:
 					score += 3
 				}
-				repoName := strings.ToLower(string(sr.File.Repo.Name))
-				fileName := strings.ToLower(sr.File.Path)
-				symbolName := strings.ToLower(sr.Symbol.Name)
-				if len(sr.Symbol.Name) >= 4 && strings.Contains(repoName+fileName, symbolName) {
+				repoName := strings.ToLower(string(sm.File.Repo.Name))
+				fileName := strings.ToLower(sm.File.Path)
+				symbolName := strings.ToLower(sm.Symbol.Name)
+				if len(sm.Symbol.Name) >= 4 && strings.Contains(repoName+fileName, symbolName) {
 					score++
 				}
 				results = append(results, symbolSuggestionResolver{
-					symbol: sr,
-					score:  score,
+					symbol: symbolResolver{
+						db: r.db,
+						commit: toGitCommitResolver(
+							NewRepositoryResolver(r.db, fileMatch.Repo.ToRepo()),
+							r.db,
+							fileMatch.CommitID,
+							nil,
+						),
+						SymbolMatch: sm,
+					},
+					score: score,
 				})
 			}
 		}

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -96,12 +96,12 @@ func TestSearchFilesInRepos(t *testing.T) {
 		Zoekt:        zoekt,
 		SearcherURLs: endpoint.Static("test"),
 	}
-	results, common, err := searchFilesInReposBatch(context.Background(), db, args)
+	matches, common, err := searchFilesInReposBatch(context.Background(), db, args)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 2 {
-		t.Errorf("expected two results, got %d", len(results))
+	if len(matches) != 2 {
+		t.Errorf("expected two results, got %d", len(matches))
 	}
 	repoNames := map[api.RepoID]string{}
 	for _, rr := range repoRevs {
@@ -186,13 +186,13 @@ func TestSearchFilesInReposStream(t *testing.T) {
 		SearcherURLs: endpoint.Static("test"),
 	}
 
-	results, _, err := searchFilesInReposBatch(context.Background(), db, args)
+	matches, _, err := searchFilesInReposBatch(context.Background(), db, args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(results) != 3 {
-		t.Errorf("expected three results, got %d", len(results))
+	if len(matches) != 3 {
+		t.Errorf("expected three results, got %d", len(matches))
 	}
 }
 
@@ -265,16 +265,16 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 	repos[0].ListRefs = func(context.Context, api.RepoName) ([]git.Ref, error) {
 		return []git.Ref{{Name: "refs/heads/branch3"}, {Name: "refs/heads/branch4"}}, nil
 	}
-	results, _, err := searchFilesInReposBatch(context.Background(), db, args)
+	matches, _, err := searchFilesInReposBatch(context.Background(), db, args)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	resultKeys := make([]result.Key, len(results))
-	for i, result := range results {
-		resultKeys[i] = result.FileMatch.Key()
+	matchKeys := make([]result.Key, len(matches))
+	for i, match := range matches {
+		matchKeys[i] = match.Key()
 	}
-	sort.Slice(resultKeys, func(i, j int) bool { return resultKeys[i].Less(resultKeys[j]) })
+	sort.Slice(matchKeys, func(i, j int) bool { return matchKeys[i].Less(matchKeys[j]) })
 
 	wantResultKeys := []result.Key{
 		{Repo: "foo", Commit: "branch3", Path: "main.go"},
@@ -282,8 +282,8 @@ func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
 		{Repo: "foo", Commit: "master", Path: "main.go"},
 		{Repo: "foo", Commit: "mybranch", Path: "main.go"},
 	}
-	if !reflect.DeepEqual(resultKeys, wantResultKeys) {
-		t.Errorf("got %v, want %v", resultKeys, wantResultKeys)
+	if !reflect.DeepEqual(matchKeys, wantResultKeys) {
+		t.Errorf("got %v, want %v", matchKeys, wantResultKeys)
 	}
 }
 

--- a/cmd/frontend/graphqlbackend/zoekt_test.go
+++ b/cmd/frontend/graphqlbackend/zoekt_test.go
@@ -35,8 +35,6 @@ import (
 )
 
 func TestIndexedSearch(t *testing.T) {
-	db := new(dbtesting.MockDB)
-
 	zeroTimeoutCtx, cancel := context.WithTimeout(context.Background(), 0)
 	defer cancel()
 	type args struct {
@@ -296,14 +294,15 @@ func TestIndexedSearch(t *testing.T) {
 			// This is a quick fix which will break once we enable the zoekt client for true streaming.
 			// Once we return more than one event we have to account for the proper order of results
 			// in the tests.
-			gotResults, gotCommon, err := collectStream(db, func(stream Sender) error {
+			gotMatches, gotCommon, err := collectStream(func(stream Sender) error {
 				return indexed.Search(tt.args.ctx, stream)
 			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("zoektSearchHEAD() error = %v, wantErr = %v", err, tt.wantErr)
 				return
 			}
-			gotFm, err := searchResultsToFileMatchResults(gotResults)
+
+			gotFm, err := matchesToFileMatches(gotMatches)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -316,8 +315,8 @@ func TestIndexedSearch(t *testing.T) {
 			var gotMatchKeys []result.Key
 			var gotMatchInputRevs []string
 			for _, m := range gotFm {
-				gotMatchCount += int(m.ResultCount())
-				gotMatchKeys = append(gotMatchKeys, m.FileMatch.Key())
+				gotMatchCount += m.ResultCount()
+				gotMatchKeys = append(gotMatchKeys, m.Key())
 				if m.InputRev != nil {
 					gotMatchInputRevs = append(gotMatchInputRevs, *m.InputRev)
 				}


### PR DESCRIPTION
This commit converts collectStream to return matches rather than resolvers.

Stacked on #20757 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
