### PR TITLE
codeintel: use repositoryId field in event_logs.argument json instead of url column

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/repo_usage.go
+++ b/enterprise/internal/codeintel/stores/dbstore/repo_usage.go
@@ -64,15 +64,14 @@ FROM (
 	SELECT
 		-- Cut out repo portion of event url
 		-- e.g. https://{github.com/owner/repo}/-/rest-of-path
-		substring(url from '//[^/]+/(.+)/-/') AS repo_name,
+		argument->'repositoryId' AS repo_id,
 		COUNT(*) FILTER (WHERE name LIKE 'codeintel.search%%%%') AS search_count,
 		COUNT(*) FILTER (WHERE name LIKE 'codeintel.lsif%%%%') AS precise_count
 	FROM event_logs
 	WHERE timestamp >= NOW() - INTERVAL '1 week'
-	GROUP BY repo_name
+	GROUP BY repo_id
 ) counts
--- Cast allows use of the uri btree index
-JOIN repo r ON r.uri = counts.repo_name::citext
+JOIN repo r ON r.id = counts.repo_id::int
 WHERE r.deleted_at IS NULL
 ORDER BY search_count DESC, precise_count DESC
 `


### PR DESCRIPTION
We dont backfill old data here, the json field selector will return NULL for rows that don't have that json key and then match nothing in the JOIN.

Related PR https://github.com/sourcegraph/code-intel-extensions/pull/621

This is part of the work for private code on dotcom, specifically https://github.com/sourcegraph/sourcegraph/issues/20628. The reliance on the argument column is still necessary, further discussion can be found on Slack

