### PR TITLE
batches: prototype of repo tag support and search

### DIFF
--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -156,6 +156,14 @@ export const externalChangesetFieldsFragment = gql`
             id
             name
             url
+            metadataTags(first: 5) {
+                nodes {
+                    tag
+                }
+                pageInfo {
+                    hasNextPage
+                }
+            }
         }
         externalURL {
             url

--- a/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ExternalChangesetInfoCell.tsx
@@ -66,10 +66,20 @@ export const ExternalChangesetInfoCell: React.FunctionComponent<ExternalChangese
             <span className="mr-2 d-block d-mdinline-block">
                 <Link to={node.repository.url} target="_blank" rel="noopener noreferrer">
                     {node.repository.name}
-                </Link>{' '}
+                </Link>
+                {node.repository.metadataTags.nodes.map(({ tag }) => (
+                    <span key={tag} className="badge badge-secondary ml-1">
+                        {tag}
+                    </span>
+                ))}
+                {node.repository.metadataTags.pageInfo.hasNextPage && (
+                    <span key="overflow" className="badge badge-secondary ml-1">
+                        &hellip;
+                    </span>
+                )}
                 {hasHeadReference(node) && (
-                    <div className="d-block d-sm-inline-block">
-                        <span className="badge badge-secondary text-monospace">{headReference(node)}</span>
+                    <div className="d-block d-sm-inline-block ml-1">
+                        <span className="badge badge-info text-monospace">{headReference(node)}</span>
                     </div>
                 )}
             </span>

--- a/client/web/src/repo/metadata/RepoTags.tsx
+++ b/client/web/src/repo/metadata/RepoTags.tsx
@@ -10,7 +10,7 @@ import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/er
 
 import { ErrorAlert } from '../../components/alerts'
 import { TreePageRepositoryFields } from '../../graphql-operations'
-import { addRepoTag, deleteRepoTag, fetchRepoTags } from '../backend'
+import { addRepoTag, deleteRepoTag, fetchRepoTags, FetchRepoTagsResult } from '../backend'
 
 interface AddRepoTagInputProps {
     onCancel: () => void
@@ -129,7 +129,12 @@ const AddRepoTag: React.FunctionComponent<AddRepoTagProps> = ({ id, onUpdate }) 
         case State.Ready:
             return (
                 <span className="badge badge-secondary">
-                    <button className="btn btn-icon d-inline" onClick={onAdd} type="button">
+                    <button
+                        className="btn btn-icon d-inline"
+                        onClick={onAdd}
+                        type="button"
+                        data-tooltip="Add repository tag"
+                    >
                         <AddIcon className="icon-inline" />
                     </button>
                 </span>
@@ -150,7 +155,7 @@ const AddRepoTag: React.FunctionComponent<AddRepoTagProps> = ({ id, onUpdate }) 
     }
 }
 
-type GetRepoTagsResult = Pick<IRepositoryMetadataTag, 'id' | 'tag'>[] | ErrorLike
+type GetRepoTagsResult = FetchRepoTagsResult | ErrorLike
 
 const getRepoTags = async (id: string): Promise<GetRepoTagsResult> =>
     fetchRepoTags({ id }, true)
@@ -170,6 +175,7 @@ export const RepoTags: React.FunctionComponent<RepoTagsProps> = ({ repo: { id, v
     // possible RxJS here and just convert it back to a promise as quickly as
     // possible so that we can use standard React from there.
 
+    const [after, setAfter] = useState<string | undefined>(undefined)
     const [tagsOrError, setTagsOrError] = useState<GetRepoTagsResult | undefined>(undefined)
 
     const update = useCallback(async () => {
@@ -202,7 +208,7 @@ export const RepoTags: React.FunctionComponent<RepoTagsProps> = ({ repo: { id, v
 
     return (
         <span className="ml-2">
-            {tagsOrError.map(tag => (
+            {tagsOrError.nodes.map(tag => (
                 <span className="badge badge-secondary mr-2" key={tag.id}>
                     {tag.tag}
                     {viewerCanAdminister && (

--- a/client/web/src/repo/metadata/RepoTags.tsx
+++ b/client/web/src/repo/metadata/RepoTags.tsx
@@ -194,7 +194,7 @@ export const RepoTags: React.FunctionComponent<RepoTagsProps> = ({ repo: { id, v
     const onUpdate = useCallback(() => update(), [update])
 
     if (tagsOrError === undefined) {
-        return <span />
+        return <LoadingSpinner className="icon-inline" />
     }
     if (isErrorLike(tagsOrError)) {
         return <ErrorAlert error={tagsOrError} prefix="Error fetching repository tags" />

--- a/client/web/src/repo/metadata/RepoTags.tsx
+++ b/client/web/src/repo/metadata/RepoTags.tsx
@@ -1,0 +1,205 @@
+import AddIcon from 'mdi-react/AddIcon'
+import CheckIcon from 'mdi-react/CheckIcon'
+import CloseIcon from 'mdi-react/CloseIcon'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { catchError } from 'rxjs/operators'
+
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { IRepositoryMetadataTag } from '@sourcegraph/shared/src/graphql/schema'
+import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { ErrorAlert } from '../../components/alerts'
+import { TreePageRepositoryFields } from '../../graphql-operations'
+import { addRepoTag, deleteRepoTag, fetchRepoTags } from '../backend'
+
+interface AddRepoTagProps {
+    id: string
+    onUpdate?: () => void
+}
+
+const AddRepoTag: React.FunctionComponent<AddRepoTagProps> = ({ id, onUpdate }) => {
+    enum State {
+        Ready,
+        Editable,
+        Saving,
+    }
+    const [state, setState] = useState<State | Error>(State.Ready)
+
+    const tagElement = useRef<HTMLInputElement | null>(null)
+
+    const submit = useCallback(async () => {
+        const tag = tagElement?.current?.value
+        if (tag === undefined) {
+            // This shouldn't happen, since the callback we're in can
+            // only fire if there is an input with its ref set to
+            // tagElement. Shrug.
+            setState(State.Ready)
+            return
+        }
+        if (tag.trim() === '') {
+            // No point submitting a blank tag.
+            setState(State.Ready)
+            return
+        }
+
+        setState(State.Saving)
+
+        try {
+            await addRepoTag(id, tag)
+            setState(State.Ready)
+        } catch (error) {
+            setState(asError(error))
+        }
+        onUpdate?.()
+    }, [State.Ready, State.Saving, id, onUpdate])
+
+    const onAdd = useCallback(
+        (event: React.MouseEvent) => {
+            event.preventDefault()
+            setState(State.Editable)
+        },
+        [State.Editable]
+    )
+
+    const onDismissError = useCallback(
+        (event: React.MouseEvent) => {
+            event.preventDefault()
+            setState(State.Ready)
+        },
+        [State.Ready]
+    )
+
+    const onInputCancel = useCallback(
+        (event: React.MouseEvent) => {
+            event.preventDefault()
+            setState(State.Ready)
+        },
+        [State.Ready]
+    )
+
+    const onInputSubmit = useCallback(
+        async (event: React.MouseEvent) => {
+            event.preventDefault()
+            await submit()
+        },
+        [submit]
+    )
+
+    const onKeyDown = useCallback(
+        async (event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === 'Escape') {
+                setState(State.Ready)
+                event.stopPropagation()
+            } else if (event.key === 'Enter') {
+                event.stopPropagation()
+                await submit()
+            }
+        },
+        [State.Ready, submit]
+    )
+
+    switch (state) {
+        case State.Ready:
+            return (
+                <span className="badge badge-secondary">
+                    <button className="btn btn-icon d-inline" onClick={onAdd} type="button">
+                        <AddIcon className="icon-inline" />
+                    </button>
+                </span>
+            )
+        case State.Editable:
+            return (
+                <span>
+                    <input ref={tagElement} autoFocus={true} onKeyDown={onKeyDown} />
+                    <button className="btn btn-icon d-inline ml-1" onClick={onInputSubmit} type="button">
+                        <CheckIcon className="icon-inline" />
+                    </button>
+                    <button className="btn btn-icon d-inline ml-1" onClick={onInputCancel} type="button">
+                        <CloseIcon className="icon-inline" />
+                    </button>
+                </span>
+            )
+        case State.Saving:
+            return <LoadingSpinner className="icon-inline" />
+        default:
+            return (
+                <>
+                    <ErrorAlert error={state} />
+                    <button className="btn btn-icon" onClick={onDismissError} type="button">
+                        <CloseIcon className="icon-inline" />
+                    </button>
+                </>
+            )
+    }
+}
+
+type GetRepoTagsResult = Pick<IRepositoryMetadataTag, 'id' | 'tag'>[] | ErrorLike
+
+const getRepoTags = async (id: string): Promise<GetRepoTagsResult> =>
+    fetchRepoTags({ id }, true)
+        .pipe(catchError((error): [ErrorLike] => [asError(error)]))
+        .toPromise()
+
+interface RepoTagsProps {
+    repo: Pick<TreePageRepositoryFields, 'id' | 'viewerCanAdminister'>
+}
+
+export const RepoTags: React.FunctionComponent<RepoTagsProps> = ({ repo: { id, viewerCanAdminister } }) => {
+    // FIXME: After a good four hours on this (that is, more than the entire
+    // rest of this prototype put together), I have no idea how to use RxJS to
+    // wire up an observable that can be refreshed when a callback is received
+    // from a child component. It seems like useEventObservable() should be able
+    // to do this, but I couldn't get it to work. Instead, let's use the minimum
+    // possible RxJS here and just convert it back to a promise as quickly as
+    // possible so that we can use standard React from there.
+
+    const [tagsOrError, setTagsOrError] = useState<GetRepoTagsResult | undefined>(undefined)
+
+    const update = useCallback(async () => {
+        setTagsOrError(await getRepoTags(id))
+    }, [id, setTagsOrError])
+
+    useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        update()
+    }, [update])
+
+    const onDeleteTag = useCallback(
+        async (event: React.MouseEvent, tag: string) => {
+            event.preventDefault()
+            await deleteRepoTag(id, tag)
+            // eslint-disable-next-line @typescript-eslint/no-floating-promises
+            update()
+        },
+        [id, update]
+    )
+
+    const onUpdate = useCallback(() => update(), [update])
+
+    if (tagsOrError === undefined) {
+        return <span />
+    }
+    if (isErrorLike(tagsOrError)) {
+        return <ErrorAlert error={tagsOrError} prefix="Error fetching repository tags" />
+    }
+
+    return (
+        <span className="ml-2">
+            {tagsOrError.map(tag => (
+                <span className="badge badge-secondary mr-2" key={tag.id}>
+                    {tag.tag}
+                    {viewerCanAdminister && (
+                        <button
+                            className="btn btn-icon d-inline ml-1"
+                            onClick={event => onDeleteTag(event, tag.tag)}
+                            type="button"
+                        >
+                            <CloseIcon className="icon-inline" />
+                        </button>
+                    )}
+                </span>
+            ))}
+            {viewerCanAdminister && <AddRepoTag id={id} onUpdate={onUpdate} />}
+        </span>
+    )
+}

--- a/client/web/src/repo/tree/TreePage.tsx
+++ b/client/web/src/repo/tree/TreePage.tsx
@@ -50,6 +50,7 @@ import { fetchTreeEntries } from '../backend'
 import { GitCommitNode, GitCommitNodeProps } from '../commits/GitCommitNode'
 import { gitCommitFragment } from '../commits/RepositoryCommitsPage'
 import { FilePathBreadcrumbs } from '../FilePathBreadcrumbs'
+import { RepoTags } from '../metadata/RepoTags'
 
 import { TreeEntriesSection } from './TreeEntriesSection'
 
@@ -365,9 +366,12 @@ export const TreePage: React.FunctionComponent<Props> = ({
                     <header className="mb-3">
                         {treeOrError.isRoot ? (
                             <>
-                                <h2 className="tree-page__title">
-                                    <SourceRepositoryIcon className="icon-inline" /> {displayRepoName(repo.name)}
-                                </h2>
+                                <div className="mb-2">
+                                    <h2 className="tree-page__title d-inline">
+                                        <SourceRepositoryIcon className="icon-inline" /> {displayRepoName(repo.name)}
+                                    </h2>
+                                    <RepoTags repo={repo} />
+                                </div>
                                 {repo.description && <p>{repo.description}</p>}
                                 <div className="btn-group mb-3">
                                     <Link className="btn btn-secondary" to={`${treeOrError.url}/-/commits`}>

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -468,6 +468,9 @@ func newSchemaResolver(db dbutil.DB) *schemaResolver {
 		"SearchContext": func(ctx context.Context, id graphql.ID) (Node, error) {
 			return r.SearchContextByID(ctx, id)
 		},
+		repositoryMetadataTagIDKind: func(ctx context.Context, id graphql.ID) (Node, error) {
+			return r.RepositoryMetadataTagByID(ctx, id)
+		},
 	}
 	return r
 }

--- a/cmd/frontend/graphqlbackend/node.go
+++ b/cmd/frontend/graphqlbackend/node.go
@@ -248,3 +248,8 @@ func (r *NodeResolver) ToBulkOperation() (BulkOperationResolver, bool) {
 	n, ok := r.Node.(BulkOperationResolver)
 	return n, ok
 }
+
+func (r *NodeResolver) ToRepositoryMetadataTag() (*repositoryMetadataTagResolver, bool) {
+	n, ok := r.Node.(*repositoryMetadataTagResolver)
+	return n, ok
+}

--- a/cmd/frontend/graphqlbackend/repository_metadata_tags.go
+++ b/cmd/frontend/graphqlbackend/repository_metadata_tags.go
@@ -1,0 +1,158 @@
+package graphqlbackend
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
+	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type metadataTagsArgs struct {
+	First int32
+	After *string
+	Tag   *string
+}
+
+func (r *RepositoryResolver) MetadataTags(ctx context.Context, args *metadataTagsArgs) (*repositoryMetadataTagConnectionResolver, error) {
+	lo := database.LimitOffset{Limit: int(args.First)}
+	if args.After != nil {
+		after, err := strconv.Atoi(*args.After)
+		if err != nil {
+			return nil, err
+		}
+		lo.Offset = after
+	}
+
+	opts := database.RepoTagsStoreListOpts{
+		LimitOffset: &lo,
+		RepoIDs:     []int{int(r.IDInt32())},
+	}
+	if args.Tag != nil {
+		term := *args.Tag
+		not := false
+		if term[0] == '-' {
+			term = term[1:]
+			not = true
+		}
+
+		opts.Tags = []database.RepoTagsStoreListSearchTerm{
+			{Term: term, Not: not},
+		}
+	}
+
+	return &repositoryMetadataTagConnectionResolver{
+		db:   r.db,
+		opts: opts,
+	}, nil
+}
+
+type repositoryMetadataTagConnectionResolver struct {
+	db   dbutil.DB
+	opts database.RepoTagsStoreListOpts
+
+	once sync.Once
+	tags []*types.RepoTag
+	next int
+	err  error
+}
+
+func (r *repositoryMetadataTagConnectionResolver) Nodes(ctx context.Context) ([]*repositoryMetadataTagResolver, error) {
+	tags, _, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resolvers := make([]*repositoryMetadataTagResolver, 0, len(tags))
+	for _, tag := range tags {
+		resolvers = append(resolvers, &repositoryMetadataTagResolver{
+			db:  r.db,
+			tag: tag,
+		})
+	}
+
+	return resolvers, nil
+}
+
+func (r *repositoryMetadataTagConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
+	count, err := database.RepoTags(r.db).Count(ctx, r.opts)
+	return int32(count), err
+}
+
+func (r *repositoryMetadataTagConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
+	_, next, err := r.compute(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if next != 0 {
+		return graphqlutil.NextPageCursor(strconv.Itoa(next)), nil
+	}
+	return graphqlutil.HasNextPage(false), nil
+}
+
+func (r *repositoryMetadataTagConnectionResolver) compute(ctx context.Context) ([]*types.RepoTag, int, error) {
+	r.once.Do(func() {
+		r.tags, r.next, r.err = database.RepoTags(r.db).List(ctx, r.opts)
+	})
+	return r.tags, r.next, r.err
+}
+
+type repositoryMetadataTagResolver struct {
+	db  dbutil.DB
+	tag *types.RepoTag
+}
+
+const repositoryMetadataTagIDKind = "RepositoryMetadataTag"
+
+func (r *repositoryMetadataTagResolver) ID() graphql.ID {
+	return relay.MarshalID(repositoryMetadataTagIDKind, r.tag.ID)
+}
+
+func (r *repositoryMetadataTagResolver) Repository(ctx context.Context) (*RepositoryResolver, error) {
+	return RepositoryByIDInt32(ctx, r.db, api.RepoID(r.tag.RepoID))
+}
+
+func (r *repositoryMetadataTagResolver) Tag() string {
+	return r.tag.Tag
+}
+
+func (r *repositoryMetadataTagResolver) CreatedAt() DateTime {
+	return DateTime{Time: r.tag.CreatedAt}
+}
+
+func (r *repositoryMetadataTagResolver) UpdatedAt() DateTime {
+	return DateTime{Time: r.tag.UpdatedAt}
+}
+
+func unmarshalRepositoryMetadataTagID(id graphql.ID) (tagID int64, err error) {
+	if kind := relay.UnmarshalKind(id); kind != repositoryMetadataTagIDKind {
+		return 0, fmt.Errorf("expected graphql ID to have kind %q; got %q", repositoryMetadataTagIDKind, kind)
+	}
+	err = relay.UnmarshalSpec(id, &tagID)
+	return
+}
+
+func (r *schemaResolver) RepositoryMetadataTagByID(ctx context.Context, id graphql.ID) (*repositoryMetadataTagResolver, error) {
+	tagID, err := unmarshalRepositoryMetadataTagID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	tag, err := database.RepoTags(r.db).GetByID(ctx, tagID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &repositoryMetadataTagResolver{
+		db:  r.db,
+		tag: tag,
+	}, nil
+}

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2215,6 +2215,11 @@ type Repository implements Node & GenericSearchResultInterface {
     for use by code intelligence features.
     """
     codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph!
+
+    """
+    Metadata tags (not to be confused with Git tags!).
+    """
+    metadataTags(first: Int = 15, after: String, tag: String): RepositoryMetadataTagConnection!
 }
 
 """
@@ -6095,4 +6100,18 @@ type CodeHostRepository {
     Is the repo private
     """
     private: Boolean!
+}
+
+type RepositoryMetadataTagConnection {
+    nodes: [RepositoryMetadataTag!]!
+    totalCount: Int!
+    pageInfo: PageInfo!
+}
+
+type RepositoryMetadataTag implements Node {
+    id: ID!
+    repository: Repository!
+    tag: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
 }

--- a/cmd/frontend/graphqlbackend/tags.go
+++ b/cmd/frontend/graphqlbackend/tags.go
@@ -24,13 +24,32 @@ func (r *schemaResolver) SetTag(ctx context.Context, args *struct {
 	if err != nil {
 		return nil, err
 	}
-	user, ok := node.(*UserResolver)
-	if !ok {
+
+	switch node := node.(type) {
+	case *UserResolver:
+		if err := database.Users(r.db).SetTag(ctx, node.user.ID, args.Tag, args.Present); err != nil {
+			return nil, err
+		}
+		return &EmptyResponse{}, nil
+
+	case *RepositoryResolver:
+		if args.Present {
+			if _, err := database.RepoTags(r.db).Create(ctx, int(node.IDInt32()), args.Tag); err != nil {
+				return nil, err
+			}
+		} else {
+			tag, err := database.RepoTags(r.db).GetByRepoAndTag(ctx, int(node.IDInt32()), args.Tag)
+			if err != nil {
+				return nil, err
+			}
+
+			if err := database.RepoTags(r.db).Delete(ctx, tag); err != nil {
+				return nil, err
+			}
+		}
+		return &EmptyResponse{}, nil
+
+	default:
 		return nil, errors.New("setting tags is only supported for users")
 	}
-
-	if err := database.Users(r.db).SetTag(ctx, user.user.ID, args.Tag, args.Present); err != nil {
-		return nil, err
-	}
-	return &EmptyResponse{}, nil
 }

--- a/enterprise/internal/batches/store/changesets.go
+++ b/enterprise/internal/batches/store/changesets.go
@@ -240,8 +240,9 @@ var countChangesetsQueryFmtstr = `
 SELECT COUNT(changesets.id)
 FROM changesets
 INNER JOIN repo ON repo.id = changesets.repo_id
