### PR TITLE
search contexts tour: fix background

### DIFF
--- a/client/branded/src/global-styles/colors.scss
+++ b/client/branded/src/global-styles/colors.scss
@@ -123,6 +123,7 @@ $text-muted: var(--text-muted);
     --web-content-link-color: #1c7cd6;
     --disabled-action-bg-color: #{$oc-gray-3};
     --disabled-action-text-color: #{$oc-gray-5};
+    --tour-bg: #ffffff;
 }
 .theme-dark {
     // Affects default browser styles
@@ -159,6 +160,7 @@ $text-muted: var(--text-muted);
     --web-content-link-color: #329af0;
     --disabled-action-bg-color: #{$oc-gray-8};
     --disabled-action-text-color: #{$oc-gray-9};
+    --tour-bg: #{$gray-19};
 }
 
 // Load redesign styles

--- a/client/web/src/search/input/SearchContextDropdown.scss
+++ b/client/web/src/search/input/SearchContextDropdown.scss
@@ -75,11 +75,15 @@
 }
 
 .search-context-highlight-tour {
-    background: var(--color-bg-3);
+    background: var(--tour-bg);
     border: none;
     border-radius: 10px;
 
     &__step {
         width: 17rem;
+    }
+
+    .shepherd-arrow::after {
+        border-bottom-color: var(--tour-bg);
     }
 }

--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -89,7 +89,7 @@ const useSearchContextHighlightTour = (
             {
                 id: 'search-contexts-start-tour',
                 text: getHighlightTourStep(() => tour.cancel()),
-                classes: 'web-content shadow-lg card py-4 px-3 search-context-highlight-tour',
+                classes: 'web-content shadow-lg py-4 px-3 search-context-highlight-tour',
                 attachTo: {
                     element: '.search-context-dropdown__button',
                     on: 'bottom',


### PR DESCRIPTION
Fixes #20345

Tour background is now a new semantic color `--tour-bg` which is different in light and dark mode.

| | Before (`--color-bg-3`) | After (`--tour-bg`) |
|---|---|---|
| Dark | ![image](https://user-images.githubusercontent.com/206864/119418816-b65f6000-bcad-11eb-9e9f-5ddaa46aadc9.png) | ![image](https://user-images.githubusercontent.com/206864/119418785-a6478080-bcad-11eb-80be-0523185ec4c7.png) |
| Light | ![image](https://user-images.githubusercontent.com/206864/119418833-beb79b00-bcad-11eb-8b06-4588675a6c47.png) | ![image](https://user-images.githubusercontent.com/206864/119418769-9c258200-bcad-11eb-9931-781db3678a6d.png)  |
