### PR TITLE
Fix incorrect labeling for Postgres exporter alert

### DIFF
--- a/monitoring/definitions/postgres.go
+++ b/monitoring/definitions/postgres.go
@@ -28,7 +28,7 @@ func Postgres() *monitoring.Container {
 						Name:              "connections",
 						Description:       "active connections",
 						Owner:             monitoring.ObservableOwnerCoreApplication,
-						Query:             `sum by (datname) (pg_stat_activity_count{datname!~"template.*|postgres|cloudsqladmin"})`,
+						Query:             `sum by (job) (pg_stat_activity_count{datname!~"template.*|postgres|cloudsqladmin"})`,
 						Panel:             monitoring.Panel().LegendFormat("{{datname}}"),
 						Warning:           monitoring.Alert().LessOrEqual(5, nil).For(5 * time.Minute),
 						PossibleSolutions: "none",


### PR DESCRIPTION
This alert was firing since it would pick up the "sg_lsif" table which is now unused and had zero connections.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