+INNER JOIN repo_tags ON repo_tags.repo_id = changesets.repo_id
 %s -- optional LEFT JOIN to changeset_specs if required
-WHERE %s
+WHERE %s AND repo_tags.deleted_at IS NULL
 `
 
 func countChangesetsQuery(opts *CountChangesetsOpts, authzConds *sqlf.Query) *sqlf.Query {
@@ -296,6 +297,7 @@ func countChangesetsQuery(opts *CountChangesetsOpts, authzConds *sqlf.Query) *sq
 				// changeset, if it has been published or if it's tracked.
 				sqlf.Sprintf("COALESCE(changesets.external_title, changeset_specs.title)"),
 				sqlf.Sprintf("repo.name"),
+				sqlf.Sprintf("repo_tags.tag"),
 			))
 		}
 	}
@@ -507,8 +509,9 @@ var listChangesetsQueryFmtstr = `
 -- source: enterprise/internal/batches/store.go:ListChangesets
 SELECT %s FROM changesets
 INNER JOIN repo ON repo.id = changesets.repo_id
+INNER JOIN repo_tags ON repo_tags.repo_id = changesets.repo_id
 %s -- optional LEFT JOIN to changeset_specs if required
-WHERE %s
+WHERE %s AND repo_tags.deleted_at IS NULL
 ORDER BY id ASC
 `
 
@@ -578,6 +581,7 @@ func listChangesetsQuery(opts *ListChangesetsOpts, authzConds *sqlf.Query) *sqlf
 				// changeset, if it has been published or if it's tracked.
 				sqlf.Sprintf("COALESCE(changesets.external_title, changeset_specs.title)"),
 				sqlf.Sprintf("repo.name"),
+				sqlf.Sprintf("repo_tags.tag"),
 			))
 		}
 	}

--- a/internal/database/mockstores.go
+++ b/internal/database/mockstores.go
@@ -17,6 +17,7 @@ type MockStores struct {
 	UserEmails      MockUserEmails
 	UserPublicRepos MockUserPublicRepos
 	SearchContexts  MockSearchContexts
+	RepoTags        MockRepoTags
 
 	Phabricator MockPhabricator
 

--- a/internal/database/repo_tags.go
+++ b/internal/database/repo_tags.go
@@ -1,0 +1,340 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/keegancsmith/sqlf"
+
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type RepoTagsStore struct {
+	*basestore.Store
+}
+
+func RepoTags(db dbutil.DB) *RepoTagsStore {
+	store := basestore.NewWithDB(db, sql.TxOptions{})
+	return &RepoTagsStore{store}
+}
+
+func RepoTagsWith(other basestore.ShareableStore) *RepoTagsStore {
+	return &RepoTagsStore{basestore.NewWithHandle(other.Handle())}
+}
+
+func (s *RepoTagsStore) With(other basestore.ShareableStore) *RepoTagsStore {
+	return &RepoTagsStore{s.Store.With(other)}
+}
+
+func (s *RepoTagsStore) Transact(ctx context.Context) (*RepoTagsStore, error) {
+	tx, err := s.Store.Transact(ctx)
+	return &RepoTagsStore{tx}, err
+}
+
+type RepoTagNotFoundErr struct{ args []interface{} }
+
+func (err RepoTagNotFoundErr) Error() string {
+	return fmt.Sprintf("repo tag not found: %v", err.args)
+}
+func (RepoTagNotFoundErr) NotFound() bool { return true }
+
+func (s *RepoTagsStore) Create(ctx context.Context, repoID int, tag string) (*types.RepoTag, error) {
+	if Mocks.RepoTags.Create != nil {
+		return Mocks.RepoTags.Create(ctx, repoID, tag)
+	}
+
+	q := sqlf.Sprintf(
+		repoTagsCreateQueryFmtstr,
+		repoID,
+		tag,
+		sqlf.Join(repoTagsColumns, ","),
+	)
+
+	rt := types.RepoTag{}
+	row := s.QueryRow(ctx, q)
+	if err := scanRepoTag(&rt, row); err != nil {
+		return nil, err
+	}
+
+	return &rt, nil
+}
+
+func (s *RepoTagsStore) Delete(ctx context.Context, rt *types.RepoTag) error {
+	if Mocks.RepoTags.Delete != nil {
+		return Mocks.RepoTags.Delete(ctx, rt)
+	}
+
+	now := time.Now()
+	rt.DeletedAt = &now
+	_, err := s.Update(ctx, rt)
+	return err
+}
+
+func (s *RepoTagsStore) GetByID(ctx context.Context, id int64) (*types.RepoTag, error) {
+	if Mocks.RepoTags.GetByID != nil {
+		return Mocks.RepoTags.GetByID(ctx, id)
+	}
+
+	q := sqlf.Sprintf(
+		repoTagsGetByIDQueryFmtstr,
+		sqlf.Join(repoTagsColumns, ","),
+		id,
+	)
+
+	rt := types.RepoTag{}
+	row := s.QueryRow(ctx, q)
+	if err := scanRepoTag(&rt, row); err == sql.ErrNoRows {
+		return nil, RepoTagNotFoundErr{args: []interface{}{id}}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &rt, nil
+}
+
+func (s *RepoTagsStore) GetByRepoAndTag(ctx context.Context, repoID int, tag string) (*types.RepoTag, error) {
+	if Mocks.RepoTags.GetByRepoAndTag != nil {
+		return Mocks.RepoTags.GetByRepoAndTag(ctx, repoID, tag)
+	}
+
+	q := sqlf.Sprintf(
+		repoTagsGetByRepoAndTagQueryFmtstr,
+		sqlf.Join(repoTagsColumns, ","),
+		repoID,
+		tag,
+	)
+
+	rt := types.RepoTag{}
+	row := s.QueryRow(ctx, q)
+	if err := scanRepoTag(&rt, row); err == sql.ErrNoRows {
+		return nil, RepoTagNotFoundErr{args: []interface{}{repoID, tag}}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &rt, nil
+}
+
+type RepoTagsStoreListOpts struct {
+	*LimitOffset
+	RepoIDs []int
+	Tags    []RepoTagsStoreListSearchTerm
+}
+
+type RepoTagsStoreListSearchTerm struct {
+	Term string
+	Not  bool
+}
+
+func (opts *RepoTagsStoreListOpts) preds() *sqlf.Query {
+	preds := []*sqlf.Query{sqlf.Sprintf("deleted_at IS NULL")}
+	if len(opts.RepoIDs) != 0 {
+		ids := make([]*sqlf.Query, len(opts.RepoIDs))
+		for i, id := range opts.RepoIDs {
+			ids[i] = sqlf.Sprintf("%s", id)
+		}
+
+		preds = append(preds, sqlf.Sprintf("repo_id IN (%s)", sqlf.Join(ids, ",")))
+	}
+	if len(opts.Tags) != 0 {
+		// TODO: unify with textSearchTermToClause
+		for _, tag := range opts.Tags {
+			var textOp *sqlf.Query
+			if tag.Not {
+				textOp = sqlf.Sprintf("!~*")
+			} else {
+				textOp = sqlf.Sprintf("~*")
+			}
+
+			preds = append(preds, sqlf.Sprintf(
+				`(tag %s ('\m'||%s||'\M'))`,
+				textOp,
+				regexp.QuoteMeta(tag.Term),
+			))
+		}
+	}
+
+	return sqlf.Join(preds, "AND")
+}
+
+func (opts *RepoTagsStoreListOpts) sql() *sqlf.Query {
+	if opts.LimitOffset == nil || opts.Limit == 0 {
+		return &sqlf.Query{}
+	}
+
+	return (&LimitOffset{Limit: opts.Limit + 1, Offset: opts.Offset}).SQL()
+}
+
+func (s *RepoTagsStore) Count(ctx context.Context, opts RepoTagsStoreListOpts) (int, error) {
+	if Mocks.RepoTags.Count != nil {
+		return Mocks.RepoTags.Count(ctx, opts)
+	}
+
+	q := sqlf.Sprintf(
+		repoTagsCountQueryFmtstr,
+		opts.preds(),
+	)
+
+	count, ok, err := basestore.ScanFirstInt(s.Query(ctx, q))
+	if err != nil || !ok {
+		return count, err
+	}
+	return count, nil
+}
+
+func (s *RepoTagsStore) List(ctx context.Context, opts RepoTagsStoreListOpts) (tags []*types.RepoTag, next int, err error) {
+	if Mocks.RepoTags.List != nil {
+		return Mocks.RepoTags.List(ctx, opts)
+	}
+
+	q := sqlf.Sprintf(
+		repoTagsListQueryFmtstr,
+		sqlf.Join(repoTagsColumns, ","),
+		opts.preds(),
+		opts.sql(),
+	)
+
+	rows, err := s.Query(ctx, q)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		rt := types.RepoTag{}
+		if err := scanRepoTag(&rt, rows); err != nil {
+			return nil, 0, err
+		}
+		tags = append(tags, &rt)
+	}
+
+	// Check if there were more results than the limit: if so, then we need to
+	// set the return cursor and lop off the extra credential that we retrieved.
+	if opts.LimitOffset != nil && opts.Limit != 0 && len(tags) == opts.Limit+1 {
+		next = opts.Offset + opts.Limit
+		tags = tags[:len(tags)-1]
+	}
+
+	return tags, next, nil
+}
+
+func (s *RepoTagsStore) Update(ctx context.Context, rt *types.RepoTag) (*types.RepoTag, error) {
+	if Mocks.RepoTags.Update != nil {
+		return Mocks.RepoTags.Update(ctx, rt)
+	}
+
+	rt.UpdatedAt = time.Now()
+	q := sqlf.Sprintf(
+		repoTagsUpdateQueryFmtstr,
+		rt.RepoID,
+		rt.Tag,
+		rt.CreatedAt,
+		rt.UpdatedAt,
+		&dbutil.NullTime{Time: rt.DeletedAt},
+		rt.ID,
+		sqlf.Join(repoTagsColumns, ","),
+	)
+
+	updated := types.RepoTag{}
+	row := s.QueryRow(ctx, q)
+	if err := scanRepoTag(&updated, row); err == sql.ErrNoRows {
+		return nil, RepoTagNotFoundErr{args: []interface{}{*rt}}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &updated, nil
+}
+
+var repoTagsColumns = []*sqlf.Query{
+	sqlf.Sprintf("id"),
+	sqlf.Sprintf("repo_id"),
+	sqlf.Sprintf("tag"),
+	sqlf.Sprintf("created_at"),
+	sqlf.Sprintf("updated_at"),
+	sqlf.Sprintf("deleted_at"),
+}
+
+const repoTagsCreateQueryFmtstr = `
+-- source: internal/database/repo_tags.go:Create
+INSERT INTO repo_tags (repo_id, tag)
+VALUES (%s, %s)
+RETURNING %s
+`
+
+const repoTagsGetByIDQueryFmtstr = `
+-- source: internal/database/repo_tags.go:GetByID
+SELECT %s
+FROM repo_tags
+WHERE id = %s AND deleted_at IS NULL
+`
+
+const repoTagsGetByRepoAndTagQueryFmtstr = `
+-- source: internal/database/repo_tags.go:GetByRepoAndTag
+SELECT %s
+FROM repo_tags
+WHERE
+	repo_id = %s
+	AND LOWER(tag) = %s
+	AND deleted_at IS NULL
+`
+
+const repoTagsCountQueryFmtstr = `
+-- source: internal/database/repo_tags.go:Count
+SELECT COUNT(id)
+FROM repo_tags
+WHERE %s
+`
+
+const repoTagsListQueryFmtstr = `
+-- source: internal/database/repo_tags.go:List
+SELECT %s
+FROM repo_tags
+WHERE %s
+ORDER BY repo_id ASC, tag ASC
+%s  -- LIMIT clause
+`
+
+const repoTagsUpdateQueryFmtstr = `
+-- source: internal/database/repo_tags.go:Update
+UPDATE repo_tags
+SET
+	repo_id = %s,
+	tag = %s,
+	created_at = %s,
+	updated_at = %s,
+	deleted_at = %s
+WHERE
+	id = %s
+RETURNING %s
+`
+
+func scanRepoTag(tag *types.RepoTag, s interface {
+	Scan(...interface{}) error
+}) error {
+	var deleted time.Time
+
+	if err := s.Scan(
+		&tag.ID,
+		&tag.RepoID,
+		&tag.Tag,
+		&tag.CreatedAt,
+		&tag.UpdatedAt,
+		&dbutil.NullTime{Time: &deleted},
+	); err != nil {
+		return err
+	}
+
+	if deleted.IsZero() {
+		tag.DeletedAt = nil
+	} else {
+		tag.DeletedAt = &deleted
+	}
+
+	return nil
+}

--- a/internal/database/repo_tags_mock.go
+++ b/internal/database/repo_tags_mock.go
@@ -1,0 +1,17 @@
+package database
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+type MockRepoTags struct {
+	Count           func(context.Context, RepoTagsStoreListOpts) (int, error)
+	Create          func(context.Context, int, string) (*types.RepoTag, error)
+	Delete          func(context.Context, *types.RepoTag) error
+	GetByID         func(context.Context, int64) (*types.RepoTag, error)
+	GetByRepoAndTag func(context.Context, int, string) (*types.RepoTag, error)
+	List            func(context.Context, RepoTagsStoreListOpts) ([]*types.RepoTag, int, error)
+	Update          func(context.Context, *types.RepoTag) (*types.RepoTag, error)
+}

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1311,6 +1311,7 @@ Referenced by:
     TABLE "external_service_repos" CONSTRAINT "external_service_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE DEFERRABLE
     TABLE "gitserver_repos" CONSTRAINT "gitserver_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "lsif_index_configuration" CONSTRAINT "lsif_index_configuration_repository_id_fkey" FOREIGN KEY (repository_id) REFERENCES repo(id) ON DELETE CASCADE
+    TABLE "repo_tags" CONSTRAINT "repo_tags_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON UPDATE CASCADE ON DELETE RESTRICT
     TABLE "search_context_repos" CONSTRAINT "search_context_repos_repo_id_fk" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
     TABLE "user_public_repos" CONSTRAINT "user_public_repos_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON DELETE CASCADE
 Triggers:
@@ -1344,6 +1345,25 @@ Indexes:
  user_ids_ints | integer[]                |           | not null | '{}'::integer[]
 Indexes:
     "repo_permissions_perm_unique" UNIQUE CONSTRAINT, btree (repo_id, permission)
+
+```
+
+# Table "public.repo_tags"
+```
+   Column   |           Type           | Collation | Nullable |                Default                
+------------+--------------------------+-----------+----------+---------------------------------------
+ id         | bigint                   |           | not null | nextval('repo_tags_id_seq'::regclass)
+ repo_id    | integer                  |           | not null | 
+ tag        | character varying(100)   |           | not null | 
+ created_at | timestamp with time zone |           | not null | now()
+ updated_at | timestamp with time zone |           | not null | now()
+ deleted_at | timestamp with time zone |           |          | 
+Indexes:
+    "repo_tags_pkey" PRIMARY KEY, btree (id)
+    "repo_tag" UNIQUE CONSTRAINT, btree (repo_id, tag, deleted_at)
+    "repo_tags_tag_trgm" gin (lower(tag::text) gin_trgm_ops)
+Foreign-key constraints:
+    "repo_tags_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON UPDATE CASCADE ON DELETE RESTRICT
 
 ```
 

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1361,6 +1361,7 @@ Indexes:
 Indexes:
     "repo_tags_pkey" PRIMARY KEY, btree (id)
     "repo_tag" UNIQUE CONSTRAINT, btree (repo_id, tag, deleted_at)
