### PR TITLE
search redesign: styling for repo results

### DIFF
--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -1,5 +1,5 @@
 import * as H from 'history'
-import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
+import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 import * as React from 'react'
 import { Observable, of, Subject, Subscription } from 'rxjs'
 import { catchError, distinctUntilChanged, endWith, map, startWith, switchMap, tap } from 'rxjs/operators'
@@ -277,7 +277,7 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                         location={this.props.location}
                         locations={of(visibleLocations)}
                         onSelect={this.props.onSelectLocation}
-                        icon={SourceRepositoryIcon}
+                        icon={FileDocumentIcon}
                         isLightTheme={this.props.isLightTheme}
                         fetchHighlightedFileLineRanges={this.props.fetchHighlightedFileLineRanges}
                         settingsCascade={this.props.settingsCascade}

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -23,9 +23,17 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
               className="result-container__header result-container__header--collapsible"
               onClick={[Function]}
             >
-              <SourceRepositoryIcon
-                className="icon-inline"
-              />
+              <svg
+                className="mdi-icon icon-inline"
+                fill="currentColor"
+                height={24}
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M15,18V16H6V18H15M18,14V12H6V14H18Z"
+                />
+              </svg>
               <div
                 className="result-container__header-divider"
               />
@@ -244,9 +252,17 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
               className="result-container__header result-container__header--collapsible"
               onClick={[Function]}
             >
-              <SourceRepositoryIcon
-                className="icon-inline"
-              />
+              <svg
+                className="mdi-icon icon-inline"
+                fill="currentColor"
+                height={24}
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M15,18V16H6V18H15M18,14V12H6V14H18Z"
+                />
+              </svg>
               <div
                 className="result-container__header-divider"
               />
@@ -415,9 +431,17 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
               className="result-container__header result-container__header--collapsible"
               onClick={[Function]}
             >
-              <SourceRepositoryIcon
-                className="icon-inline"
-              />
+              <svg
+                className="mdi-icon icon-inline"
+                fill="currentColor"
+                height={24}
+                viewBox="0 0 24 24"
+                width={24}
+              >
+                <path
+                  d="M13,9H18.5L13,3.5V9M6,2H14L20,8V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V4C4,2.89 4.89,2 6,2M15,18V16H6V18H15M18,14V12H6V14H18Z"
+                />
+              </svg>
               <div
                 className="result-container__header-divider"
               />

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -27,6 +27,9 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                 className="icon-inline"
               />
               <div
+                className="result-container__header-divider"
+              />
+              <div
                 className="result-container__header-title test-search-result-label"
                 data-testid="result-container-header"
               >
@@ -245,6 +248,9 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                 className="icon-inline"
               />
               <div
+                className="result-container__header-divider"
+              />
+              <div
                 className="result-container__header-title test-search-result-label"
                 data-testid="result-container-header"
               >
@@ -411,6 +417,9 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
             >
               <SourceRepositoryIcon
                 className="icon-inline"
+              />
+              <div
+                className="result-container__header-divider"
               />
               <div
                 className="result-container__header-title test-search-result-label"

--- a/client/shared/src/components/ResultContainer.scss
+++ b/client/shared/src/components/ResultContainer.scss
@@ -45,6 +45,12 @@
             &:not(:only-of-type) {
                 border-bottom: none;
             }
+
+            &-divider {
+                border-right: 1px solid var(--border-color-2);
+                height: 1rem;
+                margin-left: 0.25rem;
+            }
         }
     }
 

