### PR TITLE
Remove unneeded toMatch() method

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -90,10 +90,6 @@ func RepositoryByIDInt32(ctx context.Context, db dbutil.DB, repoID api.RepoID) (
 	return NewRepositoryResolver(db, repo), nil
 }
 
-func (r *RepositoryResolver) toMatch() result.Match {
-	return &r.RepoMatch
-}
-
 func (r *RepositoryResolver) ID() graphql.ID {
 	return MarshalRepositoryID(r.IDInt32())
 }

--- a/cmd/frontend/graphqlbackend/search_commits.go
+++ b/cmd/frontend/graphqlbackend/search_commits.go
@@ -39,10 +39,6 @@ type CommitSearchResultResolver struct {
 	gitCommitOnce     sync.Once
 }
 
-func (r *CommitSearchResultResolver) toMatch() result.Match {
-	return &r.CommitMatch
-}
-
 func (r *CommitSearchResultResolver) Commit() *GitCommitResolver {
 	r.gitCommitOnce.Do(func() {
 		if r.gitCommitResolver != nil {

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1817,7 +1817,6 @@ type SearchResultResolver interface {
 	ToRepository() (*RepositoryResolver, bool)
 	ToFileMatch() (*FileMatchResolver, bool)
 	ToCommitSearchResult() (*CommitSearchResultResolver, bool)
-	toMatch() result.Match
 
 	ResultCount() int32
 }

--- a/cmd/frontend/graphqlbackend/textsearch.go
+++ b/cmd/frontend/graphqlbackend/textsearch.go
@@ -41,10 +41,6 @@ type FileMatchResolver struct {
 	db           dbutil.DB
 }
 
-func (fm *FileMatchResolver) toMatch() result.Match {
-	return &fm.FileMatch
-}
-
 // Equal provides custom comparison which is used by go-cmp
 func (fm *FileMatchResolver) Equal(other *FileMatchResolver) bool {
 	return reflect.DeepEqual(fm, other)


### PR DESCRIPTION
We don't ever need to convert from resolvers to matches anymore, so this can go away!
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
