### PR TITLE
Refresh popovers: Update 'Show more' styles

### DIFF
--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -126,7 +126,6 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
         }
 
         let summary: React.ReactFragment | undefined
-
         if (!this.props.noSummaryIfAllNodesVisible || this.props.connection.nodes.length === 0 || hasNextPage) {
             if (totalCount !== null && totalCount > 0) {
                 summary = TotalCountSummaryComponent ? (

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -4,7 +4,11 @@ import * as React from 'react'
 
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
+<<<<<<< HEAD
 import { ConnectionNodesSummaryShowMore } from './ConnectionNodesSummary'
+=======
+import { ConnectionNodesSummary, ConnectionNodesSummaryShowMore } from './ConnectionNodesSummary'
+>>>>>>> f7f5061c41 (this is fun)
 import { Connection } from './ConnectionType'
 import { hasID } from './utils'
 
@@ -133,9 +137,15 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
                 ) : (
                     <p className="filtered-connection__summary" data-testid="summary">
                         <small>
-                            <span>
-                                {totalCount} {pluralize(this.props.noun, totalCount, this.props.pluralNoun)} total
-                            </span>{' '}
+                            {totalCount} {pluralize(this.props.noun, totalCount, this.props.pluralNoun)}{' '}
+                            {this.props.connectionQuery ? (
+                                <span>
+                                    {' '}
+                                    matching <strong>{this.props.connectionQuery}</strong>
+                                </span>
+                            ) : (
+                                'total'
+                            )}
                             {this.props.connection.nodes.length < totalCount &&
                                 `(showing first ${this.props.connection.nodes.length})`}
                         </small>
@@ -146,7 +156,14 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
             } else if (totalCount === 0) {
                 summary = this.props.emptyElement || (
                     <p className="filtered-connection__summary" data-testid="summary">
-                        <small>No {this.props.pluralNoun} found</small>
+                        <small>
+                            No {this.props.pluralNoun}{' '}
+                            {this.props.connectionQuery && (
+                                <span>
+                                    matching <strong>{this.props.connectionQuery}</strong>
+                                </span>
+                            )}
+                        </small>
                     </p>
                 )
             }

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -135,15 +135,7 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
                     <p className="filtered-connection__summary" data-testid="summary">
                         <small>
                             <span>
-                                {totalCount} {pluralize(this.props.noun, totalCount, this.props.pluralNoun)}{' '}
-                                {this.props.connectionQuery ? (
-                                    <span>
-                                        {' '}
-                                        matching <strong>{this.props.connectionQuery}</strong>
-                                    </span>
-                                ) : (
-                                    'total'
-                                )}
+                                {totalCount} {pluralize(this.props.noun, totalCount, this.props.pluralNoun)} total
                             </span>{' '}
                             {this.props.connection.nodes.length < totalCount &&
                                 `(showing first ${this.props.connection.nodes.length})`}
@@ -155,14 +147,7 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
             } else if (totalCount === 0) {
                 summary = this.props.emptyElement || (
                     <p className="filtered-connection__summary" data-testid="summary">
-                        <small>
-                            No {this.props.pluralNoun}{' '}
-                            {this.props.connectionQuery && (
-                                <span>
-                                    matching <strong>{this.props.connectionQuery}</strong>
-                                </span>
-                            )}
-                        </small>
+                        <small>No {this.props.pluralNoun} found</small>
                     </p>
                 )
             }

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
-import { ConnectionNodesSummaryShowMore, ConnectionNodesSummary } from './ConnectionNodesSummary'
+import { ConnectionNodesSummary } from './ConnectionNodesSummary'
 import { Connection } from './ConnectionType'
 import { hasID } from './utils'
 

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -126,6 +126,7 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
         }
 
         let summary: React.ReactFragment | undefined
+
         if (!this.props.noSummaryIfAllNodesVisible || this.props.connection.nodes.length === 0 || hasNextPage) {
             if (totalCount !== null && totalCount > 0) {
                 summary = TotalCountSummaryComponent ? (

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -192,10 +192,7 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
                 )}
                 {!this.props.connectionQuery && summary}
                 {!this.props.loading && !this.props.noShowMore && hasNextPage && (
-                    <ConnectionNodesSummaryShowMore
-                        onShowMore={this.props.onShowMore}
-                        showMoreClassName={this.props.showMoreClassName}
-                    />
+                    <ConnectionNodesSummaryShowMore onShowMore={this.props.onShowMore} loading={this.props.loading} />
                 )}
             </>
         )

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -4,11 +4,7 @@ import * as React from 'react'
 
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
-<<<<<<< HEAD
 import { ConnectionNodesSummaryShowMore } from './ConnectionNodesSummary'
-=======
-import { ConnectionNodesSummary, ConnectionNodesSummaryShowMore } from './ConnectionNodesSummary'
->>>>>>> f7f5061c41 (this is fun)
 import { Connection } from './ConnectionType'
 import { hasID } from './utils'
 
@@ -137,15 +133,17 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
                 ) : (
                     <p className="filtered-connection__summary" data-testid="summary">
                         <small>
-                            {totalCount} {pluralize(this.props.noun, totalCount, this.props.pluralNoun)}{' '}
-                            {this.props.connectionQuery ? (
-                                <span>
-                                    {' '}
-                                    matching <strong>{this.props.connectionQuery}</strong>
-                                </span>
-                            ) : (
-                                'total'
-                            )}
+                            <span>
+                                {totalCount} {pluralize(this.props.noun, totalCount, this.props.pluralNoun)}{' '}
+                                {this.props.connectionQuery ? (
+                                    <span>
+                                        {' '}
+                                        matching <strong>{this.props.connectionQuery}</strong>
+                                    </span>
+                                ) : (
+                                    'total'
+                                )}
+                            </span>{' '}
                             {this.props.connection.nodes.length < totalCount &&
                                 `(showing first ${this.props.connection.nodes.length})`}
                         </small>

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -192,7 +192,10 @@ export class ConnectionNodes<C extends Connection<N>, N, NP = {}, HP = {}> exten
                 )}
                 {!this.props.connectionQuery && summary}
                 {!this.props.loading && !this.props.noShowMore && hasNextPage && (
-                    <ConnectionNodesSummaryShowMore onShowMore={this.props.onShowMore} loading={this.props.loading} />
+                    <ConnectionNodesSummaryShowMore
+                        onShowMore={this.props.onShowMore}
+                        showMoreClassName={this.props.showMoreClassName}
+                    />
                 )}
             </>
         )

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -93,23 +93,20 @@ interface ConnectionNodesProps<C extends Connection<N>, N, NP = {}, HP = {}>
     onShowMore: () => void
 }
 
