### PR TITLE
sg: Allow overwriting of sub-attributes through deep merging

### DIFF
--- a/dev/sg/config.go
+++ b/dev/sg/config.go
@@ -51,6 +51,60 @@ type Command struct {
 	DefaultArgs      string            `yaml:"defaultArgs"`
 }
 
+func (c Command) Merge(other Command) Command {
+	merged := c
+
+	if other.Name != merged.Name && other.Name != "" {
+		merged.Name = other.Name
+	}
+	if other.Cmd != merged.Cmd && other.Cmd != "" {
+		merged.Cmd = other.Cmd
+	}
+	if other.Install != merged.Install && other.Install != "" {
+		merged.Install = other.Install
+	}
+	if other.InstallDocDarwin != merged.InstallDocDarwin && other.InstallDocDarwin != "" {
+		merged.InstallDocDarwin = other.InstallDocDarwin
+	}
+	if other.InstallDocLinux != merged.InstallDocLinux && other.InstallDocLinux != "" {
+		merged.InstallDocLinux = other.InstallDocLinux
+	}
+	if other.IgnoreStdout != merged.IgnoreStdout && !merged.IgnoreStdout {
+		merged.IgnoreStdout = other.IgnoreStdout
+	}
+	if other.IgnoreStderr != merged.IgnoreStderr && !merged.IgnoreStderr {
+		merged.IgnoreStderr = other.IgnoreStderr
+	}
+	if other.DefaultArgs != merged.DefaultArgs && other.DefaultArgs != "" {
+		merged.DefaultArgs = other.DefaultArgs
+	}
+
+	for k, v := range other.Env {
+		merged.Env[k] = v
+	}
+
+	if !equal(merged.Watch, other.Watch) {
+		merged.Watch = other.Watch
+	}
+
+	return merged
+
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 type Config struct {
 	Env         map[string]string   `yaml:"env"`
 	Commands    map[string]Command  `yaml:"commands"`
@@ -66,7 +120,11 @@ func (c *Config) Merge(other *Config) {
 	}
 
 	for k, v := range other.Commands {
-		c.Commands[k] = v
+		if original, ok := c.Commands[k]; ok {
+			c.Commands[k] = original.Merge(v)
+		} else {
+			c.Commands[k] = v
+		}
 	}
 
 	for k, v := range other.Commandsets {
@@ -74,6 +132,10 @@ func (c *Config) Merge(other *Config) {
 	}
 
 	for k, v := range other.Tests {
-		c.Tests[k] = v
+		if original, ok := c.Tests[k]; ok {
+			c.Tests[k] = original.Merge(v)
+		} else {
+			c.Tests[k] = v
+		}
 	}
 }


### PR DESCRIPTION
Given the following `sg.config.yaml` content:

```yaml
commands:
  coolcommand:
    cmd: echo "this is the $COOL_ENV_1 and $COOL_ENV_2"
    install: echo "installing!"
    env:
      COOL_ENV_1: cool-env-1
      COOL_ENV_2: cool-env-2
```

And this in `sg.config.overwrite.yaml`:

```yaml
commands:
  coolcommand:
    install: echo "new install command"
    env:
      COOL_ENV_2: overwritten-cool-env
```

then `sg run coolcommand` will print the following:

```
Installing coolcommand...
Successfully installed coolcommand
Running coolcommand...
[coolcommand] this is the cool-env-1 and overwritten-cool-env
```



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
