### PR TITLE
Proofread all texts for code insight creation UI 

### DIFF
--- a/client/web/src/insights/pages/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/intro/IntroCreationPage.tsx
@@ -44,12 +44,12 @@ export const IntroCreationPage: React.FunctionComponent = () => (
                     to="/insights/create-search-insight"
                     className={classnames(styles.createIntroPageInsightButton, 'btn', 'btn-primary')}
                 >
-                    Create custom insight
+                    Create search insight
                 </Link>
 
                 <hr className="ml-n3 mr-n3 mt-4 mb-3" />
 
-                <p className="text-muted">How your insight would look:</p>
+                <p className="text-muted">Example:</p>
                 <div className={styles.createIntroPageChartContainer}>
                     <ParentSize className={styles.createIntroPageChart}>
                         {({ width, height }) => <LineChart width={width} height={height} {...LINE_CHART_DATA} />}
@@ -66,12 +66,12 @@ export const IntroCreationPage: React.FunctionComponent = () => (
                     to="/insights/create-lang-stats-insight"
                     className={classnames(styles.createIntroPageInsightButton, 'btn', 'btn-primary')}
                 >
-                    Set up language usage insight
+                    Create language usage insight
                 </Link>
 
                 <hr className="ml-n3 mr-n3 mt-4 mb-3" />
 
-                <p className="text-muted">How your insight would look:</p>
+                <p className="text-muted">Example:</p>
                 <div className={styles.createIntroPageChartContainer}>
                     <ParentSize className={styles.createIntroPageChart}>
                         {({ width, height }) => <PieChart width={width} height={height} {...PIE_CHART_DATA} />}

--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -91,7 +91,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
                 <p className="text-muted">
                     Shows language usage in your repository based on number of lines of code.{' '}
                     <a
-                        href="https://docs.sourcegraph.com/dev/background-information/insights"
+                        href="https://docs.sourcegraph.com/code_insights"
                         target="_blank"
                         rel="noopener"
                     >

--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -90,11 +90,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
 
                 <p className="text-muted">
                     Shows language usage in your repository based on number of lines of code.{' '}
-                    <a
-                        href="https://docs.sourcegraph.com/code_insights"
-                        target="_blank"
-                        rel="noopener"
-                    >
+                    <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
                         Learn more.
                     </a>
                 </p>

--- a/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -48,7 +48,7 @@ export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsig
             mockMessage={
                 <span>
                     Here you’ll see your insight’s chart preview. <br />
-                    The chart preview will be shown here once you filled out the repository fields.
+                    The chart preview will be shown here once you filled out the repository field.
                 </span>
             }
         />

--- a/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -46,9 +46,7 @@ export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsig
             defaultMock={DEFAULT_PREVIEW_MOCK}
             onUpdateClick={update}
             mockMessage={
-                <span>
-                    The chart preview will be shown here once you have filled out the repository field.
-                </span>
+                <span>The chart preview will be shown here once you have filled out the repository field.</span>
             }
         />
     )

--- a/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -47,8 +47,7 @@ export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsig
             onUpdateClick={update}
             mockMessage={
                 <span>
-                    Here you’ll see your insight’s chart preview. <br />
-                    The chart preview will be shown here once you filled out the repository field.
+                    The chart preview will be shown here once you have filled out the repository field.
                 </span>
             }
         />

--- a/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/live-preview-chart/LangStatsInsightLivePreview.tsx
@@ -48,7 +48,7 @@ export const LangStatsInsightLivePreview: React.FunctionComponent<LangStatsInsig
             mockMessage={
                 <span>
                     Here you’ll see your insight’s chart preview. <br />
-                    You need to fill in the repository field.
+                    The chart preview will be shown here once you filled out the repository fields.
                 </span>
             }
         />

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -91,7 +91,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
                 <p className="text-muted">
                     Search-based code insights analyze your code based on any search query.{' '}
                     <a
-                        href="https://docs.sourcegraph.com/dev/background-information/insights"
+                        href="https://docs.sourcegraph.com/code_insights"
                         target="_blank"
                         rel="noopener"
                     >

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -90,11 +90,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
 
                 <p className="text-muted">
                     Search-based code insights analyze your code based on any search query.{' '}
-                    <a
-                        href="https://docs.sourcegraph.com/code_insights"
-                        target="_blank"
-                        rel="noopener"
-                    >
+                    <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
                         Learn more.
                     </a>
                 </p>

--- a/client/web/src/insights/pages/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
@@ -96,8 +96,7 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
             mockMessage={
                 <span>
                     {' '}
-                    Here you’ll see your insight’s chart preview. <br />
-                    The chart preview will be shown here once you filled out the repositories and series fields.
+                    The chart preview will be shown here once you have filled out the repositories and series fields.
                 </span>
             }
             className={className}

--- a/client/web/src/insights/pages/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/live-preview-chart/SearchInsightLivePreview.tsx
@@ -97,7 +97,7 @@ export const SearchInsightLivePreview: React.FunctionComponent<SearchInsightLive
                 <span>
                     {' '}
                     Here you’ll see your insight’s chart preview. <br />
-                    You need to fill in the repositories and series fields.
+                    The chart preview will be shown here once you filled out the repositories and series fields.
                 </span>
             }
             className={className}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -157,7 +157,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 <FormGroup
                     name="insight step group"
                     title="Granularity: distance between data points"
