### PR TITLE
Fix flaky Ticker test by giving some timing buffer

### DIFF
--- a/enterprise/internal/batches/scheduler/ticker_test.go
+++ b/enterprise/internal/batches/scheduler/ticker_test.go
@@ -75,8 +75,9 @@ func TestTickerRateLimited(t *testing.T) {
 	c <- time.Duration(0)
 
 	c = <-ticker.C
-	if have, want := time.Since(now), 10*time.Millisecond; have < want {
-		t.Errorf("unexpectedly short delay between takes: have=%v want>=%v", have, want)
+	have := time.Since(now)
+	if wantMin, wantMax := 9*time.Millisecond, 11*time.Millisecond; have < wantMin || have > wantMax {
+		t.Errorf("unexpectedly short delay between takes: have=%v want >=%v && <=%v", have, wantMin, wantMax)
 	}
 	c <- time.Duration(0)
 


### PR DESCRIPTION
Failure was here: https://buildkite.com/sourcegraph/sourcegraph/builds/95658#bbcd0b05-d301-4e80-9d69-42295cbf74bb

With the error message:

    ticker_test.go:79: unexpectedly short delay between takes: have=9.953755ms want>=10ms

So yeah. Timing is tough. I think making sure that the elapsed time is
between 9 and 11 milliseconds is fine.
