### PR TITLE
search redesign: add 2px margin to repo icons in sidebar

### DIFF
--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
@@ -51,8 +51,7 @@
     }
 
     &__icon {
-        width: 0.875rem;
-        height: 0.875rem;
+        margin: 0 0.125rem;
     }
 
     &__no-results {


### PR DESCRIPTION
Also removed the width/height because it wasn't taking effect. I can change the size later if we decide we want the icons to actually be smaller.

![image](https://user-images.githubusercontent.com/206864/118167846-000d9800-b3dc-11eb-8aa9-f4ce94bcc30e.png)
