### PR TITLE
frontend: warm default repo cache before serving traffic

### DIFF
--- a/cmd/frontend/backend/backend.go
+++ b/cmd/frontend/backend/backend.go
@@ -1,0 +1,24 @@
+package backend
+
+import (
+	"context"
+
+	"github.com/inconshreveable/log15"
+)
+
+// Warmup runs some backend functions which fill the cache. This is a kludge,
+// we have work to remove this need.
+func Warmup(ctx context.Context) error {
+	// Pre-heat default repo cache. This loads the default repos at startup,
+	// so the cache is warm when the first search query comes in. This query
+	// can take ~20s on sourcegraph.com, so this avoids users hitting a cold
+	// cache. Issue https://github.com/sourcegraph/sourcegraph/issues/20651
+	// tracks removing this again.
+	//
+	// TODO: Remove this.
+	if _, err := Repos.ListDefault(ctx); err != nil {
+		log15.Error("Failed to pre-populate default repos cache", "err", err)
+	}
+
+	return nil
+}

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -267,11 +267,10 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 		return err
 	}
 
-	ratelimitStore, err := redigostore.New(redispool.Cache, "gql:rl:", 0)
+	rateLimitWatcher, err := makeRateLimitWatcher()
 	if err != nil {
 		return err
 	}
-	rateLimitWatcher := graphqlbackend.NewBasicLimitWatcher(ratelimitStore)
 
 	server, err := makeExternalAPI(db, schema, enterprise, rateLimitWatcher)
 	if err != nil {
@@ -358,4 +357,12 @@ func isAllowedOrigin(origin string, allowedOrigins []string) bool {
 		}
 	}
 	return false
+}
+
+func makeRateLimitWatcher() (*graphqlbackend.BasicLimitWatcher, error) {
+	ratelimitStore, err := redigostore.New(redispool.Cache, "gql:rl:", 0)
+	if err != nil {
+		return nil, err
+	}
+	return graphqlbackend.NewBasicLimitWatcher(ratelimitStore), nil
 }

--- a/cmd/frontend/internal/cli/serve_cmd.go
+++ b/cmd/frontend/internal/cli/serve_cmd.go
@@ -268,7 +268,7 @@ func Main(enterpriseSetupHook func(db dbutil.DB, outOfBandMigrationRunner *oobmi
 	goroutine.Go(func() { bg.CheckRedisCacheEvictionPolicy() })
 	goroutine.Go(func() { bg.DeleteOldCacheDataInRedis() })
 	goroutine.Go(func() { bg.DeleteOldEventLogsInPostgres(context.Background(), db) })
-	go updatecheck.Start(db)
+	goroutine.Go(func() { updatecheck.Start(db) })
 
 	// Parse GraphQL schema and set up resolvers that depend on dbconn.Global
 	// being initialized

--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -103,7 +103,7 @@ commands:
       HOSTNAME: 127.0.0.1:3178
     watch:
       - cmd/github-proxy
-      - internal/debugserver"
+      - internal/debugserver
       - internal/env
       - internal/logging
       - internal/trace


### PR DESCRIPTION
Pre-heat default repo cache. This loads the default repos at startup, so the cache is warm when the first search query comes in. This query can take ~20s on sourcegraph.com, so this avoids users hitting a cold cache. Issue https://github.com/sourcegraph/sourcegraph/issues/20651 tracks removing this again.

We also do some cleanup in frontend's main function.

Co-authored-by: @eseliger
