### PR TITLE
Implement container wildcard component for redesign

### DIFF
--- a/client/wildcard/src/components/Container/Container.module.scss
+++ b/client/wildcard/src/components/Container/Container.module.scss
@@ -1,0 +1,8 @@
+.container {
+    :global(.theme-redesign) & {
+        padding: 1.5rem;
+        background-color: var(--color-bg-1);
+        border: 1px solid var(--border-color);
+        border-radius: var(--border-radius);
+    }
+}

--- a/client/wildcard/src/components/Container/Container.story.tsx
+++ b/client/wildcard/src/components/Container/Container.story.tsx
@@ -16,9 +16,9 @@ add(
         <>
             <div className="alert alert-info">
                 <p>
-                    A container is meant to group content semantically together. It should only be used once per page.
-                    Every page using it should have a header, optionally a description for the page and the container
-                    itself. Depending on the scope of a button, it should live inside or outside of the container.
+                    A container is meant to group content semantically together. Every page using it should have a
+                    header, optionally a description for the page and the container itself. Depending on the scope of a
+                    button, it should live inside or outside of the container.
                 </p>
                 <p>If the button</p>
                 <ul className="mb-0">

--- a/client/wildcard/src/components/Container/Container.story.tsx
+++ b/client/wildcard/src/components/Container/Container.story.tsx
@@ -11,30 +11,75 @@ const { add } = storiesOf('wildcard/Container', module).addDecorator(story => (
 ))
 
 add(
-    'Multiple containers',
+    'Overview',
     () => (
-        <div className="row">
-            <div className="col-6">
-                <Container>
-                    <h4>Watch for AWS secrets in commits</h4>
-                    <p>
-                        Use a search query to watch for new search results, and choose how to receive notifications in
-                        response.
-                    </p>
-                    <button className="btn btn-sm btn-secondary">View in docs →</button>
-                </Container>
+        <>
+            <div className="alert alert-info">
+                <p>
+                    A container is meant to group content semantically together. It should only be used once per page.
+                    Every page using it should have a header, optionally a description for the page and the container
+                    itself. Depending on the scope of a button, it should live inside or outside of the container.
+                </p>
+                <p>If the button</p>
+                <ul className="mb-0">
+                    <li>
+                        affects everything inside the container (ie. saves all form fields within the container), it
+                        should live outside of the container. See example 1
+                    </li>
+                    <li>
+                        affects just a subset of content inside the container (ie. submits one of multiple forms), it
+                        should live inside of the container, next to the content it is modifying. See example 2
+                    </li>
+                </ul>
             </div>
-            <div className="col-6">
-                <Container>
-                    <h4>Watch for AWS secrets in commits</h4>
-                    <p>
-                        Use a search query to watch for new search results, and choose how to receive notifications in
-                        response.
-                    </p>
-                    <button className="btn btn-sm btn-secondary">View in docs →</button>
-                </Container>
+            <hr />
+            <h1>Example 1</h1>
+            <h2>Some page explanation</h2>
+            <p className="text-muted">Optional: Add some descriptive text about what this page does.</p>
+            <Container className="mb-3">
+                <h3>Section I</h3>
+                <p>Here you change the username.</p>
+                <div className="form-group">
+                    <input type="text" className="form-control" />
+                </div>
+                <h3>Section II</h3>
+                <p>Here you change your email.</p>
+                <div className="form-group mb-0">
+                    <input type="text" className="form-control" />
+                </div>
+            </Container>
+            <div className="mb-3">
+                <button type="button" className="btn btn-primary mr-2">
+                    Save
+                </button>
+                <button type="button" className="btn btn-secondary">
+                    Cancel
+                </button>
             </div>
-        </div>
+            <hr />
+            <h1>Example 2</h1>
+            <h2>Some page explanation</h2>
+            <p className="text-muted">Optional: Add some descriptive text about what this page does.</p>
+            <Container className="mb-3">
+                <h3>Section I</h3>
+                <p>Here you change the username.</p>
+                <div className="form-group">
+                    <input type="text" className="form-control" />
+                </div>
+                <button type="button" className="btn btn-secondary mb-2">
+                    Save
+                </button>
+                <hr className="mb-2" />
+                <h3>Section II</h3>
+                <p>Here you change your email.</p>
+                <div className="form-group">
+                    <input type="text" className="form-control" />
+                </div>
+                <button type="button" className="btn btn-secondary">
+                    Save
+                </button>
+            </Container>
+        </>
     ),
     {
         design: [

--- a/client/wildcard/src/components/Container/Container.story.tsx
+++ b/client/wildcard/src/components/Container/Container.story.tsx
@@ -1,0 +1,48 @@
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+
+import { BrandedStory } from '@sourcegraph/branded/src/components/BrandedStory'
+import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
+
+import { Container } from './Container'
+
+const { add } = storiesOf('wildcard/Container', module).addDecorator(story => (
+    <BrandedStory styles={webStyles}>{() => <div className="container web-content mt-3">{story()}</div>}</BrandedStory>
+))
+
+add(
+    'Multiple containers',
+    () => (
+        <div className="row">
+            <div className="col-6">
+                <Container>
+                    <h4>Watch for AWS secrets in commits</h4>
+                    <p>
+                        Use a search query to watch for new search results, and choose how to receive notifications in
+                        response.
+                    </p>
+                    <button className="btn btn-sm btn-secondary">View in docs →</button>
+                </Container>
+            </div>
+            <div className="col-6">
+                <Container>
+                    <h4>Watch for AWS secrets in commits</h4>
+                    <p>
+                        Use a search query to watch for new search results, and choose how to receive notifications in
+                        response.
+                    </p>
+                    <button className="btn btn-sm btn-secondary">View in docs →</button>
+                </Container>
+            </div>
+        </div>
+    ),
+    {
+        design: [
+            {
+                type: 'figma',
+                name: 'Figma Redesign',
+                url: 'https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/?node-id=1478%3A3044',
+            },
+        ],
+    }
+)

--- a/client/wildcard/src/components/Container/Container.tsx
+++ b/client/wildcard/src/components/Container/Container.tsx
@@ -1,0 +1,13 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import styles from './Container.module.scss'
+
+interface Props {
+    className?: string
+}
+
+/** A container wrapper. Used for grouping content together. */
+export const Container: React.FunctionComponent<Props> = ({ children, className }) => (
+    <div className={classNames(styles.container, className)}>{children}</div>
+)

--- a/client/wildcard/src/components/Container/index.ts
+++ b/client/wildcard/src/components/Container/index.ts
@@ -1,0 +1,1 @@
+export * from './Container'

--- a/client/wildcard/src/components/index.ts
+++ b/client/wildcard/src/components/index.ts
@@ -1,2 +1,3 @@
+export { Container } from './Container'
 export { PageSelector } from './PageSelector'
 export { PageHeader } from './PageHeader'


### PR DESCRIPTION
Implements the new container component designed in https://github.com/sourcegraph/sourcegraph/issues/20177.

I have converted some pages locally to the new container and so far I was able to achieve what is in the designs, so I would consider this component "usable" at this point. I will create PRs using it in a follow-up though, so it's easier to review and get approved. 
