### PR TITLE
gomod: update zoekt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -215,7 +215,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210426140333-978e89d6b912
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210520140925-cc7c4549f311
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1604,6 +1604,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20210426140333-978e89d6b912 h1:kztzEJbRqTMp2nlDRbWOaC3DSflpiEx6tBj/v7vj7i4=
 github.com/sourcegraph/zoekt v0.0.0-20210426140333-978e89d6b912/go.mod h1:Dz5BGxhhVON8c0REOu98M7gLCwOHl7rcDRdce3DuizI=
+github.com/sourcegraph/zoekt v0.0.0-20210520140925-cc7c4549f311 h1:xbdo1/DORiUyh6ooMiyGwlGwBPy2Oigq8TDb26ViJrE=
+github.com/sourcegraph/zoekt v0.0.0-20210520140925-cc7c4549f311/go.mod h1:Dz5BGxhhVON8c0REOu98M7gLCwOHl7rcDRdce3DuizI=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
includes the following changes:
- cc7c454 indexserver: add option to print csv of trigrams [#83](https://github.com/sourcegraph/zoekt/pull/83)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
