### PR TITLE
extensibility: make extension toggle truly optimistic

### DIFF
--- a/client/web/src/extensions/ExtensionToggle.tsx
+++ b/client/web/src/extensions/ExtensionToggle.tsx
@@ -93,11 +93,6 @@ export const ExtensionToggle: React.FunctionComponent<Props> = ({
     const [optimisticEnabled, setOptimisticEnabled] = useState(enabled)
     const [askingForPermission, setAskingForPermission] = useState<boolean>(false)
 
-    // If `enabled` changes for any reason (e.g. enabled with another toggle), update optimistic state
-    useEffect(() => {
-        setOptimisticEnabled(enabled)
-    }, [enabled])
-
     const onOptimisticError = useCallback(
         (optimisticUpdateFailure: OptimisticUpdateFailure<boolean>) => {
             setOptimisticEnabled(optimisticUpdateFailure.previousValue)

--- a/client/web/src/extensions/ExtensionToggle.tsx
+++ b/client/web/src/extensions/ExtensionToggle.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Observable, of } from 'rxjs'
 import { catchError, map, switchMap } from 'rxjs/operators'
 


### PR DESCRIPTION
Don't sync optimistic state when settings are updated. This is a bandaid over the "double toggle" problem (#21062). 

For now, site admins won't see their user extension toggle updated as a result of toggling site-wide extension enablement. In a future PR, calculate site admin user extension enablement in the webapp so the toggles are optimistic _and_ correct.