### PR TITLE
graphqlbackend: only allow user to get account data for GitHub and GitLab

### DIFF
--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -67,14 +67,14 @@ func (r *externalAccountResolver) AccountData(ctx context.Context) (*JSONValue, 
 	//
 	// Therefore, the site admins and the user can view account data of GitHub and
 	// GitLab, but only site admins can view account data for all other types.
+	var err error
 	if r.account.ServiceType == extsvc.TypeGitHub || r.account.ServiceType == extsvc.TypeGitLab {
-		if err := backend.CheckSiteAdminOrSameUser(ctx, actor.FromContext(ctx).UID); err != nil {
-			return nil, err
-		}
+		err = backend.CheckSiteAdminOrSameUser(ctx, actor.FromContext(ctx).UID)
 	} else {
-		if err := backend.CheckUserIsSiteAdmin(ctx, actor.FromContext(ctx).UID); err != nil {
-			return nil, err
-		}
+		err = backend.CheckUserIsSiteAdmin(ctx, actor.FromContext(ctx).UID)
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	if r.account.Data != nil {

--- a/cmd/frontend/graphqlbackend/external_account_test.go
+++ b/cmd/frontend/graphqlbackend/external_account_test.go
@@ -1,0 +1,83 @@
+package graphqlbackend
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/actor"
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/types"
+)
+
+func TestExternalAccountResolver_AccountData(t *testing.T) {
+	database.Mocks.Users.GetByID = func(ctx context.Context, id int32) (*types.User, error) {
+		return &types.User{SiteAdmin: id == 1}, nil
+	}
+	defer func() {
+		database.Mocks.Users = database.MockUsers{}
+	}()
+
+	tests := []struct {
+		name        string
+		ctx         context.Context
+		serviceType string
+		wantErr     string
+	}{
+		{
+			name:        "github and site admin",
+			ctx:         actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
+			serviceType: extsvc.TypeGitHub,
+			wantErr:     "<nil>",
+		},
+		{
+			name:        "gitlab and site admin",
+			ctx:         actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
+			serviceType: extsvc.TypeGitLab,
+			wantErr:     "<nil>",
+		},
+		{
+			name:        "github and non-site admin",
+			ctx:         actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+			serviceType: extsvc.TypeGitHub,
+			wantErr:     "<nil>",
+		},
+		{
+			name:        "gitlab and non-site admin",
+			ctx:         actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+			serviceType: extsvc.TypeGitLab,
+			wantErr:     "<nil>",
+		},
+		{
+			name:        "other and site admin",
+			ctx:         actor.WithActor(context.Background(), &actor.Actor{UID: 1}),
+			serviceType: extsvc.TypePerforce,
+			wantErr:     "<nil>",
+		},
+		{
+			name:        "other and non-site admin",
+			ctx:         actor.WithActor(context.Background(), &actor.Actor{UID: 2}),
+			serviceType: extsvc.TypePerforce,
+			wantErr:     "must be site admin",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := &externalAccountResolver{
+				account: extsvc.Account{
+					AccountSpec: extsvc.AccountSpec{
+						ServiceType: test.serviceType,
+					},
+				},
+			}
+			_, err := r.AccountData(test.ctx)
+			got := fmt.Sprintf("%v", err)
+			if diff := cmp.Diff(test.wantErr, got); diff != "" {
+				t.Fatalf("Mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/sourcegraph/sourcegraph/issues/20978