### PR TITLE
executor: Abandon orphaned jobs

### DIFF
--- a/enterprise/cmd/executor-queue/internal/server/lifecycle_test.go
+++ b/enterprise/cmd/executor-queue/internal/server/lifecycle_test.go
@@ -22,8 +22,8 @@ func TestHeartbeat(t *testing.T) {
 
 	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 41}, store1, true, nil)
 	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store1, true, nil)
-	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store2, true, nil)
 	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 43}, store2, true, nil)
+	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 44}, store2, true, nil)
 
 	options := Options{
 		QueueOptions: map[string]QueueOptions{
@@ -55,43 +55,56 @@ func TestHeartbeat(t *testing.T) {
 
 	// missing all jobs, but they're less than UnreportedMaxAge
 	clock.Advance(time.Second / 2)
-	if err := handler.heartbeat(context.Background(), "deadbeef", []int{}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadbeef", []int{}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
-	if err := handler.heartbeat(context.Background(), "deadveal", []int{}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadveal", []int{}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
 	assertDoneCounts(0, 0)
 
 	// missing no jobs
 	clock.Advance(time.Minute * 2)
-	if err := handler.heartbeat(context.Background(), "deadbeef", []int{41, 42}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadbeef", []int{41, 43}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
-	if err := handler.heartbeat(context.Background(), "deadveal", []int{42, 43}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadveal", []int{42, 44}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
 	assertDoneCounts(0, 0)
 
 	// missing one deadbeef jobs
 	clock.Advance(time.Minute * 2)
-	if err := handler.heartbeat(context.Background(), "deadbeef", []int{41}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadbeef", []int{41}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
-	if err := handler.heartbeat(context.Background(), "deadveal", []int{42, 43}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadveal", []int{42, 44}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
 	assertDoneCounts(0, 1)
 
 	// missing two deadveal jobs
 	clock.Advance(time.Minute * 2)
-	if err := handler.heartbeat(context.Background(), "deadbeef", []int{41}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadbeef", []int{41}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
-	if err := handler.heartbeat(context.Background(), "deadveal", []int{}); err != nil {
+	if _, err := handler.heartbeat(context.Background(), "deadveal", []int{}); err != nil {
 		t.Fatalf("unexpected error performing heartbeat: %s", err)
 	}
 	assertDoneCounts(1, 2)
+
+	// unknown jobs
+	clock.Advance(time.Minute * 2)
+	if unknownIDs, err := handler.heartbeat(context.Background(), "deadbeef", []int{41, 43, 45}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	} else if diff := cmp.Diff([]int{43, 45}, unknownIDs); diff != "" {
+		t.Errorf("unexpected unknown ids (-want +got):\n%s", diff)
+	}
+	if unknownIDs, err := handler.heartbeat(context.Background(), "deadveal", []int{42, 44, 45}); err != nil {
+		t.Fatalf("unexpected error performing heartbeat: %s", err)
+	} else if diff := cmp.Diff([]int{42, 44, 45}, unknownIDs); diff != "" {
+		t.Errorf("unexpected unknown ids (-want +got):\n%s", diff)
+	}
 }
 
 func TestCleanup(t *testing.T) {
@@ -103,8 +116,8 @@ func TestCleanup(t *testing.T) {
 
 	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 41}, store1, true, nil)
 	store1.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store1, true, nil)
-	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 42}, store2, true, nil)
 	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 43}, store2, true, nil)
+	store2.DequeueWithIndependentTransactionContextFunc.PushReturn(testRecord{ID: 44}, store2, true, nil)
 
 	options := Options{
 		QueueOptions: map[string]QueueOptions{
@@ -128,7 +141,7 @@ func TestCleanup(t *testing.T) {
 	for i := 0; i < 6; i++ {
 		clock.Advance(time.Minute)
 
-		if err := handler.heartbeat(context.Background(), "deadbeef", []int{41, 42}); err != nil {
+		if _, err := handler.heartbeat(context.Background(), "deadbeef", []int{41, 43}); err != nil {
 			t.Fatalf("unexpected error performing heartbeat: %s", err)
 		}
 	}

--- a/enterprise/cmd/executor-queue/internal/server/lifecycle_test.go
+++ b/enterprise/cmd/executor-queue/internal/server/lifecycle_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/derision-test/glock"
+	"github.com/google/go-cmp/cmp"
 
 	apiclient "github.com/sourcegraph/sourcegraph/enterprise/internal/executor"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"

--- a/enterprise/cmd/executor-queue/internal/server/routes.go
+++ b/enterprise/cmd/executor-queue/internal/server/routes.go
@@ -106,8 +106,8 @@ func (h *handler) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	var payload apiclient.HeartbeatRequest
 
 	h.wrapHandler(w, r, &payload, func() (int, interface{}, error) {
-		err := h.heartbeat(r.Context(), payload.ExecutorName, payload.JobIDs)
-		return http.StatusNoContent, nil, err
+		unknownIDs, err := h.heartbeat(r.Context(), payload.ExecutorName, payload.JobIDs)
+		return http.StatusOK, unknownIDs, err
 	})
 }
 

--- a/enterprise/cmd/executor/internal/apiclient/client_test.go
+++ b/enterprise/cmd/executor/internal/apiclient/client_test.go
@@ -251,13 +251,18 @@ func TestHeartbeat(t *testing.T) {
 		expectedUsername: "test",
 		expectedPassword: "hunter2",
 		expectedPayload:  `{"executorName": "deadbeef", "jobIds": [1, 2, 3]}`,
-		responseStatus:   http.StatusNoContent,
-		responsePayload:  ``,
+		responseStatus:   http.StatusOK,
+		responsePayload:  `[1]`,
 	}
 
 	testRoute(t, spec, func(client *Client) {
-		if err := client.Heartbeat(context.Background(), []int{1, 2, 3}); err != nil {
+		unknownIDs, err := client.Heartbeat(context.Background(), []int{1, 2, 3})
+		if err != nil {
 			t.Fatalf("unexpected error performing heartbeat: %s", err)
+		}
+
+		if diff := cmp.Diff([]int{1}, unknownIDs); diff != "" {
+			t.Errorf("unexpected unknown ids (-want +got):\n%s", diff)
 		}
 	})
 }
@@ -274,7 +279,7 @@ func TestHeartbeatBadResponse(t *testing.T) {
 	}
 
 	testRoute(t, spec, func(client *Client) {
-		if err := client.Heartbeat(context.Background(), []int{1, 2, 3}); err == nil {
+		if _, err := client.Heartbeat(context.Background(), []int{1, 2, 3}); err == nil {
 			t.Fatalf("expected an error")
 		}
 	})

--- a/enterprise/cmd/executor/internal/worker/handler.go
+++ b/enterprise/cmd/executor/internal/worker/handler.go
@@ -67,12 +67,14 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 	logger := command.NewLogger(union(h.options.RedactedValues, job.RedactedValues))
 
 	defer func() {
+		log15.Info("Writing log entries", "jobID", job.ID, "repositoryName", job.RepositoryName, "commit", job.Commit)
+
 		for _, entry := range logger.Entries() {
 			// Perform this outside of the task execution context. If there is a timeout or
 			// cancellation error we don't want to skip uploading these logs as users will
 			// often want to see how far something progressed prior to a timeout.
 			if err := s.AddExecutionLogEntry(context.Background(), record.RecordID(), entry); err != nil {
-				log15.Warn("Failed to upload executor log entry for job", "id", record.RecordID(), "err", err)
+				log15.Warn("Failed to upload executor log entry for job", "id", record.RecordID(), "repositoryName", job.RepositoryName, "commit", job.Commit, "error", err)
 			}
 		}
 	}()
@@ -80,6 +82,8 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 	// Create a working directory for this job which will be removed once the job completes.
 	// If a repository is supplied as part of the job configuration, it will be cloned into
 	// the working directory.
+
+	log15.Info("Creating workspace", "jobID", job.ID, "repositoryName", job.RepositoryName, "commit", job.Commit)
 
 	hostRunner := h.runnerFactory("", logger, command.Options{}, h.operations)
 	workingDirectory, err := h.prepareWorkspace(ctx, hostRunner, job.RepositoryName, job.Commit)
@@ -142,6 +146,8 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 		scriptNames = append(scriptNames, scriptName)
 	}
 
+	log15.Info("Setting up VM", "jobID", job.ID, "repositoryName", job.RepositoryName, "commit", job.Commit)
+
 	// Setup Firecracker VM (if enabled)
 	if err := runner.Setup(ctx, imageNames, nil); err != nil {
 		return wrapError(err, "failed to setup virtual machine")
@@ -166,6 +172,8 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 			Operation:  h.operations.Exec,
 		}
 
+		log15.Info(fmt.Sprintf("Running docker step #%d", i), "jobID", job.ID, "repositoryName", job.RepositoryName, "commit", job.Commit)
+
 		if err := runner.Run(ctx, dockerStepCommand); err != nil {
 			return wrapError(err, "failed to perform docker step")
 		}
@@ -173,6 +181,8 @@ func (h *handler) Handle(ctx context.Context, s workerutil.Store, record workeru
 
 	// Invoke each src-cli step sequentially
 	for i, cliStep := range job.CliSteps {
+		log15.Info(fmt.Sprintf("Running src-cli step #%d", i), "jobID", job.ID, "repositoryName", job.RepositoryName, "commit", job.Commit)
+
 		cliStepCommand := command.CommandSpec{
 			Key:       fmt.Sprintf("step.src.%d", i),
 			Command:   append([]string{"src"}, cliStep.Commands...),

--- a/enterprise/cmd/executor/internal/worker/idset.go
+++ b/enterprise/cmd/executor/internal/worker/idset.go
@@ -1,31 +1,50 @@
 package worker
 
 import (
+	"context"
 	"sort"
 	"sync"
 )
 
 type IDSet struct {
 	sync.RWMutex
-	ids map[int]struct{}
+	ids map[int]context.CancelFunc
 }
 
 func newIDSet() *IDSet {
-	return &IDSet{ids: map[int]struct{}{}}
+	return &IDSet{ids: map[int]context.CancelFunc{}}
 }
 
-func (i *IDSet) Add(id int) {
+// Add associates the given identifier with the given cancel function
+// in the set. If the identifier was already present then the set is
+// unchanged.
+func (i *IDSet) Add(id int, cancel context.CancelFunc) bool {
 	i.Lock()
-	i.ids[id] = struct{}{}
-	i.Unlock()
+	defer i.Unlock()
+
+	if _, ok := i.ids[id]; ok {
+		return false
+	}
+
+	i.ids[id] = cancel
+	return true
 }
 
+// Remove invokes the cancel function associated with the given identifier
+// in the setand removes the identifier from the set. If the identifier is
+// not a member of the set, then no action is performed.
 func (i *IDSet) Remove(id int) {
 	i.Lock()
+	cancel, ok := i.ids[id]
 	delete(i.ids, id)
 	i.Unlock()
+
+	if ok {
+		cancel()
+	}
 }
 
+// Slice returns an ordered copy of the identifiers composing the set.
 func (i *IDSet) Slice() []int {
 	i.RLock()
 	defer i.RUnlock()

--- a/enterprise/cmd/executor/internal/worker/idset_test.go
+++ b/enterprise/cmd/executor/internal/worker/idset_test.go
@@ -1,0 +1,51 @@
+package worker
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIDAddRemove(t *testing.T) {
+	var called1, called2, called3 bool
+
+	idSet := newIDSet()
+	if !idSet.Add(1, func() { called1 = true }) {
+		t.Fatalf("expected add to succeed")
+	}
+	if !idSet.Add(2, func() { called2 = true }) {
+		t.Fatalf("expected add to succeed")
+	}
+	if idSet.Add(1, func() { called3 = true }) {
+		t.Fatalf("expected duplicate add to fail")
+	}
+
+	idSet.Remove(1)
+
+	if !called1 {
+		t.Fatalf("expected first function to be called")
+	}
+	if called2 {
+		t.Fatalf("did not expect second function to be called")
+	}
+	if called3 {
+		t.Fatalf("did not expect third function to be called")
+	}
+
+	if diff := cmp.Diff([]int{2}, idSet.Slice()); diff != "" {
+		t.Errorf("unexpected slice (-want +got):\n%s", diff)
+	}
+}
+
+func TestIDSetSlice(t *testing.T) {
+	idSet := newIDSet()
+	idSet.Add(2, nil)
+	idSet.Add(4, nil)
+	idSet.Add(5, nil)
+	idSet.Add(1, nil)
+	idSet.Add(3, nil)
+
+	if diff := cmp.Diff([]int{1, 2, 3, 4, 5}, idSet.Slice()); diff != "" {
+		t.Errorf("unexpected slice (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This PR modifies the interface of the heartbeat between executors and the executor-queue. Previously, the executors sent the list of active jobs and the executor-queue would simply log and acknowledge it. Now, the executor-queue sends back the set of ids the executor _claims_ to be processing, but should not be.

This can occur if the executor-queue restarts while there are active jobs (the jobs are lost to the executor-queue, but the executor never cancelled its attempt).

This PR modifies the executor-queue to respond with the set of unknown ids on each heartbeat request, and modifies the executor to receive the unknown ids on a heartbeat and cancel the context associated with unknown jobs.

Fixes #21635. Review by commit.