### PR TITLE
batches: remove maximum in flaky ticker test

### DIFF
--- a/enterprise/internal/batches/scheduler/ticker_test.go
+++ b/enterprise/internal/batches/scheduler/ticker_test.go
@@ -76,8 +76,8 @@ func TestTickerRateLimited(t *testing.T) {
 
 	c = <-ticker.C
 	have := time.Since(now)
-	if wantMin, wantMax := 9*time.Millisecond, 15*time.Millisecond; have < wantMin || have > wantMax {
-		t.Errorf("unexpectedly short delay between takes: have=%v want >=%v && <=%v", have, wantMin, wantMax)
+	if wantMin := 9 * time.Millisecond; have < wantMin {
+		t.Errorf("unexpectedly short delay between takes: have=%v want>=%v", have, wantMin)
 	}
 	c <- time.Duration(0)
 


### PR DESCRIPTION
See #21079 and #20881 for context: since the point of this test is more about testing the minimum period between rate ticks, not the maximum, maybe it's better to just test the minimum.