### PR TITLE
Protect from highlighting panic

### DIFF
--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -553,6 +553,19 @@ func (r *DiffHunk) Highlight(ctx context.Context, args *HighlightArgs) (*highlig
 		hunkLines = append(hunkLines[:lastMinus], hunkLines[lastMinus+1:]...)
 	}
 
+	// Even after all the logic above, we were still hitting out-of-bounds panics:
+	// https://github.com/sourcegraph/sourcegraph/issues/21054
+	// Ultimately, we'll need a cleaner solution than this, but for now, just
+	// returning an empty line div when one was trimmed unexpectedly will at least
+	// protect from panics.
+	// Tracking issue: https://github.com/sourcegraph/sourcegraph/issues/20704
+	safeIndex := func(lines []template.HTML, target int32) string {
+		if len(lines) > int(target) {
+			return string(lines[target])
+		}
+		return `<div>\n</div>`
+	}
+
 	highlightedDiffHunkLineResolvers := make([]*highlightedDiffHunkLineResolver, len(hunkLines))
 	// Lines in highlightedBase and highlightedHead are 0-indexed.
 	baseLine := r.hunk.OrigStartLine - 1
@@ -561,16 +574,16 @@ func (r *DiffHunk) Highlight(ctx context.Context, args *HighlightArgs) (*highlig
 		highlightedDiffHunkLineResolver := highlightedDiffHunkLineResolver{}
 		if hunkLine[0] == ' ' {
 			highlightedDiffHunkLineResolver.kind = "UNCHANGED"
-			highlightedDiffHunkLineResolver.html = string(highlightedBase[baseLine])
+			highlightedDiffHunkLineResolver.html = safeIndex(highlightedBase, baseLine)
 			baseLine++
 			headLine++
 		} else if hunkLine[0] == '+' {
 			highlightedDiffHunkLineResolver.kind = "ADDED"
-			highlightedDiffHunkLineResolver.html = string(highlightedHead[headLine])
+			highlightedDiffHunkLineResolver.html = safeIndex(highlightedHead, headLine)
 			headLine++
 		} else if hunkLine[0] == '-' {
 			highlightedDiffHunkLineResolver.kind = "DELETED"
-			highlightedDiffHunkLineResolver.html = string(highlightedBase[baseLine])
+			highlightedDiffHunkLineResolver.html = safeIndex(highlightedBase, baseLine)
 			baseLine++
 		} else {
 			return nil, fmt.Errorf("expected patch lines to start with ' ', '-', '+', but found %q", hunkLine[0])

--- a/cmd/frontend/graphqlbackend/repository_comparison.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/inconshreveable/log15"
 	"github.com/sourcegraph/go-diff/diff"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend/graphqlutil"
@@ -563,6 +564,7 @@ func (r *DiffHunk) Highlight(ctx context.Context, args *HighlightArgs) (*highlig
 		if len(lines) > int(target) {
 			return string(lines[target])
 		}
+		log15.Warn("returned default value for out of bounds index on highlighted code")
 		return `<div>\n</div>`
 	}
 

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -438,6 +438,114 @@ func TestDiffHunk(t *testing.T) {
 	})
 }
 
