### PR TITLE
Don't disable OAuth code host connections for users with a private co…

### DIFF
--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -15,7 +15,7 @@ import { RemoveCodeHostConnectionModal } from './RemoveCodeHostConnectionModal'
 import { ifNotNavigated } from './UserAddCodeHostsPage'
 
 interface CodeHostItemProps {
-    userID: Scalars['ID']
+    user: { id: Scalars['ID']; tags: string[] }
     kind: ExternalServiceKind
     name: string
     icon: React.ComponentType<{ className?: string }>
@@ -30,7 +30,7 @@ interface CodeHostItemProps {
 }
 
 export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
-    userID,
+    user,
     service,
     kind,
     name,
@@ -68,7 +68,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
         <div className="p-2 d-flex align-items-start">
             {isAddConnectionModalOpen && (
                 <AddCodeHostConnectionModal
-                    userID={userID}
+                    userID={user.id}
                     kind={kind}
                     name={name}
                     hintFragment={hints[kind]}
@@ -116,8 +116,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                             Connect
                         </DropdownToggle>
                         <DropdownMenu right={true}>
-                            {/* temporarily disable OAuth for GitLab */}
-                            {kind !== ExternalServiceKind.GITLAB && (
+                            {user.tags?.includes('AllowUserExternalServicePrivate') && (
                                 <DropdownItem toggle={false} onClick={toAuthProvider}>
                                     Connect with {name}
                                     {oauthInFlight && <LoadingSpinner className="icon-inline ml-2" />}

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -117,7 +117,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
         path: '/code-hosts',
         render: props => (
             <UserAddCodeHostsPageContainer
-                userID={props.user.id}
+                user={{ id: props.authenticatedUser.id, tags: props.authenticatedUser.tags }}
                 context={window.context}
                 routingPrefix={props.user.url + '/settings'}
                 onUserRepositoriesUpdate={props.onUserRepositoriesUpdate}


### PR DESCRIPTION
### Description

Don't disable OAuth code host connections for users with a private code tag, otherwise disable.
Ran more tests with a new user and there's something off with GitHub OAuth code host connection too. I can only see my own repos. Disabling this feature for now.

Continuation of: https://github.com/sourcegraph/sourcegraph/pull/20937
