### PR TITLE
oobmigrations: Startup check

### DIFF
--- a/client/web/src/site-admin/SiteAdminMigrationsPage.test.ts
+++ b/client/web/src/site-admin/SiteAdminMigrationsPage.test.ts
@@ -1,3 +1,5 @@
+import { parse } from 'semver'
+
 import { OutOfBandMigrationFields } from '../graphql-operations'
 
 import { isComplete, isInvalidForVersion } from './SiteAdminMigrationsPage'
@@ -29,23 +31,18 @@ describe('isInvalidForVersion', () => {
         expect(
             isInvalidForVersion(
                 { ...zeroFields, introduced: '3.9', deprecated: '3.10', progress: 0.5 },
-                { major: 3, minor: 10 }
+                parse('3.10.0')
             )
         ).toBeTruthy()
     })
 
     it('should not mark incomplete migrations as invalid without deprecation', () => {
-        expect(
-            isInvalidForVersion({ ...zeroFields, introduced: '3.9', progress: 0.5 }, { major: 3, minor: 10 })
-        ).toBeFalsy()
+        expect(isInvalidForVersion({ ...zeroFields, introduced: '3.9', progress: 0.5 }, parse('3.10.0'))).toBeFalsy()
     })
 
     it('should mark incomplete migrations as invalid after downgrade', () => {
         expect(
-            isInvalidForVersion(
-                { ...zeroFields, introduced: '3.9', deprecated: '3.10', progress: 0.5 },
-                { major: 3, minor: 8 }
-            )
+            isInvalidForVersion({ ...zeroFields, introduced: '3.9', deprecated: '3.10', progress: 0.5 }, parse('3.8.0'))
         ).toBeTruthy()
     })
 
@@ -53,7 +50,7 @@ describe('isInvalidForVersion', () => {
         expect(
             isInvalidForVersion(
                 { ...zeroFields, introduced: '3.9', deprecated: '3.10', progress: 0.5, nonDestructive: true },
-                { major: 3, minor: 8 }
+                parse('3.8.0')
             )
         ).toBeFalsy()
     })

--- a/cmd/frontend/backend/versions_test.go
+++ b/cmd/frontend/backend/versions_test.go
@@ -14,6 +14,30 @@ func init() {
 	dbtesting.DBNameSuffix = "backendtestdb"
 }
 
