### PR TITLE
Placeholder code insights doc update, live for <1 week

### DIFF
--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -1,0 +1,6 @@
+# Code Insights
+
+Code insights docs are actively in progress. 
+
+If you're a customer who needs support or early access, please [send us an email](mailto:feedback@sourcegraph.com). 
+

--- a/doc/dev/background-information/insights/index.md
+++ b/doc/dev/background-information/insights/index.md
@@ -6,7 +6,7 @@
 
 ## What is it?
 
-See https://about.sourcegraph.com/handbook/engineering/web/code-insights
+See https://about.sourcegraph.com/handbook/engineering/web/code-insights and the [Code Insights docs](../../../code_insights/index.md). 
 
 ## Webapp frontend
 


### PR DESCRIPTION
Putting this up just because we are about to link to this page from the 3.28 code insights flow (which itself is feature flag off by default) and it's a better UX than landing on a 404 page. 