### PR TITLE
graphqlbackend: Gracefully handle some code host failures for AffiliatedRepos

### DIFF
--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -9,7 +9,6 @@ import (
 	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
@@ -55,10 +54,8 @@ func (a *affiliatedRepositoriesConnection) Nodes(ctx context.Context) ([]*codeHo
 			}
 			// 🚨 SECURITY: if the user doesn't own this service, check they're site admin
 			if svc.NamespaceUserID != a.userID {
-				if err := backend.CheckUserIsSiteAdmin(ctx, a.userID); err != nil {
-					a.err = err
-					return
-				}
+				a.err = errors.New("external service must be owned by specified user")
+				return
 			}
 			svcs = append(svcs, svc)
 		}

--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -6,16 +6,14 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
-
 	"github.com/inconshreveable/log15"
-
-	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"

--- a/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
+++ b/cmd/frontend/graphqlbackend/affiliated_repositories_connection.go
@@ -145,6 +145,7 @@ func (a *affiliatedRepositoriesConnection) Nodes(ctx context.Context) ([]*codeHo
 
 		if len(fetchErrors) == pending {
 			// All hosts failed
+			a.nodes = nil
 			a.err = errors.New("failed to fetch from any code host")
 		}
 	})

--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -606,7 +606,7 @@ func (r *schemaResolver) AffiliatedRepositories(ctx context.Context, args *struc
 	User     graphql.ID
 	CodeHost *graphql.ID
 	Query    *string
-}) (*codeHostRepositoryConnectionResolver, error) {
+}) (*affiliatedRepositoriesConnection, error) {
 	userID, err := UnmarshalUserID(args.User)
 	if err != nil {
 		return nil, err
@@ -627,7 +627,7 @@ func (r *schemaResolver) AffiliatedRepositories(ctx context.Context, args *struc
 		query = *args.Query
 	}
 
-	return &codeHostRepositoryConnectionResolver{
+	return &affiliatedRepositoriesConnection{
 		db:       r.db,
 		userID:   userID,
 		codeHost: codeHost,

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -14,18 +15,17 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
-	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-	"github.com/sourcegraph/sourcegraph/internal/rcache"
-
-	"github.com/graph-gophers/graphql-go/errors"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/gqltesting"
 	"github.com/inconshreveable/log15"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
+	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httpcli"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -300,7 +300,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 			}
 			`,
 			ExpectedResult: `null`,
-			ExpectedErrors: []*errors.QueryError{
+			ExpectedErrors: []*gqlerrors.QueryError{
 				{
 					Path:          []interface{}{"affiliatedRepositories"},
 					Message:       "Must be authenticated as user with id 1",
@@ -367,6 +367,55 @@ func TestAffiliatedRepositories(t *testing.T) {
 					}
 				}
 			`,
+		},
+	})
+
+	// Both code hosts failing is an error
+	// Make github break too
+	httpResponder["/api/v3/user/repos"] = func(request *http.Request) (*http.Response, error) {
+		buf := &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		if err := enc.Encode([]gitlabRepository{
+			{
+				PathWithNamespace: "test-user2/test2",
+				Visibility:        "public",
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{
+			Body:       nil,
+			StatusCode: http.StatusUnauthorized,
+		}, nil
+	}
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Context: ctx,
+			Schema:  mustParseGraphQLSchema(t),
+			Query: `
+			{
+				affiliatedRepositories(
+					user: "VXNlcjox"
+				) {
+					nodes {
+						name,
+						private,
+						codeHost {
+							displayName
+						}
+					}
+				}
+			}
+			`,
+			ExpectedResult: `null`,
+			ExpectedErrors: []*gqlerrors.QueryError{
+				{
+					Path:          []interface{}{"affiliatedRepositories"},
+					Message:       "failed to fetch from any code host",
+					ResolverError: errors.New("failed to fetch from any code host"),
+				},
+			},
 		},
 	})
 }