+    "repo_tags_deleted_at_idx" btree (deleted_at)
     "repo_tags_tag_trgm" gin (lower(tag::text) gin_trgm_ops)
 Foreign-key constraints:
     "repo_tags_repo_id_fkey" FOREIGN KEY (repo_id) REFERENCES repo(id) ON UPDATE CASCADE ON DELETE RESTRICT

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1531,3 +1531,12 @@ type SearchContextRepositoryRevisions struct {
 	Repo      RepoName
 	Revisions []string
 }
+
+type RepoTag struct {
+	ID        int64
+	RepoID    int
+	Tag       string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+}

--- a/migrations/frontend/1528395823_repo_tags.down.sql
+++ b/migrations/frontend/1528395823_repo_tags.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE IF EXISTS repo_tags;
+
+COMMIT;

--- a/migrations/frontend/1528395823_repo_tags.up.sql
+++ b/migrations/frontend/1528395823_repo_tags.up.sql
@@ -1,0 +1,20 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS repo_tags (
+    id BIGSERIAL PRIMARY KEY,
+    repo_id INTEGER NOT NULL REFERENCES repo (id) ON DELETE RESTRICT ON UPDATE CASCADE,
+    tag VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMP WITH TIME ZONE,
+    CONSTRAINT repo_tag UNIQUE (repo_id, tag, deleted_at)
+);
+
+CREATE INDEX IF NOT EXISTS
+    repo_tags_tag_trgm
+ON
+    repo_tags
+USING
+    gin (lower((tag)::text) gin_trgm_ops);
+
+COMMIT;

