### PR TITLE
Add web integration test suite to sg config

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -645,6 +645,10 @@ tests:
       EMAIL: 'joe@sourcegraph.com'
       PASSWORD: '12345'
 
+  web-integration:
+    cmd: yarn test-integration
+    install: ENTERPRISE=1 yarn build-web
+
   frontend:
     cmd: yarn run jest --testPathIgnorePatterns end-to-end regression integration storybook
 


### PR DESCRIPTION
Do you think we would want to add support for the `install` command to tests, or should I just add some inline bash magic to chain the two commands?
