### PR TITLE
Correct homepage link and fix copy

### DIFF
--- a/client/web/src/search/input/LoggedOutHomepage.tsx
+++ b/client/web/src/search/input/LoggedOutHomepage.tsx
@@ -84,9 +84,9 @@ export const LoggedOutHomepage: React.FunctionComponent<LoggedOutHomepageProps> 
                 <div className="d-flex align-items-center flex-column">
                     <SignUpCta className={styles.loggedOutHomepageCta} />
                     <div className="mt-2 text-center">
-                        Prefer a local installation?{' '}
-                        <a href="https://docs.sourcegraph.com" target="_blank" rel="noopener noreferrer">
-                            Install Sourcegraph locally.
+                        Search private code by{' '}
+                        <a href="https://docs.sourcegraph.com/admin/install" target="_blank" rel="noopener noreferrer">
+                            installing Sourcegraph locally.
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
A small correction for the CTA install link copy and alters the link to install should be the admin/install page instead of the docs index.

![image](https://user-images.githubusercontent.com/539268/119043525-fa7cf880-b96d-11eb-8809-ad0462c9896f.png)
