### PR TITLE
Change series state validation management

### DIFF
--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -34,7 +34,9 @@ export interface useFieldAPI<FieldValue> {
      * Meta state of form field - like touched, valid state and last
      * native validity state.
      * */
-    meta: FieldState<FieldValue>
+    meta: FieldState<FieldValue> & {
+        setState: (dispatch: (previousState: FieldState<FieldValue>) => FieldState<FieldValue>) => void
+    }
 }
 
 /**
@@ -143,6 +145,9 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
         meta: {
             ...state,
             touched: state.touched || submitted || formTouched,
+            setState: dispatch => {
+                setState(state => ({ ...dispatch(state) }))
+            },
         },
     }
 }

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -35,6 +35,11 @@ export interface useFieldAPI<FieldValue> {
      * native validity state.
      * */
     meta: FieldState<FieldValue> & {
+        /**
+         * Set state handler gives access to set inner state of useField.
+         * Useful for complicated cases when need to deal with custom react input
+         * component.
+         * */
         setState: (dispatch: (previousState: FieldState<FieldValue>) => FieldState<FieldValue>) => void
     }
 }
@@ -145,6 +150,11 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
         meta: {
             ...state,
             touched: state.touched || submitted || formTouched,
+            /**
+             * Set state dispatcher gives access to set inner state of useField.
+             * Useful for complex cases when you need to deal with custom react input
+             * components.
+             * */
             setState: dispatch => {
                 setState(state => ({ ...dispatch(state) }))
             },

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -16,10 +16,9 @@ interface FormSeriesInputProps {
     /** Series index. */
     index: number
     /**
-     * Prop to force touched state for series form.
-     * (show all validation error)
+     * Show all validation error of all fields within the form.
      * */
-    touched?: boolean
+    showValidationErrorsOnMount?: boolean
     /** Name of series. */
     name?: string
     /** Query value of series. */
@@ -44,7 +43,7 @@ interface FormSeriesInputProps {
 export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = props => {
     const {
         index,
-        touched = false,
+        showValidationErrorsOnMount = false,
         name,
         query,
         stroke: color,
@@ -60,7 +59,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
     const hasQueryControlledValue = !!query
 
     const { formAPI, handleSubmit, ref } = useForm({
-        touched,
+        touched: showValidationErrorsOnMount,
         initialValues: {
             seriesName: name ?? '',
             seriesQuery: query ?? '',

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series-input/FormSeriesInput.tsx
@@ -15,6 +15,11 @@ const validQuery = createRequiredValidator('Query is a required field for data s
 interface FormSeriesInputProps {
     /** Series index. */
     index: number
+    /**
+     * Prop to force touched state for series form.
+     * (show all validation error)
+     * */
+    touched?: boolean
     /** Name of series. */
     name?: string
     /** Query value of series. */
@@ -31,6 +36,7 @@ interface FormSeriesInputProps {
     onSubmit?: (series: DataSeries) => void
     /** On cancel handler. */
     onCancel?: () => void
+    /** Change handler in order to listen last values of series form. */
     onChange?: (formValues: DataSeries, valid: boolean) => void
 }
 
@@ -38,6 +44,7 @@ interface FormSeriesInputProps {
 export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = props => {
     const {
         index,
+        touched = false,
         name,
         query,
         stroke: color,
@@ -53,6 +60,7 @@ export const FormSeriesInput: React.FunctionComponent<FormSeriesInputProps> = pr
     const hasQueryControlledValue = !!query
 
     const { formAPI, handleSubmit, ref } = useForm({
+        touched,
         initialValues: {
             seriesName: name ?? '',
             seriesQuery: query ?? '',

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
@@ -69,7 +69,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
             {series.map((line, index) =>
                 line.edit ? (
                     <FormSeriesInput
-                        key={`${line?.name ?? ''}-${index}`}
+                        key={line.id}
                         touched={touched}
                         index={index + 1}
                         cancel={series.length > 1}
@@ -81,13 +81,13 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                         {...line}
                     />
                 ) : (
-                    series[index] && (
+                    line && (
                         <SeriesCard
-                            key={`${series[index].name}-${index}`}
+                            key={`${line.id}-card`}
                             onEdit={() => onEditSeriesRequest(index)}
                             onRemove={() => onSeriesRemove(index)}
                             className={styles.formSeriesItem}
-                            {...series[index]}
+                            {...line}
                         />
                     )
                 )

--- a/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/form-series/FormSeries.tsx
@@ -9,10 +9,9 @@ import styles from './FormSeries.module.scss'
 
 export interface FormSeriesProps {
     /**
-     * Prop to force touched state for all series forms.
-     * (show all validation error for all forms and fields)
+     * Show all validation error for all forms and fields within the series forms.
      * */
-    touched: boolean
+    showValidationErrorsOnMount: boolean
     /**
      * Controlled value (series - chart lines) for series input component.
      * */
@@ -56,7 +55,7 @@ export interface FormSeriesProps {
 export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
     const {
         series = [],
-        touched,
+        showValidationErrorsOnMount,
         onEditSeriesRequest,
         onEditSeriesCommit,
         onEditSeriesCancel,
@@ -70,7 +69,7 @@ export const FormSeries: React.FunctionComponent<FormSeriesProps> = props => {
                 line.edit ? (
                     <FormSeriesInput
                         key={line.id}
-                        touched={touched}
+                        showValidationErrorsOnMount={showValidationErrorsOnMount}
                         index={index + 1}
                         cancel={series.length > 1}
                         autofocus={series.length > 1}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.test.tsx
@@ -190,7 +190,7 @@ describe('CreateInsightContent', () => {
             sinon.assert.notCalled(onSubmitMock)
 
             expect(seriesName).toHaveFocus()
-            expect(getByText(/series is empty/i)).toBeInTheDocument()
+            expect(getByText(/series is invalid/i)).toBeInTheDocument()
         })
 
         it('when onSubmit threw submit error', async () => {

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -88,11 +88,13 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         series,
     })
 
+    const validEditSeries = editSeries.filter(series => series.valid)
+
     // If some fields that needed to run live preview  are invalid
     // we should disabled live chart preview
     const allFieldsForPreviewAreValid =
         (repositories.meta.validState === 'VALID' || repositories.meta.validState === 'CHECKING') &&
-        (series.meta.validState === 'VALID' || editSeries.length) &&
+        (series.meta.validState === 'VALID' || validEditSeries.length) &&
         stepValue.meta.validState === 'VALID'
 
     return (

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -84,7 +84,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     const step = useField('step', formAPI)
     const stepValue = useField('stepValue', formAPI, { sync: requiredStepValueField })
 
-    const { liveSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({
+    const { editSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({
         series,
     })
 
@@ -92,7 +92,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     // we should disabled live chart preview
     const allFieldsForPreviewAreValid =
         (repositories.meta.validState === 'VALID' || repositories.meta.validState === 'CHECKING') &&
-        (series.meta.validState === 'VALID' || liveSeries.length) &&
+        (series.meta.validState === 'VALID' || editSeries.length) &&
         stepValue.meta.validState === 'VALID'
 
     return (
@@ -123,7 +123,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
             <SearchInsightLivePreview
                 disabled={!allFieldsForPreviewAreValid}
                 repositories={repositories.meta.value}
-                series={liveSeries}
+                series={editSeries}
                 step={step.meta.value}
                 stepValue={stepValue.meta.value}
                 className={styles.contentLivePreview}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -13,7 +13,7 @@ import { CreateInsightFormFields } from '../../types'
 import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLivePreview'
 import { SearchInsightCreationForm } from '../search-insight-creation-form/SearchInsightCreationForm'
 
-import { useEditableSeries } from './hooks/use-editable-series'
+import { useEditableSeries, createDefaultEditSeries } from './hooks/use-editable-series'
 import styles from './SearchInsightCreationContent.module.scss'
 import {
     repositoriesExistValidator,
@@ -24,7 +24,10 @@ import {
 
 const INITIAL_VALUES: CreateInsightFormFields = {
     visibility: 'personal',
-    series: [],
+    // If user opens creation form to create insight
+    // we want to show the series form as soon as possible without
+    // force user to click 'add another series' button
+    series: [createDefaultEditSeries({ edit: true })],
     step: 'months',
     stepValue: '2',
     title: '',
@@ -81,7 +84,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
     const step = useField('step', formAPI)
     const stepValue = useField('stepValue', formAPI, { sync: requiredStepValueField })
 
-    const { liveSeries, editSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({
+    const { liveSeries, listen, editRequest, editCommit, cancelEdit, deleteSeries } = useEditableSeries({
         series,
     })
 
@@ -101,6 +104,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 handleSubmit={handleSubmit}
                 submitErrors={formAPI.submitErrors}
                 submitting={formAPI.submitting}
+                submitted={formAPI.submitted}
                 title={title}
                 repositories={repositories}
                 visibility={visibility}
@@ -110,7 +114,6 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 stepValue={stepValue}
                 onSeriesLiveChange={listen}
                 onCancel={onCancel}
-                editSeries={editSeries}
                 onEditSeriesRequest={editRequest}
                 onEditSeriesCancel={cancelEdit}
                 onEditSeriesCommit={editCommit}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/helpers.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/helpers.ts
@@ -1,0 +1,14 @@
+
+/**
+ * Helper replace element in array by index and return new array.
+ * */
+export function replace<Element>(list: Element[], index: number, newElement: Element): Element[] {
+    return [...list.slice(0, index), newElement, ...list.slice(index + 1)]
+}
+
+/**
+ * Helper remove element from array by index
+ * */
+export function remove<Element>(list: Element[], index: number): Element[] {
+    return [...list.slice(0, index), ...list.slice(index + 1)]
+}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/helpers.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/helpers.ts
@@ -1,4 +1,3 @@
-
 /**
  * Helper replace element in array by index and return new array.
  * */

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -5,13 +5,15 @@ import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
 import { CreateInsightFormFields, EditableDataSeries } from '../../../types'
 import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput'
 
+import { remove, replace } from './helpers';
+
 export const createDefaultEditSeries = (series?: Partial<EditableDataSeries>): EditableDataSeries => ({
     ...defaultEditSeries,
     ...series,
+    id: uuid.v4(),
 })
 
 const defaultEditSeries = {
-    id: uuid.v4(),
     valid: false,
     edit: false,
     name: '',
@@ -57,10 +59,8 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     const handleSeriesLiveChange = (liveSeries: EditableDataSeries, valid: boolean, index: number): void => {
         series.meta.setState(state => {
             const newLiveSeries = { ...liveSeries, edit: true, valid }
-            const series = state.value
-            const newSeries = [...series.slice(0, index), newLiveSeries, ...series.slice(index + 1)]
 
-            return { ...state, value: newSeries }
+            return { ...state, value: replace(state.value, index, newLiveSeries) }
         })
     }
 
@@ -103,10 +103,7 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
 
             // On other case means that user clicked cancel of new series form
             // in this case we have to remove series model entirely
-
-            const newSeries = [...series.slice(0, index), ...series.slice(index + 1)]
-
-            return { ...state, value: newSeries }
+            return { ...state, value: remove(series, index) }
         })
     }
 
@@ -114,7 +111,7 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
         series.meta.setState(state => {
             const series = state.value
             const updatedSeries = { ...editedSeries, valid: true, edit: false }
-            const newSeries = [...series.slice(0, index), updatedSeries, ...series.slice(index + 1)]
+            const newSeries = replace(series, index, updatedSeries)
 
             return { ...state, value: newSeries }
         })
@@ -123,7 +120,7 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     const handleRemoveSeries = (index: number): void => {
         series.meta.setState(state => {
             const series = state.value
-            const newSeries = [...series.slice(0, index), ...series.slice(index + 1)]
+            const newSeries = remove(series, index)
 
             if (newSeries.length === 0) {
                 // If user remove all series we add fallback with another oped edit series

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -5,7 +5,7 @@ import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
 import { CreateInsightFormFields, EditableDataSeries } from '../../../types'
 import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput'
 
-import { remove, replace } from './helpers';
+import { remove, replace } from './helpers'
 
 export const createDefaultEditSeries = (series?: Partial<EditableDataSeries>): EditableDataSeries => ({
     ...defaultEditSeries,

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -1,26 +1,24 @@
 import { useState } from 'react'
-
-import { isDefined } from '@sourcegraph/shared/src/util/types'
+import * as uuid from 'uuid'
 
 import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
 import { DataSeries } from '../../../../../../core/backend/types'
 import { useDistinctValue } from '../../../../../../hooks/use-distinct-value'
-import { CreateInsightFormFields } from '../../../types'
+import { CreateInsightFormFields, EditableDataSeries } from '../../../types'
 import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput'
 
-const createDefaultEditSeries = (series = defaultEditSeries, valid = false): EditDataSeries => ({
+export const createDefaultEditSeries = (series?: Partial<EditableDataSeries>): EditableDataSeries => ({
+    ...defaultEditSeries,
     ...series,
-    valid,
 })
 
 const defaultEditSeries = {
+    id: uuid.v4(),
+    valid: false,
+    edit: false,
     name: '',
     query: '',
     stroke: DEFAULT_ACTIVE_COLOR,
-}
-
-interface EditDataSeries extends DataSeries {
-    valid: boolean
 }
 
 export interface UseEditableSeriesProps {
@@ -33,7 +31,7 @@ export interface UseEditableSeriesAPI {
      * In case of some element has undefined value we're showing
      * series card with data instead of form.
      * */
-    editSeries: (CreateInsightFormFields['series'][number] | undefined)[]
+    editSeries: CreateInsightFormFields['series']
 
     /**
      * Latest valid values of series.
@@ -43,13 +41,13 @@ export interface UseEditableSeriesAPI {
     /**
      * Handler to listen latest values of particular sereis form.
      * */
-    listen: (liveSeries: DataSeries, valid: boolean, index: number) => void
+    listen: (liveSeries: EditableDataSeries, valid: boolean, index: number) => void
 
     /**
-     * Handlers for CRUD operations over sereis.
+     * Handlers for CRUD operations over series.
      * */
     editRequest: (index: number) => void
-    editCommit: (index: number, editedSeries: DataSeries) => void
+    editCommit: (index: number, editedSeries: EditableDataSeries) => void
     cancelEdit: (index: number) => void
     deleteSeries: (index: number) => void
 }
@@ -61,88 +59,101 @@ export interface UseEditableSeriesAPI {
 export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSeriesAPI {
     const { series } = props
 
-    const [editSeries, setEditSeries] = useState<(EditDataSeries | undefined)[]>(() => {
-        const hasSeries = series.input.value.length
-
-        if (hasSeries) {
-            return series.input.value.map(() => undefined)
-        }
-
-        // If we in creation mode we should show first series editor in a first
-        // render.
-        return [createDefaultEditSeries()]
-    })
+    const [seriesBeforeEdit, setSeriesBeforeEdit] = useState<Record<string, EditableDataSeries>>({})
 
     const liveSeries = useDistinctValue(
-        editSeries
-            .map((editSeries, index) => {
-                if (editSeries) {
-                    const { valid, ...series } = editSeries
-                    return valid ? series : undefined
-                }
-
-                return series.meta.value[index]
-            })
-            .filter<DataSeries>(isDefined)
+        series.input.value
+            .filter(series => series.valid)
+            // Cut off all unnecessary for live preview fields in order to
+            // not trigger live preview update if any of unnecessary has been updated
+            // Example: edit true => false - chart shouldn't re-fetch data
+            .map<DataSeries>(line => ({ name: line.name, query: line.query, stroke: line.stroke }))
     )
 
-    const handleSeriesLiveChange = (liveSeries: DataSeries, valid: boolean, index: number): void => {
-        setEditSeries(editSeries => {
-            const newEditSeries = [...editSeries]
+    const handleSeriesLiveChange = (liveSeries: EditableDataSeries, valid: boolean, index: number): void => {
+        series.meta.setState(state => {
+            const newLiveSeries = { ...liveSeries, edit: true, valid }
+            const series = state.value
+            const newSeries = [...series.slice(0, index), newLiveSeries, ...series.slice(index + 1)]
 
-            newEditSeries[index] = { ...liveSeries, valid }
-
-            return newEditSeries
+            return { ...state, value: newSeries }
         })
     }
 
     const handleEditSeriesRequest = (index: number): void => {
-        setEditSeries(editSeries => {
-            const newEditSeries = [...editSeries]
+        const seriesValue = series.meta.value
+        const newEditSeries = [...seriesValue]
 
-            newEditSeries[index] = series.meta.value[index]
-                ? createDefaultEditSeries(series.meta.value[index], true)
-                : createDefaultEditSeries()
+        newEditSeries[index] = seriesValue[index]
+            ? { ...seriesValue[index], edit: true }
+            : createDefaultEditSeries({ edit: true })
 
-            return newEditSeries
-        })
+        // If user tries edit series we have to remember value before edit
+        // in case if user clicks cancel we return that initial value back
+        if (seriesValue[index]) {
+            const newSeriesID = newEditSeries[index].id
+
+            setSeriesBeforeEdit({
+                ...seriesBeforeEdit,
+                [newSeriesID]: seriesValue[index],
+            })
+        }
+
+        series.meta.setState(state => ({ ...state, value: newEditSeries }))
     }
 
     const handleEditSeriesCancel = (index: number): void => {
-        setEditSeries(editSeries => {
-            const newEditSeries = [...editSeries]
+        series.meta.setState(state => {
+            const series = [...state.value]
+            const seriesValueBeforeEdit = seriesBeforeEdit[series[index].id]
 
-            newEditSeries[index] = undefined
-            setEditSeries(newEditSeries)
+            // If we have series by this index that means user activated
+            // cancellation of edit mode of series that already exists
+            if (seriesValueBeforeEdit) {
+                // in this case we have to set values of settings that we had
+                // before edit happened
+                series[index] = seriesValueBeforeEdit
 
-            return editSeries
+                return { ...state, value: series }
+            }
+
+            // On other case means that user clicked cancel of new series form
+            // in this case we have to remove series model entirely
+
+            const newSeries = [...series.slice(0, index), ...series.slice(index + 1)]
+
+            return { ...state, value: newSeries }
         })
     }
 
-    const handleEditSeriesCommit = (index: number, editedSeries: DataSeries): void => {
-        setEditSeries(editSeries => {
-            const newEditedSeries = [...editSeries]
+    const handleEditSeriesCommit = (index: number, editedSeries: EditableDataSeries): void => {
+        series.meta.setState(state => {
+            const series = state.value
+            const updatedSeries = { ...editedSeries, valid: true, edit: false }
+            const newSeries = [...series.slice(0, index), updatedSeries, ...series.slice(index + 1)]
 
-            // Remove series from edited cards
-            newEditedSeries[index] = undefined
-
-            return newEditedSeries
+            return { ...state, value: newSeries }
         })
-
-        const newSeries = [...series.input.value.slice(0, index), editedSeries, ...series.input.value.slice(index + 1)]
-        series.input.onChange(newSeries)
     }
 
     const handleRemoveSeries = (index: number): void => {
-        setEditSeries(editSeries => [...editSeries.slice(0, index), ...editSeries.slice(index + 1)])
+        series.meta.setState(state => {
+            const series = state.value
+            const newSeries = [...series.slice(0, index), ...series.slice(index + 1)]
 
-        const newSeries = [...series.input.value.slice(0, index), ...series.input.value.slice(index + 1)]
-        series.input.onChange(newSeries)
+            if (newSeries.length === 0) {
+                // If user remove all series we add fallback with another oped edit series
+                // just to emphasize that user has to fill in at least one series
+                return { ...state, value: [createDefaultEditSeries({ edit: true })] }
+            }
+
+            return { ...state, value: newSeries }
+        })
     }
 
     return {
         liveSeries,
-        editSeries,
+        editSeries: series.input.value,
         listen: handleSeriesLiveChange,
         editRequest: handleEditSeriesRequest,
         editCommit: handleEditSeriesCommit,

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -2,8 +2,6 @@ import { useState } from 'react'
 import * as uuid from 'uuid'
 
 import { useFieldAPI } from '../../../../../../components/form/hooks/useField'
-import { DataSeries } from '../../../../../../core/backend/types'
-import { useDistinctValue } from '../../../../../../hooks/use-distinct-value'
 import { CreateInsightFormFields, EditableDataSeries } from '../../../types'
 import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput'
 
@@ -34,11 +32,6 @@ export interface UseEditableSeriesAPI {
     editSeries: CreateInsightFormFields['series']
 
     /**
-     * Latest valid values of series.
-     * */
-    liveSeries: DataSeries[]
-
-    /**
      * Handler to listen latest values of particular sereis form.
      * */
     listen: (liveSeries: EditableDataSeries, valid: boolean, index: number) => void
@@ -60,15 +53,6 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     const { series } = props
 
     const [seriesBeforeEdit, setSeriesBeforeEdit] = useState<Record<string, EditableDataSeries>>({})
-
-    const liveSeries = useDistinctValue(
-        series.input.value
-            .filter(series => series.valid)
-            // Cut off all unnecessary for live preview fields in order to
-            // not trigger live preview update if any of unnecessary has been updated
-            // Example: edit true => false - chart shouldn't re-fetch data
-            .map<DataSeries>(line => ({ name: line.name, query: line.query, stroke: line.stroke }))
-    )
 
     const handleSeriesLiveChange = (liveSeries: EditableDataSeries, valid: boolean, index: number): void => {
         series.meta.setState(state => {
@@ -152,7 +136,6 @@ export function useEditableSeries(props: UseEditableSeriesProps): UseEditableSer
     }
 
     return {
-        liveSeries,
         editSeries: series.input.value,
         listen: handleSeriesLiveChange,
         editRequest: handleEditSeriesRequest,

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
@@ -3,7 +3,7 @@ import { Validator } from '../../../../../components/form/hooks/useField'
 import { AsyncValidator } from '../../../../../components/form/hooks/utils/use-async-validation'
 import { createRequiredValidator } from '../../../../../components/form/validators'
 import { fetchRepositories } from '../../../../../core/backend/requests/fetch-repositories'
-import { DataSeries } from '../../../../../core/backend/types'
+import { EditableDataSeries } from '../../types'
 import { getSanitizedRepositories } from '../../utils/insight-sanitizer'
 
 export const repositoriesFieldValidator = createRequiredValidator('Repositories is a required field.')
@@ -12,8 +12,17 @@ export const requiredStepValueField = createRequiredValidator('Please specify a 
  * Custom validator for chart series. Since series has complex type
  * we can't validate this with standard validators.
  * */
-export const seriesRequired: Validator<DataSeries[]> = series =>
-    series && series.length > 0 ? undefined : 'Series is empty. You must have at least one series for code insight.'
+export const seriesRequired: Validator<EditableDataSeries[]> = series => {
+    if (!series || series.length === 0) {
+        return 'Series is empty. You must have at least one series for code insight.'
+    }
+
+    if (series.some(series => !series.valid)) {
+        return 'Some series is invalid. Remove or edit invalid series.'
+    }
+
+    return
+}
 
 export const repositoriesExistValidator: AsyncValidator<string> = async value => {
     if (!value) {

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/validators.ts
@@ -14,11 +14,11 @@ export const requiredStepValueField = createRequiredValidator('Please specify a 
  * */
 export const seriesRequired: Validator<EditableDataSeries[]> = series => {
     if (!series || series.length === 0) {
-        return 'Series is empty. You must have at least one series for code insight.'
+        return 'No series defined. You must add at least one series to create a code insight.'
     }
 
     if (series.some(series => !series.valid)) {
-        return 'Some series is invalid. Remove or edit invalid series.'
+        return 'Some series is invalid. Remove or edit the invalid series.'
     }
 
     return

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -124,7 +124,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
             >
                 <FormSeries
                     series={series.input.value}
-                    touched={submitted}
+                    showValidationErrorsOnMount={submitted}
                     onLiveChange={onSeriesLiveChange}
                     onEditSeriesRequest={onEditSeriesRequest}
                     onEditSeriesCommit={onEditSeriesCommit}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -13,8 +13,7 @@ import {
     Organization,
     VisibilityPicker,
 } from '../../../../../components/visibility-picker/VisibilityPicker'
-import { DataSeries } from '../../../../../core/backend/types'
-import { CreateInsightFormFields } from '../../types'
+import { CreateInsightFormFields, EditableDataSeries } from '../../types'
 import { FormSeries } from '../form-series/FormSeries'
 
 import styles from './SearchInsightCreationForm.module.scss'
@@ -27,6 +26,7 @@ interface CreationSearchInsightFormProps {
     handleSubmit: FormEventHandler
     submitErrors: SubmissionErrors
     submitting: boolean
+    submitted: boolean
     className?: string
 
     title: useFieldAPI<CreateInsightFormFields['title']>
@@ -42,24 +42,17 @@ interface CreationSearchInsightFormProps {
     onCancel: () => void
 
     /**
-     * Edit series array used below for rendering series edit form.
-     * In case of some element has undefined value we're showing
-     * series card with data instead of form.
-     * */
-    editSeries: (CreateInsightFormFields['series'][number] | undefined)[]
-
-    /**
      * Handler to listen latest value form particular series edit form
      * Used to get information for live preview chart.
      * */
-    onSeriesLiveChange: (liveSeries: DataSeries, isValid: boolean, index: number) => void
+    onSeriesLiveChange: (liveSeries: EditableDataSeries, isValid: boolean, index: number) => void
 
     /**
      * Handlers for CRUD operation over series. Add, delete, update and cancel
      * series edit form.
      * */
     onEditSeriesRequest: (openedCardIndex: number) => void
-    onEditSeriesCommit: (seriesIndex: number, editedSeries: DataSeries) => void
+    onEditSeriesCommit: (seriesIndex: number, editedSeries: EditableDataSeries) => void
     onEditSeriesCancel: (closedCardIndex: number) => void
     onSeriesRemove: (removedSeriesIndex: number) => void
 }
@@ -75,12 +68,12 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         handleSubmit,
         submitErrors,
         submitting,
+        submitted,
         title,
         repositories,
         visibility,
         organizations,
         series,
-        editSeries,
         stepValue,
         step,
         className,
@@ -131,7 +124,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
             >
                 <FormSeries
                     series={series.input.value}
-                    editSeries={editSeries}
+                    touched={submitted}
                     onLiveChange={onSeriesLiveChange}
                     onEditSeriesRequest={onEditSeriesRequest}
                     onEditSeriesCommit={onEditSeriesCommit}

--- a/client/web/src/insights/pages/creation/search-insight/types.ts
+++ b/client/web/src/insights/pages/creation/search-insight/types.ts
@@ -3,10 +3,16 @@ import { InsightVisibility } from '../../../core/types'
 
 export type InsightStep = 'hours' | 'days' | 'weeks' | 'months' | 'years'
 
+export interface EditableDataSeries extends DataSeries {
+    id: string
+    valid: boolean
+    edit: boolean
+}
+
 /** Creation form fields. */
 export interface CreateInsightFormFields {
     /** Code Insight series setting (name of line, line query, color) */
-    series: DataSeries[]
+    series: EditableDataSeries[]
     /** Title of code insight*/
     title: string
     /** Repositories which to be used to get the info for code insights */

--- a/client/web/src/insights/pages/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/insight-sanitizer.ts
@@ -8,8 +8,8 @@ export function getSanitizedRepositories(rawRepositories: string): string[] {
     return rawRepositories.trim().split(/\s*,\s*/)
 }
 
-export function getSanitizedSeries(rawSeries: EditableDataSeries[]): DataSeries[] {
-    return rawSeries.map(line => ({
+export function getSanitizedLine(line: EditableDataSeries): DataSeries {
+    return {
         name: line.name.trim(),
         stroke: line.stroke,
         // Query field is a reg exp field for code insight query setting
@@ -17,7 +17,11 @@ export function getSanitizedSeries(rawSeries: EditableDataSeries[]): DataSeries[
         // to prevent this behavior below we replace double escaping
         // with just one series of escape characters e.g. - //
         query: line.query.replace(/\\\\/g, '\\'),
-    }))
+    }
+}
+
+export function getSanitizedSeries(rawSeries: EditableDataSeries[]): DataSeries[] {
+    return rawSeries.map(getSanitizedLine)
 }
 
 /**

--- a/client/web/src/insights/pages/creation/search-insight/utils/insight-sanitizer.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/insight-sanitizer.ts
@@ -2,15 +2,16 @@ import { camelCase } from 'lodash'
 
 import { DataSeries } from '../../../../core/backend/types'
 import { InsightTypePrefix, SearchBasedInsight } from '../../../../core/types'
-import { CreateInsightFormFields } from '../types'
+import { CreateInsightFormFields, EditableDataSeries } from '../types'
 
 export function getSanitizedRepositories(rawRepositories: string): string[] {
     return rawRepositories.trim().split(/\s*,\s*/)
 }
 
-export function getSanitizedSeries(rawSeries: DataSeries[]): DataSeries[] {
+export function getSanitizedSeries(rawSeries: EditableDataSeries[]): DataSeries[] {
     return rawSeries.map(line => ({
-        ...line,
+        name: line.name.trim(),
+        stroke: line.stroke,
         // Query field is a reg exp field for code insight query setting
         // Native html input element adds escape symbols by itself
         // to prevent this behavior below we replace double escaping

--- a/client/web/src/insights/pages/edit/components/EditSearchInsight.tsx
+++ b/client/web/src/insights/pages/edit/components/EditSearchInsight.tsx
@@ -6,6 +6,7 @@ import { Settings } from '@sourcegraph/shared/src/settings/settings'
 import { SubmissionErrors } from '../../../components/form/hooks/useForm'
 import { Organization } from '../../../components/visibility-picker/VisibilityPicker'
 import { SearchBasedInsight } from '../../../core/types'
+import { createDefaultEditSeries } from '../../creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series'
 import { SearchInsightCreationContent } from '../../creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent'
 import { CreateInsightFormFields, InsightStep } from '../../creation/search-insight/types'
 import { getSanitizedSearchInsight } from '../../creation/search-insight/utils/insight-sanitizer'
@@ -26,7 +27,7 @@ export const EditSearchBasedInsight: React.FunctionComponent<EditSearchBasedInsi
             title: insight.title,
             visibility: insight.visibility,
             repositories: insight.repositories.join(', '),
-            series: insight.series,
+            series: insight.series.map(line => createDefaultEditSeries({ ...line, valid: true })),
             stepValue: Object.values(insight.step)[0]?.toString() ?? '3',
             step: Object.keys(insight.step)[0] as InsightStep,
         }),


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/21094

Now if a user creates an insight but skips clicking "done" then the live preview works fine but the user gets a validation error on trying to click "create insight." 

Good call from @Joelkw 
> This is not expected – a user assumes that because they've provided all the information and can see a live preview, they shouldn't need to click "done" essentially twice (in the series, and at the bottom of the form).

This PR implements the first @Joelkw proposal 
>Best UX – can we just accept "done" for you/not require you to click done as long as the fields are valid, and let you just click 'create"

Now if a user filled/edited the series card in the right way a user doesn't have to click on 'Done' button and by that kind of submit sub-form. 