### PR TITLE
search: name aggregated search events

### DIFF
--- a/internal/database/event_logs.go
+++ b/internal/database/event_logs.go
@@ -748,7 +748,7 @@ SELECT
 	(SELECT count FROM active_repositories_with_upload) AS repositories_with_uploads
 `
 
-// AggregatedCodeIntelEvents calculates AggregatedEvent for each every unique event type related to code intel.
+// AggregatedCodeIntelEvents calculates CodeIntelAggregatedEvent for each every unique event type related to code intel.
 func (l *EventLogStore) AggregatedCodeIntelEvents(ctx context.Context) ([]types.CodeIntelAggregatedEvent, error) {
 	return l.aggregatedCodeIntelEvents(ctx, time.Now().UTC())
 }
@@ -825,12 +825,12 @@ SELECT
 FROM events GROUP BY name, current_week, language_id;
 `
 
-// AggregatedSearchEvents calculates AggregatedEvent for each every unique event type related to search.
-func (l *EventLogStore) AggregatedSearchEvents(ctx context.Context) ([]types.AggregatedEvent, error) {
+// AggregatedSearchEvents calculates SearchAggregatedEvent for each every unique event type related to search.
+func (l *EventLogStore) AggregatedSearchEvents(ctx context.Context) ([]types.SearchAggregatedEvent, error) {
 	return l.aggregatedSearchEvents(ctx, time.Now().UTC())
 }
 
-func (l *EventLogStore) aggregatedSearchEvents(ctx context.Context, now time.Time) (events []types.AggregatedEvent, err error) {
+func (l *EventLogStore) aggregatedSearchEvents(ctx context.Context, now time.Time) (events []types.SearchAggregatedEvent, err error) {
 	query := sqlf.Sprintf(aggregatedSearchEventsQuery, now, now, now, now)
 
 	rows, err := l.Query(ctx, query)
@@ -840,7 +840,7 @@ func (l *EventLogStore) aggregatedSearchEvents(ctx context.Context, now time.Tim
 	defer rows.Close()
 
 	for rows.Next() {
-		var event types.AggregatedEvent
+		var event types.SearchAggregatedEvent
 		err := rows.Scan(
 			&event.Name,
 			&event.Month,
@@ -870,7 +870,7 @@ func (l *EventLogStore) aggregatedSearchEvents(ctx context.Context, now time.Tim
 	return events, nil
 }
 
-var searchEventNames = []string{
+var searchLatencyEventNames = []string{
 	"'search.latencies.literal'",
 	"'search.latencies.regexp'",
 	"'search.latencies.structural'",
@@ -898,7 +898,7 @@ WITH events AS (
   FROM event_logs
   WHERE
     timestamp >= ` + makeDateTruncExpression("month", "%s::timestamp") + `
-    AND name IN (` + strings.Join(searchEventNames, ", ") + `)
+    AND name IN (` + strings.Join(searchLatencyEventNames, ", ") + `)
 )
 SELECT
   name,

--- a/internal/database/event_logs_test.go
+++ b/internal/database/event_logs_test.go
@@ -560,7 +560,7 @@ func TestEventLogs_AggregatedSparseSearchEvents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedEvents := []types.AggregatedEvent{
+	expectedEvents := []types.SearchAggregatedEvent{
 		{
 			Name:           "search.latencies.structural",
 			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),
@@ -643,7 +643,7 @@ func TestEventLogs_AggregatedSearchEvents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedEvents := []types.AggregatedEvent{
+	expectedEvents := []types.SearchAggregatedEvent{
 		{
 			Name:           "search.latencies.literal",
 			Month:          time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC),

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1316,9 +1316,9 @@ type SiteUsageSummary struct {
 	MonitorUniquesWeek      int32
 }
 
-// AggregatedEvent represents the total events, unique users, and
-// latencies over the current month, week, and day for a single event.
-type AggregatedEvent struct {
+// SearchAggregatedEvent represents the total events, unique users, and
+// latencies over the current month, week, and day for a single search event.
+type SearchAggregatedEvent struct {
 	Name           string
 	Month          time.Time
 	Week           time.Time

--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -165,7 +165,7 @@ func GetAggregatedSearchStats(ctx context.Context, db dbutil.DB) (*types.SearchU
 // Sourcegraph's Postgres table) and returns a SearchUsageStatistics data type
 // that ends up being stored in BigQuery. SearchUsageStatistics corresponds to
 // the target DB schema.
-func groupAggregatedSearchStats(events []types.AggregatedEvent) *types.SearchUsageStatistics {
+func groupAggregatedSearchStats(events []types.SearchAggregatedEvent) *types.SearchUsageStatistics {
 	searchUsageStats := &types.SearchUsageStatistics{
 		Daily:   []*types.SearchUsagePeriod{newSearchEventPeriod()},
 		Weekly:  []*types.SearchUsagePeriod{newSearchEventPeriod()},
@@ -205,7 +205,7 @@ var searchExtractors = map[string]func(p *types.SearchUsagePeriod) *types.Search
 // value that it contains that corresponds to that event type.
 //
 // (4) Populate that SearchEventStatistics object in the SearchUsagePeriod object with usage stats (latencies, etc).
-func populateSearchEventStatistics(event types.AggregatedEvent, statistics *types.SearchUsageStatistics) {
+func populateSearchEventStatistics(event types.SearchAggregatedEvent, statistics *types.SearchUsageStatistics) {
 	extractor, ok := searchExtractors[event.Name]
 	if !ok {
 		return

--- a/internal/usagestats/aggregated_test.go
+++ b/internal/usagestats/aggregated_test.go
@@ -171,7 +171,7 @@ func TestGroupAggregateSearchStats(t *testing.T) {
 	t2 := t1.Add(time.Hour)
 	t3 := t2.Add(time.Hour)
 
-	searchStats := groupAggregatedSearchStats([]types.AggregatedEvent{
+	searchStats := groupAggregatedSearchStats([]types.SearchAggregatedEvent{
 		{
 			Name:           "search.latencies.structural",
 			Month:          t1,


### PR DESCRIPTION
Just a rename. The `AggregatedEvent` type was previously shared by code intel and search, but has since split off. It now refers exclusively to search aggregated events, so I'm naming it as such, since there is a corresponding `CodeIntelAggregatedEvent`