### PR TITLE
fix scroll regression on tabs

### DIFF
--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -27,11 +27,6 @@
 .tablist-wrapper {
     border-bottom: 3px solid var(--border-color);
     align-items: center;
-    &__full-width {
-        display: flex;
-        justify-content: space-around;
-        flex: 1;
-    }
 }
 
 .theme-redesign {

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -60,7 +60,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
             handlePosition="right"
             storageKey={SIZE_STORAGE_KEY}
             element={
-                <div className={classnames('d-flex flex-1 border-right overflow-auto', !isRedesignEnabled && 'bg-2')}>
+                <div className={classnames('d-flex w-100 border-right', !isRedesignEnabled && 'bg-2')}>
                     <Tabs
                         className="w-100 test-repo-revision-sidebar"
                         defaultIndex={tabIndex}

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -66,9 +66,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
                         defaultIndex={tabIndex}
                         onChange={handleTabsChange}
                     >
-                        <div
-                            className={classnames('tablist-wrapper d-flex flex-1', isRedesignEnabled ? 'mx-3' : 'mx-0')}
-                        >
+                        <div className={classnames('tablist-wrapper d-flex flex-1', isRedesignEnabled && 'mx-3')}>
                             <TabList>
                                 <Tab data-test-tab="files">
                                     <span className="tablist-wrapper--tab-label">Files</span>

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -60,18 +60,15 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
             handlePosition="right"
             storageKey={SIZE_STORAGE_KEY}
             element={
-                <div
-                    className={classnames(
-                        'd-flex flex-1 border-right overflow-auto',
-                        isRedesignEnabled ? 'px-3' : 'bg-2 px-0'
-                    )}
-                >
+                <div className={classnames('d-flex flex-1 border-right overflow-auto', !isRedesignEnabled && 'bg-2')}>
                     <Tabs
                         className="w-100 test-repo-revision-sidebar"
                         defaultIndex={tabIndex}
                         onChange={handleTabsChange}
                     >
-                        <div className="tablist-wrapper d-flex flex-1">
+                        <div
+                            className={classnames('tablist-wrapper d-flex flex-1', isRedesignEnabled ? 'mx-3' : 'mx-0')}
+                        >
                             <TabList>
                                 <Tab data-test-tab="files">
                                     <span className="tablist-wrapper--tab-label">Files</span>
@@ -90,7 +87,13 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
                                 <ChevronDoubleLeftIcon className="icon-inline repo-revision-container__close-icon" />
                             </Button>
                         </div>
-                        <div aria-hidden={true} className="d-flex repo-revision-container__tabpanels explorer">
+                        <div
+                            aria-hidden={true}
+                            className={classnames(
+                                'd-flex repo-revision-container__tabpanels explorer overflow-auto',
+                                isRedesignEnabled && 'px-3'
+                            )}
+                        >
                             <TabPanels className="w-100">
                                 <TabPanel tabIndex={-1}>
                                     {tabIndex === 0 && (


### PR DESCRIPTION
Sidebar file tabs have some scrolling problems since the scroll logic was moved from their original place. This fix avoids scrolling the header tab.

Changing back `overflow-auto` to the previous element and handle different behaviours between redesign with some flags.



close #20798 #20743 
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
