### PR TITLE
search redesign: move version contexts dropdown inside of search box

### DIFF
--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -56,7 +56,6 @@ import { showDotComMarketing } from '../util/features'
 
 import { NavLinks } from './NavLinks'
 import { ExtensionAlertAnimationProps, UserNavItem } from './UserNavItem'
-import { VersionContextDropdown } from './VersionContextDropdown'
 
 interface Props
     extends SettingsCascadeProps,
@@ -123,9 +122,6 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
     authRequired,
     showSearchBox,
     navbarSearchQueryState,
-    versionContext,
-    setVersionContext,
-    availableVersionContexts,
     caseSensitive,
     patternType,
     onNavbarQueryChange,
@@ -226,7 +222,6 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
             onChange={onNavbarQueryChange}
             location={location}
             history={history}
-            versionContext={versionContext}
             isLightTheme={isLightTheme}
             patternType={patternType}
             caseSensitive={caseSensitive}
@@ -361,21 +356,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         )}
                     </NavActions>
                 </NavBar>
-                {showSearchBox && (
-                    <div className="d-flex w-100 flex-row px-3 py-2 border-bottom">
-                        <VersionContextDropdown
-                            history={history}
-                            navbarSearchQuery={navbarSearchQueryState.query}
-                            caseSensitive={caseSensitive}
-                            patternType={patternType}
-                            versionContext={versionContext}
-                            setVersionContext={setVersionContext}
-                            availableVersionContexts={availableVersionContexts}
-                            selectedSearchContextSpec={props.selectedSearchContextSpec}
-                        />
-                        {searchNavBar}
-                    </div>
-                )}
+                {showSearchBox && <div className="d-flex w-100 flex-row px-3 py-2 border-bottom">{searchNavBar}</div>}
             </>
         )
     }
@@ -411,16 +392,6 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         <div className="flex-1" />
                     ) : (
                         <div className="global-navbar__search-box-container d-none d-sm-flex flex-row">
-                            <VersionContextDropdown
-                                history={history}
-                                navbarSearchQuery={navbarSearchQueryState.query}
-                                caseSensitive={caseSensitive}
-                                patternType={patternType}
-                                versionContext={versionContext}
-                                setVersionContext={setVersionContext}
-                                availableVersionContexts={availableVersionContexts}
-                                selectedSearchContextSpec={props.selectedSearchContextSpec}
-                            />
                             {searchNavBar}
                         </div>
                     )}

--- a/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/GlobalNavbar.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`GlobalNavbar default 1`] = `
   >
     <SearchNavbarItem
       authenticatedUser={null}
+      availableVersionContexts={Array []}
       caseSensitive={false}
       copyQueryButton={false}
       defaultSearchContextSpec=""
@@ -104,6 +105,7 @@ exports[`GlobalNavbar default 1`] = `
       setCaseSensitivity={[Function]}
       setPatternType={[Function]}
       setSelectedSearchContextSpec={[Function]}
