### PR TITLE
graphql: Only the owner or org member can view saved search

### DIFF
--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -11,12 +11,27 @@ import (
 
 var ErrNotAuthenticated = errors.New("not authenticated")
 
-// CheckOrgAccess returns an error if the user is NEITHER (1) a site admin NOR (2) a
-// member of the organization with the specified ID.
+// CheckOrgAccessOrSiteAdmin returns an error if the user is NEITHER (1) a site
+// admin NOR (2) a member of the organization with the specified ID.
 //
-// It is used when an action on a user can be performed by site admins and the organization's
+// It is used when an action on a user can be performed by site admins and the
+// organization's members, but nobody else.
+func CheckOrgAccessOrSiteAdmin(ctx context.Context, db dbutil.DB, orgID int32) error {
+	return checkOrgAccess(ctx, db, orgID, true)
+}
+
+// CheckOrgAccess returns an error if the user is not a member of the
+// organization with the specified ID.
+//
+// It is used when an action on a user can be performed by the organization's
 // members, but nobody else.
 func CheckOrgAccess(ctx context.Context, db dbutil.DB, orgID int32) error {
+	return checkOrgAccess(ctx, db, orgID, false)
+}
+
+// checkOrgAccess is a helper method used above which allows optionally allowing
+// site admins to access all organisations.
+func checkOrgAccess(ctx context.Context, db dbutil.DB, orgID int32, allowAdmin bool) error {
 	if hasAuthzBypass(ctx) {
 		return nil
 	}
@@ -27,7 +42,7 @@ func CheckOrgAccess(ctx context.Context, db dbutil.DB, orgID int32) error {
 	if currentUser == nil {
 		return ErrNotAuthenticated
 	}
-	if currentUser.SiteAdmin {
+	if currentUser.SiteAdmin && allowAdmin {
 		return nil
 	}
 	return checkUserIsOrgMember(ctx, db, currentUser.ID, orgID)

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -86,7 +86,7 @@ func (o *OrgResolver) CreatedAt() DateTime { return DateTime{Time: o.org.Created
 
 func (o *OrgResolver) Members(ctx context.Context) (*staticUserConnectionResolver, error) {
 	// 🚨 SECURITY: Only org members can list the org members.
-	if err := backend.CheckOrgAccess(ctx, o.db, o.org.ID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, o.db, o.org.ID); err != nil {
 		if err == backend.ErrNotAnOrgMember {
 			return nil, errors.New("must be a member of this organization to view members")
 		}
@@ -115,7 +115,7 @@ func (o *OrgResolver) settingsSubject() api.SettingsSubject {
 func (o *OrgResolver) LatestSettings(ctx context.Context) (*settingsResolver, error) {
 	// 🚨 SECURITY: Only organization members and site admins may access the settings, because they
 	// may contains secrets or other sensitive data.
-	if err := backend.CheckOrgAccess(ctx, o.db, o.org.ID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, o.db, o.org.ID); err != nil {
 		return nil, err
 	}
 
@@ -150,7 +150,7 @@ func (o *OrgResolver) ViewerPendingInvitation(ctx context.Context) (*organizatio
 }
 
 func (o *OrgResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
-	if err := backend.CheckOrgAccess(ctx, o.db, o.org.ID); err == backend.ErrNotAuthenticated || err == backend.ErrNotAnOrgMember {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, o.db, o.org.ID); err == backend.ErrNotAuthenticated || err == backend.ErrNotAnOrgMember {
 		return false, nil
 	} else if err != nil {
 		return false, err
@@ -227,7 +227,7 @@ func (r *schemaResolver) UpdateOrganization(ctx context.Context, args *struct {
 
 	// 🚨 SECURITY: Check that the current user is a member
 	// of the org that is being modified.
-	if err := backend.CheckOrgAccess(ctx, r.db, orgID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgID); err != nil {
 		return nil, err
 	}
 
@@ -254,7 +254,7 @@ func (r *schemaResolver) RemoveUserFromOrganization(ctx context.Context, args *s
 
 	// 🚨 SECURITY: Check that the current user is a member of the org that is being modified, or a
 	// site admin.
-	if err := backend.CheckOrgAccess(ctx, r.db, orgID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/org_invitations.go
+++ b/cmd/frontend/graphqlbackend/org_invitations.go
@@ -65,7 +65,7 @@ func (r *schemaResolver) InviteUserToOrganization(ctx context.Context, args *str
 	}
 	// 🚨 SECURITY: Check that the current user is a member of the org that the user is being
 	// invited to.
-	if err := backend.CheckOrgAccess(ctx, r.db, orgID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgID); err != nil {
 		return nil, err
 	}
 
@@ -154,7 +154,7 @@ func (r *schemaResolver) ResendOrganizationInvitationNotification(ctx context.Co
 	}
 
 	// 🚨 SECURITY: Check that the current user is a member of the org that the invite is for.
-	if err := backend.CheckOrgAccess(ctx, r.db, orgInvitation.v.OrgID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgInvitation.v.OrgID); err != nil {
 		return nil, err
 	}
 
@@ -201,7 +201,7 @@ func (r *schemaResolver) RevokeOrganizationInvitation(ctx context.Context, args 
 	}
 
 	// 🚨 SECURITY: Check that the current user is a member of the org that the invite is for.
-	if err := backend.CheckOrgAccess(ctx, r.db, orgInvitation.v.OrgID); err != nil {
+	if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, orgInvitation.v.OrgID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -40,7 +40,9 @@ func (r *schemaResolver) savedSearchByID(ctx context.Context, id graphql.ID) (*s
 	if err != nil {
 		return nil, err
 	}
-	// 🚨 SECURITY: Make sure the current user has permission to get the saved search.
+
+	// 🚨 SECURITY: Make sure the current user has permission to get the saved
+	// search.
 	if ss.Config.UserID != nil {
 		if *ss.Config.UserID != actor.FromContext(ctx).UID {
 			return nil, &backend.InsufficientAuthorizationError{
@@ -176,7 +178,7 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 		orgID = &o
-		if err := backend.CheckOrgAccess(ctx, r.db, o); err != nil {
+		if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, o); err != nil {
 			return nil, err
 		}
 	} else {
@@ -228,7 +230,7 @@ func (r *schemaResolver) UpdateSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 		orgID = &o
-		if err := backend.CheckOrgAccess(ctx, r.db, o); err != nil {
+		if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, o); err != nil {
 			return nil, err
 		}
 	} else {
@@ -277,7 +279,7 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 	} else if ss.Config.OrgID != nil {
-		if err := backend.CheckOrgAccess(ctx, r.db, *ss.Config.OrgID); err != nil {
+		if err := backend.CheckOrgAccessOrSiteAdmin(ctx, r.db, *ss.Config.OrgID); err != nil {
 			return nil, err
 		}
 	} else {

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/query-runner/queryrunnerapi"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -41,8 +42,10 @@ func (r *schemaResolver) savedSearchByID(ctx context.Context, id graphql.ID) (*s
 	}
 	// 🚨 SECURITY: Make sure the current user has permission to get the saved search.
 	if ss.Config.UserID != nil {
-		if err := backend.CheckSiteAdminOrSameUser(ctx, *ss.Config.UserID); err != nil {
-			return nil, err
+		if *ss.Config.UserID != actor.FromContext(ctx).UID {
+			return nil, &backend.InsufficientAuthorizationError{
+				Message: "current user has insufficient privileges to view saved search",
+			}
 		}
 	} else if ss.Config.OrgID != nil {
 		if err := backend.CheckOrgAccess(ctx, r.db, *ss.Config.OrgID); err != nil {
@@ -112,7 +115,7 @@ func (r *schemaResolver) SavedSearches(ctx context.Context) ([]*savedSearchResol
 	var savedSearches []*savedSearchResolver
 	currentUser, err := CurrentUser(ctx, r.db)
 	if currentUser == nil {
-		return nil, errors.New("No currently authenticated user")
+		return nil, errors.New("no currently authenticated user")
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/saved_searches_test.go
+++ b/cmd/frontend/graphqlbackend/saved_searches_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -46,7 +46,7 @@ func settingsSubjectForNode(ctx context.Context, n Node) (*settingsSubject, erro
 
 	case *OrgResolver:
 		// 🚨 SECURITY: Check that the current user is a member of the org.
-		if err := backend.CheckOrgAccess(ctx, s.db, s.org.ID); err != nil {
+		if err := backend.CheckOrgAccessOrSiteAdmin(ctx, s.db, s.org.ID); err != nil {
 			return nil, err
 		}
 		return &settingsSubject{org: s}, nil

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -143,7 +143,7 @@ func (p *registryPublisherID) viewerCanAdminister(ctx context.Context, db dbutil
 		return backend.CheckSiteAdminOrSameUser(ctx, p.userID)
 	case p.orgID != 0:
 		// 🚨 SECURITY: Check that the current user is a member of the publisher org.
-		return backend.CheckOrgAccess(ctx, db, p.orgID)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, p.orgID)
 	default:
 		return errRegistryUnknownPublisher
 	}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -485,7 +485,7 @@ func (s *Service) ReenqueueChangeset(ctx context.Context, id int64) (changeset *
 // If both values are zero, an error is returned.
 func checkNamespaceAccess(ctx context.Context, db dbutil.DB, namespaceUserID, namespaceOrgID int32) error {
 	if namespaceOrgID != 0 {
-		return backend.CheckOrgAccess(ctx, db, namespaceOrgID)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, namespaceOrgID)
 	} else if namespaceUserID != 0 {
 		return backend.CheckSiteAdminOrSameUser(ctx, namespaceUserID)
 	} else {

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -426,7 +426,7 @@ func (r *Resolver) isAllowedToCreate(ctx context.Context, owner graphql.ID) erro
 	case "User":
 		return backend.CheckSiteAdminOrSameUser(ctx, ownerInt32)
 	case "Org":
-		return backend.CheckOrgAccess(ctx, r.store.Handle().DB(), ownerInt32)
+		return backend.CheckOrgAccessOrSiteAdmin(ctx, r.store.Handle().DB(), ownerInt32)
 	default:
 		return fmt.Errorf("provided ID is not a namespace")
 	}


### PR DESCRIPTION
Specifically, this change disallows site admins the ability to view any saved
search.

`CheckOrgAccess`  was also renamed to `CheckOrgAccessOrSiteAdmin` to make it
more explicit that site admins are allowed access. `CheckOrgAccess` now does
*not* allow site admins by default.

Part of https://github.com/sourcegraph/sourcegraph/issues/20800

Saved search listing will be fixed in another PR