### PR TITLE
add file view - closed file tree trigger

### DIFF
--- a/client/web/src/repo/RepoRevisionSidebar.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.scss
@@ -21,7 +21,6 @@
         justify-content: center;
         z-index: 1;
         .theme-redesign & {
-            border-radius: 0;
             border-bottom-right-radius: var(--border-radius);
             color: var(--body-color);
             &:hover {

--- a/client/web/src/repo/RepoRevisionSidebar.scss
+++ b/client/web/src/repo/RepoRevisionSidebar.scss
@@ -12,6 +12,7 @@
     &__toggle {
         color: var(--link-color);
         background-color: var(--color-bg-2);
+        border-radius: 0;
         isolation: isolate;
         width: 2.5rem;
         height: 2.5rem;
@@ -19,5 +20,13 @@
         display: flex;
         justify-content: center;
         z-index: 1;
+        .theme-redesign & {
+            border-radius: 0;
+            border-bottom-right-radius: var(--border-radius);
+            color: var(--body-color);
+            &:hover {
+                background-color: var(--color-bg-3);
+            }
+        }
     }
 }

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -45,7 +45,7 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
         return (
             <button
                 type="button"
-                className="position-absolute btn btn-icon btn-link border-right border-bottom rounded-0 repo-revision-container__toggle"
+                className="position-absolute btn btn-icon btn-link border-right border-bottom repo-revision-container__toggle"
                 onClick={handleSidebarToggle}
                 data-tooltip="Show sidebar"
             >


### PR DESCRIPTION
Sidebar with files and symbols button new styles.

Utility classes on bootstrap add `!important`. That's why a property on the sass file replaced the border radius.

1. refresh design on
2. refresh design off

https://user-images.githubusercontent.com/989826/118855331-47dc6580-b89b-11eb-8208-0015f41a29ec.mov




Figma Design
- [stickersheet](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=2965%3A2595)
- [mockup](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=2965%3A1752)
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
