### PR TITLE
Open link via chart data points in a new browser tab by default

### DIFF
--- a/client/shared/src/util/link-click-handler/linkClickHandler.ts
+++ b/client/shared/src/util/link-click-handler/linkClickHandler.ts
@@ -34,24 +34,3 @@ export const createLinkClickHandler = (history: H.History): React.MouseEventHand
     const url = new URL(href)
     history.push(url.pathname + url.search + url.hash)
 }
-
-/**
- * Returns a click handler for any element that takes event and target URL
- * that will redirect to this URL and in case if cmd+click happened that will open a new browser tab
- */
-export const createProgrammaticLinkHandler = (history: H.History) => (
-    event: React.MouseEvent<unknown>,
-    target: string
-): void => {
-    const url = new URL(target)
-
-    // Do nothing if the link was requested to open in a new tab
-    if (event.ctrlKey || event.metaKey) {
-        window.open(url.origin + url.pathname + url.search + url.hash, '_blank')?.focus()
-
-        return
-    }
-
-    // Handle navigation programmatically
-    history.push(url.pathname + url.search + url.hash)
-}

--- a/client/web/src/views/ChartViewContent/ChartViewContent.tsx
+++ b/client/web/src/views/ChartViewContent/ChartViewContent.tsx
@@ -47,7 +47,7 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
             telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
 
             const url = new URL(event.link)
-            window.open(url.origin + url.pathname + url.search + url.hash, '_blank')?.focus()
+            window.open(event.link, '_blank', 'noopener')?.focus()
         },
         [viewID, telemetryService]
     )

--- a/client/web/src/views/ChartViewContent/ChartViewContent.tsx
+++ b/client/web/src/views/ChartViewContent/ChartViewContent.tsx
@@ -46,7 +46,6 @@ export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props 
 
             telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
 
-            const url = new URL(event.link)
             window.open(event.link, '_blank', 'noopener')?.focus()
         },
         [viewID, telemetryService]

--- a/client/web/src/views/ChartViewContent/ChartViewContent.tsx
+++ b/client/web/src/views/ChartViewContent/ChartViewContent.tsx
@@ -1,13 +1,9 @@
 import { ParentSize } from '@visx/responsive'
 import * as H from 'history'
-import React, { FunctionComponent, useMemo } from 'react'
+import React, { FunctionComponent, useCallback } from 'react'
 import { ChartContent } from 'sourcegraph'
 
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import {
-    createLinkClickHandler,
-    createProgrammaticLinkHandler,
-} from '@sourcegraph/shared/src/util/link-click-handler/linkClickHandler'
 
 import { BarChart } from './charts/bar/BarChart'
 import { LineChart } from './charts/line/LineChart'