-export const getTotalCount = <N,>(connection: Connection<N>, first: number): number | null => {
-    if (typeof connection.totalCount === 'number') {
-        return connection.totalCount
+export const getTotalCount = <N,>({ totalCount, nodes, pageInfo }: Connection<N>, first: number): number | null => {
+    if (typeof totalCount === 'number') {
+        return totalCount
     }
 
     if (
         // TODO(sqs): this line below is wrong because `first` might've just been changed and
-        // `connection.nodes` is still the data fetched from before `first` was changed.
+        // `nodes` is still the data fetched from before `first` was changed.
         // this causes the UI to incorrectly show "N items total" even when the count is indeterminate right
         // after the user clicks "Show more" but before the new data is loaded.
-        connection.nodes.length < first ||
-        (connection.nodes.length === first &&
-            connection.pageInfo &&
-            typeof connection.pageInfo.hasNextPage === 'boolean' &&
-            !connection.pageInfo.hasNextPage)
+        nodes.length < first ||
+        (nodes.length === first && pageInfo && typeof pageInfo.hasNextPage === 'boolean' && !pageInfo.hasNextPage)
     ) {
-        return connection.nodes.length
+        return nodes.length
     }
 
     return null

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -29,24 +29,10 @@ export const ConnectionNodesSummaryShowMore: React.FunctionComponent<ConnectionN
     )
 }
 
-interface ConnectionNodesSummaryProps {
-    summary: React.ReactFragment | undefined
-    className?: string
-}
-
-export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSummaryProps> = ({
-    summary,
-    className,
-    children,
-}) => {
-    if (!summary && !children) {
+export const ConnectionNodesSummary: React.FunctionComponent = ({ children }) => {
+    if (!children) {
         return null
     }
 
-    return (
-        <div className={classNames('filtered-connection__summary-container', className)}>
-            {summary}
-            {children}
-        </div>
-    )
+    return <div className="filtered-connection__summary-container">{children}</div>
 }

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -8,7 +8,6 @@ interface ConnectionNodesSummaryProps {
     displayShowMoreButton?: boolean
     onShowMore?: () => void
     showMoreClassName?: string
-    hasNextPage?: boolean
     className?: string
 }
 
@@ -17,7 +16,6 @@ export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSumm
     displayShowMoreButton,
     showMoreClassName,
     onShowMore,
-    hasNextPage,
     className,
 }) => {
     const [isRedesignEnabled] = useRedesignToggle()
@@ -31,7 +29,6 @@ export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSumm
                 showMoreClassName
             )}
             onClick={onShowMore}
-            disabled={!hasNextPage}
         >
             Show more
         </button>

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -1,20 +1,47 @@
 import classNames from 'classnames'
 import * as React from 'react'
 
-interface ConnectionNodesSummaryShowMoreProps {
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+
+interface ConnectionNodesSummaryProps {
+    summary: React.ReactFragment | undefined
+    displayShowMoreButton?: boolean
     onShowMore?: () => void
     showMoreClassName?: string
 }
 
 export const ConnectionNodesSummaryShowMore: React.FunctionComponent<ConnectionNodesSummaryShowMoreProps> = ({
     onShowMore,
-    showMoreClassName,
-}) => (
-    <button
-        type="button"
-        className={classNames('btn btn-sm filtered-connection__show-more btn-secondary', showMoreClassName)}
-        onClick={onShowMore}
-    >
-        Show more
-    </button>
-)
+}) => {
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    const showMoreButton = displayShowMoreButton && (
+        <button
+            type="button"
+            className={classNames(
+                'btn btn-sm filtered-connection__show-more',
+                isRedesignEnabled ? 'btn-link' : 'btn-secondary',
+                showMoreClassName
+            )}
+            onClick={onShowMore}
+        >
+            Show more
+        </button>
+    )
+
+    if (isRedesignEnabled) {
+        return (
+            <div className="filtered-connection__summary-container">
+                {summary}
+                {showMoreButton}
+            </div>
+        )
+    }
+
+    return (
+        <>
+            {summary}
+            {showMoreButton}
+        </>
+    )
+}

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -1,7 +1,11 @@
 import classNames from 'classnames'
 import * as React from 'react'
 
+import { pluralize } from '@sourcegraph/shared/src/util/strings'
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+
+import { ConnectionNodesState, ConnectionProps } from './ConnectionNodes'
+import { Connection } from './ConnectionType'
 
 interface ConnectionNodesSummaryShowMoreProps {
     onShowMore?: () => void
@@ -29,10 +33,83 @@ export const ConnectionNodesSummaryShowMore: React.FunctionComponent<ConnectionN
     )
 }
 
