### PR TITLE
extensibility: add tooltip when action item is inactive

### DIFF
--- a/client/shared/src/actions/ActionItem.tsx
+++ b/client/shared/src/actions/ActionItem.tsx
@@ -198,6 +198,10 @@ export class ActionItem extends React.PureComponent<ActionItemProps, State> {
             tooltip = this.props.action.description
         }
 
+        if (!this.props.active && tooltip) {
+            tooltip += ' (inactive)'
+        }
+
         const variantClassName = this.props.variant === 'actionItem' ? 'action-item--variant-action-item' : ''
 
         // Simple display if the action is a noop.

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -87,7 +87,6 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
         }
 
         &--inactive {
-            pointer-events: none;
             cursor: not-allowed;
             filter: saturate(0%);
             opacity: 0.7;


### PR DESCRIPTION
Closes #19338.

Show tooltips when action item is inactive now, add " (inactive)" to the description. We don't have an easy way to directly access the extension ID from the action item, but I think keeping the same description is more clear anyways (in case an extension contributes multiple action items, or it's not easy to infer what the action item will do from the extension ID).

![Screenshot from 2021-05-14 09-23-19](https://user-images.githubusercontent.com/37420160/118277271-9ef6ca80-b496-11eb-92b6-8503c63949c4.png)