@@ -33,31 +29,28 @@ export interface ChartViewContentProps {
  * Display chart content with different type of charts (line, bar, pie)
  */
 export const ChartViewContent: FunctionComponent<ChartViewContentProps> = props => {
-    const { content, className = '', history, viewID, telemetryService } = props
+    const { content, className = '', viewID, telemetryService } = props
 
-    const handleDatumLinkClick = useMemo(() => {
-        const nativeLinkHandler = createLinkClickHandler(history)
-
-        return (event: React.MouseEvent) => {
-            telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
-            nativeLinkHandler(event)
-        }
-    }, [viewID, telemetryService, history])
+    const handleDatumLinkClick = useCallback((): void => {
+        telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
+    }, [viewID, telemetryService])
 
     // Click link-zone handler for line chart only. Catch click around point and redirect user by
     // link which we've got from nearest datum point to user cursor position. This allows user
     // not to aim on small point on the chart and just click somewhere around the point.
-    const linkHandler = useMemo(() => {
-        const linkHandler = createProgrammaticLinkHandler(history)
-        return (event: DatumZoneClickEvent): void => {
+    const linkHandler = useCallback(
+        (event: DatumZoneClickEvent): void => {
             if (!event.link) {
                 return
             }
 
             telemetryService.log('InsightDataPointClick', { insightType: getInsightTypeByViewId(viewID) })
-            linkHandler(event.originEvent, event.link)
-        }
-    }, [history, viewID, telemetryService])
+
+            const url = new URL(event.link)
+            window.open(url.origin + url.pathname + url.search + url.hash, '_blank')?.focus()
+        },
+        [viewID, telemetryService]
+    )
 
     return (
         <div className={`chart-view-content ${className}`}>

--- a/client/web/src/views/ChartViewContent/charts/bar/BarChart.tsx
+++ b/client/web/src/views/ChartViewContent/charts/bar/BarChart.tsx
@@ -149,6 +149,7 @@ export function BarChart<Datum extends object>(props: BarChartProps<Datum>): Rea
                                 <MaybeLink
                                     key={`bar-${index}`}
                                     to={linkURLs?.[index]}
+                                    target="_blank"
                                     onClick={onDatumLinkClick}
                                     role={linkURLs?.[index] ? 'link' : 'graphics-dataunit'}
                                     aria-label={ariaLabel}

--- a/client/web/src/views/ChartViewContent/charts/bar/BarChart.tsx
+++ b/client/web/src/views/ChartViewContent/charts/bar/BarChart.tsx
@@ -150,6 +150,7 @@ export function BarChart<Datum extends object>(props: BarChartProps<Datum>): Rea
                                     key={`bar-${index}`}
                                     to={linkURLs?.[index]}
                                     target="_blank"
+                                    rel="noopener"
                                     onClick={onDatumLinkClick}
                                     role={linkURLs?.[index] ? 'link' : 'graphics-dataunit'}
                                     aria-label={ariaLabel}

--- a/client/web/src/views/ChartViewContent/charts/line/components/GlyphContent.tsx
+++ b/client/web/src/views/ChartViewContent/charts/line/components/GlyphContent.tsx
@@ -83,6 +83,7 @@ export function GlyphContent<Datum extends object>(props: GlyphContentProps<Datu
     return (
         <MaybeLink
             to={linkURL}
+            target="_blank"
             onPointerUp={onPointerUp}
             onClick={onClick}
             onFocus={() => linkURL && setFocusedDatum(currentDatum)}

--- a/client/web/src/views/ChartViewContent/charts/line/components/GlyphContent.tsx
+++ b/client/web/src/views/ChartViewContent/charts/line/components/GlyphContent.tsx
@@ -84,6 +84,7 @@ export function GlyphContent<Datum extends object>(props: GlyphContentProps<Datu
         <MaybeLink
             to={linkURL}
             target="_blank"
+            rel="noopener"
             onPointerUp={onPointerUp}
             onClick={onClick}
             onFocus={() => linkURL && setFocusedDatum(currentDatum)}

--- a/client/web/src/views/ChartViewContent/charts/pie/PieChart.tsx
+++ b/client/web/src/views/ChartViewContent/charts/pie/PieChart.tsx
@@ -105,6 +105,7 @@ export function PieChart<Datum extends object>(props: PieChartProps<Datum>): Rea
                                     <MaybeLink
                                         key={getKey(arc)}
                                         to={getLink(arc)}
+                                        target="_blank"
                                         className="pie-chart__link"
                                         role={getLink(arc) ? 'link' : 'graphics-dataunit'}
                                         aria-label={`Element ${index + 1} of ${arcs.length}. Name: ${getKey(

--- a/client/web/src/views/ChartViewContent/charts/pie/PieChart.tsx
+++ b/client/web/src/views/ChartViewContent/charts/pie/PieChart.tsx
@@ -106,6 +106,7 @@ export function PieChart<Datum extends object>(props: PieChartProps<Datum>): Rea
                                         key={getKey(arc)}
                                         to={getLink(arc)}
                                         target="_blank"
+                                        rel="noopener"
                                         className="pie-chart__link"
                                         role={getLink(arc) ? 'link' : 'graphics-dataunit'}
                                         aria-label={`Element ${index + 1} of ${arcs.length}. Name: ${getKey(


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/21099

This PR is adding default open in a new browser tab behavior for all links within the code insight chart.