### PR TITLE
extensibility: update action items and status bars for refresh

### DIFF
--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -22,11 +22,15 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
     &__toggle-container {
         width: $action-item-container-width;
         background-color: var(--color-bg-2);
-        padding-top: 0.125rem;
-        padding-bottom: 0.125rem;
+        padding-top: 0.375rem;
+        padding-bottom: 0.25rem;
 
         .theme-redesign & {
             background-color: var(--body-bg);
+
+            svg {
+                color: var(--icon-color);
+            }
         }
 
         &--open {
@@ -37,6 +41,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
                 // Don't need to cover RepoHeader border since it doesn't exist in the redesign.
                 // Simplify &__.toggle-container (by removing negative margin-botton) when we remove old styles.
                 border-bottom: none;
+                margin-bottom: 0;
             }
         }
     }
@@ -66,7 +71,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
         position: absolute;
         height: 1.25rem;
         width: 0.0625rem;
-        top: 0.5rem;
+        top: 0.75rem;
         transform: translateX(-0.0625rem);
 
         border-radius: 2px;

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -8,20 +8,14 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
         width: $action-item-container-width;
         background-color: var(--color-bg-2);
         list-style: none;
-    }
 
-    &__toggle {
-        background-color: var(--color-bg-2);
-        padding-left: 0.625rem;
-        padding-right: 0.625rem;
+        .theme-redesign & {
+            background-color: var(--body-bg);
 
-        &:hover {
-            background-color: var(--link-hover-bg-color);
-        }
-
-        &--open {
-            border-bottom: solid var(--color-bg-2) 1px;
-            margin-bottom: -0.0625rem;
+            // Only rendered for redesign
+            &--collapsed {
+                width: 0.5rem;
+            }
         }
     }
 
@@ -31,22 +25,52 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
         padding-top: 0.125rem;
         padding-bottom: 0.125rem;
 
+        .theme-redesign & {
+            background-color: var(--body-bg);
+        }
+
         &--open {
             border-bottom: solid var(--color-bg-2) 1px;
             margin-bottom: -0.0625rem;
+
+            .theme-redesign & {
+                // Don't need to cover RepoHeader border since it doesn't exist in the redesign.
+                // Simplify &__.toggle-container (by removing negative margin-botton) when we remove old styles.
+                border-bottom: none;
+            }
         }
     }
 
