### PR TITLE
Site admins cannot add access tokens for any user by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Only site admins can now list users on an instance. [#20619](https://github.com/sourcegraph/sourcegraph/pull/20619)
 - Repository permissions can now be enabled for site admins via the `authz.enforceForSiteAdmins` setting. [#20674](https://github.com/sourcegraph/sourcegraph/pull/20674)
 - Site admins can no longer view user added code host configuration. [#20851](https://github.com/sourcegraph/sourcegraph/pull/20851)
+- Site admins cannot add access tokens for any user by default. [#20988](https://github.com/sourcegraph/sourcegraph/pull/20988)
 
 ### Fixed
 

--- a/cmd/frontend/backend/site_admin.go
+++ b/cmd/frontend/backend/site_admin.go
@@ -85,6 +85,19 @@ func CheckSiteAdminOrSameUser(ctx context.Context, subjectUserID int32) error {
 	return &InsufficientAuthorizationError{fmt.Sprintf("must be authenticated as %s or as an admin (%s)", subjectUser.Username, isSiteAdminErr.Error())}
 }
 
+// CheckSameUser returns an error if the user is not the user specified by
+// subjectUserID.
+func CheckSameUser(ctx context.Context, subjectUserID int32) error {
+	if hasAuthzBypass(ctx) {
+		return nil
+	}
+	a := actor.FromContext(ctx)
+	if a.IsAuthenticated() && a.UID == subjectUserID {
+		return nil
+	}
+	return &InsufficientAuthorizationError{Message: fmt.Sprintf("Must be authenticated as user with id %d", subjectUserID)}
+}
+
 // CurrentUser gets the current authenticated user
 // It returns nil, nil if no user is found
 func CurrentUser(ctx context.Context) (*types.User, error) {

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -26,19 +26,23 @@ type createAccessTokenInput struct {
 }
 
 func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAccessTokenInput) (*createAccessTokenResult, error) {
-	// 🚨 SECURITY: Only site admins and the user can create an access token for a user.
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
-		return nil, err
-	}
-	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
 		return nil, err
 	}
 
 	switch conf.AccessTokensAllow() {
 	case conf.AccessTokensAll:
-		// Allow
+		// 🚨 SECURITY: Only current logged in user should be able to create a token for
+		// themselves. A site admin should NOT be allowed to do this since they could
+		// then use the token to impersonate a user and gain access to their private
+		// code.
+		if err := backend.CheckSameUser(ctx, userID); err != nil {
+			return nil, err
+		}
 	case conf.AccessTokensAdmin:
+		// 🚨 SECURITY: The site has opted in to only allow site admins to create access
+		// tokens. In this case, they can create a token for any user.
 		if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
 			return nil, errors.New("Access token creation has been restricted to admin users. Contact an admin user to create a new access token.")
 		}

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -33,8 +33,8 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 
 	switch conf.AccessTokensAllow() {
 	case conf.AccessTokensAll:
-		// 🚨 SECURITY: Only current logged in user should be able to create a token for
-		// themselves. A site admin should NOT be allowed to do this since they could
+		// 🚨 SECURITY: Only the current logged in user should be able to create a token
+		// for themselves. A site admin should NOT be allowed to do this since they could
 		// then use the token to impersonate a user and gain access to their private
 		// code.
 		if err := backend.CheckSameUser(ctx, userID); err != nil {

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -10,16 +10,14 @@ import (
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/gqltesting"
 
-	"github.com/sourcegraph/sourcegraph/schema"
-
-	"github.com/sourcegraph/sourcegraph/internal/conf"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/schema"
 )
 
 // 🚨 SECURITY: This tests that users can't create tokens for users they aren't allowed to do so for.

--- a/cmd/frontend/graphqlbackend/access_tokens_test.go
+++ b/cmd/frontend/graphqlbackend/access_tokens_test.go
@@ -2,11 +2,17 @@ package graphqlbackend
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/gqltesting"
+
+	"github.com/sourcegraph/sourcegraph/schema"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
@@ -135,7 +141,7 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 		})
 	})
 
-	t.Run("authenticated as different user who is a site-admin", func(t *testing.T) {
+	t.Run("authenticated as different user who is a site-admin. Default config", func(t *testing.T) {
 		resetMocks()
 		const differentSiteAdminUID = 234
 		mockAccessTokensCreate(t, differentSiteAdminUID, []string{authz.ScopeUserAll})
@@ -143,6 +149,42 @@ func TestMutation_CreateAccessToken(t *testing.T) {
 			return &types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil
 		}
 		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
+
+		gqltesting.RunTests(t, []*gqltesting.Test{
+			{
+				Context: actor.WithActor(context.Background(), &actor.Actor{UID: differentSiteAdminUID}),
+				Schema:  mustParseGraphQLSchema(t),
+				Query: `
+				mutation {
+					createAccessToken(user: "` + uid1GQLID + `", scopes: ["user:all"], note: "n") {
+						id
+						token
+					}
+				}
+			`,
+				ExpectedResult: `null`,
+				ExpectedErrors: []*errors.QueryError{
+					{
+						Path:          []interface{}{"createAccessToken"},
+						Message:       "Must be authenticated as user with id 1",
+						ResolverError: &backend.InsufficientAuthorizationError{Message: fmt.Sprintf("Must be authenticated as user with id %d", 1)},
+					},
+				},
+			},
+		})
+	})
+
+	t.Run("authenticated as different user who is a site-admin. Admin allowed", func(t *testing.T) {
+		resetMocks()
+		const differentSiteAdminUID = 234
+		mockAccessTokensCreate(t, differentSiteAdminUID, []string{authz.ScopeUserAll})
+		database.Mocks.Users.GetByCurrentAuthUser = func(ctx context.Context) (*types.User, error) {
+			return &types.User{ID: differentSiteAdminUID, SiteAdmin: true}, nil
+		}
+		defer func() { database.Mocks.Users.GetByCurrentAuthUser = nil }()
+
+		conf.Get().AuthAccessTokens = &schema.AuthAccessTokens{Allow: string(conf.AccessTokensAdmin)}
+		defer func() { conf.Get().AuthAccessTokens = nil }()
 
 		gqltesting.RunTests(t, []*gqltesting.Test{
 			{

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -611,8 +611,8 @@ func (r *schemaResolver) AffiliatedRepositories(ctx context.Context, args *struc
 	if err != nil {
 		return nil, err
 	}
-	// 🚨 SECURITY: make sure the user is either site admin or the same user being requested
-	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
+	// 🚨 SECURITY: Make sure the user is the same user being requested
+	if err := backend.CheckSameUser(ctx, userID); err != nil {
 		return nil, err
 	}
 	var codeHost int64

--- a/cmd/frontend/graphqlbackend/user.go
+++ b/cmd/frontend/graphqlbackend/user.go
@@ -462,7 +462,7 @@ func viewerIsChangingUsername(ctx context.Context, db dbutil.DB, subjectUserID i
 }
 
 func (r *UserResolver) Monitors(ctx context.Context, args *ListMonitorsArgs) (MonitorConnectionResolver, error) {
-	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
+	if err := backend.CheckSameUser(ctx, r.user.ID); err != nil {
 		return nil, err
 	}
 	return EnterpriseResolvers.codeMonitorsResolver.Monitors(ctx, r.user.ID, args)


### PR DESCRIPTION
By default, when any user can create access tokens, do not allow site admins to
create tokens for other users. This would allow them to potentially use the
access token to gain access to the user's private code.

Update usages of CheckSiteAdminOrSameUser and switch to CheckSameUser where it
might expose private code.

Part of https://github.com/sourcegraph/sourcegraph/issues/20983