### PR TITLE
lsif/protocol/writer: add support for MarkupContent

### DIFF
--- a/enterprise/lib/codeintel/lsif/protocol/writer/emitter.go
+++ b/enterprise/lib/codeintel/lsif/protocol/writer/emitter.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"fmt"
 	"sync/atomic"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/lsif/protocol"

--- a/enterprise/lib/codeintel/lsif/protocol/writer/emitter.go
+++ b/enterprise/lib/codeintel/lsif/protocol/writer/emitter.go
@@ -67,9 +67,9 @@ func (e *Emitter) EmitDocumentSymbolEdge(resultV, docV uint64) uint64 {
 	return id
 }
 
-func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) uint64 {
+func (e *Emitter) EmitHoverResult(contents fmt.Stringer) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewHoverResult(id, protocol.MarkedStrings(contents)))
+	e.writer.Write(protocol.NewHoverResult(id, contents))
 	return id
 }
 


### PR DESCRIPTION
to allow emitting MarkupContent from within lsif-go.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>