--- a/migrations/frontend/1528395823_repo_tags.up.sql
+++ b/migrations/frontend/1528395823_repo_tags.up.sql
@@ -11,6 +11,11 @@ CREATE TABLE IF NOT EXISTS repo_tags (
 );
 
 CREATE INDEX IF NOT EXISTS
+    repo_tags_deleted_at_idx
+ON
+    repo_tags (deleted_at);
+
+CREATE INDEX IF NOT EXISTS
     repo_tags_tag_trgm
 ON
     repo_tags


### PR DESCRIPTION
Assuming we wanted to go ahead with this (which would be a product decision, obviously), we would need to give this PR a decent amount of love before it's reviewable. Off the top of my head:

* Unit tests
* Storybook tests
* Like, all the tests
* Code and GraphQL documentation
* Refactor the bits of batch change text search I just straight copy/pasted out of the enterprise codebase into a package somewhere in `lib` or `internal`
* Proper pagination support for tags/labels in the UI, since it's all just hardcoded right now
* A decision on what to call these (tags or labels)
* Design review, because those tags are _ugly_
* A decision on what to do about filter syntax in changeset search
* Remove whatever debugging code I left in here
* Have someone who actually knows RxJS wire up the updating code for repo tags properly, instead of my "let's make it a promise and pretend RxJS doesn't exist!" approach
* Documentation, including an example of how to wire this up to a third party source of truth