### PR TITLE
extensbility: make floating status bar for refresh

### DIFF
--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -84,7 +84,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
 
     &__list {
         overflow-y: auto;
-        flex: 0 1 auto;
+        width: var(--action-item-width);
 
         scrollbar-width: none;
         &::-webkit-scrollbar {

--- a/client/web/src/extensions/components/StatusBar.scss
+++ b/client/web/src/extensions/components/StatusBar.scss
@@ -21,6 +21,10 @@
             background-color: var(--link-hover-bg-color);
         }
 
+        .theme-redesign & {
+            color: var(--icon-color);
+        }
+
         &--disabled {
             visibility: hidden;
             width: 0;

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -31,6 +31,8 @@ interface StatusBarProps extends ExtensionsControllerProps<'extHostAPI' | 'execu
     uri?: string
 
     location: H.Location
+
+    statusBarRef?: React.Ref<HTMLDivElement>
 }
 
 export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
@@ -39,6 +41,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
     extensionsController,
     uri,
     location,
+    statusBarRef,
 }) => {
     const statusBarItems = useObservable(useMemo(() => getStatusBarItems(), [getStatusBarItems]))
 
@@ -84,6 +87,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                 'percy-hide', // TODO: Fix flaky status bar in Percy tests: https://github.com/sourcegraph/sourcegraph/issues/20751
                 className
             )}
+            ref={statusBarRef}
         >
             <ErrorBoundary
                 location={location}

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames'
 import * as H from 'history'
+import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon'
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import MenuLeftIcon from 'mdi-react/MenuLeftIcon'
 import MenuRightIcon from 'mdi-react/MenuRightIcon'
 import React, { useCallback, useMemo, useState } from 'react'
@@ -13,6 +15,7 @@ import { haveInitialExtensionsLoaded } from '@sourcegraph/shared/src/api/feature
 import { ButtonLink } from '@sourcegraph/shared/src/components/LinkOrButton'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { useCarousel } from '../../components/useCarousel'
@@ -69,6 +72,11 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
         onPositiveClicked,
     } = useCarousel({ direction: 'leftToRight' })
 
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    const LeftIcon = isRedesignEnabled ? ChevronLeftIcon : MenuLeftIcon
+    const RightIcon = isRedesignEnabled ? ChevronRightIcon : MenuRightIcon
+
     return (
         <div
             className={classNames(
@@ -93,7 +101,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                         className="btn btn-link status-bar__scroll border-0"
                         onClick={onNegativeClicked}
                     >
-                        <MenuLeftIcon className="icon-inline" />
+                        <LeftIcon className="icon-inline" />
                     </button>
                 )}
                 <div className="status-bar__items d-flex px-2" ref={carouselReference}>
@@ -124,7 +132,7 @@ export const StatusBar: React.FunctionComponent<StatusBarProps> = ({
                         className="btn btn-link status-bar__scroll border-0"
                         onClick={onPositiveClicked}
                     >
-                        <MenuRightIcon className="icon-inline" />
+                        <RightIcon className="icon-inline" />
                     </button>
                 )}
             </ErrorBoundary>

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -57,10 +57,5 @@
             border-top-left-radius: 0.1875rem;
             border-top-right-radius: 0.1875rem;
         }
-
-        .theme-redesign & {
-            // For absolute positioned Blob status bar
-            position: relative;
-        }
     }
 }

--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -57,5 +57,10 @@
             border-top-left-radius: 0.1875rem;
             border-top-right-radius: 0.1875rem;
         }
+
+        .theme-redesign & {
+            // For absolute positioned Blob status bar
+            position: relative;
+        }
     }
 }

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -27,7 +27,8 @@ $blob-status-bar-horizontal-gap: 0.5rem;
                 &::after {
                     content: '';
                     display: inline-block;
-                    padding-bottom: $blob-status-bar-height + $blob-status-bar-bottom;
+                    padding-bottom: $blob-status-bar-height + $blob-status-bar-bottom + 0.5rem;
+                    // Extra 0.5rem padding on top of the minimum required to expose code;
                 }
             }
         }

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -102,7 +102,6 @@
     // Add this class to <StatusBar>
     &__body {
         position: static;
-        max-width: 100% !important; // temporary: only set in case user toggles redesign on and off.
 
         .theme-redesign & {
             // Make the status bar "float" slightly above the bottom of the code view.

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -1,9 +1,5 @@
 @import './LineDecorator.scss';
 
-$blob-status-bar-height: 2rem;
-$blob-status-bar-bottom: 1rem;
-$blob-status-bar-horizontal-gap: 0.5rem;
-
 .blob {
     position: relative;
     overflow: auto;
@@ -27,7 +23,7 @@ $blob-status-bar-horizontal-gap: 0.5rem;
                 &::after {
                     content: '';
                     display: inline-block;
-                    padding-bottom: $blob-status-bar-height + $blob-status-bar-bottom + 0.5rem;
+                    padding-bottom: calc(var(--blob-status-bar-height) + var(--blob-status-bar-bottom) + 0.5rem);
                     // Extra 0.5rem padding on top of the minimum required to expose code;
                 }
             }
@@ -81,27 +77,49 @@ $blob-status-bar-horizontal-gap: 0.5rem;
             }
         }
     }