--- a/client/shared/src/components/ResultContainer.scss
+++ b/client/shared/src/components/ResultContainer.scss
@@ -1,17 +1,17 @@
 .result-container {
-    position: relative;
-
     border: 0 solid var(--border-color);
     border-top-width: 1px;
     &:last-child {
         border-bottom-width: 1px;
     }
 
+    .theme-redesign & {
+        border: none;
+        margin-right: 1rem;
+    }
+
     &__header {
         padding: 0.5rem 0.5rem;
-
-        position: sticky;
-        top: 0;
 
         display: flex;
         align-items: center;
@@ -37,21 +37,18 @@
         &:not(:only-of-type) {
             border-bottom: 1px solid var(--border-color);
         }
+
+        .theme-redesign & {
+            background-color: transparent;
+            padding: 0.5rem 0;
+
+            &:not(:only-of-type) {
+                border-bottom: none;
+            }
+        }
     }
 
     &__toggle-matches-container {
         display: flex;
-    }
-
-    // Custom icons are <img src> URLs. We can't use .icon-inline for these, because CSS can't style
-    // SVGs included with <img src>. So, use CSS filters to make the icons light (in dark themes) and
-    // dark (in light themes).
-    .icon-inline__filtered {
-        .theme-dark & {
-            filter: contrast(0) saturate(700%) grayscale(100%) sepia(70%) hue-rotate(180deg) brightness(120%);
-        }
-        .theme-light & {
-            filter: brightness(0%);
-        }
     }
 }

--- a/client/shared/src/components/ResultContainer.scss
+++ b/client/shared/src/components/ResultContainer.scss
@@ -30,6 +30,14 @@
             overflow: hidden;
         }
 
+        &-divider {
+            .theme-redesign & {
+                border-right: 1px solid var(--border-color-2);
+                height: 1rem;
+                margin-left: 0.25rem;
+            }
+        }
+
         p {
             margin-bottom: 0;
         }
@@ -44,12 +52,6 @@
 
             &:not(:only-of-type) {
                 border-bottom: none;
-            }
-
-            &-divider {
-                border-right: 1px solid var(--border-color-2);
-                height: 1rem;
-                margin-left: 0.25rem;
             }
         }
     }

