### PR TITLE
Implement fuzzy file finder with keyboard shortcut `f`.

### DIFF
--- a/client/web/src/fuzzy/BloomFilter.js
+++ b/client/web/src/fuzzy/BloomFilter.js
@@ -1,0 +1,137 @@
+/**
+ * ===============================================================
+ * ORIGINAL LICENSE
+ * https://github.com/jasondavies/bloomfilter.js/blob/649e43e60ded806a3f0d1ca88d6a42c6dffba2db/LICENSE
+ * This file has been adapted toG
+ * ===============================================================
+ * Copyright (c) 2018, Jason Davies
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+;(function (exports) {
+  exports.BloomFilter = BloomFilter
+  exports.fnv_1a = fnv_1a
+
+  // Creates a new bloom filter.  If *m* is an array-like object, with a length
+  // property, then the bloom filter is loaded with data from the array, where
+  // each element is a 32-bit integer.  Otherwise, *m* should specify the
+  // number of bits.  Note that *m* is rounded up to the nearest multiple of
+  // 32.  *k* specifies the number of hashing functions.
+  function BloomFilter(m, k) {
+    var a
+    if (typeof m !== 'number') (a = m), (m = a.length * 32)
+    var n = Math.ceil(m / 32),
+      i = -1
+    this.m = m = n * 32
+    this.k = k
+
+    var kbytes = 1 << Math.ceil(Math.log(Math.ceil(Math.log(m) / Math.LN2 / 8)) / Math.LN2),
+      array = kbytes === 1 ? Uint8Array : kbytes === 2 ? Uint16Array : Uint32Array,
+      kbuffer = new ArrayBuffer(kbytes * k)
+    this.buckets = new Int32Array(n)
+    if (a) while (++i < n) this.buckets[i] = a[i]
+    this._locations = new array(kbuffer)
+  }
+
+  // See http://willwhim.wpengine.com/2011/09/03/producing-n-hash-functions-by-hashing-only-once/
+  BloomFilter.prototype.locations = function (v) {
+    var k = this.k,
+      m = this.m,
+      r = this._locations,
+      a = fnv_1a(v),
+      b = fnv_1a(v, 1576284489), // The seed value is chosen randomly
+      x = a % m
+    for (var i = 0; i < k; ++i) {
+      r[i] = x < 0 ? x + m : x
+      x = (x + b) % m
+    }
+    return r
+  }
+
+  BloomFilter.prototype.add = function (v) {
+    var l = this.locations(v),
+      k = this.k,
+      buckets = this.buckets
+    for (var i = 0; i < k; ++i) buckets[Math.floor(l[i] / 32)] |= 1 << l[i] % 32
+  }
+
+  BloomFilter.prototype.test = function (v) {
+    var l = this.locations(v),
+      k = this.k,
+      buckets = this.buckets
+    for (var i = 0; i < k; ++i) {
+      var b = l[i]
+      if ((buckets[Math.floor(b / 32)] & (1 << b % 32)) === 0) {
+        return false
+      }
+    }
+    return true
+  }
+
+  // Estimated cardinality.
+  BloomFilter.prototype.size = function () {
+    var buckets = this.buckets,
+      bits = 0
+    for (var i = 0, n = buckets.length; i < n; ++i) bits += popcnt(buckets[i])
+    return (-this.m * Math.log(1 - bits / this.m)) / this.k
+  }
+
+  // http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+  function popcnt(v) {
+    v -= (v >> 1) & 0x55555555
+    v = (v & 0x33333333) + ((v >> 2) & 0x33333333)
+    return (((v + (v >> 4)) & 0xf0f0f0f) * 0x1010101) >> 24
+  }
+
+  // Fowler/Noll/Vo hashing.
+  // Nonstandard variation: this function optionally takes a seed value that is incorporated
+  // into the offset basis. According to http://www.isthe.com/chongo/tech/comp/fnv/index.html
+  // "almost any offset_basis will serve so long as it is non-zero".
+  function fnv_1a(v, seed) {
+    var a = 2166136261 ^ (seed || 0)
+    var c = v,
+      d = c & 0xff00
+    if (d) a = fnv_multiply(a ^ (d >> 8))
+    a = fnv_multiply(a ^ (c & 0xff))
+    return fnv_mix(a)
+  }
+
+  // a * 16777619 mod 2**32
+  function fnv_multiply(a) {
+    return a + (a << 1) + (a << 4) + (a << 7) + (a << 8) + (a << 24)
+  }
+
+  // See https://web.archive.org/web/20131019013225/http://home.comcast.net/~bretm/hash/6.html
+  function fnv_mix(a) {
+    a += a << 13
+    a ^= a >>> 7
+    a += a << 3
+    a ^= a >>> 17
+    a += a << 5
+    return a & 0xffffffff
+  }
+})(typeof exports !== 'undefined' ? exports : this)

--- a/client/web/src/fuzzy/BloomFilter.test.ts
+++ b/client/web/src/fuzzy/BloomFilter.test.ts
@@ -1,0 +1,23 @@
+import { BloomFilter } from './BloomFilter'
+const filter = new BloomFilter(10000, 16)
+filter.add(1)
+filter.add(2)
+filter.add(3)
+
+function checkNotContains(v: number) {
+    test(`notContains-${v}`, () => {
+        expect(filter.test(v)).toBe(false)
+    })
+}
+
+function checkContains(v: number) {
+    test(`contains-${v}`, () => {
+        expect(filter.test(v)).toBe(true)
+    })
+}
+
+checkNotContains(0)
+checkContains(1)
+checkContains(2)
+checkContains(3)
+checkNotContains(4)

--- a/client/web/src/fuzzy/BloomFilterFuzzySearch.tsx
+++ b/client/web/src/fuzzy/BloomFilterFuzzySearch.tsx
@@ -1,0 +1,301 @@
+import { Hasher } from './Hasher'
+import { BloomFilter } from './BloomFilter'
+import { HighlightedTextProps, RangePosition } from './HighlightedText'
+import { FuzzySearch, FuzzySearchParameters, FuzzySearchResult } from './FuzzySearch'
+
+/**
+ * We don't index filenames with length larger than this value.
+ */
+const MAX_VALUE_LENGTH = 100
+
+const DEFAULT_BLOOM_FILTER_HASH_FUNCTION_COUNT = 8
+const DEFAULT_BLOOM_FILTER_SIZE = 2 << 17
+
+/**
+ * Returns true if the given query fuzzy matches the given value.
+ */
+export function fuzzyMatchesQuery(query: string, value: string): RangePosition[] {
+    return fuzzyMatches(allFuzzyParts(query, true), value)
+}
+
+export interface SearchValue {
+    value: string
+    url?: string
+}
+
+const DEFAULT_BUCKET_SIZE = 500
+
+/**
+ * Fuzzy search that uses bloom filters to improve performance in very large repositories.
+ *
+ * NOTE(olafur): this is a reimplementation of the fuzzy finder in the Scala
+ * language server that's documented in this blog post here
+ * https://scalameta.org/metals/blog/2019/01/22/bloom-filters.html#fuzzy-symbol-search
+ *
+ * In a nutshell, bloom filters improve performance by allowing us to skip a
+ * "bucket" of candidate files if we know that bucket does not match any words
+ * in that query. For example, the query "SymPro" is split into the words "Sym"
+ * and "Pro". If a bucket of 500 words is guaranteed to have to appearances of
+ * the words "Sym" and "Pro", then we can skip those 500 words and move on to
+ * the next bucket.
+ *
+ * One downside of the bloom filter approach is that it requires an indexing
+ * phase that can take a couple of seconds to complete on a large input size
+ * (>100k filenames). The indexing phase can take a while to complete because we
+ * need to compute all possible words that the user may query. For example,
+ * given the filename "SymbolProvider", we create a bloom filter with all
+ * possible prefixes of "Symbol" and "Provider". Fortunately, bloom filters can be
+ * serialized so that the indexing step only runs once per repoName/commitID pair.
+ */
+export class BloomFilterFuzzySearch extends FuzzySearch {
+    constructor(readonly buckets: Bucket[], readonly BUCKET_SIZE: number = DEFAULT_BUCKET_SIZE) {
+        super()
+    }
+    public static fromSearchValues(
+        files: SearchValue[],
+        BUCKET_SIZE: number = DEFAULT_BUCKET_SIZE
+    ): BloomFilterFuzzySearch {
+        const buckets = []
+        let buffer: SearchValue[] = []
+        files.forEach(file => {
+            buffer.push(file)
+            if (buffer.length >= BUCKET_SIZE) {
+                buckets.push(Bucket.fromSearchValues(buffer))
+                buffer = []
+            }
+        })
+        if (buffer) buckets.push(Bucket.fromSearchValues(buffer))
+        return new BloomFilterFuzzySearch(buckets, BUCKET_SIZE)
+    }
+
+    public serialize(): any {
+        return {
+            buckets: this.buckets.map(b => b.serialize()),
+            BUCKET_SIZE: this.BUCKET_SIZE,
+        }
+    }
+
+    public static fromSerializedString(text: string): BloomFilterFuzzySearch {
+        const json = JSON.parse(text) as any
+        return new BloomFilterFuzzySearch(json.buckets.map(Bucket.fromSerializedString), json.BUCKET_SIZE)
+    }
+
+    public search(query: FuzzySearchParameters): FuzzySearchResult {
+        if (query.value.length === 0) return this.emptyResult(query)
+        const self = this
+        const result: HighlightedTextProps[] = []
+        const finalQuery = query.value // this.actualQuery(query.value)
+        const hashParts = allQueryHashParts(finalQuery)
+        function complete(isComplete: boolean) {
+            return self.sorted({ values: result, isComplete: isComplete })
+        }
+        for (var i = 0; i < this.buckets.length; i++) {
+            const bucket = this.buckets[i]
+            const matches = bucket.matches(finalQuery, hashParts)
+            for (var j = 0; j < matches.value.length; j++) {
+                if (result.length >= query.maxResults) {
+                    return complete(false)
+                }
+                result.push(matches.value[j])
+            }
+        }
+        return complete(true)
+    }
+
+    private sorted(result: FuzzySearchResult): FuzzySearchResult {
+        result.values.sort((a, b) => {
+            const byLength = a.text.length - b.text.length
+            if (byLength !== 0) return byLength
+            const byEarliestMatch = a.offsetSum() - b.offsetSum()
+            if (byEarliestMatch !== 0) return byEarliestMatch
+
+            return a.text.localeCompare(b.text)
+        })
+        return result
+    }
+
+    private emptyResult(query: FuzzySearchParameters): FuzzySearchResult {
+        const result: HighlightedTextProps[] = []
+        const self = this
+        function complete(isComplete: boolean) {
+            return self.sorted({ values: result, isComplete: isComplete })
+        }
+
+        for (var i = 0; i < this.buckets.length; i++) {
+            const bucket = this.buckets[i]
+            if (result.length > query.maxResults) return complete(false)
+            for (var j = 0; j < bucket.files.length; j++) {
+                const value = bucket.files[j]
+                result.push(new HighlightedTextProps(value.value, [], value.url))
+                if (result.length > query.maxResults) return complete(false)
+            }
+        }
+        return complete(true)
+    }
+}
+
+export function allFuzzyParts(value: string, includeDelimeters: boolean): string[] {
+    const buf: string[] = []
+    var start = 0
+    for (var end = 0; end < value.length; end = nextFuzzyPart(value, end)) {
+        if (end > start) {
+            buf.push(value.substring(start, end))
+        }
+        while (end < value.length && isDelimeter(value[end])) {
+            if (includeDelimeters) {
+                buf.push(value[end])
+            }
+            end++
+        }
+        start = end
+        end++
+    }
+
+    if (start < value.length && end > start) {
+        buf.push(value.substring(start, end))
+    }
+
+    return buf
+}
+
+function isUppercase(str: string): boolean {
+    return str.toUpperCase() === str && str !== str.toLowerCase()
+}
+
+function isDelimeterOrUppercase(ch: string): boolean {
+    return isDelimeter(ch) || isUppercase(ch)
+}
+
+function isDelimeter(ch: string): boolean {
+    switch (ch) {
+        case '/':
+        case '_':
+        case '-':
+        case '.':
+        case ' ':
+            return true
+        default:
+            return false
+    }
+}
+
+function fuzzyMatches(queries: string[], value: string): RangePosition[] {
+    const result: RangePosition[] = []
+    var queryIndex = 0
+    function query(): string {
+        return queries[queryIndex]
+    }
+    function isQueryDelimeter(): boolean {
+        return isDelimeter(query())
+    }
+    function indexOfDelimeter(delim: string, i: number) {
+        const index = value.indexOf(delim, i)
+        return index < 0 ? value.length : index
+    }
+    var start = 0
+    while (queryIndex < queries.length && start < value.length) {
+        const isCurrentQueryDelimeter = isQueryDelimeter()
+        while (!isQueryDelimeter() && isDelimeter(value[start])) start++
+        if (value.startsWith(query(), start)) {
+            const end = start + query().length
+            result.push({
+                startOffset: start,
+                endOffset: end,
+                isExact: end < value.length && isDelimeterOrUppercase(value[end]),
+            })
+            queryIndex++
+        }
+        const nextStart = isCurrentQueryDelimeter ? start : start + 1
+        let end = isQueryDelimeter() ? indexOfDelimeter(query(), nextStart) : nextFuzzyPart(value, nextStart)
+        while (end < value.length && !isQueryDelimeter && isDelimeter(value[end])) end++
+        start = end
+    }
+    return queryIndex >= queries.length ? result : []
+}
+
+function nextFuzzyPart(value: string, start: number): number {
+    var end = start
+    while (end < value.length && !isDelimeterOrUppercase(value[end])) end++
+    return end
+}
+
+function populateBloomFilter(values: SearchValue[]): BloomFilter {
+    let hashes = new BloomFilter(DEFAULT_BLOOM_FILTER_SIZE, DEFAULT_BLOOM_FILTER_HASH_FUNCTION_COUNT)
+    values.forEach(value => {
+        if (value.value.length < MAX_VALUE_LENGTH) {
+            updateHashParts(value.value, hashes)
+        }
+    })
+    return hashes
+}
+
+function allQueryHashParts(query: string): number[] {
+    const fuzzyParts = allFuzzyParts(query, false)
+    const result: number[] = []
+    const H = new Hasher()
+    for (var i = 0; i < fuzzyParts.length; i++) {
+        H.reset()
+        const part = fuzzyParts[i]
+        for (var j = 0; j < part.length; j++) {
+            H.update(part[j])
+        }
+        const digest = H.digest()
+        result.push(digest)
+    }
+    return result
+}
+
+function updateHashParts(value: string, buf: BloomFilter): void {
+    let H = new Hasher()
+
+    for (var i = 0; i < value.length; i++) {
+        const ch = value[i]
+        if (isDelimeterOrUppercase(ch)) {
+            H.reset()
+        }
+        if (isDelimeter(ch)) continue
+        H.update(ch)
+        const digest = H.digest()
+        buf.add(digest)
+    }
+}
+
+interface BucketResult {
+    skipped: boolean
+    value: HighlightedTextProps[]
+}
+
+class Bucket {
+    constructor(readonly files: SearchValue[], readonly filter: BloomFilter, readonly id: number) {}
+    public static fromSearchValues(files: SearchValue[]): Bucket {
+        files.sort((a, b) => a.value.length - b.value.length)
+        return new Bucket(files, populateBloomFilter(files), Math.random())
+    }
+    public static fromSerializedString(json: any): Bucket {
+        return new Bucket(json.files, new BloomFilter(json.filter, DEFAULT_BLOOM_FILTER_HASH_FUNCTION_COUNT), json.id)
+    }
+    public serialize(): any {
+        return {
+            files: this.files,
+            filter: [].slice.call(this.filter.buckets),
+        }
+    }
+
+    private matchesMaybe(hashParts: number[]): boolean {
+        return hashParts.every(num => this.filter.test(num))
+    }
+    public matches(query: string, hashParts: number[]): BucketResult {
+        const matchesMaybe = this.matchesMaybe(hashParts)
+        if (!matchesMaybe) return { skipped: true, value: [] }
+        const result: HighlightedTextProps[] = []
+        const queryParts = allFuzzyParts(query, true)
+        for (var i = 0; i < this.files.length; i++) {
+            const file = this.files[i]
+            const positions = fuzzyMatches(queryParts, file.value)
+            if (positions.length > 0) {
+                result.push(new HighlightedTextProps(file.value, positions, file.url))
+            }
+        }
+        return { skipped: false, value: result }
+    }
+}

