### PR TITLE
Refresh: Popover tweaks

### DIFF
--- a/client/branded/src/global-styles/border-radius.scss
+++ b/client/branded/src/global-styles/border-radius.scss
@@ -2,10 +2,12 @@
     --border-radius: 2px;
     --border-radius-sm: 1px;
     --border-radius-lg: 4px;
+    --popover-border-radius: 4px;
 }
 
 .theme-redesign {
     --border-radius: 3px;
     --border-radius-sm: 3px;
     --border-radius-lg: 3px;
+    --popover-border-radius: 5px;
 }

--- a/client/branded/src/global-styles/border-radius.scss
+++ b/client/branded/src/global-styles/border-radius.scss
@@ -7,7 +7,9 @@
 
 .theme-redesign {
     --border-radius: 3px;
+    --popover-border-radius: 5px;
+
+    // TODO: Remove usage of these, replace with --border-radius: https://github.com/sourcegraph/sourcegraph/issues/21106
     --border-radius-sm: 3px;
     --border-radius-lg: 3px;
-    --popover-border-radius: 5px;
 }

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -31,7 +31,7 @@
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
-    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
+    --dropdown-shadow: 0 4px 16px -6px rgba(36, 41, 54, 0.2);
     .dropdown-menu {
         border-radius: 5px;
         box-shadow: var(--dropdown-shadow);
@@ -43,7 +43,7 @@
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
-    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
+    --dropdown-shadow: 0 4px 16px -6px rgba(11, 12, 15, 0.8);
     .dropdown-menu {
         border-radius: 5px;
         box-shadow: var(--dropdown-shadow);

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -1,18 +1,11 @@
 @import 'bootstrap/scss/dropdown';
 
-.dropdown-divider {
-    margin: 0.25rem 0;
-}
-
 .theme-dark {
     --dropdown-bg: #0e121b;
     --dropdown-border-color: var(--border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
-    .dropdown-menu {
-        border-radius: 4px;
-        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
-    }
+    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
 }
 
 .theme-light {
@@ -20,10 +13,7 @@
     --dropdown-border-color: var(--border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
-    .dropdown-menu {
-        border-radius: 4px;
-        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
-    }
+    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
 }
 
 .theme-light.theme-redesign {
@@ -32,10 +22,6 @@
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
     --dropdown-shadow: 0 4px 16px -6px rgba(36, 41, 54, 0.2);
-    .dropdown-menu {
-        border-radius: 5px;
-        box-shadow: var(--dropdown-shadow);
-    }
 }
 
 .theme-dark.theme-redesign {
@@ -44,8 +30,13 @@
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
     --dropdown-shadow: 0 4px 16px -6px rgba(11, 12, 15, 0.8);
-    .dropdown-menu {
-        border-radius: 5px;
-        box-shadow: var(--dropdown-shadow);
-    }
+}
+
+.dropdown-divider {
+    margin: 0.25rem 0;
+}
+
+.dropdown-menu {
+    border-radius: var(--popover-border-radius);
+    box-shadow: var(--dropdown-shadow);
 }

--- a/client/branded/src/global-styles/dropdown.scss
+++ b/client/branded/src/global-styles/dropdown.scss
@@ -26,26 +26,26 @@
     }
 }
 
-.theme-light.theme-redesign,
-.theme-light .theme-redesign {
+.theme-light.theme-redesign {
     --dropdown-bg: var(--input-bg);
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
+    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
     .dropdown-menu {
-        border-radius: 4px;
-        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.085);
+        border-radius: 5px;
+        box-shadow: var(--dropdown-shadow);
     }
 }
 
-.theme-dark.theme-redesign,
-.theme-dark .theme-redesign {
+.theme-dark.theme-redesign {
     --dropdown-bg: var(--input-bg);
     --dropdown-border-color: var(--input-border-color);
     --dropdown-link-hover-bg: var(--color-bg-2);
     --dropdown-header-color: var(--text-muted);
+    --dropdown-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
     .dropdown-menu {
-        border-radius: 4px;
-        box-shadow: 0 0 12px 0 rgba(0, 27, 76, 0.4);
+        border-radius: 5px;
+        box-shadow: var(--dropdown-shadow);
     }
 }

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -160,6 +160,11 @@ $input-transition: none;
     background-color: var(--body-bg);
     border: solid 1px var(--border-color);
     border-radius: $border-radius;
+
+    .theme-redesign & {
+        background-color: var(--color-bg-1);
+        border-radius: 5px;
+    }
 }
 
 // Show a focus ring when performing keyboard navigation. Uses the polyfill at

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -163,7 +163,7 @@ $input-transition: none;
 
     .theme-redesign & {
         background-color: var(--color-bg-1);
-        border-radius: 5px;
+        border-radius: var(--popover-border-radius);
     }
 }
 

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -89,6 +89,8 @@
     &__input {
         .theme-redesign & {
             margin: 0.5rem;
+            padding-left: 0.5rem;
+            padding-right: 0.5rem;
         }
     }
 

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -13,7 +13,7 @@
         --popover-item-padding-h: 1rem;
         --popover-item-padding-v: 0.25rem;
         background-color: var(--color-bg-1);
-        box-shadow: var(--dropdown-box-shadow);
+        box-shadow: var(--dropdown-shadow);
     }
 
     &__content {

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -14,6 +14,7 @@
         --popover-item-padding-v: 0.25rem;
         background-color: var(--color-bg-1);
         border-radius: 5px;
+        box-shadow: var(--dropdown-box-shadow);
     }
 
     &__content {

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -13,7 +13,6 @@
         --popover-item-padding-h: 1rem;
         --popover-item-padding-v: 0.25rem;
         background-color: var(--color-bg-1);
-        border-radius: 5px;
         box-shadow: var(--dropdown-box-shadow);
     }
 

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -74,7 +74,7 @@ export const ConnectionNodesSummary = <C extends Connection<N>, N, NP = {}, HP =
         emptyElement || (
             <p className="filtered-connection__summary" data-testid="summary">
                 <small>
-                    No {pluralNoun}{' '}
+                    No {pluralNoun} found{' '}
                     {connectionQuery && (
                         <span>
                             matching <strong>{connectionQuery}</strong>

--- a/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodesSummary.tsx
@@ -74,7 +74,7 @@ export const ConnectionNodesSummary = <C extends Connection<N>, N, NP = {}, HP =
         emptyElement || (
             <p className="filtered-connection__summary" data-testid="summary">
                 <small>
-                    No {pluralNoun} found{' '}
+                    No {pluralNoun}{' '}
                     {connectionQuery && (
                         <span>
                             matching <strong>{connectionQuery}</strong>

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -71,6 +71,11 @@ $compact-summary-min-height: 2.75rem;
         }
     }
 
+    &__summary {
+        .theme-redesign & {
+            color: var(--text-muted);
+        }
+    }
     &--compact &__summary {
         flex: 0 0;
         padding: var(--popover-item-padding-v) var(--popover-item-padding-h);

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -247,11 +247,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                             fade={false}
                             popperClassName="border-0"
                         >
-                            <RepositoriesPopover
-                                currentRepo={repoOrError.id}
-                                history={props.history}
-                                location={props.location}
-                            />
+                            <RepositoriesPopover currentRepo={repoOrError.id} />
                         </UncontrolledPopover>
                     </>
                 ),

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -252,7 +252,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                     </>
                 ),
             }
-        }, [repoOrError, resolvedRevisionOrError, props.history, props.location])
+        }, [repoOrError, resolvedRevisionOrError])
     )
 
     // Update the workspace roots service to reflect the current repo / resolved revision