--- a/client/shared/src/components/ResultContainer.tsx
+++ b/client/shared/src/components/ResultContainer.tsx
@@ -103,7 +103,8 @@ export const ResultContainer: React.FunctionComponent<Props> = ({
                 className={'result-container__header' + (collapsible ? ' result-container__header--collapsible' : '')}
                 onClick={toggle}
             >
-                <Icon className="icon-inline redesign-d-none" />
+                <Icon className="icon-inline" />
+                <div className="result-container__header-divider" />
                 <div
                     className={`result-container__header-title ${titleClassName || ''}`}
                     data-testid="result-container-header"

--- a/client/shared/src/components/ResultContainer.tsx
+++ b/client/shared/src/components/ResultContainer.tsx
@@ -88,7 +88,11 @@ export const ResultContainer: React.FunctionComponent<Props> = ({
 
     useEffect(() => setExpanded(allExpanded || defaultExpanded), [allExpanded, defaultExpanded])
 
-    const toggle = (): void => setExpanded(expanded => !expanded)
+    const toggle = (): void => {
+        if (collapsible) {
+            setExpanded(expanded => !expanded)
+        }
+    }
 
     const Icon = icon
     return (
@@ -99,7 +103,7 @@ export const ResultContainer: React.FunctionComponent<Props> = ({
                 className={'result-container__header' + (collapsible ? ' result-container__header--collapsible' : '')}
                 onClick={toggle}
             >
-                <Icon className="icon-inline" />
+                <Icon className="icon-inline redesign-d-none" />
                 <div
                     className={`result-container__header-title ${titleClassName || ''}`}
                     data-testid="result-container-header"

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -1,5 +1,4 @@
 import * as H from 'history'
-import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 import React from 'react'
 
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
@@ -18,17 +17,9 @@ interface Props extends ThemeProps {
     history: H.History
     repoName: string
     icon: React.ComponentType<{ className?: string }>
-    isStreamingEnabled?: boolean
 }
 
-export const SearchResult: React.FunctionComponent<Props> = ({
-    result,
-    history,
-    icon,
-    isLightTheme,
-    repoName,
-    isStreamingEnabled = false,
-}) => {
+export const SearchResult: React.FunctionComponent<Props> = ({ result, history, icon, isLightTheme, repoName }) => {
     const [isRedesignEnabled] = useRedesignToggle()
 
     const renderTitle = (): JSX.Element => {
@@ -68,10 +59,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
         if (isRedesignEnabled && result.__typename === 'Repository') {
             return (
                 <div className="search-result-match">
-                    <small>
-                        <SourceRepositoryIcon className="icon-inline text-muted mr-1" />
-                        Repository name match
-                    </small>
+                    <small>Repository name match</small>
                 </div>
             )
         }

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -32,7 +32,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
     const [isRedesignEnabled] = useRedesignToggle()
 
     const renderTitle = (): JSX.Element => {
-        if (isRedesignEnabled && isStreamingEnabled && result.__typename === 'Repository') {
+        if (isRedesignEnabled && result.__typename === 'Repository') {
             const RepoIcon = getRepoIcon(repoName)
             return (
                 <div className="search-result__title">
@@ -65,7 +65,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({
     }
 
     const renderBody = (): JSX.Element => {
-        if (isRedesignEnabled && isStreamingEnabled && result.__typename === 'Repository') {
+        if (isRedesignEnabled && result.__typename === 'Repository') {
             return (
                 <div className="search-result-match">
                     <small>

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -27,9 +27,9 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, history, 
             const RepoIcon = getRepoIcon(repoName)
             return (
                 <div className="search-result__title">
-                    {RepoIcon && <RepoIcon className="icon-inline text-muted mr-1" />}
+                    {RepoIcon && <RepoIcon className="icon-inline text-muted" />}
                     <Markdown
-                        className="test-search-result-label"
+                        className="test-search-result-label ml-1"
                         dangerousInnerHTML={renderMarkdown(result.label.text)}
                     />
                 </div>

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -30,7 +30,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, history, 
                     {RepoIcon && <RepoIcon className="icon-inline text-muted" />}
                     <Markdown
                         className="test-search-result-label ml-1"
-                        dangerousInnerHTML={renderMarkdown(result.label.text)}
+                        dangerousInnerHTML={result.label.html ? result.label.html : renderMarkdown(result.label.text)}
                     />
                 </div>
             )

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -1,4 +1,5 @@
 import * as H from 'history'
+import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
 import React from 'react'
 
 import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
@@ -6,48 +7,89 @@ import { ResultContainer } from '@sourcegraph/shared/src/components/ResultContai
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+
+import { getRepoIcon } from '../search/results/streaming/getRepoIcon'
 
 import { SearchResultMatch } from './SearchResultMatch'
 
 interface Props extends ThemeProps {
-    result: Omit<GQL.IGenericSearchResultInterface, '__typename'>
+    result: GQL.GenericSearchResultInterface
     history: H.History
+    repoName: string
     icon: React.ComponentType<{ className?: string }>
+    isStreamingEnabled?: boolean
 }
 
-export const SearchResult: React.FunctionComponent<Props> = ({ result, history, icon, isLightTheme }) => {
-    const renderTitle = (): JSX.Element => (
-        <div className="search-result__title">
-            <Markdown
-                className="test-search-result-label"
-                dangerousInnerHTML={result.label.html ? result.label.html : renderMarkdown(result.label.text)}
-            />
-            {result.detail && (
-                <>
-                    <span className="search-result__spacer" />
-                    <Markdown
-                        dangerousInnerHTML={
-                            result.detail.html ? result.detail.html : renderMarkdown(result.detail.text)
-                        }
-                    />
-                </>
-            )}
-        </div>
-    )
+export const SearchResult: React.FunctionComponent<Props> = ({
+    result,
+    history,
+    icon,
+    isLightTheme,
+    repoName,
+    isStreamingEnabled = false,
+}) => {
+    const [isRedesignEnabled] = useRedesignToggle()
 
-    const renderBody = (): JSX.Element => (
-        <>
-            {result.matches.map(match => (
-                <SearchResultMatch
-                    key={match.url}
-                    item={match}
-                    highlightRanges={match.highlights}
-                    isLightTheme={isLightTheme}
-                    history={history}
+    const renderTitle = (): JSX.Element => {
+        if (isRedesignEnabled && isStreamingEnabled && result.__typename === 'Repository') {
+            const RepoIcon = getRepoIcon(repoName)
+            return (
+                <div className="search-result__title">
+                    {RepoIcon && <RepoIcon className="icon-inline text-muted mr-1" />}
+                    <Markdown
+                        className="test-search-result-label"
+                        dangerousInnerHTML={renderMarkdown(result.label.text)}
+                    />
+                </div>
+            )
+        }
+        return (
+            <div className="search-result__title">
+                <Markdown
+                    className="test-search-result-label"
+                    dangerousInnerHTML={result.label.html ? result.label.html : renderMarkdown(result.label.text)}
                 />
-            ))}
-        </>
-    )
+                {result.detail && (
+                    <>
+                        <span className="search-result__spacer" />
+                        <Markdown
+                            dangerousInnerHTML={
+                                result.detail.html ? result.detail.html : renderMarkdown(result.detail.text)
+                            }
+                        />
+                    </>
+                )}
+            </div>
+        )
+    }
+
+    const renderBody = (): JSX.Element => {
+        if (isRedesignEnabled && isStreamingEnabled && result.__typename === 'Repository') {
+            return (
+                <div className="search-result-match">
+                    <small>
+                        <SourceRepositoryIcon className="icon-inline text-muted mr-1" />
+                        Repository name match
+                    </small>
+                </div>
+            )
+        }
+
+        return (
+            <>
+                {result.matches.map(match => (
+                    <SearchResultMatch
+                        key={match.url}
+                        item={match}
+                        highlightRanges={match.highlights}
+                        isLightTheme={isLightTheme}
+                        history={history}
+                    />
+                ))}
+            </>
+        )
+    }
 
     return (
         <ResultContainer

--- a/client/web/src/components/SearchResultMatch.scss
+++ b/client/web/src/components/SearchResultMatch.scss
@@ -19,6 +19,13 @@
         border-top: 1px solid var(--border-color);
     }
 
+    .theme-redesign & {
+        background-color: var(--color-bg-1);
+        border: 1px solid var(--border-color-2);
+        border-radius: 3px;
+        padding: 0.5rem;
+    }
+
     pre,
     code {
         width: 100%;

--- a/client/web/src/components/SearchResultMatch.scss
+++ b/client/web/src/components/SearchResultMatch.scss
@@ -22,7 +22,7 @@
     .theme-redesign & {
         background-color: var(--color-bg-1);
         border: 1px solid var(--border-color-2);
-        border-radius: 3px;
+        border-radius: var(--border-radius);
         padding: 0.5rem;
     }
 

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -438,7 +438,7 @@ describe('Search', () => {
                 )
             )
             expect(results).toEqual([
-                'github.com/sourcegraph/sourcegraph',
+                'sourcegraph/sourcegraph',
                 'sourcegraph/sourcegraph › stream.ts',
                 'sourcegraph/sourcegraph@abcd › stream.ts',
                 'sourcegraph/sourcegraph@test/branch › stream.ts',

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -530,6 +530,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     <SearchResult
                         icon={SourceCommitIcon}
                         result={result}
+                        repoName={result.commit.repository.name}
                         isLightTheme={this.props.isLightTheme}
                         history={this.props.history}
                     />
@@ -539,6 +540,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     <SearchResult
                         icon={SourceRepositoryMultipleIcon}
                         result={result}
+                        repoName={result.name}
                         isLightTheme={this.props.isLightTheme}
                         history={this.props.history}
                     />

--- a/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
@@ -1,8 +1,9 @@
 import * as H from 'history'
+import AlphaSBoxIcon from 'mdi-react/AlphaSBoxIcon'
+import FileDocumentIcon from 'mdi-react/FileDocumentIcon'
 import FileIcon from 'mdi-react/FileIcon'
 import SourceCommitIcon from 'mdi-react/SourceCommitIcon'
 import SourceRepositoryIcon from 'mdi-react/SourceRepositoryIcon'
-import SourceRepositoryMultipleIcon from 'mdi-react/SourceRepositoryMultipleIcon'
 import React, { useCallback, useEffect, useState } from 'react'
 import { Observable } from 'rxjs'
 
@@ -73,7 +74,13 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                         <FileMatch
                             location={location}
                             eventLogger={eventLogger}
-                            icon={result.lineMatches && result.lineMatches.length > 0 ? SourceRepositoryIcon : FileIcon}
+                            icon={
+                                result.lineMatches && result.lineMatches.length > 0
+                                    ? FileDocumentIcon
+                                    : result.symbols && result.symbols.length > 0
+                                    ? AlphaSBoxIcon
+                                    : FileIcon
+                            }
                             result={result}
                             onSelect={logSearchResultClicked}
                             expanded={false}
@@ -93,18 +100,16 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                             repoName={result.commit.repository.name}
                             isLightTheme={isLightTheme}
                             history={history}
-                            isStreamingEnabled={true}
                         />
                     )
                 case 'Repository':
                     return (
                         <SearchResult
-                            icon={SourceRepositoryMultipleIcon}
+                            icon={SourceRepositoryIcon}
                             result={result}
                             repoName={result.name}
                             isLightTheme={isLightTheme}
                             history={history}
-                            isStreamingEnabled={true}
                         />
                     )
             }

--- a/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
@@ -74,13 +74,7 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                         <FileMatch
                             location={location}
                             eventLogger={eventLogger}
-                            icon={
-                                result.lineMatches && result.lineMatches.length > 0
-                                    ? FileDocumentIcon
-                                    : result.symbols && result.symbols.length > 0
-                                    ? AlphaSBoxIcon
-                                    : FileIcon
-                            }
+                            icon={getFileMatchIcon(result)}
                             result={result}
                             onSelect={logSearchResultClicked}
                             expanded={false}
@@ -140,4 +134,14 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
             {itemsToShow >= (results?.results.length || 0) && <StreamingSearchResultFooter results={results} />}
         </>
     )
+}
+
+function getFileMatchIcon(result: GQL.IFileMatch): React.ComponentType<{ className?: string }> {
+    if (result.lineMatches && result.lineMatches.length > 0) {
+        return FileDocumentIcon
+    }
+    if (result.symbols && result.symbols.length > 0) {
+        return AlphaSBoxIcon
+    }
+    return FileIcon
 }

--- a/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
@@ -90,8 +90,10 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                         <SearchResult
                             icon={SourceCommitIcon}
                             result={result}
+                            repoName={result.commit.repository.name}
                             isLightTheme={isLightTheme}
                             history={history}
+                            isStreamingEnabled={true}
                         />
                     )
                 case 'Repository':
@@ -99,8 +101,10 @@ export const StreamingSearchResultsList: React.FunctionComponent<StreamingSearch
                         <SearchResult
                             icon={SourceRepositoryMultipleIcon}
                             result={result}
+                            repoName={result.name}
                             isLightTheme={isLightTheme}
                             history={history}
+                            isStreamingEnabled={true}
                         />
                     )
             }

--- a/client/web/src/search/results/streaming/getRepoIcon.ts
+++ b/client/web/src/search/results/streaming/getRepoIcon.ts
@@ -1,0 +1,23 @@
+import { MdiReactIconProps } from 'mdi-react'
+import BitbucketIcon from 'mdi-react/BitbucketIcon'
+import GithubIcon from 'mdi-react/GithubIcon'
+import GitlabIcon from 'mdi-react/GitlabIcon'
+import * as React from 'react'
+
+/**
+ * Returns the icon for the repository's code host
+ */
+export function getRepoIcon(repoName: string): React.ComponentType<MdiReactIconProps> | undefined {
+    let RepoIcon: React.ComponentType<MdiReactIconProps> | undefined
+    if (repoName.startsWith('github.com/')) {
+        RepoIcon = GithubIcon
+    }
+    if (repoName.startsWith('gitlab.com/')) {
+        RepoIcon = GitlabIcon
+    }
+    if (repoName.startsWith('bitbucket.com/')) {
+        RepoIcon = BitbucketIcon
+    }
+
+    return RepoIcon
+}

--- a/client/web/src/search/results/streaming/sidebar/FilterLink.tsx
+++ b/client/web/src/search/results/streaming/sidebar/FilterLink.tsx
@@ -1,9 +1,5 @@
 import classNames from 'classnames'
-import { MdiReactIconProps } from 'mdi-react'
-import BitbucketIcon from 'mdi-react/BitbucketIcon'
-import GithubIcon from 'mdi-react/GithubIcon'
-import GitlabIcon from 'mdi-react/GitlabIcon'
-import React, { ComponentType } from 'react'
+import React from 'react'
 
 import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -11,6 +7,7 @@ import { isSettingsValid, SettingsCascadeProps } from '@sourcegraph/shared/src/s
 import { SyntaxHighlightedSearchQuery } from '../../../../components/SyntaxHighlightedSearchQuery'
 import { Settings } from '../../../../schema/settings.schema'
 import { Filter } from '../../../stream'
+import { getRepoIcon } from '../getRepoIcon'
 
 import styles from './SearchSidebarSection.module.scss'
 
@@ -51,16 +48,7 @@ export const getRepoFilterLinks = (
     onFilterChosen: (value: string) => void
 ): React.ReactElement[] => {
     function repoLabelConverter(label: string): JSX.Element {
-        let RepoIcon: ComponentType<MdiReactIconProps> | undefined
-        if (label.startsWith('github.com/')) {
-            RepoIcon = GithubIcon
-        }
-        if (label.startsWith('gitlab.com/')) {
-            RepoIcon = GitlabIcon
-        }
-        if (label.startsWith('bitbucket.com/')) {
-            RepoIcon = BitbucketIcon
-        }
+        const RepoIcon = getRepoIcon(label)
 
         return (
             <span className={classNames('text-monospace search-query-link', styles.sidebarSectionListItemBreakWords)}>

--- a/client/web/src/search/stream.test.ts
+++ b/client/web/src/search/stream.test.ts
@@ -13,8 +13,7 @@ export const REPO_MATCH_CONTAINING_SPACES: RepositoryMatch = {
 describe('escapeSpaces', () => {
     test('escapes spaces in value', () => {
         expect(toGQLRepositoryMatch(REPO_MATCH_CONTAINING_SPACES).label).toMatchInlineSnapshot(
-            '{"__typename":"Markdown","text":"[github.com/save/the andimals](/github.com/save/the%20andimals)"}',
-            `{"__typename":"Markdown","text":"[save/the andimals](/github.com/save/the%20andimals)"}`
+            '{"__typename":"Markdown","text":"[save/the andimals](/github.com/save/the%20andimals)"}'
         )
     })
 })

--- a/client/web/src/search/stream.test.ts
+++ b/client/web/src/search/stream.test.ts
@@ -13,7 +13,8 @@ export const REPO_MATCH_CONTAINING_SPACES: RepositoryMatch = {
 describe('escapeSpaces', () => {
     test('escapes spaces in value', () => {
         expect(toGQLRepositoryMatch(REPO_MATCH_CONTAINING_SPACES).label).toMatchInlineSnapshot(
-            '{"__typename":"Markdown","text":"[github.com/save/the andimals](/github.com/save/the%20andimals)"}'
+            '{"__typename":"Markdown","text":"[github.com/save/the andimals](/github.com/save/the%20andimals)"}',
+            `{"__typename":"Markdown","text":"[save/the andimals](/github.com/save/the%20andimals)"}`
         )
     })
 })

--- a/client/web/src/search/stream.ts
+++ b/client/web/src/search/stream.ts
@@ -2,6 +2,7 @@
 import { Observable, fromEvent, Subscription, OperatorFunction, pipe, Subscriber, Notification } from 'rxjs'
 import { defaultIfEmpty, map, materialize, scan } from 'rxjs/operators'
 
+import { displayRepoName } from '@sourcegraph/shared/src/components/RepoFileLink'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
@@ -262,7 +263,7 @@ export function toGQLRepositoryMatch(repo: RepositoryMatch): GQL.IRepository {
     // We only need to return the subset defined in IGenericSearchResultInterface
     const gqlRepo: unknown = {
         __typename: 'Repository',
-        label: toMarkdown(`[${label}](${url})`),
+        label: toMarkdown(`[${displayRepoName(label)}](${url})`),
         url,
         detail: toMarkdown('Repository match'),
         matches: [],


### PR DESCRIPTION
- Closes #20807
- Also partially styles the other result types but those are still WIP.
- Fixes the inconsistency where type:repo results will display full name instead of short name, _even when redesign is disabled_
- Changes icons to match design, _even when redesign is disabled_
- Does **not** add the repo full name when hovered. That is planned for https://github.com/sourcegraph/sourcegraph/issues/20874 and potentially requires some backend refactoring

![image](https://user-images.githubusercontent.com/206864/117884031-01668580-b261-11eb-9361-52e46ab60939.png)