+      setVersionContext={[Function]}
       settingsCascade={
         Object {
           "final": null,

--- a/client/web/src/search/input/SearchBox.story.tsx
+++ b/client/web/src/search/input/SearchBox.story.tsx
@@ -34,6 +34,8 @@ const defaultProps: SearchBoxProps = {
     caseSensitive: false,
     setCaseSensitivity: () => {},
     versionContext: undefined,
+    availableVersionContexts: [],
+    setVersionContext: () => Promise.resolve(undefined),
     showSearchContext: false,
     showSearchContextManagement: false,
     selectedSearchContextSpec: 'global',

--- a/client/web/src/search/input/SearchBox.tsx
+++ b/client/web/src/search/input/SearchBox.tsx
@@ -3,7 +3,9 @@ import React from 'react'
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
-import { CaseSensitivityProps, CopyQueryButtonProps, PatternTypeProps, SearchContextProps } from '..'
+import { CopyQueryButtonProps, SearchContextProps } from '..'
+import { VersionContextDropdown } from '../../nav/VersionContextDropdown'
+import { VersionContext } from '../../schema/site.schema'
 import { QueryState, submitSearch } from '../helpers'
 
 import { LazyMonacoQueryInput } from './LazyMonacoQueryInput'
@@ -14,8 +16,6 @@ import { Toggles, TogglesProps } from './toggles/Toggles'
 export interface SearchBoxProps
     extends Omit<TogglesProps, 'navbarSearchQuery'>,
         ThemeProps,
-        CaseSensitivityProps,
-        PatternTypeProps,
         Omit<
             SearchContextProps,
             'convertVersionContextToSearchContext' | 'isSearchContextSpecAvailable' | 'fetchSearchContext'
@@ -31,15 +31,20 @@ export interface SearchBoxProps
     autoFocus?: boolean
     keyboardShortcutForFocus?: KeyboardShortcut
     submitSearchOnSearchContextChange?: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
 
-    // Whether globbing is enabled for filters.
+    /** Whether globbing is enabled for filters. */
     globbing: boolean
 
-    // Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets.
+    /** Whether to additionally highlight or provide hovers for tokens, e.g., regexp character sets. */
     enableSmartQuery: boolean
 
-    // Whether comments are parsed and highlighted
+    /** Whether comments are parsed and highlighted */
     interpretComments?: boolean
+
+    /** Don't show the version contexts dropdown. */
+    hideVersionContexts?: boolean
 }
 
 export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
@@ -47,6 +52,18 @@ export const SearchBox: React.FunctionComponent<SearchBoxProps> = props => {
 
     return (
         <div className={styles.searchBox}>
+            {!props.hideVersionContexts && (
+                <VersionContextDropdown
+                    history={props.history}
+                    caseSensitive={props.caseSensitive}
+                    patternType={props.patternType}
+                    navbarSearchQuery={queryState.query}
+                    versionContext={props.versionContext}
+                    setVersionContext={props.setVersionContext}
+                    availableVersionContexts={props.availableVersionContexts}
+                    selectedSearchContextSpec={props.selectedSearchContextSpec}
+                />
+            )}
             {props.showSearchContext && (
                 <SearchContextDropdown query={queryState.query} submitSearch={submitSearch} {...props} />
             )}

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -14,6 +14,7 @@ import {
     OnboardingTourProps,
     SearchContextProps,
 } from '..'
+import { VersionContext } from '../../schema/site.schema'
 import { submitSearch, QueryState } from '../helpers'
 
 import { SearchBox } from './SearchBox'
@@ -41,6 +42,8 @@ interface Props
     globbing: boolean
     enableSmartQuery: boolean
     isSearchAutoFocusRequired?: boolean
+    setVersionContext: (versionContext: string | undefined) => Promise<void>
+    availableVersionContexts: VersionContext[] | undefined
 }
 
 /**

--- a/client/web/src/search/input/SearchPageInput.tsx
+++ b/client/web/src/search/input/SearchPageInput.tsx
@@ -21,7 +21,6 @@ import {
 import { AuthenticatedUser } from '../../auth'
 import { Notices } from '../../global/Notices'
 import { KeyboardShortcutsProps } from '../../keyboardShortcuts/keyboardShortcuts'
-import { VersionContextDropdown } from '../../nav/VersionContextDropdown'
 import { Settings } from '../../schema/settings.schema'
 import { VersionContext } from '../../schema/site.schema'
 import { ThemePreferenceProps } from '../../theme'
@@ -123,18 +122,6 @@ export const SearchPageInput: React.FunctionComponent<Props> = (props: Props) =>
         <div className="d-flex flex-row flex-shrink-past-contents">
             <Form className="flex-grow-1 flex-shrink-past-contents" onSubmit={onSubmit}>
                 <div className="search-page__input-container">
-                    {!props.hideVersionContexts && (
-                        <VersionContextDropdown
-                            history={props.history}
-                            caseSensitive={props.caseSensitive}
-                            patternType={props.patternType}
-                            navbarSearchQuery={userQueryState.query}
-                            versionContext={props.versionContext}
-                            setVersionContext={props.setVersionContext}
-                            availableVersionContexts={props.availableVersionContexts}
-                            selectedSearchContextSpec={props.selectedSearchContextSpec}
-                        />
-                    )}
                     <SearchBox
                         {...props}
                         {...onboardingTourQueryInputProps}


### PR DESCRIPTION
Required to later implement responsive layout #20685