--- a/cmd/frontend/graphqlbackend/graphqlbackend_test.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend_test.go
@@ -389,7 +389,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 		}, nil
 	}
 
-	gqltesting.RunTests(t, []*gqltesting.Test{
+	RunTests(t, []*Test{
 		{
 			Context: ctx,
 			Schema:  mustParseGraphQLSchema(t),
@@ -411,7 +411,7 @@ func TestAffiliatedRepositories(t *testing.T) {
 			ExpectedResult: `null`,
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					Path:          []interface{}{"affiliatedRepositories"},
+					Path:          []interface{}{"affiliatedRepositories", "nodes"},
 					Message:       "failed to fetch from any code host",
 					ResolverError: errors.New("failed to fetch from any code host"),
 				},

--- a/cmd/frontend/graphqlbackend/testing.go
+++ b/cmd/frontend/graphqlbackend/testing.go
@@ -1,10 +1,20 @@
 package graphqlbackend
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
 	"sync"
 	"testing"
 
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/google/go-cmp/cmp"
 	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/errors"
 )
 
 var (
@@ -24,4 +34,99 @@ func mustParseGraphQLSchema(t *testing.T) *graphql.Schema {
 	}
 
 	return parsedSchema
+}
+
+// Code below copied from graph-gophers and has been modified to improve
+// error messages
+
+// Test is a GraphQL test case to be used with RunTest(s).
+type Test struct {
+	Context        context.Context
+	Schema         *graphql.Schema
+	Query          string
+	OperationName  string
+	Variables      map[string]interface{}
+	ExpectedResult string
+	ExpectedErrors []*errors.QueryError
+}
+
+// RunTests runs the given GraphQL test cases as subtests.
+func RunTests(t *testing.T, tests []*Test) {
+	if len(tests) == 1 {
+		RunTest(t, tests[0])
+		return
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i+1), func(t *testing.T) {
+			RunTest(t, test)
+		})
+	}
+}
+
+// RunTest runs a single GraphQL test case.
+func RunTest(t *testing.T, test *Test) {
+	if test.Context == nil {
+		test.Context = context.Background()
+	}
+	result := test.Schema.Exec(test.Context, test.Query, test.OperationName, test.Variables)
+
+	checkErrors(t, test.ExpectedErrors, result.Errors)
+
+	if test.ExpectedResult == "" {
+		if result.Data != nil {
+			t.Errorf("got: %s", result.Data)
+			t.Fatal("want: null")
+		}
+		return
+	}
+
+	// Verify JSON to avoid red herring errors.
+	got, err := formatJSON(result.Data)
+	if err != nil {
+		t.Fatalf("got: invalid JSON: %s", err)
+	}
+	want, err := formatJSON([]byte(test.ExpectedResult))
+	if err != nil {
+		t.Fatalf("want: invalid JSON: %s", err)
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Logf("got:  %s", got)
+		t.Logf("want: %s", want)
+		t.Fail()
+	}
+}
+
+func formatJSON(data []byte) ([]byte, error) {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return nil, err
+	}
+	formatted, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return formatted, nil
+}
+
+func checkErrors(t *testing.T, want, got []*errors.QueryError) {
+	t.Helper()
+
+	sortErrors(want)
+	sortErrors(got)
+
+	// Compare without caring about the concrete type of the error returned
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(errors.QueryError{}, "ResolverError")); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func sortErrors(errors []*errors.QueryError) {
+	if len(errors) <= 1 {
+		return
+	}
+	sort.Slice(errors, func(i, j int) bool {
+		return fmt.Sprintf("%s", errors[i].Path) < fmt.Sprintf("%s", errors[j].Path)
+	})
 }


### PR DESCRIPTION
This change allows us to gracefully handle failures in only some of the code
hosts when listing affiliated repos.

The resolver type and file were also renamed to make them more consistent.

Closes: https://github.com/sourcegraph/sourcegraph/issues/20934

Note that the final test is failing which I'll look into tomorrow. It's most likely something to do with
error formatting.