### PR TITLE
search: comment docs on how search metrics are processed

### DIFF
--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -150,7 +150,8 @@ func groupAggregatedCodeIntelStats(rawEvents []types.CodeIntelAggregatedEvent) *
 	}
 }
 
-// GetAggregatedSearchStats returns aggregates statistics for search usage.
+// GetAggregatedSearchStats queries the database for search usage and returns
+// the aggregates statistics in the format of our BigQuery schema.
 func GetAggregatedSearchStats(ctx context.Context, db dbutil.DB) (*types.SearchUsageStatistics, error) {
 	events, err := database.EventLogs(db).AggregatedSearchEvents(ctx)
 	if err != nil {
@@ -160,6 +161,10 @@ func GetAggregatedSearchStats(ctx context.Context, db dbutil.DB) (*types.SearchU
 	return groupAggregatedSearchStats(events), nil
 }
 
+// groupAggregatedSearchStats takes a set of input events (originating from
+// Sourcegraph's Postgres table) and returns a SearchUsageStatistics data type
+// that ends up being stored in BigQuery. SearchUsageStatistics corresponds to
+// the target DB schema.
 func groupAggregatedSearchStats(events []types.AggregatedEvent) *types.SearchUsageStatistics {
 	searchUsageStats := &types.SearchUsageStatistics{
 		Daily:   []*types.SearchUsagePeriod{newSearchEventPeriod()},
@@ -167,13 +172,15 @@ func groupAggregatedSearchStats(events []types.AggregatedEvent) *types.SearchUsa
 		Monthly: []*types.SearchUsagePeriod{newSearchEventPeriod()},
 	}
 
+	// Iterate over events, updating searchUsageStats for each event
 	for _, event := range events {
-		insertSearchEventStatistics(event, searchUsageStats)
+		populateSearchEventStatistics(event, searchUsageStats)
 	}
 
 	return searchUsageStats
 }
 
+// utility functions that resolve a SearchEventStatistics value for a given event name for some SearchUsagePeriod.
 var searchExtractors = map[string]func(p *types.SearchUsagePeriod) *types.SearchEventStatistics{
 	"search.latencies.literal":    func(p *types.SearchUsagePeriod) *types.SearchEventStatistics { return p.Literal },
 	"search.latencies.regexp":     func(p *types.SearchUsagePeriod) *types.SearchEventStatistics { return p.Regexp },
@@ -185,7 +192,20 @@ var searchExtractors = map[string]func(p *types.SearchUsagePeriod) *types.Search
 	"search.latencies.symbol":     func(p *types.SearchUsagePeriod) *types.SearchEventStatistics { return p.Symbol },
 }
 
-func insertSearchEventStatistics(event types.AggregatedEvent, statistics *types.SearchUsageStatistics) {
+// populateSearchEventStatistics is a side-effecting function that populates the
+// `statistics` object. The `statistics` event value is our target output type.
+//
+// Overview how it works:
+// (1) To populate the `statistics` object, we expect an event to have a supported event.Name.
+//
+// (2) Create a SearchUsagePeriod target object based on the event's period (i.e., Month, Week, Day).
+//
+// (3) Use the SearchUsagePeriod object as an argument for the utility functions
+// above, to get a handle on the (currently zero-valued) SearchEventStatistics
+// value that it contains that corresponds to that event type.
+//
+// (4) Populate that SearchEventStatistics object in the SearchUsagePeriod object with usage stats (latencies, etc).
+func populateSearchEventStatistics(event types.AggregatedEvent, statistics *types.SearchUsageStatistics) {
 	extractor, ok := searchExtractors[event.Name]
 	if !ok {
 		return


### PR DESCRIPTION
Documenting my understanding of this code after reading it. 

---

Optional reading for search metrics, for my own record keeping and posterity. 

There be dragons here. Some things I noticed that need to change:

- We have these list data structures:

```go
type SearchUsageStatistics struct
	Daily   []*SearchUsagePeriod
	Weekly  []*SearchUsagePeriod
	Monthly []*SearchUsagePeriod
}
```

But only ever populate one entry (they are always size 1). I don't know why this is. I added latency for search periods about a year ago and that was just the type that existed IIRC. I don't know why we do Daily/Weekly/Monthly in the big query table. We should follow suit with https://github.com/sourcegraph/sourcegraph/pull/15635 and have an event summary associated with some time stamp only, IMO. 

- The part that's missing about query count statistics is that we don't query for events under `argument->'code_search'->query_Data'->'query'` in the `event_logs` table, which we can then process to yield `SearchCountStatistics` objects, which already exist in the query schema. This DB [query part was removed](https://github.com/sourcegraph/sourcegraph/pull/11307/files#diff-e993544416f22e361ec7b6f4716ed3543680165a4bec786b7e592dc04282b7caL256) after the internal parts that process these events [were no longer being called](https://k8s.sgdev.org/github.com/sourcegraph/sourcegraph/-/commit/69553e0e63e047db36b965b10b1c2aafcebdcf1e#diff-3216a1ad32f304098f6200e28898bea2L172).

---

Summary: We should follow ideally suit with https://github.com/sourcegraph/sourcegraph/pull/15635 and define a new pubsub schema. I'm going to try use our existing types/schema to see if I can reclaim our lost metrics, but the current event processing code is excessive for what we need, and why doing it like https://github.com/sourcegraph/sourcegraph/pull/15635  is better.