### PR TITLE
Remove insight creation UI local storage flag

### DIFF
--- a/client/web/src/insights/InsightsRouter.tsx
+++ b/client/web/src/insights/InsightsRouter.tsx
@@ -2,8 +2,6 @@ import MapSearchIcon from 'mdi-react/MapSearchIcon'
 import React from 'react'
 import { RouteComponentProps, Switch, Route } from 'react-router'
 
-import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
-
 import { AuthenticatedUser } from '../auth'
 import { HeroPage } from '../components/HeroPage'
 import { lazyComponent } from '../util/lazyComponent'
@@ -31,11 +29,6 @@ const LangStatsInsightCreationLazyPage = lazyComponent(
 
 const EditInsightLazyPage = lazyComponent(() => import('./pages/edit/EditInsightPage'), 'EditInsightPage')
 
-/**
- * Feature flag for new code insights creation UI.
- * */
-const CREATION_UI_ENABLED_KEY = 'enableCodeInsightCreationUI'
-
 const NotFoundPage: React.FunctionComponent = () => <HeroPage icon={MapSearchIcon} title="404: Not Found" />
 
 /**
@@ -58,46 +51,35 @@ export interface InsightsRouterProps
 /** Main Insight routing component. Main entry point to code insights UI. */
 export const InsightsRouter: React.FunctionComponent<InsightsRouterProps> = props => {
     const { match, ...outerProps } = props
-    const [isCreationUIEnabled] = useLocalStorage(CREATION_UI_ENABLED_KEY, false)
 
     return (
         <Switch>
+            <Route render={props => <InsightsLazyPage {...outerProps} {...props} />} path={match.url} exact={true} />
+
             <Route
-                render={props => (
-                    <InsightsLazyPage isCreationUIEnabled={isCreationUIEnabled} {...outerProps} {...props} />
-                )}
-                path={match.url}
-                exact={true}
+                path={`${match.url}/create-search-insight`}
+                render={props => <SearchInsightCreationLazyPage {...outerProps} {...props} />}
             />
 
-            {isCreationUIEnabled && (
-                <>
-                    <Route
-                        path={`${match.url}/create-search-insight`}
-                        render={props => <SearchInsightCreationLazyPage {...outerProps} {...props} />}
-                    />
+            <Route
+                path={`${match.url}/create-lang-stats-insight`}
+                render={props => <LangStatsInsightCreationLazyPage {...outerProps} {...props} />}
+            />
 
-                    <Route
-                        path={`${match.url}/create-lang-stats-insight`}
-                        render={props => <LangStatsInsightCreationLazyPage {...outerProps} {...props} />}
-                    />
+            <Route path={`${match.url}/create-intro`} component={IntroCreationLazyPage} />
 
-                    <Route path={`${match.url}/create-intro`} component={IntroCreationLazyPage} />
-
-                    <Route
-                        path={`${match.url}/edit/:insightID`}
-                        /* eslint-disable-next-line react/jsx-no-bind */
-                        render={(props: RouteComponentProps<{ insightID: string }>) => (
-                            <EditInsightLazyPage
-                                platformContext={outerProps.platformContext}
-                                authenticatedUser={outerProps.authenticatedUser}
-                                settingsCascade={outerProps.settingsCascade}
-                                insightID={props.match.params.insightID}
-                            />
-                        )}
+            <Route
+                path={`${match.url}/edit/:insightID`}
+                /* eslint-disable-next-line react/jsx-no-bind */
+                render={(props: RouteComponentProps<{ insightID: string }>) => (
+                    <EditInsightLazyPage
+                        platformContext={outerProps.platformContext}
+                        authenticatedUser={outerProps.authenticatedUser}
+                        settingsCascade={outerProps.settingsCascade}
+                        insightID={props.match.params.insightID}
                     />
-                </>
-            )}
+                )}
+            />
 
             <Route component={NotFoundPage} key="hardcoded-key" />
         </Switch>

--- a/client/web/src/insights/pages/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/intro/IntroCreationPage.tsx
@@ -21,11 +21,7 @@ export const IntroCreationPage: React.FunctionComponent = () => (
 
             <p className="text-muted">
                 Code insights analyze your code based on any search query.{' '}
-                <a
-                    href="https://docs.sourcegraph.com/dev/background-information/insights"
-                    target="_blank"
-                    rel="noopener"
-                >
+                <a href="https://docs.sourcegraph.com/code_insights" target="_blank" rel="noopener">
                     Learn more.
                 </a>
             </p>

--- a/client/web/src/insights/pages/dashboard/InsightsPage.tsx
+++ b/client/web/src/insights/pages/dashboard/InsightsPage.tsx
@@ -1,4 +1,3 @@
-import GearIcon from 'mdi-react/GearIcon'
 import PlusIcon from 'mdi-react/PlusIcon'
 import React, { useCallback, useEffect, useMemo, useContext } from 'react'
 
@@ -21,15 +20,13 @@ export interface InsightsPageProps
     extends ExtensionsControllerProps,
         Omit<InsightsViewGridProps, 'views'>,
         TelemetryProps,
-        PlatformContextProps<'updateSettings'> {
-    isCreationUIEnabled: boolean
-}
+        PlatformContextProps<'updateSettings'> {}
 
 /**
  * Renders insight page. (insights grid and navigation for insight)
  */
 export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props => {
-    const { isCreationUIEnabled, settingsCascade, platformContext } = props
+    const { settingsCascade, platformContext } = props
     const { getInsightCombinedViews } = useContext(InsightsApiContext)
 
     const views = useObservable(
@@ -46,10 +43,6 @@ export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props =>
         props.telemetryService.logViewEvent('Insights')
     }, [props.telemetryService])
 
-    const logConfigureClick = useCallback(() => {
-        props.telemetryService.log('InsightConfigureClick')
-    }, [props.telemetryService])
-
     const logAddMoreClick = useCallback(() => {
         props.telemetryService.log('InsightAddMoreClick')
     }, [props.telemetryService])
@@ -61,28 +54,9 @@ export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props =>
                     annotation={<FeedbackBadge status="prototype" feedback={{ mailto: 'support@sourcegraph.com' }} />}
                     path={[{ icon: InsightsIcon, text: 'Code insights' }]}
                     actions={
-                        !isCreationUIEnabled ? (
-                            <>
-                                <Link
-                                    to="/extensions?query=category:Insights"
-                                    onClick={logAddMoreClick}
-                                    className="btn btn-secondary mr-1"
-                                >
-                                    <PlusIcon className="icon-inline" /> Add more insights
-                                </Link>
-                                <Link to="/user/settings" onClick={logConfigureClick} className="btn btn-secondary">
-                                    <GearIcon className="icon-inline" /> Configure insights
-                                </Link>
-                            </>
-                        ) : (
-                            <Link
-                                to="/insights/create-intro"
-                                onClick={logAddMoreClick}
-                                className="btn btn-secondary mr-1"
-                            >
-                                <PlusIcon className="icon-inline" /> Create new insight
-                            </Link>
-                        )
+                        <Link to="/insights/create-intro" onClick={logAddMoreClick} className="btn btn-secondary mr-1">
+                            <PlusIcon className="icon-inline" /> Create new insight
+                        </Link>
                     }
                     className="mb-3"
                 />
@@ -91,12 +65,7 @@ export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props =>
                         <LoadingSpinner className="my-4" />
                     </div>
                 ) : (
-                    <InsightsViewGrid
-                        {...props}
-                        views={views}
-                        hasContextMenu={isCreationUIEnabled}
-                        onDelete={handleDelete}
-                    />
+                    <InsightsViewGrid {...props} views={views} hasContextMenu={true} onDelete={handleDelete} />
                 )}
             </Page>
         </div>


### PR DESCRIPTION
Resolves: https://github.com/sourcegraph/sourcegraph/issues/21077

For 3.28 release we want to release code insights creation UI for all user who uses code insights now (who has turned on experimental flag not the `localStorage` flag in their settings)

This PR removes our local storage flag `enableCodeInsightCreationUI` for the creation UI