### PR TITLE
search redesign: styling for diff and commit results

### DIFF
--- a/client/web/src/components/SearchResult.scss
+++ b/client/web/src/components/SearchResult.scss
@@ -3,6 +3,7 @@
         display: flex;
         align-items: center;
         flex-grow: 1;
+        min-width: 0;
     }
     &__spacer {
         flex: 1;

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -26,15 +26,16 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, history, 
             const RepoIcon = getRepoIcon(repoName)
             return (
                 <div className="search-result__title">
-                    {RepoIcon && <RepoIcon className="icon-inline text-muted" />}
+                    {RepoIcon && <RepoIcon className="icon-inline text-muted flex-shrink-0" />}
                     <Markdown
-                        className="test-search-result-label ml-1"
+                        className="test-search-result-label ml-1 flex-shrink-past-contents text-truncate"
                         dangerousInnerHTML={result.label.html ? result.label.html : renderMarkdown(result.label.text)}
                     />
                     {result.__typename !== 'Repository' && result.detail && (
                         <>
                             <span className="search-result__spacer" />
                             <Markdown
+                                className="flex-shrink-0"
                                 dangerousInnerHTML={
                                     result.detail.html ? result.detail.html : renderMarkdown(result.detail.text)
                                 }

--- a/client/web/src/components/SearchResult.tsx
+++ b/client/web/src/components/SearchResult.tsx
@@ -22,7 +22,7 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, history, 
     const [isRedesignEnabled] = useRedesignToggle()
 
     const renderTitle = (): JSX.Element => {
-        if (isRedesignEnabled && result.__typename === 'Repository') {
+        if (isRedesignEnabled) {
             const RepoIcon = getRepoIcon(repoName)
             return (
                 <div className="search-result__title">
@@ -31,9 +31,20 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, history, 
                         className="test-search-result-label ml-1"
                         dangerousInnerHTML={result.label.html ? result.label.html : renderMarkdown(result.label.text)}
                     />
+                    {result.__typename !== 'Repository' && result.detail && (
+                        <>
+                            <span className="search-result__spacer" />
+                            <Markdown
+                                dangerousInnerHTML={
+                                    result.detail.html ? result.detail.html : renderMarkdown(result.detail.text)
+                                }
+                            />
+                        </>
+                    )}
                 </div>
             )
         }
+
         return (
             <div className="search-result__title">
                 <Markdown
@@ -81,7 +92,8 @@ export const SearchResult: React.FunctionComponent<Props> = ({ result, history, 
     return (
         <ResultContainer
             icon={icon}
-            collapsible={result && result.matches.length > 0}
+            // Don't allow collapsing in the redesign
+            collapsible={!isRedesignEnabled && result && result.matches.length > 0}
             defaultExpanded={true}
             title={renderTitle()}
             expandedChildren={renderBody()}

--- a/client/web/src/components/SearchResultMatch.scss
+++ b/client/web/src/components/SearchResultMatch.scss
@@ -88,6 +88,10 @@
         padding-right: 0;
         color: var(--body-color);
 
+        .theme-redesign & {
+            padding: 0 0.5rem;
+        }
+
         table {
             margin-bottom: 0 !important; // Override docsite Markdown table CSS. A currently open PR removes that CSS and lets us remove this override.
         }


### PR DESCRIPTION
Just some minor tweaks needed for this one. Long commit messages will be truncated with ellipses.

![image](https://user-images.githubusercontent.com/206864/119051292-d8887380-b977-11eb-9513-cebf7a83767b.png)

![image](https://user-images.githubusercontent.com/206864/119051332-e211db80-b977-11eb-88fc-c6e5650191aa.png)

Fixes #20811
Fixes #20810
