### PR TITLE
Temporarily disable all LSIF uploads to dogfood to make builds green

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -12,10 +12,11 @@ jobs:
         run: lsif-go
       - name: Upload LSIF data to .com
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-go-lib:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -29,11 +30,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: lib/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: lib/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: lib/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-web:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -53,11 +55,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/web/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/web/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-shared:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -77,11 +80,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/shared/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/shared/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-branded:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -101,11 +105,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/branded/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/branded/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/branded/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-browser:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -125,11 +130,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/browser/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/browser/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-tsc-wildcard:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -149,11 +155,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/wildcard/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/wildcard/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/wildcard/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-eslint-web:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -175,11 +182,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/web/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/web/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/web/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-eslint-shared:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -201,11 +209,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/shared/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/shared/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/shared/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-eslint-browser:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -227,11 +236,12 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/browser/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/browser/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/browser/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/
 
   lsif-eslint-wildcard:
     if: github.repository == 'sourcegraph/sourcegraph'
@@ -253,8 +263,9 @@ jobs:
       - name: Upload LSIF data to .com
         working-directory: client/wildcard/
         run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-      - name: Upload LSIF data to dogfood
-        working-directory: client/wildcard/
-        run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
-        env:
-          SRC_ENDPOINT: https://k8s.sgdev.org/
+      # TODO: Re-enable this (https://github.com/sourcegraph/sourcegraph/issues/21232)
+      # - name: Upload LSIF data to dogfood
+      #   working-directory: client/wildcard/
+      #   run: src lsif upload -github-token=${{ secrets.GITHUB_TOKEN }}
+      #   env:
+      #     SRC_ENDPOINT: https://k8s.sgdev.org/


### PR DESCRIPTION
Builds have been red on main since around noon yesterday, due to a problem uploading LSIF data to the dogfood instance. Temporarily disabling this step to get things green again.

Ticket to re-enable is #21232.