### PR TITLE
sg: install script uses rw mode for go.sum

### DIFF
--- a/dev/sg/install.sh
+++ b/dev/sg/install.sh
@@ -5,7 +5,10 @@ pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null
 
 echo "Compiling..."
 
-go install .
+# -mod=mod: default is -mod=readonly. However, because our lib dependency is
+#           not fixed everytime it changes we need to update go.sum. By making
+#           it rw we prevent failing go install.
+go install -mod=mod .
 
 # Let's figure out where this got installed. First, we need to calculate the
 # effective $GOBIN; this logic is documented at


### PR DESCRIPTION
This makes the install script more robust to regular dep updates to
lib. Without this you would often see an error message like:

```
  go: github.com/sourcegraph/sourcegraph/lib@v0.0.0-00010101000000-000000000000 requires
      github.com/klauspost/compress@v1.12.2: missing go.sum entry; to add it:
      go mod download github.com/klauspost/compress
```