-                    description="The prototype supports 7 datapoints, so your total x-axis timeframe is 7 times the distance between each point."
+                    description="The prototype supports 6 datapoints, so your total x-axis timeframe is 7 times the distance between each point."
                     error={stepValue.meta.touched && stepValue.meta.error}
                     className="mt-4"
                     labelClassName={styles.creationInsightFormGroupLabel}

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -157,7 +157,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                 <FormGroup
                     name="insight step group"
                     title="Granularity: distance between data points"
-                    description="The prototype supports 6 datapoints, so your total x-axis timeframe is 7 times the distance between each point."
+                    description="The prototype supports 7 datapoints, so your total x-axis timeframe is 6 times the distance between each point."
                     error={stepValue.meta.touched && stepValue.meta.error}
                     className="mt-4"
                     labelClassName={styles.creationInsightFormGroupLabel}

--- a/client/web/src/insights/pages/edit/EditInsightPage.tsx
+++ b/client/web/src/insights/pages/edit/EditInsightPage.tsx
@@ -177,7 +177,7 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
                 <p className="text-muted">
                     Insights analyze your code based on any search query.{' '}
                     <a
-                        href="https://docs.sourcegraph.com/dev/background-information/insights"
+                        href="https://docs.sourcegraph.com/code_insights"
                         target="_blank"
                         rel="noopener"
                     >

--- a/client/web/src/insights/pages/edit/EditInsightPage.tsx
+++ b/client/web/src/insights/pages/edit/EditInsightPage.tsx
@@ -176,11 +176,7 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
 
                 <p className="text-muted">
                     Insights analyze your code based on any search query.{' '}
-                    <a
-                        href="https://docs.sourcegraph.com/code_insights"
-                        target="_blank"
-                        rel="noopener"
-                    >
+                    <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
                         Learn more.
                     </a>
                 </p>


### PR DESCRIPTION
Fixes: https://github.com/sourcegraph/sourcegraph/issues/21100, https://github.com/sourcegraph/sourcegraph/issues/21101, https://github.com/sourcegraph/sourcegraph/issues/21102,
https://github.com/sourcegraph/sourcegraph/issues/21103, https://github.com/sourcegraph/sourcegraph/issues/21105

- [x] 7 points = 6 "ranges" between points.
- [x] Copy – change "how your insight would look:" to "example:" 
- [x] Copy – unify the button text. 
- [x] Copy – modify live preview text
- [x] Copy/link – Make "learn more" take you to the top-level feature docs page instead of dev docs page