### PR TITLE
Add new mechanism for listening value for insight live preview

### DIFF
--- a/client/sandboxes/code-insights/webpack.config.ts
+++ b/client/sandboxes/code-insights/webpack.config.ts
@@ -20,7 +20,7 @@ export default {
     devtool: 'source-map',
     resolve: {
         alias: { react: require.resolve('react') },
-        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+        extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
     },
     module: {
         rules: [

--- a/client/web/src/components/alerts.tsx
+++ b/client/web/src/components/alerts.tsx
@@ -7,7 +7,7 @@ import { Markdown } from '@sourcegraph/shared/src/components/Markdown'
 import { asError } from '@sourcegraph/shared/src/util/errors'
 import { renderMarkdown } from '@sourcegraph/shared/src/util/markdown'
 
-const renderError = (error: unknown): string =>
+export const renderError = (error: unknown): string =>
     renderMarkdown(upperFirst((asError(error).message || 'Unknown Error').replace(/\t/g, '')), { breaks: true })
         .trim()
         .replace(/^<p>/, '')

--- a/client/web/src/insights/components/form/form-input/FormInput.tsx
+++ b/client/web/src/insights/components/form/form-input/FormInput.tsx
@@ -1,6 +1,8 @@
 import classnames from 'classnames'
 import React, { forwardRef, InputHTMLAttributes, ReactNode } from 'react'
 
+import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput';
+
 interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
     /** Title of input. */
     title?: string
@@ -13,6 +15,7 @@ interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
     errorInputState?: boolean
     /** Valid sign to show valid state on input. */
     valid?: boolean
+    loading?: boolean
     /** Turn on or turn off autofocus for input. */
     autofocus?: boolean
     /** Custom class name for input element. */
@@ -32,6 +35,7 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>((props, re
         inputSymbol,
         valid,
         error,
+        loading = false,
         errorInputState,
         ...otherProps
     } = props
@@ -40,7 +44,7 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>((props, re
         <label className={classnames(className)}>
             {title && <div className="mb-2">{title}</div>}
 
-            <div className="d-flex">
+            <LoaderInput className="d-flex" loading={loading}>
                 <input
                     type={type}
                     className={classnames(inputClassName, 'form-control', {
@@ -52,7 +56,7 @@ export const FormInput = forwardRef<HTMLInputElement, FormInputProps>((props, re
                 />
 
                 {inputSymbol}
-            </div>
+            </LoaderInput>
 
             {error && (
                 <small className="text-danger form-text" role="alert">

--- a/client/web/src/insights/components/form/form-input/FormInput.tsx
+++ b/client/web/src/insights/components/form/form-input/FormInput.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames'
 import React, { forwardRef, InputHTMLAttributes, ReactNode } from 'react'
 
-import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput';
+import { LoaderInput } from '@sourcegraph/branded/src/components/LoaderInput'
 
 interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
     /** Title of input. */

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -26,7 +26,7 @@ export interface useFieldAPI<FieldValue> {
     input: {
         ref: RefObject<HTMLInputElement & HTMLFieldSetElement>
         name: string
-        value: FieldValue | undefined
+        value: FieldValue
         onChange: (event: ChangeEvent<HTMLInputElement> | FieldValue) => void
         onBlur: FocusEventHandler<HTMLInputElement>
     }
@@ -79,7 +79,6 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
     setFieldStateReference.current = setFieldState
 
     useEffect(() => {
-        console.log('HELLO use field validity effect')
         const inputElement = inputReference.current
 
         // Clear custom validity from the last validation call.

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -63,14 +63,10 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
         validity: null,
     })
 
-    const onValidationChange = useCallback((asyncState: Partial<FieldState<FormValues[FieldValueKey]>>) => {
-        setState(previousState => ({ ...previousState, ...asyncState }))
-    }, [])
-
     const { start: startAsyncValidation, cancel: cancelAsyncValidation } = useAsyncValidation({
         inputReference,
         asyncValidator: async,
-        onValidationChange,
+        onValidationChange: asyncState => setState(previousState => ({ ...previousState, ...asyncState })),
     })
 
     // Use useRef for form api handler in order to avoid unnecessary
@@ -129,17 +125,20 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
     // validation is going.
     useEffect(() => setFieldStateReference.current(name, state), [name, state])
 
+    const handleBlur = useCallback(() => setState(state => ({ ...state, touched: true })), [])
+    const handleChange = useCallback((event: ChangeEvent<HTMLInputElement> | FormValues[FieldValueKey]) => {
+        const value = getEventValue(event)
+
+        setState(state => ({ ...state, value }))
+    }, [])
+
     return {
         input: {
             name: name.toString(),
             ref: inputReference,
             value: state.value,
-            onBlur: () => setState(state => ({ ...state, touched: true })),
-            onChange: (event: ChangeEvent<HTMLInputElement> | FormValues[FieldValueKey]) => {
-                const value = getEventValue(event)
-
-                setState(state => ({ ...state, value }))
-            },
+            onBlur: handleBlur,
+            onChange: handleChange,
         },
         meta: {
             ...state,

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -2,13 +2,13 @@ import { ChangeEvent, FocusEventHandler, RefObject, useEffect, useRef, useState 
 import { noop } from 'rxjs'
 
 import { FieldState, FormAPI, ValidationResult } from './useForm'
-import { getEventValue } from './utils/get-event-value';
-import { AsyncValidator, useAsyncValidation } from './utils/use-async-validation';
+import { getEventValue } from './utils/get-event-value'
+import { AsyncValidator, useAsyncValidation } from './utils/use-async-validation'
 
 export type Validator<FieldValue> = (value: FieldValue | undefined, validity?: ValidityState | null) => ValidationResult
 
 export interface Validators<FieldValue> {
-    sync?: Validator<FieldValue>,
+    sync?: Validator<FieldValue>
     async?: AsyncValidator<FieldValue>
 }
 
@@ -47,11 +47,11 @@ export interface useFieldAPI<FieldValue> {
 export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormValues>['initialValues']>(
     name: FieldValueKey,
     formApi: FormAPI<FormValues>,
-    validators?: Validators<FormValues[FieldValueKey]>,
+    validators?: Validators<FormValues[FieldValueKey]>
 ): useFieldAPI<FormValues[FieldValueKey]> {
     const { setFieldState, initialValues, submitted, touched: formTouched } = formApi
 
-    const { sync = noop, async } = validators ?? {};
+    const { sync = noop, async } = validators ?? {}
 
     const inputReference = useRef<HTMLInputElement & HTMLFieldSetElement>(null)
 
@@ -68,9 +68,7 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
     const { start: startAsyncValidation, cancel: cancelAsyncValidation } = useAsyncValidation({
         inputReference,
         asyncValidator: async,
-        onValidationChange: state => setState(
-            previousState => ({ ...previousState, ...state, value: selfValue })
-        )
+        onValidationChange: state => setState(previousState => ({ ...previousState, ...state, value: selfValue })),
     })
 
     // Use useRef for form api handler in order to avoid unnecessary
@@ -150,4 +148,3 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
         },
     }
 }
-

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -70,7 +70,7 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
     const { start: startAsyncValidation, cancel: cancelAsyncValidation } = useAsyncValidation({
         inputReference,
         asyncValidator: async,
-        onValidationChange
+        onValidationChange,
     })
 
     // Use useRef for form api handler in order to avoid unnecessary
@@ -127,10 +127,7 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
     // Sync field state with state on form level - useForm hook will used this state to run
     // onSubmit handler and track validation state to prevent onSubmit run when async
     // validation is going.
-    useEffect(
-        () => setFieldStateReference.current(name, state),
-        [name, state]
-    )
+    useEffect(() => setFieldStateReference.current(name, state), [name, state])
 
     return {
         input: {
@@ -141,7 +138,7 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
             onChange: (event: ChangeEvent<HTMLInputElement> | FormValues[FieldValueKey]) => {
                 const value = getEventValue(event)
 
-                setState(state => ({...state, value }))
+                setState(state => ({ ...state, value }))
             },
         },
         meta: {

--- a/client/web/src/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/insights/components/form/hooks/useForm.ts
@@ -5,6 +5,7 @@ import { noop } from 'rxjs'
 export const FORM_ERROR = 'useForm/submissionErrors'
 
 export type SubmissionErrors = Record<string, any> | undefined
+export type ValidationResult = string | undefined | void
 
 interface UseFormProps<FormValues extends object> {
     /**

--- a/client/web/src/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/insights/components/form/hooks/useForm.ts
@@ -205,7 +205,7 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
 
     useEffect(() => {
         if (Object.keys(changeEvent.values).length === 0) {
-            return;
+            return
         }
 
         onChangeReference.current?.(changeEvent)

--- a/client/web/src/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/insights/components/form/hooks/useForm.ts
@@ -1,11 +1,19 @@
-import { EventHandler, FormEventHandler, RefObject, SyntheticEvent, useEffect, useRef, useState } from 'react'
+import { debounce } from 'lodash'
+import { EventHandler, FormEventHandler, RefObject, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { noop } from 'rxjs'
+
+import { useDistinctValue } from '../../../hooks/use-distinct-value';
 
 // Special key for the submit error store.
 export const FORM_ERROR = 'useForm/submissionErrors'
 
 export type SubmissionErrors = Record<string, any> | undefined
 export type ValidationResult = string | undefined | void
+
+interface FormChangeEvent<FormValues> {
+    values: FormValues,
+    valid: boolean
+}
 
 interface UseFormProps<FormValues extends object> {
     /**
@@ -27,7 +35,7 @@ interface UseFormProps<FormValues extends object> {
      * Change handler will be called every time when some field withing the form
      * has been changed with last fields values.
      * */
-    onChange?: (values: FormValues) => void
+    onChange?: (event: FormChangeEvent<FormValues>) => void
 }
 
 /**
@@ -76,6 +84,8 @@ export interface FormAPI<FormValues> {
      * */
     submitted: boolean
 
+    valid: boolean
+
     /**
      * State to understand there some field is processing async validations.
      * It might be useful to disable submit button for example if we got async
@@ -111,13 +121,15 @@ export interface FormAPI<FormValues> {
  * Field state which present public state from useField hook. On order to aggregate
  * state of all fields within the form we store all fields state on form level as well.
  * */
-export interface FieldState<Value> {
+export interface FieldState<Value> extends FieldMetaState {
     /**
      * Field (input) controlled value. This value might be not only some primitive value
      * like string, number but array, object, tuple and other complex types as consumer set.
      * */
     value: Value
+}
 
+export interface FieldMetaState {
     /**
      * State to understand when users focused and blurred input element.
      * */
@@ -147,7 +159,7 @@ export interface FieldState<Value> {
  * Used below to keep tracking of fields value, touched, validity and other
  * fields state data.
  * */
-type FieldsState<FormValues> = Record<keyof FormValues, FieldState<unknown>>
+type FieldsState<FormValues> = Record<keyof FormValues, FieldState<FormValues>>
 
 /**
  * Unified form abstraction to track form state and provide form fields management
@@ -168,23 +180,29 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
     const formElementReference = useRef<HTMLFormElement>(null)
     const onSubmitReference = useRef<UseFormProps<FormValues>['onSubmit']>()
 
+    // Debounced onChange handler.
+    const onChangeReference = useRef<UseFormProps<FormValues>['onChange']>(debounce(onChange, 0))
+
     // Track unmounted state to prevent setState if async validation or async submitting
     // will be resolved after component has been unmounted.
     const isUnmounted = useRef<boolean>(false)
 
     const setFieldState = (name: keyof FormValues, state: FieldState<unknown>): void => {
         setFields(fields => ({ ...fields, [name]: state }))
-
-        // On first render all fields within the form trigger setFieldState
-        // in order to set initial state. OnChange handler shouldn't being run
-        // on first render so we have to skip setFieldState calls during the first
-        // fields render.
-        const hasRegisterField = fields[name] !== undefined
-
-        if (hasRegisterField && fields[name].value !== state.value) {
-            onChange(getFormValues({ ...fields, [name]: state }))
-        }
     }
+
+    const changeEvent = useDistinctValue(
+        useMemo(
+            () => ({
+                    values: getFormValues(fields),
+                    valid: Object.values<Pick<FieldState<unknown>, 'validState'>>(fields)
+                        .every(state => state.validState === 'VALID'),
+                }),
+            [fields]
+        )
+    )
+
+    useEffect(() => onChangeReference.current?.(changeEvent), [changeEvent])
 
     useEffect(
         () => () => {
@@ -205,6 +223,7 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
             submitErrors,
             initialValues,
             setFieldState,
+            valid: Object.values<FieldState<unknown>>(fields).every(state => state.validState === 'VALID'),
             validating: Object.values<FieldState<unknown>>(fields).some(state => state.validState === 'CHECKING'),
         },
         ref: formElementReference,
@@ -243,7 +262,7 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
  * Creates form values object and omits all other internal states of a form field.
  * Used to form values for onSubmit and onChange handlers.
  * */
-function getFormValues<FormValues>(fields: Record<string, FieldState<unknown>>): FormValues {
+function getFormValues<FormValues>(fields: Record<string, Pick<FieldState<FormValues>, 'value'>>): FormValues {
     return Object.keys(fields).reduce(
         (values, fieldName) => ({ ...values, [fieldName]: fields[fieldName].value }),
         {} as FormValues

--- a/client/web/src/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/insights/components/form/hooks/useForm.ts
@@ -203,7 +203,13 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
         )
     )
 
-    useEffect(() => onChangeReference.current?.(changeEvent), [changeEvent])
+    useEffect(() => {
+        if (Object.keys(changeEvent.values).length === 0) {
+            return;
+        }
+
+        onChangeReference.current?.(changeEvent)
+    }, [changeEvent])
 
     useEffect(
         () => () => {

--- a/client/web/src/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/insights/components/form/hooks/useForm.ts
@@ -2,7 +2,7 @@ import { debounce } from 'lodash'
 import { EventHandler, FormEventHandler, RefObject, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { noop } from 'rxjs'
 
-import { useDistinctValue } from '../../../hooks/use-distinct-value';
+import { useDistinctValue } from '../../../hooks/use-distinct-value'
 
 // Special key for the submit error store.
 export const FORM_ERROR = 'useForm/submissionErrors'
@@ -11,7 +11,7 @@ export type SubmissionErrors = Record<string, any> | undefined
 export type ValidationResult = string | undefined | void
 
 interface FormChangeEvent<FormValues> {
-    values: FormValues,
+    values: FormValues
     valid: boolean
 }
 
@@ -194,10 +194,11 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
     const changeEvent = useDistinctValue(
         useMemo(
             () => ({
-                    values: getFormValues(fields),
-                    valid: Object.values<Pick<FieldState<unknown>, 'validState'>>(fields)
-                        .every(state => state.validState === 'VALID'),
-                }),
+                values: getFormValues(fields),
+                valid: Object.values<Pick<FieldState<unknown>, 'validState'>>(fields).every(
+                    state => state.validState === 'VALID'
+                ),
+            }),
             [fields]
         )
     )

--- a/client/web/src/insights/components/form/hooks/useForm.ts
+++ b/client/web/src/insights/components/form/hooks/useForm.ts
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash'
+import { debounce, DebouncedFunc } from 'lodash'
 import { EventHandler, FormEventHandler, RefObject, SyntheticEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { noop } from 'rxjs'
 
@@ -14,6 +14,8 @@ interface FormChangeEvent<FormValues> {
     values: FormValues
     valid: boolean
 }
+
+type ChangeHandler<FormValues> = (event: FormChangeEvent<FormValues>) => void
 
 interface UseFormProps<FormValues extends object> {
     /**
@@ -35,7 +37,7 @@ interface UseFormProps<FormValues extends object> {
      * Change handler will be called every time when some field withing the form
      * has been changed with last fields values.
      * */
-    onChange?: (event: FormChangeEvent<FormValues>) => void
+    onChange?: ChangeHandler<FormValues>
 }
 
 /**
@@ -181,7 +183,7 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
     const onSubmitReference = useRef<UseFormProps<FormValues>['onSubmit']>()
 
     // Debounced onChange handler.
-    const onChangeReference = useRef<UseFormProps<FormValues>['onChange']>(debounce(onChange, 0))
+    const onChangeReference = useRef<DebouncedFunc<ChangeHandler<FormValues>>>(debounce(onChange, 0))
 
     // Track unmounted state to prevent setState if async validation or async submitting
     // will be resolved after component has been unmounted.
@@ -213,6 +215,7 @@ export function useForm<FormValues extends object>(props: UseFormProps<FormValue
 
     useEffect(
         () => () => {
+            onChangeReference.current?.cancel()
             isUnmounted.current = true
         },
         []

--- a/client/web/src/insights/components/form/hooks/utils/get-event-value.ts
+++ b/client/web/src/insights/components/form/hooks/utils/get-event-value.ts
@@ -1,0 +1,32 @@
+import { ChangeEvent } from 'react';
+
+/**
+ * Type guard for change event. Since useField might be used on custom element there's the case
+ * when onChange handler will be called on custom element without synthetic event but with some
+ * custom input value.
+ * */
+function isChangeEvent<Value>(possibleEvent: ChangeEvent | Value): possibleEvent is ChangeEvent {
+    return !!(possibleEvent as ChangeEvent).target
+}
+
+/**
+ * Selector function which takes target value from the event.
+ *
+ * We can have a few different source of value due to what kind of event
+ * we've got. For example: Checkbox - target.checked, input element - target.value
+ * and if run onChange on custom form field therefore we've got value as event itself.
+ * */
+export function getEventValue<Value>(event: ChangeEvent<HTMLInputElement> | Value): Value {
+    if (isChangeEvent(event)) {
+        // Checkbox input case
+        if (event.target.type === 'checkbox') {
+            return (event.target.checked as unknown) as Value
+        }
+
+        // Native input value case
+        return (event.target.value as unknown) as Value
+    }
+
+    // Custom input without event but with value of input itself.
+    return event
+}

--- a/client/web/src/insights/components/form/hooks/utils/get-event-value.ts
+++ b/client/web/src/insights/components/form/hooks/utils/get-event-value.ts
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react';
+import { ChangeEvent } from 'react'
 
 /**
  * Type guard for change event. Since useField might be used on custom element there's the case

--- a/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
+++ b/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
@@ -1,14 +1,17 @@
-import { RefObject, useCallback, useRef } from 'react';
-import { EMPTY, from, Observable } from 'rxjs';
-import { debounceTime, switchMap, tap } from 'rxjs/operators';
+import { RefObject, useCallback, useRef } from 'react'
+import { EMPTY, from, Observable } from 'rxjs'
+import { debounceTime, switchMap, tap } from 'rxjs/operators'
 
-import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable';
+import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable'
 
-import { FieldState, ValidationResult } from '../useForm';
+import { FieldState, ValidationResult } from '../useForm'
 
-const ASYNC_VALIDATION_DEBOUNCE_TIME = 500;
+const ASYNC_VALIDATION_DEBOUNCE_TIME = 500
 
-export type AsyncValidator<FieldValue> = (value: FieldValue | undefined, validity: ValidityState | null) => Promise<ValidationResult>
+export type AsyncValidator<FieldValue> = (
+    value: FieldValue | undefined,
+    validity: ValidityState | null
+) => Promise<ValidationResult>
 
 export interface UseAsyncValidationProps<FieldValue> {
     /**
@@ -40,7 +43,7 @@ export interface AsyncValidationEvent<FieldValue> {
     /**
      * Value of form filed.
      */
-    value: FieldValue | undefined,
+    value: FieldValue | undefined
 
     /**
      * Constraint API validity state.
@@ -65,8 +68,10 @@ export interface useAsyncValidationAPI<FieldValue> {
 /**
  * Internal util hook for async validation. Part of implementation of useField hook.
  */
-export function useAsyncValidation<FieldValue>(props: UseAsyncValidationProps<FieldValue>): useAsyncValidationAPI<FieldValue> {
-    const { inputReference, asyncValidator, onValidationChange } = props;
+export function useAsyncValidation<FieldValue>(
+    props: UseAsyncValidationProps<FieldValue>
+): useAsyncValidationAPI<FieldValue> {
+    const { inputReference, asyncValidator, onValidationChange } = props
 
     // Reference hack to allow consumers pass handlers without useMemo
     const onValidationChangeReference = useRef<UseAsyncValidationProps<FieldValue>['onValidationChange']>()
@@ -88,11 +93,13 @@ export function useAsyncValidation<FieldValue>(props: UseAsyncValidationProps<Fi
                             validState: 'CHECKING',
                             touched: true,
                             error: '',
-                            validity: inputElement?.validity ?? null
+                            validity: inputElement?.validity ?? null,
                         })
                     }
                 }),
-                switchMap(({ value, validity, canceled }) => !canceled ? from(asyncValidator!(value, validity)) : EMPTY),
+                switchMap(({ value, validity, canceled }) =>
+                    !canceled ? from(asyncValidator!(value, validity)) : EMPTY
+                ),
                 tap(validationMessage => {
                     const inputElement = inputReference.current
                     const validity = inputElement?.validity ?? null
@@ -110,7 +117,7 @@ export function useAsyncValidation<FieldValue>(props: UseAsyncValidationProps<Fi
                         handleValidationChange({
                             validState: 'VALID' as const,
                             error: '',
-                            validity
+                            validity,
                         })
                     }
                 })
@@ -118,14 +125,15 @@ export function useAsyncValidation<FieldValue>(props: UseAsyncValidationProps<Fi
         [inputReference, handleValidationChange, asyncValidator]
     )
 
-    const [startAsyncValidation] = useEventObservable(asyncValidationPipeline);
+    const [startAsyncValidation] = useEventObservable(asyncValidationPipeline)
 
     const cancelAsyncValidation = useCallback(
-        () => startAsyncValidation({
-            value: undefined,
-            validity: null,
-            canceled: true
-        }),
+        () =>
+            startAsyncValidation({
+                value: undefined,
+                validity: null,
+                canceled: true,
+            }),
         [startAsyncValidation]
     )
 

--- a/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
+++ b/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
@@ -81,8 +81,6 @@ export function useAsyncValidation<FieldValue>(
     const onValidationChangeReference = useRef<UseAsyncValidationProps<FieldValue>['onValidationChange']>()
     onValidationChangeReference.current = onValidationChange
 
-    const handleValidationChange = onValidationChangeReference.current
-
     const asyncValidationPipeline = useCallback(
         (validationEvents: Observable<AsyncValidationEvent<FieldValue>>) =>
             validationEvents.pipe(
@@ -93,7 +91,7 @@ export function useAsyncValidation<FieldValue>(
 
                         // Reset validation (native and custom) before async validation
                         inputElement?.setCustomValidity?.('')
-                        handleValidationChange({
+                        onValidationChangeReference.current?.({
                             validState: 'CHECKING',
                             touched: true,
                             error: '',
@@ -110,13 +108,13 @@ export function useAsyncValidation<FieldValue>(
 
                     if (validationMessage) {
                         inputElement?.setCustomValidity?.(validationMessage)
-                        handleValidationChange({
+                        onValidationChangeReference.current?.({
                             validState: 'INVALID',
                             error: validationMessage,
                             validity,
                         })
                     } else {
-                        handleValidationChange({
+                        onValidationChangeReference.current?.({
                             validState: 'VALID' as const,
                             error: '',
                             validity,
@@ -124,7 +122,7 @@ export function useAsyncValidation<FieldValue>(
                     }
                 })
             ),
-        [inputReference, handleValidationChange, asyncValidator]
+        [inputReference, asyncValidator]
     )
 
     const [startAsyncValidation] = useEventObservable(asyncValidationPipeline)

--- a/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
+++ b/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
@@ -1,0 +1,136 @@
+import { RefObject, useCallback, useRef } from 'react';
+import { EMPTY, from, Observable } from 'rxjs';
+import { debounceTime, switchMap, tap } from 'rxjs/operators';
+
+import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable';
+
+import { FieldState, ValidationResult } from '../useForm';
+
+const ASYNC_VALIDATION_DEBOUNCE_TIME = 500;
+
+export type AsyncValidator<FieldValue> = (value: FieldValue | undefined, validity: ValidityState | null) => Promise<ValidationResult>
+
+export interface UseAsyncValidationProps<FieldValue> {
+    /**
+     * Native input element used below to set validation state via html5
+     * constraint validation API.
+     * */
+    inputReference: RefObject<HTMLInputElement>
+
+    /**
+     * Async validator, just an async function which returns or not returns
+     * validation error.
+     * */
+    asyncValidator?: AsyncValidator<FieldValue>
+
+    /**
+     * Validation state change handler. Used below to update state of consumer
+     * according to async logic aspects (mark field as touched, set validity state, etc).
+     * */
+    onValidationChange: (state: Partial<FieldState<FieldValue>>) => void
+}
+
+/**
+ * Async validation event.
+ * With that event consumer should start async validation pipeline.
+ *
+ * start(event: AsyncValidationEvent)
+ * */
+export interface AsyncValidationEvent<FieldValue> {
+    /**
+     * Value of form filed.
+     */
+    value: FieldValue | undefined,
+
+    /**
+     * Constraint API validity state.
+     */
+    validity: ValidityState | null
+
+    /**
+     * Internal param to cancel all ongoing asyn validation processes.
+     * used below to implement cancel handler from public API.
+     * */
+    canceled?: boolean
+}
+
+export interface useAsyncValidationAPI<FieldValue> {
+    /**
+     * cancel hander for cancalation ongoing
+     * */
+    cancel: () => void
+    start: (event: AsyncValidationEvent<FieldValue>) => void
+}
+
+/**
+ * Internal util hook for async validation. Part of implementation of useField hook.
+ */
+export function useAsyncValidation<FieldValue>(props: UseAsyncValidationProps<FieldValue>): useAsyncValidationAPI<FieldValue> {
+    const { inputReference, asyncValidator, onValidationChange } = props;
+
+    // Reference hack to allow consumers pass handlers without useMemo
+    const onValidationChangeReference = useRef<UseAsyncValidationProps<FieldValue>['onValidationChange']>()
+    onValidationChangeReference.current = onValidationChange
+
+    const handleValidationChange = onValidationChangeReference.current
+
+    const asyncValidationPipeline = useCallback(
+        (validationEvents: Observable<AsyncValidationEvent<FieldValue>>) =>
+            validationEvents.pipe(
+                debounceTime(ASYNC_VALIDATION_DEBOUNCE_TIME),
+                tap(event => {
+                    if (!event.canceled) {
+                        const inputElement = inputReference.current
+
+                        // Reset validation (native and custom) before async validation
+                        inputElement?.setCustomValidity?.('')
+                        handleValidationChange({
+                            validState: 'CHECKING',
+                            touched: true,
+                            error: '',
+                            validity: inputElement?.validity ?? null
+                        })
+                    }
+                }),
+                switchMap(({ value, validity, canceled }) => !canceled ? from(asyncValidator!(value, validity)) : EMPTY),
+                tap(validationMessage => {
+                    const inputElement = inputReference.current
+                    const validity = inputElement?.validity ?? null
+
+                    if (validationMessage) {
+                        console.log('Async validation result', validationMessage)
+
+                        inputElement?.setCustomValidity?.(validationMessage)
+                        handleValidationChange({
+                            validState: 'INVALID',
+                            error: validationMessage,
+                            validity,
+                        })
+                    } else {
+                        handleValidationChange({
+                            validState: 'VALID' as const,
+                            error: '',
+                            validity
+                        })
+                    }
+                })
+            ),
+        [inputReference, handleValidationChange, asyncValidator]
+    )
+
+    const [startAsyncValidation] = useEventObservable(asyncValidationPipeline);
+
+    const cancelAsyncValidation = useCallback(
+        () => startAsyncValidation({
+            value: undefined,
+            validity: null,
+            canceled: true
+        }),
+        [startAsyncValidation]
+    )
+
+    return {
+        cancel: cancelAsyncValidation,
+        start: startAsyncValidation,
+    }
+}

--- a/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
+++ b/client/web/src/insights/components/form/hooks/utils/use-async-validation.ts
@@ -59,9 +59,13 @@ export interface AsyncValidationEvent<FieldValue> {
 
 export interface useAsyncValidationAPI<FieldValue> {
     /**
-     * cancel hander for cancalation ongoing
+     * Cancel handler to cancel ongoing async validation pipeline
      * */
     cancel: () => void
+
+    /**
+     * Start async validation pipeline.
+     * */
     start: (event: AsyncValidationEvent<FieldValue>) => void
 }
 
@@ -105,8 +109,6 @@ export function useAsyncValidation<FieldValue>(
                     const validity = inputElement?.validity ?? null
 
                     if (validationMessage) {
-                        console.log('Async validation result', validationMessage)
-
                         inputElement?.setCustomValidity?.(validationMessage)
                         handleValidationChange({
                             validState: 'INVALID',

--- a/client/web/src/insights/components/form/validators.ts
+++ b/client/web/src/insights/components/form/validators.ts
@@ -1,4 +1,5 @@
-import { ValidationResult, Validator } from './hooks/useField'
+import { Validator } from './hooks/useField'
+import { ValidationResult } from './hooks/useForm'
 
 /**
  * Validator for required form field which returns error massage

--- a/client/web/src/insights/core/backend/requests/fetch-repositories.ts
+++ b/client/web/src/insights/core/backend/requests/fetch-repositories.ts
@@ -37,6 +37,16 @@ export function fetchRepositories(repositories: string[]): Observable<BulkSearch
     ).pipe(
         map(dataOrThrowErrors),
         map(search =>
+            /**
+             * Gather information from bulk search to array of search results
+             *
+             * Raw search:
+             * { repoSearch0: { repo content 1 }, repoSearch1: { repo content 2 } ... }
+             *
+             * Transformed array result
+             *
+             * [{ repo content 1}, { repo content 2 }, ... { repo content N }]
+             * */
             Object.keys(search).reduce<BulkSearchRepositories[]>((result, key) => {
                 const index = +key.slice('repoSearch'.length)
 

--- a/client/web/src/insights/core/backend/requests/fetch-repositories.ts
+++ b/client/web/src/insights/core/backend/requests/fetch-repositories.ts
@@ -1,0 +1,46 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql';
+
+import { requestGraphQL } from '../../../../backend/graphql';
+import { BulkSearchRepositories } from '../../../../graphql-operations';
+
+const bulkSearchRepositoriesFragment = gql`
+    fragment BulkSearchRepositories on RepositoryRedirect {
+         ... on Repository {
+            name
+         }
+        ... on Redirect {
+            url
+        }
+    }
+`
+
+export function fetchRepositories(repositories: string[]): Observable<BulkSearchRepositories[]> {
+    return requestGraphQL<Record<string, BulkSearchRepositories>>(`
+        ${bulkSearchRepositoriesFragment}
+        query BulkRepositoriesSearch(${repositories.map((repo, index) => `$query${index}: String!`).join(', ')}) {
+            ${repositories
+                .map((_repo, index) => `
+                    repoSearch${index}: repositoryRedirect(name: $query${index}) {
+                        ...BulkSearchRepositories
+                    }
+                `).join('\n')
+            }
+        }
+    `,
+        Object.fromEntries(repositories.map((query, index) => [`query${index}`, query]))
+    ).pipe(
+        map(dataOrThrowErrors),
+        map(search =>
+            Object.keys(search).reduce<BulkSearchRepositories[]>((result, key) => {
+                const index = +key.slice('repoSearch'.length);
+
+                result[index] = search[key];
+
+                return result;
+            }, [])
+        )
+    )
+}

--- a/client/web/src/insights/core/backend/requests/fetch-repositories.ts
+++ b/client/web/src/insights/core/backend/requests/fetch-repositories.ts
@@ -1,16 +1,16 @@
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs'
+import { map } from 'rxjs/operators'
 
-import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql';
+import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 
-import { requestGraphQL } from '../../../../backend/graphql';
-import { BulkSearchRepositories } from '../../../../graphql-operations';
+import { requestGraphQL } from '../../../../backend/graphql'
+import { BulkSearchRepositories } from '../../../../graphql-operations'
 
 const bulkSearchRepositoriesFragment = gql`
     fragment BulkSearchRepositories on RepositoryRedirect {
-         ... on Repository {
+        ... on Repository {
             name
-         }
+        }
         ... on Redirect {
             url
         }
@@ -18,16 +18,19 @@ const bulkSearchRepositoriesFragment = gql`
 `
 
 export function fetchRepositories(repositories: string[]): Observable<BulkSearchRepositories[]> {
-    return requestGraphQL<Record<string, BulkSearchRepositories>>(`
+    return requestGraphQL<Record<string, BulkSearchRepositories>>(
+        `
         ${bulkSearchRepositoriesFragment}
         query BulkRepositoriesSearch(${repositories.map((repo, index) => `$query${index}: String!`).join(', ')}) {
             ${repositories
-                .map((_repo, index) => `
+                .map(
+                    (_repo, index) => `
                     repoSearch${index}: repositoryRedirect(name: $query${index}) {
                         ...BulkSearchRepositories
                     }
-                `).join('\n')
-            }
+                `
+                )
+                .join('\n')}
         }
     `,
         Object.fromEntries(repositories.map((query, index) => [`query${index}`, query]))
@@ -35,11 +38,11 @@ export function fetchRepositories(repositories: string[]): Observable<BulkSearch
         map(dataOrThrowErrors),
         map(search =>
             Object.keys(search).reduce<BulkSearchRepositories[]>((result, key) => {
-                const index = +key.slice('repoSearch'.length);
+                const index = +key.slice('repoSearch'.length)
 
-                result[index] = search[key];
+                result[index] = search[key]
 
-                return result;
+                return result
             }, [])
         )
     )

--- a/client/web/src/insights/hooks/use-distinct-value.ts
+++ b/client/web/src/insights/hooks/use-distinct-value.ts
@@ -1,0 +1,12 @@
+import { isEqual } from 'lodash'
+import { useRef } from 'react';
+
+export function useDistinctValue<Value>(value: Value): Value {
+    const previousValueReference = useRef<Value>(value);
+
+    if (!isEqual(previousValueReference.current, value)) {
+        previousValueReference.current = value;
+    }
+
+    return previousValueReference.current
+}

--- a/client/web/src/insights/hooks/use-distinct-value.ts
+++ b/client/web/src/insights/hooks/use-distinct-value.ts
@@ -1,11 +1,11 @@
 import { isEqual } from 'lodash'
-import { useRef } from 'react';
+import { useRef } from 'react'
 
 export function useDistinctValue<Value>(value: Value): Value {
-    const previousValueReference = useRef<Value>(value);
+    const previousValueReference = useRef<Value>(value)
 
     if (!isEqual(previousValueReference.current, value)) {
-        previousValueReference.current = value;
+        previousValueReference.current = value
     }
 
     return previousValueReference.current

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -7,16 +7,13 @@ import { Settings } from '@sourcegraph/shared/src/settings/settings'
 import { useField } from '../../../../../components/form/hooks/useField'
 import { SubmissionErrors, useForm } from '../../../../../components/form/hooks/useForm'
 import { useTitleValidator } from '../../../../../components/form/hooks/useTitleValidator'
-import { createRequiredValidator } from '../../../../../components/form/validators'
 import { InsightTypePrefix } from '../../../../../core/types'
 import { LangStatsCreationFormFields } from '../../types'
 import { LangStatsInsightCreationForm } from '../lang-stats-insight-creation-form/LangStatsInsightCreationForm'
 import { LangStatsInsightLivePreview } from '../live-preview-chart/LangStatsInsightLivePreview'
 
 import styles from './LangStatsInsightCreationContent.module.scss'
-
-const repositoriesFieldValidator = createRequiredValidator('Repositories is a required field for code insight.')
-const thresholdFieldValidator = createRequiredValidator('Threshold is a required field for code insight.')
+import { repositoriesFieldValidator, repositoryFieldAsyncValidator, thresholdFieldValidator } from './validators';
 
 const INITIAL_VALUES: LangStatsCreationFormFields = {
     repository: '',
@@ -56,9 +53,12 @@ export const LangStatsInsightCreationContent: React.FunctionComponent<LangStatsI
     // We can't have two or more insights with the same name, since we rely on name as on id of insights.
     const titleValidator = useTitleValidator({ settings, insightType: InsightTypePrefix.langStats })
 
-    const repository = useField('repository', formAPI, repositoriesFieldValidator)
-    const title = useField('title', formAPI, titleValidator)
-    const threshold = useField('threshold', formAPI, thresholdFieldValidator)
+    const repository = useField('repository', formAPI, {
+        sync: repositoriesFieldValidator,
+        async: repositoryFieldAsyncValidator,
+    })
+    const title = useField('title', formAPI, { sync: titleValidator })
+    const threshold = useField('threshold', formAPI, { sync: thresholdFieldValidator })
     const visibility = useField('visibility', formAPI)
 
     // If some fields that needed to run live preview  are invalid

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -64,8 +64,8 @@ export const LangStatsInsightCreationContent: React.FunctionComponent<LangStatsI
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview
     const allFieldsForPreviewAreValid =
-        repository.meta.validState === 'VALID' || repository.meta.validState === 'CHECKING' &&
-        threshold.meta.validState === 'VALID'
+        repository.meta.validState === 'VALID' ||
+        (repository.meta.validState === 'CHECKING' && threshold.meta.validState === 'VALID')
 
     return (
         <div className={classnames(styles.content, className)}>

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -63,7 +63,9 @@ export const LangStatsInsightCreationContent: React.FunctionComponent<LangStatsI
 
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview
-    const allFieldsForPreviewAreValid = repository.meta.validState === 'VALID' && threshold.meta.validState === 'VALID'
+    const allFieldsForPreviewAreValid =
+        repository.meta.validState === 'VALID' || repository.meta.validState === 'CHECKING' &&
+        threshold.meta.validState === 'VALID'
 
     return (
         <div className={classnames(styles.content, className)}>

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/LangStatsInsightCreationContent.tsx
@@ -13,7 +13,7 @@ import { LangStatsInsightCreationForm } from '../lang-stats-insight-creation-for
 import { LangStatsInsightLivePreview } from '../live-preview-chart/LangStatsInsightLivePreview'
 
 import styles from './LangStatsInsightCreationContent.module.scss'
-import { repositoriesFieldValidator, repositoryFieldAsyncValidator, thresholdFieldValidator } from './validators';
+import { repositoriesFieldValidator, repositoryFieldAsyncValidator, thresholdFieldValidator } from './validators'
 
 const INITIAL_VALUES: LangStatsCreationFormFields = {
     repository: '',

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/validators.ts
@@ -1,0 +1,27 @@
+import { renderError } from '../../../../../../components/alerts';
+import { AsyncValidator } from '../../../../../components/form/hooks/utils/use-async-validation';
+import { createRequiredValidator } from '../../../../../components/form/validators';
+import { fetchRepositories } from '../../../../../core/backend/requests/fetch-repositories';
+
+export const repositoriesFieldValidator = createRequiredValidator('Repositories is a required field for code insight.')
+export const thresholdFieldValidator = createRequiredValidator('Threshold is a required field for code insight.')
+
+// [TODO] [VK] Move this validator behind insight api context for better testing approach
+export const repositoryFieldAsyncValidator: AsyncValidator<string> = async value => {
+    if (!value) {
+        return;
+    }
+
+    try {
+        const repositories = await fetchRepositories([value.trim()]).toPromise()
+
+        if (!repositories) {
+            return `We couldn't find repository with ${value} name. Please check the repo URL.`
+        }
+
+        return
+
+    } catch (error) {
+        return renderError(error);
+    }
+}

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/validators.ts
@@ -16,7 +16,7 @@ export const repositoryFieldAsyncValidator: AsyncValidator<string> = async value
         const repositories = await fetchRepositories([value.trim()]).toPromise()
 
         if (!repositories) {
-            return `We couldn't find repository with ${value} name. Please check the repo URL.`
+            return `We couldn't find the repository ${value}. Please ensure the repository exists.`
         }
 
         return

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-content/validators.ts
@@ -1,7 +1,7 @@
-import { renderError } from '../../../../../../components/alerts';
-import { AsyncValidator } from '../../../../../components/form/hooks/utils/use-async-validation';
-import { createRequiredValidator } from '../../../../../components/form/validators';
-import { fetchRepositories } from '../../../../../core/backend/requests/fetch-repositories';
+import { renderError } from '../../../../../../components/alerts'
+import { AsyncValidator } from '../../../../../components/form/hooks/utils/use-async-validation'
+import { createRequiredValidator } from '../../../../../components/form/validators'
+import { fetchRepositories } from '../../../../../core/backend/requests/fetch-repositories'
 
 export const repositoriesFieldValidator = createRequiredValidator('Repositories is a required field for code insight.')
 export const thresholdFieldValidator = createRequiredValidator('Threshold is a required field for code insight.')
@@ -9,7 +9,7 @@ export const thresholdFieldValidator = createRequiredValidator('Threshold is a r
 // [TODO] [VK] Move this validator behind insight api context for better testing approach
 export const repositoryFieldAsyncValidator: AsyncValidator<string> = async value => {
     if (!value) {
-        return;
+        return
     }
 
     try {
@@ -20,8 +20,7 @@ export const repositoryFieldAsyncValidator: AsyncValidator<string> = async value
         }
 
         return
-
     } catch (error) {
-        return renderError(error);
+        return renderError(error)
     }
 }

--- a/client/web/src/insights/pages/creation/search-insight/components/form-color-input/FormColorInput.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-color-input/FormColorInput.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames'
 import { startCase } from 'lodash'
 import openColor from 'open-color'
-import React, { ChangeEventHandler } from 'react'
+import React, { ChangeEventHandler, memo } from 'react'
 import { noop } from 'rxjs'
 
 import styles from './FormColorInput.module.scss'
@@ -28,7 +28,7 @@ const DEFAULT_COLOURS = Object.keys(openColor)
 export const DEFAULT_ACTIVE_COLOR = 'var(--oc-grape-7)'
 
 /** Displays custom radio group for picking color of code insight chart line. */
-export const FormColorInput: React.FunctionComponent<FormColorInputProps> = props => {
+export const FormColorInput: React.FunctionComponent<FormColorInputProps> = memo(props => {
     const { className, value = null, title, name, colours = DEFAULT_COLOURS, onChange = noop } = props
 
     return (
@@ -60,4 +60,4 @@ export const FormColorInput: React.FunctionComponent<FormColorInputProps> = prop
             </div>
         </fieldset>
     )
-}
+})

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -13,6 +13,8 @@ const requiredNameField = createRequiredValidator('Name is a required field for 
 const validQuery = createRequiredValidator('Query is a required field for data series.')
 
 interface FormSeriesInputProps {
+    /** Series index. */
+    index: number
     /** Name of series. */
     name?: string
     /** Query value of series. */
@@ -35,6 +37,7 @@ interface FormSeriesInputProps {
 /** Displays form series input (three field - name field, query field and color picker). */
 export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = props => {
     const {
+        index,
         name,
         query,
         stroke: color,
@@ -109,7 +112,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
             />
 
             <FormColorInput
-                name="series color group"
+                name={`color group of ${index} series`}
                 title="Color"
                 className="mt-4"
                 value={colorField.input.value}

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -52,8 +52,8 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
             }),
     })
 
-    const nameField = useField('seriesName', formAPI, requiredNameField)
-    const queryField = useField('seriesQuery', formAPI, validQuery)
+    const nameField = useField('seriesName', formAPI, { sync: requiredNameField})
+    const queryField = useField('seriesQuery', formAPI, { sync: validQuery })
     const colorField = useField('seriesColor', formAPI)
 
     return (

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -28,13 +28,23 @@ interface FormSeriesInputProps {
     /** On submit handler of series form. */
     onSubmit?: (series: DataSeries) => void
     /** On cancel handler. */
-    onCancel?: () => void,
+    onCancel?: () => void
     onChange?: (formValues: DataSeries, valid: boolean) => void
 }
 
 /** Displays form series input (three field - name field, query field and color picker). */
 export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = props => {
-    const { name, query, stroke: color, className, cancel = false, autofocus = true, onCancel = noop, onSubmit = noop, onChange = noop } = props
+    const {
+        name,
+        query,
+        stroke: color,
+        className,
+        cancel = false,
+        autofocus = true,
+        onCancel = noop,
+        onSubmit = noop,
+        onChange = noop,
+    } = props
 
     const hasNameControlledValue = !!name
     const hasQueryControlledValue = !!query
@@ -52,17 +62,20 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
                 stroke: values.seriesColor,
             }),
         onChange: event => {
-            const { values } = event;
+            const { values } = event
 
-            onChange({
-                name: values.seriesName,
-                query: values.seriesQuery,
-                stroke: values.seriesColor,
-            }, event.valid);
-        }
+            onChange(
+                {
+                    name: values.seriesName,
+                    query: values.seriesQuery,
+                    stroke: values.seriesColor,
+                },
+                event.valid
+            )
+        },
     })
 
-    const nameField = useField('seriesName', formAPI, { sync: requiredNameField})
+    const nameField = useField('seriesName', formAPI, { sync: requiredNameField })
     const queryField = useField('seriesQuery', formAPI, { sync: validQuery })
     const colorField = useField('seriesColor', formAPI)
 

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -18,7 +18,7 @@ interface FormSeriesInputProps {
     /** Query value of series. */
     query?: string
     /** Color value for line chart. (series) */
-    color?: string
+    stroke?: string
     /** Enable autofocus behavior of first input of form. */
     autofocus?: boolean
     /** Enable cancel button. */
@@ -28,12 +28,13 @@ interface FormSeriesInputProps {
     /** On submit handler of series form. */
     onSubmit?: (series: DataSeries) => void
     /** On cancel handler. */
-    onCancel?: () => void
+    onCancel?: () => void,
+    onChange?: (formValues: DataSeries, valid: boolean) => void
 }
 
 /** Displays form series input (three field - name field, query field and color picker). */
 export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = props => {
-    const { name, query, color, className, cancel = false, autofocus = true, onCancel = noop, onSubmit = noop } = props
+    const { name, query, stroke: color, className, cancel = false, autofocus = true, onCancel = noop, onSubmit = noop, onChange = noop } = props
 
     const hasNameControlledValue = !!name
     const hasQueryControlledValue = !!query
@@ -50,6 +51,15 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
                 query: values.seriesQuery,
                 stroke: values.seriesColor,
             }),
+        onChange: event => {
+            const { values } = event;
+
+            onChange({
+                name: values.seriesName,
+                query: values.seriesQuery,
+                stroke: values.seriesColor,
+            }, event.valid);
+        }
     })
 
     const nameField = useField('seriesName', formAPI, { sync: requiredNameField})

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.module.scss
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.module.scss
@@ -13,15 +13,14 @@
 }
 
 .form-series-card {
-    transition: background-color 0.2s ease;
-
     &:hover {
-        background-color: var(--link-hover-bg-color-2);
+        box-shadow: 0 0 0 0.1875rem var(--primary);
+        border-color: transparent;
     }
 
     &__color {
-        width: 2rem;
-        height: 2rem;
+        width: 1rem;
+        height: 1rem;
         align-self: center;
         flex-grow: 0;
         border-radius: 50%;

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.module.scss
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.module.scss
@@ -11,19 +11,3 @@
         }
     }
 }
-
-.form-series-card {
-    &:hover {
-        box-shadow: 0 0 0 0.1875rem var(--primary);
-        border-color: transparent;
-    }
-
-    &__color {
-        width: 1rem;
-        height: 1rem;
-        align-self: center;
-        flex-grow: 0;
-        border-radius: 50%;
-        background-color: currentColor;
-    }
-}

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
@@ -83,7 +83,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
     return (
         <ul className="list-unstyled d-flex flex-column">
             {editSeries.map((line, index) =>
-                editSeries[index] ? (
+                line ? (
                     <FormSeriesInput
                         key={`${line?.name ?? ''}-${index}`}
                         index={index + 1}

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
@@ -71,6 +71,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
     if (series.length === 0) {
         return (
             <FormSeriesInput
+                index={1}
                 autofocus={false}
                 className="card card-body p-3"
                 onSubmit={series => onEditSeriesCommit(0, series)}
@@ -85,6 +86,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                 editSeries[index] ? (
                     <FormSeriesInput
                         key={`${line?.name ?? ''}-${index}`}
+                        index={index + 1}
                         cancel={true}
                         onSubmit={series => onEditSeriesCommit(index, series)}
                         onCancel={() => onEditSeriesCancel(index)}

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
@@ -1,29 +1,54 @@
 import classnames from 'classnames'
-import React, { ReactElement } from 'react'
+import React from 'react'
 
 import { DataSeries } from '../../../../../core/backend/types'
 import { FormSeriesInput } from '../form-series-input/FormSeriesInput'
 
+import { SeriesCard } from './components/series-card/SeriesCard';
 import styles from './FormSeries.module.scss'
 
 export interface FormSeriesProps {
-    /** Controlled value (series - chart lines) for series input component. */
+    /**
+     * Controlled value (series - chart lines) for series input component.
+     * */
     series?: DataSeries[]
 
+    /**
+     * Edit series used below for rendering edit series form. Element of
+     * this array has undefined value when there are no series to edit
+     * and has DataSeries value when user activated edit for some series.
+     * */
     editSeries: (DataSeries | undefined)[]
 
-    /** Change handler. */
-    // onChange: (series: DataSeries[]) => void
-
     /**
-     * Live change series while user typing in active series form.
-     * Used by consumers for getting latest values for live preview chart.
+     * Live change series handler while user typing in active series form.
+     * Used by consumers to get latest values from series inputs and pass
+     * them tp live preview chart.
      * */
     onLiveChange: (liveSeries: DataSeries, isValid: boolean, index: number) => void
 
-    onEditSeriesRequest: (openedCardIndex: number) => void
+    /**
+     * Handler that runs every time user clicked edit on particular
+     * series card.
+     * */
+    onEditSeriesRequest: (editSeriesIndex: number) => void
+
+    /**
+     * Handler that runs every time use clicked commit (done) in
+     * series edit form.
+     * */
     onEditSeriesCommit: (seriesIndex: number, editedSeries: DataSeries) => void
+
+    /**
+     * Handler that runs every time use canceled (click cancel) in
+     * series edit form.
+     * */
     onEditSeriesCancel: (closedCardIndex: number) => void
+
+    /**
+     * Handler that runs every time use removed (click remove) in
+     * series card.
+     * */
     onSeriesRemove: (removedSeriesIndex: number) => void
 }
 
@@ -85,58 +110,5 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                 + Add another data series
             </button>
         </ul>
-    )
-}
-
-interface SeriesCardProps {
-    /** Name of series. */
-    name: string
-    /** Query value of series. */
-    query: string
-    /** Color value of series. */
-    stroke: string
-    /** Custom class name for root button element. */
-    className?: string
-    /** Edit handler. */
-    onEdit?: () => void
-    /** Remove handler. */
-    onRemove?: () => void
-}
-
-/**
- * Renders series card component, visual list item of series (name, color, query)
- * */
-function SeriesCard(props: SeriesCardProps): ReactElement {
-    const { name, query, stroke: color, className, onEdit, onRemove } = props
-
-    return (
-        <li
-            aria-label={`Edit button for ${name} data series`}
-            className={classnames(styles.formSeriesCard, className, 'card d-flex flex-row p-3')}
-        >
-            <div className="flex-grow-1 d-flex flex-column align-items-start">
-
-                <div className='d-flex align-items-center mb-1 '>
-                    {/* eslint-disable-next-line react/forbid-dom-props */}
-                    <div style={{ color }} className={styles.formSeriesCardColor} />
-                    <span className="ml-1 font-weight-bold">{name}</span>
-                </div>
-
-                <span className="mb-0 text-muted">{query}</span>
-            </div>
-
-            <div className='d-flex align-items-center'>
-
-                <button
-                    type="button"
-                    onClick={onEdit}
-                    className='border-0 btn btn-outline-primary'>Edit</button>
-
-                <button
-                    type="button"
-                    onClick={onRemove}
-                    className='border-0 btn btn-outline-danger ml-1'>Remove</button>
-            </div>
-        </li>
     )
 }

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { DataSeries } from '../../../../../core/backend/types'
 import { FormSeriesInput } from '../form-series-input/FormSeriesInput'
 
-import { SeriesCard } from './components/series-card/SeriesCard';
+import { SeriesCard } from './components/series-card/SeriesCard'
 import styles from './FormSeries.module.scss'
 
 export interface FormSeriesProps {
@@ -63,18 +63,20 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
         onEditSeriesCommit,
         onEditSeriesCancel,
         onSeriesRemove,
-        onLiveChange
+        onLiveChange,
     } = props
 
     // In case if we don't have series we have to skip series list ui (components below)
     // and render simple series form component.
     if (series.length === 0) {
-        return <FormSeriesInput
-            autofocus={false}
-            className="card card-body p-3"
-            onSubmit={series => onEditSeriesCommit(0, series)}
-            onChange={(values, valid) => onLiveChange(values, valid, 0)}
-        />
+        return (
+            <FormSeriesInput
+                autofocus={false}
+                className="card card-body p-3"
+                onSubmit={series => onEditSeriesCommit(0, series)}
+                onChange={(values, valid) => onLiveChange(values, valid, 0)}
+            />
+        )
     }
 
     return (
@@ -91,7 +93,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                         {...line}
                     />
                 ) : (
-                    series[index] &&
+                    series[index] && (
                         <SeriesCard
                             key={`${series[index].name}-${index}`}
                             onEdit={() => onEditSeriesRequest(index)}
@@ -99,6 +101,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                             className={styles.formSeriesItem}
                             {...series[index]}
                         />
+                    )
                 )
             )}
 

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.module.scss
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.module.scss
@@ -1,0 +1,16 @@
+
+.form-series-card {
+    &:hover {
+        box-shadow: 0 0 0 0.1875rem var(--primary);
+        border-color: transparent;
+    }
+
+    &__color {
+        width: 1rem;
+        height: 1rem;
+        align-self: center;
+        flex-grow: 0;
+        border-radius: 50%;
+        background-color: currentColor;
+    }
+}

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.module.scss
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.module.scss
@@ -1,15 +1,34 @@
-.form-series-card {
+.card {
     &:hover {
         box-shadow: 0 0 0 0.1875rem var(--primary);
         border-color: transparent;
     }
 
-    &__color {
+    &__info {
+        flex-grow: 1;
+        // A hack to make flex box parent treat truncated flex child
+        // properly, see https://css-tricks.com/using-flexbox-and-text-ellipsis-together/
+        min-width: 0;
+    }
+
+    &__title {
+        display: flex;
+        min-width: 0;
+    }
+
+    &__color-mark {
         width: 1rem;
         height: 1rem;
+        flex-shrink: 0;
         align-self: center;
         flex-grow: 0;
         border-radius: 50%;
         background-color: currentColor;
+    }
+
+    &__name {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.module.scss
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.module.scss
@@ -1,4 +1,3 @@
-
 .form-series-card {
     &:hover {
         box-shadow: 0 0 0 0.1875rem var(--primary);

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
@@ -1,7 +1,7 @@
-import classnames from 'classnames';
-import React, { ReactElement } from 'react';
+import classnames from 'classnames'
+import React, { ReactElement } from 'react'
 
-import styles from './SeriesCard.module.scss';
+import styles from './SeriesCard.module.scss'
 
 interface SeriesCardProps {
     /** Name of series. */
@@ -30,8 +30,7 @@ export function SeriesCard(props: SeriesCardProps): ReactElement {
             className={classnames(styles.formSeriesCard, className, 'card d-flex flex-row p-3')}
         >
             <div className="flex-grow-1 d-flex flex-column align-items-start">
-
-                <div className='d-flex align-items-center mb-1 '>
+                <div className="d-flex align-items-center mb-1 ">
                     {/* eslint-disable-next-line react/forbid-dom-props */}
                     <div style={{ color }} className={styles.formSeriesCardColor} />
                     <span className="ml-1 font-weight-bold">{name}</span>
@@ -40,17 +39,14 @@ export function SeriesCard(props: SeriesCardProps): ReactElement {
                 <span className="mb-0 text-muted">{query}</span>
             </div>
 
-            <div className='d-flex align-items-center'>
+            <div className="d-flex align-items-center">
+                <button type="button" onClick={onEdit} className="border-0 btn btn-outline-primary">
+                    Edit
+                </button>
 
-                <button
-                    type="button"
-                    onClick={onEdit}
-                    className='border-0 btn btn-outline-primary'>Edit</button>
-
-                <button
-                    type="button"
-                    onClick={onRemove}
-                    className='border-0 btn btn-outline-danger ml-1'>Remove</button>
+                <button type="button" onClick={onRemove} className="border-0 btn btn-outline-danger ml-1">
+                    Remove
+                </button>
             </div>
         </li>
     )

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
@@ -26,7 +26,7 @@ export function SeriesCard(props: SeriesCardProps): ReactElement {
 
     return (
         <li
-            aria-label={`Edit button for ${name} data series`}
+            aria-label={`${name} data series`}
             className={classnames(styles.card, className, 'card d-flex flex-row p-3')}
         >
             <div className={styles.cardInfo}>

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
@@ -27,13 +27,15 @@ export function SeriesCard(props: SeriesCardProps): ReactElement {
     return (
         <li
             aria-label={`Edit button for ${name} data series`}
-            className={classnames(styles.formSeriesCard, className, 'card d-flex flex-row p-3')}
+            className={classnames(styles.card, className, 'card d-flex flex-row p-3')}
         >
-            <div className="flex-grow-1 d-flex flex-column align-items-start">
-                <div className="d-flex align-items-center mb-1 ">
+            <div className={styles.cardInfo}>
+                <div className={classnames('mb-1 ', styles.cardTitle)}>
                     {/* eslint-disable-next-line react/forbid-dom-props */}
-                    <div style={{ color }} className={styles.formSeriesCardColor} />
-                    <span className="ml-1 font-weight-bold">{name}</span>
+                    <div style={{ color }} className={styles.cardColorMark} />
+                    <span title={name} className={classnames(styles.cardName, 'ml-1 font-weight-bold')}>
+                        {name}
+                    </span>
                 </div>
 
                 <span className="mb-0 text-muted">{query}</span>

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/components/series-card/SeriesCard.tsx
@@ -1,0 +1,57 @@
+import classnames from 'classnames';
+import React, { ReactElement } from 'react';
+
+import styles from './SeriesCard.module.scss';
+
+interface SeriesCardProps {
+    /** Name of series. */
+    name: string
+    /** Query value of series. */
+    query: string
+    /** Color value of series. */
+    stroke: string
+    /** Custom class name for root button element. */
+    className?: string
+    /** Edit handler. */
+    onEdit?: () => void
+    /** Remove handler. */
+    onRemove?: () => void
+}
+
+/**
+ * Renders series card component, visual list item of series (name, color, query)
+ * */
+export function SeriesCard(props: SeriesCardProps): ReactElement {
+    const { name, query, stroke: color, className, onEdit, onRemove } = props
+
+    return (
+        <li
+            aria-label={`Edit button for ${name} data series`}
+            className={classnames(styles.formSeriesCard, className, 'card d-flex flex-row p-3')}
+        >
+            <div className="flex-grow-1 d-flex flex-column align-items-start">
+
+                <div className='d-flex align-items-center mb-1 '>
+                    {/* eslint-disable-next-line react/forbid-dom-props */}
+                    <div style={{ color }} className={styles.formSeriesCardColor} />
+                    <span className="ml-1 font-weight-bold">{name}</span>
+                </div>
+
+                <span className="mb-0 text-muted">{query}</span>
+            </div>
+
+            <div className='d-flex align-items-center'>
+
+                <button
+                    type="button"
+                    onClick={onEdit}
+                    className='border-0 btn btn-outline-primary'>Edit</button>
+
+                <button
+                    type="button"
+                    onClick={onRemove}
+                    className='border-0 btn btn-outline-danger ml-1'>Remove</button>
+            </div>
+        </li>
+    )
+}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.module.scss
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.module.scss
@@ -8,6 +8,9 @@
         order: 1;
         flex-grow: 1;
         flex-basis: 25rem;
+        // A hack to make flex box parent treat truncated flex child
+        // properly, see https://css-tricks.com/using-flexbox-and-text-ellipsis-together/
+        min-width: 0;
     }
 
     &__live-preview {

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -133,8 +133,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         setEditSeries(newEditSeries)
     }
 
-    const handleAddEditCard = (index: number): void => {
-        console.log('Add edit series card')
+    const handleEditSeriesRequest = (index: number): void => {
         const newEditSeries = [...editSeries];
 
         newEditSeries[index] = series.meta.value[index]
@@ -144,12 +143,40 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         setEditSeries(newEditSeries)
     }
 
-    const handleCancelEditCard = (index: number): void => {
+    const handleEditSeriesCancel = (index: number): void => {
         const newEditSeries = [...editSeries];
 
         newEditSeries[index] = undefined
-
         setEditSeries(newEditSeries)
+    }
+
+    const handleEditSeriesCommit = (index: number, editedSeries: DataSeries): void => {
+        const newEditedSeries = [...editSeries];
+        const newSeries = [
+            ...series.input.value.slice(0, index),
+            editedSeries,
+            ...series.input.value.slice(index + 1),
+        ]
+
+        // Remove series from edited cards
+        newEditedSeries[index] = undefined
+
+        setEditSeries(newEditedSeries)
+        series.input.onChange(newSeries)
+    }
+
+    const handleRemoveSeries = (index: number): void => {
+        const newSeries = [
+            ...series.input.value.slice(0, index),
+            ...series.input.value.slice(index + 1),
+        ]
+        const newEditedSereis = [
+            ...editSeries.slice(0, index),
+            ...editSeries.slice(index + 1),
+        ]
+
+        setEditSeries(newEditedSereis)
+        series.input.onChange(newSeries)
     }
 
     return (
@@ -170,8 +197,10 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 onSeriesLiveChange={handleSeriesLiveChange}
                 onCancel={onCancel}
                 editSeries={editSeries}
-                onEditSeries={handleAddEditCard}
-                onCancelSeries={handleCancelEditCard}/>
+                onEditSeriesRequest={handleEditSeriesRequest}
+                onEditSeriesCancel={handleEditSeriesCancel}
+                onEditSeriesCommit={handleEditSeriesCommit}
+                onSeriesRemove={handleRemoveSeries}/>
 
             <SearchInsightLivePreview
                 disabled={!allFieldsForPreviewAreValid}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -12,14 +12,14 @@ import { CreateInsightFormFields } from '../../types'
 import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLivePreview'
 import { SearchInsightCreationForm } from '../search-insight-creation-form/SearchInsightCreationForm'
 
-import { useEditableSeries } from './hooks/use-editable-series';
+import { useEditableSeries } from './hooks/use-editable-series'
 import styles from './SearchInsightCreationContent.module.scss'
 import {
     repositoriesExistValidator,
     repositoriesFieldValidator,
     requiredStepValueField,
-    seriesRequired
-} from './validators';
+    seriesRequired,
+} from './validators'
 
 const INITIAL_VALUES: CreateInsightFormFields = {
     visibility: 'personal',
@@ -62,7 +62,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     const title = useField('title', formAPI, { sync: titleValidator })
     const repositories = useField('repositories', formAPI, {
         sync: repositoriesFieldValidator,
-        async: repositoriesExistValidator
+        async: repositoriesExistValidator,
     })
     const visibility = useField('visibility', formAPI)
 
@@ -70,14 +70,9 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     const step = useField('step', formAPI)
     const stepValue = useField('stepValue', formAPI, { sync: requiredStepValueField })
 
-    const {
-        liveSeries,
-        editSeries,
-        listen,
-        editRequest,
-        editCommit,
-        cancelEdit,
-        deleteSeries } = useEditableSeries({ series })
+    const { liveSeries, editSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({
+        series,
+    })
 
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview
@@ -107,7 +102,8 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 onEditSeriesRequest={editRequest}
                 onEditSeriesCancel={cancelEdit}
                 onEditSeriesCommit={editCommit}
-                onSeriesRemove={deleteSeries}/>
+                onSeriesRemove={deleteSeries}
+            />
 
             <SearchInsightLivePreview
                 disabled={!allFieldsForPreviewAreValid}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -77,7 +77,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview
     const allFieldsForPreviewAreValid =
-        repositories.meta.validState === 'VALID' &&
+        (repositories.meta.validState === 'VALID' || repositories.meta.validState === 'CHECKING') &&
         (series.meta.validState === 'VALID' || liveSeries.length) &&
         stepValue.meta.validState === 'VALID'
 

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -4,26 +4,21 @@ import { noop } from 'rxjs'
 
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
-import { useField, Validator } from '../../../../../components/form/hooks/useField'
+import { useField } from '../../../../../components/form/hooks/useField'
 import { SubmissionErrors, useForm } from '../../../../../components/form/hooks/useForm'
 import { useTitleValidator } from '../../../../../components/form/hooks/useTitleValidator'
-import { createRequiredValidator } from '../../../../../components/form/validators'
-import { DataSeries } from '../../../../../core/backend/types'
 import { InsightTypePrefix } from '../../../../../core/types'
 import { CreateInsightFormFields } from '../../types'
 import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLivePreview'
 import { SearchInsightCreationForm } from '../search-insight-creation-form/SearchInsightCreationForm'
 
 import styles from './SearchInsightCreationContent.module.scss'
-
-const repositoriesFieldValidator = createRequiredValidator('Repositories is a required field.')
-const requiredStepValueField = createRequiredValidator('Please specify a step between points.')
-/**
- * Custom validator for chart series. Since series has complex type
- * we can't validate this with standard validators.
- * */
-const seriesRequired: Validator<DataSeries[]> = series =>
-    series && series.length > 0 ? undefined : 'Series is empty. You must have at least one series for code insight.'
+import {
+    repositoriesExistValidator,
+    repositoriesFieldValidator,
+    requiredStepValueField,
+    seriesRequired
+} from './validators';
 
 const INITIAL_VALUES: CreateInsightFormFields = {
     visibility: 'personal',
@@ -63,13 +58,16 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     // We can't have two or more insights with the same name, since we rely on name as on id of insights.
     const titleValidator = useTitleValidator({ settings, insightType: InsightTypePrefix.search })
 
-    const title = useField('title', formAPI, titleValidator)
-    const repositories = useField('repositories', formAPI, repositoriesFieldValidator)
+    const title = useField('title', formAPI, { sync: titleValidator })
+    const repositories = useField('repositories', formAPI, {
+        sync: repositoriesFieldValidator,
+        async: repositoriesExistValidator
+    })
     const visibility = useField('visibility', formAPI)
 
-    const series = useField('series', formAPI, seriesRequired)
+    const series = useField('series', formAPI, { sync: seriesRequired })
     const step = useField('step', formAPI)
-    const stepValue = useField('stepValue', formAPI, requiredStepValueField)
+    const stepValue = useField('stepValue', formAPI, { sync: requiredStepValueField })
 
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 
 import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
 import { DataSeries } from '../../../../../../core/backend/types'
@@ -72,22 +72,16 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     })
 
     const liveSeries = useDistinctValue(
-        useMemo<DataSeries[]>(
-            () =>
-                editSeries
-                    .map((editSeries, index) => {
-                        if (editSeries) {
-                            const { valid, ...series } = editSeries
-                            return valid ? series : undefined
-                        }
+        editSeries
+            .map((editSeries, index) => {
+                if (editSeries) {
+                    const { valid, ...series } = editSeries
+                    return valid ? series : undefined
+                }
 
-                        return series.meta.value[index]
-                    })
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
-                    .filter<DataSeries>(series => !!series),
-            [series, editSeries]
-        )
+                return series.meta.value[index]
+            })
+            .filter<DataSeries>((series): series is DataSeries => !!series)
     )
 
     const handleSeriesLiveChange = (liveSeries: DataSeries, valid: boolean, index: number): void => {

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -1,0 +1,155 @@
+import { useMemo, useState } from 'react';
+
+import { useFieldAPI } from '../../../../../../components/form/hooks/useField';
+import { DataSeries } from '../../../../../../core/backend/types';
+import { useDistinctValue } from '../../../../../../hooks/use-distinct-value';
+import { CreateInsightFormFields } from '../../../types';
+import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput';
+
+const createDefaultEditSeries = (series = defaultEditSeries, valid = false): EditDataSeries => ({
+    ...series,
+    valid,
+})
+
+const defaultEditSeries = {
+    name: '',
+    query: '',
+    stroke: DEFAULT_ACTIVE_COLOR,
+}
+
+interface EditDataSeries extends DataSeries {
+    valid: boolean;
+}
+
+export interface UseEditableSeriesProps {
+    series: useFieldAPI<CreateInsightFormFields['series']>
+}
+
+export interface UseEditableSeriesAPI {
+    /**
+     * Edit series array used below for rendering series edit form.
+     * In case of some element has undefined value we're showing
+     * series card with data instead of form.
+     * */
+    editSeries: (CreateInsightFormFields['series'][number] | undefined)[],
+
+    /**
+     * Latest valid values of series.
+     * */
+    liveSeries: DataSeries[],
+
+    /**
+     * Handler to listen latest values of particular sereis form.
+     * */
+    listen: (liveSeries: DataSeries, valid: boolean, index: number) => void
+
+    /**
+     * Handlers for CRUD operations over sereis.
+     * */
+    editRequest: (index: number) => void
+    editCommit: (index: number, editedSeries: DataSeries) => void
+    cancelEdit: (index: number) => void
+    deleteSeries: (index: number) => void
+}
+
+/**
+ * Implementation of CRUD operation over insight series. Used in form to manage
+ * edit, delete, add, and cancel series forms.
+ * */
+export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSeriesAPI {
+    const { series } = props;
+
+    const [editSeries, setEditSeries] = useState<(EditDataSeries | undefined)[]>(() => {
+        const hasSeries = series.input.value.length;
+
+        if (hasSeries) {
+            return series.input.value.map(() => undefined);
+        }
+
+        // If we in creation mode we should show first series editor in a first
+        // render.
+        return [createDefaultEditSeries()]
+    })
+
+    const liveSeries = useDistinctValue(
+        useMemo<DataSeries[]>(
+            () => editSeries
+                .map((editSeries, index) => {
+                    if (editSeries) {
+                        const { valid, ...series } = editSeries
+                        return valid ? series : undefined
+                    }
+
+                    return series.meta.value[index];
+                })
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                .filter<DataSeries>(series => !!series),
+            [series, editSeries]
+        )
+    );
+
+    const handleSeriesLiveChange = (liveSeries: DataSeries, valid: boolean, index: number): void => {
+        const newEditSeries = [...editSeries];
+
+        newEditSeries[index] = { ...liveSeries, valid }
+
+        setEditSeries(newEditSeries)
+    }
+
+    const handleEditSeriesRequest = (index: number): void => {
+        const newEditSeries = [...editSeries];
+
+        newEditSeries[index] = series.meta.value[index]
+            ? createDefaultEditSeries(series.meta.value[index], true)
+            : createDefaultEditSeries()
+
+        setEditSeries(newEditSeries)
+    }
+
+    const handleEditSeriesCancel = (index: number): void => {
+        const newEditSeries = [...editSeries];
+
+        newEditSeries[index] = undefined
+        setEditSeries(newEditSeries)
+    }
+
+    const handleEditSeriesCommit = (index: number, editedSeries: DataSeries): void => {
+        const newEditedSeries = [...editSeries];
+        const newSeries = [
+            ...series.input.value.slice(0, index),
+            editedSeries,
+            ...series.input.value.slice(index + 1),
+        ]
+
+        // Remove series from edited cards
+        newEditedSeries[index] = undefined
+
+        setEditSeries(newEditedSeries)
+        series.input.onChange(newSeries)
+    }
+
+    const handleRemoveSeries = (index: number): void => {
+        const newSeries = [
+            ...series.input.value.slice(0, index),
+            ...series.input.value.slice(index + 1),
+        ]
+        const newEditedSereis = [
+            ...editSeries.slice(0, index),
+            ...editSeries.slice(index + 1),
+        ]
+
+        setEditSeries(newEditedSereis)
+        series.input.onChange(newSeries)
+    }
+
+    return {
+        liveSeries,
+        editSeries,
+        listen: handleSeriesLiveChange,
+        editRequest: handleEditSeriesRequest,
+        editCommit: handleEditSeriesCommit,
+        cancelEdit: handleEditSeriesCancel,
+        deleteSeries: handleRemoveSeries,
+    }
+}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -1,5 +1,7 @@
 import { useState } from 'react'
 
+import { isDefined } from '@sourcegraph/shared/src/util/types'
+
 import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
 import { DataSeries } from '../../../../../../core/backend/types'
 import { useDistinctValue } from '../../../../../../hooks/use-distinct-value'
@@ -81,7 +83,7 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
 
                 return series.meta.value[index]
             })
-            .filter<DataSeries>((series): series is DataSeries => !!series)
+            .filter<DataSeries>(isDefined)
     )
 
     const handleSeriesLiveChange = (liveSeries: DataSeries, valid: boolean, index: number): void => {

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -1,10 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react'
 
-import { useFieldAPI } from '../../../../../../components/form/hooks/useField';
-import { DataSeries } from '../../../../../../core/backend/types';
-import { useDistinctValue } from '../../../../../../hooks/use-distinct-value';
-import { CreateInsightFormFields } from '../../../types';
-import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput';
+import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
+import { DataSeries } from '../../../../../../core/backend/types'
+import { useDistinctValue } from '../../../../../../hooks/use-distinct-value'
+import { CreateInsightFormFields } from '../../../types'
+import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput'
 
 const createDefaultEditSeries = (series = defaultEditSeries, valid = false): EditDataSeries => ({
     ...series,
@@ -18,7 +18,7 @@ const defaultEditSeries = {
 }
 
 interface EditDataSeries extends DataSeries {
-    valid: boolean;
+    valid: boolean
 }
 
 export interface UseEditableSeriesProps {
@@ -31,12 +31,12 @@ export interface UseEditableSeriesAPI {
      * In case of some element has undefined value we're showing
      * series card with data instead of form.
      * */
-    editSeries: (CreateInsightFormFields['series'][number] | undefined)[],
+    editSeries: (CreateInsightFormFields['series'][number] | undefined)[]
 
     /**
      * Latest valid values of series.
      * */
-    liveSeries: DataSeries[],
+    liveSeries: DataSeries[]
 
     /**
      * Handler to listen latest values of particular sereis form.
@@ -57,13 +57,13 @@ export interface UseEditableSeriesAPI {
  * edit, delete, add, and cancel series forms.
  * */
 export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSeriesAPI {
-    const { series } = props;
+    const { series } = props
 
     const [editSeries, setEditSeries] = useState<(EditDataSeries | undefined)[]>(() => {
-        const hasSeries = series.input.value.length;
+        const hasSeries = series.input.value.length
 
         if (hasSeries) {
-            return series.input.value.map(() => undefined);
+            return series.input.value.map(() => undefined)
         }
 
         // If we in creation mode we should show first series editor in a first
@@ -73,24 +73,25 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
 
     const liveSeries = useDistinctValue(
         useMemo<DataSeries[]>(
-            () => editSeries
-                .map((editSeries, index) => {
-                    if (editSeries) {
-                        const { valid, ...series } = editSeries
-                        return valid ? series : undefined
-                    }
+            () =>
+                editSeries
+                    .map((editSeries, index) => {
+                        if (editSeries) {
+                            const { valid, ...series } = editSeries
+                            return valid ? series : undefined
+                        }
 
-                    return series.meta.value[index];
-                })
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                .filter<DataSeries>(series => !!series),
+                        return series.meta.value[index]
+                    })
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    .filter<DataSeries>(series => !!series),
             [series, editSeries]
         )
-    );
+    )
 
     const handleSeriesLiveChange = (liveSeries: DataSeries, valid: boolean, index: number): void => {
-        const newEditSeries = [...editSeries];
+        const newEditSeries = [...editSeries]
 
         newEditSeries[index] = { ...liveSeries, valid }
 
@@ -98,7 +99,7 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     }
 
     const handleEditSeriesRequest = (index: number): void => {
-        const newEditSeries = [...editSeries];
+        const newEditSeries = [...editSeries]
 
         newEditSeries[index] = series.meta.value[index]
             ? createDefaultEditSeries(series.meta.value[index], true)
@@ -108,19 +109,15 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     }
 
     const handleEditSeriesCancel = (index: number): void => {
-        const newEditSeries = [...editSeries];
+        const newEditSeries = [...editSeries]
 
         newEditSeries[index] = undefined
         setEditSeries(newEditSeries)
     }
 
     const handleEditSeriesCommit = (index: number, editedSeries: DataSeries): void => {
-        const newEditedSeries = [...editSeries];
-        const newSeries = [
-            ...series.input.value.slice(0, index),
-            editedSeries,
-            ...series.input.value.slice(index + 1),
-        ]
+        const newEditedSeries = [...editSeries]
+        const newSeries = [...series.input.value.slice(0, index), editedSeries, ...series.input.value.slice(index + 1)]
 
         // Remove series from edited cards
         newEditedSeries[index] = undefined
@@ -130,14 +127,8 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     }
 
     const handleRemoveSeries = (index: number): void => {
-        const newSeries = [
-            ...series.input.value.slice(0, index),
-            ...series.input.value.slice(index + 1),
-        ]
-        const newEditedSereis = [
-            ...editSeries.slice(0, index),
-            ...editSeries.slice(index + 1),
-        ]
+        const newSeries = [...series.input.value.slice(0, index), ...series.input.value.slice(index + 1)]
+        const newEditedSereis = [...editSeries.slice(0, index), ...editSeries.slice(index + 1)]
 
         setEditSeries(newEditedSereis)
         series.input.onChange(newSeries)

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -91,46 +91,56 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     )
 
     const handleSeriesLiveChange = (liveSeries: DataSeries, valid: boolean, index: number): void => {
-        const newEditSeries = [...editSeries]
+        setEditSeries(editSeries => {
+            const newEditSeries = [...editSeries]
 
-        newEditSeries[index] = { ...liveSeries, valid }
+            newEditSeries[index] = { ...liveSeries, valid }
 
-        setEditSeries(newEditSeries)
+            return newEditSeries
+        })
     }
 
     const handleEditSeriesRequest = (index: number): void => {
-        const newEditSeries = [...editSeries]
+        setEditSeries(editSeries => {
+            const newEditSeries = [...editSeries]
 
-        newEditSeries[index] = series.meta.value[index]
-            ? createDefaultEditSeries(series.meta.value[index], true)
-            : createDefaultEditSeries()
+            newEditSeries[index] = series.meta.value[index]
+                ? createDefaultEditSeries(series.meta.value[index], true)
+                : createDefaultEditSeries()
 
-        setEditSeries(newEditSeries)
+            return newEditSeries
+        })
     }
 
     const handleEditSeriesCancel = (index: number): void => {
-        const newEditSeries = [...editSeries]
+        setEditSeries(editSeries => {
+            const newEditSeries = [...editSeries]
 
-        newEditSeries[index] = undefined
-        setEditSeries(newEditSeries)
+            newEditSeries[index] = undefined
+            setEditSeries(newEditSeries)
+
+            return editSeries
+        })
     }
 
     const handleEditSeriesCommit = (index: number, editedSeries: DataSeries): void => {
-        const newEditedSeries = [...editSeries]
+        setEditSeries(editSeries => {
+            const newEditedSeries = [...editSeries]
+
+            // Remove series from edited cards
+            newEditedSeries[index] = undefined
+
+            return newEditedSeries
+        })
+
         const newSeries = [...series.input.value.slice(0, index), editedSeries, ...series.input.value.slice(index + 1)]
-
-        // Remove series from edited cards
-        newEditedSeries[index] = undefined
-
-        setEditSeries(newEditedSeries)
         series.input.onChange(newSeries)
     }
 
     const handleRemoveSeries = (index: number): void => {
-        const newSeries = [...series.input.value.slice(0, index), ...series.input.value.slice(index + 1)]
-        const newEditedSereis = [...editSeries.slice(0, index), ...editSeries.slice(index + 1)]
+        setEditSeries(editSeries => [...editSeries.slice(0, index), ...editSeries.slice(index + 1)])
 
-        setEditSeries(newEditedSereis)
+        const newSeries = [...series.input.value.slice(0, index), ...series.input.value.slice(index + 1)]
         series.input.onChange(newSeries)
     }
 

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
@@ -27,8 +27,8 @@ export const repositoriesExistValidator: AsyncValidator<string> = async value =>
         const nullRepositoryIndex = repositories.findIndex(repo => !repo)
 
         if (nullRepositoryIndex !== -1) {
-            const repoName = repositoryNames[nullRepositoryIndex])
-            return `We couldn't find the repository ${repoName}. Please ensure the repository exists at ${new URL(repoName, location.href)}.`
+            const repoName = repositoryNames[nullRepositoryIndex]
+            return `We couldn't find the repository ${repoName}. Please ensure the repository exists.`
         }
 
         return

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
@@ -1,10 +1,10 @@
-import { renderError } from '../../../../../../components/alerts';
-import { Validator } from '../../../../../components/form/hooks/useField';
-import { AsyncValidator } from '../../../../../components/form/hooks/utils/use-async-validation';
-import { createRequiredValidator } from '../../../../../components/form/validators';
-import { fetchRepositories } from '../../../../../core/backend/requests/fetch-repositories';
-import { DataSeries } from '../../../../../core/backend/types';
-import { getSanitizedRepositories } from '../../utils/insight-sanitizer';
+import { renderError } from '../../../../../../components/alerts'
+import { Validator } from '../../../../../components/form/hooks/useField'
+import { AsyncValidator } from '../../../../../components/form/hooks/utils/use-async-validation'
+import { createRequiredValidator } from '../../../../../components/form/validators'
+import { fetchRepositories } from '../../../../../core/backend/requests/fetch-repositories'
+import { DataSeries } from '../../../../../core/backend/types'
+import { getSanitizedRepositories } from '../../utils/insight-sanitizer'
 
 export const repositoriesFieldValidator = createRequiredValidator('Repositories is a required field.')
 export const requiredStepValueField = createRequiredValidator('Please specify a step between points.')
@@ -17,11 +17,11 @@ export const seriesRequired: Validator<DataSeries[]> = series =>
 
 export const repositoriesExistValidator: AsyncValidator<string> = async value => {
     if (!value) {
-        return;
+        return
     }
 
     try {
-        const repositoryNames = getSanitizedRepositories(value);
+        const repositoryNames = getSanitizedRepositories(value)
         const repositories = await fetchRepositories(repositoryNames).toPromise()
 
         const nullRepositoryIndex = repositories.findIndex(repo => !repo)
@@ -31,8 +31,7 @@ export const repositoriesExistValidator: AsyncValidator<string> = async value =>
         }
 
         return
-
     } catch (error) {
-        return renderError(error);
+        return renderError(error)
     }
 }

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
@@ -27,7 +27,8 @@ export const repositoriesExistValidator: AsyncValidator<string> = async value =>
         const nullRepositoryIndex = repositories.findIndex(repo => !repo)
 
         if (nullRepositoryIndex !== -1) {
-            return `We couldn't find repository with ${repositoryNames[nullRepositoryIndex]}. Please check the repo URL.`
+            const repoName = repositoryNames[nullRepositoryIndex])
+            return `We couldn't find the repository ${repoName}. Please ensure the repository exists at ${new URL(repoName, location.href)}.`
         }
 
         return

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
@@ -1,0 +1,38 @@
+import { renderError } from '../../../../../../components/alerts';
+import { Validator } from '../../../../../components/form/hooks/useField';
+import { AsyncValidator } from '../../../../../components/form/hooks/utils/use-async-validation';
+import { createRequiredValidator } from '../../../../../components/form/validators';
+import { fetchRepositories } from '../../../../../core/backend/requests/fetch-repositories';
+import { DataSeries } from '../../../../../core/backend/types';
+import { getSanitizedRepositories } from '../../utils/insight-sanitizer';
+
+export const repositoriesFieldValidator = createRequiredValidator('Repositories is a required field.')
+export const requiredStepValueField = createRequiredValidator('Please specify a step between points.')
+/**
+ * Custom validator for chart series. Since series has complex type
+ * we can't validate this with standard validators.
+ * */
+export const seriesRequired: Validator<DataSeries[]> = series =>
+    series && series.length > 0 ? undefined : 'Series is empty. You must have at least one series for code insight.'
+
+export const repositoriesExistValidator: AsyncValidator<string> = async value => {
+    if (!value) {
+        return;
+    }
+
+    try {
+        const repositoryNames = getSanitizedRepositories(value);
+        const repositories = await fetchRepositories(repositoryNames).toPromise()
+
+        const nullRepositoryIndex = repositories.findIndex(repo => !repo)
+
+        if (nullRepositoryIndex !== -1) {
+            return `We couldn't find repository with ${repositoryNames[nullRepositoryIndex]}. Please check the repo URL.`
+        }
+
+        return
+
+    } catch (error) {
+        return renderError(error);
+    }
+}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -8,6 +8,7 @@ import { FormInput } from '../../../../../components/form/form-input/FormInput'
 import { FormRadioInput } from '../../../../../components/form/form-radio-input/FormRadioInput'
 import { useFieldAPI } from '../../../../../components/form/hooks/useField'
 import { FORM_ERROR, SubmissionErrors } from '../../../../../components/form/hooks/useForm'
+import { DataSeries } from '../../../../../core/backend/types';
 import { CreateInsightFormFields } from '../../types'
 import { FormSeries } from '../form-series/FormSeries'
 
@@ -30,6 +31,10 @@ interface CreationSearchInsightFormProps {
     step: useFieldAPI<CreateInsightFormFields['step']>
     stepValue: useFieldAPI<CreateInsightFormFields['stepValue']>
 
+    editSeries: (CreateInsightFormFields['series'][number] | undefined)[],
+    onCancelSeries: (index: number) => void,
+    onEditSeries: (index: number) => void
+    onSeriesLiveChange: (liveSeries: DataSeries, isValid: boolean, index: number) => void
     onCancel: () => void
 }
 
@@ -48,10 +53,14 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         repositories,
         visibility,
         series,
+        editSeries,
         stepValue,
         step,
         className,
         onCancel,
+        onCancelSeries,
+        onEditSeries,
+        onSeriesLiveChange,
     } = props
 
     const isEditMode = mode === 'edit'
@@ -127,7 +136,14 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 innerRef={series.input.ref}
                 className="mb-0"
             >
-                <FormSeries series={series.input.value} onChange={series.input.onChange} />
+                <FormSeries
+                    series={series.input.value}
+                    editSeries={editSeries}
+                    onChange={series.input.onChange}
+                    onLiveChange={onSeriesLiveChange}
+                    onEditCard={onEditSeries}
+                    onEditCardClose={onCancelSeries}
+                />
             </FormGroup>
 
             <hr className={styles.creationInsightFormSeparator} />

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -81,6 +81,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 required={true}
                 description="Create a list of repositories to run your search over. Separate them with commas."
                 placeholder="Add or search for repositories"
+                loading={repositories.meta.validState === 'CHECKING'}
                 valid={repositories.meta.touched && repositories.meta.validState === 'VALID'}
                 error={repositories.meta.touched && repositories.meta.error}
                 {...repositories.input}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -33,8 +33,23 @@ interface CreationSearchInsightFormProps {
 
     onCancel: () => void
 
+    /**
+     * Edit series array used below for rendering series edit form.
+     * In case of some element has undefined value we're showing
+     * series card with data instead of form.
+     * */
     editSeries: (CreateInsightFormFields['series'][number] | undefined)[],
+
+    /**
+     * Handler to listen latest value form particular series edit form
+     * Used to get information for live preview chart.
+     * */
     onSeriesLiveChange: (liveSeries: DataSeries, isValid: boolean, index: number) => void
+
+    /**
+     * Handlers for CRUD operation over series. Add, delete, update and cancel
+     * series edit form.
+     * */
     onEditSeriesRequest: (openedCardIndex: number) => void
     onEditSeriesCommit: (seriesIndex: number, editedSeries: DataSeries) => void
     onEditSeriesCancel: (closedCardIndex: number) => void

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -31,11 +31,14 @@ interface CreationSearchInsightFormProps {
     step: useFieldAPI<CreateInsightFormFields['step']>
     stepValue: useFieldAPI<CreateInsightFormFields['stepValue']>
 
-    editSeries: (CreateInsightFormFields['series'][number] | undefined)[],
-    onCancelSeries: (index: number) => void,
-    onEditSeries: (index: number) => void
-    onSeriesLiveChange: (liveSeries: DataSeries, isValid: boolean, index: number) => void
     onCancel: () => void
+
+    editSeries: (CreateInsightFormFields['series'][number] | undefined)[],
+    onSeriesLiveChange: (liveSeries: DataSeries, isValid: boolean, index: number) => void
+    onEditSeriesRequest: (openedCardIndex: number) => void
+    onEditSeriesCommit: (seriesIndex: number, editedSeries: DataSeries) => void
+    onEditSeriesCancel: (closedCardIndex: number) => void
+    onSeriesRemove: (removedSeriesIndex: number) => void
 }
 
 /**
@@ -58,9 +61,11 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         step,
         className,
         onCancel,
-        onCancelSeries,
-        onEditSeries,
         onSeriesLiveChange,
+        onEditSeriesRequest,
+        onEditSeriesCommit,
+        onEditSeriesCancel,
+        onSeriesRemove
     } = props
 
     const isEditMode = mode === 'edit'
@@ -139,10 +144,11 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 <FormSeries
                     series={series.input.value}
                     editSeries={editSeries}
-                    onChange={series.input.onChange}
                     onLiveChange={onSeriesLiveChange}
-                    onEditCard={onEditSeries}
-                    onEditCardClose={onCancelSeries}
+                    onEditSeriesRequest={onEditSeriesRequest}
+                    onEditSeriesCommit={onEditSeriesCommit}
+                    onEditSeriesCancel={onEditSeriesCancel}
+                    onSeriesRemove={onSeriesRemove}
                 />
             </FormGroup>
 

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -8,7 +8,7 @@ import { FormInput } from '../../../../../components/form/form-input/FormInput'
 import { FormRadioInput } from '../../../../../components/form/form-radio-input/FormRadioInput'
 import { useFieldAPI } from '../../../../../components/form/hooks/useField'
 import { FORM_ERROR, SubmissionErrors } from '../../../../../components/form/hooks/useForm'
-import { DataSeries } from '../../../../../core/backend/types';
+import { DataSeries } from '../../../../../core/backend/types'
 import { CreateInsightFormFields } from '../../types'
 import { FormSeries } from '../form-series/FormSeries'
 
@@ -38,7 +38,7 @@ interface CreationSearchInsightFormProps {
      * In case of some element has undefined value we're showing
      * series card with data instead of form.
      * */
-    editSeries: (CreateInsightFormFields['series'][number] | undefined)[],
+    editSeries: (CreateInsightFormFields['series'][number] | undefined)[]
 
     /**
      * Handler to listen latest value form particular series edit form
@@ -80,7 +80,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         onEditSeriesRequest,
         onEditSeriesCommit,
         onEditSeriesCancel,
-        onSeriesRemove
+        onSeriesRemove,
     } = props
 
     const isEditMode = mode === 'edit'

--- a/client/web/src/views/ChartViewContent/charts/line/LineChart.scss
+++ b/client/web/src/views/ChartViewContent/charts/line/LineChart.scss
@@ -103,6 +103,7 @@
     &__legend-mark {
         width: 0.75rem;
         height: 0.75rem;
+        flex-shrink: 0;
         margin-right: 0.25rem;
         border-radius: 50%;
     }


### PR DESCRIPTION
Closes: https://github.com/sourcegraph/sourcegraph/issues/20985

## Details of this PR 
This PR is the first PR in three polishing PR's before 3.28 release

1. **This PR**
2. **[Support multi org logic for code insights](https://github.com/sourcegraph/sourcegraph/pull/21019)**
3. [**Polish visual aspects of form and creation UI flow** ](https://github.com/sourcegraph/sourcegraph/pull/21043)

### What has been done in this PR
- [x] Add async validation to repositories/repository fields creation UI
- [x] Listen to series changes without actually submitting the series to see a live preview chart in search based creation UI
- [x] Add edit/delete buttons for live series 