### PR TITLE
validate settings JSON for sideloaded extensions

### DIFF
--- a/client/shared/src/api/client/mainthread-api.ts
+++ b/client/shared/src/api/client/mainthread-api.ts
@@ -202,7 +202,7 @@ interface SideloadedExtensionManifest extends Omit<ExtensionManifest, 'url'> {
     main: string
 }
 
-const getConfiguredSideloadedExtension = (baseUrl: string): Observable<ConfiguredExtension> =>
+export const getConfiguredSideloadedExtension = (baseUrl: string): Observable<ConfiguredExtension> =>
     fromFetch(`${baseUrl}/package.json`, { selector: response => checkOk(response).json() }).pipe(
         map(
             (response: SideloadedExtensionManifest): ConfiguredExtension => ({


### PR DESCRIPTION
Previously, the settings JSON Schema of a sideloaded extension was not passed to the Monaco settings editor. This meant that settings did not validate or complete using the sideloaded extension's schema. For example, if you had an extension that added a new property `foo`, you wouldn't see that property or its docs in the Monaco completion menu.

Now, the sideloaded extension's JSON Schema is passed to the Monaco editor (along with that of all the enabled extensions from the registry).

Screenshot where the Codecov extension is sideloaded showing that its properties are shown in the Monaco completion menu:

![image](https://user-images.githubusercontent.com/1976/117547073-7415fd80-afe2-11eb-9399-672da6eb8639.png)
