### PR TITLE
search: reorder search statistics by event kind

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1232,21 +1232,27 @@ type SearchUsageStatistics struct {
 // to the updatecheck handler. This struct is marshalled and sent to
 // BigQuery, which requires the input match its schema exactly.
 type SearchUsagePeriod struct {
-	StartTime          time.Time
-	TotalUsers         int32
-	Literal            *SearchEventStatistics
-	Regexp             *SearchEventStatistics
+	StartTime  time.Time
+	TotalUsers int32
+
+	// Counts and latency statistics for different kinds of searches.
+	Literal    *SearchEventStatistics
+	Regexp     *SearchEventStatistics
+	Commit     *SearchEventStatistics
+	Diff       *SearchEventStatistics
+	File       *SearchEventStatistics
+	Structural *SearchEventStatistics
+	Symbol     *SearchEventStatistics
+
+	// Counts statistics for fields.
 	After              *SearchCountStatistics
 	Archived           *SearchCountStatistics
 	Author             *SearchCountStatistics
 	Before             *SearchCountStatistics
 	Case               *SearchCountStatistics
-	Commit             *SearchEventStatistics
 	Committer          *SearchCountStatistics
 	Content            *SearchCountStatistics
 	Count              *SearchCountStatistics
-	Diff               *SearchEventStatistics
-	File               *SearchEventStatistics
 	Fork               *SearchCountStatistics
 	Index              *SearchCountStatistics
 	Lang               *SearchCountStatistics
@@ -1256,11 +1262,11 @@ type SearchUsagePeriod struct {
 	Repohascommitafter *SearchCountStatistics
 	Repohasfile        *SearchCountStatistics
 	Repogroup          *SearchCountStatistics
-	Structural         *SearchEventStatistics
-	Symbol             *SearchEventStatistics
 	Timeout            *SearchCountStatistics
 	Type               *SearchCountStatistics
-	SearchModes        *SearchModeUsageStatistics
+
+	// Search modes statistics is deprecated.
+	SearchModes *SearchModeUsageStatistics
 }
 
 type SearchModeUsageStatistics struct {

--- a/internal/usagestats/aggregated.go
+++ b/internal/usagestats/aggregated.go
@@ -181,7 +181,7 @@ func groupAggregatedSearchStats(events []types.SearchAggregatedEvent) *types.Sea
 }
 
 // utility functions that resolve a SearchEventStatistics value for a given event name for some SearchUsagePeriod.
-var searchExtractors = map[string]func(p *types.SearchUsagePeriod) *types.SearchEventStatistics{
+var searchLatencyExtractors = map[string]func(p *types.SearchUsagePeriod) *types.SearchEventStatistics{
 	"search.latencies.literal":    func(p *types.SearchUsagePeriod) *types.SearchEventStatistics { return p.Literal },
 	"search.latencies.regexp":     func(p *types.SearchUsagePeriod) *types.SearchEventStatistics { return p.Regexp },
 	"search.latencies.structural": func(p *types.SearchUsagePeriod) *types.SearchEventStatistics { return p.Structural },
@@ -206,7 +206,7 @@ var searchExtractors = map[string]func(p *types.SearchUsagePeriod) *types.Search
 //
 // (4) Populate that SearchEventStatistics object in the SearchUsagePeriod object with usage stats (latencies, etc).
 func populateSearchEventStatistics(event types.SearchAggregatedEvent, statistics *types.SearchUsageStatistics) {
-	extractor, ok := searchExtractors[event.Name]
+	extractor, ok := searchLatencyExtractors[event.Name]
 	if !ok {
 		return
 	}


### PR DESCRIPTION
Stacked on #20974. 

This is a rename and reordering of type fields, no functional changes. What's going on is that we have a type `SearchUsagePeriod` that's our schema in BigQuery. Internally we have two disjoint types to represent the kinds of statistics of this `SearchUsagePeriod`: 

- `SearchEventStatistics` which is latency and counts of search kinds

- `SearchCountStatistics` which is counts of filter usage. This is the data that is not currently populated as of > 8 months 

Although these are disjoint they exist in the Go-esque style of one-big-struct. To make the logic around these data types clearer I'm reordering the fields in the schema and renaming the handler lookup map which acts only on the latency `SearchEventStatistics` type.