### PR TITLE
codeintel: Give remote and tag information to index jobs

### DIFF
--- a/enterprise/cmd/executor/internal/command/observability.go
+++ b/enterprise/cmd/executor/internal/command/observability.go
@@ -43,7 +43,7 @@ func NewOperations(observationContext *observation.Context) *Operations {
 		SetupGitInit:              op("setup.git.init"),
 		SetupGitFetch:             op("setup.git.fetch"),
 		SetupGitFetchTags:         op("setup.git.fetch-tags"),
-		SetupGitAddRemote:         op("setup.git.add-add"),
+		SetupGitAddRemote:         op("setup.git.add-remote"),
 		SetupGitCheckout:          op("setup.git.checkout"),
 		SetupDockerPull:           op("setup.docker.pull"),
 		SetupDockerSave:           op("setup.docker.save"),

--- a/enterprise/cmd/executor/internal/command/observability.go
+++ b/enterprise/cmd/executor/internal/command/observability.go
@@ -10,6 +10,8 @@ import (
 type Operations struct {
 	SetupGitInit              *observation.Operation
 	SetupGitFetch             *observation.Operation
+	SetupGitFetchTags         *observation.Operation
+	SetupGitAddRemote         *observation.Operation
 	SetupGitCheckout          *observation.Operation
 	SetupDockerPull           *observation.Operation
 	SetupDockerSave           *observation.Operation
@@ -40,6 +42,8 @@ func NewOperations(observationContext *observation.Context) *Operations {
 	return &Operations{
 		SetupGitInit:              op("setup.git.init"),
 		SetupGitFetch:             op("setup.git.fetch"),
+		SetupGitFetchTags:         op("setup.git.fetch-tags"),
+		SetupGitAddRemote:         op("setup.git.add-add"),
 		SetupGitCheckout:          op("setup.git.checkout"),
 		SetupDockerPull:           op("setup.docker.pull"),
 		SetupDockerSave:           op("setup.docker.save"),

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -44,7 +44,7 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
 			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit}, Operation: h.operations.SetupGitFetch},
 			{Key: "setup.git.fetch-tags", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), "-t"}, Operation: h.operations.SetupGitFetchTags},
-			{Key: "setup.git.remote-add", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupGitAddRemote},
+			{Key: "setup.git.add-remote", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupGitAddRemote},
 			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
 		}
 		for _, spec := range gitCommands {

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -43,6 +43,8 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 		gitCommands := []command.CommandSpec{
 			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
 			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit}, Operation: h.operations.SetupGitFetch},
+			{Key: "setup.git.fetch-tags", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", "-t"}, Operation: h.operations.SetupGitFetchTags},
+			{Key: "setup.git.remote-add", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupGitAddRemote},
 			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
 		}
 		for _, spec := range gitCommands {

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -43,7 +43,7 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 		gitCommands := []command.CommandSpec{
 			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
 			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit}, Operation: h.operations.SetupGitFetch},
-			{Key: "setup.git.fetch-tags", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", "-t"}, Operation: h.operations.SetupGitFetchTags},
+			{Key: "setup.git.fetch-tags", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), "-t"}, Operation: h.operations.SetupGitFetchTags},
 			{Key: "setup.git.remote-add", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupGitAddRemote},
 			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
 		}


### PR DESCRIPTION
Currently lsif-go auto index jobs are failing as it uses the git remote and tags to determine package information. These are currently blank as we don't set a remote on the clone, or supply an explicit one in the index job generation.

This fetches tags and sets a remote, which are likely to be needed for other tools (and seems like a more general solution than explicitly supplying this data directly to lsif-go).