### PR TITLE
search redesign: force streaming search if redesign is enabled

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -17,6 +17,7 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { ErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { parseHash } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { AuthenticatedUser, authRequired as authRequiredObservable } from './auth'
 import { CodeMonitoringProps } from './code-monitoring'
@@ -44,7 +45,7 @@ import { RepoHeaderActionButton } from './repo/RepoHeader'
 import { RepoRevisionContainerRoute } from './repo/RepoRevisionContainer'
 import { RepoSettingsAreaRoute } from './repo/settings/RepoSettingsArea'
 import { RepoSettingsSideBarGroup } from './repo/settings/RepoSettingsSidebar'
-import { LayoutRouteProps } from './routes'
+import { LayoutRouteProps, LayoutRouteComponentProps } from './routes'
 import { Settings } from './schema/settings.schema'
 import {
     parseSearchURLQuery,
@@ -254,6 +255,8 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
 
     const breadcrumbProps = useBreadcrumbs()
 
+    const [isRedesignEnabled] = useRedesignToggle()
+
     // Control browser extension discoverability animation here.
     // `Layout` is the lowest common ancestor of `UserNavItem` (target) and `RepoContainer` (trigger)
     const { isExtensionAlertAnimating, startExtensionAlertAnimation } = useExtensionAlertAnimation()
@@ -267,10 +270,11 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
         return <Redirect to={{ ...props.location, pathname: props.location.pathname.slice(0, -1) }} />
     }
 
-    const context = {
+    const context: LayoutRouteComponentProps<any> = {
         ...props,
         ...breadcrumbProps,
         onExtensionAlertDismissed,
+        isRedesignEnabled,
     }
 
     return (

--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -3,7 +3,7 @@ import { test } from 'mocha'
 import { Key } from 'ts-key-enum'
 
 import { SharedGraphQlOperations, SymbolKind } from '@sourcegraph/shared/src/graphql-operations'
-import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
+import { Driver, createDriverForTest, percySnapshot } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
 import {
@@ -128,13 +128,14 @@ describe('Search', () => {
     const getSearchFieldValue = (driver: Driver): Promise<string | undefined> =>
         driver.page.evaluate(() => document.querySelector<HTMLTextAreaElement>('#monaco-query-input textarea')?.value)
 
-    test('Styled correctly on results page', async () => {
+    test('Styled correctly on GraphQL search results page', async () => {
         testContext.overrideGraphQL({
             ...commonSearchGraphQLResults,
         })
         await driver.page.goto(driver.sourcegraphBaseUrl + '/search?q=foo')
         await driver.page.waitForSelector('#monaco-query-input')
-        await percySnapshotWithVariants(driver.page, 'Search results page')
+        // GraphQL search is not supported with redesign enabled so no need to take snapshots of variants
+        await percySnapshot(driver.page, 'Search results page')
     })
 
     describe('Search filters', () => {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -29,7 +29,7 @@ const SignUpPage = lazyComponent(() => import('./auth/SignUpPage'), 'SignUpPage'
 const PostSignUpPage = lazyComponent(() => import('./auth/PostSignUpPage'), 'PostSignUpPage')
 const SiteInitPage = lazyComponent(() => import('./site-admin/init/SiteInitPage'), 'SiteInitPage')
 
-interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof RouteParameters]?: string }>
+export interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof RouteParameters]?: string }>
     extends RouteComponentProps<RouteParameters>,
         Omit<LayoutProps, 'match'>,
         BreadcrumbsProps,
@@ -37,6 +37,7 @@ interface LayoutRouteComponentProps<RouteParameters extends { [K in keyof RouteP
         ExtensionAlertProps,
         UserRepositoriesUpdateProps {
     isSourcegraphDotCom: boolean
+    isRedesignEnabled: boolean
 }
 
 export interface LayoutRouteProps<Parameters_ extends { [K in keyof Parameters_]?: string }> {
@@ -79,8 +80,9 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         path: '/search',
         render: props =>
             props.parsedSearchQuery ? (
-                !isErrorLike(props.settingsCascade.final) &&
-                props.settingsCascade.final?.experimentalFeatures?.searchStreaming ? (
+                props.isRedesignEnabled || // Force streaming search if redesing is enabled
+                (!isErrorLike(props.settingsCascade.final) &&
+                    props.settingsCascade.final?.experimentalFeatures?.searchStreaming) ? (
                     <StreamingSearchResults {...props} />
                 ) : (
                     <SearchResults {...props} deployType={window.context.deployType} />

--- a/client/web/src/search/results/SearchResultsList.tsx
+++ b/client/web/src/search/results/SearchResultsList.tsx
@@ -530,7 +530,7 @@ export class SearchResultsList extends React.PureComponent<SearchResultsListProp
                     <SearchResult
                         icon={SourceCommitIcon}
                         result={result}
-                        repoName={result.commit.repository.name}
+                        repoName={result.commit?.repository?.name}
                         isLightTheme={this.props.isLightTheme}
                         history={this.props.history}
                     />


### PR DESCRIPTION
- Closes #20912 
- Also fixes a crash with graphql search rendering diff/commit results