### PR TITLE
Implement reenqueue bulk operation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights workers now support a rate limit for query execution and historical data frame analysis using the `insights.query.worker.rateLimit` and `insights.historical.worker.rateLimit` site configurations. [#21533](https://github.com/sourcegraph/sourcegraph/pull/21533)
 - The GraphQL `Site` `SettingsSubject` type now has an `allowSiteSettingsEdits` field to allow clients to determine whether the instance uses the `GLOBAL_SETTINGS_FILE` environment variable. [#21827](https://github.com/sourcegraph/sourcegraph/pull/21827)
 - Code Insights creation UI now has auto-save logic and clear all fields functionality [#21744](https://github.com/sourcegraph/sourcegraph/pull/21744)
+- A new bulk operation to retry many changesets at once has been added to Batch Changes. [#21173](https://github.com/sourcegraph/sourcegraph/pull/21173)
 
 ### Changed
 

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -39,6 +39,8 @@ import {
     AllChangesetIDsResult,
     AllChangesetIDsVariables,
     ChangesetIDConnectionFields,
+    ReenqueueChangesetsResult,
+    ReenqueueChangesetsVariables,
 } from '../../../graphql-operations'
 
 const changesetsStatsFragment = gql`
@@ -651,6 +653,20 @@ export async function createChangesetComments(
             }
         `,
         { batchChange, changesets, body }
+    ).toPromise()
+    dataOrThrowErrors(result)
+}
+
+export async function reenqueueChangesets(batchChange: Scalars['ID'], changesets: Scalars['ID'][]): Promise<void> {
+    const result = await requestGraphQL<ReenqueueChangesetsResult, ReenqueueChangesetsVariables>(
+        gql`
+            mutation ReenqueueChangesets($batchChange: ID!, $changesets: [ID!]!) {
+                reenqueueChangesets(batchChange: $batchChange, changesets: $changesets) {
+                    id
+                }
+            }
+        `,
+        { batchChange, changesets }
     ).toPromise()
     dataOrThrowErrors(result)
 }

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import CommentOutlineIcon from 'mdi-react/CommentOutlineIcon'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import LinkVariantRemoveIcon from 'mdi-react/LinkVariantRemoveIcon'
+import SyncIcon from 'mdi-react/SyncIcon'
 import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
@@ -25,6 +26,11 @@ const OPERATION_TITLES: Record<BulkOperationType, JSX.Element> = {
     DETACH: (
         <>
             <LinkVariantRemoveIcon className="icon-inline text-muted" /> Detach changesets
+        </>
+    ),
+    REENQUEUE: (
+        <>
+            <SyncIcon className="icon-inline text-muted" /> Retry changesets
         </>
     ),
 }

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import InfoCircleOutlineIcon from 'mdi-react/InfoCircleOutlineIcon'
 import React, { Fragment, useCallback, useMemo, useState } from 'react'
 
+import { ChangesetState } from '@sourcegraph/shared/src/graphql-operations'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
 
 import { AllChangesetIDsVariables, Scalars } from '../../../../graphql-operations'
@@ -11,6 +12,7 @@ import { queryAllChangesetIDs } from '../backend'
 import styles from './ChangesetSelectRow.module.scss'
 import { CreateCommentModal } from './CreateCommentModal'
 import { DetachChangesetsModal } from './DetachChangesetsModal'
+import { ReenqueueChangesetsModal } from './ReenqueueChangesetsModal'
 
 /**
  * Describes a possible action on the changeset list.
@@ -54,6 +56,22 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
                 afterCreate={onDone}
                 onCancel={onCancel}
                 telemetryService={eventLogger}
+            />
+        ),
+    },
+    {
+        type: 'retry',
+        buttonLabel: 'Retry changesets',
+        dropdownTitle: 'Retry changesets',
+        dropdownDescription: 'Re-enqueues the selected changesets for processing, if they failed.',
+        // Only show when filtering by state === FAILED:
+        isAvailable: ({ state }) => state === ChangesetState.FAILED,
+        onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
+            <ReenqueueChangesetsModal
+                batchChangeID={batchChangeID}
+                changesetIDs={changesetIDs}
+                afterCreate={onDone}
+                onCancel={onCancel}
             />
         ),
     },

--- a/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.tsx
@@ -1,0 +1,70 @@
+import Dialog from '@reach/dialog'
+import React, { useCallback, useState } from 'react'
+
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { ErrorAlert } from '../../../../components/alerts'
+import { Scalars } from '../../../../graphql-operations'
+import { reenqueueChangesets as _reenqueueChangesets } from '../backend'
+
+export interface ReenqueueChangesetsModalProps {
+    onCancel: () => void
+    afterCreate: () => void
+    batchChangeID: Scalars['ID']
+    changesetIDs: () => Promise<Scalars['ID'][]>
+
+    /** For testing only. */
+    reenqueueChangesets?: typeof _reenqueueChangesets
+}
+
+export const ReenqueueChangesetsModal: React.FunctionComponent<ReenqueueChangesetsModalProps> = ({
+    onCancel,
+    afterCreate,
+    batchChangeID,
+    changesetIDs,
+    reenqueueChangesets = _reenqueueChangesets,
+}) => {
+    const [isLoading, setIsLoading] = useState<boolean | Error>(false)
+
+    const onSubmit = useCallback<React.FormEventHandler>(async () => {
+        setIsLoading(true)
+        try {
+            const ids = await changesetIDs()
+            await reenqueueChangesets(batchChangeID, ids)
+            afterCreate()
+        } catch (error) {
+            setIsLoading(asError(error))
+        }
+    }, [changesetIDs, reenqueueChangesets, batchChangeID, afterCreate])
+
+    return (
+        <Dialog
+            className="modal-body modal-body--top-third p-4 rounded border"
+            onDismiss={onCancel}
+            aria-labelledby={LABEL_ID}
+        >
+            <div className="web-content">
+                <h3 id={LABEL_ID}>Re-enqueue changesets</h3>
+                <p className="mb-4">Are you sure you want to re-enqueue all the selected changesets?</p>
+                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
+                <div className="d-flex justify-content-end">
+                    <button
+                        type="button"
+                        disabled={isLoading === true}
+                        className="btn btn-outline-secondary mr-2"
+                        onClick={onCancel}
+                    >
+                        Cancel
+                    </button>
+                    <button type="button" onClick={onSubmit} disabled={isLoading === true} className="btn btn-primary">
+                        {isLoading === true && <LoadingSpinner className="icon-inline" />}
+                        Re-enqueue
+                    </button>
+                </div>
+            </div>
+        </Dialog>
+    )
+}
+
+const LABEL_ID = 'reenqueue-changesets-modal-title'

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -199,9 +199,13 @@ type ListViewerBatchChangesCodeHostsArgs struct {
 	OnlyWithoutCredential bool
 }
 
-type DetachChangesetsArgs struct {
+type BulkOperationBaseArgs struct {
 	BatchChange graphql.ID
 	Changesets  []graphql.ID
+}
+
+type DetachChangesetsArgs struct {
+	BulkOperationBaseArgs
 }
 
 type ListBatchChangeBulkOperationArgs struct {
@@ -211,9 +215,12 @@ type ListBatchChangeBulkOperationArgs struct {
 }
 
 type CreateChangesetCommentsArgs struct {
-	BatchChange graphql.ID
-	Changesets  []graphql.ID
-	Body        string
+	BulkOperationBaseArgs
+	Body string
+}
+
+type ReenqueueChangesetsArgs struct {
+	BulkOperationBaseArgs
 }
 
 type BatchChangesResolver interface {
@@ -244,6 +251,7 @@ type BatchChangesResolver interface {
 	ReenqueueChangeset(ctx context.Context, args *ReenqueueChangesetArgs) (ChangesetResolver, error)
 	DetachChangesets(ctx context.Context, args *DetachChangesetsArgs) (BulkOperationResolver, error)
 	CreateChangesetComments(ctx context.Context, args *CreateChangesetCommentsArgs) (BulkOperationResolver, error)
+	ReenqueueChangesets(ctx context.Context, args *ReenqueueChangesetsArgs) (BulkOperationResolver, error)
 
 	// Queries
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -1946,9 +1946,7 @@ extend type Mutation {
     Re-enqueue the changeset for processing by the reconciler. The changeset must be in FAILED state.
     """
     reenqueueChangeset(changeset: ID!): Changeset!
-}
 
-extend type Mutation {
     """
     Create a batch change from a batch spec and locally computed changeset specs. The newly created
     batch change is returned.
@@ -2084,6 +2082,13 @@ extend type Mutation {
     Experimental: This API is likely to change in the future.
     """
     createChangesetComments(batchChange: ID!, changesets: [ID!]!, body: String!): BulkOperation!
+
+    """
+    Reenqueue multiple changesets for processing.
+
+    Experimental: This API is likely to change in the future.
+    """
+    reenqueueChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
 }
 
 extend type Query {
@@ -2358,6 +2363,10 @@ enum BulkOperationType {
     Bulk detach changesets from a batch change.
     """
     DETACH
+    """
+    Bulk reenqueue failed changesets.
+    """
+    REENQUEUE
 }
 
 """

--- a/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
+++ b/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
@@ -22,7 +22,7 @@ Bulk operations allow a single action to be performed across many changesets in 
 
 - Commenting: Post a comment on all selected changesets. This can be particularly useful for pinging people, reminding them to take a look at the changeset, or posting your favorite emoji 🦡.
 - Detach: Only available in the archived tab. Detach a selection of changesets from the batch change to remove them from the archived tab.
-- Retry: Only available if filtering by state `failed`. Retries performing changes for all selected changesets that failed.
+- Re-enqueue: Only available if filtering by state `failed`. Re-enqueues the pending changes for all selected changesets that failed.
 
 _More types coming soon._
 

--- a/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
+++ b/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
@@ -22,6 +22,7 @@ Bulk operations allow a single action to be performed across many changesets in 
 
 - Commenting: Post a comment on all selected changesets. This can be particularly useful for pinging people, reminding them to take a look at the changeset, or posting your favorite emoji 🦡.
 - Detach: Only available in the archived tab. Detach a selection of changesets from the batch change to remove them from the archived tab.
+- Retry: Only available if filtering by state `failed`. Retries performing changes for all selected changesets that failed.
 
 _More types coming soon._
 

--- a/enterprise/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation.go
@@ -113,6 +113,8 @@ func changesetJobTypeToBulkOperationType(t btypes.ChangesetJobType) (string, err
 		return "COMMENT", nil
 	case btypes.ChangesetJobTypeDetach:
 		return "DETACH", nil
+	case btypes.ChangesetJobTypeReenqueue:
+		return "REENQUEUE", nil
 	default:
 		return "", fmt.Errorf("invalid job type %q", t)
 	}

--- a/enterprise/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/internal/batches/resolvers/permissions_test.go
@@ -736,6 +736,12 @@ func TestPermissionLevels(t *testing.T) {
 					return fmt.Sprintf(`mutation { createChangesetComments(batchChange: %q, changesets: [%q], body: "test") { id } }`, batchChangeID, changesetID)
 				},
 			},
+			{
+				name: "reenqueueChangesets",
+				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+					return fmt.Sprintf(`mutation { reenqueueChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
+				},
+			},
 		}
 
 		for _, m := range mutations {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1144,27 +1144,9 @@ func (r *Resolver) DetachChangesets(ctx context.Context, args *graphqlbackend.De
 		return nil, err
 	}
 
-	batchChangeID, err := unmarshalBatchChangeID(args.BatchChange)
+	batchChangeID, changesetIDs, err := unmarshalBulkOperationBaseArgs(args.BulkOperationBaseArgs)
 	if err != nil {
 		return nil, err
-	}
-
-	if batchChangeID == 0 {
-		return nil, ErrIDIsZero{}
-	}
-
-	var changesetIDs []int64
-	for _, raw := range args.Changesets {
-		id, err := unmarshalChangesetID(raw)
-		if err != nil {
-			return nil, err
-		}
-
-		if id == 0 {
-			return nil, ErrIDIsZero{}
-		}
-
-		changesetIDs = append(changesetIDs, id)
 	}
 
 	// 🚨 SECURITY: CreateChangesetJobs checks whether current user is authorized.
@@ -1201,35 +1183,14 @@ func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbac
 		return nil, errors.New("empty comment body is not allowed")
 	}
 
-	batchChangeID, err := unmarshalBatchChangeID(args.BatchChange)
+	batchChangeID, changesetIDs, err := unmarshalBulkOperationBaseArgs(args.BulkOperationBaseArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	if batchChangeID == 0 {
-		return nil, ErrIDIsZero{}
-	}
-
-	var changesetIDs []int64
-	for _, raw := range args.Changesets {
-		id, err := unmarshalChangesetID(raw)
-		if err != nil {
-			return nil, err
-		}
-
-		if id == 0 {
-			return nil, ErrIDIsZero{}
-		}
-
-		changesetIDs = append(changesetIDs, id)
-	}
-
-	if len(changesetIDs) == 0 {
-		return nil, errors.New("specify at least one changeset")
-	}
-
 	// 🚨 SECURITY: CreateChangesetJobs checks whether current user is authorized.
 	svc := service.New(r.store)
+	published := btypes.ChangesetPublicationStatePublished
 	bulkGroupID, err := svc.CreateChangesetJobs(
 		ctx,
 		batchChangeID,
@@ -1241,6 +1202,43 @@ func (r *Resolver) CreateChangesetComments(ctx context.Context, args *graphqlbac
 		store.ListChangesetsOpts{
 			// Also include archived changesets, we allow commenting on them as well.
 			IncludeArchived: true,
+			// We can only comment on published changesets.
+			PublicationState: &published,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.bulkOperationByIDString(ctx, bulkGroupID)
+}
+
+func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend.ReenqueueChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.ReenqueueChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+	if err := batchChangesEnabled(ctx); err != nil {
+		return nil, err
+	}
+
+	batchChangeID, changesetIDs, err := unmarshalBulkOperationBaseArgs(args.BulkOperationBaseArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	// 🚨 SECURITY: CreateChangesetJobs checks whether current user is authorized.
+	svc := service.New(r.store)
+	bulkGroupID, err := svc.CreateChangesetJobs(
+		ctx,
+		batchChangeID,
+		changesetIDs,
+		btypes.ChangesetJobTypeReenqueue,
+		&btypes.ChangesetJobReenqueuePayload{},
+		store.ListChangesetsOpts{
+			// Only allow to retry failed changesets.
+			ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateFailed},
 		},
 	)
 	if err != nil {
@@ -1288,4 +1286,34 @@ const defaultMaxFirstParam = 10000
 
 func validateFirstParamDefaults(first int32) error {
 	return validateFirstParam(first, defaultMaxFirstParam)
+}
+
+func unmarshalBulkOperationBaseArgs(args graphqlbackend.BulkOperationBaseArgs) (batchChangeID int64, changesetIDs []int64, err error) {
+	batchChangeID, err = unmarshalBatchChangeID(args.BatchChange)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	if batchChangeID == 0 {
+		return 0, nil, ErrIDIsZero{}
+	}
+
+	for _, raw := range args.Changesets {
+		id, err := unmarshalChangesetID(raw)
+		if err != nil {
+			return 0, nil, err
+		}
+
+		if id == 0 {
+			return 0, nil, ErrIDIsZero{}
+		}
+
+		changesetIDs = append(changesetIDs, id)
+	}
+
+	if len(changesetIDs) == 0 {
+		return 0, nil, errors.New("specify at least one changeset")
+	}
+
+	return batchChangeID, changesetIDs, nil
 }

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1219,7 +1219,7 @@ func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend
 		tr.SetError(err)
 		tr.Finish()
 	}()
-	if err := batchChangesEnabled(ctx); err != nil {
+	if err := batchChangesEnabled(ctx, r.store.DB()); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -598,9 +598,6 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 	opts := listOpts
 	opts.IDs = ids
 	opts.BatchChangeID = batchChangeID
-	published := btypes.ChangesetPublicationStatePublished
-	// We can only run jobs on published changesets.
-	opts.PublicationState = &published
 	// We only want to allow changesets the user has access to.
 	opts.EnforceAuthz = true
 	cs, _, err := s.store.ListChangesets(ctx, opts)

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -899,7 +899,9 @@ func TestService(t *testing.T) {
 				[]int64{changeset.ID},
 				btypes.ChangesetJobTypeComment,
 				btypes.ChangesetJobCommentPayload{Message: "test"},
-				store.ListChangesetsOpts{},
+				store.ListChangesetsOpts{
+					ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
+				},
 			)
 			if err != ErrChangesetsForJobNotFound {
 				t.Fatalf("wrong error. want=%s, got=%s", ErrChangesetsForJobNotFound, err)

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -182,6 +182,8 @@ func scanChangesetJob(c *btypes.ChangesetJob, s scanner) error {
 		c.Payload = new(btypes.ChangesetJobCommentPayload)
 	case btypes.ChangesetJobTypeDetach:
 		c.Payload = new(btypes.ChangesetJobDetachPayload)
+	case btypes.ChangesetJobTypeReenqueue:
+		c.Payload = new(btypes.ChangesetJobReenqueuePayload)
 	default:
 		return fmt.Errorf("unknown job type %q", c.JobType)
 	}

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -41,8 +41,9 @@ func (s ChangesetJobState) ToDB() string { return strings.ToLower(string(s)) }
 type ChangesetJobType string
 
 var (
-	ChangesetJobTypeComment ChangesetJobType = "commentatore"
-	ChangesetJobTypeDetach  ChangesetJobType = "detach"
+	ChangesetJobTypeComment   ChangesetJobType = "commentatore"
+	ChangesetJobTypeDetach    ChangesetJobType = "detach"
+	ChangesetJobTypeReenqueue ChangesetJobType = "reenqueue"
 )
 
 type ChangesetJobCommentPayload struct {
@@ -50,6 +51,8 @@ type ChangesetJobCommentPayload struct {
 }
 
 type ChangesetJobDetachPayload struct{}
+
+type ChangesetJobReenqueuePayload struct{}
 
 // ChangesetJob describes a one-time action to be taken on a changeset.
 type ChangesetJob struct {


### PR DESCRIPTION
This PR implements a bulk operation type that allows to retry multiple changesets at once. Currently it is only available when filtering by `state === "FAILED"`. We will be able to losen that constraint, once we have backend evaluation of possible operation types.

Closes https://github.com/sourcegraph/sourcegraph/issues/20867