### PR TITLE
e2e: Fix References panel XPath selector

### DIFF
--- a/client/shared/src/testing/driver.ts
+++ b/client/shared/src/testing/driver.ts
@@ -468,7 +468,7 @@ export class Driver {
     public async assertNonemptyLocalRefs(): Promise<void> {
         // verify active group is references
         await this.page.waitForXPath(
-            "//*[contains(@class, 'panel')]//*[contains(@tabindex, '0') and contains(text(), 'References')]"
+            "//*[contains(@class, 'panel')]//*[contains(@tabindex, '0')]//*[contains(text(), 'References')]"
         )
         // verify there are some references
         await this.page.waitForSelector('.panel__tabs-content .file-match-children__item', { visible: true })
@@ -477,7 +477,7 @@ export class Driver {
     public async assertNonemptyExternalRefs(): Promise<void> {
         // verify active group is references
         await this.page.waitForXPath(
-            "//*[contains(@class, 'panel')]//*[contains(@tabindex, '0') and contains(text(), 'References')]"
+            "//*[contains(@class, 'panel')]//*[contains(@tabindex, '0')]//*[contains(text(), 'References')]"
         )
         // verify there are some references
         await this.page.waitForSelector('.panel__tabs-content .hierarchical-locations-view__item', { visible: true })


### PR DESCRIPTION
The 'References' text was nested inside another `<span>`, so the previous selector did not find it.