--- a/client/web/src/fuzzy/FuzzyModal.tsx
+++ b/client/web/src/fuzzy/FuzzyModal.tsx
@@ -1,0 +1,336 @@
+import { gql } from '@sourcegraph/shared/src/graphql/graphql'
+import React from 'react'
+import { requestGraphQL } from '../backend/graphql'
+import { BloomFilterFuzzySearch } from './BloomFilterFuzzySearch'
+import { FuzzySearch, FuzzySearchResult } from './FuzzySearch'
+import { HighlightedText, HighlightedTextProps } from './HighlightedText'
+import { useEphemeralState, useLocalStorage, State } from './useLocalStorage'
+
+const DEFAULT_MAX_RESULTS = 100
+
+export interface FuzzyModalProps {
+    isVisible: boolean
+    onClose(): void
+    repoName: string
+    commitID: string
+}
+
+/**
+ * React component that interactively displays filenames in the open repository when given fuzzy queries.
+ *
+ * Similar to "Go to file" in VS Code or the "t" keyboard shortcut on github.com
+ */
+export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
+    if (!props.isVisible) {
+        return null
+    }
+
+    // NOTE(olafur): the query is cached in local storage to mimic IntelliJ.
+    // It' quite annoying in VS Code when it doesn't cache the "Go to symbol in
+    // workspace" query. For example, I can't count the times I have typed a
+    // query like "FilePro", browsed the results and want to update the query to
+    // become "FileProvider" but VS Code has forgotten the original query so I
+    // have to type it out from scratch again.
+    const query = useLocalStorage(`fuzzy-modal.query.${props.repoName}`, '')
+
+    // The "focus index" is the index of the file result that the user has
+    // select with up/down arrow keys. The focused item is highlighted and the
+    // window.location is moved to that URL when the user presses the enter key.
+    const focusIndex = useEphemeralState(0)
+
+    const maxResults = useEphemeralState(DEFAULT_MAX_RESULTS)
+
+    const files = renderFiles(props, query, focusIndex, maxResults)
+
+    // Sets the new "focus index" so that it's rounded by the number of
+    // displayed filenames.  Cycles so that the user can press-hold the down
+    // arrow and it goes all the way down and back up to the top result.
+    function setRoundedFocusIndex(newNumber: number) {
+        const N = files.results.length
+        const i = newNumber % N
+        const nextIndex = i < 0 ? N + i : i
+        focusIndex.set(nextIndex)
+        document.getElementById(`fuzzy-modal-result-${nextIndex}`)?.scrollIntoView(false)
+    }
+
+    function onInputKeyDown(e: React.KeyboardEvent): void {
+        switch (e.key) {
+            case 'Escape':
+                props.onClose()
+                break
+            case 'ArrowDown':
+                e.preventDefault() // Don't move the cursor to the end of the input.
+                setRoundedFocusIndex(focusIndex.value + 1)
+                break
+            case 'PageDown':
+                setRoundedFocusIndex(focusIndex.value + 10)
+                break
+            case 'ArrowUp':
+                e.preventDefault() // Don't move the cursor to the start of the input.
+                setRoundedFocusIndex(focusIndex.value - 1)
+                break
+            case 'PageUp':
+                setRoundedFocusIndex(focusIndex.value - 10)
+                break
+            case 'Enter':
+                if (focusIndex.value < files.results.length) {
+                    const url = files.results[focusIndex.value].url
+                    if (url) {
+                        window.location.href = url
+                    }
+                }
+                break
+            default:
+        }
+    }
+
+    return (
+        <div className="fuzzy-modal" onClick={props.onClose}>
+            <div className="fuzzy-modal-content" onClick={e => e.stopPropagation()}>
+                <div className="fuzzy-modal-header">
+                    <div className="fuzzy-modal-cursor">
+                        <input
+                            autoComplete="off"
+                            id="fuzzy-modal-input"
+                            value={query.value}
+                            onChange={e => {
+                                query.set(e.target.value)
+                                focusIndex.set(0)
+                            }}
+                            type="text"
+                            onKeyDown={onInputKeyDown}
+                        />
+                        <i></i>
+                    </div>
+                </div>
+                <div className="fuzzy-modal-body">{files.element}</div>
+                <div className="fuzzy-modal-footer">
+                    <button className="btn btn-secondary" onClick={props.onClose}>
+                        Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+/**
+ * The fuzzy finder modal is implemented as a state machine with the following transitions:
+ *
+ * Empty ──> Loading ──> Indexing ──> Ready
+ *            ╰─────────────────────> Failed
+ *
+ * - Empty: start state.
+ * - Loading: downloading filenames from the remote server.
+ * - Indexing: processing the downloaded filenames. This step is usually
+ * instant, unless the repo is HUGE.
+ * - Ready: user can fuzzy find filenames.
+ * - Failed: error, the user can't fuzzy find files.
+ */
+type Loaded = Empty | Loading | Indexing | Ready | Failed
+interface Empty {
+    key: 'empty'
+}
+interface Loading {
+    key: 'loading'
+}
+interface Indexing {
+    key: 'indexing'
+    filenames: string[]
+}
+interface Ready {
+    key: 'ready'
+    fuzzy: FuzzySearch
+}
+interface Failed {
+    key: 'failed'
+    errorMessage: string
+}
+
+interface RenderedFiles {
+    element: JSX.Element
+    results: HighlightedTextProps[]
+}
+
+// Cache for the last fuzzy query. This value is only used to avoid redoing the
+// full fuzzy search on every re-render when the user presses the down/up arrow
+// keys to move the "focus index".
+const lastFuzzySearchResult = new Map<string, FuzzySearchResult>()
+
+function renderFiles(
+    props: FuzzyModalProps,
+    query: State<string>,
+    focusIndex: State<number>,
+    maxResults: State<number>
+): RenderedFiles {
+    let loaded = useEphemeralState<Loaded>({ key: 'empty' })
+
+    function empty(elem: JSX.Element): RenderedFiles {
+        return {
+            element: elem,
+            results: [],
+        }
+    }
+
+    const usuallyFast =
+        "This step is usually fast unless it's a very large repository. The result is cached so you only have to wait for it once :)"
+
+    switch (loaded.value.key) {
+        case 'empty':
+            handleEmpty(props, loaded)
+            return empty(<></>)
+        case 'loading':
+            return empty(<p>Downloading... {usuallyFast}</p>)
+        case 'failed':
+            return empty(<p>Error: {loaded.value.errorMessage}</p>)
+        case 'indexing':
+            handleIndexing(props, loaded.value.filenames).then(next => {
+                loaded.set(next)
+            })
+            return empty(<p>Indexing... {usuallyFast}</p>)
+        case 'ready':
+            const cacheKey = `${query.value}-${maxResults.value}`
+            let fuzzyResult = lastFuzzySearchResult.get(cacheKey)
+            if (!fuzzyResult) {
+                fuzzyResult = loaded.value.fuzzy.search({
+                    value: query.value,
+                    maxResults: maxResults.value,
+                })
+                lastFuzzySearchResult.clear() // Only cache the last query.
+                lastFuzzySearchResult.set(cacheKey, fuzzyResult)
+            }
+            const matchingFiles = fuzzyResult.values
+
+            if (matchingFiles.length === 0) {
+                return empty(<p>No files matching '{query.value}'</p>)
+            }
+            const filesToRender = matchingFiles.slice(0, maxResults.value)
+            return {
+                element: (
+                    <ul className="fuzzy-modal-results">
+                        {filesToRender.map((file, i) => (
+                            <li
+                                id={`fuzzy-modal-result-${i}`}
+                                key={file.text}
+                                className={i === focusIndex.value ? 'fuzzy-modal-focused' : ''}
+                            >
+                                <HighlightedText value={file} />
+                            </li>
+                        ))}
+                        {!fuzzyResult.isComplete && (
+                            <li>
+                                <button
+                                    onClick={() => {
+                                        console.log('EXPAND')
+                                        maxResults.set(maxResults.value * 2)
+                                    }}
+                                >
+                                    (...truncated, click to show more results){' '}
+                                </button>
+                            </li>
+                        )}
+                    </ul>
+                ),
+                results: filesToRender,
+            }
+        default:
+            return empty(<p>ERROR</p>)
+    }
+}
+
+function filesCacheKey(props: FuzzyModalProps): string {
+    return `/fuzzy-modal.files.${props.repoName}.${props.commitID}`
+}
+
+function openCaches(): Promise<Cache> {
+    return caches.open('fuzzy-modal')
+}
+
+async function handleIndexing(props: FuzzyModalProps, files: string[]): Promise<Ready> {
+    const result = await new Promise<Ready>(resolve =>
+        setTimeout(
+            () =>
+                resolve({
+                    key: 'ready',
+                    fuzzy: BloomFilterFuzzySearch.fromSearchValues(
+                        files.map(f => ({ value: f, url: `/${props.repoName}@${props.commitID}/-/blob/${f}` }))
+                    ),
+                }),
+            0
+        )
+    )
+    const cache = await openCaches()
+    const text = serializeIndex(result)
+    if (text) {
+        await cache.put(new Request(filesCacheKey(props)), text)
+    }
+    return result
+}
+
+async function deserializeIndex(ready: Response): Promise<Ready> {
+    return {
+        key: 'ready',
+        fuzzy: BloomFilterFuzzySearch.fromSerializedString(await ready.text()),
+    }
+}
+
+function serializeIndex(ready: Ready): Response | undefined {
+    const serializable = ready.fuzzy.serialize()
+    return serializable ? new Response(JSON.stringify(serializable)) : undefined
+}
+
+async function handleEmpty(props: FuzzyModalProps, files: State<Loaded>): Promise<void> {
+    const cache = await openCaches()
+    const cacheKey = filesCacheKey(props)
+    const cacheRequest = new Request(cacheKey)
+    const fromCache = await cache.match(cacheRequest)
+    if (fromCache) {
+        files.set(await deserializeIndex(fromCache))
+    } else {
+        let request = requestGraphQL(
+            gql`
+                query Files($repository: String!, $commit: String!) {
+                    repository(name: $repository) {
+                        commit(rev: $commit) {
+                            tree(recursive: true) {
+                                files(first: 1000000, recursive: true) {
+                                    path
+                                }
+                            }
+                        }
+                    }
+                }
+            `,
+            {
+                repository: props.repoName,
+                commit: props.commitID,
+            }
+        )
+        files.set({ key: 'loading' })
+        request.subscribe(
+            (e: any) => {
+                const response = e.data?.repository?.commit?.tree?.files?.map((f: any) => f.path) as
+                    | string[]
+                    | undefined
+                if (response) {
+                    cache.put(cacheRequest, new Response(JSON.stringify(response)))
+                    files.set({
+                        key: 'indexing',
+                        filenames: response,
+                    })
+                } else {
+                    files.set({
+                        key: 'failed',
+                        errorMessage: JSON.stringify(e.data),
+                    })
+                }
+            },
+            e => {
+                files.set({
+                    key: 'failed',
+                    errorMessage: JSON.stringify(e),
+                })
+            }
+        )
+    }
+}

--- a/client/web/src/fuzzy/FuzzySearch.test.tsx
+++ b/client/web/src/fuzzy/FuzzySearch.test.tsx
@@ -1,0 +1,67 @@
+import { BloomFilterFuzzySearch, allFuzzyParts, fuzzyMatchesQuery } from './BloomFilterFuzzySearch'
+
+const all = [
+    '.tsconfig.json',
+    'to/the/moon.jpg',
+    'lol/business.txt',
+    'haha/business.txt',
+    'business/crazy.txt',
+    'fuzzy/business.txt',
+    '.travis/workflows/config.json',
+]
+
+const fuzzy = BloomFilterFuzzySearch.fromSearchValues(all.map(f => ({ value: f })))
+
+function checkSearch(query: string, expected: string[]) {
+    test(`search-${query}`, () => {
+        const actual = fuzzy.search({ value: query, maxResults: 1000 }).values.map(t => t.text)
+        expect(actual).toStrictEqual(expected)
+    })
+}
+
+function checkParts(name: string, original: string, expected: string[]) {
+    test(`allFuzzyParts-${name}`, () => {
+        expect(allFuzzyParts(original, false)).toStrictEqual(expected)
+    })
+}
+
+function checkFuzzyMatch(name: string, query: string, value: string, expected: string[]) {
+    test(`fuzzyMatchesQuery-${name}`, () => {
+        const obtained = fuzzyMatchesQuery(query, value)
+        const parts: string[] = []
+        obtained.forEach(pos => {
+            parts.push(value.substring(pos.startOffset, pos.endOffset))
+        })
+
+        expect(parts).toStrictEqual(expected)
+    })
+}
+checkParts('basic', 'haha/business.txt', ['haha', 'business', 'txt'])
+checkParts('snake_case', 'haha_business.txt', ['haha', 'business', 'txt'])
+checkParts('camelCase', 'hahaBusiness.txt', ['haha', 'Business', 'txt'])
+checkParts('CamelCase', 'HahaBusiness.txt', ['Haha', 'Business', 'txt'])
+checkParts('kebab-case', 'haha-business.txt', ['haha', 'business', 'txt'])
+checkParts('kebab-case', 'haha-business.txt', ['haha', 'business', 'txt'])
+checkParts('dotfile', '.tsconfig.json', ['tsconfig', 'json'])
+checkFuzzyMatch('dotfile', 'ts', '.tsconfig.json', ['ts'])
+
+checkFuzzyMatch('basic', 'ha/busi', 'haha/business.txt', ['ha', '/', 'busi'])
+
+checkSearch('h/bus', ['haha/business.txt'])
+checkSearch('moon', ['to/the/moon.jpg'])
+checkSearch('t/moon', ['to/the/moon.jpg'])
+checkSearch('t/t/moon', ['to/the/moon.jpg'])
+checkSearch('t.t.moon', [])
+checkSearch('t t moon', [])
+checkSearch('jpg', ['to/the/moon.jpg'])
+checkSearch('t/m', ['to/the/moon.jpg'])
+checkSearch('mo', ['to/the/moon.jpg'])
+checkSearch('t', all)
+
+checkFuzzyMatch('consume-delimeter-negative', 'ts/json', '.tsconfig.json', [])
+checkFuzzyMatch('consume-delimeter-positive', 'ts/json', '.tsconfig/json', ['ts', '/', 'json'])
+checkFuzzyMatch('consume-delimeter-end-of-word', 'ts/', '.tsconfig/json', ['ts', '/'])
+checkFuzzyMatch('consume-delimeter-start-of-word', '.ts/', '.tsconfig/json', ['.', 'ts', '/'])
+
+// TODO(olafurpg): treat all-lowercase queries as case insensitive
+// checkSearch('readme', ["Documentation/README.md"])

--- a/client/web/src/fuzzy/FuzzySearch.ts
+++ b/client/web/src/fuzzy/FuzzySearch.ts
@@ -1,0 +1,27 @@
+import { HighlightedTextProps } from './HighlightedText'
+
+export interface FuzzySearchParameters {
+    value: string
+    maxResults: number
+}
+export interface FuzzySearchResult {
+    values: HighlightedTextProps[]
+    isComplete: boolean
+}
+
+/**
+ * Superclass for different fuzzy finding algorithms.
+ *
+ * NOTE(olafur): Currently, there is only one implementation that uses bloom
+ * filters. This implementation is specifically tailored for large repos that
+ * have >400k source files. It could be that some users prefer a different
+ * fuzzy-finding algorithm that is more fuzzy (relaxed with capitalization) but
+ * has worse performance in XXL repos. Consider this superclass as an open
+ * invitation to contribute a different fuzzy finding implementation that suits
+ * your personal preferences :)
+ */
+export abstract class FuzzySearch {
+    constructor() {}
+    public abstract search(params: FuzzySearchParameters): FuzzySearchResult
+    public abstract serialize(): string | undefined
+}

--- a/client/web/src/fuzzy/Hasher.ts
+++ b/client/web/src/fuzzy/Hasher.ts
@@ -1,0 +1,26 @@
+/**
+ * Computes the hashcode from a streaming input of characters. Every hashcode is
+ * computed in O(1) time.
+ *
+ * This class makes it possible to compute a hashcode for every prefix of a
+ * given string of length N in O(N) time.  For example, given the string "Doc",
+ * we can compute the hashcode for the string "D", "Do" and "Doc" in three
+ * constant operations. If implemented naively, computing every individual
+ * hashcode would be a linear operation resulting in a total runtime of O(N^2).
+ */
+export class Hasher {
+    private h: number = 0
+    constructor() {}
+    public update(ch: string): Hasher {
+        for (let i = 0; i < ch.length; i++) {
+            this.h = (Math.imul(31, this.h) + ch.charCodeAt(i)) | 0
+        }
+        return this
+    }
+    public digest(): number {
+        return this.h
+    }
+    public reset() {
+        this.h = 0
+    }
+}

--- a/client/web/src/fuzzy/HighlightedText.tsx
+++ b/client/web/src/fuzzy/HighlightedText.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+
+export interface RangePosition {
+    startOffset: number
+    endOffset: number
+    /**
+     * Does this range enclose an exact word?
+     */
+    isExact: boolean
+}
+
+export class HighlightedTextProps {
+    constructor(readonly text: string, readonly positions: RangePosition[], readonly url?: string) {}
+    offsetSum(): number {
+        let sum = 0
+        this.positions.forEach(pos => {
+            sum += pos.startOffset
+        })
+        return sum
+    }
+    exactCount(): number {
+        let result = 0
+        this.positions.forEach(pos => {
+            if (pos.isExact) {
+                result++
+            }
+        })
+        return result
+    }
+    isExact(): boolean {
+        return this.positions.length === 1 && this.positions[0].isExact
+    }
+}
+
+export interface HighlightedTextPropsInstance {
+    value: HighlightedTextProps
+}
+
+/**
+ * React component that re
+ */
+export const HighlightedText: React.FunctionComponent<HighlightedTextPropsInstance> = propsInstance => {
+    const props = propsInstance.value
+    const spans: JSX.Element[] = []
+    let start = 0
+    function pushSpan(className: string, startOffset: number, endOffset: number): void {
+        if (startOffset >= endOffset) return
+        const text = props.text.substring(startOffset, endOffset)
+        const key = `${text}-${className}`
+        const span = (
+            <span key={key} className={className}>
+                {text}
+            </span>
+        )
+        spans.push(span)
+    }
+    for (let i = 0; i < props.positions.length; i++) {
+        const pos = props.positions[i]
+        if (pos.startOffset > start) {
+            pushSpan('fuzzy-modal-plaintext', start, pos.startOffset)
+        }
+        start = pos.endOffset
+        const classNameSuffix = pos.isExact ? 'exact' : 'fuzzy'
+        pushSpan(`fuzzy-modal-highlighted fuzzy-modal-highlighted-${classNameSuffix}`, pos.startOffset, pos.endOffset)
+    }
+    pushSpan('fuzzy-modal-plaintext', start, props.text.length)
+
+    return props.url ? (
+        <a className="fuzzy-modal-link" href={props.url}>
+            {spans}
+        </a>
+    ) : (
+        <>{spans}</>
+    )
+}

--- a/client/web/src/fuzzy/useLocalStorage.tsx
+++ b/client/web/src/fuzzy/useLocalStorage.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+export type Dispatch<A> = (value: A) => void
+export type Precondition<A> = (value: A) => boolean
+
+export interface State<T> {
+    value: T
+    set(newValue: T): void
+}
+
+/**
+ * Wrapper around React `useState` that returns `State<T>
+ */
+export function useEphemeralState<T>(initialValue: T): State<T> {
+    const [value, set] = useState(initialValue)
+    return {
+        value: value,
+        set: set,
+    }
+}
+
+/**
+ * Wrapper around React `useState` that returns `State<T> and caches the result in window.localStorage.
+ */
+export function useLocalStorage<T>(key: string, initialValue: T, precondition?: Precondition<T>): State<T> {
+    const [storedValue, setStoredValue] = useState(() => {
+        try {
+            const item = window.localStorage.getItem(key)
+            return item ? JSON.parse(item) : initialValue
+        } catch (error) {
+            console.log(error)
+            return initialValue
+        }
+    })
+
+    const setValue = (value: T) => {
+        try {
+            const valueToStore = value instanceof Function ? value(storedValue) : value
+            setStoredValue(valueToStore)
+            const shouldCache = !precondition || precondition(valueToStore)
+            if (shouldCache) {
+                window.localStorage.setItem(key, JSON.stringify(valueToStore))
+            }
+        } catch (error) {
+            console.log(error)
+        }
+    }
+
+    return {
+        value: storedValue,
+        set: setValue,
+    }
+}

--- a/client/web/src/keyboardShortcuts/keyboardShortcuts.ts
+++ b/client/web/src/keyboardShortcuts/keyboardShortcuts.ts
@@ -27,6 +27,18 @@ export const KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR: KeyboardShortcut = {
     keybindings: [{ ordered: ['/'] }],
 }
 
+export const KEYBOARD_SHORTCUT_FUZZY_FILES: KeyboardShortcut = {
+    id: 'fuzzyFiles',
+    title: 'Fuzzy search files',
+    keybindings: [{ ordered: ['t'] }],
+}
+
+export const KEYBOARD_SHORTCUT_CLOSE_FUZZY_FILES: KeyboardShortcut = {
+    id: 'closeFuzzyFiles',
+    title: 'Close fuzzy search files',
+    keybindings: [{ ordered: ['Escape'] }],
+}
+
 export const KEYBOARD_SHORTCUT_COPY_FULL_QUERY: KeyboardShortcut = {
     id: 'copyFullQuery',
     title: 'Copy full query',
@@ -42,6 +54,8 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     KEYBOARD_SHORTCUT_SWITCH_THEME,
     KEYBOARD_SHORTCUT_SHOW_HELP,
     KEYBOARD_SHORTCUT_FOCUS_SEARCHBAR,
+    KEYBOARD_SHORTCUT_FUZZY_FILES,
+    KEYBOARD_SHORTCUT_CLOSE_FUZZY_FILES,
     KEYBOARD_SHORTCUT_COPY_FULL_QUERY,
 ]
 

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -64,6 +64,12 @@ import { RepoSettingsAreaRoute } from './settings/RepoSettingsArea'
 import { RepoSettingsSideBarGroup } from './settings/RepoSettingsSidebar'
 
 import { redirectToExternalHost } from '.'
+import { Shortcut } from '@slimsag/react-shortcuts'
+import {
+    KEYBOARD_SHORTCUT_CLOSE_FUZZY_FILES,
+    KEYBOARD_SHORTCUT_FUZZY_FILES,
+} from '../keyboardShortcuts/keyboardShortcuts'
+import { FuzzyModal } from '../fuzzy/FuzzyModal'
 
 /**
  * Props passed to sub-routes of {@link RepoContainer}.
@@ -316,6 +322,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
     // Browser extension discoverability features (alert, popover for `GoToCodeHostAction)
     const [hasDismissedExtensionAlert, setHasDismissedExtensionAlert] = useLocalStorage(HAS_DISMISSED_ALERT_KEY, false)
     const [hasDismissedPopover, setHasDismissedPopover] = useState(false)
+    const [isFuzzyModalVisible, setIsFuzzyModalVisible] = useState(false)
     const [hoverCount, setHoverCount] = useLocalStorage(HOVER_COUNT_KEY, 0)
     const canShowPopover =
         !hasDismissedPopover &&
@@ -386,6 +393,27 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
 
     return (
         <div className="repo-container test-repo-container w-100 d-flex flex-column">
+            <Shortcut
+                {...KEYBOARD_SHORTCUT_FUZZY_FILES.keybindings[0]}
+                onMatch={() => {
+                    setIsFuzzyModalVisible(true)
+                    const input = document.getElementById('fuzzy-modal-input') as any
+                    input?.focus()
+                    input?.select()
+                }}
+            />
+            <Shortcut
+                {...KEYBOARD_SHORTCUT_CLOSE_FUZZY_FILES.keybindings[0]}
+                onMatch={() => setIsFuzzyModalVisible(false)}
+            />
+            {resolvedRevisionOrError && !isErrorLike(resolvedRevisionOrError) && (
+                <FuzzyModal
+                    isVisible={isFuzzyModalVisible}
+                    onClose={() => setIsFuzzyModalVisible(false)}
+                    repoName={repoName}
+                    commitID={resolvedRevisionOrError.commitID}
+                />
+            )}
             {showExtensionAlert && (
                 <InstallBrowserExtensionAlert
                     isChrome={IS_CHROME}

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -110,3 +110,103 @@
         }
     }
 }
+
+// TODO(olafur): move the CSS below to a separate "FuzzyModal.scss" file
+
+.fuzzy-modal {
+    z-index: 1000;
+    position: fixed;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.fuzzy-modal-content {
+    width: 80vw;
+    background-color: var(--color-bg-2);
+}
+
+.fuzzy-modal-header,
+.fuzzy-modal-footer {
+    padding: 10px;
+}
+
+.fuzzy-modal-title {
+    margin: 0;
+}
+
+.fuzzy-modal-body {
+    height: 80vh;
+    overflow-y: scroll;
+    padding: 10px;
+}
+
+#fuzzy-modal-input {
+    border: none;
+    width: 100%;
+    height: 1em;
+    font-size: 2em;
+}
+
+.fuzzy-modal-results {
+    text-align: left;
+    font-family: monospace;
+    list-style-type: none;
+    padding: unset;
+    color: var(--body-color);
+}
+
+.fuzzy-modal-highlighted {
+    color: #000;
+}
+.fuzzy-modal-highlighted-fuzzy {
+    background-color: #756c00;
+}
+.fuzzy-modal-highlighted-exact {
+    background-color: #ebdd4d;
+}
+
+.fuzzy-modal-focused {
+    // background-color: #eee;
+    background-color: var(--color-bg-3);
+}
+.fuzzy-modal-cursor {
+    position: relative;
+}
+.fuzzy-modal-cursor i {
+    position: absolute;
+    width: 1px;
+    height: 80%;
+    background-color: gray;
+    left: 5px;
+    top: 10%;
+    animation-name: fuzzy-cursor-blink;
+    animation-duration: 1200ms;
+    animation-iteration-count: infinite;
+    opacity: 1;
+}
+
+.fuzzy-modal-cursor input:focus + i {
+    display: none;
+}
+
+@keyframes fuzzy-cursor-blink {
+    from {
+        opacity: 1;
+    }
+    to {
+        opacity: 0;
+    }
+}
+
+.fuzzy-modal-link {
+    display: inline-block;
+    width: 100%;
+    height: 100%;
+    max-height: 1em;
+}

--- a/client/web/src/tree/TreeRoot.tsx
+++ b/client/web/src/tree/TreeRoot.tsx
@@ -59,6 +59,7 @@ const LOADING = 'loading' as const
 interface TreeRootState {
     treeOrError?: typeof LOADING | TreeFields | ErrorLike
     fileDecorationsByPath: FileDecorationsByPath
+    isFuzzyModalVisible: boolean
 }
 
 export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
@@ -78,6 +79,7 @@ export class TreeRoot extends React.Component<TreeRootProps, TreeRootState> {
         }
         this.state = {
             fileDecorationsByPath: {},
+            isFuzzyModalVisible: false,
         }
     }
 


### PR DESCRIPTION
Previously, there was no way to interactively search for a file that
matches a given fuzzy query. This commit adds a new modal that activates
on the keyboard shortcut `t` and allows the user to quickly open a file
that fuzzily matches a given query.

The implementation in this commit is specifically designed to handle
large repositories with >100k source files. The fuzzy finder achieves
low-latency by:

1) implementating all the filtering inside the browser on the
   client-side
2) using bloom filters to quickly discard buckets of filenames that are
   guaranteed to not match a given query.  This techniqueis used by the
   Scala language server and documented in this blog post
   https://scalameta.org/metals/blog/2019/01/22/bloom-filters.html

The downside of this approach:

1) it can take a while to first download all filenames in the
   repository, especially for large repos like chromium/chromium
2) constructing the bloom filters may take a while on very large
   repositories. It's possible to work around this issue, but it's not
   implemented in this commit.
3) the bloom filter algorithmm is sometimes more strict compared to the
   fuzzy finder in VS Code and IntelliJ. There are techniques to make
   the fuzzy finder more fuzzy, for example we could make all-lowercase
   queries case-insensitive. It's also worth consider whether we want
   scrap the bloom filters altogether and use an entirely different
   approach, for example by reusing techniques from nvim-telescope.


Demo: low-latency filtering in the chromium/chromium repository (~400k source files). Observe that negative results (0 matches) return instantly, this is a key-feature of the bloom-filter approach.

![CleanShot 2021-05-12 at 21 24 48](https://user-images.githubusercontent.com/1408093/118044360-d9694600-b376-11eb-8c55-282d17f67550.gif)

Demo: exact matches are highlighted differently from incomplete matches making it easier to visually parse the results

![CleanShot 2021-05-12 at 22 14 33](https://user-images.githubusercontent.com/1408093/118044459-f43bba80-b376-11eb-868f-b9b6d6932818.png)

Demo: the intermediary page while the fuzzy finder is downloading filenames. For most repos with <20k source files, this step is usually instant. The result is cached for every repoName/commitID pair.

![CleanShot 2021-05-12 at 22 41 57](https://user-images.githubusercontent.com/1408093/118044619-2baa6700-b377-11eb-98a0-fc1d32948a14.png)