--- a/client/web/src/repo/RepoContainer.tsx
+++ b/client/web/src/repo/RepoContainer.tsx
@@ -244,6 +244,7 @@ export const RepoContainer: React.FunctionComponent<RepoContainerProps> = props 
                             target="repo-popover"
                             trigger="legacy"
                             hideArrow={true}
+                            fade={false}
                             popperClassName="border-0"
                         >
                             <RepositoriesPopover

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -132,6 +132,7 @@ const RepoRevisionContainerPopover: React.FunctionComponent<RepoRevisionContaine
             target="repo-revision-popover"
             trigger="legacy"
             hideArrow={true}
+            fade={false}
             popperClassName="border-0"
         >
             <RevisionsPopover

--- a/client/web/src/repo/RepositoriesPopover.tsx
+++ b/client/web/src/repo/RepositoriesPopover.tsx
@@ -9,11 +9,11 @@ import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
 import { gql } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { createAggregateError } from '@sourcegraph/shared/src/util/errors'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { queryGraphQL } from '../backend/graphql'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../components/FilteredConnection'
 import { eventLogger } from '../tracking/eventLogger'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 function fetchRepositories(args: { first?: number; query?: string }): Observable<GQL.IRepositoryConnection> {
     return queryGraphQL(

--- a/client/web/src/repo/RepositoriesPopover.tsx
+++ b/client/web/src/repo/RepositoriesPopover.tsx
@@ -1,6 +1,5 @@
-import * as H from 'history'
-import * as React from 'react'
-import { Link } from 'react-router-dom'
+import React, { useCallback, useEffect } from 'react'
+import { Link, useHistory, useLocation } from 'react-router-dom'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 
@@ -14,6 +13,7 @@ import { createAggregateError } from '@sourcegraph/shared/src/util/errors'
 import { queryGraphQL } from '../backend/graphql'
 import { FilteredConnection, FilteredConnectionQueryArguments } from '../components/FilteredConnection'
 import { eventLogger } from '../tracking/eventLogger'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 function fetchRepositories(args: { first?: number; query?: string }): Observable<GQL.IRepositoryConnection> {
     return queryGraphQL(
@@ -63,14 +63,11 @@ const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({ node, cu
     </li>
 )
 
-interface Props {
+interface RepositoriesPopoverProps {
     /**
      * The current repository (shown as selected in the list), if any.
      */
     currentRepo?: Scalars['ID']
-
-    history: H.History
-    location: H.Location
 }
 
 class FilteredRepositoryConnection extends FilteredConnection<GQL.IRepository> {}
@@ -78,38 +75,43 @@ class FilteredRepositoryConnection extends FilteredConnection<GQL.IRepository> {
 /**
  * A popover that displays a searchable list of repositories.
  */
-export class RepositoriesPopover extends React.PureComponent<Props> {
-    public componentDidMount(): void {
+export const RepositoriesPopover: React.FunctionComponent<RepositoriesPopoverProps> = ({ currentRepo }) => {
+    const location = useLocation()
+    const history = useHistory()
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    useEffect(() => {
         eventLogger.logViewEvent('RepositoriesPopover')
-    }
+    }, [])
 
-    public render(): JSX.Element | null {
-        const nodeProps: Pick<RepositoryNodeProps, 'currentRepo'> = { currentRepo: this.props.currentRepo }
+    const queryRepositories = useCallback(
+        (args: FilteredConnectionQueryArguments): Observable<GQL.IRepositoryConnection> =>
+            fetchRepositories({ ...args }),
+        []
+    )
 
-        return (
-            <div className="repositories-popover connection-popover">
-                <FilteredRepositoryConnection
-                    className="connection-popover__content"
-                    showMoreClassName="connection-popover__show-more"
-                    inputClassName="connection-popover__input"
-                    listClassName="connection-popover__nodes"
-                    compact={true}
-                    noun="repository"
-                    pluralNoun="repositories"
-                    queryConnection={this.queryRepositories}
-                    nodeComponent={RepositoryNode}
-                    nodeComponentProps={nodeProps}
-                    defaultFirst={10}
-                    autoFocus={true}
-                    history={this.props.history}
-                    location={this.props.location}
-                    noSummaryIfAllNodesVisible={true}
-                    useURLQuery={false}
-                />
-            </div>
-        )
-    }
+    const nodeProps: Pick<RepositoryNodeProps, 'currentRepo'> = { currentRepo }
 
-    private queryRepositories = (args: FilteredConnectionQueryArguments): Observable<GQL.IRepositoryConnection> =>
-        fetchRepositories({ ...args })
+    return (
+        <div className="repositories-popover connection-popover">
+            <FilteredRepositoryConnection
+                className="connection-popover__content"
+                showMoreClassName={isRedesignEnabled ? '' : 'connection-popover__show-more'}
+                inputClassName="connection-popover__input"
+                listClassName="connection-popover__nodes"
+                compact={true}
+                noun="repository"
+                pluralNoun="repositories"
+                queryConnection={queryRepositories}
+                nodeComponent={RepositoryNode}
+                nodeComponentProps={nodeProps}
+                defaultFirst={10}
+                autoFocus={true}
+                history={history}
+                location={location}
+                noSummaryIfAllNodesVisible={true}
+                useURLQuery={false}
+            />
+        </div>
+    )
 }

--- a/client/web/src/repo/RevisionsPopover.scss
+++ b/client/web/src/repo/RevisionsPopover.scss
@@ -12,6 +12,10 @@
             padding-right: 1rem;
             margin-top: 0.25rem;
         }
+
+        &-close {
+            color: var(--icon-color);
+        }
     }
 
     &-git-commit-node {

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -237,7 +237,7 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
         className: 'connection-popover__content',
         inputClassName: 'connection-popover__input',
         listClassName: 'connection-popover__nodes',
-        showMoreClassName: 'connection-popover__show-more',
+        showMoreClassName: isRedesignEnabled ? '' : 'connection-popover__show-more',
         inputPlaceholder: 'Find...',
         compact: true,
         autoFocus: true,

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -257,7 +257,12 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
                         </Tab>
                     ))}
                 </TabList>
-                <button onClick={props.togglePopover} type="button" className="btn btn-icon" aria-label="Close">
+                <button
+                    onClick={props.togglePopover}
+                    type="button"
+                    className="btn btn-icon revisions-popover__tabs-close"
+                    aria-label="Close"
+                >
                     <CloseIcon className="icon-inline" />
                 </button>
             </div>

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -151,20 +151,24 @@ const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({ node, curr
         <li key={node.oid} className="connection-popover__node revisions-popover-git-commit-node">
             <Link
                 to={replaceRevisionInURL(location.pathname + location.search + location.hash, node.oid)}
-                className={`connection-popover__node-link ${
-                    isCurrent ? 'connection-popover__node-link--active' : ''
-                } revisions-popover-git-commit-node__link`}
-            >
-                <code className="revisions-popover-git-commit-node__oid" title={node.oid}>
-                    {node.abbreviatedOID}
-                </code>
-                <small className="revisions-popover-git-commit-node__message">{node.subject.slice(0, 200)}</small>
-                {isCurrent && (
-                    <CircleChevronLeftIcon
-                        className="icon-inline connection-popover__node-link-icon"
-                        data-tooltip="Current commit"
-                    />
+                className={classNames(
+                    'connection-popover__node-link',
+                    isCurrent && 'connection-popover__node-link--active',
+                    'revisions-popover-git-commit-node__link'
                 )}
+            >
+                <span>
+                    <code className="revisions-popover-git-commit-node__oid" title={node.oid}>
+                        {node.abbreviatedOID}
+                    </code>
+                    <small className="revisions-popover-git-commit-node__message">{node.subject.slice(0, 200)}</small>
+                    {isCurrent && (
+                        <CircleChevronLeftIcon
+                            className="icon-inline connection-popover__node-link-icon"
+                            data-tooltip="Current commit"
+                        />
+                    )}
+                </span>
             </Link>
         </li>
     )


### PR DESCRIPTION
Addressing feedback from https://github.com/sourcegraph/sourcegraph/issues/19927#issuecomment-843174212

Changes:
- Updates global dropdown-menu and popover styles to use updated refresh `box-shadow` and `border-radius` values
- Fixes inner input padding to align with branch/tag/commit node to match designs
- Removes additional padding on 'Show more' button in popovers
- Updates close icon color to match designs
- Remove fade in/out transitions on popovers
- Ensures nodes for commits are the same height as nodes for branches/tags