### PR TITLE
oauth: Re-enable OAuth and switch to read_api for GitLab

### DIFF
--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -116,12 +116,10 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                             Connect
                         </DropdownToggle>
                         <DropdownMenu right={true}>
-                            {user.tags?.includes('AllowUserExternalServicePrivate') && (
-                                <DropdownItem toggle={false} onClick={toAuthProvider}>
-                                    Connect with {name}
-                                    {oauthInFlight && <LoadingSpinner className="icon-inline ml-2" />}
-                                </DropdownItem>
-                            )}
+                            <DropdownItem toggle={false} onClick={toAuthProvider}>
+                                Connect with {name}
+                                {oauthInFlight && <LoadingSpinner className="icon-inline ml-2" />}
+                            </DropdownItem>
                             <DropdownItem onClick={toggleAddConnectionModal}>Connect with access token</DropdownItem>
                         </DropdownMenu>
                     </ButtonDropdown>

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -245,7 +245,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
 
             {codeHostExternalServices && isServicesByKind(statusOrError) ? (
                 <>
-                    {user.tags?.includes('AllowUserExternalServicePrivate') && codeHostOAuthButtons.length > 0 && (
+                    {codeHostOAuthButtons.length > 0 && (
                         <div className="border rounded p-4 mb-4">
                             <b>Connect with code host</b>
                             <div className="container">

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/config_test.go
@@ -63,7 +63,7 @@ func TestParseConfig(t *testing.T) {
 						AuthURL:  "https://gitlab.com/oauth/authorize",
 						TokenURL: "https://gitlab.com/oauth/token",
 					},
-					Scopes: []string{"read_user", "api"},
+					Scopes: []string{"read_user", "read_api"},
 				}),
 			},
 		},
@@ -104,7 +104,7 @@ func TestParseConfig(t *testing.T) {
 						AuthURL:  "https://gitlab.com/oauth/authorize",
 						TokenURL: "https://gitlab.com/oauth/token",
 					},
-					Scopes: []string{"read_user", "api"},
+					Scopes: []string{"read_user", "read_api"},
 				}),
 				{
 					ClientID:     "my-client-id-2",
@@ -120,7 +120,7 @@ func TestParseConfig(t *testing.T) {
 						AuthURL:  "https://mycompany.com/oauth/authorize",
 						TokenURL: "https://mycompany.com/oauth/token",
 					},
-					Scopes: []string{"read_user", "api"},
+					Scopes: []string{"read_user", "read_api"},
 				}),
 			},
 		},
@@ -148,7 +148,6 @@ func TestParseConfig(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotProviders, tt.wantProviders) {
 				dmp := diffmatchpatch.New()
-
 				t.Errorf("parseConfig() gotProviders != tt.wantProviders, diff:\n%s",
 					dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(tt.wantProviders), spew.Sdump(gotProviders), false)),
 				)
@@ -159,7 +158,6 @@ func TestParseConfig(t *testing.T) {
 
 			if !reflect.DeepEqual(gotConfigs, wantConfigs) {
 				dmp := diffmatchpatch.New()
-
 				t.Errorf("parseConfig() gotConfigs != wantConfigs, diff:\n%s",
 					dmp.DiffPrettyText(dmp.DiffMain(spew.Sdump(gotConfigs), spew.Sdump(wantConfigs), false)),
 				)

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/middleware_test.go
@@ -123,7 +123,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockGitLabCom.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "read_user api"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "read_user read_api"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {
@@ -156,7 +156,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockPrivateGitLab.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "read_user api"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "read_user read_api"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {
@@ -189,7 +189,7 @@ func TestMiddleware(t *testing.T) {
 		if got, want := uredirect.Query().Get("client_id"), mockGitLabCom.Provider.CachedInfo().ClientID; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-		if got, want := uredirect.Query().Get("scope"), "read_user api"; got != want {
+		if got, want := uredirect.Query().Get("scope"), "read_user read_api"; got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
 		if got, want := uredirect.Query().Get("response_type"), "code"; got != want {

--- a/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
+++ b/enterprise/cmd/frontend/internal/auth/gitlaboauth/provider.go
@@ -8,7 +8,6 @@ import (
 	"github.com/dghubble/gologin"
 	"golang.org/x/oauth2"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/envvar"
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/auth/oauth"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -75,10 +74,7 @@ func getStateConfig() gologin.CookieConfig {
 }
 
 func requestedScopes(extraScopes []string) []string {
-	scopes := []string{"read_user"}
-	if !envvar.SourcegraphDotComMode() {
-		scopes = append(scopes, "api")
-	}
+	scopes := []string{"read_user", "read_api"}
 
 	// Append extra scopes and ensure there are no duplicates
 	for _, s := range extraScopes {

--- a/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
+++ b/enterprise/cmd/frontend/internal/auth/oauth/middleware.go
@@ -118,7 +118,7 @@ func getExtraScopes(ctx context.Context, db dbutil.DB, serviceType string) ([]st
 	case extsvc.TypeGitHub:
 		return []string{"repo"}, nil
 	case extsvc.TypeGitLab:
-		return []string{"api"}, nil
+		return []string{}, nil
 	default:
 		return nil, errors.Errorf("unknown service type: %q", serviceType)
 	}


### PR DESCRIPTION
We need to request full api access for GitLab even if the user only
requires public code access since GitLab doesn't appear to offer scopes
with the granularity we need. You either get access to everything for a
user or nothing.

We've reverted to asking for full api access again and re-enabled OAuth
for user added code, but we're now only requesting read access whereas
before we requested read/write access.