+func TestGetFirstServiceVersion(t *testing.T) {
+	dbtesting.SetupGlobalTestDB(t)
+
+	ctx := context.Background()
+
+	if err := UpdateServiceVersion(ctx, "service", "1.2.3"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := UpdateServiceVersion(ctx, "service", "1.2.4"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if err := UpdateServiceVersion(ctx, "service", "1.3.0"); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	firstVersion, err := GetFirstServiceVersion(ctx, "service")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if firstVersion != "1.2.3" {
+		t.Errorf("unexpected first version. want=%s have=%s", "1.2.3", firstVersion)
+	}
+}
+
 func TestUpdateServiceVersion(t *testing.T) {
 	dbtesting.SetupGlobalTestDB(t)
 

--- a/cmd/frontend/graphqlbackend/oobmigrations.go
+++ b/cmd/frontend/graphqlbackend/oobmigrations.go
@@ -92,11 +92,18 @@ func (r *outOfBandMigrationResolver) ID() graphql.ID {
 	return MarshalOutOfBandMigrationID(int32(r.m.ID))
 }
 
-func (r *outOfBandMigrationResolver) Team() string           { return r.m.Team }
-func (r *outOfBandMigrationResolver) Component() string      { return r.m.Component }
-func (r *outOfBandMigrationResolver) Description() string    { return r.m.Description }
-func (r *outOfBandMigrationResolver) Introduced() string     { return r.m.Introduced }
-func (r *outOfBandMigrationResolver) Deprecated() *string    { return r.m.Deprecated }
+func (r *outOfBandMigrationResolver) Team() string        { return r.m.Team }
+func (r *outOfBandMigrationResolver) Component() string   { return r.m.Component }
+func (r *outOfBandMigrationResolver) Description() string { return r.m.Description }
+func (r *outOfBandMigrationResolver) Introduced() string  { return r.m.Introduced.String() }
+func (r *outOfBandMigrationResolver) Deprecated() *string {
+	if r.m.Deprecated == nil {
+		return nil
+	}
+
+	return strptr(r.m.Deprecated.String())
+}
+
 func (r *outOfBandMigrationResolver) Progress() float64      { return r.m.Progress }
 func (r *outOfBandMigrationResolver) Created() DateTime      { return DateTime{r.m.Created} }
 func (r *outOfBandMigrationResolver) LastUpdated() *DateTime { return DateTimeOrNil(r.m.LastUpdated) }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1308,7 +1308,9 @@ type OutOfBandMigration implements Node {
     description: String!
 
     """
-    The Sourcegraph version in which this migration was introduced.
+    The Sourcegraph version in which this migration was introduced. The format of this version
+    includes only major and minor parts separated by a dot. The patch version can always be assumed
+    to be zero as we'll never introduce or deprecate an out-of-band migration within a patch release.
 
     It is necessary to completely this migration in reverse (if destructive) before downgrading
     to or past this version. Otherwise, the previous instance version will not be aware of the
@@ -1317,7 +1319,8 @@ type OutOfBandMigration implements Node {
     introduced: String!
 
     """
-    The Sourcegraph version in which this migration is assumed to have completed.
+    The Sourcegraph version by which this migration is assumed to have completed. The format of
+    this version mirrors introduced and includes only major and minor parts separated by a dot.
 
     It is necessary to have completed this migration before upgrading to or past this version.
     Otherwsie, the next instance version will no longer be aware of the old data format.

--- a/cmd/frontend/internal/cli/migrations.go
+++ b/cmd/frontend/internal/cli/migrations.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/oobmigration"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+	"github.com/sourcegraph/sourcegraph/internal/version"
+)
+
+// newOutOfBandMigrationRunner creates and validates an out of band migrator instance.
+// This method may issue a `log.Fatal` when there are migrations left in an unexpected
+// state for the current application version.
+func newOutOfBandMigrationRunner(ctx context.Context, db *sql.DB) *oobmigration.Runner {
+	outOfBandMigrationRunner := oobmigration.NewRunnerWithDB(db, time.Second*30, &observation.Context{
+		Logger:     log15.Root(),
+		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+		Registerer: prometheus.DefaultRegisterer,
+	})
+
+	validateOutOfBandMigrationRunner(ctx, outOfBandMigrationRunner)
+	return outOfBandMigrationRunner
+}
+
+func validateOutOfBandMigrationRunner(ctx context.Context, outOfBandMigrationRunner *oobmigration.Runner) {
+	if version.IsDev(version.Version()) {
+		log15.Warn("Skipping out-of-band migrations check (dev mode)", "version", version.Version())
+		return
+	}
+	currentSemver, err := semver.NewVersion(version.Version())
+	if err != nil {
+		log15.Warn("Skipping out-of-band migrations check", "version", version.Version(), "error", err)
+		return
+	}
+
+	firstVersion, err := backend.GetFirstServiceVersion(ctx, "frontend")
+	if err != nil {
+		log.Fatalf("Failed to retrieve first instance version: %v", err)
+	}
+	firstVersionSemver, err := semver.NewVersion(firstVersion)
+	if err != nil {
+		log15.Warn("Skipping out-of-band migrations check", "version", version.Version(), "error", err)
+		return
+	}
+
+	// Ensure that there are no unfinished migrations that would cause inconsistent
+	// results. If there are unfinished migrations, the site-admin needs to run the
+	// previous version of Sourcegraph for longer while the migrations finish.
+	//
+	// This condition should only be hit when the site-admin prematurely updates to
+	// a version that requires the migration process to be already finished. There
+	// are warnings on the site-admin migration page indicating this danger.
+	if err := outOfBandMigrationRunner.Validate(
+		ctx,
+		oobmigration.NewVersion(int(currentSemver.Major()), int(currentSemver.Minor())),
+		oobmigration.NewVersion(int(firstVersionSemver.Major()), int(firstVersionSemver.Minor())),
+	); err != nil {
+		log.Fatalf("Unfinished migrations: %v", err)
+	}
+}

--- a/cmd/frontend/internal/cli/migrations.go
+++ b/cmd/frontend/internal/cli/migrations.go
@@ -71,6 +71,6 @@ func validateOutOfBandMigrationRunner(ctx context.Context, outOfBandMigrationRun
 		oobmigration.NewVersion(int(currentSemver.Major()), int(currentSemver.Minor())),
 		oobmigration.NewVersion(int(firstVersionSemver.Major()), int(firstVersionSemver.Minor())),
 	); err != nil {
-		log.Fatalf("Unfinished migrations: %v", err)
+		log.Fatalf("ERROR: %v", err)
 	}
 }

--- a/cmd/frontend/internal/cli/migrations.go
+++ b/cmd/frontend/internal/cli/migrations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"log"
+	"os"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -33,6 +34,11 @@ func newOutOfBandMigrationRunner(ctx context.Context, db *sql.DB) *oobmigration.
 }
 
 func validateOutOfBandMigrationRunner(ctx context.Context, outOfBandMigrationRunner *oobmigration.Runner) {
+	if os.Getenv("SRC_DISABLE_OOBMIGRATION_VALIDATION") != "" {
+		log15.Warn("Skipping out-of-band migrations check")
+		return
+	}
+
 	if version.IsDev(version.Version()) {
 		log15.Warn("Skipping out-of-band migrations check (dev mode)", "version", version.Version())
 		return

--- a/doc/dev/background-information/oobmigrations.md
+++ b/doc/dev/background-information/oobmigrations.md
@@ -34,9 +34,9 @@ For every registered migrator, the migration runner will periodically check for 
 
 #### Upgrades
 
-Site admins will be prevented from upgrading beyond the version where an incomplete migration has been deprecated. i.e., site-admin must wait for these migrations to finish before an upgrade. Otherwise, the instance will have data in a format that is no longer readable by the new version.
+Site admins will be prevented from upgrading beyond the version where an incomplete migration has been deprecated. i.e., site-admin must wait for these migrations to finish before an upgrade. Otherwise, the instance will have data in a format that is no longer readable by the new version. In these cases, the instance will shut down with an error message similar to what happens when an in-band migration fails to apply.
 
-Today, this is not actually enforced - [in the future](https://github.com/sourcegraph/sourcegraph/issues/18240), we'll ensure that the instance gives plenty of warnings prior to an upgrade and ensure the instance does not start in such an invalid state.
+The `Site Admin > Maintenance > Migrations` page shows the current progress of each out-of-band migration, as well as disclaimers warning when an immediate upgrade would fail due to an incomplete migration.
 
 #### Downgrades
 

--- a/enterprise/cmd/frontend/main.go
+++ b/enterprise/cmd/frontend/main.go
@@ -32,6 +32,10 @@ func main() {
 	shared.Main(enterpriseSetupHook)
 }
 
+func init() {
+	oobmigration.ReturnEnterpriseMigrations = true
+}
+
 var initFunctions = map[string]func(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigration.Runner, enterpriseServices *enterprise.Services) error{
 	"authz":        authz.Init,
 	"licensing":    licensing.Init,

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1164,26 +1164,27 @@ Referenced by:
 
 # Table "public.out_of_band_migrations"
 ```
-     Column      |           Type           | Collation | Nullable |                      Default                       
------------------+--------------------------+-----------+----------+----------------------------------------------------
- id              | integer                  |           | not null | nextval('out_of_band_migrations_id_seq'::regclass)
- team            | text                     |           | not null | 
- component       | text                     |           | not null | 
- description     | text                     |           | not null | 
- introduced      | text                     |           | not null | 
- deprecated      | text                     |           |          | 
- progress        | double precision         |           | not null | 0
- created         | timestamp with time zone |           | not null | now()
- last_updated    | timestamp with time zone |           |          | 
- non_destructive | boolean                  |           | not null | 
- apply_reverse   | boolean                  |           | not null | false
+          Column          |           Type           | Collation | Nullable |                      Default                       
+--------------------------+--------------------------+-----------+----------+----------------------------------------------------
+ id                       | integer                  |           | not null | nextval('out_of_band_migrations_id_seq'::regclass)
+ team                     | text                     |           | not null | 
+ component                | text                     |           | not null | 
+ description              | text                     |           | not null | 
+ progress                 | double precision         |           | not null | 0
+ created                  | timestamp with time zone |           | not null | now()
+ last_updated             | timestamp with time zone |           |          | 
+ non_destructive          | boolean                  |           | not null | 
+ apply_reverse            | boolean                  |           | not null | false
+ is_enterprise            | boolean                  |           | not null | false
+ introduced_version_major | integer                  |           | not null | 
+ introduced_version_minor | integer                  |           | not null | 
+ deprecated_version_major | integer                  |           |          | 
+ deprecated_version_minor | integer                  |           |          | 
 Indexes:
     "out_of_band_migrations_pkey" PRIMARY KEY, btree (id)
 Check constraints:
     "out_of_band_migrations_component_nonempty" CHECK (component <> ''::text)
-    "out_of_band_migrations_deprecated_valid_version" CHECK (deprecated ~ '^(\d+)\.(\d+)\.(\d+)$'::text)
     "out_of_band_migrations_description_nonempty" CHECK (description <> ''::text)
-    "out_of_band_migrations_introduced_valid_version" CHECK (introduced ~ '^(\d+)\.(\d+)\.(\d+)$'::text)
     "out_of_band_migrations_progress_range" CHECK (progress >= 0::double precision AND progress <= 1::double precision)
     "out_of_band_migrations_team_nonempty" CHECK (team <> ''::text)
 Referenced by:
@@ -1199,13 +1200,19 @@ Stores metadata and progress about an out-of-band migration routine.
 
 **created**: The date and time the migration was inserted into the database (via an upgrade).
 
-**deprecated**: The lowest Sourcegraph version that assumes the migration has completed.
+**deprecated_version_major**: The lowest Sourcegraph version (major component) that assumes the migration has completed.
+
+**deprecated_version_minor**: The lowest Sourcegraph version (minor component) that assumes the migration has completed.
 
 **description**: A brief description about the migration.
 
 **id**: A globally unique primary key for this migration. The same key is used consistently across all Sourcegraph instances for the same migration.
 
-**introduced**: The Sourcegraph version in which this migration was first introduced.
+**introduced_version_major**: The Sourcegraph version (major component) in which this migration was first introduced.
+
+**introduced_version_minor**: The Sourcegraph version (minor component) in which this migration was first introduced.
+
+**is_enterprise**: When true, these migrations are invisible to OSS mode.
 
 **last_updated**: The date and time the migration was last updated.
 
@@ -1762,11 +1769,12 @@ Triggers:
 
 # Table "public.versions"
 ```
-   Column   |           Type           | Collation | Nullable | Default 
-------------+--------------------------+-----------+----------+---------
- service    | text                     |           | not null | 
- version    | text                     |           | not null | 
- updated_at | timestamp with time zone |           | not null | now()
+    Column     |           Type           | Collation | Nullable | Default 
+---------------+--------------------------+-----------+----------+---------
+ service       | text                     |           | not null | 
+ version       | text                     |           | not null | 
+ updated_at    | timestamp with time zone |           | not null | now()
+ first_version | text                     |           | not null | 
 Indexes:
     "versions_pkey" PRIMARY KEY, btree (service)
 

--- a/internal/oobmigration/runner_test.go
+++ b/internal/oobmigration/runner_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/derision-test/glock"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/sourcegraph/sourcegraph/internal/observation"
 )
@@ -338,10 +337,8 @@ func TestRunnerValidate(t *testing.T) {
 
 	runner := newRunner(store, nil, &observation.TestContext)
 	statusErr := runner.Validate(context.Background(), NewVersion(3, 12), NewVersion(0, 0))
-	expectedErr := error(nil)
-
-	if diff := cmp.Diff(expectedErr, statusErr, cmpopts.EquateErrors()); diff != "" {
-		t.Errorf("unexpected status error (-want +got):\n%s", diff)
+	if statusErr != nil {
+		t.Errorf("unexpected status error: %s ", statusErr)
 	}
 }
 
@@ -354,7 +351,7 @@ func TestRunnerValidateUnfinishedUp(t *testing.T) {
 	runner := newRunner(store, nil, &observation.TestContext)
 	statusErr := runner.Validate(context.Background(), NewVersion(3, 12), NewVersion(0, 0))
 
-	if diff := cmp.Diff(newMigrationStatusError(1, 1, 0.65), statusErr, cmpopts.EquateErrors()); diff != "" {
+	if diff := cmp.Diff(wrapMigrationErrors(newMigrationStatusError(1, 1, 0.65)).Error(), statusErr.Error()); diff != "" {
 		t.Errorf("unexpected status error (-want +got):\n%s", diff)
 	}
 }
@@ -368,7 +365,7 @@ func TestRunnerValidateUnfinishedDown(t *testing.T) {
 	runner := newRunner(store, nil, &observation.TestContext)
 	statusErr := runner.Validate(context.Background(), NewVersion(3, 12), NewVersion(0, 0))
 
-	if diff := cmp.Diff(newMigrationStatusError(1, 0, 0.15), statusErr, cmpopts.EquateErrors()); diff != "" {
+	if diff := cmp.Diff(wrapMigrationErrors(newMigrationStatusError(1, 0, 0.15)).Error(), statusErr.Error()); diff != "" {
 		t.Errorf("unexpected status error (-want +got):\n%s", diff)
 	}
 }

--- a/internal/oobmigration/version.go
+++ b/internal/oobmigration/version.go
@@ -1,0 +1,44 @@
+package oobmigration
+
+import "fmt"
+
+type Version struct {
+	Major int
+	Minor int
+}
+
+func NewVersion(major, minor int) Version {
+	return Version{
+		Major: major,
+		Minor: minor,
+	}
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
+}
+
+type VersionOrder int
+
+const (
+	VersionOrderBefore VersionOrder = iota
+	VersionOrderEqual
+	VersionOrderAfter
+)
+
+// compareVersions returns the relationship between `a (op) b`.
+func compareVersions(a, b Version) (VersionOrder, error) {
+	for _, pair := range [][2]int{
+		{a.Major, b.Major},
+		{a.Minor, b.Minor},
+	} {
+		if pair[0] < pair[1] {
+			return VersionOrderBefore, nil
+		}
+		if pair[0] > pair[1] {
+			return VersionOrderAfter, nil
+		}
+	}
+
+	return VersionOrderEqual, nil
+}

--- a/internal/oobmigration/version_test.go
+++ b/internal/oobmigration/version_test.go
@@ -1,0 +1,28 @@
+package oobmigration
+
+import "testing"
+
+func TestCompareVersions(t *testing.T) {
+	testCases := []struct {
+		left     Version
+		right    Version
+		expected VersionOrder
+		err      bool
+	}{
+		{left: NewVersion(3, 12), right: NewVersion(3, 12), expected: VersionOrderEqual},
+		{left: NewVersion(3, 11), right: NewVersion(3, 12), expected: VersionOrderBefore},
+		{left: NewVersion(3, 12), right: NewVersion(3, 11), expected: VersionOrderAfter},
+		{left: NewVersion(3, 12), right: NewVersion(4, 11), expected: VersionOrderBefore},
+		{left: NewVersion(4, 11), right: NewVersion(3, 12), expected: VersionOrderAfter},
+	}
+
+	for _, testCase := range testCases {
+		order, err := compareVersions(testCase.left, testCase.right)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if order != testCase.expected {
+			t.Errorf("unexpected order. want=%d have=%d", testCase.expected, order)
+		}
+	}
+}

--- a/migrations/frontend/1528395823_feature_flags.down.sql
+++ b/migrations/frontend/1528395823_feature_flags.down.sql
@@ -4,5 +4,6 @@ DROP TABLE IF EXISTS feature_flag_overrides;
 
 DROP TABLE IF EXISTS feature_flags;
 
+DROP TYPE feature_flag_type;
 
 COMMIT;

--- a/migrations/frontend/1528395826_track_first_version.down.sql
+++ b/migrations/frontend/1528395826_track_first_version.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE versions DROP COLUMN first_version;
+
+COMMIT;

--- a/migrations/frontend/1528395826_track_first_version.up.sql
+++ b/migrations/frontend/1528395826_track_first_version.up.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE versions ADD COLUMN first_version text;
+UPDATE versions set first_version = version;
+ALTER TABLE versions ALTER COLUMN first_version SET NOT NULL;
+
+COMMIT;

--- a/migrations/frontend/1528395827_oob_enterprise_flag.down.sql
+++ b/migrations/frontend/1528395827_oob_enterprise_flag.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TABLE out_of_band_migrations DROP COLUMN is_enterprise;
+
+COMMIT;

--- a/migrations/frontend/1528395827_oob_enterprise_flag.up.sql
+++ b/migrations/frontend/1528395827_oob_enterprise_flag.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- Add enterprise flag to out of band migrations so we know what to ignore in OSS
+-- If we don't run the migrators but the progress for the enterprise migration
+-- record stays at 0% it will block all upgrades after the migration deprecation.
+
+ALTER TABLE out_of_band_migrations ADD COLUMN is_enterprise boolean DEFAULT false;
+UPDATE out_of_band_migrations SET is_enterprise = true WHERE id NOT IN (3, 6);
+ALTER TABLE out_of_band_migrations ALTER COLUMN is_enterprise SET NOT NULL;
+
+COMMENT ON COLUMN out_of_band_migrations.is_enterprise IS 'When true, these migrations are invisible to OSS mode.';
+
+COMMIT;

--- a/migrations/frontend/1528395828_split_oob_version_columns.down.sql
+++ b/migrations/frontend/1528395828_split_oob_version_columns.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+ALTER TABLE out_of_band_migrations ADD COLUMN introduced text;
+UPDATE out_of_band_migrations SET introduced = concat(introduced_version_major, '.', introduced_version_minor);
+ALTER TABLE out_of_band_migrations ALTER COLUMN introduced SET NOT NULL;
+ALTER TABLE out_of_band_migrations DROP COLUMN introduced_version_major;
+ALTER TABLE out_of_band_migrations DROP COLUMN introduced_version_minor;
+
+ALTER TABLE out_of_band_migrations ADD COLUMN deprecated text;
+UPDATE out_of_band_migrations SET deprecated = concat(deprecated_version_major, '.', deprecated_version_minor) WHERE deprecated_version_major IS NOT NULL;
+ALTER TABLE out_of_band_migrations DROP COLUMN deprecated_version_major;
+ALTER TABLE out_of_band_migrations DROP COLUMN deprecated_version_minor;
+
+COMMIT;

--- a/migrations/frontend/1528395828_split_oob_version_columns.up.sql
+++ b/migrations/frontend/1528395828_split_oob_version_columns.up.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+--
+-- Switch out introduced column
+
+ALTER TABLE out_of_band_migrations ADD COLUMN introduced_version_major int;
+ALTER TABLE out_of_band_migrations ADD COLUMN introduced_version_minor int;
+
+WITH t(id, parts) AS (
+    SELECT
+        id,
+        regexp_matches(introduced, E'^(\\d+)\.(\\d+)')
+    FROM
+        out_of_band_migrations
+)
+UPDATE out_of_band_migrations SET
+    introduced_version_major = parts[1]::int,
+    introduced_version_minor = parts[2]::int
+FROM t WHERE t.id = out_of_band_migrations.id;
+
+ALTER TABLE out_of_band_migrations ALTER COLUMN introduced_version_major SET NOT NULL;
+ALTER TABLE out_of_band_migrations ALTER COLUMN introduced_version_minor SET NOT NULL;
+ALTER TABLE out_of_band_migrations DROP COLUMN introduced;
+
+--
+-- Switch out deprecation column (keep nullable, no data exists yet)
+
+ALTER TABLE out_of_band_migrations ADD COLUMN deprecated_version_major int;
+ALTER TABLE out_of_band_migrations ADD COLUMN deprecated_version_minor int;
+ALTER TABLE out_of_band_migrations DROP COLUMN deprecated;
+
+COMMENT ON COLUMN out_of_band_migrations.introduced_version_major IS 'The Sourcegraph version (major component) in which this migration was first introduced.';
+COMMENT ON COLUMN out_of_band_migrations.introduced_version_minor IS 'The Sourcegraph version (minor component) in which this migration was first introduced.';
+COMMENT ON COLUMN out_of_band_migrations.deprecated_version_major IS 'The lowest Sourcegraph version (major component) that assumes the migration has completed.';
+COMMENT ON COLUMN out_of_band_migrations.deprecated_version_minor IS 'The lowest Sourcegraph version (minor component) that assumes the migration has completed.';
+
+COMMIT;


### PR DESCRIPTION
Update frontend startup to check out of band migration status and block startup if there are unfinished up or down migrations that may result in data loss. Fixes https://github.com/sourcegraph/sourcegraph/issues/18240. Fixes https://github.com/sourcegraph/sourcegraph/issues/20906. Fixes https://github.com/sourcegraph/sourcegraph/issues/18241.

Summary of changes (review by commit):

- DB Changes:
  - Add `first_version` field to `versions` table that is populated with the first value of `version` written to the table (via upsert or migration)
  - Add `is_enterprise` flag to `out_of_band_migrations` table
  - Split `introduced` and `deprecated` columns into `introduced_version_{major,minor}` and `deprecated_version_{major,minor}` columns
- Code changes:
  - Add utility method in `cmd/frontend/backend` package to query it new `first_version` column
  - Modify `oobmigration/Store.List` to omit enterprise-only migrations in OSS mode
  - Add `oobmigration/Runner.Validate` method that tells which migrations are breaking their guarantees based on the current instance version
  - Invoke `Validate` on frontend startup