### PR TITLE
Enable babel loader cache in storybooks

### DIFF
--- a/client/storybook/src/main.ts
+++ b/client/storybook/src/main.ts
@@ -108,6 +108,7 @@ const config = {
             test: /\.tsx?$/,
             loader: require.resolve('babel-loader'),
             options: {
+                cacheDirectory: true,
                 configFile: path.resolve(rootPath, 'babel.config.js'),
             },
         })


### PR DESCRIPTION
In sync with what we set for the web webpack build. Very hard to test, but it feels faster on my local machine.