### PR TITLE
Use match types to calculate language statistics

### DIFF
--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -12,6 +12,9 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/sourcegraph/sourcegraph/internal/search/result"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
 func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatisticsResolver, error) {
@@ -20,7 +23,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 		return nil, err
 	}
 
-	langs, err := searchResultsStatsLanguages(ctx, srr.Results())
+	langs, err := searchResultsStatsLanguages(ctx, srr.SearchResults)
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +35,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 	return wrapped, nil
 }
 
-func searchResultsStatsLanguages(ctx context.Context, results []SearchResultResolver) ([]inventory.Lang, error) {
+func searchResultsStatsLanguages(ctx context.Context, matches []result.Match) ([]inventory.Lang, error) {
 	// Batch our operations by repo-commit.
 	type repoCommit struct {
 		repo     api.RepoID
@@ -46,7 +49,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 	}
 
 	var (
-		repos    = map[api.RepoID]*RepositoryResolver{}
+		repos    = map[api.RepoID]types.RepoName{}
 		filesMap = map[repoCommit]*fileStatsWork{}
 
 		run = parallel.NewRun(16)
@@ -56,9 +59,9 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 	)
 
 	// Track the mapping of repo ID -> repo object as we iterate.
-	sawRepo := func(repo *RepositoryResolver) {
-		if _, ok := repos[repo.IDInt32()]; !ok {
-			repos[repo.IDInt32()] = repo
+	sawRepo := func(repo types.RepoName) {
+		if _, ok := repos[repo.ID]; !ok {
+			repos[repo.ID] = repo
 		}
 	}
 
@@ -66,59 +69,52 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 	// because we might have a match of a repo *and* a file in the repo. We would need to avoid
 	// double-counting. In this case, we will just count the matching files.
 	hasNonRepoMatches := false
-	for _, res := range results {
-		if _, ok := res.ToRepository(); !ok {
+	for _, match := range matches {
+		if _, ok := match.(*result.RepoMatch); !ok {
 			hasNonRepoMatches = true
 		}
 	}
 
-	for _, res := range results {
-		if fileMatch, ok := res.ToFileMatch(); ok {
-			sawRepo(fileMatch.Repository())
-			key := repoCommit{repo: fileMatch.Repository().IDInt32(), commitID: fileMatch.CommitID}
+	for _, res := range matches {
+		if fileMatch, ok := res.(*result.FileMatch); ok {
+			sawRepo(fileMatch.Repo)
+			key := repoCommit{repo: fileMatch.Repo.ID, commitID: fileMatch.CommitID}
 
 			if _, ok := filesMap[key]; !ok {
 				filesMap[key] = &fileStatsWork{}
 			}
 
-			if len(fileMatch.LineMatches()) > 0 {
+			if len(fileMatch.LineMatches) > 0 {
 				// Only count matching lines. TODO(sqs): bytes are not counted for these files
 				if filesMap[key].partialFiles == nil {
 					filesMap[key].partialFiles = map[string]uint64{}
 				}
-				filesMap[key].partialFiles[fileMatch.Path] += uint64(len(fileMatch.LineMatches()))
+				filesMap[key].partialFiles[fileMatch.Path] += uint64(len(fileMatch.LineMatches))
 			} else {
 				// Count entire file.
 				filesMap[key].fullEntries = append(filesMap[key].fullEntries, &fileInfo{
 					path:  fileMatch.Path,
-					isDir: fileMatch.File().IsDirectory(),
+					isDir: false,
 				})
 			}
-		} else if repo, ok := res.ToRepository(); ok && !hasNonRepoMatches {
-			sawRepo(repo)
+		} else if repoMatch, ok := res.(*result.RepoMatch); ok && !hasNonRepoMatches {
+			sawRepo(repoMatch.RepoName())
 			run.Acquire()
 			goroutine.Go(func() {
 				defer run.Release()
 
-				branchRef, err := repo.DefaultBranch(ctx)
+				repoName := repoMatch.RepoName()
+				refName, err := getDefaultBranchForRepo(ctx, repoName.Name)
 				if err != nil {
 					run.Error(err)
 					return
 				}
-				if branchRef == nil || branchRef.Target() == nil {
-					return
-				}
-				target, err := branchRef.Target().OID(ctx)
+				oid, _, err := git.GetObject(ctx, repoName.Name, refName)
 				if err != nil {
 					run.Error(err)
 					return
 				}
-				repo, err := repo.repo(ctx)
-				if err != nil {
-					run.Error(err)
-					return
-				}
-				inv, err := backend.Repos.GetInventory(ctx, repo, api.CommitID(target), true)
+				inv, err := backend.Repos.GetInventory(ctx, repoName.ToRepo(), api.CommitID(oid.String()), true)
 				if err != nil {
 					run.Error(err)
 					return
@@ -127,7 +123,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 				allInventories = append(allInventories, *inv)
 				allInventoriesMu.Unlock()
 			})
-		} else if _, ok := res.ToCommitSearchResult(); ok {
+		} else if _, ok := res.(*result.CommitMatch); ok {
 			return nil, errors.New("language statistics do not support diff searches")
 		}
 	}
@@ -139,7 +135,7 @@ func searchResultsStatsLanguages(ctx context.Context, results []SearchResultReso
 		goroutine.Go(func() {
 			defer run.Release()
 
-			invCtx, err := backend.InventoryContext(repos[key.repo].RepoName(), key.commitID, true)
+			invCtx, err := backend.InventoryContext(repos[key.repo].Name, key.commitID, true)
 			if err != nil {
 				run.Error(err)
 				return

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages_test.go
@@ -9,11 +9,9 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
@@ -21,8 +19,6 @@ import (
 )
 
 func TestSearchResultsStatsLanguages(t *testing.T) {
-	db := new(dbtesting.MockDB)
-
 	wantCommitID := api.CommitID(strings.Repeat("a", 40))
 	rcache.SetupForTest(t)
 
@@ -59,23 +55,17 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 	}
 	defer git.ResetMocks()
 
-	fileMatch := func(path string, lineNumbers ...int32) *FileMatchResolver {
-		var lines []*result.LineMatch
-		for _, n := range lineNumbers {
-			lines = append(lines, &result.LineMatch{LineNumber: n})
+	mkResult := func(path string, lineNumbers ...int32) *result.FileMatch {
+		rn := types.RepoName{
+			Name: "r",
 		}
-		return mkResolverFromFileMatch(db, result.FileMatch{
-			File: result.File{
-				Path:     path,
-				Repo:     types.RepoName{Name: "r"},
-				CommitID: wantCommitID,
-			},
-			LineMatches: lines,
-		})
+		fm := mkFileMatch(rn, path, lineNumbers...)
+		fm.CommitID = wantCommitID
+		return fm
 	}
 
 	tests := map[string]struct {
-		results  []SearchResultResolver
+		results  []result.Match
 		getFiles []os.FileInfo
 		want     []inventory.Lang // TotalBytes values are incorrect (known issue doc'd in GraphQL schema)
 	}{
@@ -84,27 +74,27 @@ func TestSearchResultsStatsLanguages(t *testing.T) {
 			want:    []inventory.Lang{},
 		},
 		"1 entire file": {
-			results: []SearchResultResolver{
-				fileMatch("three.go"),
+			results: []result.Match{
+				mkResult("three.go"),
 			},
 			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 3}},
 		},
 		"line matches in 1 file": {
-			results: []SearchResultResolver{
-				fileMatch("three.go", 1),
+			results: []result.Match{
+				mkResult("three.go", 1),
 			},
 			want: []inventory.Lang{{Name: "Go", TotalBytes: 6, TotalLines: 1}},
 		},
 		"line matches in 2 files": {
-			results: []SearchResultResolver{
-				fileMatch("two.go", 1, 2),
-				fileMatch("three.go", 1),
+			results: []result.Match{
+				mkResult("two.go", 1, 2),
+				mkResult("three.go", 1),
 			},
 			want: []inventory.Lang{{Name: "Go", TotalBytes: 10, TotalLines: 3}},
 		},
 		"1 entire repo": {
-			results: []SearchResultResolver{
-				NewRepositoryResolver(db, &types.Repo{Name: "r", CreatedAt: time.Now()}),
+			results: []result.Match{
+				&result.RepoMatch{Name: "r"},
 			},
 			getFiles: []os.FileInfo{
 				fileInfo{path: "two.go"},


### PR DESCRIPTION
This commit modifies language statistic calculation to use match types
rather than resolver types. This removes the last reference to
`SearchResultResolver` outside of `search_results.go` 🎉 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
