### PR TITLE
ci: rename master-dry-run prefix to main-dry-run

### DIFF
--- a/dev/gqltest/README.md
+++ b/dev/gqltest/README.md
@@ -82,4 +82,4 @@ Adding new tests to this test suite is as easy as adding a Go test, here are som
   - Delete new users created during the test.
   - Delete external service created during the test.
   - Although, sometimes you would not want to delete an entity so you could login and inspect the failure state.
-- Prefix your branch name with `master-dry-run/` will run integration tests in CI on your pull request.
+- Prefix your branch name with `main-dry-run/` will run integration tests in CI on your pull request.

--- a/doc/dev/how-to/testing.md
+++ b/doc/dev/how-to/testing.md
@@ -322,7 +322,7 @@ include:
 
 ### Running backend integration and end-to-end tests in CI
 
-For pull requests, only a limited set of tests are run in CI. If you would like to run the full `main` test suite in a PR, including backend integration tests, e2e, and qa, you can name your branch with the prefix `master-dry-run/` and this will run all the tests that will be ran when the PR is checked into `main`.
+For pull requests, only a limited set of tests are run in CI. If you would like to run the full `main` test suite in a PR, including backend integration tests, e2e, and qa, you can name your branch with the prefix `main-dry-run/` and this will run all the tests that will be ran when the PR is checked into `main`.
 
 ## Release testing
 

--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -39,7 +39,7 @@ type Config struct {
 	patch               bool
 	patchNoTest         bool
 	isQuick             bool
-	isMasterDryRun      bool
+	isMainDryRun        bool
 	isBackendDryRun     bool
 
 	// profilingEnabled, if true, tells buildkite to print timing and resource utilization information
@@ -75,7 +75,7 @@ func ComputeConfig() Config {
 
 	isBackendDryRun := strings.HasPrefix(branch, "backend-dry-run/")
 
-	isMasterDryRun := strings.HasPrefix(branch, "master-dry-run/")
+	isMainDryRun := strings.HasPrefix(branch, "main-dry-run/") || strings.HasPrefix(branch, "master-dry-run/")
 
 	isQuick := strings.HasPrefix(branch, "quick/")
 
@@ -112,7 +112,7 @@ func ComputeConfig() Config {
 		patch:               patch,
 		patchNoTest:         patchNoTest,
 		isQuick:             isQuick,
-		isMasterDryRun:      isMasterDryRun,
+		isMainDryRun:        isMainDryRun,
 		isBackendDryRun:     isBackendDryRun,
 		profilingEnabled:    profilingEnabled,
 		isBextNightly:       os.Getenv("BEXT_NIGHTLY") == "true",
@@ -162,7 +162,7 @@ func (c Config) isPR() bool {
 		!c.taggedRelease &&
 		c.branch != "master" &&
 		!c.isMainBranch() &&
-		!c.isMasterDryRun &&
+		!c.isMainDryRun &&
 		!c.patch
 }
 
@@ -185,7 +185,7 @@ func (c Config) isGoOnly() bool {
 }
 
 func (c Config) shouldRunE2EandQA() bool {
-	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.isMainBranch() || c.isMasterDryRun
+	return c.releaseBranch || c.taggedRelease || c.isBextReleaseBranch || c.patch || c.isMainBranch() || c.isMainDryRun
 }
 
 // candidateImageTag provides the tag for a candidate image built for this Buildkite run.

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -90,7 +90,7 @@ func addSharedTests(c Config) func(pipeline *bk.Pipeline) {
 			bk.Cmd("dev/ci/codecov.sh -c -F typescript -F integration"),
 			bk.ArtifactPaths("./puppeteer/*.png"))
 
-		if c.isMasterDryRun || c.isStorybookAffected() {
+		if c.isMainDryRun || c.isStorybookAffected() {
 			// Upload storybook to Chromatic
 			chromaticCommand := "yarn chromatic --exit-zero-on-changes --exit-once-uploaded"
 			if c.isMainBranch() {
@@ -150,7 +150,7 @@ func addDockerfileLint(pipeline *bk.Pipeline) {
 // Adds backend integration tests step.
 func addBackendIntegrationTests(c Config) func(*bk.Pipeline) {
 	return func(pipeline *bk.Pipeline) {
-		if !c.isBackendDryRun && !c.isMasterDryRun && c.branch != "master" && !c.isMainBranch() {
+		if !c.isBackendDryRun && !c.isMainDryRun && c.branch != "master" && !c.isMainBranch() {
 			return
 		}
 


### PR DESCRIPTION
We still support master-dry-run as a prefix to do dry runs.

Co-authored-by: @eseliger 