### PR TITLE
extensiblity: add experimental extension filter to registry

### DIFF
--- a/client/shared/src/extensions/extensionManifest.ts
+++ b/client/shared/src/extensions/extensionManifest.ts
@@ -3,6 +3,7 @@ import { isPlainObject } from 'lodash'
 import { ExtensionManifest as ExtensionManifestSchema, EXTENSION_HEADER_COLORS } from '../schema/extensionSchema'
 import { ErrorLike, isErrorLike } from '../util/errors'
 import { parseJSONCOrError } from '../util/jsonc'
+import { isDefined } from '../util/types'
 
 /**
  * Represents an input object that is validated against a subset of properties of the {@link ExtensionManifest}
@@ -11,6 +12,7 @@ import { parseJSONCOrError } from '../util/jsonc'
 export type ExtensionManifest = Pick<
     ExtensionManifestSchema,
     | 'description'
+    | 'wip'
     | 'repository'
     | 'categories'
     | 'tags'
@@ -48,6 +50,9 @@ export function parseExtensionManifestOrError(input: string): ExtensionManifest 
                     problems.push('"repository" property "url" must be a string')
                 }
             }
+        }
+        if (isDefined(value.wip) && typeof value.wip !== 'boolean') {
+            problems.push('"wip" property "type" must be a boolean')
         }
         if (
             value.categories &&

--- a/client/shared/src/schema/extension.schema.json
+++ b/client/shared/src/schema/extension.schema.json
@@ -29,6 +29,10 @@
       "type": "string",
       "enum": ["blue", "yellow", "orange", "pink", "red", "purple", "green", "grey"]
     },
+    "wip": {
+      "description": "Whether the extension is in development and not ready for use ('work-in-progress').",
+      "type": "boolean"
+    },
     "url": {
       "description": "A URL to a file containing the bundled JavaScript source code of this extension.",
       "type": "string",

--- a/client/shared/src/schema/extensionSchema.ts
+++ b/client/shared/src/schema/extensionSchema.ts
@@ -58,6 +58,7 @@ export interface ExtensionManifest {
     description?: string
     readme?: string
     url: string
+    wip?: boolean
     repository?: {
         type?: string
         url: string

--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -12,6 +12,7 @@ import { ExtensionCategory, EXTENSION_CATEGORIES } from '@sourcegraph/shared/src
 import { Settings, SettingsCascadeProps, SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { createAggregateError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 import { useEventObservable } from '@sourcegraph/shared/src/util/useObservable'
 
 import { PageTitle } from '../components/PageTitle'
@@ -40,6 +41,7 @@ interface Props
 const LOADING = 'loading' as const
 const URL_QUERY_PARAM = 'query'
 const URL_CATEGORY_PARAM = 'category'
+const SHOW_EXPERIMENTAL_EXTENSIONS_KEY = 'show-experimental-extensions'
 
 export type ExtensionListData = typeof LOADING | (ConfiguredExtensionRegistry & { error: string | null }) | ErrorLike
 
@@ -126,6 +128,13 @@ export const ExtensionRegistry: React.FunctionComponent<Props> = props => {
     // Note: It'll be worth refactoring the query pipeline (probably split between category changes and
     // query changes) when any more complexity is introduced.
     const [changedCategory, setChangedCategory] = useState(false)
+
+    // Whether to show extensions that set "wip" to true in their manifests.
+    const [showExperimentalExtensions, setShowExperimentalExtensions] = useLocalStorage(
+        SHOW_EXPERIMENTAL_EXTENSIONS_KEY,
+        false
+    )
+    const toggleExperimentalExtensions = (): void => setShowExperimentalExtensions(!showExperimentalExtensions)
 
     /**
      * Note: pass `settingsCascade` instead of making it a dependency to prevent creating
@@ -265,6 +274,8 @@ export const ExtensionRegistry: React.FunctionComponent<Props> = props => {
                         onSelectCategory={onSelectCategory}
                         enablementFilter={enablementFilter}
                         setEnablementFilter={setEnablementFilter}
+                        showExperimentalExtensions={showExperimentalExtensions}
+                        toggleExperimentalExtensions={toggleExperimentalExtensions}
                     />
                     <div className="flex-grow-1">
                         <div className="mb-5">
@@ -307,6 +318,7 @@ export const ExtensionRegistry: React.FunctionComponent<Props> = props => {
                                 enablementFilter={enablementFilter}
                                 selectedCategory={selectedCategory}
                                 onShowFullCategoryClicked={onSelectCategory}
+                                showExperimentalExtensions={showExperimentalExtensions}
                             />
                         </div>
                         {/* Only show the banner when there are no selected categories and it is not loading */}

