### PR TITLE
doc: Add Flaky Test bug template, and link to it from the doc.

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -2,7 +2,9 @@
 name: Flaky Test
 about: Capture information about a flaky test that has been disabled.
 title: 'Flake: $TEST_NAME disabled'
-labels: 'testing'
+labels:
+  - 'testing'
+  - 'flake'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,7 +1,7 @@
 ---
 name: Flaky Test
 about: Capture information about a flaky test that has been disabled.
-title: 'Flake: $TEST_NAME disabled '
+title: 'Flake: $TEST_NAME disabled'
 labels: 'testing'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/flaky_test.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test.md
@@ -1,0 +1,16 @@
+---
+name: Flaky Test
+about: Capture information about a flaky test that has been disabled.
+title: 'Flake: $TEST_NAME disabled '
+labels: 'testing'
+assignees: ''
+
+---
+
+- **Name of test:** <!-- Name of the test that was disabled -->
+- **Example failure:** <!-- Buildkite link to an example faiure -->
+- **PR**: <!-- Link to PR that disabled the test. E.g., #1234 >
+
+#### Additional details
+
+<!-- Notes and/or screenshot describing the problem -->

--- a/doc/dev/background-information/testing_principles.md
+++ b/doc/dev/background-information/testing_principles.md
@@ -19,7 +19,7 @@ Engineers should budget an appropriate amount of time for writing tests when mak
 
 ## Flaky tests
 
-A *flaky* test is defined as a test that is unreliable or non-deterministic, meaning that it doesn't consistently produce the same pass/fail result.
+A *flaky* test is defined as a test that is unreliable or non-deterministic, i.e. it exhibits both a passing and a failing result with the same code.
 
 Typical reasons why a test may be flaky:
 
@@ -31,7 +31,7 @@ Typical reasons why a test may be flaky:
 We do not tolerate flaky tests of any kind. Any engineer that sees a flaky test should immediately:
 
 1. Open a PR to disable the flaky test.
-1. Open an issue to re-enable the flaky test, assign it to the most likely owner, and add it to the current release milestone.
+1. Open an issue to re-enable the flaky test (use the [Flaky Test template](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=flaky_test.md&title=)), assign it to the most likely owner, and add it to the current release milestone.
 
 If the build or test infrastructure itself is flaky, then [open an issue](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/distribution) and notify the [distribution team](https://about.sourcegraph.com/handbook/engineering/distribution#contact).
 

--- a/doc/dev/background-information/testing_principles.md
+++ b/doc/dev/background-information/testing_principles.md
@@ -31,7 +31,7 @@ Typical reasons why a test may be flaky:
 We do not tolerate flaky tests of any kind. Any engineer that sees a flaky test should immediately:
 
 1. Open a PR to disable the flaky test.
-1. Open an issue to re-enable the flaky test (use the [Flaky Test template](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=flaky_test.md&title=)), assign it to the most likely owner, and add it to the current release milestone.
+1. Open an issue to re-enable the flaky test (use the [Flaky Test template](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=flaky_test.md&title=Flake%3A+%24TEST_NAME+disabled)), and assign it to the most likely owner, and add it to the current release milestone.
 
 If the build or test infrastructure itself is flaky, then [open an issue](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/distribution) and notify the [distribution team](https://about.sourcegraph.com/handbook/engineering/distribution#contact).
 


### PR DESCRIPTION
- Add a GitHub issue template to capture information about flaky tests that have been disabled.
- Link to the template from the "Flaky test" section of the _Testing Principles_ page.