### PR TITLE
client/web: Don't send email and username to Sentry

### DIFF
--- a/client/web/src/sentry.ts
+++ b/client/web/src/sentry.ts
@@ -12,8 +12,7 @@ if (window.context.sentryDSN) {
     authenticatedUser.subscribe(user => {
         sentry.configureScope(scope => {
             if (user) {
-                const { id, username, email } = user
-                scope.setUser({ id, username, email })
+                scope.setUser({ id: user.id })
             }
         })
     })


### PR DESCRIPTION
We still send IP address by default to group and identify anonymous user errors. We won't be scrubbing potentially private metadata like repo names or file paths, since these can be essential in debugging certain errors. We'll include the necessary provisions in the legal agreements with Sentry (cc @RafLeszczynski).

Closes https://github.com/sourcegraph/security-issues/issues/148



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
