### PR TITLE
web: remove jsx-no-bind ignore comments

### DIFF
--- a/client/branded/src/global-styles/GlobalStylesStory/FormFieldVariants/FormFieldVariants.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/FormFieldVariants/FormFieldVariants.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/jsx-no-bind */
 import classNames from 'classnames'
 import React from 'react'
 import 'storybook-addon-designs'

--- a/client/browser/src/shared/code-hosts/shared/codeHost.tsx
+++ b/client/browser/src/shared/code-hosts/shared/codeHost.tsx
@@ -762,7 +762,6 @@ export function handleCodeHost({
                         repoExistsOrError={repoExistsOrError}
                         showSignInButton={showSignInButton}
                         // The bound function is constant
-                        // eslint-disable-next-line react/jsx-no-bind
                         onSignInClose={nextSignInClose}
                         onConfigureSourcegraphClick={isInPage ? undefined : onConfigureSourcegraphClick}
                     />,
@@ -818,7 +817,6 @@ export function handleCodeHost({
                                     extensionsController={extensionsController}
                                     buttonProps={codeViewEvent.toolbarButtonProps}
                                     // The bound function is constant
-                                    // eslint-disable-next-line react/jsx-no-bind
                                     onSignInClose={nextSignInClose}
                                     location={H.createLocation(window.location)}
                                 />,
@@ -1155,7 +1153,6 @@ export function handleCodeHost({
                             location={H.createLocation(window.location)}
                             scope={scopeEditor}
                             // The bound function is constant
-                            // eslint-disable-next-line react/jsx-no-bind
                             onSignInClose={nextSignInClose}
                         />,
                         mount

--- a/client/sandboxes/code-insights/src/demo.tsx
+++ b/client/sandboxes/code-insights/src/demo.tsx
@@ -60,7 +60,6 @@ export function App(): ReactElement {
                     }
                 >
                     <Switch>
-                        {/* eslint-disable react/jsx-no-bind */}
                         {routes.map(({ render, ...route }) => (
                             <Route
                                 {...route}
@@ -76,7 +75,6 @@ export function App(): ReactElement {
                         ))}
 
                         <Redirect to="/insights" />
-                        {/* eslint-enable react/jsx-no-bind */}
                     </Switch>
                 </Suspense>
             </InsightsApiContext.Provider>

--- a/client/shared/src/components/VirtualList.tsx
+++ b/client/shared/src/components/VirtualList.tsx
@@ -55,7 +55,6 @@ export class VirtualList<TItem, TExtraItemProps = undefined> extends React.PureC
             <div className={this.props.className} ref={this.props.onRef}>
                 {this.props.items.slice(0, this.props.itemsToShow).map((item, index) => (
                     <VisibilitySensor
-                        // eslint-disable-next-line react/jsx-no-bind
                         onChange={isVisible => this.onChangeVisibility(isVisible, index)}
                         key={this.props.itemKey(item)}
                         containment={this.props.containment}

--- a/client/storybook/src/redesign-toggle-toolbar/RedesignToggleStorybook.tsx
+++ b/client/storybook/src/redesign-toggle-toolbar/RedesignToggleStorybook.tsx
@@ -15,7 +15,6 @@ export const RedesignToggleStorybook = (): ReactElement => {
             key="redesign-toolbar"
             active={isRedesignEnabled}
             title={isRedesignEnabled ? 'Disable redesign theme' : 'Enable redesign theme'}
-            // eslint-disable-next-line react/jsx-no-bind
             onClick={handleRedesignToggle}
         >
             <Icons icon="beaker" />

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -314,7 +314,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                     }
                 >
                     <Switch>
-                        {/* eslint-disable react/jsx-no-bind */}
                         {props.routes.map(
                             ({ render, condition = () => true, ...route }) =>
                                 condition(context) && (
@@ -330,7 +329,6 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                                     />
                                 )
                         )}
-                        {/* eslint-enable react/jsx-no-bind */}
                     </Switch>
                 </Suspense>
             </ErrorBoundary>

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -467,7 +467,6 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
             <ErrorBoundary location={null}>
                 <ShortcutProvider>
                     <BrowserRouter key={0}>
-                        {/* eslint-disable react/jsx-no-bind */}
                         <Route
                             path="/"
                             render={routeComponentProps => (
@@ -529,7 +528,6 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
                                 />
                             )}
                         />
-                        {/* eslint-enable react/jsx-no-bind */}
                     </BrowserRouter>
                     <Tooltip key={1} />
                     <Notifications

--- a/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
+++ b/client/web/src/enterprise/batches/global/GlobalBatchChangesArea.tsx
@@ -77,7 +77,6 @@ interface AuthenticatedProps extends Props {
 
 export const AuthenticatedBatchChangesArea = withAuthenticatedUser<AuthenticatedProps>(({ match, ...outerProps }) => (
     <Page>
-        {/* eslint-disable react/jsx-no-bind */}
         <Switch>
             <Route render={props => <BatchChangeListPage {...outerProps} {...props} />} path={match.url} exact={true} />
             <Route
@@ -87,7 +86,6 @@ export const AuthenticatedBatchChangesArea = withAuthenticatedUser<Authenticated
             />
             <Route component={NotFoundPage} key="hardcoded-key" />
         </Switch>
-        {/* eslint-enable react/jsx-no-bind */}
     </Page>
 ))
 
@@ -99,7 +97,6 @@ export const NamespaceBatchChangesArea = withAuthenticatedUser<
     NamespaceBatchChangesAreaProps & { authenticatedUser: AuthenticatedUser }
 >(({ match, namespaceID, ...outerProps }) => (
     <Page>
-        {/* eslint-disable react/jsx-no-bind */}
         <Switch>
             <Route
                 path={`${match.url}/apply/:specID`}
@@ -139,6 +136,5 @@ export const NamespaceBatchChangesArea = withAuthenticatedUser<
                 exact={true}
             />
         </Switch>
-        {/* eslint-enable react/jsx-no-bind */}
     </Page>
 ))

--- a/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
+++ b/client/web/src/enterprise/code-monitoring/global/GlobalCodeMonitoringArea.tsx
@@ -60,7 +60,6 @@ export const AuthenticatedCodeMonitoringArea = withAuthenticatedUser<Authenticat
     return (
         <div className="w-100">
             <Page>
-                {/* eslint-disable react/jsx-no-bind */}
                 <Switch>
                     <Route
                         render={props => <CodeMonitoringPage {...outerProps} {...props} />}

--- a/client/web/src/enterprise/extensions/registry/RegistryArea.tsx
+++ b/client/web/src/enterprise/extensions/registry/RegistryArea.tsx
@@ -43,7 +43,6 @@ export const RegistryArea: React.FunctionComponent<Props> = ({
     return (
         <div className="registry-area">
             <Switch>
-                {/* eslint-disable react/jsx-no-bind */}
                 <Route
                     path={`${match.url}/new`}
                     key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
@@ -52,7 +51,7 @@ export const RegistryArea: React.FunctionComponent<Props> = ({
                         <RegistryNewExtensionPage {...routeComponentProps} {...transferProps} />
                     )}
                 />
-                {/* eslint-enable react/jsx-no-bind */}
+
                 <Route key="hardcoded-key" component={NotFoundPage} />
             </Switch>
         </div>

--- a/client/web/src/extensions/ExtensionsArea.tsx
+++ b/client/web/src/extensions/ExtensionsArea.tsx
@@ -91,7 +91,6 @@ export const ExtensionsArea: React.FunctionComponent<ExtensionsAreaProps> = prop
             />
             <Switch>
                 {props.routes.map(
-                    /* eslint-disable react/jsx-no-bind */
                     ({ path, exact, condition = () => true, render }) =>
                         condition(context) && (
                             <Route
@@ -101,7 +100,6 @@ export const ExtensionsArea: React.FunctionComponent<ExtensionsAreaProps> = prop
                                 render={routeComponentProps => render({ ...context, ...routeComponentProps })}
                             />
                         )
-                    /* eslint-enable react/jsx-no-bind */
                 )}
                 <Route key="hardcoded-key" component={NotFoundPage} />
             </Switch>

--- a/client/web/src/extensions/ExtensionsQueryInputToolbar.tsx
+++ b/client/web/src/extensions/ExtensionsQueryInputToolbar.tsx
@@ -65,22 +65,16 @@ export const ExtensionsQueryInputToolbar: React.FunctionComponent<Props> = ({
                     {enablementFilterToLabel[enablementFilter]}
                 </DropdownToggle>
                 <DropdownMenu right={true}>
-                    <DropdownItem
-                        // eslint-disable-next-line react/jsx-no-bind
-                        onClick={() => setEnablementFilter('all')}
-                        disabled={enablementFilter === 'all'}
-                    >
+                    <DropdownItem onClick={() => setEnablementFilter('all')} disabled={enablementFilter === 'all'}>
                         Show all
                     </DropdownItem>
                     <DropdownItem
-                        // eslint-disable-next-line react/jsx-no-bind
                         onClick={() => setEnablementFilter('enabled')}
                         disabled={enablementFilter === 'enabled'}
                     >
                         Show enabled extensions
                     </DropdownItem>
                     <DropdownItem
-                        // eslint-disable-next-line react/jsx-no-bind
                         onClick={() => setEnablementFilter('disabled')}
                         disabled={enablementFilter === 'disabled'}
                     >

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -211,7 +211,6 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(props => {
     return (
         <div className="action-items__bar p-0 border-left position-relative d-flex flex-column" ref={barReference}>
             {/* To be clear to users that this isn't an error reported by extensions about e.g. the code they're viewing. */}
-            {/* eslint-disable-next-line react/jsx-no-bind */}
             <ErrorBoundary location={props.location} render={error => <span>Component error: {error.message}</span>}>
                 <ActionItemsDivider />
                 {canScrollNegative && (

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -81,7 +81,6 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                 location={location}
                 // To be clear to users that this isn't an error reported by extensions
                 // about e.g. the code they're viewing.
-                // eslint-disable-next-line react/jsx-no-bind
                 render={error => (
                     <div className="status-bar__item ml-2">
                         <small className="text-muted">Status bar component error: {error.message}</small>

--- a/client/web/src/extensions/extension/ExtensionArea.tsx
+++ b/client/web/src/extensions/extension/ExtensionArea.tsx
@@ -227,7 +227,6 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
                         <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                             <Switch>
                                 {this.props.routes.map(
-                                    /* eslint-disable react/jsx-no-bind */
                                     ({ path, render, exact, condition = () => true }) =>
                                         condition(context) && (
                                             <Route
@@ -239,7 +238,6 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
                                                 }
                                             />
                                         )
-                                    /* eslint-enable react/jsx-no-bind */
                                 )}
                                 <Route key="hardcoded-key" component={NotFoundPage} />
                             </Switch>

--- a/client/web/src/insights/InsightsRouter.tsx
+++ b/client/web/src/insights/InsightsRouter.tsx
@@ -52,7 +52,6 @@ export const InsightsRouter: React.FunctionComponent<InsightsRouterProps> = prop
     return (
         <Switch>
             <Route
-                /* eslint-disable-next-line react/jsx-no-bind */
                 render={props => (
                     <InsightsLazyPage isCreationUIEnabled={isCreationUIEnabled} {...outerProps} {...props} />
                 )}
@@ -64,13 +63,11 @@ export const InsightsRouter: React.FunctionComponent<InsightsRouterProps> = prop
                 <>
                     <Route
                         path={`${match.url}/create-search-insight`}
-                        /* eslint-disable-next-line react/jsx-no-bind */
                         render={props => <SearchInsightCreationLazyPage {...outerProps} {...props} />}
                     />
 
                     <Route
                         path={`${match.url}/create-lang-stats-insight`}
-                        /* eslint-disable-next-line react/jsx-no-bind */
                         render={props => <LangStatsInsightCreationLazyPage {...outerProps} {...props} />}
                     />
 

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
@@ -63,7 +63,6 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
     // In case if we don't have series we have to skip series list ui (components below)
     // and render simple series form component.
     if (series.length === 0) {
-        /* eslint-disable react/jsx-no-bind */
         return <FormSeriesInput autofocus={false} className="card card-body p-3" onSubmit={handleSubmitNewSeries} />
     }
 

--- a/client/web/src/org/OrgsArea.tsx
+++ b/client/web/src/org/OrgsArea.tsx
@@ -46,7 +46,6 @@ interface Props
  * Renders a layout of a sidebar and a content area to display organization-related pages.
  */
 export const OrgsArea: React.FunctionComponent<Props> = props => (
-    /* eslint-disable react/jsx-no-bind */
     <Switch>
         <Route path={`${props.match.url}/new`} component={NewOrganizationPage} exact={true} />
         <Route
@@ -55,5 +54,4 @@ export const OrgsArea: React.FunctionComponent<Props> = props => (
         />
         <Route component={NotFoundPage} />
     </Switch>
-    /* eslint-enable react/jsx-no-bind */
 )

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -252,7 +252,6 @@ export class OrgArea extends React.Component<Props> {
                         <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                             <Switch>
                                 {this.props.orgAreaRoutes.map(
-                                    /* eslint-disable react/jsx-no-bind */
                                     ({ path, exact, render, condition = () => true }) =>
                                         condition(context) && (
                                             <Route
@@ -264,7 +263,6 @@ export class OrgArea extends React.Component<Props> {
                                                 }
                                             />
                                         )
-                                    /* eslint-enable react/jsx-no-bind */
                                 )}
                                 <Route key="hardcoded-key" component={NotFoundPage} />
                             </Switch>

--- a/client/web/src/org/settings/OrgSettingsArea.tsx
+++ b/client/web/src/org/settings/OrgSettingsArea.tsx
@@ -43,7 +43,6 @@ export const OrgSettingsArea: React.FunctionComponent<Props> = props => {
                 <ErrorBoundary location={props.location}>
                     <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                         <Switch>
-                            {/* eslint-disable react/jsx-no-bind */}
                             <Route
                                 path={props.match.path}
                                 key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
@@ -88,7 +87,6 @@ export const OrgSettingsArea: React.FunctionComponent<Props> = props => {
                                 )}
                             />
                             <Route component={NotFoundPage} />
-                            {/* eslint-enable react/jsx-no-bind */}
                         </Switch>
                     </React.Suspense>
                 </ErrorBoundary>

--- a/client/web/src/org/settings/members/InviteForm.tsx
+++ b/client/web/src/org/settings/members/InviteForm.tsx
@@ -184,14 +184,12 @@ export const InviteForm: React.FunctionComponent<Props> = ({
                 </DismissibleAlert>
             )}
             {invited.map((invite, index) => (
-                /* eslint-disable react/jsx-no-bind */
                 <InvitedNotification
                     key={index}
                     {...invite}
                     className="alert alert-success invite-form__alert"
                     onDismiss={() => dismissNotification(index)}
                 />
-                /* eslint-enable react/jsx-no-bind */
             ))}
             {isErrorLike(loading) && <ErrorAlert className="invite-form__alert" error={loading} />}
         </div>

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -438,7 +438,6 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
             </RepoHeaderContributionPortal>
             <ErrorBoundary location={props.location}>
                 <Switch>
-                    {/* eslint-disable react/jsx-no-bind */}
                     {[
                         '',
                         ...(rawRevision ? [`@${rawRevision}`] : []), // must exactly match how the revision was encoded in the URL
@@ -478,7 +477,6 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                             )
                     )}
                     <Route key="hardcoded-key" component={RepoPageNotFound} />
-                    {/* eslint-enable react/jsx-no-bind */}
                 </Switch>
             </ErrorBoundary>
         </div>

--- a/client/web/src/repo/RepoHeader.tsx
+++ b/client/web/src/repo/RepoHeader.tsx
@@ -237,7 +237,6 @@ export const RepoHeader: React.FunctionComponent<Props> = ({
                 location={props.location}
                 // To be clear to users that this isn't an error reported by extensions
                 // about e.g. the code they're viewing.
-                // eslint-disable-next-line react/jsx-no-bind
                 render={error => (
                     <ul className="navbar-nav">
                         <li className="nav-item repo-header__action-list-item">

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -229,7 +229,6 @@ export const RepoRevisionContainer: React.FunctionComponent<RepoRevisionContaine
     return (
         <div className="repo-revision-container">
             <Switch>
-                {/* eslint-disable react/jsx-no-bind */}
                 {props.routes.map(
                     ({ path, render, exact, condition = () => true }) =>
                         condition(context) && (

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -265,7 +265,6 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
                                 compact={true}
                                 noun={tab.noun}
                                 pluralNoun={tab.pluralNoun}
-                                // eslint-disable-next-line react/jsx-no-bind
                                 queryConnection={queryRepositoryCommits}
                                 nodeComponent={GitCommitNode}
                                 nodeComponentProps={{

--- a/client/web/src/repo/branches/RepositoryBranchesArea.tsx
+++ b/client/web/src/repo/branches/RepositoryBranchesArea.tsx
@@ -55,7 +55,6 @@ export const RepositoryBranchesArea: React.FunctionComponent<Props> = ({ useBrea
         <div className="repository-branches-area container">
             <RepositoryBranchesNavbar className="my-3" repo={repo.name} />
             <Switch>
-                {/* eslint-disable react/jsx-no-bind */}
                 <Route
                     path={`${match.url}`}
                     key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
@@ -73,7 +72,6 @@ export const RepositoryBranchesArea: React.FunctionComponent<Props> = ({ useBrea
                     )}
                 />
                 <Route key="hardcoded-key" component={NotFoundPage} />
-                {/* eslint-enable react/jsx-no-bind */}
             </Switch>
         </div>
     )

--- a/client/web/src/repo/compare/RepositoryCompareArea.tsx
+++ b/client/web/src/repo/compare/RepositoryCompareArea.tsx
@@ -196,7 +196,6 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
                     <div className="alert alert-danger">Invalid comparison specifier</div>
                 ) : (
                     <Switch>
-                        {/* eslint-disable react/jsx-no-bind */}
                         <Route
                             path={`${this.props.match.url}`}
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
@@ -212,7 +211,6 @@ export class RepositoryCompareArea extends React.Component<RepositoryCompareArea
                             )}
                         />
                         <Route key="hardcoded-key" component={NotFoundPage} />
-                        {/* eslint-enable react/jsx-no-bind */}
                     </Switch>
                 )}
                 {this.state.hoverOverlayProps && (

--- a/client/web/src/repo/releases/RepositoryReleasesArea.tsx
+++ b/client/web/src/repo/releases/RepositoryReleasesArea.tsx
@@ -60,7 +60,6 @@ export const RepositoryReleasesArea: React.FunctionComponent<Props> = ({ useBrea
             <div className="container">
                 <div className="container-inner">
                     <Switch>
-                        {/* eslint-disable react/jsx-no-bind */}
                         <Route
                             path={`${routePrefix}/-/tags`}
                             key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
@@ -70,7 +69,6 @@ export const RepositoryReleasesArea: React.FunctionComponent<Props> = ({ useBrea
                             )}
                         />
                         <Route key="hardcoded-key" component={NotFoundPage} />
-                        {/* eslint-enable react/jsx-no-bind */}
                     </Switch>
                 </div>
             </div>

--- a/client/web/src/repo/settings/RepoSettingsArea.tsx
+++ b/client/web/src/repo/settings/RepoSettingsArea.tsx
@@ -95,7 +95,6 @@ export const RepoSettingsArea: React.FunctionComponent<Props> = ({
                 <Switch>
                     {props.repoSettingsAreaRoutes.map(
                         ({ render, path, exact, condition = () => true }) =>
-                            /* eslint-disable react/jsx-no-bind */
                             condition(context) && (
                                 <Route
                                     // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490

--- a/client/web/src/repo/stats/RepositoryStatsArea.tsx
+++ b/client/web/src/repo/stats/RepositoryStatsArea.tsx
@@ -49,7 +49,6 @@ export const RepositoryStatsArea: React.FunctionComponent<Props> = ({
         <div className="repository-stats-area container mt-3">
             {showNavbar && <RepositoryStatsNavbar className="mb-3" repo={props.repo.name} />}
             <Switch>
-                {/* eslint-disable react/jsx-no-bind */}
                 <Route
                     path={`${props.match.url}/contributors`}
                     key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
@@ -59,7 +58,6 @@ export const RepositoryStatsArea: React.FunctionComponent<Props> = ({
                     )}
                 />
                 <Route key="hardcoded-key" component={NotFoundPage} />
-                {/* eslint-enable react/jsx-no-bind */}
             </Switch>
         </div>
     )

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -453,7 +453,7 @@ export const TreePage: React.FunctionComponent<Props> = ({
                             </section>
                         )}
                     </ActionsContainer>
-                    {/* eslint-enable react/jsx-no-bind */}
+
                     <div className="tree-page__section">
                         <h3 className="tree-page__section-header">Changes</h3>
                         <FilteredConnection<GitCommitFields, Pick<GitCommitNodeProps, 'className' | 'compact'>>
@@ -473,7 +473,6 @@ export const TreePage: React.FunctionComponent<Props> = ({
                             useURLQuery={false}
                             hideSearch={true}
                             emptyElement={emptyElement}
-                            // eslint-disable-next-line react/jsx-no-bind
                             totalCountSummaryComponent={TotalCountSummary}
                         />
                     </div>

--- a/client/web/src/savedSearches/SavedSearchUpdateForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchUpdateForm.tsx
@@ -115,7 +115,6 @@ export class SavedSearchUpdateForm extends React.Component<Props, State> {
             <div>
                 {this.state.savedSearchOrError === LOADING && <LoadingSpinner className="icon-inline" />}
                 {this.props.authenticatedUser && savedSearch && (
-                    /* eslint-disable react/jsx-no-bind */
                     <SavedSearchForm
                         {...this.props}
                         submitLabel="Update saved search"
@@ -134,7 +133,6 @@ export class SavedSearchUpdateForm extends React.Component<Props, State> {
                         }
                         error={isErrorLike(this.state.updatedOrError) ? this.state.updatedOrError : undefined}
                     />
-                    /* eslint-enable react/jsx-no-bind */
                 )}
                 {this.state.updatedOrError === true && (
                     <p className="alert alert-success user-settings-profile-page__alert">Updated!</p>

--- a/client/web/src/settings/SettingsArea.tsx
+++ b/client/web/src/settings/SettingsArea.tsx
@@ -166,7 +166,6 @@ export class SettingsArea extends React.Component<Props, State> {
                 <h2>{term} settings</h2>
                 {this.props.extraHeader}
                 <Switch>
-                    {/* eslint-disable react/jsx-no-bind */}
                     <Route
                         path={this.props.match.url}
                         key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
@@ -174,7 +173,6 @@ export class SettingsArea extends React.Component<Props, State> {
                         render={routeComponentProps => <SettingsPage {...routeComponentProps} {...transferProps} />}
                     />
                     <Route key="hardcoded-key" component={NotFoundPage} />
-                    {/* eslint-enable react/jsx-no-bind */}
                 </Switch>
             </div>
         )

--- a/client/web/src/site-admin/SiteAdminArea.tsx
+++ b/client/web/src/site-admin/SiteAdminArea.tsx
@@ -103,7 +103,6 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<SiteAdminAreaProps> = 
                         <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
                             <Switch>
                                 {props.routes.map(
-                                    /* eslint-disable react/jsx-no-bind */
                                     ({ render, path, exact, condition = () => true }) =>
                                         condition(context) && (
                                             <Route
@@ -116,7 +115,6 @@ const AuthenticatedSiteAdminArea: React.FunctionComponent<SiteAdminAreaProps> = 
                                                 }
                                             />
                                         )
-                                    /* eslint-enable react/jsx-no-bind */
                                 )}
                                 <Route component={NotFoundPage} />
                             </Switch>

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -217,7 +217,6 @@ export const UserArea: React.FunctionComponent<UserAreaProps> = ({
                                 ({ path, exact, render, condition = () => true }) =>
                                     condition(context) && (
                                         <Route
-                                            // eslint-disable-next-line react/jsx-no-bind
                                             render={routeComponentProps =>
                                                 render({ ...context, ...routeComponentProps })
                                             }

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -92,7 +92,6 @@ export const UserSettingsArea = withAuthenticatedUser(
                                         ({ path, exact, render, condition = () => true }) =>
                                             condition(context) && (
                                                 <Route
-                                                    // eslint-disable-next-line react/jsx-no-bind
                                                     render={routeComponentProps =>
                                                         render({ ...context, ...routeComponentProps })
                                                     }

--- a/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
+++ b/client/web/src/user/settings/accessTokens/UserSettingsTokensArea.tsx
@@ -24,7 +24,6 @@ export const UserSettingsTokensArea: React.FunctionComponent<Props> = outerProps
         setNewToken(undefined)
     }, [])
     return (
-        /* eslint-disable react/jsx-no-bind */
         <Switch>
             <Route
                 exact={true}
@@ -51,6 +50,5 @@ export const UserSettingsTokensArea: React.FunctionComponent<Props> = outerProps
             />
             <Route component={NotFoundPage} key="hardcoded-key" />
         </Switch>
-        /* eslint-enable react/jsx-no-bind */
     )
 }

--- a/client/web/src/views/ChartViewContent/charts/bar/BarChart.tsx
+++ b/client/web/src/views/ChartViewContent/charts/bar/BarChart.tsx
@@ -161,9 +161,7 @@ export function BarChart<Datum extends object>(props: BarChartProps<Datum>): Rea
                                         height={barHeight}
                                         width={xScale.bandwidth()}
                                         fill={fill}
-                                        /* eslint-disable-next-line react/jsx-no-bind */
                                         onMouseLeave={handleMouseLeave}
-                                        /* eslint-disable-next-line react/jsx-no-bind */
                                         onMouseMove={event => {
                                             if (tooltipTimeout) {
                                                 clearTimeout(tooltipTimeout)

--- a/client/web/src/views/ChartViewContent/charts/line/components/GlyphContent.tsx
+++ b/client/web/src/views/ChartViewContent/charts/line/components/GlyphContent.tsx
@@ -85,9 +85,7 @@ export function GlyphContent<Datum extends object>(props: GlyphContentProps<Datu
             to={linkURL}
             onPointerUp={onPointerUp}
             onClick={onClick}
-            /* eslint-disable-next-line react/jsx-no-bind */
             onFocus={() => linkURL && setFocusedDatum(currentDatum)}
-            /* eslint-disable-next-line react/jsx-no-bind */
             onBlur={() => linkURL && setFocusedDatum(null)}
             className="line-chart__glyph-link"
             role={linkURL ? 'link' : 'graphics-dataunit'}

--- a/client/web/src/views/ChartViewContent/charts/line/components/LineChartContent.tsx
+++ b/client/web/src/views/ChartViewContent/charts/line/components/LineChartContent.tsx
@@ -320,7 +320,6 @@ export function LineChartContent<Datum extends object>(props: LineChartContentPr
                                         yAccessor={accessors.y[line.dataKey]}
                                         // Don't have info about line in props. @visx/xychart doesn't expose this information
                                         // Move this arrow function in separate component when API of GlyphSeries will be fixed.
-                                        /* eslint-disable-next-line react/jsx-no-bind */
                                         renderGlyph={glyphProps => (
                                             <GlyphContent
                                                 {...glyphProps}

--- a/client/web/src/views/ChartViewContent/charts/pie/PieChart.tsx
+++ b/client/web/src/views/ChartViewContent/charts/pie/PieChart.tsx
@@ -83,7 +83,6 @@ export function PieChart<Datum extends object>(props: PieChartProps<Datum>): Rea
     }
 
     return (
-        /* eslint-disable react/jsx-no-bind */
         <svg aria-label="Pie chart" className="pie-chart" width={width} height={height}>
             <Group top={centerY + padding.top} left={centerX + padding.left}>
                 <Pie

--- a/client/web/src/views/ViewsArea.tsx
+++ b/client/web/src/views/ViewsArea.tsx
@@ -51,7 +51,6 @@ export const ViewsArea: React.FunctionComponent<Props> = ({ match, ...outerProps
 
     return (
         <div className="container mt-4">
-            {/* eslint-disable react/jsx-no-bind */}
             <Switch>
                 <Route path={match.url} exact={true}>
                     <div className="alert alert-info">No view specified in the URL.</div>
@@ -70,7 +69,6 @@ export const ViewsArea: React.FunctionComponent<Props> = ({ match, ...outerProps
                     )}
                 />
             </Switch>
-            {/* eslint-enable react/jsx-no-bind */}
         </div>
     )
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@pollyjs/persister-fs": "^5.0.0",
     "@slack/web-api": "^5.10.0",
     "@sourcegraph/babel-plugin-transform-react-hot-loader-wrapper": "^1.0.0",
-    "@sourcegraph/eslint-config": "^0.24.0",
+    "@sourcegraph/eslint-config": "^0.25.0",
     "@sourcegraph/eslint-plugin-sourcegraph": "1.0.0",
     "@sourcegraph/prettierrc": "^3.0.3",
     "@sourcegraph/stylelint-config": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2928,10 +2928,10 @@
     sourcegraph "^24.0.0 || ^25.0.0"
     ts-key-enum "^2.0.0"
 
-"@sourcegraph/eslint-config@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.24.0.tgz#0bc0a090863da12b92fde0e6ec9d4f2d55be5c8b"
-  integrity sha512-cQH/rIxSmvtxKx1MSZWTCwfQacPBnbex+iElK7Hlo76M06SkL0dstHLUiu/9p7x9TWv3loI67uOKK+e03njt7A==
+"@sourcegraph/eslint-config@^0.25.0":
+  version "0.25.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/eslint-config/-/eslint-config-0.25.0.tgz#bdc561a8f90eccabb5606584c018d8fd3c8e823d"
+  integrity sha512-dloepkXWZkLppvsRgLCuRDAbAWkF5mdB3gUO9qzA6eRfOaYNHly5hWAnSugVIuA6VFS44nCIr3uK2ij8UCAdzw==
   dependencies:
     "@sourcegraph/prettierrc" "^3.0.3"
     "@typescript-eslint/eslint-plugin" "^4.9.1"


### PR DESCRIPTION
## Changes 
- Cleanup `react/jsx-no-bind` ignore statements after [disabling](https://github.com/sourcegraph/eslint-config/pull/202) this rule in our ESLint config.
- Update `@sourcegraph/eslint-config` to the latest version.