### PR TITLE
batches: add and use a new field for the desired publication state

### DIFF
--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -483,7 +483,7 @@ type GitBranchChangesetDescriptionResolver interface {
 
 	Commits() []GitCommitDescriptionResolver
 
-	Published() batches.PublishedValue
+	Published() *batches.PublishedValue
 }
 
 type GitCommitDescriptionResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1625,7 +1625,7 @@ type GitBranchChangesetDescription {
     can be previewed.
 
     Another ChangesetSpec with the same description, but "published: true",
-    can later be applied publish the changeset.
+    can later be applied to publish the changeset.
     """
     published: PublishedValue
 }

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1541,7 +1541,7 @@ type ExistingChangesetReference {
 }
 
 """
-A triple that represents all possible states of the published value: true, false or 'draft'.
+A quadruple that represents all possible states of the published value: true, false, 'draft', or null.
 """
 scalar PublishedValue
 
@@ -1627,7 +1627,7 @@ type GitBranchChangesetDescription {
     Another ChangesetSpec with the same description, but "published: true",
     can later be applied publish the changeset.
     """
-    published: PublishedValue!
+    published: PublishedValue
 }
 
 """

--- a/enterprise/internal/batches/reconciler/executor.go
+++ b/enterprise/internal/batches/reconciler/executor.go
@@ -30,7 +30,6 @@ func executePlan(ctx context.Context, gitserverClient GitserverClient, sourcer s
 		tx:                tx,
 		ch:                plan.Changeset,
 		spec:              plan.ChangesetSpec,
-		delta:             plan.Delta,
 	}
 
 	return e.Run(ctx, plan)
@@ -43,7 +42,6 @@ type executor struct {
 	tx                *store.Store
 	ch                *btypes.Changeset
 	spec              *btypes.ChangesetSpec
-	delta             *ChangesetSpecDelta
 
 	css  sources.ChangesetSource
 	repo *types.Repo

--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -179,6 +179,9 @@ func DeterminePlan(previousSpec, currentSpec *btypes.ChangesetSpec, ch *btypes.C
 			pl.SetOp(btypes.ReconcilerOperationPublishDraft)
 			pl.AddOp(btypes.ReconcilerOperationPush)
 		}
+		// TODO: test for Published.Nil() and then plan based on the UI
+		// publication state. For now, we'll let it fall through and treat it
+		// the same as being unpublished.
 
 	case btypes.ChangesetPublicationStatePublished:
 		// Don't take any actions for merged changesets.

--- a/enterprise/internal/batches/reconciler/plan.go
+++ b/enterprise/internal/batches/reconciler/plan.go
@@ -331,19 +331,14 @@ func compareChangesetSpecs(previous, current *btypes.ChangesetSpec, uiPublicatio
 }
 
 type ChangesetSpecDelta struct {
-	// General metadata changes.
 	TitleChanged         bool
 	BodyChanged          bool
+	Undraft              bool
 	BaseRefChanged       bool
 	DiffChanged          bool
 	CommitMessageChanged bool
 	AuthorNameChanged    bool
 	AuthorEmailChanged   bool
-
-	// Publication state changes.
-	Undraft      bool
-	Publish      bool
-	PublishDraft bool
 }
 
 func (d *ChangesetSpecDelta) String() string { return fmt.Sprintf("%#v", d) }

--- a/enterprise/internal/batches/reconciler/publication_state.go
+++ b/enterprise/internal/batches/reconciler/publication_state.go
@@ -1,0 +1,33 @@
+package reconciler
+
+import (
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/lib/batches"
+)
+
+// publicationStateCalculator calculates the desired publication state based on
+// the published field of a changeset spec and the UI publication state of the
+// changeset, if any.
+type publicationStateCalculator struct {
+	spec batches.PublishedValue
+	ui   *btypes.ChangesetUiPublicationState
+}
+
+func calculatePublicationState(specPublished batches.PublishedValue, uiPublished *btypes.ChangesetUiPublicationState) *publicationStateCalculator {
+	return &publicationStateCalculator{
+		spec: specPublished,
+		ui:   uiPublished,
+	}
+}
+
+func (c *publicationStateCalculator) IsPublished() bool {
+	return c.spec.True() || (c.spec.Nil() && c.ui != nil && *c.ui == btypes.ChangesetUiPublicationStatePublished)
+}
+
+func (c *publicationStateCalculator) IsDraft() bool {
+	return c.spec.Draft() || (c.spec.Nil() && c.ui != nil && *c.ui == btypes.ChangesetUiPublicationStateDraft)
+}
+
+func (c *publicationStateCalculator) IsUnpublished() bool {
+	return c.spec.False() || (c.spec.Nil() && (c.ui == nil || *c.ui == btypes.ChangesetUiPublicationStateUnpublished))
+}

--- a/enterprise/internal/batches/reconciler/publication_state_test.go
+++ b/enterprise/internal/batches/reconciler/publication_state_test.go
@@ -1,0 +1,72 @@
+package reconciler
+
+import (
+	"testing"
+
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	"github.com/sourcegraph/sourcegraph/lib/batches"
+)
+
+func TestPublicationStateCalculator(t *testing.T) {
+	type want struct {
+		published   bool
+		draft       bool
+		unpublished bool
+	}
+
+	for name, tc := range map[string]struct {
+		spec batches.PublishedValue
+		ui   *btypes.ChangesetUiPublicationState
+		want want
+	}{
+		"unpublished; no ui": {
+			spec: batches.PublishedValue{Val: false},
+			ui:   nil,
+			want: want{false, false, true},
+		},
+		"draft; no ui": {
+			spec: batches.PublishedValue{Val: "draft"},
+			ui:   nil,
+			want: want{false, true, false},
+		},
+		"published; no ui": {
+			spec: batches.PublishedValue{Val: true},
+			ui:   nil,
+			want: want{true, false, false},
+		},
+		"no published value; no ui": {
+			spec: batches.PublishedValue{Val: nil},
+			ui:   nil,
+			want: want{false, false, true},
+		},
+		"no published value; unpublished ui": {
+			spec: batches.PublishedValue{Val: nil},
+			ui:   uiPublicationStatePtr(btypes.ChangesetUiPublicationStateUnpublished),
+			want: want{false, false, true},
+		},
+		"no published value; draft ui": {
+			spec: batches.PublishedValue{Val: nil},
+			ui:   uiPublicationStatePtr(btypes.ChangesetUiPublicationStateDraft),
+			want: want{false, true, false},
+		},
+		"no published value; published ui": {
+			spec: batches.PublishedValue{Val: nil},
+			ui:   uiPublicationStatePtr(btypes.ChangesetUiPublicationStatePublished),
+			want: want{true, false, false},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			calc := &publicationStateCalculator{tc.spec, tc.ui}
+
+			if have, want := calc.IsPublished(), tc.want.published; have != want {
+				t.Errorf("unexpected IsPublished result: have=%v want=%v", have, want)
+			}
+			if have, want := calc.IsDraft(), tc.want.draft; have != want {
+				t.Errorf("unexpected IsDraft result: have=%v want=%v", have, want)
+			}
+			if have, want := calc.IsUnpublished(), tc.want.unpublished; have != want {
+				t.Errorf("unexpected IsUnpublished result: have=%v want=%v", have, want)
+			}
+		})
+	}
+}

--- a/enterprise/internal/batches/resolvers/changeset_spec.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec.go
@@ -151,8 +151,11 @@ func (r *changesetDescriptionResolver) HeadRepository() *graphqlbackend.Reposito
 func (r *changesetDescriptionResolver) HeadRef() string { return git.AbbreviateRef(r.desc.HeadRef) }
 func (r *changesetDescriptionResolver) Title() string   { return r.desc.Title }
 func (r *changesetDescriptionResolver) Body() string    { return r.desc.Body }
-func (r *changesetDescriptionResolver) Published() batches.PublishedValue {
-	return r.desc.Published
+func (r *changesetDescriptionResolver) Published() *batches.PublishedValue {
+	if published := r.desc.Published; !published.Nil() {
+		return &published
+	}
+	return nil
 }
 
 func (r *changesetDescriptionResolver) DiffStat() *graphqlbackend.DiffStat {

--- a/enterprise/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec_test.go
@@ -184,6 +184,61 @@ func TestChangesetSpecResolver(t *testing.T) {
 			},
 		},
 		{
+			name:    "GitBranchChangesetDescription publish from UI",
+			rawSpec: ct.NewPublishedRawChangesetSpecGitBranch(repoID, string(testRev), batches.PublishedValue{Val: nil}),
+			want: func(spec *btypes.ChangesetSpec) apitest.ChangesetSpec {
+				return apitest.ChangesetSpec{
+					Typename: "VisibleChangesetSpec",
+					ID:       string(marshalChangesetSpecRandID(spec.RandID)),
+					Description: apitest.ChangesetSpecDescription{
+						Typename: "GitBranchChangesetDescription",
+						BaseRepository: apitest.Repository{
+							ID: string(spec.Spec.BaseRepository),
+						},
+						ExternalID: "",
+						BaseRef:    git.AbbreviateRef(spec.Spec.BaseRef),
+						HeadRepository: apitest.Repository{
+							ID: string(spec.Spec.HeadRepository),
+						},
+						HeadRef: git.AbbreviateRef(spec.Spec.HeadRef),
+						Title:   spec.Spec.Title,
+						Body:    spec.Spec.Body,
+						Commits: []apitest.GitCommitDescription{
+							{
+								Author: apitest.Person{
+									Email: spec.Spec.Commits[0].AuthorEmail,
+									Name:  user.Username,
+									User: &apitest.User{
+										ID: string(graphqlbackend.MarshalUserID(user.ID)),
+									},
+								},
+								Diff:    spec.Spec.Commits[0].Diff,
+								Message: spec.Spec.Commits[0].Message,
+								Subject: "git commit message",
+								Body:    "and some more content in a second paragraph.",
+							},
+						},
+						Published: batches.PublishedValue{Val: nil},
+						Diff: struct{ FileDiffs apitest.FileDiffs }{
+							FileDiffs: apitest.FileDiffs{
+								DiffStat: apitest.DiffStat{
+									Added:   1,
+									Deleted: 1,
+									Changed: 2,
+								},
+							},
+						},
+						DiffStat: apitest.DiffStat{
+							Added:   1,
+							Deleted: 1,
+							Changed: 2,
+						},
+					},
+					ExpiresAt: &graphqlbackend.DateTime{Time: spec.ExpiresAt().Truncate(time.Second)},
+				}
+			},
+		},
+		{
 			name:    "ExistingChangesetReference",
 			rawSpec: ct.NewRawChangesetSpecExisting(repoID, "9999"),
 			want: func(spec *btypes.ChangesetSpec) apitest.ChangesetSpec {

--- a/enterprise/internal/batches/testing/changeset.go
+++ b/enterprise/internal/batches/testing/changeset.go
@@ -32,7 +32,8 @@ type TestChangesetOpts struct {
 	DiffStatChanged int32
 	DiffStatDeleted int32
 
-	PublicationState btypes.ChangesetPublicationState
+	PublicationState   btypes.ChangesetPublicationState
+	UiPublicationState *btypes.ChangesetUiPublicationState
 
 	ReconcilerState btypes.ReconcilerState
 	FailureMessage  string
@@ -85,7 +86,8 @@ func BuildChangeset(opts TestChangesetOpts) *btypes.Changeset {
 		ExternalReviewState: opts.ExternalReviewState,
 		ExternalCheckState:  opts.ExternalCheckState,
 
-		PublicationState: opts.PublicationState,
+		PublicationState:   opts.PublicationState,
+		UiPublicationState: opts.UiPublicationState,
 
 		OwnedByBatchChangeID: opts.OwnedByBatchChange,
 
@@ -127,6 +129,7 @@ type ChangesetAssertions struct {
 	OwnedByBatchChange int64
 	ReconcilerState    btypes.ReconcilerState
 	PublicationState   btypes.ChangesetPublicationState
+	UiPublicationState *btypes.ChangesetUiPublicationState
 	ExternalState      btypes.ChangesetExternalState
 	ExternalID         string
 	ExternalBranch     string
@@ -177,6 +180,10 @@ func AssertChangeset(t *testing.T, c *btypes.Changeset, a ChangesetAssertions) {
 
 	if have, want := c.PublicationState, a.PublicationState; have != want {
 		t.Fatalf("changeset PublicationState wrong. want=%s, have=%s", want, have)
+	}
+
+	if diff := cmp.Diff(c.UiPublicationState, a.UiPublicationState); diff != "" {
+		t.Fatalf("changeset UiPublicationState wrong. (-have +want):\n%s", diff)
 	}
 
 	if have, want := c.ExternalState, a.ExternalState; have != want {

--- a/enterprise/internal/batches/testing/changeset_spec.go
+++ b/enterprise/internal/batches/testing/changeset_spec.go
@@ -47,10 +47,6 @@ func BuildChangesetSpec(t *testing.T, opts TestSpecOpts) *btypes.ChangesetSpec {
 	t.Helper()
 
 	published := batches.PublishedValue{Val: opts.Published}
-	if opts.Published == nil {
-		// Set false as the default.
-		published.Val = false
-	}
 	if !published.Valid() {
 		t.Fatalf("invalid value for published passed, got %v (%T)", opts.Published, opts.Published)
 	}

--- a/enterprise/internal/batches/types/changeset.go
+++ b/enterprise/internal/batches/types/changeset.go
@@ -82,6 +82,25 @@ func (s ChangesetPublicationState) Unpublished() bool {
 	return s == ChangesetPublicationStateUnpublished
 }
 
+type ChangesetUiPublicationState string
+
+const (
+	ChangesetUiPublicationStateUnpublished ChangesetUiPublicationState = "UNPUBLISHED"
+	ChangesetUiPublicationStateDraft       ChangesetUiPublicationState = "DRAFT"
+	ChangesetUiPublicationStatePublished   ChangesetUiPublicationState = "PUBLISHED"
+)
+
+func (s ChangesetUiPublicationState) Valid() bool {
+	switch s {
+	case ChangesetUiPublicationStateUnpublished,
+		ChangesetUiPublicationStateDraft,
+		ChangesetUiPublicationStatePublished:
+		return true
+	default:
+		return false
+	}
+}
+
 // ReconcilerState defines the possible states of a Reconciler.
 type ReconcilerState string
 
@@ -237,7 +256,8 @@ type Changeset struct {
 	CurrentSpecID  int64
 	PreviousSpecID int64
 
-	PublicationState ChangesetPublicationState // "unpublished", "published"
+	PublicationState   ChangesetPublicationState // "unpublished", "published"
+	UiPublicationState *ChangesetUiPublicationState
 
 	// All of the following fields are used by workerutil.Worker.
 	ReconcilerState  ReconcilerState

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -197,43 +197,44 @@ Referenced by:
 
 # Table "public.changesets"
 ```
-          Column          |           Type           | Collation | Nullable |                Default                 
---------------------------+--------------------------+-----------+----------+----------------------------------------
- id                       | bigint                   |           | not null | nextval('changesets_id_seq'::regclass)
- batch_change_ids         | jsonb                    |           | not null | '{}'::jsonb
- repo_id                  | integer                  |           | not null | 
- created_at               | timestamp with time zone |           | not null | now()
- updated_at               | timestamp with time zone |           | not null | now()
- metadata                 | jsonb                    |           |          | '{}'::jsonb
- external_id              | text                     |           |          | 
- external_service_type    | text                     |           | not null | 
- external_deleted_at      | timestamp with time zone |           |          | 
- external_branch          | text                     |           |          | 
- external_updated_at      | timestamp with time zone |           |          | 
- external_state           | text                     |           |          | 
- external_review_state    | text                     |           |          | 
- external_check_state     | text                     |           |          | 
- diff_stat_added          | integer                  |           |          | 
- diff_stat_changed        | integer                  |           |          | 
- diff_stat_deleted        | integer                  |           |          | 
- sync_state               | jsonb                    |           | not null | '{}'::jsonb
- current_spec_id          | bigint                   |           |          | 
- previous_spec_id         | bigint                   |           |          | 
- publication_state        | text                     |           |          | 'UNPUBLISHED'::text
- owned_by_batch_change_id | bigint                   |           |          | 
- reconciler_state         | text                     |           |          | 'queued'::text
- failure_message          | text                     |           |          | 
- started_at               | timestamp with time zone |           |          | 
- finished_at              | timestamp with time zone |           |          | 
- process_after            | timestamp with time zone |           |          | 
- num_resets               | integer                  |           | not null | 0
- closing                  | boolean                  |           | not null | false
- num_failures             | integer                  |           | not null | 0
- log_contents             | text                     |           |          | 
- execution_logs           | json[]                   |           |          | 
- syncer_error             | text                     |           |          | 
- external_title           | text                     |           |          | 
- worker_hostname          | text                     |           | not null | ''::text
+          Column          |                     Type                     | Collation | Nullable |                Default                 
+--------------------------+----------------------------------------------+-----------+----------+----------------------------------------
+ id                       | bigint                                       |           | not null | nextval('changesets_id_seq'::regclass)
+ batch_change_ids         | jsonb                                        |           | not null | '{}'::jsonb
+ repo_id                  | integer                                      |           | not null | 
+ created_at               | timestamp with time zone                     |           | not null | now()
+ updated_at               | timestamp with time zone                     |           | not null | now()
+ metadata                 | jsonb                                        |           |          | '{}'::jsonb
+ external_id              | text                                         |           |          | 
+ external_service_type    | text                                         |           | not null | 
+ external_deleted_at      | timestamp with time zone                     |           |          | 
+ external_branch          | text                                         |           |          | 
+ external_updated_at      | timestamp with time zone                     |           |          | 
+ external_state           | text                                         |           |          | 
+ external_review_state    | text                                         |           |          | 
+ external_check_state     | text                                         |           |          | 
+ diff_stat_added          | integer                                      |           |          | 
+ diff_stat_changed        | integer                                      |           |          | 
+ diff_stat_deleted        | integer                                      |           |          | 
+ sync_state               | jsonb                                        |           | not null | '{}'::jsonb
+ current_spec_id          | bigint                                       |           |          | 
+ previous_spec_id         | bigint                                       |           |          | 
+ publication_state        | text                                         |           |          | 'UNPUBLISHED'::text
+ owned_by_batch_change_id | bigint                                       |           |          | 
+ reconciler_state         | text                                         |           |          | 'queued'::text
+ failure_message          | text                                         |           |          | 
+ started_at               | timestamp with time zone                     |           |          | 
+ finished_at              | timestamp with time zone                     |           |          | 
+ process_after            | timestamp with time zone                     |           |          | 
+ num_resets               | integer                                      |           | not null | 0
+ closing                  | boolean                                      |           | not null | false
+ num_failures             | integer                                      |           | not null | 0
+ log_contents             | text                                         |           |          | 
+ execution_logs           | json[]                                       |           |          | 
+ syncer_error             | text                                         |           |          | 
+ external_title           | text                                         |           |          | 
+ worker_hostname          | text                                         |           | not null | ''::text
+ ui_publication_state     | batch_changes_changeset_ui_publication_state |           |          | 
 Indexes:
     "changesets_pkey" PRIMARY KEY, btree (id)
     "changesets_repo_external_id_unique" UNIQUE CONSTRAINT, btree (repo_id, external_id)
@@ -2129,41 +2130,44 @@ Triggers:
 
 # View "public.reconciler_changesets"
 ```
-          Column          |           Type           | Collation | Nullable | Default 
---------------------------+--------------------------+-----------+----------+---------
- id                       | bigint                   |           |          | 
- batch_change_ids         | jsonb                    |           |          | 
- repo_id                  | integer                  |           |          | 
- created_at               | timestamp with time zone |           |          | 
- updated_at               | timestamp with time zone |           |          | 
- metadata                 | jsonb                    |           |          | 
- external_id              | text                     |           |          | 
- external_service_type    | text                     |           |          | 
- external_deleted_at      | timestamp with time zone |           |          | 
- external_branch          | text                     |           |          | 
- external_updated_at      | timestamp with time zone |           |          | 
- external_state           | text                     |           |          | 
- external_review_state    | text                     |           |          | 
- external_check_state     | text                     |           |          | 
- diff_stat_added          | integer                  |           |          | 
- diff_stat_changed        | integer                  |           |          | 
- diff_stat_deleted        | integer                  |           |          | 
- sync_state               | jsonb                    |           |          | 
- current_spec_id          | bigint                   |           |          | 
- previous_spec_id         | bigint                   |           |          | 
- publication_state        | text                     |           |          | 
- owned_by_batch_change_id | bigint                   |           |          | 
- reconciler_state         | text                     |           |          | 
- failure_message          | text                     |           |          | 
- started_at               | timestamp with time zone |           |          | 
- finished_at              | timestamp with time zone |           |          | 
- process_after            | timestamp with time zone |           |          | 
- num_resets               | integer                  |           |          | 
- closing                  | boolean                  |           |          | 
- num_failures             | integer                  |           |          | 
- log_contents             | text                     |           |          | 
- execution_logs           | json[]                   |           |          | 
- syncer_error             | text                     |           |          | 
+          Column          |                     Type                     | Collation | Nullable | Default 
+--------------------------+----------------------------------------------+-----------+----------+---------
+ id                       | bigint                                       |           |          | 
+ batch_change_ids         | jsonb                                        |           |          | 
+ repo_id                  | integer                                      |           |          | 
+ created_at               | timestamp with time zone                     |           |          | 
+ updated_at               | timestamp with time zone                     |           |          | 
+ metadata                 | jsonb                                        |           |          | 
+ external_id              | text                                         |           |          | 
+ external_service_type    | text                                         |           |          | 
+ external_deleted_at      | timestamp with time zone                     |           |          | 
+ external_branch          | text                                         |           |          | 
+ external_updated_at      | timestamp with time zone                     |           |          | 
+ external_state           | text                                         |           |          | 
+ external_review_state    | text                                         |           |          | 
+ external_check_state     | text                                         |           |          | 
+ diff_stat_added          | integer                                      |           |          | 
+ diff_stat_changed        | integer                                      |           |          | 
+ diff_stat_deleted        | integer                                      |           |          | 
+ sync_state               | jsonb                                        |           |          | 
+ current_spec_id          | bigint                                       |           |          | 
+ previous_spec_id         | bigint                                       |           |          | 
+ publication_state        | text                                         |           |          | 
+ owned_by_batch_change_id | bigint                                       |           |          | 
+ reconciler_state         | text                                         |           |          | 
+ failure_message          | text                                         |           |          | 
+ started_at               | timestamp with time zone                     |           |          | 
+ finished_at              | timestamp with time zone                     |           |          | 
+ process_after            | timestamp with time zone                     |           |          | 
+ num_resets               | integer                                      |           |          | 
+ closing                  | boolean                                      |           |          | 
+ num_failures             | integer                                      |           |          | 
+ log_contents             | text                                         |           |          | 
+ execution_logs           | json[]                                       |           |          | 
+ syncer_error             | text                                         |           |          | 
+ external_title           | text                                         |           |          | 
+ worker_hostname          | text                                         |           |          | 
+ ui_publication_state     | batch_changes_changeset_ui_publication_state |           |          | 
 
 ```
 
@@ -2202,7 +2206,10 @@ Triggers:
     c.num_failures,
     c.log_contents,
     c.execution_logs,
-    c.syncer_error
+    c.syncer_error,
+    c.external_title,
+    c.worker_hostname,
+    c.ui_publication_state
    FROM (changesets c
      JOIN repo r ON ((r.id = c.repo_id)))
   WHERE ((r.deleted_at IS NULL) AND (EXISTS ( SELECT 1
@@ -2262,6 +2269,12 @@ Triggers:
      JOIN repo ON ((changeset_specs.repo_id = repo.id)))
   WHERE ((changeset_specs.external_id IS NOT NULL) AND (repo.deleted_at IS NULL));
 ```
+
+# Type batch_changes_changeset_ui_publication_state
+
+- UNPUBLISHED
+- DRAFT
+- PUBLISHED
 
 # Type cm_email_priority
 

--- a/lib/batches/published_test.go
+++ b/lib/batches/published_test.go
@@ -14,11 +14,13 @@ func TestPublishedValue(t *testing.T) {
 		True    bool
 		False   bool
 		Draft   bool
+		Nil     bool
 		Invalid bool
 	}{
 		{name: "True", val: true, True: true},
 		{name: "False", val: false, False: true},
 		{name: "Draft", val: "draft", Draft: true},
+		{name: "Nil", val: nil, Nil: true},
 		{name: "Invalid", val: "invalid", Invalid: true},
 	}
 	for _, tc := range tests {
@@ -32,6 +34,9 @@ func TestPublishedValue(t *testing.T) {
 			}
 			if have, want := p.Draft(), tc.Draft; have != want {
 				t.Fatalf("invalid `draft` value: want=%t have=%t", want, have)
+			}
+			if have, want := p.Nil(), tc.Nil; have != want {
+				t.Fatalf("invalid `nil` value: want=%t have=%t", want, have)
 			}
 			if have, want := p.Valid(), !tc.Invalid; have != want {
 				t.Fatalf("invalid `valid` value: want=%t have=%t", want, have)
@@ -47,6 +52,7 @@ func TestPublishedValue(t *testing.T) {
 			{name: "true", val: true, expected: "true"},
 			{name: "false", val: false, expected: "false"},
 			{name: "draft", val: "draft", expected: `"draft"`},
+			{name: "nil", val: nil, expected: "null"},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -70,6 +76,7 @@ func TestPublishedValue(t *testing.T) {
 			{name: "true", val: "true", expected: true},
 			{name: "false", val: "false", expected: false},
 			{name: "draft", val: `"draft"`, expected: "draft"},
+			{name: "nil", val: "null", expected: nil},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {
@@ -95,6 +102,7 @@ func TestPublishedValue(t *testing.T) {
 			{name: "false", val: "no", expected: false},
 			{name: "draft", val: "draft", expected: "draft"},
 			{name: "draft", val: `"draft"`, expected: "draft"},
+			{name: "nil", val: "null", expected: nil},
 		}
 		for _, tc := range tests {
 			t.Run(tc.name, func(t *testing.T) {

--- a/migrations/frontend/1528395798_changeset_title.down.sql
+++ b/migrations/frontend/1528395798_changeset_title.down.sql
@@ -1,6 +1,28 @@
 BEGIN;
 
+-- Note that we have to regenerate the reconciler_changesets view, as the SELECT
+-- c.* in the view definition isn't refreshed when the fields change within the
+-- changesets table.
+DROP VIEW IF EXISTS
+    reconciler_changesets;
+
 DROP INDEX IF EXISTS changesets_external_title_idx;
 ALTER TABLE changesets DROP COLUMN IF EXISTS external_title;
+
+CREATE VIEW reconciler_changesets AS
+    SELECT c.* FROM changesets c
+    INNER JOIN repo r on r.id = c.repo_id
+    WHERE
+        r.deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM batch_changes
+            LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+            LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+            WHERE
+                c.batch_change_ids ? batch_changes.id::text AND
+                namespace_user.deleted_at IS NULL AND
+                namespace_org.deleted_at IS NULL
+        )
+;
 
 COMMIT;

--- a/migrations/frontend/1528395798_changeset_title.up.sql
+++ b/migrations/frontend/1528395798_changeset_title.up.sql
@@ -1,10 +1,32 @@
 BEGIN;
 
+-- Note that we have to regenerate the reconciler_changesets view, as the SELECT
+-- c.* in the view definition isn't refreshed when the fields change within the
+-- changesets table.
+DROP VIEW IF EXISTS
+    reconciler_changesets;
+
 ALTER TABLE changesets ADD COLUMN IF NOT EXISTS external_title text;
 COMMENT ON COLUMN changesets.external_title IS 'Normalized property generated on save using Changeset.Title()';
 
 UPDATE changesets SET external_title = COALESCE(changesets.metadata->>'Title', changesets.metadata->>'title', NULL);
 
 CREATE INDEX IF NOT EXISTS changesets_external_title_idx ON changesets USING BTREE(external_title);
+
+CREATE VIEW reconciler_changesets AS
+    SELECT c.* FROM changesets c
+    INNER JOIN repo r on r.id = c.repo_id
+    WHERE
+        r.deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM batch_changes
+            LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+            LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+            WHERE
+                c.batch_change_ids ? batch_changes.id::text AND
+                namespace_user.deleted_at IS NULL AND
+                namespace_org.deleted_at IS NULL
+        )
+;
 
 COMMIT;

--- a/migrations/frontend/1528395836_dbworkers_worker_hostname.down.sql
+++ b/migrations/frontend/1528395836_dbworkers_worker_hostname.down.sql
@@ -1,7 +1,30 @@
 BEGIN;
 
-ALTER TABLE changeset_jobs DROP COLUMN IF EXISTS worker_hostname;
+-- Note that we have to regenerate the reconciler_changesets view, as the SELECT
+-- c.* in the view definition isn't refreshed when the fields change within the
+-- changesets table.
+DROP VIEW IF EXISTS
+    reconciler_changesets;
+
 ALTER TABLE changesets DROP COLUMN IF EXISTS worker_hostname;
+
+CREATE VIEW reconciler_changesets AS
+    SELECT c.* FROM changesets c
+    INNER JOIN repo r on r.id = c.repo_id
+    WHERE
+        r.deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM batch_changes
+            LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+            LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+            WHERE
+                c.batch_change_ids ? batch_changes.id::text AND
+                namespace_user.deleted_at IS NULL AND
+                namespace_org.deleted_at IS NULL
+        )
+;
+
+ALTER TABLE changeset_jobs DROP COLUMN IF EXISTS worker_hostname;
 ALTER TABLE cm_action_jobs DROP COLUMN IF EXISTS worker_hostname;
 ALTER TABLE cm_trigger_jobs DROP COLUMN IF EXISTS worker_hostname;
 ALTER TABLE external_service_sync_jobs DROP COLUMN IF EXISTS worker_hostname;

--- a/migrations/frontend/1528395836_dbworkers_worker_hostname.up.sql
+++ b/migrations/frontend/1528395836_dbworkers_worker_hostname.up.sql
@@ -1,7 +1,30 @@
 BEGIN;
 
-ALTER TABLE changeset_jobs ADD COLUMN worker_hostname text NOT NULL DEFAULT '';
+-- Note that we have to regenerate the reconciler_changesets view, as the SELECT
+-- c.* in the view definition isn't refreshed when the fields change within the
+-- changesets table.
+DROP VIEW IF EXISTS
+    reconciler_changesets;
+
 ALTER TABLE changesets ADD COLUMN IF NOT EXISTS worker_hostname text NOT NULL DEFAULT '';
+
+CREATE VIEW reconciler_changesets AS
+    SELECT c.* FROM changesets c
+    INNER JOIN repo r on r.id = c.repo_id
+    WHERE
+        r.deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM batch_changes
+            LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+            LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+            WHERE
+                c.batch_change_ids ? batch_changes.id::text AND
+                namespace_user.deleted_at IS NULL AND
+                namespace_org.deleted_at IS NULL
+        )
+;
+
+ALTER TABLE changeset_jobs ADD COLUMN worker_hostname text NOT NULL DEFAULT '';
 ALTER TABLE cm_action_jobs ADD COLUMN IF NOT EXISTS worker_hostname text NOT NULL DEFAULT '';
 ALTER TABLE cm_trigger_jobs ADD COLUMN IF NOT EXISTS worker_hostname text NOT NULL DEFAULT '';
 ALTER TABLE external_service_sync_jobs ADD COLUMN IF NOT EXISTS worker_hostname text NOT NULL DEFAULT '';

--- a/migrations/frontend/1528395838_ui_publish_state.down.sql
+++ b/migrations/frontend/1528395838_ui_publish_state.down.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+-- Note that we have to regenerate the reconciler_changesets view, as the SELECT
+-- c.* in the view definition isn't refreshed when the fields change within the
+-- changesets table.
+DROP VIEW IF EXISTS
+    reconciler_changesets;
+
+ALTER TABLE
+    changesets
+DROP COLUMN IF EXISTS
+    ui_publication_state;
+
+DROP TYPE IF EXISTS
+    batch_changes_changeset_ui_publication_state;
+
+CREATE VIEW reconciler_changesets AS
+    SELECT c.* FROM changesets c
+    INNER JOIN repo r on r.id = c.repo_id
+    WHERE
+        r.deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM batch_changes
+            LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+            LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+            WHERE
+                c.batch_change_ids ? batch_changes.id::text AND
+                namespace_user.deleted_at IS NULL AND
+                namespace_org.deleted_at IS NULL
+        )
+;
+
+COMMIT;

--- a/migrations/frontend/1528395838_ui_publish_state.up.sql
+++ b/migrations/frontend/1528395838_ui_publish_state.up.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+CREATE TYPE
+    batch_changes_changeset_ui_publication_state
+AS ENUM (
+    'UNPUBLISHED',
+    'DRAFT',
+    'PUBLISHED'
+);
+
+-- Note that we have to regenerate the reconciler_changesets view, as the SELECT
+-- c.* in the view definition isn't refreshed when the fields change within the
+-- changesets table.
+DROP VIEW IF EXISTS
+    reconciler_changesets;
+
+ALTER TABLE
+    changesets
+ADD COLUMN IF NOT EXISTS
+    ui_publication_state batch_changes_changeset_ui_publication_state NULL DEFAULT NULL;
+
+CREATE VIEW reconciler_changesets AS
+    SELECT c.* FROM changesets c
+    INNER JOIN repo r on r.id = c.repo_id
+    WHERE
+        r.deleted_at IS NULL AND
+        EXISTS (
+            SELECT 1 FROM batch_changes
+            LEFT JOIN users namespace_user ON batch_changes.namespace_user_id = namespace_user.id
+            LEFT JOIN orgs namespace_org ON batch_changes.namespace_org_id = namespace_org.id
+            WHERE
+                c.batch_change_ids ? batch_changes.id::text AND
+                namespace_user.deleted_at IS NULL AND
+                namespace_org.deleted_at IS NULL
+        )
+;
+
+COMMIT;

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -69,12 +69,21 @@
           "rootAtLocationOf": {
             "type": "string",
             "description": "The name of the file that sits at the root of the desired workspace.",
-            "examples": ["package.json", "go.mod", "Gemfile", "Cargo.toml", "README.md"]
+            "examples": [
+              "package.json",
+              "go.mod",
+              "Gemfile",
+              "Cargo.toml",
+              "README.md"
+            ]
           },
           "in": {
             "type": "string",
             "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
-            "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
+            "examples": [
+              "github.com/sourcegraph/src-cli",
+              "github.com/sourcegraph/*"
+            ]
           },
           "onlyFetchWorkspace": {
             "type": "boolean",
@@ -113,7 +122,11 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
+                  "examples": [
+                    "hello world",
+                    "${{ step.stdout }}",
+                    "${{ repository.name }}"
+                  ]
                 },
                 "format": {
                   "type": "string",
@@ -240,7 +253,7 @@
       "type": "object",
       "description": "A template describing how to create (and update) changesets with the file changes produced by the command steps.",
       "additionalProperties": false,
-      "required": ["title", "branch", "commit", "published"],
+      "required": ["title", "branch", "commit"],
       "properties": {
         "title": {
           "type": "string",
@@ -286,7 +299,7 @@
           }
         },
         "published": {
-          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.",
+          "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host. If omitted, the publication state is controlled from the Batch Changes UI.",
           "oneOf": [
             {
               "oneOf": [

--- a/schema/batch_spec.schema.json
+++ b/schema/batch_spec.schema.json
@@ -69,21 +69,12 @@
           "rootAtLocationOf": {
             "type": "string",
             "description": "The name of the file that sits at the root of the desired workspace.",
-            "examples": [
-              "package.json",
-              "go.mod",
-              "Gemfile",
-              "Cargo.toml",
-              "README.md"
-            ]
+            "examples": ["package.json", "go.mod", "Gemfile", "Cargo.toml", "README.md"]
           },
           "in": {
             "type": "string",
             "description": "The repositories in which to apply the workspace configuration. Supports globbing.",
-            "examples": [
-              "github.com/sourcegraph/src-cli",
-              "github.com/sourcegraph/*"
-            ]
+            "examples": ["github.com/sourcegraph/src-cli", "github.com/sourcegraph/*"]
           },
           "onlyFetchWorkspace": {
             "type": "boolean",
@@ -122,11 +113,7 @@
                 "value": {
                   "type": "string",
                   "description": "The value of the output, which can be a template string.",
-                  "examples": [
-                    "hello world",
-                    "${{ step.stdout }}",
-                    "${{ repository.name }}"
-                  ]
+                  "examples": ["hello world", "${{ step.stdout }}", "${{ repository.name }}"]
                 },
                 "format": {
                   "type": "string",

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -88,17 +88,7 @@
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
         }
       },
-      "required": [
-        "baseRepository",
-        "baseRef",
-        "baseRev",
-        "headRepository",
-        "headRef",
-        "title",
-        "body",
-        "commits",
-        "published"
-      ],
+      "required": ["baseRepository", "baseRef", "baseRev", "headRepository", "headRef", "title", "body", "commits"],
       "additionalProperties": false
     }
   ]

--- a/schema/changeset_spec.schema.json
+++ b/schema/changeset_spec.schema.json
@@ -84,7 +84,7 @@
           }
         },
         "published": {
-          "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }],
+          "oneOf": [{ "type": "boolean" }, { "type": "string", "pattern": "^draft$" }, { "type": "null" }],
           "description": "Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host."
         }
       },

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -368,8 +368,8 @@ type ChangesetTemplate struct {
 	Branch string `json:"branch"`
 	// Commit description: The Git commit to create with the changes.
 	Commit ExpandedGitCommitDescription `json:"commit"`
-	// Published description: Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host.
-	Published interface{} `json:"published"`
+	// Published description: Whether to publish the changeset. An unpublished changeset can be previewed on Sourcegraph by any person who can view the batch change, but its commit, branch, and pull request aren't created on the code host. A published changeset results in a commit, branch, and pull request being created on the code host. If omitted, the publication state is controlled from the Batch Changes UI.
+	Published interface{} `json:"published,omitempty"`
 	// Title description: The title of the changeset.
 	Title string `json:"title"`
 }


### PR DESCRIPTION
This PR includes #21005; I'm going to open it up for review just to speed things up, but please excuse the duplicate code.

This PR adds a new database field to track the UI publication state of each changeset, and extends the reconciler to be able to handle looking up that field when required. What it doesn't include is anything to actually manipulate that field (without directly updating the database).

Part three of #18277.