+}
 
-    &__status-bar {
-        // Make the status bar "float" slightly above the bottom of the code view.
-        position: absolute;
-        bottom: $blob-status-bar-bottom;
+// Styles for floating + scrollable status bar
+.blob-status-bar {
+    // Add this class to the parent container of <Blob> and <StatusBar>.
+    // Why not add this to <Blob>? Absolutely-positioned elements
+    // in a scrolling overflow container move with the content on scroll.
+    // See: https://www.bennadel.com/blog/3409-using-position-absolute-inside-a-scrolling-overflow-container.htm
+    // Unfortunately, <StatusBar> can overlap with <Blob>'s scrollbar, so calculate <StatusBar>'s
+    // `right` and `maxWidth` at runtime.
+    &__container {
+        .theme-redesign & {
+            position: relative;
 
-        // Override default bootstrap `.w-100`, ensure that the status bar "sticks" to the right side.
-        width: auto !important;
-        right: $blob-status-bar-horizontal-gap;
-        max-width: calc(100% - (2 * #{$blob-status-bar-horizontal-gap}));
-
-        // Misc. style
-        height: $blob-status-bar-height;
-        border-radius: var(--border-radius);
-        border: 1px solid var(--border-color);
-        background-color: var(--body-bg);
+            --blob-status-bar-height: 2rem;
+            --blob-status-bar-bottom: 1rem;
+            // Used to calculate status bar `right` along with scrollbar width.
+            --blob-status-bar-horizontal-gap: 0.5rem;
+        }
     }
 
-    &__spacer {
-        // Give room to view the last few lines of code
-        // without the floating status bar getting in the way.
-        height: $blob-status-bar-height + $blob-status-bar-bottom;
+    // Add this class to <StatusBar>
+    &__body {
+        position: static;
+        max-width: 100% !important; // temporary: only set in case user toggles redesign on and off.
+
+        .theme-redesign & {
+            // Make the status bar "float" slightly above the bottom of the code view.
+            position: absolute;
+            bottom: var(--blob-status-bar-bottom);
+
+            // Override default bootstrap `.w-100`, ensure that the status bar "sticks" to the right side.
+            width: auto !important;
+            // Default `right`, should be added with scrollbar width at runtime.
+            right: var(--blob-status-bar-horizontal-gap);
+            // `maxWidth` will also be subtracted by scrollbar width at runtime
+            max-width: calc(100% - (2 * var(--blob-status-bar-horizontal-gap)));
+
+            // Misc. style
+            height: var(--blob-status-bar-height);
+            border-radius: var(--border-radius);
+            border: 1px solid var(--border-color);
+            background-color: var(--body-bg);
+        }
     }
 }

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -92,7 +92,8 @@
             position: relative;
 
             --blob-status-bar-height: 2rem;
-            --blob-status-bar-bottom: 1rem;
+            // Used to calculate status bar `bottom` along with scrollbar width.
+            --blob-status-bar-vertical-gap: 1rem;
             // Used to calculate status bar `right` along with scrollbar width.
             --blob-status-bar-horizontal-gap: 0.5rem;
         }
@@ -106,7 +107,7 @@
         .theme-redesign & {
             // Make the status bar "float" slightly above the bottom of the code view.
             position: absolute;
-            bottom: var(--blob-status-bar-bottom);
+            bottom: var(--blob-status-bar-vertical-gap);
 
             // Override default bootstrap `.w-100`, ensure that the status bar "sticks" to the right side.
             width: auto !important;

--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -1,5 +1,9 @@
 @import './LineDecorator.scss';
 
+$blob-status-bar-height: 2rem;
+$blob-status-bar-bottom: 1rem;
+$blob-status-bar-horizontal-gap: 0.5rem;
+
 .blob {
     position: relative;
     overflow: auto;
@@ -16,6 +20,16 @@
 
         table {
             border-collapse: collapse;
+
+            .theme-redesign & {
+                // Give room to view the last few lines of code
+                // without the floating status bar getting in the way.
+                &::after {
+                    content: '';
+                    display: inline-block;
+                    padding-bottom: $blob-status-bar-height + $blob-status-bar-bottom;
+                }
+            }
         }
 
         td.line {
@@ -65,5 +79,28 @@
                 white-space: pre-wrap;
             }
         }
+    }
+
+    &__status-bar {
+        // Make the status bar "float" slightly above the bottom of the code view.
+        position: absolute;
+        bottom: $blob-status-bar-bottom;
+
+        // Override default bootstrap `.w-100`, ensure that the status bar "sticks" to the right side.
+        width: auto !important;
+        right: $blob-status-bar-horizontal-gap;
+        max-width: calc(100% - (2 * #{$blob-status-bar-horizontal-gap}));
+
+        // Misc. style
+        height: $blob-status-bar-height;
+        border-radius: var(--border-radius);
+        border: 1px solid var(--border-color);
+        background-color: var(--body-bg);
+    }
+
+    &__spacer {
+        // Give room to view the last few lines of code
+        // without the floating status bar getting in the way.
+        height: $blob-status-bar-height + $blob-status-bar-bottom;
     }
 }

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { Remote } from 'comlink'
 import * as H from 'history'
 import iterate from 'iterare'
@@ -41,6 +42,7 @@ import {
     toURIWithPath,
 } from '@sourcegraph/shared/src/util/url'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { getHover, getDocumentHighlights } from '../../backend/features'
 import { WebHoverOverlay } from '../../components/shared'
@@ -507,11 +509,22 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                         return of('loading' as const)
                     }
 
-                    return wrapRemoteObservable(viewerData.extensionHostAPI.getStatusBarItems(viewerData.viewerId))
+                    return wrapRemoteObservable(
+                        viewerData.extensionHostAPI.getStatusBarItems(viewerData.viewerId)
+                    ).pipe(
+                        map(items => [
+                            ...items,
+                            ...new Array(20)
+                                .fill(null)
+                                .map((value, index) => ({ text: 'fake status bar item', key: `${index}` })),
+                        ])
+                    )
                 })
             ),
         [viewerUpdates]
     )
