### PR TITLE
Provide link to code host if changeset is already published

### DIFF
--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -1,9 +1,7 @@
 import classNames from 'classnames'
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 
 import {
     ExternalChangesetFields,
@@ -13,6 +11,7 @@ import {
 
 import { ChangesetLabel } from './ChangesetLabel'
 import { ChangesetLastSynced } from './ChangesetLastSynced'
+import { ExternalChangesetTitle } from './ExternalChangesetTitle'
 
 export interface ExternalChangesetInfoCellProps {
     node: ExternalChangesetFields
@@ -24,67 +23,50 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
     node,
     viewerCanAdminister,
     className,
-}) => (
-    <div className={classNames('d-flex flex-column', className)}>
-        <div className="m-0">
-            <h3 className="m-0 d-block d-md-inline">
-                <LinkOrSpan
-                    to={node.externalURL?.url ?? undefined}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mr-2"
-                >
-                    {(isImporting(node) || importingFailed(node)) && (
-                        <>
-                            Importing changeset
-                            {node.externalID && <> #{node.externalID} </>}
-                        </>
-                    )}
-                    {!isImporting(node) && !importingFailed(node) && (
-                        <>
-                            {node.title}
-                            {node.externalID && <> (#{node.externalID}) </>}
-                        </>
-                    )}
-                    {node.externalURL?.url && (
-                        <>
-                            {' '}
-                            <ExternalLinkIcon size="1rem" />
-                        </>
-                    )}
-                </LinkOrSpan>
-            </h3>
-            {node.labels.length > 0 && (
-                <span className="d-block d-md-inline-block">
-                    {node.labels.map(label => (
-                        <ChangesetLabel label={label} key={label.text} />
-                    ))}
-                </span>
-            )}
-        </div>
-        <div>
-            <span className="mr-2 d-block d-mdinline-block">
-                <Link to={node.repository.url} target="_blank" rel="noopener noreferrer">
-                    {node.repository.name}
-                </Link>{' '}
-                {hasHeadReference(node) && (
-                    <div className="d-block d-sm-inline-block">
-                        <span className="badge badge-secondary text-monospace">{headReference(node)}</span>
-                    </div>
+}) => {
+    const changesetTitle =
+        isImporting(node) || importingFailed(node)
+            ? `Importing changeset ${node.externalID ? `#${node.externalID}` : ''}`
+            : `${node.title} ${node.externalID ? `(#${node.externalID})` : ''}`
+
+    return (
+        <div className={classNames('d-flex flex-column', className)}>
+            <div className="m-0">
+                <ExternalChangesetTitle className="m-0 d-block d-md-inline" externalURL={node.externalURL}>
+                    {changesetTitle}
+                </ExternalChangesetTitle>
+                {node.labels.length > 0 && (
+                    <span className="d-block d-md-inline-block">
+                        {node.labels.map(label => (
+                            <ChangesetLabel label={label} key={label.text} />
+                        ))}
+                    </span>
                 )}
-            </span>
-            {![
-                ChangesetState.FAILED,
-                ChangesetState.PROCESSING,
-                ChangesetState.RETRYING,
-                ChangesetState.UNPUBLISHED,
-                ChangesetState.SCHEDULED,
-            ].includes(node.state) && (
-                <ChangesetLastSynced changeset={node} viewerCanAdminister={viewerCanAdminister} />
-            )}
+            </div>
+            <div>
+                <span className="mr-2 d-block d-mdinline-block">
+                    <Link to={node.repository.url} target="_blank" rel="noopener noreferrer">
+                        {node.repository.name}
+                    </Link>{' '}
+                    {hasHeadReference(node) && (
+                        <div className="d-block d-sm-inline-block">
+                            <span className="badge badge-secondary text-monospace">{headReference(node)}</span>
+                        </div>
+                    )}
+                </span>
+                {![
+                    ChangesetState.FAILED,
+                    ChangesetState.PROCESSING,
+                    ChangesetState.RETRYING,
+                    ChangesetState.UNPUBLISHED,
+                    ChangesetState.SCHEDULED,
+                ].includes(node.state) && (
+                    <ChangesetLastSynced changeset={node} viewerCanAdminister={viewerCanAdminister} />
+                )}
+            </div>
         </div>
-    </div>
-)
+    )
+}
 
 function isImporting(node: ExternalChangesetFields): boolean {
     return node.state === ChangesetState.PROCESSING && !hasHeadReference(node)

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -25,16 +25,21 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
     className,
 }) => {
     const changesetTitle =
-        isImporting(node) || importingFailed(node)
-            ? `Importing changeset ${node.externalID ? `#${node.externalID}` : ''}`
-            : `${node.title} ${node.externalID ? `(#${node.externalID})` : ''}`
+        isImporting(node) || importingFailed(node) ? (
+            `Importing changeset ${node.externalID ? `#${node.externalID}` : ''}`
+        ) : (
+            <ExternalChangesetTitle
+                className="m-0 d-block d-md-inline"
+                externalID={node.externalID}
+                externalURL={node.externalURL}
+                title={node.title}
+            />
+        )
 
     return (
         <div className={classNames('d-flex flex-column', className)}>
             <div className="m-0">
-                <ExternalChangesetTitle className="m-0 d-block d-md-inline" externalURL={node.externalURL}>
-                    {changesetTitle}
-                </ExternalChangesetTitle>
+                <h3 className="m-0">{changesetTitle}</h3>
                 {node.labels.length > 0 && (
                     <span className="d-block d-md-inline-block">
                         {node.labels.map(label => (
@@ -44,7 +49,7 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
                 )}
             </div>
             <div>
-                <span className="mr-2 d-block d-mdinline-block">
+                <span className="mr-2 d-block d-md-inline-block">
                     <Link to={node.repository.url} target="_blank" rel="noopener noreferrer">
                         {node.repository.name}
                     </Link>{' '}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -7,7 +7,6 @@ import {
     ExternalChangesetFields,
     GitBranchChangesetDescriptionFields,
     ChangesetState,
-    ChangesetLabelFields,
 } from '../../../../graphql-operations'
 
 import { ChangesetLabel } from './ChangesetLabel'
@@ -40,9 +39,11 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
     return (
         <div className={classNames('d-flex flex-column', className)}>
             <div className="m-0">
-                <h3 className="m-0 d-md-inline-block">{changesetTitle}</h3>
+                <h3 className={classNames('m-0 d-md-inline-block', { 'mr-2': node.labels.length > 0 })}>
+                    {changesetTitle}
+                </h3>
                 {node.labels.length > 0 && (
-                    <span className="d-block d-md-inline-block ml-2">
+                    <span className="d-block d-md-inline-block mr-2">
                         {node.labels.map(label => (
                             <ChangesetLabel label={label} key={label.text} />
                         ))}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -49,7 +49,7 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
                 )}
             </div>
             <div>
-                <span className="mr-2 d-block d-md-inline-block">
+                <span className="mr-2 d-block">
                     <Link to={node.repository.url} target="_blank" rel="noopener noreferrer">
                         {node.repository.name}
                     </Link>{' '}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -7,6 +7,7 @@ import {
     ExternalChangesetFields,
     GitBranchChangesetDescriptionFields,
     ChangesetState,
+    ChangesetLabelFields,
 } from '../../../../graphql-operations'
 
 import { ChangesetLabel } from './ChangesetLabel'
@@ -39,9 +40,9 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
     return (
         <div className={classNames('d-flex flex-column', className)}>
             <div className="m-0">
-                <h3 className="m-0">{changesetTitle}</h3>
+                <h3 className="m-0 d-md-inline-block">{changesetTitle}</h3>
                 {node.labels.length > 0 && (
-                    <span className="d-block d-md-inline-block">
+                    <span className="d-block d-md-inline-block ml-2">
                         {node.labels.map(label => (
                             <ChangesetLabel label={label} key={label.text} />
                         ))}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetNode.story.tsx
@@ -53,7 +53,13 @@ add('All states', () => {
                                         changed: 20,
                                         deleted: 8,
                                     },
-                                    labels: [],
+                                    labels: [
+                                        {
+                                            color: '93ba13',
+                                            description: 'Very awesome description',
+                                            text: 'Some label',
+                                        },
+                                    ],
                                     repository: {
                                         id: 'repoid',
                                         name: 'github.com/sourcegraph/sourcegraph',
@@ -119,7 +125,7 @@ add('Unpublished', () => {
                             changed: 20,
                             deleted: 8,
                         },
-                        labels: [],
+                        labels: [{ color: '93ba13', description: 'Very awesome description', text: 'Some label' }],
                         repository: {
                             id: 'repoid',
                             name: 'github.com/sourcegraph/sourcegraph',
@@ -180,7 +186,7 @@ add('Importing', () => {
                         externalID: '12345',
                         externalURL: null,
                         diffStat: null,
-                        labels: [],
+                        labels: [{ color: '93ba13', description: 'Very awesome description', text: 'Some label' }],
                         repository: {
                             id: 'repoid',
                             name: 'github.com/sourcegraph/sourcegraph',
@@ -234,7 +240,7 @@ add('Importing failed', () => {
                         externalID: '99999',
                         externalURL: null,
                         diffStat: null,
-                        labels: [],
+                        labels: [{ color: '93ba13', description: 'Very awesome description', text: 'Some label' }],
                         repository: {
                             id: 'repoid',
                             name: 'github.com/sourcegraph/sourcegraph',
@@ -278,7 +284,7 @@ add('Sync failed', () => {
                         externalID: '99999',
                         externalURL: null,
                         diffStat: null,
-                        labels: [],
+                        labels: [{ color: '93ba13', description: 'Very awesome description', text: 'Some label' }],
                         repository: {
                             id: 'repoid',
                             name: 'github.com/sourcegraph/sourcegraph',

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import React from 'react'
 
@@ -12,12 +11,7 @@ export const ExternalChangesetTitle: React.FunctionComponent<
         className?: string
     }
 > = ({ className, externalID, externalURL, title }) => (
-    <LinkOrSpan
-        to={externalURL?.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={classNames('mr-2', className)}
-    >
+    <LinkOrSpan to={externalURL?.url} target="_blank" rel="noopener noreferrer" className={className}>
         {title}
         {externalID && <> (#{externalID}) </>}
         {externalURL?.url && (

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
@@ -6,38 +6,19 @@ import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ExternalChangesetFields } from '../../../../graphql-operations'
 
 export const ExternalChangesetTitle: React.FunctionComponent<
-    Pick<ExternalChangesetFields, 'externalURL'> & {
-        /** Optionally, any class names to apply to the wrapping `h3` element */
+    Pick<ExternalChangesetFields, 'externalID' | 'externalURL' | 'title'> & {
+        /** Optionally, any class names to forward as a prop to the inner `LinkOrSpan` */
         className?: string
-        /** If provided, will render the original title (`children`) in ~strikethrough~
-         * with `newTitle` to the side */
-        newTitle?: string
     }
-> = ({ children, className, externalURL, newTitle }) => {
-    const linkOrSpan = (
-        <LinkOrSpan
-            to={externalURL?.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`mr-2 ${newTitle ? 'text-muted' : ''}`}
-        >
-            {children}
-            {externalURL?.url && (
-                <>
-                    {' '}
-                    <ExternalLinkIcon size="1rem" />
-                </>
-            )}
-        </LinkOrSpan>
-    )
-
-    if (newTitle) {
-        return (
-            <h3 className={className}>
-                <del>{linkOrSpan}</del>
-                {newTitle}
-            </h3>
-        )
-    }
-    return <h3 className={className}>{linkOrSpan}</h3>
-}
+> = ({ className, externalID, externalURL, title }) => (
+    <LinkOrSpan to={externalURL?.url} target="_blank" rel="noopener noreferrer" className={`mr-2 ${className || ''}`}>
+        {title}
+        {externalID && <> (#{externalID}) </>}
+        {externalURL?.url && (
+            <>
+                {' '}
+                <ExternalLinkIcon size="1rem" />
+            </>
+        )}
+    </LinkOrSpan>
+)

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
@@ -1,0 +1,43 @@
+import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
+import React from 'react'
+
+import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
+
+import { ExternalChangesetFields } from '../../../../graphql-operations'
+
+export const ExternalChangesetTitle: React.FunctionComponent<
+    Pick<ExternalChangesetFields, 'externalURL'> & {
+        /** Optionally, any class names to apply to the wrapping `h3` element */
+        className?: string
+        /** If provided, will render the original title (`children`) in ~strikethrough~
+         * with `newTitle` to the side */
+        newTitle?: string
+    }
+> = ({ children, className, externalURL, newTitle }) => {
+    const linkOrSpan = (
+        <LinkOrSpan
+            to={externalURL?.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`mr-2 ${newTitle ? 'text-muted' : ''}`}
+        >
+            {children}
+            {externalURL?.url && (
+                <>
+                    {' '}
+                    <ExternalLinkIcon size="1rem" />
+                </>
+            )}
+        </LinkOrSpan>
+    )
+
+    if (newTitle) {
+        return (
+            <h3 className={className}>
+                <del>{linkOrSpan}</del>
+                {newTitle}
+            </h3>
+        )
+    }
+    return <h3 className={className}>{linkOrSpan}</h3>
+}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
@@ -5,15 +5,20 @@ import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 
 import { ExternalChangesetFields } from '../../../../graphql-operations'
 
-export const ExternalChangesetTitle: React.FunctionComponent<
-    Pick<ExternalChangesetFields, 'externalID' | 'externalURL' | 'title'> & {
-        /** Optionally, any class names to forward as a prop to the inner `LinkOrSpan` */
-        className?: string
-    }
-> = ({ className, externalID, externalURL, title }) => (
+interface Props extends Pick<ExternalChangesetFields, 'externalID' | 'externalURL' | 'title'> {
+    /** Optionally, any class names to forward as a prop to the inner `LinkOrSpan` */
+    className?: string
+}
+
+export const ExternalChangesetTitle: React.FunctionComponent<Props> = ({
+    className,
+    externalID,
+    externalURL,
+    title,
+}) => (
     <LinkOrSpan to={externalURL?.url} target="_blank" rel="noopener noreferrer" className={className}>
         {title}
-        {externalID && <> (#{externalID}) </>}
+        {externalID && <> (#{externalID})</>}
         {externalURL?.url && (
             <>
                 {' '}

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetTitle.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import React from 'react'
 
@@ -11,7 +12,12 @@ export const ExternalChangesetTitle: React.FunctionComponent<
         className?: string
     }
 > = ({ className, externalID, externalURL, title }) => (
-    <LinkOrSpan to={externalURL?.url} target="_blank" rel="noopener noreferrer" className={`mr-2 ${className || ''}`}>
+    <LinkOrSpan
+        to={externalURL?.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={classNames('mr-2', className)}
+    >
         {title}
         {externalID && <> (#{externalID}) </>}
         {externalURL?.url && (

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -161,6 +161,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'the old title',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',
@@ -212,6 +216,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'the old title',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',
@@ -263,6 +271,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'Le draft changeset',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',
@@ -314,6 +326,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'Le closed changeset',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',
@@ -419,6 +435,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'Change base ref',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',
@@ -470,6 +490,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'Change base ref',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',
@@ -521,6 +545,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'the old title',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',
@@ -572,6 +600,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 id: '123123',
                 title: 'the old title',
                 state: ChangesetState.OPEN,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 currentSpec: {
                     description: {
                         __typename: 'GitBranchChangesetDescription',

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.story.tsx
@@ -381,6 +381,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 title: 'Le open changeset',
                 state: ChangesetState.OPEN,
                 repository: testRepo,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 diffStat: {
                     added: 2,
                     changed: 8,
@@ -408,6 +412,10 @@ export const visibleChangesetApplyPreviewNodeStories: Record<string, VisibleChan
                 title: 'Le open changeset',
                 state: ChangesetState.OPEN,
                 repository: testRepo,
+                externalID: '123',
+                externalURL: {
+                    url: 'http://test.test/123',
+                },
                 diffStat: {
                     added: 2,
                     changed: 8,

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -454,7 +454,7 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
         <h3>
             {newTitle ? (
                 <>
-                    <del>
+                    <del className="mr-1">
                         <ExternalChangesetTitle
                             className="text-muted"
                             externalID={externalID}

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -5,10 +5,12 @@ import CardTextOutlineIcon from 'mdi-react/CardTextOutlineIcon'
 import CheckboxBlankCircleIcon from 'mdi-react/CheckboxBlankCircleIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import FileDocumentEditOutlineIcon from 'mdi-react/FileDocumentEditOutlineIcon'
 import React, { useCallback, useState } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { DiffStat } from '../../../../components/diff/DiffStat'
@@ -429,10 +431,30 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
         return <h3>Import changeset #{spec.targets.changesetSpec.description.externalID}</h3>
     }
     if (
-        spec.operations.length === 0 ||
-        !spec.delta.titleChanged ||
-        spec.targets.__typename === 'VisibleApplyPreviewTargetsAttach'
+        spec.targets.__typename === 'VisibleApplyPreviewTargetsUpdate' &&
+        (spec.operations.length === 0 || !spec.delta.titleChanged)
     ) {
+        return (
+            <h3>
+                <LinkOrSpan
+                    to={spec.targets.changeset.externalURL?.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mr-2"
+                >
+                    {spec.targets.changeset.title}
+                    {spec.targets.changeset.externalID && <> (#{spec.targets.changeset.externalID}) </>}
+                    {spec.targets.changeset.externalURL?.url && (
+                        <>
+                            {' '}
+                            <ExternalLinkIcon size="1rem" />
+                        </>
+                    )}
+                </LinkOrSpan>
+            </h3>
+        )
+    }
+    if (spec.targets.__typename === 'VisibleApplyPreviewTargetsAttach') {
         return <h3>{spec.targets.changesetSpec.description.title}</h3>
     }
     return (

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -433,7 +433,7 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
     if (spec.targets.__typename === 'VisibleApplyPreviewTargetsAttach') {
         return <h3>{spec.targets.changesetSpec.description.title}</h3>
     }
-    const useStrikethrough = spec.operations.length === 0 || spec.delta.titleChanged
+    const useStrikethrough = spec.operations.length > 0 || spec.delta.titleChanged
 
     // default, spec.targets.__typename === 'VisibleApplyPreviewTargetsUpdate'
     const linkOrSpan = (
@@ -454,7 +454,7 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
         </LinkOrSpan>
     )
 
-    if (spec.operations.length > 0 || spec.delta.titleChanged) {
+    if (useStrikethrough) {
         return (
             <h3>
                 <del>{linkOrSpan}</del>

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -5,12 +5,10 @@ import CardTextOutlineIcon from 'mdi-react/CardTextOutlineIcon'
 import CheckboxBlankCircleIcon from 'mdi-react/CheckboxBlankCircleIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
-import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import FileDocumentEditOutlineIcon from 'mdi-react/FileDocumentEditOutlineIcon'
 import React, { useCallback, useState } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
 import { Maybe } from '@sourcegraph/shared/src/graphql-operations'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
@@ -20,13 +18,13 @@ import { FileDiffNode } from '../../../../components/diff/FileDiffNode'
 import { FilteredConnectionQueryArguments } from '../../../../components/FilteredConnection'
 import {
     ChangesetState,
-    ExternalChangesetFields,
     VisibleChangesetApplyPreviewFields,
     VisibleChangesetSpecFields,
 } from '../../../../graphql-operations'
 import { PersonLink } from '../../../../person/PersonLink'
 import { Description } from '../../Description'
 import { ChangesetStatusCell } from '../../detail/changesets/ChangesetStatusCell'
+import { ExternalChangesetTitle } from '../../detail/changesets/ExternalChangesetTitle'
 import { PreviewPageAuthenticatedUser } from '../BatchChangePreviewPage'
 
 import { queryChangesetSpecFileDiffs as _queryChangesetSpecFileDiffs } from './backend'
@@ -425,46 +423,13 @@ const ChangesetSpecFileDiffConnection: React.FunctionComponent<
     )
 }
 
-const ExternalChangesetTitle: React.FunctionComponent<
-    Pick<ExternalChangesetFields, 'title' | 'externalID' | 'externalURL'> & { newTitle?: string }
-> = ({ title, externalID, externalURL, newTitle }) => {
-    const linkOrSpan = (
-        <LinkOrSpan
-            to={externalURL?.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`mr-2 ${newTitle ? 'text-muted' : ''}`}
-        >
-            {title}
-            {externalID && <> (#{externalID}) </>}
-            {externalURL?.url && (
-                <>
-                    {' '}
-                    <ExternalLinkIcon size="1rem" />
-                </>
-            )}
-        </LinkOrSpan>
-    )
-
-    if (newTitle) {
-        return (
-            <h3>
-                <del>{linkOrSpan}</del>
-                {newTitle}
-            </h3>
-        )
-    }
-    return <h3>{linkOrSpan}</h3>
-}
-
 const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyPreviewFields }> = ({ spec }) => {
     if (spec.targets.__typename === 'VisibleApplyPreviewTargetsDetach') {
         return (
-            <ExternalChangesetTitle
-                title={spec.targets.changeset.title}
-                externalID={spec.targets.changeset.externalID as Maybe<string>}
-                externalURL={spec.targets.changeset.externalURL as Maybe<{ url: string }>}
-            />
+            <ExternalChangesetTitle externalURL={spec.targets.changeset.externalURL as Maybe<{ url: string }>}>
+                {spec.targets.changeset.title}
+                {spec.targets.changeset.externalID && <> (#{spec.targets.changeset.externalID}) </>}
+            </ExternalChangesetTitle>
         )
     }
     if (spec.targets.changesetSpec.description.__typename === 'ExistingChangesetReference') {
@@ -477,11 +442,12 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
     // (default) spec.targets.__typename === 'VisibleApplyPreviewTargetsUpdate'
     return (
         <ExternalChangesetTitle
-            title={spec.targets.changeset.title}
-            externalID={spec.targets.changeset.externalID}
             externalURL={spec.targets.changeset.externalURL}
             newTitle={spec.targets.changesetSpec.description.title}
-        />
+        >
+            {spec.targets.changeset.title}
+            {spec.targets.changeset.externalID && <> (#{spec.targets.changeset.externalID}) </>}
+        </ExternalChangesetTitle>
     )
 }
 

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -430,39 +430,36 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
     if (spec.targets.changesetSpec.description.__typename === 'ExistingChangesetReference') {
         return <h3>Import changeset #{spec.targets.changesetSpec.description.externalID}</h3>
     }
-    if (
-        spec.targets.__typename === 'VisibleApplyPreviewTargetsUpdate' &&
-        (spec.operations.length === 0 || !spec.delta.titleChanged)
-    ) {
-        return (
-            <h3>
-                <LinkOrSpan
-                    to={spec.targets.changeset.externalURL?.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mr-2"
-                >
-                    {spec.targets.changeset.title}
-                    {spec.targets.changeset.externalID && <> (#{spec.targets.changeset.externalID}) </>}
-                    {spec.targets.changeset.externalURL?.url && (
-                        <>
-                            {' '}
-                            <ExternalLinkIcon size="1rem" />
-                        </>
-                    )}
-                </LinkOrSpan>
-            </h3>
-        )
-    }
     if (spec.targets.__typename === 'VisibleApplyPreviewTargetsAttach') {
         return <h3>{spec.targets.changesetSpec.description.title}</h3>
     }
-    return (
-        <h3>
-            <del className="text-muted">{spec.targets.changeset.title}</del>{' '}
-            {spec.targets.changesetSpec.description.title}
-        </h3>
+    // default, spec.targets.__typename === 'VisibleApplyPreviewTargetsUpdate'
+    const linkOrSpan = (
+        <LinkOrSpan
+            to={spec.targets.changeset.externalURL?.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mr-2"
+        >
+            {spec.targets.changeset.title}
+            {spec.targets.changeset.externalID && <> (#{spec.targets.changeset.externalID}) </>}
+            {spec.targets.changeset.externalURL?.url && (
+                <>
+                    {' '}
+                    <ExternalLinkIcon size="1rem" />
+                </>
+            )}
+        </LinkOrSpan>
     )
+
+    if (spec.operations.length > 0 || spec.delta.titleChanged) {
+        return (
+            <h3>
+                <del className="text-muted">{linkOrSpan}</del>
+            </h3>
+        )
+    }
+    return <h3>{linkOrSpan}</h3>
 }
 
 const RepoLink: React.FunctionComponent<{ spec: VisibleChangesetApplyPreviewFields }> = ({ spec }) => {

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -433,13 +433,15 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
     if (spec.targets.__typename === 'VisibleApplyPreviewTargetsAttach') {
         return <h3>{spec.targets.changesetSpec.description.title}</h3>
     }
+    const useStrikethrough = spec.operations.length === 0 || spec.delta.titleChanged
+
     // default, spec.targets.__typename === 'VisibleApplyPreviewTargetsUpdate'
     const linkOrSpan = (
         <LinkOrSpan
             to={spec.targets.changeset.externalURL?.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="mr-2"
+            className={`mr-2 ${useStrikethrough ? 'text-muted' : ''}`}
         >
             {spec.targets.changeset.title}
             {spec.targets.changeset.externalID && <> (#{spec.targets.changeset.externalID}) </>}
@@ -455,7 +457,8 @@ const ChangesetSpecTitle: React.FunctionComponent<{ spec: VisibleChangesetApplyP
     if (spec.operations.length > 0 || spec.delta.titleChanged) {
         return (
             <h3>
-                <del className="text-muted">{linkOrSpan}</del>
+                <del>{linkOrSpan}</del>
+                {spec.targets.changesetSpec.description.title}
             </h3>
         )
     }

--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -153,6 +153,10 @@ const batchSpecApplyPreviewConnectionFieldsFragment = gql`
                     id
                     title
                     state
+                    externalURL {
+                        url
+                    }
+                    externalID
                     currentSpec {
                         description {
                             __typename

--- a/client/web/src/enterprise/batches/preview/list/backend.ts
+++ b/client/web/src/enterprise/batches/preview/list/backend.ts
@@ -191,6 +191,10 @@ const batchSpecApplyPreviewConnectionFieldsFragment = gql`
                     id
                     title
                     state
+                    externalURL {
+                        url
+                    }
+                    externalID
                     repository {
                         url
                         name


### PR DESCRIPTION
Closes #19607! 

Before:
<img width="966" alt="Screen Shot 2021-05-10 at 2 48 16 PM" src="https://user-images.githubusercontent.com/8942601/117733756-f2bb9800-b1a6-11eb-9471-3b9338c5f543.png">

After:
<img width="1028" alt="Screen Shot 2021-05-10 at 3 47 23 PM" src="https://user-images.githubusercontent.com/8942601/117733801-0535d180-b1a7-11eb-97c4-213cb4dacc8b.png">

I'm not sure how to add "operations" (`spec.operations`) or change the title of a changeset (`spec.delta.titleChanged`) that comes back with the GraphQL response, but it appears that if we have either of those things on this node, we show the title with ~strikethrough~. Since it only looks like we'd have this published changeset link on a `VisibleApplyPreviewTargetsUpdate`, I rearranged the conditionals a bit to accommodate this link in both the strikethrough and non-strikethrough styles. The strikethrough style looks like this:

<img width="1009" alt="Screen Shot 2021-05-10 at 3 59 39 PM" src="https://user-images.githubusercontent.com/8942601/117734848-2992ad80-b1a9-11eb-90ae-263674bbb5b3.png">

Since it's not entirely apparent to me what the strikethrough signifies, I'd love feedback on if having both the strikethrough **and** the link is too much.

Or, if you would have done something completely different here, I'd love to hear about that, too! I borrowed the styles/pattern from the `ExternalChangesetInfoCell`:

![image](https://user-images.githubusercontent.com/8942601/117735279-01f01500-b1aa-11eb-9b05-b696d3a0e570.png)
