### PR TITLE
web: add redesign card styles

### DIFF
--- a/client/branded/src/global-styles/GlobalStylesStory/CardsStory.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/CardsStory.tsx
@@ -1,0 +1,42 @@
+import { StoryFn } from '@storybook/addons'
+import React, { ReactElement } from 'react'
+
+export const CardsStory: StoryFn<ReactElement> = () => (
+    <>
+        <h1>Cards</h1>
+        <p>
+            A card is a flexible and extensible content container. It includes options for headers and footers, a wide
+            variety of content, contextual background colors, and powerful display options.{' '}
+            <a href="https://getbootstrap.com/docs/4.5/components/card/">Bootstrap documentation</a>
+        </p>
+
+        <h2>Examples</h2>
+
+        <div className="card mb-3">
+            <div className="card-body">This is some text within a card body.</div>
+        </div>
+
+        <div className="card mb-3" style={{ maxWidth: '18rem' }}>
+            <div className="card-body">
+                <h3 className="card-title">Card title</h3>
+                <p className="card-text">
+                    Some quick example text to build on the card title and make up the bulk of the card's content.
+                </p>
+                <button type="button" className="btn btn-primary">
+                    Do something
+                </button>
+            </div>
+        </div>
+
+        <div className="card">
+            <div className="card-header">Featured</div>
+            <div className="card-body">
+                <h3 className="card-title">Special title treatment</h3>
+                <p className="card-text">With supporting text below as a natural lead-in to additional content.</p>
+                <a href="https://example.com" target="_blank" rel="noopener noreferrer" className="btn btn-primary">
+                    Go somewhere
+                </a>
+            </div>
+        </div>
+    </>
+)

--- a/client/branded/src/global-styles/GlobalStylesStory/CardsStory.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/CardsStory.tsx
@@ -16,6 +16,7 @@ export const CardsStory: StoryFn<ReactElement> = () => (
             <div className="card-body">This is some text within a card body.</div>
         </div>
 
+        {/* eslint-disable-next-line react/forbid-dom-props */}
         <div className="card mb-3" style={{ maxWidth: '18rem' }}>
             <div className="card-body">
                 <h3 className="card-title">Card title</h3>

--- a/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -22,6 +22,7 @@ import { Form } from '../../components/Form'
 import { AlertsStory } from './AlertsStory'
 import { BadgeVariants } from './BadgeVariants/BadgeVariants'
 import { ButtonVariants } from './ButtonVariants'
+import { CardsStory } from './CardsStory'
 import { ColorVariants } from './ColorVariants'
 import { SEMANTIC_COLORS } from './constants'
 import { FormFieldVariants } from './FormFieldVariants'
@@ -795,54 +796,21 @@ add(
     }
 )
 
-add(
-    'Cards',
-    () => (
-        <>
-            <h1>Cards</h1>
-            <p>
-                A card is a flexible and extensible content container. It includes options for headers and footers, a
-                wide variety of content, contextual background colors, and powerful display options.{' '}
-                <a href="https://getbootstrap.com/docs/4.5/components/card/">Bootstrap documentation</a>
-            </p>
-
-            <h2>Examples</h2>
-
-            <div className="card mb-3">
-                <div className="card-body">This is some text within a card body.</div>
-            </div>
-
-            <div className="card mb-3" style={{ maxWidth: '18rem' }}>
-                <div className="card-body">
-                    <h3 className="card-title">Card title</h3>
-                    <p className="card-text">
-                        Some quick example text to build on the card title and make up the bulk of the card's content.
-                    </p>
-                    <button type="button" className="btn btn-primary">
-                        Do something
-                    </button>
-                </div>
-            </div>
-
-            <div className="card">
-                <div className="card-header">Featured</div>
-                <div className="card-body">
-                    <h3 className="card-title">Special title treatment</h3>
-                    <p className="card-text">With supporting text below as a natural lead-in to additional content.</p>
-                    <a href="https://example.com" target="_blank" rel="noopener noreferrer" className="btn btn-primary">
-                        Go somewhere
-                    </a>
-                </div>
-            </div>
-        </>
-    ),
-    {
-        design: {
+add('Cards', CardsStory, {
+    design: [
+        {
+            name: 'Figma',
             type: 'figma',
             url: 'https://www.figma.com/file/BkY8Ak997QauG0Iu2EqArv/Sourcegraph-Components?node-id=109%3A2',
         },
-    }
-)
+        {
+            name: 'Figma Redesign',
+            type: 'figma',
+            url:
+                'https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=1172%3A285',
+        },
+    ],
+})
 
 add('List groups', () => (
     <>

--- a/client/branded/src/global-styles/card.scss
+++ b/client/branded/src/global-styles/card.scss
@@ -5,3 +5,8 @@ $card-border-color: var(--border-color);
 $card-cap-bg: var(--color-bg-2);
 
 @import 'bootstrap/scss/card';
+
+.theme-redesign .card {
+    background: var(--color-bg-1);
+    border-color: var(--border-color-2);
+}

--- a/client/branded/src/global-styles/card.scss
+++ b/client/branded/src/global-styles/card.scss
@@ -1,12 +1,17 @@
+.card {
+    --card-bg: var(--body-bg);
+    --card-border-color: var(--border-color);
+}
+
+.theme-redesign .card {
+    --card-bg: var(--color-bg-1);
+    --card-border-color: var(--border-color-2);
+}
+
 $card-spacer-y: 0.5rem;
 $card-spacer-x: 0.5rem;
-$card-bg: var(--body-bg);
-$card-border-color: var(--border-color);
+$card-bg: var(--card-bg);
+$card-border-color: var(--card-border-color);
 $card-cap-bg: var(--color-bg-2);
 
 @import 'bootstrap/scss/card';
-
-.theme-redesign .card {
-    background: var(--color-bg-1);
-    border-color: var(--border-color-2);
-}

--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -36,8 +36,7 @@ const getCSSLoaders = (...loaders: RuleSetUseItem[]): RuleSetUse => [
 ]
 
 const config = {
-    // stories: [...storiesGlobs, chromaticStoriesGlob],
-    stories: [path.resolve(rootPath, 'client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx')],
+    stories: [...storiesGlobs, chromaticStoriesGlob],
     addons: [
         '@storybook/addon-knobs',
         '@storybook/addon-actions',

--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -36,7 +36,8 @@ const getCSSLoaders = (...loaders: RuleSetUseItem[]): RuleSetUse => [
 ]
 
 const config = {
-    stories: [...storiesGlobs, chromaticStoriesGlob],
+    // stories: [...storiesGlobs, chromaticStoriesGlob],
+    stories: [path.resolve(rootPath, 'client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx')],
     addons: [
         '@storybook/addon-knobs',
         '@storybook/addon-actions',

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringNode.scss
@@ -30,4 +30,16 @@
         // stylelint-disable-next-line declaration-property-unit-whitelist
         margin-bottom: -2px;
     }
+
+    .theme-redesign & {
+        color: var(--body-color);
+
+        &:focus-visible {
+            border-color: transparent;
+        }
+
+        &:hover {
+            border-color: var(--border-active-color);
+        }
+    }
 }


### PR DESCRIPTION
## Changes

- Updated global `.card` styles to match [Figma mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=1172%3A285).
- Updated code monitoring cards to match [Figma mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=1172%3A285).
- Extracted cards story into a separate file.

It might be useful to extract a code-monitoring card as a reusable component, but it's not clear if we need it. See [this thread](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw?node-id=1172:285#81038706) in Figma. If we decide to do so it can be done in a separate PR.