### PR TITLE
gitserver: Decompress input to git-upload-pack

### DIFF
--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"compress/gzip"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -75,7 +74,7 @@ func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		gzipReader, err := gzip.NewReader(body)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("malformed payload: %s", err), http.StatusBadRequest)
+			http.Error(w, "malformed payload: "+err.Error(), http.StatusBadRequest)
 			return
 		}
 		defer gzipReader.Close()

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -75,7 +75,8 @@ func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Content-Encoding") == "gzip" {
 		gzipReader, err := gzip.NewReader(body)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("malformed payload: %s", err), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("malformed payload: %s", err), http.StatusBadRequest)
+			return
 		}
 		defer gzipReader.Close()
 

--- a/cmd/gitserver/server/gitservice.go
+++ b/cmd/gitserver/server/gitservice.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"compress/gzip"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -67,6 +69,19 @@ func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	body := r.Body
+	defer body.Close()
+
+	if r.Header.Get("Content-Encoding") == "gzip" {
+		gzipReader, err := gzip.NewReader(body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("malformed payload: %s", err), http.StatusInternalServerError)
+		}
+		defer gzipReader.Close()
+
+		body = gzipReader
+	}
+
 	start := time.Now()
 	metricServiceRunning.WithLabelValues(svc).Inc()
 	defer func() {
@@ -91,9 +106,6 @@ func (s *gitServiceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	args = append(args, dir)
-
-	body := r.Body
-	defer body.Close()
 
 	env := os.Environ()
 	if protocol := r.Header.Get("Git-Protocol"); protocol != "" {


### PR DESCRIPTION
Ensure that if the `Content-Encoding` of a gitservice request is `gzip` then we read it as a compressed input. `git-upload-pack` does not accept gzipped input and fails. This is only _sometimes_ gzipped and I'm not sure of the conditions so we can't rely on it being always or never encoded.

I didn't use any standard middleware as our already-used nytimes handler decodes _responses_, and middleware that decodes _requests_ tend to be messy. This solution is explicit.

Before-merge:

- [x] Add a test that hits the gzip condition