### PR TITLE
Update extensions.allowRemoteExtensions

### DIFF
--- a/doc/admin/extensions/index.md
+++ b/doc/admin/extensions/index.md
@@ -57,7 +57,9 @@ You can disable extensions from Sourcegraph.com by setting [`extensions.remoteRe
 
 ## Allow only specific extensions from Sourcegraph.com
 
-On Sourcegraph Enterprise, you can set [`extensions.allowRemoteExtensions`](../config/site_config.md) so that only the explicitly specified extensions can be used from Sourcegraph.com:
+On Sourcegraph Enterprise, you can set [`extensions.allowRemoteExtensions`](../config/site_config.md) so that only the explicitly specified extensions can be used from Sourcegraph.com.
+
+Note: When enabling this setting, desired extensions and languages need to be specifically set in the [Sourcegraph site configuration](https://docs.sourcegraph.com/admin/config/site_config) in order to work. Example:
 
 ```json
 {

--- a/doc/admin/extensions/index.md
+++ b/doc/admin/extensions/index.md
@@ -66,6 +66,8 @@ Note: When enabling this setting, desired extensions and languages need to be sp
   "extensions": { "allowRemoteExtensions": ["chris/token-highlights"] }
 }
 ```
+You will also need to manually enable language extensions for Code Intelligence to work properly by adding them to `"DefaultSettings"` in your site configuration. List of languages can be found here: [Sourcegraph default language settings](
+https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/graphqlbackend/default_settings.go#L14-51)
 
 ## [Client-side security and privacy](../../extensions/security.md)
 


### PR DESCRIPTION
Added a line to clarify that when using allowRemoteExtensions, the desired extensions need to be set. This was prompted by a customer using this setting and they were unaware it would stop code intelligence from working if they did not add all the languages.

Feel free to suggest edits - the goal is to make it clear that when enabling the setting, there are other things to consider like which languages for code intelligence, etc.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
