### PR TITLE
codeintel: Do not fall back to input range when it cannot be adjusted

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_diagnostics.go
@@ -113,14 +113,14 @@ func (r *queryResolver) adjustDiagnostic(ctx context.Context, adjustedUpload adj
 	// call below, and is also reflected in the embedded diagnostic value in the return.
 	diagnostic.Path = adjustedUpload.Upload.Root + diagnostic.Path
 
-	adjustedCommit, adjustedRange, err := r.adjustRange(
+	adjustedCommit, adjustedRange, ok, err := r.adjustRange(
 		ctx,
 		adjustedUpload.Upload.RepositoryID,
 		adjustedUpload.Upload.Commit,
 		diagnostic.Path,
 		rn,
 	)
-	if err != nil {
+	if err != nil || !ok {
 		return AdjustedDiagnostic{}, err
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover.go
@@ -56,9 +56,12 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ strin
 		}
 
 		// Adjust the highlighted range back to the appropriate range in the target commit
-		_, adjustedRange, err := r.adjustRange(ctx, r.uploads[i].RepositoryID, r.uploads[i].Commit, r.path, rn)
+		_, adjustedRange, ok, err := r.adjustRange(ctx, r.uploads[i].RepositoryID, r.uploads[i].Commit, r.path, rn)
 		if err != nil {
 			return "", lsifstore.Range{}, false, err
+		}
+		if !ok {
+			continue
 		}
 
 		return text, adjustedRange, true, nil


### PR DESCRIPTION
When adjusting ranges from the commit for which we have a code intelligence index and the commit the user is browsing, we fall back to the original range (for unknown reasons) when the adjustment fails. This caused some weird behaviors to happen with Range queries in particular (see an [example](https://sourcegraph.slack.com/archives/CHXHX7XAS/p1621511791063000)).