### PR TITLE
Fix error message for edit code stats page

### DIFF
--- a/client/web/src/insights/pages/edit/EditInsightPage.tsx
+++ b/client/web/src/insights/pages/edit/EditInsightPage.tsx
@@ -146,11 +146,12 @@ export const EditInsightPage: React.FunctionComponent<EditInsightPageProps> = pr
                 title="Oops, we couldn't find insight"
                 subtitle={
                     <span>
-                        Try find insight with id: <code className="badge badge-secondary">{insightID}</code> in{' '}
+                        We couldn't find that insight. Try to find the insight with ID:{' '}
+                        <code className="badge badge-secondary">{insightID}</code> in your{' '}
                         {authenticatedUser ? (
-                            <Link to={`/users/${authenticatedUser?.username}/settings`}>user/org settings</Link>
+                            <Link to={`/users/${authenticatedUser?.username}/settings`}>user or org settings</Link>
                         ) : (
-                            <span>user/org settings</span>
+                            <span>user or org settings</span>
                         )}
                     </span>
                 }


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21214

This PR fixes the error message for the code stats edit page for the case when we couldn't find insight with ID in edit page route param.

<img width="878" alt="image" src="https://user-images.githubusercontent.com/18492575/119104147-96693b80-ba24-11eb-833d-c736636dc82f.png">


A bit context 

For the code stats edit page we have an error message for case when we couldn't find insight for editing in user or org settings. Now you can see this error permanently for old code stats (Language usage) because this insight has the old version of the settings API 

Old code stats API

```json
 "codeStatsInsights.query": "repo:^github\\.com/sourcegraph/sourcegraph$",
 "codeStatsInsights.otherThreshold": 0.01,
```
 
New code stats API

```json
"codeStatsInsights.insight.metabaseSearchVisibilityTest": {
  "title": "Metabase search visibility test",
  "repository": "github.com/metabase/metabase",
  "otherThreshold": 0.03
}
```

In theory, we can support the old version of insights to parse `codeStatsInsights.query` field and extract the repository URL for the new repository setting in the new API. But that was cut off for the sake of hitting 3.28 release goals. For me it seems we can sacrifice support for such cases as we are still in the experiment but if our customers tell us this is the important thing for them let's fix it even if it's something old and experimental. 

