### PR TITLE
Fix issue with file filters causing invalid diff results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Repository search patterns like `^repo/(prefix-suffix|prefix)$` now correctly match both `repo/prefix-suffix` and `repo/prefix`. [#20389](https://github.com/sourcegraph/sourcegraph/issues/20389)
 - Ephemeral storage requests and limits now match the default cache size to avoid Symbols pods being evicted. The symbols pod now requires 10GB of ephemeral space as a minimum to scheduled. [#2369](https://github.com/sourcegraph/deploy-sourcegraph/pull/2369)
 - Minor query syntax highlighting bug for `repo:contains` predicate. [#21038](https://github.com/sourcegraph/sourcegraph/pull/21038)
+- An issue causing diff and commit results with file filters to return invalid results. [#21039](https://github.com/sourcegraph/sourcegraph/pull/21039)
 
 ### Removed
 

--- a/dev/gqltest/search_test.go
+++ b/dev/gqltest/search_test.go
@@ -1113,6 +1113,12 @@ func testSearchClient(t *testing.T, client searchClient) {
 				counts: counts{Commit: 1},
 			},
 			{
+				// https://github.com/sourcegraph/sourcegraph/issues/21031
+				name:   `search diffs with file filter and time filters`,
+				query:  `repo:go-diff patterntype:literal type:diff lang:go before:"May 10 2020" after:"May 5 2020" unquotedOrigName`,
+				counts: counts{Commit: 1},
+			},
+			{
 				name:   `select diffs with added lines containing pattern`,
 				query:  `repo:go-diff patterntype:literal type:diff select:commit.diff.added sample_binary_inline`,
 				counts: counts{Commit: 1},

--- a/internal/vcs/git/diff_search.go
+++ b/internal/vcs/git/diff_search.go
@@ -372,7 +372,6 @@ func rawShowSearch(ctx context.Context, repo api.RepoName, opt RawLogDiffSearchO
 	if hasPathFilters {
 		showArgs = append(showArgs, "--patch")
 	}
-	showArgs = append(showArgs, logDiffCommonArgs(opt)...)
 	if !isAllowedGitCmd(showArgs) {
 		return nil, false, fmt.Errorf("command failed: %q is not a allowed git command", showArgs)
 	}


### PR DESCRIPTION
This commit fixes an issue where adding a `lang:` filter to a diff
search would cause non-matching commits to show up in the results.

This was ultimately caused by the `--max-count` flag on `git show`,
which, very unintuitively, ends up causing `git show` to ignore the
passed-in commit hashes and just list up to the number of commits
specified to `--max-count`. Additionally, I could not find any
references to using `--max-count` with `git show`, so my guess is it's
just not a supported argument for `git show`.

Really, though, we just don't need to be appending the `logDiffCommonArgs` to
the `git show` command at all, since we are just getting more
information for a specific set of commits. So, this commit removes those
args entirely.

Fixes #21031 
Fixes sourcegraph/customer#355

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
