### PR TITLE
Add org description to visibility picker

### DIFF
--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -71,7 +71,9 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
 
     const descriptionText = !possibleOrg
         ? 'This insight will only be visible to you. It will not be shown to other users in your organization.'
-        : `This insight will be visible to all users in the ${possibleOrg.displayName || possibleOrg.name} organization who have enabled code insights.`
+        : `This insight will be visible to all users in the ${
+              possibleOrg.displayName || possibleOrg.name
+          } organization who have enabled code insights.`
 
     return (
         <FormGroup

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -67,12 +67,17 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
         }
     }
 
+    const possibleOrg = organizations.find(org => org.id === value)
+
+    const descriptionText = !possibleOrg?.displayName
+        ? 'This insight will be visible only on your personal dashboard. It will not be show to other users in your organization.'
+        : `This insight will be visible to all users in the ${possibleOrg.displayName} organization who have enabled code insights.`
+
     return (
         <FormGroup
             name="visibility"
             title="Visibility"
-            description="This insight will be visible only on your personal dashboard. It will not be show to other
-                            users in your organization."
+            description={descriptionText}
             className="mb-0 mt-4"
             labelClassName={labelClassName}
             contentClassName="d-flex flex-wrap mb-n2"

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -69,7 +69,7 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
 
     const possibleOrg = organizations.find(org => org.id === value)
 
-    const descriptionText = !possibleOrg?.displayName
+    const descriptionText = !possibleOrg
         ? 'This insight will be visible only on your personal dashboard. It will not be show to other users in your organization.'
         : `This insight will be visible to all users in the ${possibleOrg.displayName} organization who have enabled code insights.`
 

--- a/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
+++ b/client/web/src/insights/components/visibility-picker/VisibilityPicker.tsx
@@ -70,8 +70,8 @@ export const VisibilityPicker: React.FunctionComponent<VisibilityPickerProps> = 
     const possibleOrg = organizations.find(org => org.id === value)
 
     const descriptionText = !possibleOrg
-        ? 'This insight will be visible only on your personal dashboard. It will not be show to other users in your organization.'
-        : `This insight will be visible to all users in the ${possibleOrg.displayName} organization who have enabled code insights.`
+        ? 'This insight will only be visible to you. It will not be shown to other users in your organization.'
+        : `This insight will be visible to all users in the ${possibleOrg.displayName || possibleOrg.name} organization who have enabled code insights.`
 
     return (
         <FormGroup


### PR DESCRIPTION
Resolves: https://github.com/sourcegraph/sourcegraph/issues/21095

In case if a user is changing visibility value (from personal to org) we have to change the description to this field according to the last visibility value. 