### PR TITLE
Remove .code selector from highlights to fix diff highlighting

### DIFF
--- a/client/branded/src/global-styles/highlight.scss
+++ b/client/branded/src/global-styles/highlight.scss
@@ -107,363 +107,364 @@
     --hl-bg-red: #f5dbdd;
     --hl-bg-green: #deeade;
 
-    .code {
+    .hl-source,
+    .hl-text {
         color: var(--hl-gray-3);
+    }
 
-        // Comments
-        .hl-comment,
-        .hl-meta.hl-documentation {
-            color: var(--hl-gray-0);
-        }
+    // Comments
+    .hl-comment,
+    .hl-meta.hl-documentation {
+        color: var(--hl-gray-0);
+    }
 
-        /* String constants */
-        // contents
-        .hl-string {
-            color: var(--hl-cyan);
-        }
-        // surrounding quotes
-        .hl-punctuation.hl-definition.hl-string {
-            color: var(--hl-gray-1);
-        }
-        // escape sequences
-        .hl-constant.hl-character.hl-escape {
-            color: var(--hl-red);
-        }
+    /* String constants */
+    // contents
+    .hl-string {
+        color: var(--hl-cyan);
+    }
+    // surrounding quotes
+    .hl-punctuation.hl-definition.hl-string {
+        color: var(--hl-gray-1);
+    }
+    // escape sequences
+    .hl-constant.hl-character.hl-escape {
+        color: var(--hl-red);
+    }
 
-        // Other constants
-        .hl-constant {
-            color: var(--hl-yellow);
-        }
-        .hl-constant.hl-language {
-            color: var(--hl-yellow);
-        }
-        .hl-constant.hl-numeric {
-            color: var(--hl-purple);
-        }
-        .hl-constant.hl-character {
+    // Other constants
+    .hl-constant {
+        color: var(--hl-yellow);
+    }
+    .hl-constant.hl-language {
+        color: var(--hl-yellow);
+    }
+    .hl-constant.hl-numeric {
+        color: var(--hl-purple);
+    }
+    .hl-constant.hl-character {
+        color: var(--hl-orange);
+    }
+    .hl-constant.hl-other {
+        color: var(--hl-orange);
+    }
+    .hl-meta.hl-preprocessor {
+        color: var(--hl-yellow);
+    }
+
+    // Variables
+    .hl-variable {
+        color: var(--hl-blue);
+    }
+    // function calls, etc.
+    .hl-variable.hl-function {
+        color: var(--hl-yellow);
+    }
+    // reserved variables like this or self
+    .hl-variable.hl-language {
+        color: var(--hl-pink);
+    }
+    // punctuation in variable definitions like $ in shell
+    .hl-punctuation.hl-definition.hl-variable {
+        color: var(--hl-green);
+    }
+
+    // Keywords and storage
+    .hl-keyword.hl-operator {
+        color: var(--hl-gray-3);
+    }
+    .hl-keyword {
+        color: var(--hl-green);
+        &.hl-import,
+        &.hl-include {
             color: var(--hl-orange);
         }
-        .hl-constant.hl-other {
-            color: var(--hl-orange);
-        }
-        .hl-meta.hl-preprocessor {
+        &.hl-class {
             color: var(--hl-yellow);
         }
+    }
+    .hl-keyword.hl-other.hl-new {
+        color: var(--hl-red);
+    }
+    .hl-keyword.hl-other.hl-special-method {
+        color: var(--hl-orange);
+    }
+    .hl-storage {
+        color: var(--hl-green);
+    }
+    // const, public, inline
+    .hl-storage.hl-modifier {
+        color: var(--hl-gray-4);
+    }
+    // int, bool, char
+    .hl-storage.hl-type {
+        color: var(--hl-blue);
+    }
 
-        // Variables
-        .hl-variable {
-            color: var(--hl-blue);
-        }
-        // function calls, etc.
-        .hl-variable.hl-function {
+    // Entities
+    .hl-entity.hl-name {
+        color: var(--hl-yellow);
+    }
+    .hl-entity.hl-name.hl-tag {
+        color: var(--hl-blue);
+    }
+    .hl-entity.hl-other.hl-inherited-class {
+        color: var(--hl-blue);
+    }
+    .hl-entity.hl-other.hl-attribute-name {
+        color: var(--hl-yellow);
+    }
+
+    // Support (builtin libraries like browser)
+    .hl-support.hl-function {
+        color: var(--hl-green);
+    }
+    .hl-support.hl-function.hl-construct {
+        color: var(--hl-red);
+    }
+    .hl-support.hl-type.hl-exception {
+        color: var(--hl-orange);
+    }
+    .hl-support.hl-type,
+    .hl-support.hl-class {
+        color: var(--hl-green);
+    }
+    // color constants #ababab
+    .hl-support.hl-constant.hl-color {
+        color: var(--hl-yellow);
+    }
+
+    // Braces
+    .hl-punctuation.hl-section.hl-braces {
+        color: var(--hl-gray-3);
+    }
+    .hl-punctuation.hl-section.hl-block {
+        color: var(--hl-gray-3);
+    }
+
+    // Parens
+    .hl-punctuation.hl-section.hl-parens {
+        color: var(--hl-gray-3);
+    }
+    .hl-punctuation.hl-section.hl-group {
+        color: var(--hl-gray-3);
+    }
+
+    // Brackets
+    .hl-punctuation.hl-section.hl-brackets {
+        color: var(--hl-blue);
+    }
+
+    // Other
+    // line continuation \
+    .hl-punctuation.hl-separator.hl-continuation {
+        color: var(--hl-red);
+    }
+    // tag delimiters <>
+    .hl-punctuation.hl-definition.hl-tag {
+        color: var(--hl-gray-2);
+    }
+    .hl-invalid {
+        background: var(--hl-bg-red);
+    }
+
+    //////////////////////////////////
+    // Language-specific highlights //
+    //////////////////////////////////
+
+    .hl-source.hl-scss {
+        .hl-invalid.hl-deprecated.hl-color.hl-w3c-non-standard-color-name {
             color: var(--hl-yellow);
         }
-        // reserved variables like this or self
-        .hl-variable.hl-language {
-            color: var(--hl-pink);
+        .hl-keyword.hl-control.hl-untitled {
+            color: var(--hl-yellow);
         }
-        // punctuation in variable definitions like $ in shell
-        .hl-punctuation.hl-definition.hl-variable {
-            color: var(--hl-green);
-        }
+    }
 
-        // Keywords and storage
-        .hl-keyword.hl-operator {
-            color: var(--hl-gray-3);
+    .hl-source.hl-less {
+        .hl-keyword.hl-control.hl-html.hl-elements {
+            color: var(--hl-yellow);
         }
-        .hl-keyword {
-            color: var(--hl-green);
-            &.hl-import,
-            &.hl-include {
-                color: var(--hl-orange);
-            }
+    }
+
+    .hl-source.hl-scss,
+    .hl-source.hl-css,
+    .hl-source.hl-less {
+        .hl-entity.hl-name.hl-tag {
+            color: var(--hl-yellow);
+        }
+        .hl-entity.hl-other {
             &.hl-class {
                 color: var(--hl-yellow);
             }
+            &.hl-id {
+                color: var(--hl-yellow);
+            }
+            &.hl-pseudo-class {
+                color: var(--hl-blue);
+            }
+            // :hover
+            &.hl-pseudo-element {
+                color: var(--hl-blue);
+            }
         }
-        .hl-keyword.hl-other.hl-new {
-            color: var(--hl-red);
-        }
+    }
+
+    .hl-source.hl-ruby {
         .hl-keyword.hl-other.hl-special-method {
             color: var(--hl-orange);
         }
-        .hl-storage {
-            color: var(--hl-green);
-        }
-        // const, public, inline
-        .hl-storage.hl-modifier {
-            color: var(--hl-gray-4);
-        }
-        // int, bool, char
-        .hl-storage.hl-type {
-            color: var(--hl-blue);
-        }
-
-        // Entities
-        .hl-entity.hl-name {
+        .hl-variable.hl-other.hl-constant {
             color: var(--hl-yellow);
         }
-        .hl-entity.hl-name.hl-tag {
-            color: var(--hl-blue);
+        .hl-constant.hl-other.hl-symbol {
+            color: var(--hl-cyan);
         }
-        .hl-entity.hl-other.hl-inherited-class {
-            color: var(--hl-blue);
+        .hl-punctuation.hl-definition.hl-constant {
+            color: var(--hl-cyan);
         }
-        .hl-entity.hl-other.hl-attribute-name {
+    }
+
+    .hl-source.hl-php {
+        .hl-meta.hl-array .hl-support.hl-function.hl-construct {
             color: var(--hl-yellow);
         }
+    }
 
-        // Support (builtin libraries like browser)
-        .hl-support.hl-function {
-            color: var(--hl-green);
-        }
-        .hl-support.hl-function.hl-construct {
-            color: var(--hl-red);
-        }
-        .hl-support.hl-type.hl-exception {
+    // c\2b\2b is escaped c++
+    .hl-source.hl-c,
+    .hl-source.hl-c\2b\2b {
+        .hl-entity.hl-name.hl-function.hl-preprocessor {
             color: var(--hl-orange);
         }
-        .hl-support.hl-type,
-        .hl-support.hl-class {
+        .hl-meta.hl-preprocessor.hl-macro {
+            color: var(--hl-orange);
+        }
+        // include <> and ""
+        .hl-meta.hl-preprocessor.hl-include .hl-punctuation.hl-definition.hl-string {
+            color: var(--hl-cyan);
+        }
+    }
+
+    // c\2b\2b is escaped c++
+    .hl-source.hl-c\2b\2b {
+        .hl-storage.hl-modifier {
             color: var(--hl-green);
         }
-        // color constants #ababab
-        .hl-support.hl-constant.hl-color {
-            color: var(--hl-yellow);
-        }
+    }
 
-        // Braces
-        .hl-punctuation.hl-section.hl-braces {
-            color: var(--hl-gray-3);
-        }
-        .hl-punctuation.hl-section.hl-block {
-            color: var(--hl-gray-3);
-        }
-
-        // Parens
-        .hl-punctuation.hl-section.hl-parens {
-            color: var(--hl-gray-3);
-        }
+    .hl-text.hl-tex,
+    .hl-text.hl-latex {
         .hl-punctuation.hl-section.hl-group {
-            color: var(--hl-gray-3);
-        }
-
-        // Brackets
-        .hl-punctuation.hl-section.hl-brackets {
-            color: var(--hl-blue);
-        }
-
-        // Other
-        // line continuation \
-        .hl-punctuation.hl-separator.hl-continuation {
             color: var(--hl-red);
         }
-        // tag delimiters <>
-        .hl-punctuation.hl-definition.hl-tag {
-            color: var(--hl-gray-2);
+        .hl-punctuation.hl-definition.hl-arguments {
+            color: var(--hl-red);
         }
-        .hl-invalid {
+        .hl-meta.hl-group.hl-braces {
+            color: var(--hl-yellow);
+        }
+        .hl-variable.hl-parameter.hl-function {
+            color: var(--hl-orange);
+        }
+
+        .hl-string.hl-other.hl-math {
+            color: var(--hl-yellow);
+        }
+        .hl-constant.hl-other.hl-math {
+            color: var(--hl-cyan);
+        }
+        .hl-constant.hl-character.hl-math {
+            color: var(--hl-cyan);
+        }
+        .hl-punctuation.hl-definition.hl-constant.hl-math {
+            color: var(--hl-red);
+        }
+        .hl-punctuation.hl-definition.hl-string {
+            color: var(--hl-red);
+        }
+
+        .hl-variable.hl-parameter.hl-definition.hl-label {
+            color: var(--hl-orange);
+        }
+        .hl-support.hl-function.hl-be {
+            color: var(--hl-green);
+        }
+        // \subsection
+        .hl-support.hl-function.hl-section {
+            color: var(--hl-orange);
+        }
+        .hl-support.hl-function.hl-general {
+            color: var(--hl-cyan);
+        }
+        // \label
+        .hl-storage.hl-type.hl-label {
+            color: var(--hl-cyan);
+        }
+        // \ref
+        .hl-keyword.hl-other.hl-reference {
+            color: var(--hl-cyan);
+        }
+    }
+
+    .hl-source.hl-python {
+        .hl-storage.hl-type.hl-class {
+            color: var(--hl-green);
+        }
+        .hl-storage.hl-type.hl-function {
+            color: var(--hl-green);
+        }
+        .hl-storage.hl-modifier.hl-global {
+            color: var(--hl-green);
+        }
+        .hl-support.hl-type.hl-exception {
+            color: var(--hl-yellow);
+        }
+    }
+
+    .hl-source.hl-shell {
+        // the #* in "${1#*=}"
+        .hl-keyword.hl-operator.hl-expansion {
+            color: var(--hl-green);
+        }
+    }
+
+    .hl-source.hl-perl {
+        .hl-support.hl-function {
+            color: var(--hl-blue);
+        }
+    }
+
+    .hl-source.hl-diff {
+        .hl-meta.hl-range {
+            color: var(--hl-blue);
+        }
+        .hl-entity.hl-name.hl-section {
+            color: var(--hl-orange);
+        }
+        .hl-markup.hl-deleted {
+            color: var(--hl-gray-5);
             background: var(--hl-bg-red);
         }
+        .hl-markup.hl-inserted {
+            color: var(--hl-gray-5);
+            background: var(--hl-bg-green);
+        }
+    }
 
-        //////////////////////////////////
-        // Language-specific highlights //
-        //////////////////////////////////
-
-        .hl-source.hl-scss {
-            .hl-invalid.hl-deprecated.hl-color.hl-w3c-non-standard-color-name {
-                color: var(--hl-yellow);
-            }
-            .hl-keyword.hl-control.hl-untitled {
-                color: var(--hl-yellow);
+    .hl-js {
+        .hl-variable.hl-other {
+            &.hl-readwrite,
+            &.hl-object,
+            &.hl-constant {
+                color: var(--hl-gray-3);
             }
         }
+    }
 
-        .hl-source.hl-less {
-            .hl-keyword.hl-control.hl-html.hl-elements {
-                color: var(--hl-yellow);
-            }
-        }
-
-        .hl-source.hl-scss,
-        .hl-source.hl-css,
-        .hl-source.hl-less {
-            .hl-entity.hl-name.hl-tag {
-                color: var(--hl-yellow);
-            }
-            .hl-entity.hl-other {
-                &.hl-class {
-                    color: var(--hl-yellow);
-                }
-                &.hl-id {
-                    color: var(--hl-yellow);
-                }
-                &.hl-pseudo-class {
-                    color: var(--hl-blue);
-                }
-                // :hover
-                &.hl-pseudo-element {
-                    color: var(--hl-blue);
-                }
-            }
-        }
-
-        .hl-source.hl-ruby {
-            .hl-keyword.hl-other.hl-special-method {
-                color: var(--hl-orange);
-            }
-            .hl-variable.hl-other.hl-constant {
-                color: var(--hl-yellow);
-            }
-            .hl-constant.hl-other.hl-symbol {
-                color: var(--hl-cyan);
-            }
-            .hl-punctuation.hl-definition.hl-constant {
-                color: var(--hl-cyan);
-            }
-        }
-
-        .hl-source.hl-php {
-            .hl-meta.hl-array .hl-support.hl-function.hl-construct {
-                color: var(--hl-yellow);
-            }
-        }
-
-        // c\2b\2b is escaped c++
-        .hl-source.hl-c,
-        .hl-source.hl-c\2b\2b {
-            .hl-entity.hl-name.hl-function.hl-preprocessor {
-                color: var(--hl-orange);
-            }
-            .hl-meta.hl-preprocessor.hl-macro {
-                color: var(--hl-orange);
-            }
-            // include <> and ""
-            .hl-meta.hl-preprocessor.hl-include .hl-punctuation.hl-definition.hl-string {
-                color: var(--hl-cyan);
-            }
-        }
-
-        // c\2b\2b is escaped c++
-        .hl-source.hl-c\2b\2b {
-            .hl-storage.hl-modifier {
-                color: var(--hl-green);
-            }
-        }
-
-        .hl-text.hl-tex,
-        .hl-text.hl-latex {
-            .hl-punctuation.hl-section.hl-group {
-                color: var(--hl-red);
-            }
-            .hl-punctuation.hl-definition.hl-arguments {
-                color: var(--hl-red);
-            }
-            .hl-meta.hl-group.hl-braces {
-                color: var(--hl-yellow);
-            }
-            .hl-variable.hl-parameter.hl-function {
-                color: var(--hl-orange);
-            }
-
-            .hl-string.hl-other.hl-math {
-                color: var(--hl-yellow);
-            }
-            .hl-constant.hl-other.hl-math {
-                color: var(--hl-cyan);
-            }
-            .hl-constant.hl-character.hl-math {
-                color: var(--hl-cyan);
-            }
-            .hl-punctuation.hl-definition.hl-constant.hl-math {
-                color: var(--hl-red);
-            }
-            .hl-punctuation.hl-definition.hl-string {
-                color: var(--hl-red);
-            }
-
-            .hl-variable.hl-parameter.hl-definition.hl-label {
-                color: var(--hl-orange);
-            }
-            .hl-support.hl-function.hl-be {
-                color: var(--hl-green);
-            }
-            // \subsection
-            .hl-support.hl-function.hl-section {
-                color: var(--hl-orange);
-            }
-            .hl-support.hl-function.hl-general {
-                color: var(--hl-cyan);
-            }
-            // \label
-            .hl-storage.hl-type.hl-label {
-                color: var(--hl-cyan);
-            }
-            // \ref
-            .hl-keyword.hl-other.hl-reference {
-                color: var(--hl-cyan);
-            }
-        }
-
-        .hl-source.hl-python {
-            .hl-storage.hl-type.hl-class {
-                color: var(--hl-green);
-            }
-            .hl-storage.hl-type.hl-function {
-                color: var(--hl-green);
-            }
-            .hl-storage.hl-modifier.hl-global {
-                color: var(--hl-green);
-            }
-            .hl-support.hl-type.hl-exception {
-                color: var(--hl-yellow);
-            }
-        }
-
-        .hl-source.hl-shell {
-            // the #* in "${1#*=}"
-            .hl-keyword.hl-operator.hl-expansion {
-                color: var(--hl-green);
-            }
-        }
-
-        .hl-source.hl-perl {
-            .hl-support.hl-function {
-                color: var(--hl-blue);
-            }
-        }
-
-        .hl-source.hl-diff {
-            .hl-meta.hl-range {
-                color: var(--hl-blue);
-            }
-            .hl-entity.hl-name.hl-section {
-                color: var(--hl-orange);
-            }
-            .hl-markup.hl-deleted {
-                color: var(--hl-gray-5);
-                background: var(--hl-bg-red);
-            }
-            .hl-markup.hl-inserted {
-                color: var(--hl-gray-5);
-                background: var(--hl-bg-green);
-            }
-        }
-
-        .hl-js {
-            .hl-variable.hl-other {
-                &.hl-readwrite,
-                &.hl-object,
-                &.hl-constant {
-                    color: var(--hl-gray-3);
-                }
-            }
-        }
-
-        .hl-ts {
-            .hl-keyword.hl-control {
-                color: var(--hl-orange);
-            }
+    .hl-ts {
+        .hl-keyword.hl-control {
+            color: var(--hl-orange);
         }
     }
 }
@@ -595,169 +596,170 @@
     --hl-bg-dark-red: #350b10;
     --hl-bg-dark-green: #0e2414;
 
-    .code {
+    .hl-source,
+    .hl-text {
         color: var(--hl-gray-2);
+    }
 
-        .hl-variable.hl-parameter.hl-function {
-            color: var(--hl-gray-0);
-        }
-        .hl-punctuation.hl-definition {
-            color: var(--hl-gray-0);
-        }
+    .hl-variable.hl-parameter.hl-function {
+        color: var(--hl-gray-0);
+    }
+    .hl-punctuation.hl-definition {
+        color: var(--hl-gray-0);
+    }
 
-        // Comments
-        .hl-comment,
-        .hl-punctuation.hl-definition.hl-comment {
-            color: var(--hl-dark-green);
-        }
+    // Comments
+    .hl-comment,
+    .hl-punctuation.hl-definition.hl-comment {
+        color: var(--hl-dark-green);
+    }
 
-        .hl-keyword.hl-operator {
-            color: var(--hl-dark-blue-1);
-        }
-        .hl-keyword {
-            color: var(--hl-dark-blue-3);
-        }
+    .hl-keyword.hl-operator {
+        color: var(--hl-dark-blue-1);
+    }
+    .hl-keyword {
+        color: var(--hl-dark-blue-3);
+    }
 
-        .hl-variable {
-            color: var(--hl-blue);
-        }
+    .hl-variable {
+        color: var(--hl-blue);
+    }
 
-        // Functions
-        .hl-entity.hl-name.hl-function,
-        .hl-meta.hl-require,
-        .hl-support.hl-function.hl-any-method,
-        .hl-variable.hl-function {
-            color: var(--hl-yellow);
-        }
+    // Functions
+    .hl-entity.hl-name.hl-function,
+    .hl-meta.hl-require,
+    .hl-support.hl-function.hl-any-method,
+    .hl-variable.hl-function {
+        color: var(--hl-yellow);
+    }
 
-        // Classes
-        .hl-support.hl-class,
-        .hl-entity.hl-name.hl-class,
-        .hl-meta.hl-class {
-            color: var(--hl-blue);
-        }
-        .hl-entity.hl-other.hl-inherited-class {
-            color: var(--hl-red);
-        }
+    // Classes
+    .hl-support.hl-class,
+    .hl-entity.hl-name.hl-class,
+    .hl-meta.hl-class {
+        color: var(--hl-blue);
+    }
+    .hl-entity.hl-other.hl-inherited-class {
+        color: var(--hl-red);
+    }
 
-        // Methods
-        .hl-keyword.hl-other.hl-special-method {
-            color: var(--hl-gray-1);
-        }
+    // Methods
+    .hl-keyword.hl-other.hl-special-method {
+        color: var(--hl-gray-1);
+    }
 
-        // Storage
-        .hl-storage {
-            color: var(--hl-dark-blue-1);
-        }
+    // Storage
+    .hl-storage {
+        color: var(--hl-dark-blue-1);
+    }
 
-        // Support
-        .hl-support.hl-function {
-            color: var(--hl-yellow);
-        }
+    // Support
+    .hl-support.hl-function {
+        color: var(--hl-yellow);
+    }
 
-        // Strings
-        .hl-string,
-        .hl-constant.hl-other.hl-symbol {
-            color: var(--hl-red);
-        }
-        // regexp literals
-        .hl-string.hl-regexp {
-            color: var(--hl-gray-5);
-        }
-        // escape sequences
-        .hl-constant.hl-character.hl-escape {
-            color: var(--hl-gray-5);
-        }
+    // Strings
+    .hl-string,
+    .hl-constant.hl-other.hl-symbol {
+        color: var(--hl-red);
+    }
+    // regexp literals
+    .hl-string.hl-regexp {
+        color: var(--hl-gray-5);
+    }
+    // escape sequences
+    .hl-constant.hl-character.hl-escape {
+        color: var(--hl-gray-5);
+    }
 
-        // Constants
-        .hl-constant {
-            color: var(--hl-dark-blue-1);
-        }
-        .hl-constant.hl-numeric {
-            color: var(--hl-green-1);
-        }
-        .hl-constant.hl-other.hl-color {
-            color: var(--hl-gray-5);
-        }
+    // Constants
+    .hl-constant {
+        color: var(--hl-dark-blue-1);
+    }
+    .hl-constant.hl-numeric {
+        color: var(--hl-green-1);
+    }
+    .hl-constant.hl-other.hl-color {
+        color: var(--hl-gray-5);
+    }
 
-        // Tags
-        .hl-entity.hl-name.hl-tag {
-            color: var(--hl-dark-blue-1);
-        }
+    // Tags
+    .hl-entity.hl-name.hl-tag {
+        color: var(--hl-dark-blue-1);
+    }
 
-        // Attributes
-        .hl-entity.hl-other.hl-attribute-name {
-            color: var(--hl-blue);
-        }
+    // Attributes
+    .hl-entity.hl-other.hl-attribute-name {
+        color: var(--hl-blue);
+    }
 
-        // Attribute IDs
-        .hl-entity.hl-other.hl-attribute-name.hl-id,
-        .hl-punctuation.hl-definition.hl-entity {
-            color: var(--hl-gray-1);
-        }
+    // Attribute IDs
+    .hl-entity.hl-other.hl-attribute-name.hl-id,
+    .hl-punctuation.hl-definition.hl-entity {
+        color: var(--hl-gray-1);
+    }
 
-        // Selector
-        .hl-meta.hl-selector {
-            color: var(--hl-purple);
-        }
+    // Selector
+    .hl-meta.hl-selector {
+        color: var(--hl-purple);
+    }
 
-        // Headings
-        .hl-markup.hl-heading,
-        .hl-punctuation.hl-definition.hl-heading,
-        .hl-entity.hl-name.hl-section {
-            color: var(--hl-gray-1);
-        }
+    // Headings
+    .hl-markup.hl-heading,
+    .hl-punctuation.hl-definition.hl-heading,
+    .hl-entity.hl-name.hl-section {
+        color: var(--hl-gray-1);
+    }
 
-        // Units
-        .hl-keyword.hl-other.hl-unit {
-            color: var(--hl-orange);
-        }
+    // Units
+    .hl-keyword.hl-other.hl-unit {
+        color: var(--hl-orange);
+    }
 
-        // Code
-        .hl-markup.hl-raw.hl-inline {
-            color: var(--hl-green-2);
-        }
+    // Code
+    .hl-markup.hl-raw.hl-inline {
+        color: var(--hl-green-2);
+    }
 
-        /* Links */
-        // link text
-        .hl-string.hl-other.hl-link {
-            color: var(--hl-dark-red);
-        }
-        // link URL
-        .hl-meta.hl-link {
-            color: var(--hl-orange);
-        }
-        // image URL
-        .hl-meta.hl-image {
-            color: var(--hl-orange);
-        }
+    /* Links */
+    // link text
+    .hl-string.hl-other.hl-link {
+        color: var(--hl-dark-red);
+    }
+    // link URL
+    .hl-meta.hl-link {
+        color: var(--hl-orange);
+    }
+    // image URL
+    .hl-meta.hl-image {
+        color: var(--hl-orange);
+    }
 
-        // Lists
-        .hl-markup.hl-list {
-            color: var(--hl-dark-red);
+    // Lists
+    .hl-markup.hl-list {
+        color: var(--hl-dark-red);
+    }
+
+    // Embedded
+    .hl-punctuation.hl-section.hl-embedded,
+    .hl-variable.hl-interpolation {
+        color: var(--hl-brown);
+    }
+
+    // Diff
+    .hl-source.hl-diff {
+        color: var(--hl-gray-6);
+
+        .hl-meta.hl-range {
+            color: var(--hl-dark-blue-2);
         }
-
-        // Embedded
-        .hl-punctuation.hl-section.hl-embedded,
-        .hl-variable.hl-interpolation {
-            color: var(--hl-brown);
+        .hl-markup.hl-deleted {
+            color: var(--hl-white);
+            background: var(--hl-bg-dark-red);
         }
-
-        // Diff
-        .hl-source.hl-diff {
-            color: var(--hl-gray-6);
-
-            .hl-meta.hl-range {
-                color: var(--hl-dark-blue-2);
-            }
-            .hl-markup.hl-deleted {
-                color: var(--hl-white);
-                background: var(--hl-bg-dark-red);
-            }
-            .hl-markup.hl-inserted {
-                color: var(--hl-white);
-                background: var(--hl-bg-dark-green);
-            }
+        .hl-markup.hl-inserted {
+            color: var(--hl-white);
+            background: var(--hl-bg-dark-green);
         }
     }
 }


### PR DESCRIPTION
Previously, we nested all our syntax highlighting styles inside a
`.code` selector, but for diff highlighting, the lines are recombined
and no longer are contained by that top-level div with the .code class.
So instead, we can just use the hl-source and hl-text selectors for our
base text color. I believe this was a regression introduced sometime 
during the CSS syntax highlighting effort. 

I recommend viewing the diff without whitespace changes since there
was a massive unindent.

Before:
<img width="880" alt="Screen Shot 2021-05-19 at 15 22 19" src="https://user-images.githubusercontent.com/12631702/118886465-348ac380-b8b6-11eb-983a-6bfa86a15d87.png">

After:
<img width="1061" alt="Screen Shot 2021-05-19 at 15 21 49" src="https://user-images.githubusercontent.com/12631702/118886517-45d3d000-b8b6-11eb-8787-6b319520ec11.png">




<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
