### PR TITLE
search: commit search result should include repository name

### DIFF
--- a/client/web/src/integration/streaming-search-mocks.ts
+++ b/client/web/src/integration/streaming-search-mocks.ts
@@ -13,6 +13,7 @@ export const diffSearchStreamEvents: SearchEvent[] = [
                 url: '/gitlab.sgdev.org/sourcegraph/sourcegraph/-/commit/b6dd338737c090fdab31d324542bfdaa7ce9f766',
                 detail:
                     '[`b6dd338` one year ago](/gitlab.sgdev.org/sourcegraph/sourcegraph/-/commit/b6dd338737c090fdab31d324542bfdaa7ce9f766)',
+                repository: 'gitlab.sgdev.org/sourcegraph/sourcegraph',
                 content:
                     "```diff\nweb/src/regression/search.test.ts web/src/regression/search.test.ts\n@@ -434,0 +435,3 @@ describe('Search regression test suite', () => {\n+        test('Fork repos excluded by default', async () => {\n+            const urlQuery = buildSearchURLQuery('type:repo sgtest/mux', GQL.SearchPatternType.regexp, false)\n+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)\n@@ -434,0 +439,4 @@ describe('Search regression test suite', () => {\n+        })\n+        test('Forked repos included by by fork option', async () => {\n+            const urlQuery = buildSearchURLQuery('type:repo sgtest/mux fork:yes', GQL.SearchPatternType.regexp, false)\n+            await driver.page.goto(config.sourcegraphBaseUrl + '/search?' + urlQuery)\n```",
                 ranges: [
@@ -48,6 +49,7 @@ export const commitSearchStreamEvents: SearchEvent[] = [
                 url: '/github.com/sourcegraph/sourcegraph/-/commit/f7d28599cad80e200913d9c4612618a73199bac1',
                 detail:
                     '[`f7d2859` 2 days ago](/github.com/sourcegraph/sourcegraph/-/commit/f7d28599cad80e200913d9c4612618a73199bac1)',
+                repository: 'github.com/sourcegraph/sourcegraph',
                 content:
                     '```COMMIT_EDITMSG\nsearch: Incorporate search blitz (#19567)\n\nIncorporates search blitz into sourcegraph/sourcegraph so it has access to the internal streaming client\n```',
                 ranges: [

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -66,6 +66,7 @@ interface CommitMatch {
     label: MarkdownText
     url: string
     detail: MarkdownText
+    repository: string
 
     content: MarkdownText
     ranges: number[][]
@@ -290,6 +291,7 @@ function toGQLCommitMatch(commit: CommitMatch): GQL.ICommitSearchResult {
         label: toMarkdown(commit.label),
         url: commit.url,
         detail: toMarkdown(commit.detail),
+        repository: commit.repository,
         matches: [match],
     }
 

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1784,6 +1784,10 @@ type CommitSearchResult implements GenericSearchResultInterface {
     """
     url: String!
     """
+    Full name of the repository the commit is based on. May not always be present.
+    """
+    repository: String
+    """
     A markdown string of that is rendered less prominently.
     """
     detail: Markdown!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1784,7 +1784,8 @@ type CommitSearchResult implements GenericSearchResultInterface {
     """
     url: String!
     """
-    Full name of the repository the commit is based on.
+    UNSTABLE: Full name of the repository the commit is based on. Will be removed when GraphQL search
+    is removed from the web UI. This is already accessible through `commit{ repository { name }}`.
     """
     repository: String!
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1784,9 +1784,9 @@ type CommitSearchResult implements GenericSearchResultInterface {
     """
     url: String!
     """
-    Full name of the repository the commit is based on. May not always be present.
+    Full name of the repository the commit is based on.
     """
-    repository: String
+    repository: String!
     """
     A markdown string of that is rendered less prominently.
     """

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -117,6 +117,10 @@ func (r *CommitSearchResultResolver) URL() string {
 	return r.CommitMatch.URL().String()
 }
 
+func (r *CommitSearchResultResolver) Repository() string {
+	return string(r.CommitMatch.RepoName.Name)
+}
+
 func (r *CommitSearchResultResolver) Detail() Markdown {
 	return Markdown(r.CommitMatch.Detail())
 }

--- a/cmd/frontend/internal/search/search.go
+++ b/cmd/frontend/internal/search/search.go
@@ -472,12 +472,13 @@ func fromCommit(commit *result.CommitMatch) *streamhttp.EventCommitMatch {
 	}
 
 	return &streamhttp.EventCommitMatch{
-		Type:    streamhttp.CommitMatchType,
-		Label:   commit.Label(),
-		URL:     commit.URL().String(),
-		Detail:  commit.Detail(),
-		Content: content,
-		Ranges:  ranges,
+		Type:       streamhttp.CommitMatchType,
+		Label:      commit.Label(),
+		URL:        commit.URL().String(),
+		Detail:     commit.Detail(),
+		Repository: string(commit.RepoName.Name),
+		Content:    content,
+		Ranges:     ranges,
 	}
 }
 

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -55,7 +55,7 @@ type EventSymbolMatch struct {
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
-	Symbols    []Symbol `json:"symbols"`
+	Symbols []Symbol `json:"symbols"`
 }
 
 func (e *EventSymbolMatch) eventMatch() {}
@@ -81,7 +81,7 @@ type EventCommitMatch struct {
 	Repository string `json:"repository"`
 	Content    string `json:"content"`
 	// [line, character, length]
-	Ranges     [][3]int32 `json:"ranges"`
+	Ranges [][3]int32 `json:"ranges"`
 }
 
 func (e *EventCommitMatch) eventMatch() {}

--- a/internal/search/streaming/http/events.go
+++ b/internal/search/streaming/http/events.go
@@ -55,7 +55,7 @@ type EventSymbolMatch struct {
 	Branches   []string `json:"branches,omitempty"`
 	Version    string   `json:"version,omitempty"`
 
-	Symbols []Symbol `json:"symbols"`
+	Symbols    []Symbol `json:"symbols"`
 }
 
 func (e *EventSymbolMatch) eventMatch() {}
@@ -75,12 +75,13 @@ type EventCommitMatch struct {
 	// Type is always CommitMatchType. Included here for marshalling.
 	Type MatchType `json:"type"`
 
-	Label   string `json:"label"`
-	URL     string `json:"url"`
-	Detail  string `json:"detail"`
-	Content string `json:"content"`
+	Label      string `json:"label"`
+	URL        string `json:"url"`
+	Detail     string `json:"detail"`
+	Repository string `json:"repository"`
+	Content    string `json:"content"`
 	// [line, character, length]
-	Ranges [][3]int32 `json:"ranges"`
+	Ranges     [][3]int32 `json:"ranges"`
 }
 
 func (e *EventCommitMatch) eventMatch() {}


### PR DESCRIPTION
This is required for rendering the code host icon as part of the redesign. diff/commit results are the only ones that don't return the repo name as plain strings.