### PR TITLE
search: use streaming search protocol when creating patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
+- Search returned inconsistent result counts when a `count:` limit was not specified.
 - Indexed search failed when the `master` branch needed indexing but was not the default. [#20260](https://github.com/sourcegraph/sourcegraph/pull/20260)
 - `repo:contains(...)` built-in did not respect parameters that affect repo filtering (e.g., `repogroup`, `fork`). It now respects these. [#20339](https://github.com/sourcegraph/sourcegraph/pull/20339)
 - An issue where duplicate results would render for certain `or`-expressions. [#20480](https://github.com/sourcegraph/sourcegraph/pull/20480)

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -262,6 +262,17 @@ func (r *searchResolver) countIsSet() bool {
 	return count != nil
 }
 
+// protocol returns what type of search we are doing (batch, stream,
+// paginated).
+func (r *searchResolver) protocol() search.Protocol {
+	if r.SearchInputs.Pagination != nil {
+		return search.Pagination
+	} else if r.stream != nil {
+		return search.Streaming
+	}
+	return search.Batch
+}
+
 const defaultMaxSearchResults = 30
 const defaultMaxSearchResultsStreaming = 500
 const maxSearchResultsPerPaginatedRequest = 5000
@@ -414,7 +425,7 @@ func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]Sea
 		// Not an atomic pattern, can't guarantee it will behave well.
 		return nil, nil
 	}
-	p := search.ToTextPatternInfo(q, search.Batch, query.PatternToFile)
+	p := search.ToTextPatternInfo(q, r.protocol(), query.PatternToFile)
 
 	args := search.TextParameters{
 		PatternInfo:     p,

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1585,7 +1585,7 @@ func (r *searchResolver) doResults(ctx context.Context, forceResultTypes result.
 	if err != nil {
 		return nil, err
 	}
-	p := search.ToTextPatternInfo(q, search.Batch, query.Identity)
+	p := search.ToTextPatternInfo(q, r.protocol(), query.Identity)
 
 	// Fallback to literal search for searching repos and files if
 	// the structural search pattern is empty.


### PR DESCRIPTION
The commit which introduced ToTextPatternInfo (a2f7bc9772e) never passed
in the streaming protocol. This meant that when a user did not specify a
limit, we would use the defaults for batch search.

This had some bad interactions, since all the layers above the specific
backends would only think a limit was hit when we had 500 or more
results. But the backends would stop searching after 30. This lead to
very strange result counts that would change on every search.

This has been a regression since v3.27 series. We have a known work
around (specify a limit), but I believe its a relatively bad user
experience. As such this may justify a patch release on the 3.27
series (and not just be destined for 3.28).