-export const ConnectionNodesSummary: React.FunctionComponent = ({ children }) => {
-    if (!children) {
+interface ConnectionNodesSummaryProps<C extends Connection<N>, N, NP = {}, HP = {}>
+    extends Pick<
+        ConnectionProps<N, NP, HP> & ConnectionNodesState,
+        | 'noSummaryIfAllNodesVisible'
+        | 'totalCountSummaryComponent'
+        | 'noun'
+        | 'pluralNoun'
+        | 'connectionQuery'
+        | 'emptyElement'
+    > {
+    /** The fetched connection data or an error (if an error occurred). */
+    connection: C
+
+    hasNextPage: boolean
+
+    totalCount: number | null
+}
+
+export const ConnectionNodesSummary = <C extends Connection<N>, N, NP = {}, HP = {}>({
+    noSummaryIfAllNodesVisible,
+    connection,
+    hasNextPage,
+    totalCount,
+    totalCountSummaryComponent: TotalCountSummaryComponent,
+    noun,
+    pluralNoun,
+    connectionQuery,
+    emptyElement,
+}: ConnectionNodesSummaryProps<C, N, NP, HP>): JSX.Element | null => {
+    const shouldShowSummary = !noSummaryIfAllNodesVisible || connection.nodes.length === 0 || hasNextPage
+
+    if (!shouldShowSummary) {
         return null
     }
 
-    return <div className="filtered-connection__summary-container">{children}</div>
+    if (totalCount !== null && totalCount > 0 && TotalCountSummaryComponent) {
+        return <TotalCountSummaryComponent totalCount={totalCount} />
+    }
+
+    if (totalCount !== null && totalCount > 0 && !TotalCountSummaryComponent) {
+        return (
+            <p className="filtered-connection__summary" data-testid="summary">
+                <small>
+                    <span>
+                        {totalCount} {pluralize(noun, totalCount, pluralNoun)}{' '}
+                        {connectionQuery ? (
+                            <span>
+                                {' '}
+                                matching <strong>{connectionQuery}</strong>
+                            </span>
+                        ) : (
+                            'total'
+                        )}
+                    </span>{' '}
+                    {connection.nodes.length < totalCount && `(showing first ${connection.nodes.length})`}
+                </small>
+            </p>
+        )
+    }
+
+    if (connection.pageInfo?.hasNextPage) {
+        // No total count to show, but it will show a 'Show more' button.
+        return null
+    }
+
+    return (
+        emptyElement || (
+            <p className="filtered-connection__summary" data-testid="summary">
+                <small>
+                    No {pluralNoun}{' '}
+                    {connectionQuery && (
+                        <span>
+                            matching <strong>{connectionQuery}</strong>
+                        </span>
+                    )}
+                </small>
+            </p>
+        )
+    )
 }

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -3,24 +3,18 @@ import * as React from 'react'
 
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
-interface ConnectionNodesSummaryProps {
-    summary: React.ReactFragment | undefined
-    displayShowMoreButton?: boolean
+interface ConnectionNodesSummaryShowMoreProps {
     onShowMore?: () => void
     showMoreClassName?: string
-    className?: string
 }
 
-export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSummaryProps> = ({
-    summary,
-    displayShowMoreButton,
-    showMoreClassName,
+export const ConnectionNodesSummaryShowMore: React.FunctionComponent<ConnectionNodesSummaryShowMoreProps> = ({
     onShowMore,
-    className,
+    showMoreClassName,
 }) => {
     const [isRedesignEnabled] = useRedesignToggle()
 
-    const showMoreButton = displayShowMoreButton && (
+    return (
         <button
             type="button"
             className={classNames(
@@ -33,11 +27,26 @@ export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSumm
             Show more
         </button>
     )
+}
+
+interface ConnectionNodesSummaryProps {
+    summary: React.ReactFragment | undefined
+    className?: string
+}
+
+export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSummaryProps> = ({
+    summary,
+    className,
+    children,
+}) => {
+    if (!summary && !children) {
+        return null
+    }
 
     return (
         <div className={classNames('filtered-connection__summary-container', className)}>
             {summary}
-            {showMoreButton}
+            {children}
         </div>
     )
 }

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -8,6 +8,8 @@ interface ConnectionNodesSummaryProps {
     displayShowMoreButton?: boolean
     onShowMore?: () => void
     showMoreClassName?: string
+    hasNextPage?: boolean
+    className?: string
 }
 
 export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSummaryProps> = ({
@@ -15,6 +17,8 @@ export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSumm
     displayShowMoreButton,
     showMoreClassName,
     onShowMore,
+    hasNextPage,
+    className,
 }) => {
     const [isRedesignEnabled] = useRedesignToggle()
 
@@ -27,13 +31,14 @@ export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSumm
                 showMoreClassName
             )}
             onClick={onShowMore}
+            disabled={!hasNextPage}
         >
             Show more
         </button>
     )
 
     return (
-        <div className="filtered-connection__summary-container">
+        <div className={classNames('filtered-connection__summary-container', className)}>
             {summary}
             {showMoreButton}
         </div>

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames'
 import * as React from 'react'
 
-import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 interface ConnectionNodesSummaryProps {
@@ -9,21 +8,13 @@ interface ConnectionNodesSummaryProps {
     displayShowMoreButton?: boolean
     onShowMore?: () => void
     showMoreClassName?: string
-    loading?: boolean
 }
-
-const Loading: React.FunctionComponent = () => (
-    <span className="filtered-connection__loader test-filtered-connection__loader">
-        <LoadingSpinner className="icon-inline" />
-    </span>
-)
 
 export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSummaryProps> = ({
     summary,
     displayShowMoreButton,
     showMoreClassName,
     onShowMore,
-    loading,
 }) => {
     const [isRedesignEnabled] = useRedesignToggle()
 
@@ -43,14 +34,8 @@ export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSumm
 
     return (
         <div className="filtered-connection__summary-container">
-            {loading ? (
-                <Loading />
-            ) : (
-                <>
-                    {summary}
-                    {showMoreButton}
-                </>
-            )}
+            {summary}
+            {showMoreButton}
         </div>
     )
 }

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import * as React from 'react'
 
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 interface ConnectionNodesSummaryProps {
@@ -8,10 +9,21 @@ interface ConnectionNodesSummaryProps {
     displayShowMoreButton?: boolean
     onShowMore?: () => void
     showMoreClassName?: string
+    loading?: boolean
 }
 
-export const ConnectionNodesSummaryShowMore: React.FunctionComponent<ConnectionNodesSummaryShowMoreProps> = ({
+const Loading: React.FunctionComponent = () => (
+    <span className="filtered-connection__loader test-filtered-connection__loader">
+        <LoadingSpinner className="icon-inline" />
+    </span>
+)
+
+export const ConnectionNodesSummary: React.FunctionComponent<ConnectionNodesSummaryProps> = ({
+    summary,
+    displayShowMoreButton,
+    showMoreClassName,
     onShowMore,
+    loading,
 }) => {
     const [isRedesignEnabled] = useRedesignToggle()
 
@@ -29,19 +41,16 @@ export const ConnectionNodesSummaryShowMore: React.FunctionComponent<ConnectionN
         </button>
     )
 
-    if (isRedesignEnabled) {
-        return (
-            <div className="filtered-connection__summary-container">
-                {summary}
-                {showMoreButton}
-            </div>
-        )
-    }
-
     return (
-        <>
-            {summary}
-            {showMoreButton}
-        </>
+        <div className="filtered-connection__summary-container">
+            {loading ? (
+                <Loading />
+            ) : (
+                <>
+                    {summary}
+                    {showMoreButton}
+                </>
+            )}
+        </div>
     )
 }

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -1,37 +1,9 @@
-import classNames from 'classnames'
 import * as React from 'react'
 
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { ConnectionNodesState, ConnectionProps } from './ConnectionNodes'
 import { Connection } from './ConnectionType'
-
-interface ConnectionNodesSummaryShowMoreProps {
-    onShowMore?: () => void
-    showMoreClassName?: string
-}
-
-export const ConnectionNodesSummaryShowMore: React.FunctionComponent<ConnectionNodesSummaryShowMoreProps> = ({
-    onShowMore,
-    showMoreClassName,
-}) => {
-    const [isRedesignEnabled] = useRedesignToggle()
-
-    return (
-        <button
-            type="button"
-            className={classNames(
-                'btn btn-sm filtered-connection__show-more',
-                isRedesignEnabled ? 'btn-link' : 'btn-secondary',
-                showMoreClassName
-            )}
-            onClick={onShowMore}
-        >
-            Show more
-        </button>
-    )
-}
 
 interface ConnectionNodesSummaryProps<C extends Connection<N>, N, NP = {}, HP = {}>
     extends Pick<

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -112,4 +112,9 @@ $compact-summary-min-height: 2.75rem;
             margin-left: auto;
         }
     }
+    &__noncompact &__show-more {
+        .theme-redesign & {
+            margin-bottom: 1rem;
+        }
+    }
 }

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -1,3 +1,5 @@
+$summary-padding: 0.5rem 0.75rem;
+
 .filtered-connection-filter-control {
     display: flex;
     align-items: center;
@@ -19,7 +21,7 @@
             justify-content: space-between;
             align-items: center;
             border-top: solid 1px var(--border-color-2);
-            padding: 0.5rem 0.75rem;
+            padding: $summary-padding;
         }
     }
 
@@ -43,7 +45,7 @@
         flex: 0 0;
 
         .theme-redesign & {
-            flex: 1;
+            padding: $summary-padding;
         }
     }
     &--compact &__error {

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -63,16 +63,6 @@ $compact-summary-min-height: 2.75rem;
             padding: $compact-summary-padding;
             border-top: $compact-summary-divider;
             min-height: $compact-summary-min-height;
-
-            // No need to display summary twice in compact mode
-            &--top {
-                display: none;
-            }
-
-            // Ensure bottom is aligned to bottom of container
-            &--bottom {
-                margin-top: auto;
-            }
         }
     }
     &--noncompact &__summary-container {

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -71,11 +71,6 @@ $compact-summary-min-height: 2.75rem;
         }
     }
 
-    &__summary {
-        .theme-redesign & {
-            margin-bottom: 0;
-        }
-    }
     &--compact &__summary {
         flex: 0 0;
         padding: var(--popover-item-padding-v) var(--popover-item-padding-h);

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -109,13 +109,13 @@ $compact-summary-min-height: 2.75rem;
     &__show-more {
         flex: 0 0 auto;
         .theme-redesign & {
-            margin-right: initial;
             margin-left: auto;
         }
     }
-    &__noncompact &__show-more {
+    &--noncompact &__show-more {
         margin-right: auto;
         .theme-redesign & {
+            margin-right: initial;
             margin-bottom: 1rem;
         }
     }

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -109,10 +109,12 @@ $compact-summary-min-height: 2.75rem;
     &__show-more {
         flex: 0 0 auto;
         .theme-redesign & {
+            margin-right: initial;
             margin-left: auto;
         }
     }
     &__noncompact &__show-more {
+        margin-right: auto;
         .theme-redesign & {
             margin-bottom: 1rem;
         }

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -1,5 +1,6 @@
 $compact-summary-padding: 0.5rem 0.75rem;
 $compact-summary-divider: solid 1px var(--border-color-2);
+$compact-summary-min-height: 2.75rem;
 
 .filtered-connection-filter-control {
     display: flex;
@@ -33,8 +34,10 @@ $compact-summary-divider: solid 1px var(--border-color-2);
         flex: 0 0;
 
         .theme-redesign & {
+            // Consistent with the summary to avoid layout shifting
             border-top: $compact-summary-divider;
             padding: $compact-summary-padding;
+            min-height: $compact-summary-min-height;
         }
     }
     &--compact &__error {
@@ -53,12 +56,23 @@ $compact-summary-divider: solid 1px var(--border-color-2);
             flex-direction: row;
             justify-content: space-between;
             align-items: center;
+            min-height: $compact-summary-min-height;
         }
     }
     &--compact &__summary-container {
         .theme-redesign & {
             padding: $compact-summary-padding;
             border-top: $compact-summary-divider;
+
+            // No need to display summary twice in compact mode
+            &--top {
+                display: none;
+            }
+
+            // Ensure bottom is aligned to bottom of container
+            &--bottom {
+                margin-top: auto;
+            }
         }
     }
     &--noncompact &__summary-container {
@@ -105,6 +119,8 @@ $compact-summary-divider: solid 1px var(--border-color-2);
 
     &__show-more {
         flex: 0 0 auto;
-        margin-left: auto;
+        .theme-redesign & {
+            margin-left: auto;
+        }
     }
 }

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -70,11 +70,6 @@ $compact-summary-min-height: 2.75rem;
             min-height: $compact-summary-min-height;
         }
     }
-    &--noncompact &__summary-container {
-        .theme-redesign & {
-            margin-bottom: 1rem;
-        }
-    }
 
     &__summary {
         .theme-redesign & {

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -1,4 +1,5 @@
-$summary-padding: 0.5rem 0.75rem;
+$compact-summary-padding: 0.5rem 0.75rem;
+$compact-summary-divider: solid 1px var(--border-color-2);
 
 .filtered-connection-filter-control {
     display: flex;
@@ -10,19 +11,6 @@ $summary-padding: 0.5rem 0.75rem;
     &__nodes {
         list-style-type: none;
         padding: 0;
-    }
-
-    &__summary-container {
-        display: flex;
-        flex-direction: column;
-
-        .theme-redesign & {
-            flex-direction: row;
-            justify-content: space-between;
-            align-items: center;
-            border-top: solid 1px var(--border-color-2);
-            padding: $summary-padding;
-        }
     }
 
     &--noncompact &__form {
@@ -45,7 +33,8 @@ $summary-padding: 0.5rem 0.75rem;
         flex: 0 0;
 
         .theme-redesign & {
-            padding: $summary-padding;
+            border-top: $compact-summary-divider;
+            padding: $compact-summary-padding;
         }
     }
     &--compact &__error {
@@ -54,6 +43,34 @@ $summary-padding: 0.5rem 0.75rem;
     &--compact &__nodes {
         flex: 1 1;
         overflow-y: auto;
+    }
+
+    &__summary-container {
+        display: flex;
+        flex-direction: column;
+
+        .theme-redesign & {
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+        }
+    }
+    &--compact &__summary-container {
+        .theme-redesign & {
+            padding: $compact-summary-padding;
+            border-top: $compact-summary-divider;
+        }
+    }
+    &--noncompact &__summary-container {
+        .theme-redesign & {
+            margin-bottom: 1rem;
+        }
+    }
+
+    &__summary {
+        .theme-redesign & {
+            margin-bottom: 0;
+        }
     }
     &--compact &__summary {
         flex: 0 0;

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -10,9 +10,12 @@
         padding: 0;
     }
 
-    &--summary-container {
+    &__summary-container {
+        display: flex;
+        flex-direction: column;
+
         .theme-redesign & {
-            display: flex;
+            flex-direction: row;
             justify-content: space-between;
             align-items: center;
             border-top: solid 1px var(--border-color-2);
@@ -38,6 +41,10 @@
     &--compact &__loader {
         padding: var(--popover-item-padding-v) var(--popover-item-padding-h);
         flex: 0 0;
+
+        .theme-redesign & {
+            flex: 1;
+        }
     }
     &--compact &__error {
         border-radius: 0;

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -110,6 +110,10 @@ $compact-summary-min-height: 2.75rem;
     &__loader {
         display: flex;
         justify-content: center;
+
+        .theme-redesign & {
+            align-items: center;
+        }
     }
 
     &__show-more {

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -56,13 +56,13 @@ $compact-summary-min-height: 2.75rem;
             flex-direction: row;
             justify-content: space-between;
             align-items: center;
-            min-height: $compact-summary-min-height;
         }
     }
     &--compact &__summary-container {
         .theme-redesign & {
             padding: $compact-summary-padding;
             border-top: $compact-summary-divider;
+            min-height: $compact-summary-min-height;
 
             // No need to display summary twice in compact mode
             &--top {

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -52,6 +52,11 @@ $compact-summary-min-height: 2.75rem;
         display: flex;
         flex-direction: column;
 
+        &:empty {
+            // Hide if no children
+            display: none;
+        }
+
         .theme-redesign & {
             flex-direction: row;
             justify-content: space-between;

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -10,6 +10,16 @@
         padding: 0;
     }
 
+    &--summary-container {
+        .theme-redesign & {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            border-top: solid 1px var(--border-color-2);
+            padding: 0.5rem 0.75rem;
+        }
+    }
+
     &--noncompact &__form {
         margin-bottom: 0.5rem;
     }
@@ -41,6 +51,13 @@
         padding: var(--popover-item-padding-v) var(--popover-item-padding-h);
         opacity: 0.7;
         border-top: solid 1px var(--border-color);
+
+        .theme-redesign & {
+            flex: 1;
+            opacity: 1;
+            border-top: none;
+            padding: 0;
+        }
     }
 
     &--noncompact {

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -105,5 +105,6 @@ $compact-summary-divider: solid 1px var(--border-color-2);
 
     &__show-more {
         flex: 0 0 auto;
+        margin-left: auto;
     }
 }

--- a/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.test.tsx
@@ -41,7 +41,7 @@ const defaultConnectionNodesProps = {
 describe('ConnectionNodes', () => {
     afterAll(cleanup)
 
-    it('has a "Show more" button when *not* loading', () => {
+    it('has a "Show more" button and summary when *not* loading', () => {
         render(
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
@@ -54,7 +54,7 @@ describe('ConnectionNodes', () => {
         expect(screen.getByText('(showing first 1)')).toBeVisible()
     })
 
-    it("*doesn't* have a 'Show more' button when loading", () => {
+    it("*doesn't* have a 'Show more' button or summary when loading", () => {
         render(
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
@@ -63,8 +63,8 @@ describe('ConnectionNodes', () => {
             />
         )
         expect(screen.queryByRole('button')).not.toBeInTheDocument()
-        expect(screen.getByText('2 cats total')).toBeVisible()
-        expect(screen.getByText('(showing first 1)')).toBeVisible()
+        expect(screen.queryByText('2 cats total')).not.toBeInTheDocument()
+        expect(screen.queryByText('(showing first 1)')).not.toBeInTheDocument()
         // NOTE: we also expect a LoadingSpinner, but that is not provided by ConnectionNodes.
     })
 
@@ -87,7 +87,7 @@ describe('ConnectionNodes', () => {
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
                 connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [{}] })}
-                loading={true}
+                loading={false}
             />
         )
         expect(screen.queryByRole('button')).not.toBeInTheDocument()
@@ -113,7 +113,7 @@ describe('ConnectionNodes', () => {
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
                 connection={fakeConnection({ hasNextPage: true, totalCount: null, nodes: [{}] })}
-                loading={true}
+                loading={false}
             />
         )
         expect(screen.queryByTestId('summary')).not.toBeInTheDocument()
@@ -124,7 +124,7 @@ describe('ConnectionNodes', () => {
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
                 connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [{}] })}
-                loading={true}
+                loading={false}
                 noSummaryIfAllNodesVisible={false}
             />
         )
@@ -142,19 +142,7 @@ describe('ConnectionNodes', () => {
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
                 connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [] })}
-                loading={true}
-            />
-        )
-        expect(screen.getByText('1 cat total')).toBeVisible()
-        expect(screen.queryByText('(showing first 1)')).not.toBeInTheDocument()
-    })
-
-    it('shows a summary if nodes.length is 0', () => {
-        render(
-            <ConnectionNodes
-                {...defaultConnectionNodesProps}
-                connection={fakeConnection({ hasNextPage: false, totalCount: 1, nodes: [] })}
-                loading={true}
+                loading={false}
             />
         )
         expect(screen.getByText('1 cat total')).toBeVisible()
@@ -166,7 +154,7 @@ describe('ConnectionNodes', () => {
             <ConnectionNodes
                 {...defaultConnectionNodesProps}
                 connection={fakeConnection({ hasNextPage: false, totalCount: 0, nodes: [] })}
-                loading={true}
+                loading={false}
             />
         )
         expect(screen.getByText('No cats')).toBeVisible()

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -20,7 +20,6 @@ import {
 } from 'rxjs/operators'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
-import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { ErrorMessage } from '../alerts'
@@ -585,11 +584,6 @@ export class FilteredConnection<
                         emptyElement={this.props.emptyElement}
                         totalCountSummaryComponent={this.props.totalCountSummaryComponent}
                     />
-                )}
-                {this.state.loading && (
-                    <span className="filtered-connection__loader test-filtered-connection__loader">
-                        <LoadingSpinner className="icon-inline" />
-                    </span>
                 )}
             </div>
         )

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -20,6 +20,7 @@ import {
 } from 'rxjs/operators'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { ErrorMessage } from '../alerts'
@@ -584,6 +585,11 @@ export class FilteredConnection<
                         emptyElement={this.props.emptyElement}
                         totalCountSummaryComponent={this.props.totalCountSummaryComponent}
                     />
+                )}
+                {this.state.loading && (
+                    <span className="filtered-connection__loader test-filtered-connection__loader">
+                        <LoadingSpinner className="icon-inline" />
+                    </span>
                 )}
             </div>
         )

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -504,6 +504,9 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                 pluralNoun="code monitors"
                 query=""
               >
+                <div
+                  className="filtered-connection__summary-container"
+                />
                 <ul
                   className="filtered-connection__nodes"
                   data-testid="nodes"
@@ -1589,6 +1592,289 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
                     </AnchorLink>
                   </CodeMonitorNode>
                 </ul>
+                <div
+                  className="filtered-connection__summary-container"
+                >
+                  <ConnectionNodesSummary
+                    connection={
+                      Object {
+                        "nodes": Array [
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-0",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-0 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-0",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Test code monitor",
+                            "enabled": true,
+                            "id": "foo0",
+                            "trigger": Object {
+                              "id": "test-0",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-1",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-1 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-1",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Second test code monitor",
+                            "enabled": true,
+                            "id": "foo1",
+                            "trigger": Object {
+                              "id": "test-1",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-2",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-2 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-2",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Third test code monitor",
+                            "enabled": true,
+                            "id": "foo2",
+                            "trigger": Object {
+                              "id": "test-2",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-3",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-3 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-3",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Fourth test code monitor",
+                            "enabled": true,
+                            "id": "foo3",
+                            "trigger": Object {
+                              "id": "test-3",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-4",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-4 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-4",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Fifth test code monitor",
+                            "enabled": true,
+                            "id": "foo4",
+                            "trigger": Object {
+                              "id": "test-4",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-5",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-5 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-5",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Sixth test code monitor",
+                            "enabled": true,
+                            "id": "foo5",
+                            "trigger": Object {
+                              "id": "test-5",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-6",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-6 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-6",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Seventh test code monitor",
+                            "enabled": true,
+                            "id": "foo6",
+                            "trigger": Object {
+                              "id": "test-6",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-7",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-7 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-7",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Eighth test code monitor",
+                            "enabled": true,
+                            "id": "foo7",
+                            "trigger": Object {
+                              "id": "test-7",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-9",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-9 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-9",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Ninth test code monitor",
+                            "enabled": true,
+                            "id": "foo9",
+                            "trigger": Object {
+                              "id": "test-9",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-0",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-0 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-0",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Tenth test code monitor",
+                            "enabled": true,
+                            "id": "foo10",
+                            "trigger": Object {
+                              "id": "test-0",
+                              "query": "test",
+                            },
+                          },
+                        ],
+                        "pageInfo": Object {
+                          "endCursor": "foo10",
+                          "hasNextPage": false,
+                        },
+                        "totalCount": 10,
+                      }
+                    }
+                    connectionQuery=""
+                    hasNextPage={false}
+                    noSummaryIfAllNodesVisible={true}
+                    noun="code monitor"
+                    pluralNoun="code monitors"
+                    totalCount={10}
+                  />
+                </div>
               </ConnectionNodes>
             </div>
           </FilteredConnection>
@@ -1932,6 +2218,9 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                 pluralNoun="code monitors"
                 query=""
               >
+                <div
+                  className="filtered-connection__summary-container"
+                />
                 <ul
                   className="filtered-connection__nodes"
                   data-testid="nodes"
@@ -2261,6 +2550,107 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
                     </AnchorLink>
                   </CodeMonitorNode>
                 </ul>
+                <div
+                  className="filtered-connection__summary-container"
+                >
+                  <ConnectionNodesSummary
+                    connection={
+                      Object {
+                        "nodes": Array [
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-0",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-0 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-0",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Test code monitor",
+                            "enabled": true,
+                            "id": "foo0",
+                            "trigger": Object {
+                              "id": "test-0",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-1",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-1 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-1",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Second test code monitor",
+                            "enabled": true,
+                            "id": "foo1",
+                            "trigger": Object {
+                              "id": "test-1",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-2",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-2 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-2",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Third test code monitor",
+                            "enabled": true,
+                            "id": "foo2",
+                            "trigger": Object {
+                              "id": "test-2",
+                              "query": "test",
+                            },
+                          },
+                        ],
+                        "pageInfo": Object {
+                          "endCursor": "foo3",
+                          "hasNextPage": false,
+                        },
+                        "totalCount": 3,
+                      }
+                    }
+                    connectionQuery=""
+                    hasNextPage={false}
+                    noSummaryIfAllNodesVisible={true}
+                    noun="code monitor"
+                    pluralNoun="code monitors"
+                    totalCount={3}
+                  />
+                </div>
               </ConnectionNodes>
             </div>
           </FilteredConnection>
@@ -2838,6 +3228,9 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                 pluralNoun="code monitors"
                 query=""
               >
+                <div
+                  className="filtered-connection__summary-container"
+                />
                 <ul
                   className="filtered-connection__nodes"
                   data-testid="nodes"
@@ -4139,24 +4532,356 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                     </AnchorLink>
                   </CodeMonitorNode>
                 </ul>
-                <p
-                  className="filtered-connection__summary"
-                  data-testid="summary"
+                <div
+                  className="filtered-connection__summary-container"
                 >
-                  <small>
-                    <span>
-                      12
-                       
-                      code monitors
-                       
-                      total
-                    </span>
-                     
-                  </small>
-                </p>
-                <ConnectionNodesSummaryShowMore
-                  onShowMore={[Function]}
-                >
+                  <ConnectionNodesSummary
+                    connection={
+                      Object {
+                        "nodes": Array [
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-0",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-0 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-0",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Test code monitor",
+                            "enabled": true,
+                            "id": "foo0",
+                            "trigger": Object {
+                              "id": "test-0",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-1",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-1 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-1",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Second test code monitor",
+                            "enabled": true,
+                            "id": "foo1",
+                            "trigger": Object {
+                              "id": "test-1",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-2",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-2 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-2",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Third test code monitor",
+                            "enabled": true,
+                            "id": "foo2",
+                            "trigger": Object {
+                              "id": "test-2",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-3",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-3 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-3",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Fourth test code monitor",
+                            "enabled": true,
+                            "id": "foo3",
+                            "trigger": Object {
+                              "id": "test-3",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-4",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-4 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-4",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Fifth test code monitor",
+                            "enabled": true,
+                            "id": "foo4",
+                            "trigger": Object {
+                              "id": "test-4",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-5",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-5 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-5",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Sixth test code monitor",
+                            "enabled": true,
+                            "id": "foo5",
+                            "trigger": Object {
+                              "id": "test-5",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-6",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-6 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-6",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Seventh test code monitor",
+                            "enabled": true,
+                            "id": "foo6",
+                            "trigger": Object {
+                              "id": "test-6",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-7",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-7 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-7",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Eighth test code monitor",
+                            "enabled": true,
+                            "id": "foo7",
+                            "trigger": Object {
+                              "id": "test-7",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-9",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-9 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-9",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Ninth test code monitor",
+                            "enabled": true,
+                            "id": "foo9",
+                            "trigger": Object {
+                              "id": "test-9",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-0",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-0 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-0",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Tenth test code monitor",
+                            "enabled": true,
+                            "id": "foo10",
+                            "trigger": Object {
+                              "id": "test-0",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-1",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-1 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-1",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Eleventh test code monitor",
+                            "enabled": true,
+                            "id": "foo11",
+                            "trigger": Object {
+                              "id": "test-1",
+                              "query": "test",
+                            },
+                          },
+                          Object {
+                            "actions": Object {
+                              "enabled": true,
+                              "id": "test-2",
+                              "nodes": Array [
+                                Object {
+                                  "enabled": true,
+                                  "id": "test-action-2 ",
+                                  "recipients": Object {
+                                    "nodes": Array [
+                                      Object {
+                                        "id": "baz-2",
+                                      },
+                                    ],
+                                  },
+                                },
+                              ],
+                            },
+                            "description": "Twelfth test code monitor",
+                            "enabled": true,
+                            "id": "foo12",
+                            "trigger": Object {
+                              "id": "test-2",
+                              "query": "test",
+                            },
+                          },
+                        ],
+                        "pageInfo": Object {
+                          "endCursor": "foo12",
+                          "hasNextPage": true,
+                        },
+                        "totalCount": 12,
+                      }
+                    }
+                    connectionQuery=""
+                    hasNextPage={true}
+                    noSummaryIfAllNodesVisible={true}
+                    noun="code monitor"
+                    pluralNoun="code monitors"
+                    totalCount={12}
+                  >
+                    <p
+                      className="filtered-connection__summary"
+                      data-testid="summary"
+                    >
+                      <small>
+                        <span>
+                          12
+                           
+                          code monitors
+                           
+                          total
+                        </span>
+                         
+                      </small>
+                    </p>
+                  </ConnectionNodesSummary>
                   <button
                     className="btn btn-sm filtered-connection__show-more btn-secondary"
                     onClick={[Function]}
@@ -4164,7 +4889,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
                   >
                     Show more
                   </button>
-                </ConnectionNodesSummaryShowMore>
+                </div>
               </ConnectionNodes>
             </div>
           </FilteredConnection>

--- a/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
+++ b/client/web/src/enterprise/site-admin/dotcom/productSubscriptions/__snapshots__/SiteAdminProductSubscriptionPage.test.tsx.snap
@@ -173,7 +173,11 @@ exports[`SiteAdminProductSubscriptionPage renders 1`] = `
     <div
       className="filtered-connection test-filtered-connection filtered-connection--compact list-group list-group-flush"
     >
-      
+      <div
+        className="filtered-connection__summary-container"
+      >
+        
+      </div>
       <ul
         className="filtered-connection__nodes"
         data-testid="nodes"
@@ -203,6 +207,9 @@ exports[`SiteAdminProductSubscriptionPage renders 1`] = `
           showSubscription={false}
         />
       </ul>
+      <div
+        className="filtered-connection__summary-container"
+      />
     </div>
   </div>
   <div

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -231,6 +231,20 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
             revision: props.currentRev || props.defaultBranch,
         })
 
+    const sharedPanelProps = {
+        className: 'connection-popover__content',
+        inputClassName: 'connection-popover__input',
+        listClassName: 'connection-popover__nodes',
+        showMoreClassName: 'connection-popover__show-more',
+        inputPlaceholder: 'Find...',
+        compact: true,
+        autoFocus: true,
+        history: props.history,
+        location: props.location,
+        noSummaryIfAllNodesVisible: true,
+        useURLQuery: false,
+    }
+
     return (
         <Tabs defaultIndex={tabIndex} className="revisions-popover connection-popover" onChange={handleTabsChange}>
             <div className="tablist-wrapper revisions-popover__tabs">
@@ -250,13 +264,9 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
                     <TabPanel key={tab.id}>
                         {tab.type ? (
                             <FilteredConnection<GitRefFields, Omit<GitReferencePopoverNodeProps, 'node'>>
+                                {...sharedPanelProps}
                                 key={tab.id}
-                                className="connection-popover__content"
-                                showMoreClassName="connection-popover__show-more"
-                                inputClassName="connection-popover__input"
-                                listClassName="connection-popover__nodes"
-                                inputPlaceholder="Find..."
-                                compact={true}
+                                defaultFirst={50}
                                 noun={tab.noun}
                                 pluralNoun={tab.pluralNoun}
                                 queryConnection={tab.type === GitRefType.GIT_BRANCH ? queryGitBranches : queryGitTags}
@@ -266,21 +276,12 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
                                     currentRevision: props.currentRev,
                                     location: props.location,
                                 }}
-                                defaultFirst={50}
-                                autoFocus={true}
-                                noSummaryIfAllNodesVisible={true}
-                                useURLQuery={false}
-                                history={props.history}
-                                location={props.location}
                             />
                         ) : (
                             <FilteredConnection<GitCommitAncestorFields, Omit<GitCommitNodeProps, 'node'>>
+                                {...sharedPanelProps}
                                 key={tab.id}
-                                className="connection-popover__content"
-                                inputClassName="connection-popover__input"
-                                listClassName="connection-popover__nodes"
-                                inputPlaceholder="Find..."
-                                compact={true}
+                                defaultFirst={15}
                                 noun={tab.noun}
                                 pluralNoun={tab.pluralNoun}
                                 queryConnection={queryRepositoryCommits}
@@ -289,12 +290,6 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
                                     currentCommitID: props.currentCommitID,
                                     location: props.location,
                                 }}
-                                defaultFirst={15}
-                                autoFocus={true}
-                                history={props.history}
-                                location={props.location}
-                                noSummaryIfAllNodesVisible={true}
-                                useURLQuery={false}
                             />
                         )}
                     </TabPanel>

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -217,6 +217,7 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
     const [tabIndex, setTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
     const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
     const [isRedesignEnabled] = useRedesignToggle()
+
     const queryGitBranches = (args: FilteredConnectionQueryArguments): Observable<GitRefConnectionFields> =>
         queryGitReferences({ ...args, repo: props.repo, type: GitRefType.GIT_BRANCH, withBehindAhead: false })
 

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -13,6 +13,7 @@ import { gql, dataOrThrowErrors } from '@sourcegraph/shared/src/graphql/graphql'
 import { memoizeObservable } from '@sourcegraph/shared/src/util/memoizeObservable'
 import { RevisionSpec } from '@sourcegraph/shared/src/util/url'
 import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { requestGraphQL } from '../backend/graphql'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../components/FilteredConnection'
@@ -28,7 +29,6 @@ import { eventLogger } from '../tracking/eventLogger'
 import { replaceRevisionInURL } from '../util/url'
 
 import { GitReferenceNode, queryGitReferences } from './GitReference'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 const fetchRepositoryCommits = memoizeObservable(
     (
@@ -243,7 +243,7 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
         autoFocus: true,
         history: props.history,
         location: props.location,
-        noSummaryIfAllNodesVisible: isRedesignEnabled ? false : true,
+        noSummaryIfAllNodesVisible: !isRedesignEnabled,
         useURLQuery: false,
     }
 

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -28,6 +28,7 @@ import { eventLogger } from '../tracking/eventLogger'
 import { replaceRevisionInURL } from '../util/url'
 
 import { GitReferenceNode, queryGitReferences } from './GitReference'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 const fetchRepositoryCommits = memoizeObservable(
     (
@@ -215,7 +216,7 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
 
     const [tabIndex, setTabIndex] = useLocalStorage(LAST_TAB_STORAGE_KEY, 0)
     const handleTabsChange = useCallback((index: number) => setTabIndex(index), [setTabIndex])
-
+    const [isRedesignEnabled] = useRedesignToggle()
     const queryGitBranches = (args: FilteredConnectionQueryArguments): Observable<GitRefConnectionFields> =>
         queryGitReferences({ ...args, repo: props.repo, type: GitRefType.GIT_BRANCH, withBehindAhead: false })
 
@@ -241,7 +242,7 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
         autoFocus: true,
         history: props.history,
         location: props.location,
-        noSummaryIfAllNodesVisible: true,
+        noSummaryIfAllNodesVisible: isRedesignEnabled ? false : true,
         useURLQuery: false,
     }
 


### PR DESCRIPTION
## FilteredConnection Summary updates
- Updates styling for summary text and 'show more' button in FilteredConnection
- Updating loading styling in FilteredConnection
- Refactors ConnectionNodes to functional component and splits out utils for hooks usage and readability improvements

### Example 1: Compact `FilteredConnection`: Branch/Tag/Commit selector
https://user-images.githubusercontent.com/9516420/118284758-ac2cad00-b4c8-11eb-8cd8-edc91d1ece83.mov

### Example 2: NonCompact `FilteredConnection`: Extensions List
https://user-images.githubusercontent.com/9516420/118286072-ffebc600-b4c9-11eb-8773-0a94b99c7304.mov

## Notes
1. The PR includes a refactor to `ConnectionNodes` to a functional component. It is not a large refactor, but, as this has required moving some code around, it is worth hiding whitespace changes in the diff to make it easier to see exact changes.

Making almost any logic changes in `FilteredConnection` results in major regressions in different parts of the app. I think we should **maintain the logic of this component as much as possible until we can refactor this into new components**. Due to this, there are some slight differences to the design.

1. There was no design to display the summary above the list, I'll check if this was intended or not, but it is not feasible to remove this without an extensive refactor. It is used to display 'No [type] found' messages after search input and, more significantly, it is required on longer versions of `FilteredComponent` where the message may not easily be visible at the bottom.
1. The designs specify that the 'Show more' button (and the summary section) should now appear but be disabled if it has no use. This isn't feasible without a major refactor as large parts of the app rely on this section _not_ showing to maintain a consistent UI. 