### PR TITLE
docs: update pings for RFC 384

### DIFF
--- a/doc/admin/pings.md
+++ b/doc/admin/pings.md
@@ -30,12 +30,16 @@ By default, Sourcegraph also aggregates usage and performance metrics for some p
 - Whether a code search has ever been executed (true/false)
 - Whether code intelligence has ever been used (true/false)
 - Aggregate counts of current daily, weekly, and monthly users
-- Aggregate counts of current daily, weekly, and monthly users, by:
-  - Whether they are using code host integrations
-  - Search filters used (e.g. "type:", "repo:", "file:", "lang:", etc.)
+- Aggregate counts of current daily, weekly, and monthly users, by whether they are using code host integrations
 - Aggregate daily, weekly, and monthly latencies (in ms) of search queries
-- Aggregate daily, weekly, and monthly counts of:
-  - Searches using each search filter (e.g. "type:", "repo:", "file:", "lang:", etc.)
+- Aggregate daily, weekly, and monthly integer counts of the following query syntax:
+  - The number of boolean operators (`and`, `or`, `not` keywords)
+  - The number of built-in predicate keywords (`contains`, `contains.file`, `contains.repo`, `contains.commit.after`)
+  - The number of `select` keywords by kind (`repo`, `file`, `content`, `symbol`, `commit.diff.added`, `commit.diff.removed`)
+  - The number of queries using the `context:` filter without the default `global` value
+  - The number of queries with only patterns (e.g., without filters like `repo:` or `file:`)
+  - The number of queries with three or more patterns
+- Aggregate daily, weekly, and monthly user counts of search queries with the above properties
 - Code intelligence usage data
   - Total number of repositories with and without an uploaded LSIF index
   - Total number of code intelligence queries (e.g., hover tooltips) per week grouped by language


### PR DESCRIPTION
[RFC 358](https://docs.google.com/document/d/1VCUWV5DoOPxq5dryaQkoMZbDAFFFD3L6v0qEZktlv4U/edit#). This will log much less data than we were before, but the description is longer because it's more specific, and I'm erring on the side of being maximally explicit here. Let me know if we can improve wording or be less explicit.

Subject to the following PRs being merged:

- [x] https://github.com/sourcegraph/sourcegraph/pull/21301
- [x] https://github.com/sourcegraph/analytics/pull/175