### PR TITLE
Don't run TS compiler on dev start

### DIFF
--- a/dev/start.sh
+++ b/dev/start.sh
@@ -179,14 +179,6 @@ EOF
 # Kick off all build processes in parallel
 goreman --set-ports=false --exit-on-error -f "${tmp_install_procfile}" start
 
-# Once we've built the Go code and the frontend code, we build the frontend
-# code once in the background to make sure editor codeintel works.
-# This is fast if no changes were made.
-# Don't fail if it errors as this is only for codeintel, not for the build.
-trap 'kill $build_ts_pid; exit' EXIT
-(yarn --silent run build-ts || true) &
-build_ts_pid="$!"
-
 # Now launch the services in $PROCFILE
 export PROCFILE=${PROCFILE:-dev/Procfile}
 


### PR DESCRIPTION
The reason this was here was that code intel in the editor works best if you have a fresh compile of the current ts project. However, the VS Code settings we ship include a ts watcher task already so this is redundant and causes additional load on startup, which isn't great. Also, it often causes logspam when people are pulling latest main and someone added a new gql operation and the type gen hasn't finished running before tsc gets to it. I think every engineer who needs this can either use the vscode watcher or set it up themselves and it should not be part of the dev stack starting up.