+
+    const [isRedesignEnabled] = useRedesignToggle()
 
     return (
         <>
@@ -519,7 +532,9 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 <code
                     className={`blob__code ${props.wrapCode ? ' blob__code--wrapped' : ''} test-blob`}
                     ref={nextCodeViewElement}
-                    dangerouslySetInnerHTML={{ __html: blobInfo.html }}
+                    dangerouslySetInnerHTML={{
+                        __html: blobInfo.html,
+                    }}
                 />
                 {hoverState.hoverOverlayProps && (
                     <WebHoverOverlay
@@ -553,6 +568,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                 extensionsController={extensionsController}
                 uri={toURIWithPath(blobInfo)}
                 location={location}
+                className={classNames(isRedesignEnabled && 'blob__status-bar')}
             />
         </>
     )

--- a/client/web/src/repo/blob/Blob.tsx
+++ b/client/web/src/repo/blob/Blob.tsx
@@ -509,16 +509,7 @@ export const Blob: React.FunctionComponent<BlobProps> = props => {
                         return of('loading' as const)
                     }
 
-                    return wrapRemoteObservable(
-                        viewerData.extensionHostAPI.getStatusBarItems(viewerData.viewerId)
-                    ).pipe(
-                        map(items => [
-                            ...items,
-                            ...new Array(20)
-                                .fill(null)
-                                .map((value, index) => ({ text: 'fake status bar item', key: `${index}` })),
-                        ])
-                    )
+                    return wrapRemoteObservable(viewerData.extensionHostAPI.getStatusBarItems(viewerData.viewerId))
                 })
             ),
         [viewerUpdates]

--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -182,7 +182,9 @@ export const repoRevisionContainerRoutes: readonly RepoRevisionContainerRoute[] 
                         defaultBranch={defaultBranch || 'HEAD'}
                     />
                     {!hideRepoRevisionContent && (
-                        <div className="repo-revision-container__content">
+                        // Add `.blob-status-bar__container` because this is the
+                        // lowest common ancestor of Blob and the absolutely-positioned Blob status bar
+                        <div className="repo-revision-container__content blob-status-bar__container">
                             <ErrorBoundary location={context.location}>
                                 {objectType === 'blob' ? (
                                     <BlobPage


### PR DESCRIPTION
Closes #20854.

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/37420160/119396423-d178a280-bca2-11eb-95b5-4dc1647ac77f.png" />
</details>

<details open>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/37420160/119396231-9aa28c80-bca2-11eb-89f0-8199ab842fb8.png" />
</details>

<details>
<summary>Interaction (resizing window with many items, scrolling)</summary>
<img src="https://user-images.githubusercontent.com/37420160/119396604-100e5d00-bca3-11eb-93b8-0629829b91fa.gif" />
</details>

<details>
<summary>Extra padding-bottom for code ("spacer" pseudo-element for table elem)</summary>
<img src="https://user-images.githubusercontent.com/37420160/119398309-62e91400-bca5-11eb-807f-2fe83c3df90b.png" />
</details>

### Questions

- We've specified an 8px gap between the status bar and the action items bar [in Figma](), but this results in overlap with the scrollbar. Should we increase this gap?