### PR TITLE
executors: Fetch tags for workspace

### DIFF
--- a/enterprise/cmd/executor/internal/command/observability.go
+++ b/enterprise/cmd/executor/internal/command/observability.go
@@ -10,6 +10,7 @@ import (
 type Operations struct {
 	SetupGitInit              *observation.Operation
 	SetupGitFetch             *observation.Operation
+	SetupAddRemote            *observation.Operation
 	SetupGitCheckout          *observation.Operation
 	SetupDockerPull           *observation.Operation
 	SetupDockerSave           *observation.Operation
@@ -40,6 +41,7 @@ func NewOperations(observationContext *observation.Context) *Operations {
 	return &Operations{
 		SetupGitInit:              op("setup.git.init"),
 		SetupGitFetch:             op("setup.git.fetch"),
+		SetupAddRemote:            op("setup.git.add-remote"),
 		SetupGitCheckout:          op("setup.git.checkout"),
 		SetupDockerPull:           op("setup.docker.pull"),
 		SetupDockerSave:           op("setup.docker.save"),

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -43,6 +43,7 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 		gitCommands := []command.CommandSpec{
 			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
 			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit}, Operation: h.operations.SetupGitFetch},
+			{Key: "setup.git.add-remote", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupAddRemote},
 			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
 		}
 		for _, spec := range gitCommands {

--- a/enterprise/cmd/executor/internal/worker/workspace.go
+++ b/enterprise/cmd/executor/internal/worker/workspace.go
@@ -42,7 +42,7 @@ func (h *handler) prepareWorkspace(ctx context.Context, commandRunner command.Ru
 
 		gitCommands := []command.CommandSpec{
 			{Key: "setup.git.init", Command: []string{"git", "-C", tempDir, "init"}, Operation: h.operations.SetupGitInit},
-			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), commit}, Operation: h.operations.SetupGitFetch},
+			{Key: "setup.git.fetch", Command: []string{"git", "-C", tempDir, "-c", "protocol.version=2", "fetch", cloneURL.String(), "-t", commit}, Operation: h.operations.SetupGitFetch},
 			{Key: "setup.git.add-remote", Command: []string{"git", "-C", tempDir, "remote", "add", "origin", repositoryName}, Operation: h.operations.SetupAddRemote},
 			{Key: "setup.git.checkout", Command: []string{"git", "-C", tempDir, "checkout", commit}, Operation: h.operations.SetupGitCheckout},
 		}

--- a/enterprise/cmd/executor/internal/worker/workspace_test.go
+++ b/enterprise/cmd/executor/internal/worker/workspace_test.go
@@ -29,14 +29,14 @@ func TestPrepareWorkspace(t *testing.T) {
 		operations: command.NewOperations(&observation.TestContext),
 	}
 
-	dir, err := handler.prepareWorkspace(context.Background(), runner, "linux", "deadbeef")
+	dir, err := handler.prepareWorkspace(context.Background(), runner, "torvalds/linux", "deadbeef")
 	if err != nil {
 		t.Fatalf("unexpected error preparing workspace: %s", err)
 	}
 	defer os.RemoveAll(dir)
 
-	if value := len(runner.RunFunc.History()); value != 3 {
-		t.Fatalf("unexpected number of calls to Run. want=%d have=%d", 3, value)
+	if value := len(runner.RunFunc.History()); value != 4 {
+		t.Fatalf("unexpected number of calls to Run. want=%d have=%d", 4, value)
 	}
 
 	var commands [][]string
@@ -46,7 +46,8 @@ func TestPrepareWorkspace(t *testing.T) {
 
 	expectedCommands := [][]string{
 		{"git", "-C", dir, "init"},
-		{"git", "-C", dir, "-c", "protocol.version=2", "fetch", "https://test:hunter2@test.io/internal/git/linux", "deadbeef"},
+		{"git", "-C", dir, "-c", "protocol.version=2", "fetch", "https://test:hunter2@test.io/internal/git/torvalds/linux", "-t", "deadbeef"},
+		{"git", "-C", dir, "remote", "add", "origin", "torvalds/linux"},
 		{"git", "-C", dir, "checkout", "deadbeef"},
 	}
 	if diff := cmp.Diff(expectedCommands, commands); diff != "" {


### PR DESCRIPTION
This ensures we fetch tags from gitserver and also set up a sensible git remote name for tools to use within the executor. We may want to use the actual repo URI instead of the name in the future. This happens to work with lsif-go today.