### PR TITLE
Convert detachChangesets to be a bulk operation

### DIFF
--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsPage.story.tsx
@@ -263,6 +263,20 @@ const queryBulkOperations: typeof _queryBulkOperations = () =>
             },
             {
                 id: 'id3',
+                type: BulkOperationType.DETACH,
+                state: BulkOperationState.COMPLETED,
+                errors: [],
+                progress: 1,
+                createdAt: subDays(now, 5).toISOString(),
+                finishedAt: subDays(now, 4).toISOString(),
+                changesetCount: 25,
+                initiator: {
+                    url: '/users/alice',
+                    username: 'alice',
+                },
+            },
+            {
+                id: 'id4',
                 type: BulkOperationType.COMMENT,
                 state: BulkOperationState.FAILED,
                 errors: [

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -628,7 +628,7 @@ export async function detachChangesets(batchChange: Scalars['ID'], changesets: S
         gql`
             mutation DetachChangesets($batchChange: ID!, $changesets: [ID!]!) {
                 detachChangesets(batchChange: $batchChange, changesets: $changesets) {
-                    alwaysNil
+                    id
                 }
             }
         `,

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -1,11 +1,12 @@
 import classNames from 'classnames'
 import CommentOutlineIcon from 'mdi-react/CommentOutlineIcon'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
+import LinkVariantRemoveIcon from 'mdi-react/LinkVariantRemoveIcon'
 import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { LinkOrSpan } from '@sourcegraph/shared/src/components/LinkOrSpan'
-import { BulkOperationState } from '@sourcegraph/shared/src/graphql-operations'
+import { BulkOperationState, BulkOperationType } from '@sourcegraph/shared/src/graphql-operations'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { ErrorMessage } from '../../../../components/alerts'
@@ -14,6 +15,19 @@ import { Timestamp } from '../../../../components/time/Timestamp'
 import { BulkOperationFields } from '../../../../graphql-operations'
 
 import styles from './BulkOperationNode.module.scss'
+
+const OPERATION_TITLES: Record<BulkOperationType, JSX.Element> = {
+    COMMENT: (
+        <>
+            <CommentOutlineIcon className="icon-inline text-muted" /> Comment on changesets
+        </>
+    ),
+    DETACH: (
+        <>
+            <LinkVariantRemoveIcon className="icon-inline text-muted" /> Detach changesets
+        </>
+    ),
+}
 
 export interface BulkOperationNodeProps {
     node: BulkOperationFields
@@ -33,9 +47,7 @@ export const BulkOperationNode: React.FunctionComponent<BulkOperationNodeProps> 
             </div>
             <div className={styles.bulkOperationNodeDivider} />
             <div className="flex-grow-1 ml-3">
-                <h4>
-                    <CommentOutlineIcon className="icon-inline text-muted" /> Comment on changesets
-                </h4>
+                <h4>{OPERATION_TITLES[node.type]}</h4>
                 <p className="mb-0">
                     <Link to={node.initiator.url}>{node.initiator.username}</Link> <Timestamp date={node.createdAt} />
                 </p>

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -242,7 +242,7 @@ type BatchChangesResolver interface {
 	CreateChangesetSpec(ctx context.Context, args *CreateChangesetSpecArgs) (ChangesetSpecResolver, error)
 	SyncChangeset(ctx context.Context, args *SyncChangesetArgs) (*EmptyResponse, error)
 	ReenqueueChangeset(ctx context.Context, args *ReenqueueChangesetArgs) (ChangesetResolver, error)
-	DetachChangesets(ctx context.Context, args *DetachChangesetsArgs) (*EmptyResponse, error)
+	DetachChangesets(ctx context.Context, args *DetachChangesetsArgs) (BulkOperationResolver, error)
 	CreateChangesetComments(ctx context.Context, args *CreateChangesetCommentsArgs) (BulkOperationResolver, error)
 
 	// Queries

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2076,7 +2076,7 @@ extend type Mutation {
 
     Experimental: This API is likely to change in the future.
     """
-    detachChangesets(batchChange: ID!, changesets: [ID!]!): EmptyResponse!
+    detachChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
 
     """
     Comment on multiple changesets from a batch change.
@@ -2354,6 +2354,10 @@ enum BulkOperationType {
     Bulk post comments over all involved changesets.
     """
     COMMENT
+    """
+    Bulk detach changesets from a batch change.
+    """
+    DETACH
 }
 
 """

--- a/enterprise/internal/batches/background/bulk_processor_test.go
+++ b/enterprise/internal/batches/background/bulk_processor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
+	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
@@ -20,7 +21,9 @@ func TestBulkProcessor(t *testing.T) {
 	user := ct.CreateTestUser(t, db, true)
 	repos, _ := ct.CreateTestRepos(t, ctx, db, 1)
 	repo := repos[0]
-	changeset := ct.CreateChangeset(t, ctx, bstore, ct.TestChangesetOpts{Repo: repo.ID})
+	batchSpec := ct.CreateBatchSpec(t, ctx, bstore, "test-bulk", user.ID)
+	batchChange := ct.CreateBatchChange(t, ctx, bstore, "test-bulk", user.ID, batchSpec.ID)
+	changeset := ct.CreateChangeset(t, ctx, bstore, ct.TestChangesetOpts{Repo: repo.ID, BatchChanges: []types.BatchChangeAssoc{{BatchChangeID: batchChange.ID}}})
 
 	t.Run("Unknown job type", func(t *testing.T) {
 		fake := &sources.FakeChangesetSource{}
@@ -63,6 +66,40 @@ func TestBulkProcessor(t *testing.T) {
 		}
 		if !fake.CreateCommentCalled {
 			t.Fatal("expected CreateComment to be called but wasn't")
+		}
+	})
+
+	t.Run("Detach job", func(t *testing.T) {
+		fake := &sources.FakeChangesetSource{}
+		bp := &bulkProcessor{
+			store:   bstore,
+			sourcer: sources.NewFakeSourcer(nil, fake),
+		}
+		job := &types.ChangesetJob{
+			JobType:       types.ChangesetJobTypeDetach,
+			ChangesetID:   changeset.ID,
+			UserID:        user.ID,
+			BatchChangeID: batchChange.ID,
+		}
+		if err := bstore.CreateChangesetJob(ctx, job); err != nil {
+			t.Fatal(err)
+		}
+		err := bp.process(ctx, job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ch, err := bstore.GetChangesetByID(ctx, changeset.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ch.BatchChanges) != 1 {
+			t.Fatalf("invalid batch changes associated, expected one, got=%+v", ch.BatchChanges)
+		}
+		if !ch.BatchChanges[0].Detach {
+			t.Fatal("not marked as to be detached")
+		}
+		if ch.ReconcilerState != btypes.ReconcilerStateQueued {
+			t.Fatalf("invalid reconciler state, got=%q", ch.ReconcilerState)
 		}
 	})
 }

--- a/enterprise/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation.go
@@ -111,6 +111,8 @@ func changesetJobTypeToBulkOperationType(t btypes.ChangesetJobType) (string, err
 	switch t {
 	case btypes.ChangesetJobTypeComment:
 		return "COMMENT", nil
+	case btypes.ChangesetJobTypeDetach:
+		return "DETACH", nil
 	default:
 		return "", fmt.Errorf("invalid job type %q", t)
 	}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -566,77 +566,6 @@ func (s *Service) ValidateAuthenticator(ctx context.Context, externalServiceID, 
 	return nil
 }
 
-// ErrChangesetsToDetachNotFound can be returned by (*Service).DetachChangesets
-// if the number of changesets returned from the database doesn't match the
-// number if IDs passed in.
-var ErrChangesetsToDetachNotFound = errors.New("some changesets that should be detached could not be found")
-
-// DetachChangesets detaches the given Changeset from the given BatchChange
-// by checking whether the actor in the context has permission to enqueue a
-// reconciler run and then enqueues it by calling ResetReconcilerState.
-func (s *Service) DetachChangesets(ctx context.Context, batchChangeID int64, ids []int64) (err error) {
-	traceTitle := fmt.Sprintf("batchChangeID: %d, len(changeset): %d", batchChangeID, len(ids))
-	tr, ctx := trace.New(ctx, "service.DetachChangesets", traceTitle)
-	defer func() {
-		tr.SetError(err)
-		tr.Finish()
-	}()
-
-	// Load the BatchChange to check for admin rights.
-	batchChange, err := s.store.GetBatchChange(ctx, store.GetBatchChangeOpts{ID: batchChangeID})
-	if err != nil {
-		return err
-	}
-
-	// 🚨 SECURITY: Only the Author of the batch change can detach changesets.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, batchChange.InitialApplierID); err != nil {
-		return err
-	}
-
-	cs, _, err := s.store.ListChangesets(ctx, store.ListChangesetsOpts{
-		IDs:           ids,
-		BatchChangeID: batchChangeID,
-		OnlyArchived:  true,
-		// We only want to detach the changesets the user has access to
-		EnforceAuthz: true,
-	})
-	if err != nil {
-		return err
-	}
-
-	if len(cs) != len(ids) {
-		return ErrChangesetsToDetachNotFound
-	}
-
-	tx, err := s.store.Transact(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() { err = tx.Done(err) }()
-
-	for _, changeset := range cs {
-		var detach bool
-		for i, assoc := range changeset.BatchChanges {
-			if assoc.BatchChangeID == batchChangeID {
-				changeset.BatchChanges[i].Detach = true
-				detach = true
-			}
-		}
-
-		if !detach {
-			continue
-		}
-
-		changeset.ResetReconcilerState(global.DefaultReconcilerEnqueueState())
-
-		if err := tx.UpdateChangeset(ctx, changeset); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // ErrChangesetsForJobNotFound can be returned by (*Service).CreateChangesetJobs
 // if the number of changesets returned from the database doesn't match the
 // number if IDs passed in. That can happen if some of the changesets are not
@@ -646,7 +575,7 @@ var ErrChangesetsForJobNotFound = errors.New("some changesets could not be found
 // CreateChangesetJobs creates one changeset job for each given Changeset in the
 // given BatchChange, checking whether the actor in the context has permission to
 // trigger a job, and enqueues it.
-func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, ids []int64, jobType btypes.ChangesetJobType, payload interface{}) (bulkGroupID string, err error) {
+func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, ids []int64, jobType btypes.ChangesetJobType, payload interface{}, listOpts store.ListChangesetsOpts) (bulkGroupID string, err error) {
 	traceTitle := fmt.Sprintf("batchChangeID: %d, len(changesets): %d", batchChangeID, len(ids))
 	tr, ctx := trace.New(ctx, "service.CreateChangesetJobs", traceTitle)
 	defer func() {
@@ -665,17 +594,16 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 		return bulkGroupID, err
 	}
 
+	// Construct list options.
+	opts := listOpts
+	opts.IDs = ids
+	opts.BatchChangeID = batchChangeID
 	published := btypes.ChangesetPublicationStatePublished
-	cs, _, err := s.store.ListChangesets(ctx, store.ListChangesetsOpts{
-		IDs:           ids,
-		BatchChangeID: batchChangeID,
-		// We can only run jobs on published changesets.
-		PublicationState: &published,
-		// Also include archived changesets, we allow commenting on them as well.
-		IncludeArchived: true,
-		// We only want to allow changesets the user has access to.
-		EnforceAuthz: true,
-	})
+	// We can only run jobs on published changesets.
+	opts.PublicationState = &published
+	// We only want to allow changesets the user has access to.
+	opts.EnforceAuthz = true
+	cs, _, err := s.store.ListChangesets(ctx, opts)
 	if err != nil {
 		return bulkGroupID, errors.Wrap(err, "listing changesets")
 	}

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -180,6 +180,8 @@ func scanChangesetJob(c *btypes.ChangesetJob, s scanner) error {
 	switch c.JobType {
 	case btypes.ChangesetJobTypeComment:
 		c.Payload = new(btypes.ChangesetJobCommentPayload)
+	case btypes.ChangesetJobTypeDetach:
+		c.Payload = new(btypes.ChangesetJobDetachPayload)
 	default:
 		return fmt.Errorf("unknown job type %q", c.JobType)
 	}

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -49,9 +49,7 @@ type ChangesetJobCommentPayload struct {
 	Message string `json:"message"`
 }
 
-type ChangesetJobDetachPayload struct {
-	Nothing string `json:"-"`
-}
+type ChangesetJobDetachPayload struct {}
 
 // ChangesetJob describes a one-time action to be taken on a changeset.
 type ChangesetJob struct {

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -42,10 +42,15 @@ type ChangesetJobType string
 
 var (
 	ChangesetJobTypeComment ChangesetJobType = "commentatore"
+	ChangesetJobTypeDetach  ChangesetJobType = "detach"
 )
 
 type ChangesetJobCommentPayload struct {
 	Message string `json:"message"`
+}
+
+type ChangesetJobDetachPayload struct {
+	Nothing string `json:"-"`
 }
 
 // ChangesetJob describes a one-time action to be taken on a changeset.

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -49,7 +49,7 @@ type ChangesetJobCommentPayload struct {
 	Message string `json:"message"`
 }
 
-type ChangesetJobDetachPayload struct {}
+type ChangesetJobDetachPayload struct{}
 
 // ChangesetJob describes a one-time action to be taken on a changeset.
 type ChangesetJob struct {


### PR DESCRIPTION
This makes detachChangesets a proper bulk operation, so it appears in the UI and behaves the same as commenting. 

Closes https://github.com/sourcegraph/sourcegraph/issues/20900