### PR TITLE
Convert mock functions to return matches

### DIFF
--- a/cmd/frontend/graphqlbackend/search_pagination_test.go
+++ b/cmd/frontend/graphqlbackend/search_pagination_test.go
@@ -50,7 +50,7 @@ func TestSearchPagination_sliceSearchResults(t *testing.T) {
 		id := name[len(name)-1] - '0'
 		return types.RepoName{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
-	result := mkFileMatch
+	result := mkFileMatchResolver
 	format := func(r slicedSearchResults) string {
 		var b bytes.Buffer
 		fmt.Fprintln(&b, "results:")
@@ -261,7 +261,7 @@ func TestSearchPagination_repoPaginationPlan(t *testing.T) {
 		return types.RepoName{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
 	result := func(db dbutil.DB, repo types.RepoName, path, rev string) *FileMatchResolver {
-		fm := mkFileMatch(db, repo, path)
+		fm := mkFileMatchResolver(db, repo, path)
 		fm.InputRev = &rev
 		return fm
 	}
@@ -473,7 +473,7 @@ func TestSearchPagination_issue_6287(t *testing.T) {
 		id := name[len(name)-1] - '0'
 		return types.RepoName{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
-	result := mkFileMatch
+	result := mkFileMatchResolver
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
 			Repo: repoName(name),
@@ -593,7 +593,7 @@ func TestSearchPagination_cloning_missing(t *testing.T) {
 		id := name[len(name)-1] - 'a' + 1
 		return types.RepoName{ID: api.RepoID(id), Name: api.RepoName(name)}
 	}
-	result := mkFileMatch
+	result := mkFileMatchResolver
 	repoRevs := func(name string, rev ...string) *search.RepositoryRevisions {
 		return &search.RepositoryRevisions{
 			Repo: repoName(name),

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -64,7 +64,7 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 		for _, n := range lineNumbers {
 			lines = append(lines, &result.LineMatch{LineNumber: n})
 		}
-		return mkFileMatchResolver(db, result.FileMatch{
+		return mkResolverFromFileMatch(db, result.FileMatch{
 			File: result.File{
 				Path:     path,
 				Repo:     types.RepoName{Name: "r"},

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -113,7 +113,7 @@ func TestSearchResults(t *testing.T) {
 		database.Mocks.Repos.MockGet(t, 1)
 		database.Mocks.Repos.Count = mockCount
 
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
 			return nil, &streaming.Stats{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -166,14 +166,14 @@ func TestSearchResults(t *testing.T) {
 		defer func() { mockSearchSymbols = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := `(foo\d).*?(bar\*)`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			repo := types.RepoName{ID: 1, Name: "repo"}
-			fm := mkFileMatch(db, repo, "dir/file", 123)
-			return []*FileMatchResolver{fm}, &streaming.Stats{}, nil
+			fm := mkFileMatch(repo, "dir/file", 123)
+			return []*result.FileMatch{fm}, &streaming.Stats{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -231,14 +231,14 @@ func TestSearchResults(t *testing.T) {
 		defer func() { mockSearchSymbols = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := `foo\\d "bar\*"`; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
 			repo := types.RepoName{ID: 1, Name: "repo"}
-			fm := mkFileMatch(db, repo, "dir/file", 123)
-			return []*FileMatchResolver{fm}, &streaming.Stats{}, nil
+			fm := mkFileMatch(repo, "dir/file", 123)
+			return []*result.FileMatch{fm}, &streaming.Stats{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 
@@ -281,7 +281,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 	repo := types.RepoName{Name: "testRepo"}
 	repoMatch := NewRepositoryResolver(db, repo.ToRepo())
 	fileMatch := func(path string) *FileMatchResolver {
-		return mkFileMatch(db, repo, path)
+		return mkFileMatchResolver(db, repo, path)
 	}
 
 	rev := "develop3.0"
@@ -819,7 +819,7 @@ func TestCompareSearchResults(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
 	makeResult := func(repo, file string) *FileMatchResolver {
-		return mkFileMatchResolver(db, result.FileMatch{File: result.File{
+		return mkResolverFromFileMatch(db, result.FileMatch{File: result.File{
 			Repo: types.RepoName{Name: api.RepoName(repo)},
 			Path: file,
 		}})

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/search"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -107,16 +108,16 @@ func TestSearchSuggestions(t *testing.T) {
 		defer git.ResetMocks()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
 			calledSearchFilesInRepos.Store(true)
 			if want := "foo"; args.PatternInfo.Pattern != want {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, want)
 			}
-			fm := mkFileMatch(db, types.RepoName{Name: "repo"}, "dir/file")
+			fm := mkFileMatch(types.RepoName{Name: "repo"}, "dir/file")
 			rev := "rev"
 			fm.CommitID = "rev"
 			fm.InputRev = &rev
-			return []*FileMatchResolver{fm}, &streaming.Stats{}, nil
+			return []*result.FileMatch{fm}, &streaming.Stats{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 		for _, v := range searchVersions {
@@ -165,21 +166,21 @@ func TestSearchSuggestions(t *testing.T) {
 		backend.Mocks.Repos.MockResolveRev_NoCheck(t, api.CommitID("deadbeef"))
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
 			if args.PatternInfo.Pattern != "." && args.PatternInfo.Pattern != "foo" {
 				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, `"foo" or "."`)
 			}
-			mk := func(name api.RepoName, path string) *FileMatchResolver {
-				fm := mkFileMatch(db, types.RepoName{Name: name}, path)
+			mk := func(name api.RepoName, path string) *result.FileMatch {
+				fm := mkFileMatch(types.RepoName{Name: name}, path)
 				fm.CommitID = "rev"
 				rev := "rev"
 				fm.InputRev = &rev
 				return fm
 			}
-			return []*FileMatchResolver{
+			return []*result.FileMatch{
 				mk("repo3", "dir/foo-repo3-file-name-match"),
 				mk("repo1", "dir/foo-repo1-file-name-match"),
 				mk("repo", "dir/file-content-match"),
@@ -246,7 +247,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
@@ -257,8 +258,8 @@ func TestSearchSuggestions(t *testing.T) {
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}
-			return []*FileMatchResolver{
-				mkFileMatch(db, types.RepoName{Name: "foo-repo"}, "dir/file"),
+			return []*result.FileMatch{
+				mkFileMatch(types.RepoName{Name: "foo-repo"}, "dir/file"),
 			}, &streaming.Stats{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
@@ -367,7 +368,7 @@ func TestSearchSuggestions(t *testing.T) {
 		defer func() { mockShowLangSuggestions = nil }()
 
 		calledSearchFilesInRepos := atomic.NewBool(false)
-		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*FileMatchResolver, *streaming.Stats, error) {
+		mockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
 			mu.Lock()
 			defer mu.Unlock()
 			calledSearchFilesInRepos.Store(true)
@@ -378,9 +379,7 @@ func TestSearchSuggestions(t *testing.T) {
 			if want := "foo-repo"; len(repos) != 1 || string(repos[0].Repo.Name) != want {
 				t.Errorf("got %q, want %q", repos, want)
 			}
-			return []*FileMatchResolver{
-				mkFileMatch(db, types.RepoName{Name: "foo-repo"}, "dir/bar-file"),
-			}, &streaming.Stats{}, nil
+			return []*result.FileMatch{mkFileMatch(types.RepoName{Name: "foo-repo"}, "dir/bar-file")}, &streaming.Stats{}, nil
 		}
 		defer func() { mockSearchFilesInRepos = nil }()
 

--- a/cmd/frontend/graphqlbackend/search_symbols.go
+++ b/cmd/frontend/graphqlbackend/search_symbols.go
@@ -139,7 +139,7 @@ func symbolCount(fmrs []*FileMatchResolver) int {
 	return nsym
 }
 
-func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []result.FileMatch, err error) {
+func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisions, patternInfo *search.TextPatternInfo, limit int) (res []*result.FileMatch, err error) {
 	span, ctx := ot.StartSpanFromContext(ctx, "Search symbols in repo")
 	defer func() {
 		if err != nil {
@@ -183,7 +183,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 	}
 
 	// Create file matches from partitioned symbols
-	fileMatches := make([]result.FileMatch, 0, len(symbolsByPath))
+	fileMatches := make([]*result.FileMatch, 0, len(symbolsByPath))
 	for path, symbols := range symbolsByPath {
 		file := result.File{
 			Path:     path,
@@ -200,7 +200,7 @@ func searchSymbolsInRepo(ctx context.Context, repoRevs *search.RepositoryRevisio
 			})
 		}
 
-		fileMatches = append(fileMatches, result.FileMatch{
+		fileMatches = append(fileMatches, &result.FileMatch{
 			Symbols: symbolMatches,
 			File:    file,
 		})

--- a/cmd/frontend/graphqlbackend/search_symbols_test.go
+++ b/cmd/frontend/graphqlbackend/search_symbols_test.go
@@ -183,7 +183,7 @@ func TestLimitingSymbolResults(t *testing.T) {
 func mkSymbolFileMatchResolvers(db dbutil.DB, symbols ...[]*result.SymbolMatch) []*FileMatchResolver {
 	var resolvers []*FileMatchResolver
 	for _, s := range symbols {
-		resolvers = append(resolvers, mkFileMatchResolver(db, result.FileMatch{
+		resolvers = append(resolvers, mkResolverFromFileMatch(db, result.FileMatch{
 			Symbols: s,
 		}))
 	}

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -515,12 +515,26 @@ func TestVersionContext(t *testing.T) {
 	}
 }
 
-func mkFileMatch(db dbutil.DB, repo types.RepoName, path string, lineNumbers ...int32) *FileMatchResolver {
+func mkFileMatch(repo types.RepoName, path string, lineNumbers ...int32) *result.FileMatch {
 	var lines []*result.LineMatch
 	for _, n := range lineNumbers {
 		lines = append(lines, &result.LineMatch{LineNumber: n})
 	}
-	return mkFileMatchResolver(db, result.FileMatch{
+	return &result.FileMatch{
+		File: result.File{
+			Path: path,
+			Repo: repo,
+		},
+		LineMatches: lines,
+	}
+}
+
+func mkFileMatchResolver(db dbutil.DB, repo types.RepoName, path string, lineNumbers ...int32) *FileMatchResolver {
+	var lines []*result.LineMatch
+	for _, n := range lineNumbers {
+		lines = append(lines, &result.LineMatch{LineNumber: n})
+	}
+	return mkResolverFromFileMatch(db, result.FileMatch{
 		File: result.File{
 			Path: path,
 			Repo: repo,

--- a/cmd/frontend/graphqlbackend/textsearch_test.go
+++ b/cmd/frontend/graphqlbackend/textsearch_test.go
@@ -36,11 +36,11 @@ import (
 )
 
 func TestSearchFilesInRepos(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.FileMatch, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*result.FileMatch, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []result.FileMatch{{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -48,7 +48,7 @@ func TestSearchFilesInRepos(t *testing.T) {
 				},
 			}}, false, nil
 		case "foo/two":
-			return []result.FileMatch{{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -131,11 +131,11 @@ func TestSearchFilesInRepos(t *testing.T) {
 }
 
 func TestSearchFilesInReposStream(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.FileMatch, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*result.FileMatch, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo/one":
-			return []result.FileMatch{{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -143,7 +143,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 				},
 			}}, false, nil
 		case "foo/two":
-			return []result.FileMatch{{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -151,7 +151,7 @@ func TestSearchFilesInReposStream(t *testing.T) {
 				},
 			}}, false, nil
 		case "foo/three":
-			return []result.FileMatch{{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     repo,
 					InputRev: &rev,
@@ -215,11 +215,11 @@ func mkStatusMap(m map[string]search.RepoStatus) search.RepoStatusMap {
 }
 
 func TestSearchFilesInRepos_multipleRevsPerRepo(t *testing.T) {
-	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []result.FileMatch, limitHit bool, err error) {
+	mockSearchFilesInRepo = func(ctx context.Context, repo types.RepoName, gitserverRepo api.RepoName, rev string, info *search.TextPatternInfo, fetchTimeout time.Duration) (matches []*result.FileMatch, limitHit bool, err error) {
 		repoName := repo.Name
 		switch repoName {
 		case "foo":
-			return []result.FileMatch{{
+			return []*result.FileMatch{{
 				File: result.File{
 					Repo:     repo,
 					CommitID: api.CommitID(rev),

--- a/cmd/frontend/graphqlbackend/zoekt.go
+++ b/cmd/frontend/graphqlbackend/zoekt.go
@@ -321,7 +321,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 				return
 			}
 
-			matches := make([]result.FileMatch, 0, len(files))
+			matches := make([]*result.FileMatch, 0, len(files))
 			for _, file := range files {
 				fileLimitHit := false
 				if len(file.LineMatches) > maxLineMatches {
@@ -359,7 +359,7 @@ func zoektSearch(ctx context.Context, args *search.TextParameters, repos *indexe
 							Path:     file.FileName,
 						},
 					}
-					matches = append(matches, fm)
+					matches = append(matches, &fm)
 				}
 			}
 


### PR DESCRIPTION
This PR converts a bunch of our mocks to return matches rather than resolvers. 
It also converts a few instances of `[]result.FileMatch` to the more standard `[]*result.FileMatch`

Stacked on #20764 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
