### PR TITLE
codeintel: Improve go dependency indexing

### DIFF
--- a/lib/codeintel/autoindex/inference/paths.go
+++ b/lib/codeintel/autoindex/inference/paths.go
@@ -57,9 +57,10 @@ func containsNoSegments(path string, segments ...string) bool {
 // completely automatic index job inference and won't stop any  repositories with an
 // index configuration from indexing such paths.
 var segmentBlockList = []string{
-	"test",
-	"tests",
 	"example",
 	"examples",
 	"integration",
+	"test",
+	"testdata",
+	"tests",
 }

--- a/lib/codeintel/autoindex/inference/patterns.go
+++ b/lib/codeintel/autoindex/inference/patterns.go
@@ -18,12 +18,36 @@ var Patterns = func() *regexp.Regexp {
 	return regexp.MustCompile(strings.Join(patterns, "|"))
 }()
 
-// suffixPattern creates a regular expression that matches the given literal suffix.
-func suffixPattern(s string) *regexp.Regexp {
-	return regexp.MustCompile(regexp.QuoteMeta(s) + "$")
+// rawPattern creates a regular expression matching the given string literal.
+func rawPattern(s string) *regexp.Regexp {
+	return regexp.MustCompile(regexp.QuoteMeta(s))
 }
 
-// segmentPattern creates a regular expression that matches paths with the given segment.
-func segmentPattern(s string) *regexp.Regexp {
-	return regexp.MustCompile("(^|/)" + regexp.QuoteMeta(s) + "($|/)")
+// prefixPattern creates a regular expression that matches strings beginning with
+// the given pattern.
+func prefixPattern(pattern *regexp.Regexp) *regexp.Regexp {
+	return regexp.MustCompile("^" + pattern.String())
+}
+
+// suffixPattern creates a regular expression that matches strings ending with the
+// given pattern.
+func suffixPattern(pattern *regexp.Regexp) *regexp.Regexp {
+	return regexp.MustCompile(pattern.String() + "$")
+}
+
+// segmentPattern creates a regular expression that matches strings containing the
+// given path segment (surrounded by path separators or occurring at the head or tail).
+func segmentPattern(pattern *regexp.Regexp) *regexp.Regexp {
+	return regexp.MustCompile("(^|/)" + pattern.String() + "($|/)")
+}
+
+// extensionPattern creates a regular expression that matches paths with the given
+// extension. The extension separator is added automatically.
+func extensionPattern(pattern *regexp.Regexp) *regexp.Regexp {
+	return suffixPattern(regexp.MustCompile("(^|/)[^/]+." + pattern.String()))
+}
+
+// pathPattern creates a regular expression that matches paths with the given basename.
+func pathPattern(pattern *regexp.Regexp) *regexp.Regexp {
+	return suffixPattern(regexp.MustCompile("(^|/)" + pattern.String()))
 }

--- a/lib/codeintel/autoindex/inference/typescript_test.go
+++ b/lib/codeintel/autoindex/inference/typescript_test.go
@@ -11,6 +11,38 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/autoindex/config"
 )
 
+func TestTypeScriptPatterns(t *testing.T) {
+	testCases := []struct {
+		path     string
+		expected bool
+	}{
+		{"tsconfig.json", true},
+		{"tsconfig.json/subdir", false},
+		{".nvmrc", true},
+		{"subdir/package.json", true},
+		{"subdir/yarn.lock", true},
+	}
+
+	for _, testCase := range testCases {
+		match := false
+		for _, pattern := range TypeScriptPatterns() {
+			if pattern.MatchString(testCase.path) {
+				match = true
+				break
+			}
+		}
+
+		if match {
+			if !testCase.expected {
+				t.Error(fmt.Sprintf("did not expect match: %s", testCase.path))
+			}
+
+		} else if testCase.expected {
+			t.Error(fmt.Sprintf("expected match: %s", testCase.path))
+		}
+	}
+}
+
 func TestCanIndexTypeScriptRepo(t *testing.T) {
 	testCases := []struct {
 		paths    []string
@@ -171,27 +203,6 @@ func TestInferTypeScriptIndexJobsInstallSteps(t *testing.T) {
 	}
 	if diff := cmp.Diff(expectedIndexJobs, InferTypeScriptIndexJobs(NewMockGitClient(), paths)); diff != "" {
 		t.Errorf("unexpected index jobs (-want +got):\n%s", diff)
-	}
-}
-
-func TestTypeScriptPatterns(t *testing.T) {
-	paths := []string{
-		"tsconfig.json",
-		"subdir/tsconfig.json",
-	}
-
-	for _, path := range paths {
-		match := false
-		for _, pattern := range TypeScriptPatterns() {
-			if pattern.MatchString(path) {
-				match = true
-				break
-			}
-		}
-
-		if !match {
-			t.Error(fmt.Sprintf("failed to match %s", path))
-		}
 	}
 }
 


### PR DESCRIPTION
Infer an lsif-go run on projects with go files in the root directory but otherwise has no inferred lsif-go index jobs. This covers a large number of small utility and leaf repositories from the _dark times_.