### PR TITLE
add refresh design sub nav styles

### DIFF
--- a/client/branded/src/global-styles/nav.scss
+++ b/client/branded/src/global-styles/nav.scss
@@ -18,7 +18,7 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
         border-radius: var(--border-radius);
         color: var(--text-muted);
         &:not(.active):hover {
-            border-bottom: 3px solid var(--border-color);
+            border-bottom: 3px solid var(--border-color-2);
             margin-top: 0;
             color: var(--body-color);
         }

--- a/client/branded/src/global-styles/nav.scss
+++ b/client/branded/src/global-styles/nav.scss
@@ -14,11 +14,16 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
 .nav-tabs > .nav-item > .nav-link {
     height: 100%;
     .theme-redesign & {
-        border: none;
-        border-radius: var(--border-radius);
         color: var(--text-muted);
+        border: none;
+        &:focus-visible {
+            border-radius: var(--border-radius);
+            // Add this new stacking context in order to show the focus ring without cutting any edge.
+            isolation: isolate;
+            z-index: 1;
+        }
         &:not(.active):hover {
-            border-bottom: 3px solid var(--border-color-2);
+            border-bottom: 2px solid var(--border-color-2);
             margin-top: 0;
             color: var(--body-color);
         }
@@ -28,8 +33,8 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
 .nav-tabs > .nav-item > .nav-link.active {
     .theme-redesign & {
         color: var(--body-color);
-        font-weight: bold;
-        border-bottom: 3px solid var(--brand-secondary);
+        font-weight: 600;
+        border-bottom: 2px solid var(--brand-secondary);
     }
 }
 

--- a/client/branded/src/global-styles/nav.scss
+++ b/client/branded/src/global-styles/nav.scss
@@ -13,6 +13,24 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
 // to have an undesirable bottom border when active.
 .nav-tabs > .nav-item > .nav-link {
     height: 100%;
+    .theme-redesign & {
+        border: none;
+        border-radius: var(--border-radius);
+        color: var(--text-muted);
+        &:not(.active):hover {
+            border-bottom: 3px solid var(--border-color);
+            margin-top: 0;
+            color: var(--body-color);
+        }
+    }
+}
+
+.nav-tabs > .nav-item > .nav-link.active {
+    .theme-redesign & {
+        color: var(--body-color);
+        font-weight: bold;
+        border-bottom: 3px solid var(--brand-secondary);
+    }
 }
 
 // Bootstrap's nav base class does not include styles for the active state.


### PR DESCRIPTION

The sub-navigation bar changes are entirely CSS changes. 

This look and feel are notably similar to the tabs component. The main difference is how the a11y behaves. Sub nav is only navigable with the tab key as any navigation list of links.

This time the idea was to modify the original bootstrap nav-tabs items from the `nav.css` file. It's being handled in global styles meaning the change will be general in any navigation tab section across the codebase.

Sub nav with icons isn't modified since this is not part of the tabs per se. Any change around icons in the sub-nav is feasible, and the only step needed is to remove or add icons as you need.

Below is the video with a small demo on how this change is applied.

https://user-images.githubusercontent.com/989826/118712466-6d5b6780-b7e6-11eb-8530-43778adb1167.mov


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
