### PR TITLE
search frontend: fix query predicate paren highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Pull request event webhooks received from GitHub with unexpected actions no longer cause panics. [#20571](https://github.com/sourcegraph/sourcegraph/pull/20571)
 - Repository search patterns like `^repo/(prefix-suffix|prefix)$` now correctly match both `repo/prefix-suffix` and `repo/prefix`. [#20389](https://github.com/sourcegraph/sourcegraph/issues/20389)
 - Ephemeral storage requests and limits now match the default cache size to avoid Symbols pods being evicted. The symbols pod now requires 10GB of ephemeral space as a minimum to scheduled. [#2369](https://github.com/sourcegraph/deploy-sourcegraph/pull/2369)
+- Minor query syntax highlighting bug for `repo:contains` predicate. [#21038](https://github.com/sourcegraph/sourcegraph/pull/21038)
 
 ### Removed
 

--- a/client/shared/src/search/query/predicates.ts
+++ b/client/shared/src/search/query/predicates.ts
@@ -51,6 +51,12 @@ export const resolveAccess = (path: string[], tree: Access[]): Access[] | undefi
     return resolveAccess(path.slice(1), subtree.fields)
 }
 
+// scans a string up to closing parentheses. Examples:
+// - `foo` succeeds, parentheses are absent, so it is vacuously balanced
+// - `foo(...)` succeeds up to the closing `)`
+// - `foo(...))` succeeds up to the first `)`, which is recognized as the closing paren
+// - `foo(` does not succeed, it is not balanced
+// - `foo)` does not succeed, it is not balanced
 export const scanBalancedParens = (input: string): string | undefined => {
     let adjustedStart = 0
     let balanced = 0
@@ -70,6 +76,10 @@ export const scanBalancedParens = (input: string): string | undefined => {
         } else if (current === ')') {
             balanced -= 1
             result.push(current)
+            if (balanced === 0) {
+                // we've reached a closing parenthesis where the string is balanced
+                break
+            }
         } else if (current === '\\') {
             if (input[adjustedStart] !== undefined) {
                 nextChar() // consume escaped

--- a/client/shared/src/search/query/scanner.test.ts
+++ b/client/shared/src/search/query/scanner.test.ts
@@ -211,4 +211,10 @@ describe('scanSearchQuery() with predicate', () => {
             '{"type":"success","term":[{"type":"filter","range":{"start":0,"end":29},"field":{"type":"literal","value":"repo","range":{"start":0,"end":4}},"value":{"type":"literal","value":"contains(file:README.md)","range":{"start":5,"end":29},"quoted":false},"negated":false},{"type":"whitespace","range":{"start":29,"end":31}},{"type":"filter","range":{"start":31,"end":54},"field":{"type":"literal","value":"repo","range":{"start":31,"end":35}},"value":{"type":"literal","value":"contains.file(foo)","range":{"start":36,"end":54},"quoted":false},"negated":false}]}'
         )
     })
+
+    test('recognize parenthesized predicate', () => {
+        expect(scanSearchQuery('(repo:contains(file:bar))')).toMatchInlineSnapshot(
+            '{"type":"success","term":[{"type":"openingParen","range":{"start":0,"end":1}},{"type":"filter","range":{"start":1,"end":24},"field":{"type":"literal","value":"repo","range":{"start":1,"end":5}},"value":{"type":"literal","value":"contains(file:bar)","range":{"start":6,"end":24},"quoted":false},"negated":false},{"type":"closingParen","range":{"start":24,"end":25}}]}'
+        )
+    })
 })


### PR DESCRIPTION
Before:

<img width="234" alt="" src="https://user-images.githubusercontent.com/888624/115366390-27c16580-a17a-11eb-880c-9aef12a64ea3.png">

Now:

<img width="234" alt="Screen Shot 2021-05-17 at 5 44 46 PM" src="https://user-images.githubusercontent.com/888624/118573620-c6b88d80-b737-11eb-9b96-e3cbacff67e3.png">

Fixes https://github.com/sourcegraph/sourcegraph/issues/20196