+func TestDiffHunk2(t *testing.T) {
+	ctx := context.Background()
+	filediff := `diff --git cmd/staticcheck/README.md cmd/staticcheck/README.md
+index 4d14577..10ef458 100644
+--- cmd/staticcheck/README.md
++++ cmd/staticcheck/README.md
+@@ -13,3 +13,5 @@ See [the main README](https://github.com/dominikh/go-tools#installation) for ins
+ Detailed documentation can be found on
+ [staticcheck.io](https://staticcheck.io/docs/).
+` + " " + `
++
++(c) Copyright Sourcegraph 2013-2021.
+\ No newline at end of file
+`
+	dr := diff.NewMultiFileDiffReader(strings.NewReader(filediff))
+	// We only read the first file diff from testDiff
+	fileDiff, err := dr.ReadFile()
+	if err != nil && err != io.EOF {
+		t.Fatalf("parsing diff failed: %s", err)
+	}
+
+	hunk := &DiffHunk{hunk: fileDiff.Hunks[0]}
+
+	t.Run("Highlight", func(t *testing.T) {
+		hunk.highlighter = &dummyFileHighlighter{
+			highlightedBase: []template.HTML{
+				"<div><span class=\"hl-text hl-html hl-markdown\"><span class=\"hl-meta hl-block-level hl-markdown\"><span class=\"hl-markup hl-heading hl-1 hl-markdown\"><span class=\"hl-punctuation hl-definition hl-heading hl-begin hl-markdown\">#</span> </span><span class=\"hl-markup hl-heading hl-1 hl-markdown\"><span class=\"hl-entity hl-name hl-section hl-markdown\">staticcheck</span><span class=\"hl-meta hl-whitespace hl-newline hl-markdown\">\n</span></span></span></span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">_staticcheck_ offers extensive analysis of Go code, covering a myriad\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">of categories. It will detect bugs, suggest code simplifications,\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">point out dead code, and more.\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\"><span class=\"hl-meta hl-block-level hl-markdown\"><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-punctuation hl-definition hl-heading hl-begin hl-markdown\">##</span> </span><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-entity hl-name hl-section hl-markdown\">Installation</span><span class=\"hl-meta hl-whitespace hl-newline hl-markdown\">\n</span></span></span></span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">See [the main README](https://github.com/dominikh/go-tools#installation) for installation instructions.\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\"><span class=\"hl-meta hl-block-level hl-markdown\"><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-punctuation hl-definition hl-heading hl-begin hl-markdown\">##</span> </span><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-entity hl-name hl-section hl-markdown\">Documentation</span><span class=\"hl-meta hl-whitespace hl-newline hl-markdown\">\n</span></span></span></span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">Detailed documentation can be found on\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">[staticcheck.io](https://staticcheck.io/docs/).\n</span></div>",
+			},
+			highlightedHead: []template.HTML{
+				"<div><span class=\"hl-text hl-html hl-markdown\"><span class=\"hl-meta hl-block-level hl-markdown\"><span class=\"hl-markup hl-heading hl-1 hl-markdown\"><span class=\"hl-punctuation hl-definition hl-heading hl-begin hl-markdown\">#</span> </span><span class=\"hl-markup hl-heading hl-1 hl-markdown\"><span class=\"hl-entity hl-name hl-section hl-markdown\">staticcheck</span><span class=\"hl-meta hl-whitespace hl-newline hl-markdown\">\n</span></span></span></span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">_staticcheck_ offers extensive analysis of Go code, covering a myriad\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">of categories. It will detect bugs, suggest code simplifications,\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">point out dead code, and more.\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\"><span class=\"hl-meta hl-block-level hl-markdown\"><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-punctuation hl-definition hl-heading hl-begin hl-markdown\">##</span> </span><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-entity hl-name hl-section hl-markdown\">Installation</span><span class=\"hl-meta hl-whitespace hl-newline hl-markdown\">\n</span></span></span></span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">See [the main README](https://github.com/dominikh/go-tools#installation) for installation instructions.\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\"><span class=\"hl-meta hl-block-level hl-markdown\"><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-punctuation hl-definition hl-heading hl-begin hl-markdown\">##</span> </span><span class=\"hl-markup hl-heading hl-2 hl-markdown\"><span class=\"hl-entity hl-name hl-section hl-markdown\">Documentation</span><span class=\"hl-meta hl-whitespace hl-newline hl-markdown\">\n</span></span></span></span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">Detailed documentation can be found on\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">[staticcheck.io](https://staticcheck.io/docs/).\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">\n</span></div>",
+				"<div><span class=\"hl-text hl-html hl-markdown\">(c) Copyright Sourcegraph 2013-2021.</span></div>",
+			},
+		}
+
+		body, err := hunk.Highlight(ctx, &HighlightArgs{
+			DisableTimeout:     false,
+			HighlightLongLines: false,
+			IsLightTheme:       true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if body.Aborted() {
+			t.Fatal("highlighting is aborted")
+		}
+
+		// wantLines := []struct {
+		// 	kind, html string
+		// }{
+		// 	{kind: "UNCHANGED", html: "B3"},
+		// 	{kind: "UNCHANGED", html: "B4"},
+		// 	{kind: "UNCHANGED", html: "B5"},
+		// 	{kind: "DELETED", html: "B6"},
+		// 	{kind: "ADDED", html: "H6"},
+		// 	{kind: "UNCHANGED", html: "B7"},
+		// 	{kind: "UNCHANGED", html: "B8"},
+		// 	{kind: "DELETED", html: "B9"},
+		// 	{kind: "DELETED", html: "B10"},
+		// 	{kind: "ADDED", html: "H9"},
+		// 	{kind: "ADDED", html: "H10"},
+		// 	{kind: "UNCHANGED", html: "B11"},
+		// 	{kind: "UNCHANGED", html: "B12"},
+		// }
+
+		// lines := body.Lines()
+		// if have, want := len(lines), len(wantLines); have != want {
+		// 	t.Fatalf("len(Highlight.Lines) is wrong. want = %d, have = %d", want, have)
+		// }
+		// for i, n := range lines {
+		// 	wantedLine := wantLines[i]
+		// 	if n.Kind() != wantedLine.kind {
+		// 		t.Fatalf("Kind is wrong. want = %q, have = %q", wantedLine.kind, n.Kind())
+		// 	}
+		// 	if n.HTML() != wantedLine.html {
+		// 		t.Fatalf("HTML is wrong. want = %q, have = %q", wantedLine.html, n.HTML())
+		// 	}
+		// }
+	})
+}
+
 const testDiffFiles = 3
 const testDiff = `diff --git INSTALL.md INSTALL.md
 index e5af166..d44c3fc 100644

--- a/cmd/frontend/graphqlbackend/repository_comparison_test.go
+++ b/cmd/frontend/graphqlbackend/repository_comparison_test.go
@@ -439,6 +439,9 @@ func TestDiffHunk(t *testing.T) {
 }
 
 func TestDiffHunk2(t *testing.T) {
+	// This test exists to protect against panics related to
+	// https://github.com/sourcegraph/sourcegraph/pull/21068
+
 	ctx := context.Background()
 	filediff := `diff --git cmd/staticcheck/README.md cmd/staticcheck/README.md
 index 4d14577..10ef458 100644
@@ -511,38 +514,6 @@ index 4d14577..10ef458 100644
 		if body.Aborted() {
 			t.Fatal("highlighting is aborted")
 		}
-
-		// wantLines := []struct {
-		// 	kind, html string
-		// }{
-		// 	{kind: "UNCHANGED", html: "B3"},
-		// 	{kind: "UNCHANGED", html: "B4"},
-		// 	{kind: "UNCHANGED", html: "B5"},
-		// 	{kind: "DELETED", html: "B6"},
-		// 	{kind: "ADDED", html: "H6"},
-		// 	{kind: "UNCHANGED", html: "B7"},
-		// 	{kind: "UNCHANGED", html: "B8"},
-		// 	{kind: "DELETED", html: "B9"},
-		// 	{kind: "DELETED", html: "B10"},
-		// 	{kind: "ADDED", html: "H9"},
-		// 	{kind: "ADDED", html: "H10"},
-		// 	{kind: "UNCHANGED", html: "B11"},
-		// 	{kind: "UNCHANGED", html: "B12"},
-		// }
-
-		// lines := body.Lines()
-		// if have, want := len(lines), len(wantLines); have != want {
-		// 	t.Fatalf("len(Highlight.Lines) is wrong. want = %d, have = %d", want, have)
-		// }
-		// for i, n := range lines {
-		// 	wantedLine := wantLines[i]
-		// 	if n.Kind() != wantedLine.kind {
-		// 		t.Fatalf("Kind is wrong. want = %q, have = %q", wantedLine.kind, n.Kind())
-		// 	}
-		// 	if n.HTML() != wantedLine.html {
-		// 		t.Fatalf("HTML is wrong. want = %q, have = %q", wantedLine.html, n.HTML())
-		// 	}
-		// }
 	})
 }
 


### PR DESCRIPTION
New highlighting changes uncovered a lot of complexity in how we handle
trailing newlines. We've made quick attempts to correct this before, but
were still hitting more edge cases. In attempt to at least stop the
panics from occuring, this commit wraps all accesses to highlighted code
that might have had newlines truncated in a `safeIndex` function, which
will return a default value in the cases where it would otherwise have
panicked with an out-of-bounds error.

This is not a complete fix, but will at least stop the panics. 

I tested this against the panicking test in #21053 

Fixes #21054 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