-    &__divider {
+    // Used to visually separate action items bar sections.
+    &__divider-horizontal {
         height: 0.0625rem;
         width: 1.25rem;
         background-color: var(--border-color);
         left: 0.625rem;
 
         &:first-of-type {
+            // Special case (pre-redesign): action items toggle belongs to the repo header, which
+            // had 1px border-bottom. We used to have to cover it with this divider.
             top: 0;
             transform: translateY(-0.0625rem);
+
+            .theme-redesign & {
+                top: auto;
+                transform: none;
+            }
         }
+    }
+
+    // Used to visually separate action items bar toggle from repo header actions.
+    &__divider-vertical {
+        position: absolute;
+        height: 1.25rem;
+        width: 0.0625rem;
+        top: 0.5rem;
+        transform: translateX(-0.0625rem);
+
+        border-radius: 2px;
+        background-color: var(--border-color);
     }
 
     &__list {
@@ -72,6 +96,12 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
     &__action {
         width: $action-item-width;
         height: 2rem;
+
+        .theme-redesign & {
+            width: 2rem;
+            margin-left: 0.25rem;
+            border-radius: 0.1875rem;
+        }
 
         &:hover {
             background-color: var(--link-hover-bg-color);

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -1,15 +1,19 @@
-$action-item-width: 2.5rem;
-$action-item-container-width: 2.5625; // 2.5rem + 1px
-
 $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-pink-8;
 
+// Add this class to the lowest common ancestor of <ActionItemsBar> and <ActionItemsToggle>
 .action-items {
+    --action-item-width: 2.5rem;
+    --action-item-container-width: 2.5625rem; // 2.5rem + 1px
+
     &__bar {
-        width: $action-item-container-width;
+        // We won't need hacky container width in the redesign.
+        // Remove this var and use --action-item-width everywhere.
+        width: var(--action-item-container-width);
         background-color: var(--color-bg-2);
         list-style: none;
 
         .theme-redesign & {
+            width: var(--action-item-width);
             background-color: var(--body-bg);
 
             // Only rendered for redesign
@@ -20,7 +24,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
     }
 
     &__toggle-container {
-        width: $action-item-container-width;
+        width: var(--action-item-width);
         background-color: var(--color-bg-2);
         padding-top: 0.375rem;
         padding-bottom: 0.25rem;
@@ -99,7 +103,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
     }
 
     &__action {
-        width: $action-item-width;
+        width: var(--action-item-width);
         height: 2rem;
 
         .theme-redesign & {
@@ -166,7 +170,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
     }
 
     &__scroll {
-        width: $action-item-width;
+        width: var(--action-item-width);
 
         &:hover {
             background-color: var(--link-hover-bg-color);

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -84,7 +84,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
 
     &__list {
         overflow-y: auto;
-        flex: 0 1 auto;
+        width: var(--action-item-width);
 
         scrollbar-width: none;
         &::-webkit-scrollbar {

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -6,6 +6,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
     --action-item-container-width: 2.5625rem; // 2.5rem + 1px
 
     &__bar {
+        flex: 0 0 auto;
         // We won't need hacky container width in the redesign.
         // Remove this var and use --action-item-width everywhere.
         width: var(--action-item-container-width);
@@ -84,7 +85,6 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
 
     &__list {
         overflow-y: auto;
-        width: var(--action-item-width);
 
         scrollbar-width: none;
         &::-webkit-scrollbar {

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -24,6 +24,7 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { LocalStorageSubject } from '@sourcegraph/shared/src/util/LocalStorageSubject'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { useCarousel } from '../../components/useCarousel'
@@ -204,12 +205,21 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(props => {
         useMemo(() => haveInitialExtensionsLoaded(props.extensionsController.extHostAPI), [props.extensionsController])
     )
 
+    const [isRedesignEnabled] = useRedesignToggle()
+
     if (!isOpen) {
-        return null
+        return isRedesignEnabled ? <div className="action-items__bar--collapsed " /> : null
     }
 
     return (
-        <div className="action-items__bar p-0 border-left position-relative d-flex flex-column" ref={barReference}>
+        <div
+            className={classNames(
+                'action-items__bar p-0 position-relative d-flex flex-column',
+                isRedesignEnabled ? 'mr-2' : 'border-left'
+                // RepoRevisionContainer content provides the border after redesign
+            )}
+            ref={barReference}
+        >
             {/* To be clear to users that this isn't an error reported by extensions about e.g. the code they're viewing. */}
             <ErrorBoundary location={props.location} render={error => <span>Component error: {error.message}</span>}>
                 <ActionItemsDivider />
@@ -307,35 +317,41 @@ export const ActionItemsToggle: React.FunctionComponent<ActionItemsToggleProps> 
         useMemo(() => haveInitialExtensionsLoaded(extensionsController.extHostAPI), [extensionsController])
     )
 
+    const [isRedesignEnabled] = useRedesignToggle()
+
     return barInPage ? (
-        <li
-            data-tooltip={`${isOpen ? 'Close' : 'Open'} extensions panel`}
-            className={classNames(className, 'nav-item border-left')}
-        >
-            <div
-                className={classNames(
-                    'action-items__toggle-container',
-                    isOpen && 'action-items__toggle-container--open'
-                )}
+        <>
+            {isRedesignEnabled && <div className="action-items__divider-vertical" />}
+            <li
+                data-tooltip={`${isOpen ? 'Close' : 'Open'} extensions panel`}
+                className={classNames(className, 'nav-item', isRedesignEnabled ? 'mr-2' : 'border-left')}
+                // RepoRevisionContainer content provides the border after redesign
             >
-                <ButtonLink
-                    className={classNames(actionItemClassName)}
-                    onSelect={toggle}
-                    buttonLinkRef={toggleReference}
-                >
-                    {!haveExtensionsLoaded ? (
-                        <LoadingSpinner className="icon-inline" />
-                    ) : isOpen ? (
-                        <ChevronDoubleUpIcon className="icon-inline" />
-                    ) : (
-                        <PuzzleOutlineIcon className="icon-inline" />
+                <div
+                    className={classNames(
+                        'action-items__toggle-container',
+                        isOpen && 'action-items__toggle-container--open'
                     )}
-                </ButtonLink>
-            </div>
-        </li>
+                >
+                    <ButtonLink
+                        className={classNames(actionItemClassName)}
+                        onSelect={toggle}
+                        buttonLinkRef={toggleReference}
+                    >
+                        {!haveExtensionsLoaded ? (
+                            <LoadingSpinner className="icon-inline" />
+                        ) : isOpen ? (
+                            <ChevronDoubleUpIcon className="icon-inline" />
+                        ) : (
+                            <PuzzleOutlineIcon className="icon-inline" />
+                        )}
+                    </ButtonLink>
+                </div>
+            </li>
+        </>
     ) : null
 }
 
 const ActionItemsDivider: React.FunctionComponent<{ className?: string }> = ({ className }) => (
-    <li className={classNames(className, 'action-items__divider position-relative rounded-sm d-flex')} />
+    <li className={classNames(className, 'action-items__divider-horizontal position-relative rounded-sm d-flex')} />
 )

--- a/client/web/src/extensions/components/StatusBar.scss
+++ b/client/web/src/extensions/components/StatusBar.scss
@@ -21,6 +21,10 @@
             background-color: var(--link-hover-bg-color);
         }
 
+        .theme-redesign & {
+            color: var(--icon-color);
+        }
+
         &--disabled {
             visibility: hidden;
             width: 0;

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames'
 import * as H from 'history'
+import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import MenuLeftIcon from 'mdi-react/MenuLeftIcon'
 import MenuRightIcon from 'mdi-react/MenuRightIcon'
 import React, { useCallback, useMemo, useState } from 'react'
@@ -13,6 +15,7 @@ import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/feature
 import { ButtonLink } from '@sourcegraph/shared/src/components/LinkOrButton'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { useCarousel } from '../../components/useCarousel'
@@ -28,6 +31,8 @@ interface StatusBarProps extends ExtensionsControllerProps<'extHostAPI' | 'execu
     uri?: string
 
     location: H.Location
+
+    statusBarRef?: React.Ref<HTMLDivElement>
 }
 
 export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
@@ -36,6 +41,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
     extensionsController,
     uri,
     location,
+    statusBarRef,
 }) => {
     const statusBarItems = useObservable(useMemo(() => getStatusBarItems(), [getStatusBarItems]))
 
@@ -69,6 +75,11 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
         onPositiveClicked,
     } = useCarousel({ direction: 'leftToRight' })
 
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    const LeftIcon = isRedesignEnabled ? ChevronLeftIcon : MenuLeftIcon
+    const RightIcon = isRedesignEnabled ? ChevronRightIcon : MenuRightIcon
+
     return (
         <div
             className={classNames(
@@ -76,6 +87,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                 'percy-hide', // TODO: Fix flaky status bar in Percy tests: https://github.com/sourcegraph/sourcegraph/issues/20751
                 className
             )}
+            ref={statusBarRef}
         >
             <ErrorBoundary
                 location={location}
@@ -93,7 +105,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                         className="btn btn-link status-bar__scroll border-0"
                         onClick={onNegativeClicked}
                     >
-                        <MenuLeftIcon className="icon-inline" />
+                        <LeftIcon className="icon-inline" />
                     </button>
                 )}
                 <div className="status-bar__items d-flex px-2" ref={carouselReference}>
@@ -124,7 +136,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                         className="btn btn-link status-bar__scroll border-0"
                         onClick={onPositiveClicked}
                     >
-                        <MenuRightIcon className="icon-inline" />
+                        <RightIcon className="icon-inline" />
                     </button>
                 )}
             </ErrorBoundary>

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -399,7 +399,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
     }
 
     return (
-        <div className="repo-container test-repo-container w-100 d-flex flex-column">
+        <div className="repo-container test-repo-container w-100 d-flex flex-column action-items">
             {!isErrorLike(props.settingsCascade.final) &&
                 props.settingsCascade.final?.experimentalFeatures?.fuzzyFinder &&
                 resolvedRevisionOrError &&

--- a/client/web/src/repo/RepoHeader.scss
+++ b/client/web/src/repo/RepoHeader.scss
@@ -9,6 +9,10 @@
     border-style: solid;
     border-width: 0 0 1px;
 
+    .theme-redesign & {
+        border: none;
+    }
+
     &--alert {
         border-width: 1px 0;
     }

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -48,5 +48,11 @@
         min-width: 0;
 
         background-color: var(--body-bg);
+
+        .theme-redesign & {
+            border: 1px solid var(--border-color);
+            border-top-left-radius: 0.1875rem;
+            border-top-right-radius: 0.1875rem;
+        }
     }
 }

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -49,7 +49,10 @@
 
         background-color: var(--body-bg);
 
-        .theme-redesign & {
+        // Add border to repo revision container content
+        // but enable variable margin-bottom (by setting it on child div)
+        // without having to repeat border styles.
+        .theme-redesign & > div:first-of-type {
             border: 1px solid var(--border-color);
             border-top-left-radius: 0.1875rem;
             border-top-right-radius: 0.1875rem;

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -60,7 +60,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
             handlePosition="right"
             storageKey={SIZE_STORAGE_KEY}
             element={
-                <div className={classnames('d-flex w-100 border-right', !isRedesignEnabled && 'bg-2')}>
+                <div className={classnames('d-flex w-100', !isRedesignEnabled && 'bg-2 border-right')}>
                     <Tabs
                         className="w-100 test-repo-revision-sidebar"
                         defaultIndex={tabIndex}

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -16,6 +16,17 @@
 
         table {
             border-collapse: collapse;
+
+            .theme-redesign & {
+                // Give room to view the last few lines of code
+                // without the floating status bar getting in the way.
+                &::after {
+                    content: '';
+                    display: inline-block;
+                    padding-bottom: calc(var(--blob-status-bar-height) + var(--blob-status-bar-bottom) + 0.5rem);
+                    // Extra 0.5rem padding on top of the minimum required to expose code;
+                }
+            }
         }
 
         td.line {
@@ -64,6 +75,51 @@
             td.code {
                 white-space: pre-wrap;
             }
+        }
+    }
+}
+
+// Styles for floating + scrollable status bar
+.blob-status-bar {
+    // Add this class to the parent container of <Blob> and <StatusBar>.
+    // Why not add this to <Blob>? Absolutely-positioned elements
+    // in a scrolling overflow container move with the content on scroll.
+    // See: https://www.bennadel.com/blog/3409-using-position-absolute-inside-a-scrolling-overflow-container.htm
+    // Unfortunately, <StatusBar> can overlap with <Blob>'s scrollbar, so calculate <StatusBar>'s
+    // `right` and `maxWidth` at runtime.
+    &__container {
+        .theme-redesign & {
+            position: relative;
+
+            --blob-status-bar-height: 2rem;
+            // Used to calculate status bar `bottom` along with scrollbar width.
+            --blob-status-bar-vertical-gap: 1rem;
+            // Used to calculate status bar `right` along with scrollbar width.
+            --blob-status-bar-horizontal-gap: 0.5rem;
+        }
+    }
+
+    // Add this class to <StatusBar>
+    &__body {
+        position: static;
+
+        .theme-redesign & {
+            // Make the status bar "float" slightly above the bottom of the code view.
+            position: absolute;
+            bottom: var(--blob-status-bar-vertical-gap);
+
+            // Override default bootstrap `.w-100`, ensure that the status bar "sticks" to the right side.
+            width: auto !important;
+            // Default `right`, should be added with scrollbar width at runtime.
+            right: var(--blob-status-bar-horizontal-gap);
+            // `maxWidth` will also be subtracted by scrollbar width at runtime
+            max-width: calc(100% - (2 * var(--blob-status-bar-horizontal-gap)));
+
+            // Misc. style
+            height: var(--blob-status-bar-height);
+            border-radius: var(--border-radius);
+            border: 1px solid var(--border-color);
+            background-color: var(--body-bg);
         }
     }
 }

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -7,6 +7,10 @@
     tab-size: 4;
     display: flex;
 
+    .theme-redesign & {
+        background-color: var(--code-bg);
+    }
+
     &__code {
         flex: 1;
 

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -182,7 +182,9 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                         defaultBranch={defaultBranch || 'HEAD'}
                     />
                     {!hideRepoRevisionContent && (
-                        <div className="repo-revision-container__content">
+                        // Add `.blob-status-bar__container` because this is the
+                        // lowest common ancestor of Blob and the absolutely-positioned Blob status bar
+                        <div className="repo-revision-container__content blob-status-bar__container">
                             <ErrorBoundary location={context.location}>
                                 {objectType === 'blob' ? (
                                     <BlobPage

--- a/client/web/src/repo/tree/TreePage.scss
+++ b/client/web/src/repo/tree/TreePage.scss
@@ -7,6 +7,11 @@
     padding: 1rem 2rem;
     flex: 1;
 
+    .theme-redesign & {
+        background-color: var(--code-bg);
+        margin-bottom: 2rem;
+    }
+
     &__title {
         display: flex;
         align-items: center;


### PR DESCRIPTION
Closes #20853, closes #20854.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/37420160/118370973-3c75fb00-b578-11eb-960d-231e77b2b755.png" />
</details>

<details open>
<summary>After</summary>
<h3>Blob</h3>
<img src="https://user-images.githubusercontent.com/37420160/119721615-53023900-be39-11eb-98ba-0b1d0878fae5.png" />
<h3>Tree</h3>
<img src="https://user-images.githubusercontent.com/37420160/119721662-5e556480-be39-11eb-8fa6-c781db3e7da9.png" />
</details>

#### Changes

- Use new `code-bg` color for `<Blob>` and `<TreePage>`
- Remove borders from `<RepoHeader>`, `<ActionItemsBar>`, and `<RepoRevisionSidebar>`
- Add border to `<RepoRevisionContainer>` content to achieve rounded top-left and top-right corners
- Add spacer `<div>` for collapsed action items bar state
- Update action items bar colors
- Make status bar float at the bottom right of code view (implemented in #21299)