### PR TITLE
Refresh: Further popover tweaks

### DIFF
--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -5,6 +5,7 @@
 $border-radius: var(--border-radius);
 $border-radius-sm: var(--border-radius-sm);
 $border-radius-lg: var(--border-radius-lg);
+$popover-border-radius: var(--popover-border-radius);
 
 $font-size-base: 0.875rem;
 $line-height-base: (20/14);
@@ -164,6 +165,8 @@ $input-transition: none;
     .theme-redesign & {
         background-color: var(--color-bg-1);
         border-radius: var(--popover-border-radius);
+        // Ensure content is clipped by border
+        overflow: hidden;
     }
 }
 

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -164,6 +164,7 @@ $input-transition: none;
 
     .theme-redesign & {
         background-color: var(--color-bg-1);
+        box-shadow: var(--dropdown-shadow);
         border-radius: var(--popover-border-radius);
         // Ensure content is clipped by border
         overflow: hidden;

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -13,7 +13,6 @@
         --popover-item-padding-h: 1rem;
         --popover-item-padding-v: 0.25rem;
         background-color: var(--color-bg-1);
-        box-shadow: var(--dropdown-shadow);
     }
 
     &__content {

--- a/client/web/src/components/ConnectionPopover.scss
+++ b/client/web/src/components/ConnectionPopover.scss
@@ -38,6 +38,7 @@
         .theme-redesign & {
             border-top: solid 1px var(--border-color-2);
             padding-top: 0.25rem;
+            padding-bottom: 0.25rem;
         }
     }
 

--- a/client/web/src/repo/GitReference.tsx
+++ b/client/web/src/repo/GitReference.tsx
@@ -55,7 +55,7 @@ export const GitReferenceNode: React.FunctionComponent<GitReferenceNodeProps> = 
             className={classNames('git-ref-node list-group-item', className)}
             to={!ancestorIsLink ? url : undefined}
         >
-            <span>
+            <span className="d-flex align-items-center">
                 <code className="git-ref-tag-2">{node.displayName}</code>
                 {mostRecentSig && (
                     <small className="pl-2">

--- a/client/web/src/repo/RevisionsPopover.scss
+++ b/client/web/src/repo/RevisionsPopover.scss
@@ -28,6 +28,10 @@
             text-overflow: ellipsis;
             overflow: hidden;
             padding: 0 0.5rem;
+
+            .theme-redesign & {
+                padding: 0 0.5rem 0;
+            }
         }
         &__link:not(:hover) &__message {
             color: var(--body-color);

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -157,18 +157,16 @@ const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({ node, curr
                     'revisions-popover-git-commit-node__link'
                 )}
             >
-                <span>
-                    <code className="revisions-popover-git-commit-node__oid" title={node.oid}>
-                        {node.abbreviatedOID}
-                    </code>
-                    <small className="revisions-popover-git-commit-node__message">{node.subject.slice(0, 200)}</small>
-                    {isCurrent && (
-                        <CircleChevronLeftIcon
-                            className="icon-inline connection-popover__node-link-icon"
-                            data-tooltip="Current commit"
-                        />
-                    )}
-                </span>
+                <code className="revisions-popover-git-commit-node__oid" title={node.oid}>
+                    {node.abbreviatedOID}
+                </code>
+                <small className="revisions-popover-git-commit-node__message">{node.subject.slice(0, 200)}</small>
+                {isCurrent && (
+                    <CircleChevronLeftIcon
+                        className="icon-inline connection-popover__node-link-icon"
+                        data-tooltip="Current commit"
+                    />
+                )}
             </Link>
         </li>
     )


### PR DESCRIPTION
This PR:
- Fixes bug where commit message content was not overflowing and showing an ellipsis correctly
- Fixes clipping of popover content due to an increased border radius in the refresh
- Adds padding-bottom to connection node list for connection popovers