### PR TITLE
batches: make the published field optional

### DIFF
--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -179,6 +179,9 @@ func DeterminePlan(previousSpec, currentSpec *btypes.ChangesetSpec, ch *btypes.C
 			pl.SetOp(btypes.ReconcilerOperationPublishDraft)
 			pl.AddOp(btypes.ReconcilerOperationPush)
 		}
+		// TODO: test for Published.Nil() and then plan based on the UI
+		// publication state. For now, we'll let it fall through and treat it
+		// the same as being unpublished.
 
 	case btypes.ChangesetPublicationStatePublished:
 		// Don't take any actions for merged changesets.

--- a/lib/batches/published_test.go
+++ b/lib/batches/published_test.go
@@ -14,11 +14,13 @@ func TestPublishedValue(t *testing.T) {
 		True    bool
 		False   bool
 		Draft   bool
+		Nil     bool
 		Invalid bool
 	}{
 		{name: "True", val: true, True: true},
 		{name: "False", val: false, False: true},
 		{name: "Draft", val: "draft", Draft: true},
+		{name: "Nil", val: nil, Nil: true},
 		{name: "Invalid", val: "invalid", Invalid: true},
 	}
 	for _, tc := range tests {
@@ -32,6 +34,9 @@ func TestPublishedValue(t *testing.T) {
 			}
 			if have, want := p.Draft(), tc.Draft; have != want {
 				t.Fatalf("invalid `draft` value: want=%t have=%t", want, have)
+			}
+			if have, want := p.Nil(), tc.Nil; have != want {
+				t.Fatalf("invalid `nil` value: want=%t have=%t", want, have)
 			}
 			if have, want := p.Valid(), !tc.Invalid; have != want {
 				t.Fatalf("invalid `valid` value: want=%t have=%t", want, have)
@@ -47,6 +52,7 @@ func TestPublishedValue(t *testing.T) {
 			{name: "true", val: true, expected: "true"},
 			{name: "false", val: false, expected: "false"},
 			{name: "draft", val: "draft", expected: `"draft"`},
+			{name: "nil", val: nil, expected: "null"},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -70,6 +76,7 @@ func TestPublishedValue(t *testing.T) {
 			{name: "true", val: "true", expected: true},
 			{name: "false", val: "false", expected: false},
 			{name: "draft", val: `"draft"`, expected: "draft"},
+			{name: "nil", val: "null", expected: nil},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -95,6 +102,7 @@ func TestPublishedValue(t *testing.T) {
 			{name: "false", val: "no", expected: false},
 			{name: "draft", val: "draft", expected: "draft"},
 			{name: "draft", val: `"draft"`, expected: "draft"},
+			{name: "nil", val: "null", expected: nil},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -69,12 +69,21 @@
           "rootAtLocationOf": {
             "type": "string",
             "description": "The name of the file that sits at the root of the desired workspace.",
-            "examples": ["package.json", "go.mod", "Gemfile", "Cargo.toml", "README.md"]
+            "examples": [
+              "package.json",
+              "go.mod",
+              "Gemfile",
+              "Cargo.toml",
+              "README.md"
+            ]
           },
           "in": {
             "type": "string",
             "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
-            "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
+            "examples": [
+              "github.com/sourcegraph/src-cli",
+              "github.com/sourcegraph/*"
+            ]
           },
           "onlyFetchWorkspace": {
             "type": "boolean",
@@ -113,7 +122,11 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
+                  "examples": [
+                    "hello world",
+                    "${{ step.stdout }}",
+                    "${{ repository.name }}"
+                  ]
                 },
                 "format": {
                   "type": "string",
@@ -240,7 +253,7 @@
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",
       "additionalProperties": false,
-      "required": ["title", "branch", "commit", "published"],
+      "required": ["title", "branch", "commit"],
       "properties": {
         "title": {
           "type": "string",
@@ -286,7 +299,7 @@
           }
         },
         "published": {
-          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
+          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host. If omitted, the publication state is controlled from the Batch Changes UI.",
           "oneOf": [
             {
               "oneOf": [

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -69,21 +69,12 @@
           "rootAtLocationOf": {
             "type": "string",
             "description": "The name of the file that sits at the root of the desired workspace.",
-            "examples": [
-              "package.json",
-              "go.mod",
-              "Gemfile",
-              "Cargo.toml",
-              "README.md"
-            ]
+            "examples": ["package.json", "go.mod", "Gemfile", "Cargo.toml", "README.md"]
           },
           "in": {
             "type": "string",
             "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
-            "examples": [
-              "github.com/sourcegraph/src-cli",
-              "github.com/sourcegraph/*"
-            ]
+            "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
           },
           "onlyFetchWorkspace": {
             "type": "boolean",
@@ -122,11 +113,7 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": [
-                    "hello world",
-                    "${{ step.stdout }}",
-                    "${{ repository.name }}"
-                  ]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -88,17 +88,7 @@
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
         }
       },
-      "required": [
-        "baseRepository",
-        "baseRef",
-        "baseRev",
-        "headRepository",
-        "headRef",
-        "title",
-        "body",
-        "commits",
-        "published"
-      ],
+      "required": ["baseRepository", "baseRef", "baseRev", "headRepository", "headRef", "title", "body", "commits"],
       "additionalProperties": false
     }
   ]

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -84,7 +84,7 @@
           }
         },
         "published": {
-          "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
+          "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }, { "type": "null" }],
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
         }
       },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -368,8 +368,8 @@ type ChangesetTemplate struct {
 	Branch string `json:"branch"`
 	// Commit description: The Git commit to create with the changes.
 	Commit ExpandedGitCommitDescription `json:"commit"`
-	// Published description: Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.
-	Published interface{} `json:"published"`
+	// Published description: Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host. If omitted, the publication state is controlled from the Batch Changes UI.
+	Published interface{} `json:"published,omitempty"`
 	// Title description: The title of the changeset.
 	Title string `json:"title"`
 }


### PR DESCRIPTION
For now, we'll just treat a missing field as being equivalent to being unpublished, so there's no functional difference in practice for users.

This is very much a table setting PR; #21092 is next.

Part two of #18277.