--- a/client/web/src/extensions/ExtensionRegistrySidenav.test.tsx
+++ b/client/web/src/extensions/ExtensionRegistrySidenav.test.tsx
@@ -13,6 +13,8 @@ describe('ExtensionsQueryInputToolbar', () => {
                         onSelectCategory={() => {}}
                         enablementFilter="all"
                         setEnablementFilter={() => {}}
+                        showExperimentalExtensions={true}
+                        toggleExperimentalExtensions={() => {}}
                     />
                 )
                 .toJSON()

--- a/client/web/src/extensions/ExtensionRegistrySidenav.tsx
+++ b/client/web/src/extensions/ExtensionRegistrySidenav.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import React, { useCallback, useState } from 'react'
+import React, { useState } from 'react'
 import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap'
 
 import { EXTENSION_CATEGORIES } from '@sourcegraph/shared/src/schema/extensionSchema'
@@ -20,6 +20,9 @@ interface ExtensionsCategoryFiltersProps {
 interface ExtensionsEnablementDropdownProps {
     enablementFilter: ExtensionsEnablement
     setEnablementFilter: React.Dispatch<React.SetStateAction<ExtensionsEnablement>>
+
+    showExperimentalExtensions: boolean
+    toggleExperimentalExtensions: () => void
 }
 
 /**
@@ -28,13 +31,20 @@ interface ExtensionsEnablementDropdownProps {
  */
 export const ExtensionRegistrySidenav: React.FunctionComponent<
     ExtensionsCategoryFiltersProps & ExtensionsEnablementDropdownProps
-> = ({ selectedCategory, onSelectCategory, enablementFilter, setEnablementFilter }) => {
+> = ({
+    selectedCategory,
+    onSelectCategory,
+    enablementFilter,
+    setEnablementFilter,
+    showExperimentalExtensions,
+    toggleExperimentalExtensions,
+}) => {
     const [isOpen, setIsOpen] = useState(false)
-    const toggleIsOpen = useCallback(() => setIsOpen(open => !open), [])
+    const toggleIsOpen = (): void => setIsOpen(open => !open)
 
-    const showAll = useCallback(() => setEnablementFilter('all'), [setEnablementFilter])
-    const showEnabled = useCallback(() => setEnablementFilter('enabled'), [setEnablementFilter])
-    const showDisabled = useCallback(() => setEnablementFilter('disabled'), [setEnablementFilter])
+    const showAll = (): void => setEnablementFilter('all')
+    const showEnabled = (): void => setEnablementFilter('enabled')
+    const showDisabled = (): void => setEnablementFilter('disabled')
 
     return (
         <div className={classnames(styles.column, 'mr-4 flex-grow-0 flex-shrink-0')}>
@@ -64,14 +74,37 @@ export const ExtensionRegistrySidenav: React.FunctionComponent<
                     {enablementFilterToLabel[enablementFilter]}
                 </DropdownToggle>
                 <DropdownMenu>
-                    <DropdownItem onClick={showAll} disabled={enablementFilter === 'all'}>
+                    <DropdownItem onClick={showAll} disabled={enablementFilter === 'all'} toggle={false}>
                         Show all
                     </DropdownItem>
-                    <DropdownItem onClick={showEnabled} disabled={enablementFilter === 'enabled'}>
+                    <DropdownItem onClick={showEnabled} disabled={enablementFilter === 'enabled'} toggle={false}>
                         Show enabled extensions
                     </DropdownItem>
-                    <DropdownItem onClick={showDisabled} disabled={enablementFilter === 'disabled'}>
+                    <DropdownItem onClick={showDisabled} disabled={enablementFilter === 'disabled'} toggle={false}>
                         Show disabled extensions
+                    </DropdownItem>
+
+                    <DropdownItem divider={true} />
+
+                    <DropdownItem
+                        // Hack: clicking <label> inside <DropdownItem> doesn't affect checked state,
+                        // so use a <span> for which click events are handled by <DropdownItem>.
+                        onClick={toggleExperimentalExtensions}
+                        // Ensure that clicking the checkbox doesn't close the dropdown.
+                        toggle={false}
+                    >
+                        <div className="d-flex align-items-center">
+                            <input
+                                type="checkbox"
+                                checked={showExperimentalExtensions}
+                                onChange={toggleExperimentalExtensions}
+                                className=""
+                                aria-labelledby="show-experimental-extensions"
+                            />
+                            <span className="m-0 pl-2" id="show-experimental-extensions">
+                                Show experimental extensions
+                            </span>
+                        </div>
                     </DropdownItem>
                 </DropdownMenu>
             </ButtonDropdown>

--- a/client/web/src/extensions/ExtensionRegistrySidenav.tsx
+++ b/client/web/src/extensions/ExtensionRegistrySidenav.tsx
@@ -74,13 +74,13 @@ export const ExtensionRegistrySidenav: React.FunctionComponent<
                     {enablementFilterToLabel[enablementFilter]}
                 </DropdownToggle>
                 <DropdownMenu>
-                    <DropdownItem onClick={showAll} disabled={enablementFilter === 'all'} toggle={false}>
+                    <DropdownItem onClick={showAll} disabled={enablementFilter === 'all'}>
                         Show all
                     </DropdownItem>
-                    <DropdownItem onClick={showEnabled} disabled={enablementFilter === 'enabled'} toggle={false}>
+                    <DropdownItem onClick={showEnabled} disabled={enablementFilter === 'enabled'}>
                         Show enabled extensions
                     </DropdownItem>
-                    <DropdownItem onClick={showDisabled} disabled={enablementFilter === 'disabled'} toggle={false}>
+                    <DropdownItem onClick={showDisabled} disabled={enablementFilter === 'disabled'}>
                         Show disabled extensions
                     </DropdownItem>
 
@@ -90,8 +90,6 @@ export const ExtensionRegistrySidenav: React.FunctionComponent<
                         // Hack: clicking <label> inside <DropdownItem> doesn't affect checked state,
                         // so use a <span> for which click events are handled by <DropdownItem>.
                         onClick={toggleExperimentalExtensions}
-                        // Ensure that clicking the checkbox doesn't close the dropdown.
-                        toggle={false}
                     >
                         <div className="d-flex align-items-center">
                             <input

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -14,8 +14,8 @@ import { ErrorAlert } from '../components/alerts'
 
 import { ExtensionCard } from './ExtensionCard'
 import { ExtensionCategoryOrAll, ExtensionListData, ExtensionsEnablement } from './ExtensionRegistry'
-import { ExtensionsAreaRouteContext } from './ExtensionsArea'
 import { applyEnablementFilter, applyWIPFilter } from './extensions'
+import { ExtensionsAreaRouteContext } from './ExtensionsArea'
 
 interface Props
     extends SettingsCascadeProps,

--- a/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
@@ -129,6 +129,33 @@ exports[`ExtensionsQueryInputToolbar renders 1`] = `
       >
         Show disabled extensions
       </button>
+      <div
+        className="dropdown-divider"
+        onClick={[Function]}
+        tabIndex="-1"
+      />
+      <button
+        className="dropdown-item"
+        onClick={[Function]}
+        role="menuitem"
+        tabIndex="0"
+      >
+        <div
+          className="d-flex align-items-center"
+        >
+          <input
+            aria-labelledby="show-experimental-extensions"
+            className=""
+            type="checkbox"
+          />
+          <span
+            className="m-0 pl-2"
+            id="show-experimental-extensions"
+          >
+            Show experimental extensions
+          </span>
+        </div>
+      </button>
     </div>
   </div>
 </div>

--- a/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
@@ -139,13 +139,16 @@ exports[`ExtensionsQueryInputToolbar renders 1`] = `
         onClick={[Function]}
         role="menuitem"
         tabIndex="0"
+        type="button"
       >
         <div
           className="d-flex align-items-center"
         >
           <input
             aria-labelledby="show-experimental-extensions"
+            checked={true}
             className=""
+            onChange={[Function]}
             type="checkbox"
           />
           <span

--- a/client/web/src/extensions/extensions.test.ts
+++ b/client/web/src/extensions/extensions.test.ts
@@ -1,10 +1,16 @@
 import { ConfiguredRegistryExtension } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionManifest } from '@sourcegraph/shared/src/extensions/extensionManifest'
+import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { RegistryExtensionFieldsForList } from '../graphql-operations'
 
 import { ConfiguredExtensionCache } from './ExtensionRegistry'
-import { configureExtensionRegistry } from './extensions'
+import {
+    applyEnablementFilter,
+    applyWIPFilter,
+    ConfiguredRegistryExtensions,
+    configureExtensionRegistry,
+} from './extensions'
 
 describe('extension registry helpers', () => {
     describe('configureExtensionRegistry', () => {
@@ -40,6 +46,70 @@ describe('extension registry helpers', () => {
             const { extensionIDsByCategory } = configureExtensionRegistry(nodes, configuredExtensionCache)
             expect(extensionIDsByCategory['External services'].primaryExtensionIDs).toStrictEqual(['sourcegraph/snyk'])
             expect(extensionIDsByCategory['Code analysis'].primaryExtensionIDs).toStrictEqual(['sourcegraph/eslint'])
+        })
+    })
+
+    describe('applyEnablementFilter', () => {
+        const extensionIDs = ['sourcegraph/codecov', 'sourcegraph/snyk', 'sourcegraph/eslint']
+        const settings: Settings = {
+            extensions: {
+                'sourcegraph/codecov': true,
+                'sourcegraph/eslint': false,
+            },
+        }
+
+        test('returns all extensionIDs when filter is "all"', () => {
+            expect(applyEnablementFilter(extensionIDs, 'all', settings)).toStrictEqual([
+                'sourcegraph/codecov',
+                'sourcegraph/snyk',
+                'sourcegraph/eslint',
+            ])
+        })
+        test('returns only enabled extensionIDs when filter is "enabled"', () => {
+            expect(applyEnablementFilter(extensionIDs, 'enabled', settings)).toStrictEqual(['sourcegraph/codecov'])
+        })
+        test('returns only disabled extensionIDs when filter is "disabled"', () => {
+            expect(applyEnablementFilter(extensionIDs, 'disabled', settings)).toStrictEqual([
+                'sourcegraph/snyk',
+                'sourcegraph/eslint',
+            ])
+        })
+    })
+
+    describe('appyWIPFilter', () => {
+        const extensionIDs = ['sourcegraph/codecov', 'sourcegraph/snyk', 'sourcegraph/eslint']
+        const extensions: ConfiguredRegistryExtensions = {
+            'sourcegraph/codecov': {
+                id: 'sourcegraph/codecov',
+                manifest: {} as ExtensionManifest,
+            },
+            'sourcegraph/snyk': {
+                id: 'sourcegraph/snyk',
+                manifest: {
+                    wip: true,
+                } as ExtensionManifest,
+            },
+            'sourcegraph/eslint': {
+                id: 'sourcegraph/eslint',
+                manifest: {
+                    wip: false,
+                } as ExtensionManifest,
+            },
+        }
+
+        test('returns all extensionIDs when filter is `true`', () => {
+            expect(applyWIPFilter(extensionIDs, true, extensions)).toStrictEqual([
+                'sourcegraph/codecov',
+                'sourcegraph/snyk',
+                'sourcegraph/eslint',
+            ])
+        })
+
+        test('returns only non-wip extensions when filter is `false`', () => {
+            expect(applyWIPFilter(extensionIDs, false, extensions)).toStrictEqual([
+                'sourcegraph/codecov',
+                'sourcegraph/eslint',
+            ])
         })
     })
 })

--- a/client/web/src/extensions/extensions.ts
+++ b/client/web/src/extensions/extensions.ts
@@ -15,10 +15,7 @@ import { validCategories } from './extension/extension'
 import { ConfiguredExtensionCache, ExtensionsEnablement } from './ExtensionRegistry'
 
 export interface ConfiguredRegistryExtensions {
-    [id: string]: Pick<
-        ConfiguredRegistryExtension<RegistryExtensionFieldsForList>,
-        'manifest' | 'id' | 'registryExtension'
-    >
+    [id: string]: Pick<ConfiguredRegistryExtension<RegistryExtensionFieldsForList>, 'manifest' | 'id'>
 }
 
 export interface ConfiguredExtensionRegistry {

--- a/client/web/src/extensions/extensions.ts
+++ b/client/web/src/extensions/extensions.ts
@@ -1,18 +1,24 @@
 import {
     ConfiguredRegistryExtension,
+    isExtensionEnabled,
     toConfiguredRegistryExtension,
 } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionCategory, EXTENSION_CATEGORIES } from '@sourcegraph/shared/src/schema/extensionSchema'
+import { Settings } from '@sourcegraph/shared/src/settings/settings'
 import { createRecord } from '@sourcegraph/shared/src/util/createRecord'
-import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { isDefined } from '@sourcegraph/shared/src/util/types'
 
 import { RegistryExtensionFieldsForList } from '../graphql-operations'
 
 import { validCategories } from './extension/extension'
-import { ConfiguredExtensionCache } from './ExtensionRegistry'
+import { ConfiguredExtensionCache, ExtensionsEnablement } from './ExtensionRegistry'
 
 export interface ConfiguredRegistryExtensions {
-    [id: string]: Pick<ConfiguredRegistryExtension<RegistryExtensionFieldsForList>, 'manifest' | 'id'>
+    [id: string]: Pick<
+        ConfiguredRegistryExtension<RegistryExtensionFieldsForList>,
+        'manifest' | 'id' | 'registryExtension'
+    >
 }
 
 export interface ConfiguredExtensionRegistry {
@@ -80,4 +86,57 @@ export function configureExtensionRegistry(
     }
 
     return { extensions, extensionIDsByCategory }
+}
+
+/**
+ * Removes extensions that do not satify the enablement filter.
+ *
+ * For example, if the user wants to see only enabled extensions, remove disabled extensions.
+ */
+export function applyEnablementFilter(
+    extensionIDs: string[],
+    enablementFilter: ExtensionsEnablement,
+    settings: Settings | ErrorLike | null
+): string[] {
+    if (enablementFilter === 'all') {
+        return extensionIDs
+    }
+
+    return extensionIDs.filter(extensionID => {
+        const showEnabled = enablementFilter === 'enabled'
+        const isEnabled = isExtensionEnabled(settings, extensionID)
+
+        return showEnabled === isEnabled
+    })
+}
+
+/**
+ * Removes extensions that do not satisfy the WIP/experimental filter.
+ *
+ * For example, if the user does not want to see experimental extensions,
+ * remove all extensions where WIP === true.
+ */
+export function applyWIPFilter(
+    extensionIDs: string[],
+    wipFilter: boolean,
+    extensions: ConfiguredRegistryExtensions
+): string[] {
+    if (wipFilter === true) {
+        return extensionIDs
+    }
+
+    return extensionIDs.filter(extensionID => {
+        const extension = extensions[extensionID]
+        if (!extension) {
+            return false // Shouldn't be reached
+        }
+
+        if (extension.manifest && !isErrorLike(extension.manifest) && isDefined(extension.manifest.wip)) {
+            return !extension.manifest.wip // Don't include WIP extensions
+        }
+
+        // Don't filter it out if we don't have enough information to determine
+        // that the extension is WIP.
+        return true
+    })
 }


### PR DESCRIPTION
Closes #21008. Add checkbox to extension registry sidenav dropdown to allow users to filter out experimental extensions (`"wip"` set to `true` in extension manifest).

<details>
<summary>For "all"</summary>
<img src="https://user-images.githubusercontent.com/37420160/119037591-2b662900-b980-11eb-9551-8ee1820136d4.gif" />
</details>

<details>
<summary>For one category</summary>
<img src="https://user-images.githubusercontent.com/37420160/119037583-299c6580-b980-11eb-966c-894b0c4eaf51.gif" />
</details>
