### PR TITLE
Refresh: Use `--text-disabled` for buttons, inputs, textareas and selects

### DIFF
--- a/client/branded/src/global-styles/buttons-redesign.scss
+++ b/client/branded/src/global-styles/buttons-redesign.scss
@@ -64,8 +64,7 @@
         &.disabled,
         &:disabled {
             opacity: 1;
-            color: var(--text-muted);
-            background-color: var(--color-bg-1);
+            color: var(--text-disabled);
             border-color: $light-color-variant;
         }
 
@@ -76,7 +75,7 @@
             }
 
             &:hover:not(.focus):not(:focus) {
-                background-color: var(--body-bg);
+                background-color: var(--color-bg-1);
                 @at-root #{selector-append('.theme-light', &)} {
                     color: $dark-color-variant;
                     border-color: $dark-color-variant;

--- a/client/branded/src/global-styles/buttons-redesign.scss
+++ b/client/branded/src/global-styles/buttons-redesign.scss
@@ -136,7 +136,7 @@
         $dark-color-variant: var(--secondary-3),
         // Use darker text colors for contrast
         $text-color: var(--body-color),
-        $disabled-text-color: var(--text-muted)
+        $disabled-text-color: var(--text-disabled)
     );
 
     @include redesign-button-variant(
@@ -160,7 +160,7 @@
         $dark-color-variant: var(--warning-3),
         // Use darker text colors for contrast
         $text-color: var(--dark-text),
-        $disabled-text-color: var(--text-muted)
+        $disabled-text-color: var(--text-disabled)
     );
 
     @include redesign-button-variant(
@@ -170,7 +170,7 @@
         $dark-color-variant: var(--info-3),
         // Use darker text colors for contrast
         $text-color: var(--dark-text),
-        $disabled-text-color: var(--text-muted)
+        $disabled-text-color: var(--text-disabled)
     );
 
     @include redesign-button-variant(

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -107,6 +107,7 @@ $theme-colors-redesign: (
     --mark-bg: #f8e688;
     --merged-4: #eee9fd;
     --text-muted: var(--gray-07);
+    --text-disabled: var(--gray-05);
     --link-color: var(--primary);
     --link-color-2: #0766cc;
     --link-active-color: #0c7bf0;
@@ -155,6 +156,7 @@ $theme-colors-redesign: (
     --mark-bg: #7a341e;
     --merged-4: #1f0a5c;
     --text-muted: var(--gray-05);
+    --text-disabled: var(--gray-07);
     --link-color: #4393e7;
     --link-color-2: #70b0f3;
     --link-active-color: #489ffa;

--- a/client/branded/src/global-styles/forms.scss
+++ b/client/branded/src/global-styles/forms.scss
@@ -112,6 +112,18 @@
         }
     }
 
+    // Update text color to better indicate disabled fields
+    .form-control,
+    .custom-select {
+        &:disabled {
+            color: var(--text-disabled);
+
+            &::placeholder {
+                color: var(--text-disabled);
+            }
+        }
+    }
+
     // Valid form inputs and selects
     .was-validated .form-control:valid,
     .was-validated .custom-select:valid,


### PR DESCRIPTION
Figma discussion: https://www.figma.com/file/NIsN34NH7lPu04olBzddTw?node-id=875:585#82005851

This PR:
- [x] Adds `text-disabled` light and dark variants
- [x] Uses `text-disabled` for all btn:disabled variants that require darker contrast
- [x] Uses `text-disabled` for all input,textarea,select:disabled variants
- [x] Removes `color-bg-1` on disabled buttons, uses transparency
- [x] Fixes background color on outline buttons

Issue: https://github.com/sourcegraph/sourcegraph/issues/21255