### PR TITLE
Pass -q flag to netcat to quit post EOF on stdin

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -321,7 +321,7 @@ checks:
     failMessage: "Failed to run 'docker -v'. Please make sure Docker is running."
 
   redis:
-    cmd: echo "PING" | nc localhost 6379
+    cmd: echo "PING" | nc -q0 localhost 6379
     failMessage: "Failed to connect to Redis on port 6379. Please make sure Redis is running."
 
   postgres:

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -321,7 +321,7 @@ checks:
     failMessage: "Failed to run 'docker -v'. Please make sure Docker is running."
 
   redis:
-    cmd: echo "PING" | nc -q0 localhost 6379
+    cmd: redis-cli ping
     failMessage: "Failed to connect to Redis on port 6379. Please make sure Redis is running."
 
   postgres:


### PR DESCRIPTION
The `sg doctor` health check pings Redis to see if it is up and running using netcat.  On Ubuntu 20.04.2 LTS I was finding that netcat would just hang upon executing the health check of `echo "PING" | nc localhost 6379`.

This small change passes in the `-q0` flag so that it shuts once the response has been written as per the man [page](https://www.commandlinux.com/man-page/man1/nc.1.html): `after EOF on stdin, wait the specified number of seconds and then quit. If seconds is negative, wait forever.`

