### PR TITLE
improve tabs UI for design refresh

### DIFF
--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -45,6 +45,7 @@
         display: inline-flex;
         flex-direction: column;
         justify-content: center;
+        border-bottom: 2px solid transparent;
         &:active {
             background-color: transparent;
         }
@@ -56,20 +57,16 @@
             font-weight: 700;
             border-bottom: 2px solid var(--brand-secondary);
         }
+        // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
         &::after {
             content: attr(data-test-tab);
-            content: attr(data-test-tab) / '';
             height: 0;
             text-transform: capitalize;
-            visibility: hidden;
+            visibility: hidden; // a11y: avoid detection for voice over
             overflow: hidden;
             user-select: none;
             pointer-events: none;
             font-weight: 700;
-
-            @media speech {
-                display: none;
-            }
         }
 
         &:focus-visible {

--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -38,23 +38,47 @@
         align-items: center;
         letter-spacing: normal;
         font-size: 0.75rem;
-        padding: 0 0.625rem;
-        margin: 0;
+        margin: 0 0.375rem;
+        padding: 0;
         color: var(--body-color);
         text-transform: none;
+        display: inline-flex;
+        flex-direction: column;
+        justify-content: center;
+        &:active {
+            background-color: transparent;
+        }
         &:hover {
-            border-bottom: 3px solid var(--border-color);
+            border-bottom: 2px solid var(--border-color);
         }
         &[data-selected] {
             color: var(--body-color);
-            font-weight: bold;
-            border-bottom: 3px solid var(--brand-secondary);
+            font-weight: 700;
+            border-bottom: 2px solid var(--brand-secondary);
         }
+        &::after {
+            content: attr(data-test-tab);
+            content: attr(data-test-tab) / '';
+            height: 0;
+            text-transform: capitalize;
+            visibility: hidden;
+            overflow: hidden;
+            user-select: none;
+            pointer-events: none;
+            font-weight: 700;
+
+            @media speech {
+                display: none;
+            }
+        }
+
         &:focus-visible {
             outline: none;
             box-shadow: none;
             > .tablist-wrapper--tab-label {
-                border-radius: 3px;
+                padding: 0.125rem;
+                margin: 0 -0.125rem;
+                border-radius: var(--border-radius);
                 outline: 1px solid transparent;
                 box-shadow: var(--focus-box-shadow);
             }


### PR DESCRIPTION
For better visibility, the points below are pasted from #21134

- [x] There should be no _visible_ padding on the left and right sides of the tabs. I say no visible, because the offset focus highlight extends past the indicator, so it may need a bit of trickery to pull it off. The padding around the text and the focus indicator will also need to adjust. To compare:

- [x] If possible, I'd like to find a way to handle the spacing/padding/sizing/etc. so that when a tab is selected or deselected, there's no visible "shift" other than that single tab's font weight changing, from the centre axis. This is less of an issue on the file sidebar and more of an issue on the popovers.
- [x] There's an active state visible when the tab is pressed in light mode, which I don't think we need. It becomes a challenge when we have a delay before showing content, because it remains visible until the content loads, which looks sluggish.
