### PR TITLE
make external services the first extension category

### DIFF
--- a/client/shared/src/schema/extensionSchema.ts
+++ b/client/shared/src/schema/extensionSchema.ts
@@ -19,8 +19,8 @@ import { Contributions, Raw } from '../api/protocol/contribution'
  * string constant (e.g., `ProgrammingLanguages = 'Programming languages'`).
  */
 export const EXTENSION_CATEGORIES = array([
-    'Reports and stats',
     'External services',
+    'Reports and stats',
     'Linters',
     'Code editors',
     'Code analysis',

--- a/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
@@ -22,19 +22,19 @@ exports[`ExtensionsQueryInputToolbar renders 1`] = `
     </button>
     <button
       className="btn text-left inactiveCategory"
-      data-test-extension-category="Reports and stats"
-      onClick={[Function]}
-      type="button"
-    >
-      Reports and stats
-    </button>
-    <button
-      className="btn text-left inactiveCategory"
       data-test-extension-category="External services"
       onClick={[Function]}
       type="button"
     >
       External services
+    </button>
+    <button
+      className="btn text-left inactiveCategory"
+      data-test-extension-category="Reports and stats"
+      onClick={[Function]}
+      type="button"
+    >
+      Reports and stats
     </button>
     <button
       className="btn text-left inactiveCategory"


### PR DESCRIPTION
Promote "External services" extensions above "Reports and stats" extensions in the extension registry.

#### Before

![Screenshot from 2021-05-20 10-15-46](https://user-images.githubusercontent.com/37420160/118995646-52f3cc00-b955-11eb-99b2-bb4ea90d8ca6.png)


#### After

![Screenshot from 2021-05-20 10-15-32](https://user-images.githubusercontent.com/37420160/118995667-55eebc80-b955-11eb-96ec-1cda22fc01da.png)
