### PR TITLE
web: extract `WebHoverOverlay` story into a separate file

### DIFF
--- a/client/shared/src/hover/HoverOverlay.fixtures.ts
+++ b/client/shared/src/hover/HoverOverlay.fixtures.ts
@@ -1,0 +1,68 @@
+import { action } from '@storybook/addon-actions'
+import { boolean } from '@storybook/addon-knobs'
+import { createMemoryHistory } from 'history'
+import { of } from 'rxjs'
+import { MarkupContent, Badged, AggregableBadge } from 'sourcegraph'
+
+import { MarkupKind } from '@sourcegraph/extension-api-classes'
+
+import { ActionItemAction } from '../actions/ActionItem'
+import { PlatformContext } from '../platform/context'
+import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
+
+import { HoverOverlayProps } from './HoverOverlay'
+
+const history = createMemoryHistory()
+const NOOP_EXTENSIONS_CONTROLLER = { executeCommand: () => Promise.resolve() }
+const NOOP_PLATFORM_CONTEXT: Pick<PlatformContext, 'forceUpdateTooltip' | 'settings'> = {
+    forceUpdateTooltip: () => undefined,
+    settings: of({ final: {}, subjects: [] }),
+}
+
+export const commonProps = (): HoverOverlayProps => ({
+    showCloseButton: boolean('showCloseButton', true),
+    location: history.location,
+    telemetryService: NOOP_TELEMETRY_SERVICE,
+    extensionsController: NOOP_EXTENSIONS_CONTROLLER,
+    platformContext: NOOP_PLATFORM_CONTEXT,
+    isLightTheme: true,
+    overlayPosition: { top: 16, left: 16 },
+    onAlertDismissed: action('onAlertDismissed'),
+    onCloseButtonClick: action('onCloseButtonClick'),
+})
+
+export const FIXTURE_CONTENT: Badged<MarkupContent> = {
+    value:
+        '```go\nfunc RegisterMiddlewares(m ...*Middleware)\n```\n\n' +
+        '---\n\nRegisterMiddlewares registers additional authentication middlewares. Currently this is used to register enterprise-only SSO middleware. This should only be called from an init function.\n',
+    kind: MarkupKind.Markdown,
+}
+
+export const FIXTURE_SEMANTIC_BADGE: AggregableBadge = {
+    text: 'semantic',
+    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence',
+    hoverMessage: 'Sample hover message',
+}
+
+export const FIXTURE_ACTIONS: ActionItemAction[] = [
+    {
+        action: {
+            id: 'goToDefinition.preloaded',
+            title: 'Go to definition',
+            command: 'open',
+            commandArguments: ['/github.com/sourcegraph/codeintellify/-/blob/src/hoverifier.ts?subtree=true#L57:1'],
+        },
+        active: true,
+    },
+    {
+        action: {
+            id: 'findReferences',
+            title: 'Find references',
+            command: 'open',
+            commandArguments: [
+                '/github.com/sourcegraph/codeintellify/-/blob/src/hoverifier.ts?subtree=true#L57:18&tab=references',
+            ],
+        },
+        active: true,
+    },
+]

--- a/client/shared/src/hover/HoverOverlay.story.tsx
+++ b/client/shared/src/hover/HoverOverlay.story.tsx
@@ -9,7 +9,6 @@ import { MarkupContent, Badged, AggregableBadge } from 'sourcegraph'
 
 import browserExtensionStyles from '@sourcegraph/browser/src/app.scss'
 import { MarkupKind } from '@sourcegraph/extension-api-classes'
-import webStyles from '@sourcegraph/web/src/SourcegraphWebApp.scss'
 
 import { registerHighlightContributions } from '../highlight/contributions'
 import { PlatformContext } from '../platform/context'
@@ -28,7 +27,7 @@ const NOOP_PLATFORM_CONTEXT: Pick<PlatformContext, 'forceUpdateTooltip' | 'setti
     settings: of({ final: {}, subjects: [] }),
 }
 
-const commonProps = () => ({
+export const commonProps = () => ({
     showCloseButton: boolean('showCloseButton', true),
     location: history.location,
     telemetryService: NOOP_TELEMETRY_SERVICE,
@@ -39,14 +38,7 @@ const commonProps = () => ({
     onAlertDismissed: action('onAlertDismissed'),
     onCloseButtonClick: action('onCloseButtonClick'),
 })
-const webHoverOverlayClassProps: HoverOverlayClassProps = {
-    className: 'card',
-    iconClassName: 'icon-inline',
-    iconButtonClassName: 'btn btn-icon',
-    actionItemClassName: 'btn btn-secondary',
-    infoAlertClassName: 'alert alert-info',
-    errorAlertClassName: 'alert alert-danger',
-}
+
 const bitbucketClassProps: HoverOverlayClassProps = {
     className: 'aui-dialog',
     actionItemClassName: 'aui-button hover-action-item--bitbucket-server',
@@ -56,33 +48,20 @@ const bitbucketClassProps: HoverOverlayClassProps = {
     iconClassName: 'aui-icon',
 }
 
-const FIXTURE_CONTENT: Badged<MarkupContent> = {
+export const FIXTURE_CONTENT: Badged<MarkupContent> = {
     value:
-        '```typescript\nexport interface TestInterface<A, B, C>\n```\n\n' +
-        '---\n\nVeniam voluptate quis magna mollit aliqua enim id ea fugiat. Aliqua anim eiusmod nisi excepteur.\n',
+        '```go\nfunc RegisterMiddlewares(m ...*Middleware)\n```\n\n' +
+        '---\n\nRegisterMiddlewares registers additional authentication middlewares. Currently this is used to register enterprise-only SSO middleware. This should only be called from an init function.\n',
     kind: MarkupKind.Markdown,
 }
 
-const FIXTURE_BADGE: AggregableBadge = {
+export const FIXTURE_SEMANTIC_BADGE: AggregableBadge = {
     text: 'semantic',
     linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence',
     hoverMessage: 'Sample hover message',
 }
 
-const FIXTURE_CONTENT_LONG_CODE = {
-    ...FIXTURE_CONTENT,
-    value:
-        '```typescript\nexport interface LongTestInterface<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z>\n```\n\n' +
-        '---\n\nNisi id deserunt culpa dolore aute pariatur ut amet veniam. Proident id Lorem reprehenderit veniam sunt velit.\n',
-}
-
-const FIXTURE_CONTENT_LONG_TEXT_ONLY = {
-    ...FIXTURE_CONTENT,
-    value:
-        'Mollit ea esse magna incididunt aliquip mollit non reprehenderit veniam anim. Veniam in dolor elit sint aliqua non cillum. Est sit pariatur ut cupidatat magna dolore. Sint et culpa voluptate ad sit eu ea dolor. Dolore Lorem cillum esse pariatur elit dolore dolor quis fugiat labore non. Elit nostrud minim aliqua adipisicing laborum ad sunt velit amet. In voluptate est voluptate labore consectetur proident. Nostrud exercitation ut officia enim minim tempor qui adipisicing sunt et occaecat anim irure. Culpa irure reprehenderit reprehenderit dolore sint aliquip non ex excepteur ipsum dolor. Et qui anim officia magna enim laboris enim exercitation pariatur. Cillum consequat elit dolore tempor magna exercitation ad laborum consequat aute consequat.',
-}
-
-const FIXTURE_ACTIONS = [
+export const FIXTURE_ACTIONS = [
     {
         action: {
             id: 'goToDefinition.preloaded',
@@ -105,240 +84,6 @@ const FIXTURE_ACTIONS = [
     },
 ]
 
-add('Loading', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError="loading"
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('Error', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={
-                new Error(
-                    'Something terrible happened: Eiusmod voluptate deserunt in sint cillum pariatur laborum eiusmod.'
-                )
-            }
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('Common content', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('Aggregated Badges', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT],
-                aggregatedBadges: [FIXTURE_BADGE],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('Only actions', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={null}
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('Long code', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT_LONG_CODE],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('Long text only', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT_LONG_TEXT_ONLY],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('Multiple MarkupContents', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT, FIXTURE_CONTENT, FIXTURE_CONTENT],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-        />
-    </>
-))
-
-add('With small-text alert', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT],
-                alerts: [
-                    {
-                        summary: {
-                            kind: MarkupKind.Markdown,
-                            value:
-                                '<small>This is a test alert. Enim esse quis commodo ex. Pariatur tempor laborum officiairure est do est laborum nostrud cillum. Cupidatat id consectetur et eiusmod Loremproident cupidatat ullamco dolor nostrud. Cupidatat sit do dolor aliqua labore adlaboris cillum deserunt dolor. Sunt labore veniam Lorem reprehenderit quis occaecatsint do mollit aliquip. Consectetur mollit mollit magna eiusmod duis ex. Sint nisilabore labore nulla laboris.</small>',
-                        },
-                        type: 'test-alert-type',
-                    },
-                ],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-            onAlertDismissed={action('onAlertDismissed')}
-        />
-    </>
-))
-
-add('With one-line alert', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT],
-                alerts: [
-                    {
-                        summary: {
-                            kind: MarkupKind.PlainText,
-                            value: 'This is a test alert.',
-                        },
-                    },
-                ],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-            onAlertDismissed={action('onAlertDismissed')}
-        />
-    </>
-))
-
-add('With alert with icon', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT],
-                alerts: [
-                    {
-                        summary: {
-                            kind: MarkupKind.PlainText,
-                            value: 'This is a test alert.',
-                        },
-                        iconKind: 'info',
-                    },
-                ],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-            onAlertDismissed={action('onAlertDismissed')}
-        />
-    </>
-))
-
-add('With dismissible alert with icon', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT],
-                alerts: [
-                    {
-                        summary: {
-                            kind: MarkupKind.Markdown,
-                            value: 'This is a test alert.',
-                        },
-                        type: 'test-alert-type',
-                        iconKind: 'info',
-                    },
-                ],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-            onAlertDismissed={action('onAlertDismissed')}
-        />
-    </>
-))
-
-add('With long markdown text dismissible alert with icon.', () => (
-    <>
-        <style>{webStyles}</style>
-        <HoverOverlay
-            {...commonProps()}
-            {...webHoverOverlayClassProps}
-            hoverOrError={{
-                contents: [FIXTURE_CONTENT],
-                alerts: [
-                    {
-                        summary: {
-                            kind: MarkupKind.Markdown,
-                            value:
-                                'This is a test alert. [It uses Markdown.](https://sourcegraph.com) `To render things easily`. *Cool!*',
-                        },
-                        type: 'test-alert-type',
-                        iconKind: 'info',
-                    },
-                ],
-            }}
-            actionsOrError={FIXTURE_ACTIONS}
-            onAlertDismissed={action('onAlertDismissed')}
-        />
-    </>
-))
-
 add('Bitbucket styles', () => (
     <>
         <style>{bitbucketStyles}</style>
@@ -348,7 +93,7 @@ add('Bitbucket styles', () => (
             {...bitbucketClassProps}
             hoverOrError={{
                 contents: [FIXTURE_CONTENT],
-                aggregatedBadges: [FIXTURE_BADGE],
+                aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
             }}
             actionsOrError={FIXTURE_ACTIONS}
         />

--- a/client/shared/src/hover/HoverOverlay.story.tsx
+++ b/client/shared/src/hover/HoverOverlay.story.tsx
@@ -1,43 +1,17 @@
 import bitbucketStyles from '@atlassian/aui/dist/aui/css/aui.css'
-import { action } from '@storybook/addon-actions'
-import { boolean } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
-import { createMemoryHistory } from 'history'
 import React from 'react'
-import { of } from 'rxjs'
-import { MarkupContent, Badged, AggregableBadge } from 'sourcegraph'
 
 import browserExtensionStyles from '@sourcegraph/browser/src/app.scss'
-import { MarkupKind } from '@sourcegraph/extension-api-classes'
 
 import { registerHighlightContributions } from '../highlight/contributions'
-import { PlatformContext } from '../platform/context'
-import { NOOP_TELEMETRY_SERVICE } from '../telemetry/telemetryService'
 
 import { HoverOverlay, HoverOverlayClassProps } from './HoverOverlay'
+import { commonProps, FIXTURE_ACTIONS, FIXTURE_CONTENT, FIXTURE_SEMANTIC_BADGE } from './HoverOverlay.fixtures'
 
 registerHighlightContributions()
 
 const { add } = storiesOf('shared/HoverOverlay', module)
-
-const history = createMemoryHistory()
-const NOOP_EXTENSIONS_CONTROLLER = { executeCommand: () => Promise.resolve() }
-const NOOP_PLATFORM_CONTEXT: Pick<PlatformContext, 'forceUpdateTooltip' | 'settings'> = {
-    forceUpdateTooltip: () => undefined,
-    settings: of({ final: {}, subjects: [] }),
-}
-
-export const commonProps = () => ({
-    showCloseButton: boolean('showCloseButton', true),
-    location: history.location,
-    telemetryService: NOOP_TELEMETRY_SERVICE,
-    extensionsController: NOOP_EXTENSIONS_CONTROLLER,
-    platformContext: NOOP_PLATFORM_CONTEXT,
-    isLightTheme: true,
-    overlayPosition: { top: 16, left: 16 },
-    onAlertDismissed: action('onAlertDismissed'),
-    onCloseButtonClick: action('onCloseButtonClick'),
-})
 
 const bitbucketClassProps: HoverOverlayClassProps = {
     className: 'aui-dialog',
@@ -47,42 +21,6 @@ const bitbucketClassProps: HoverOverlayClassProps = {
     errorAlertClassName: 'aui-message aui-message-error',
     iconClassName: 'aui-icon',
 }
-
-export const FIXTURE_CONTENT: Badged<MarkupContent> = {
-    value:
-        '```go\nfunc RegisterMiddlewares(m ...*Middleware)\n```\n\n' +
-        '---\n\nRegisterMiddlewares registers additional authentication middlewares. Currently this is used to register enterprise-only SSO middleware. This should only be called from an init function.\n',
-    kind: MarkupKind.Markdown,
-}
-
-export const FIXTURE_SEMANTIC_BADGE: AggregableBadge = {
-    text: 'semantic',
-    linkURL: 'https://docs.sourcegraph.com/code_intelligence/explanations/precise_code_intelligence',
-    hoverMessage: 'Sample hover message',
-}
-
-export const FIXTURE_ACTIONS = [
-    {
-        action: {
-            id: 'goToDefinition.preloaded',
-            title: 'Go to definition',
-            command: 'open',
-            commandArguments: ['/github.com/sourcegraph/codeintellify/-/blob/src/hoverifier.ts?subtree=true#L57:1'],
-        },
-        active: true,
-    },
-    {
-        action: {
-            id: 'findReferences',
-            title: 'Find references',
-            command: 'open',
-            commandArguments: [
-                '/github.com/sourcegraph/codeintellify/-/blob/src/hoverifier.ts?subtree=true#L57:18&tab=references',
-            ],
-        },
-        active: true,
-    },
-]
 
 add('Bitbucket styles', () => (
     <>

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.fixtures.ts
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.fixtures.ts
@@ -1,0 +1,41 @@
+import { AggregableBadge, HoverAlert } from 'sourcegraph'
+
+import { MarkupKind } from '@sourcegraph/extension-api-classes'
+import { FIXTURE_SEMANTIC_BADGE, FIXTURE_CONTENT } from '@sourcegraph/shared/src/hover/HoverOverlay.fixtures'
+
+export const FIXTURE_CONTENT_LONG_CODE = {
+    ...FIXTURE_CONTENT,
+    value:
+        '```typescript\nexport interface LongTestInterface<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z>\n```\n\n' +
+        '---\n\nNisi id deserunt culpa dolore aute pariatur ut amet veniam. Proident id Lorem reprehenderit veniam sunt velit.\n',
+}
+
+export const FIXTURE_CONTENT_LONG_TEXT_ONLY = {
+    ...FIXTURE_CONTENT,
+    value:
+        'WebAssembly (sometimes abbreviated Wasm) is an open standard that defines a portable binary-code format for executable programs, and a corresponding textual assembly language, as well as interfaces for facilitating interactions between such programs and their host environment. The main goal of WebAssembly is to enable high-performance applications on web pages, but the format is designed to be executed and integrated in other environments as well, including standalone ones.  WebAssembly (i.e. WebAssembly Core Specification (then version 1.0, 1.1 is in draft) and WebAssembly JavaScript Interface) became a World Wide Web Consortium recommendation on 5 December 2019, alongside HTML, CSS, and JavaScript. WebAssembly can support (at least in theory) any language (e.g. compiled or interpreted) on any operating system (with help of appropriate tools), and in practice all of the most popular languages already have at least some level of support.  The Emscripten SDK can compile any LLVM-supported languages (such as C, C++ or Rust, among others) source code into a binary file which runs in the same sandbox as JavaScript code. Emscripten provides bindings for several commonly used environment interfaces like WebGL. There is no direct Document Object Model (DOM) access; however, it is possible to create proxy functions for this, for example through stdweb, web_sys, and js_sys when using the Rust language.  WebAssembly implementations usually use either ahead-of-time (AOT) or just-in-time (JIT) compilation, but may also use an interpreter. While the currently best-known implementations may be in web browsers, there are also non-browser implementations for general-purpose use, including WebAssembly Micro Runtime, a Bytecode Alliance project (with subproject iwasm code VM supporting "interpreter, ahead of time compilation (AoT) and Just-in-Time compilation (JIT)"), Wasmtime, and Wasmer.',
+}
+
+export const FIXTURE_PARTIAL_BADGE: AggregableBadge = {
+    ...FIXTURE_SEMANTIC_BADGE,
+    text: 'partial semantic',
+}
+
+export const FIXTURE_SMALL_TEXT_MARKDOWN_ALERT: HoverAlert = {
+    summary: {
+        kind: MarkupKind.Markdown,
+        value:
+            '<small>This is an info alert wrapped into a \\<small\\> element. Enim esse quis commodo ex. Pariatur tempor laborum officiairure est do est laborum nostrud cillum. Cupidatat id consectetur et eiusmod Loremproident cupidatat ullamco dolor nostrud. Cupidatat sit do dolor aliqua labore adlaboris cillum deserunt dolor. Sunt labore veniam Lorem reprehenderit quis occaecatsint do mollit aliquip. Consectetur mollit mollit magna eiusmod duis ex. Sint nisilabore labore nulla laboris.</small>',
+    },
+    type: 'test-alert-type',
+}
+
+export const FIXTURE_WARNING_MARKDOWN_ALERT: HoverAlert = {
+    summary: {
+        kind: MarkupKind.Markdown,
+        value:
+            'This is a warning alert. [It uses Markdown.](https://sourcegraph.com) `To render things easily`. *Cool!*',
+    },
+    type: 'test-alert-type',
+    iconKind: 'warning',
+}

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -1,0 +1,231 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import React from 'react'
+import { AggregableBadge, HoverAlert } from 'sourcegraph'
+
+import { MarkupKind } from '@sourcegraph/extension-api-classes'
+import { registerHighlightContributions } from '@sourcegraph/shared/src/highlight/contributions'
+import {
+    commonProps,
+    FIXTURE_ACTIONS,
+    FIXTURE_SEMANTIC_BADGE,
+    FIXTURE_CONTENT,
+} from '@sourcegraph/shared/src/hover/HoverOverlay.story'
+
+import { WebStory } from '../WebStory'
+
+import { WebHoverOverlay } from './WebHoverOverlay'
+
+registerHighlightContributions()
+
+const { add } = storiesOf('web/WebHoverOverlay', module).addDecorator(story => <WebStory>{() => story()}</WebStory>)
+
+const FIXTURE_CONTENT_LONG_CODE = {
+    ...FIXTURE_CONTENT,
+    value:
+        '```typescript\nexport interface LongTestInterface<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z>\n```\n\n' +
+        '---\n\nNisi id deserunt culpa dolore aute pariatur ut amet veniam. Proident id Lorem reprehenderit veniam sunt velit.\n',
+}
+
+const FIXTURE_CONTENT_LONG_TEXT_ONLY = {
+    ...FIXTURE_CONTENT,
+    value:
+        'WebAssembly (sometimes abbreviated Wasm) is an open standard that defines a portable binary-code format for executable programs, and a corresponding textual assembly language, as well as interfaces for facilitating interactions between such programs and their host environment. The main goal of WebAssembly is to enable high-performance applications on web pages, but the format is designed to be executed and integrated in other environments as well, including standalone ones.  WebAssembly (i.e. WebAssembly Core Specification (then version 1.0, 1.1 is in draft) and WebAssembly JavaScript Interface) became a World Wide Web Consortium recommendation on 5 December 2019, alongside HTML, CSS, and JavaScript. WebAssembly can support (at least in theory) any language (e.g. compiled or interpreted) on any operating system (with help of appropriate tools), and in practice all of the most popular languages already have at least some level of support.  The Emscripten SDK can compile any LLVM-supported languages (such as C, C++ or Rust, among others) source code into a binary file which runs in the same sandbox as JavaScript code. Emscripten provides bindings for several commonly used environment interfaces like WebGL. There is no direct Document Object Model (DOM) access; however, it is possible to create proxy functions for this, for example through stdweb, web_sys, and js_sys when using the Rust language.  WebAssembly implementations usually use either ahead-of-time (AOT) or just-in-time (JIT) compilation, but may also use an interpreter. While the currently best-known implementations may be in web browsers, there are also non-browser implementations for general-purpose use, including WebAssembly Micro Runtime, a Bytecode Alliance project (with subproject iwasm code VM supporting "interpreter, ahead of time compilation (AoT) and Just-in-Time compilation (JIT)"), Wasmtime, and Wasmer.',
+}
+
+const FIXTURE_PARITAL_BADGE: AggregableBadge = {
+    ...FIXTURE_SEMANTIC_BADGE,
+    text: 'partial semantic',
+}
+
+const FIXTURE_SMALL_TEXT_MARKDOWN_ALERT: HoverAlert = {
+    summary: {
+        kind: MarkupKind.Markdown,
+        value:
+            '<small>This is an info alert wrapped into a \\<small\\> element. Enim esse quis commodo ex. Pariatur tempor laborum officiairure est do est laborum nostrud cillum. Cupidatat id consectetur et eiusmod Loremproident cupidatat ullamco dolor nostrud. Cupidatat sit do dolor aliqua labore adlaboris cillum deserunt dolor. Sunt labore veniam Lorem reprehenderit quis occaecatsint do mollit aliquip. Consectetur mollit mollit magna eiusmod duis ex. Sint nisilabore labore nulla laboris.</small>',
+    },
+    type: 'test-alert-type',
+}
+
+const FIXTURE_WARNING_MARKDOWN_ALERT: HoverAlert = {
+    summary: {
+        kind: MarkupKind.Markdown,
+        value:
+            'This is a warning alert. [It uses Markdown.](https://sourcegraph.com) `To render things easily`. *Cool!*',
+    },
+    type: 'test-alert-type',
+    iconKind: 'warning',
+}
+
+add('Loading', () => <WebHoverOverlay {...commonProps()} hoverOrError="loading" actionsOrError={FIXTURE_ACTIONS} />)
+
+add('Error', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={
+            new Error(
+                'Something terrible happened: Eiusmod voluptate deserunt in sint cillum pariatur laborum eiusmod.'
+            )
+        }
+        actionsOrError={FIXTURE_ACTIONS}
+    />
+))
+
+add('No hover information', () => (
+    <WebHoverOverlay {...commonProps()} hoverOrError={null} actionsOrError={FIXTURE_ACTIONS} />
+))
+
+add('Common content without actions', () => (
+    <WebHoverOverlay {...commonProps()} hoverOrError={{ contents: [FIXTURE_CONTENT] }} />
+))
+
+add('Common content with actions', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+    />
+))
+
+add('Aggregated Badges', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT],
+            aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+    />
+))
+
+add('Long code', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT_LONG_CODE],
+            aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+    />
+))
+
+add('Long text only', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT_LONG_TEXT_ONLY],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+    />
+))
+
+add('Multiple MarkupContents', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT, FIXTURE_CONTENT, FIXTURE_CONTENT],
+            aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+    />
+))
+
+add('With small-text alert', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT],
+            alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
+    />
+))
+
+add('With one-line alert', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT],
+            alerts: [
+                {
+                    summary: {
+                        kind: MarkupKind.PlainText,
+                        value: 'This is a test alert.',
+                    },
+                },
+            ],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
+    />
+))
+
+add('With alert with warning icon', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT],
+            alerts: [
+                {
+                    summary: {
+                        kind: MarkupKind.PlainText,
+                        value: 'This is a warning alert.',
+                    },
+                    iconKind: 'warning',
+                },
+            ],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
+    />
+))
+
+add('With dismissible alert with icon', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT],
+            alerts: [
+                {
+                    summary: {
+                        kind: MarkupKind.Markdown,
+                        value: 'This is a test alert.',
+                    },
+                    type: 'test-alert-type',
+                    iconKind: 'info',
+                },
+            ],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
+    />
+))
+
+add('With long markdown text dismissible alert with icon.', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT],
+            alerts: [FIXTURE_WARNING_MARKDOWN_ALERT],
+            aggregatedBadges: [FIXTURE_PARITAL_BADGE, FIXTURE_SEMANTIC_BADGE],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
+    />
+))
+
+add('Multiple MarkupContents with badges and alerts', () => (
+    <WebHoverOverlay
+        {...commonProps()}
+        hoverOrError={{
+            contents: [FIXTURE_CONTENT, FIXTURE_CONTENT, FIXTURE_CONTENT],
+            aggregatedBadges: [FIXTURE_SEMANTIC_BADGE],
+            alerts: [FIXTURE_SMALL_TEXT_MARKDOWN_ALERT, FIXTURE_WARNING_MARKDOWN_ALERT],
+        }}
+        actionsOrError={FIXTURE_ACTIONS}
+        onAlertDismissed={action('onAlertDismissed')}
+    />
+))

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -1,7 +1,6 @@
 import { action } from '@storybook/addon-actions'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
-import { AggregableBadge, HoverAlert } from 'sourcegraph'
 
 import { MarkupKind } from '@sourcegraph/extension-api-classes'
 import { registerHighlightContributions } from '@sourcegraph/shared/src/highlight/contributions'
@@ -10,52 +9,22 @@ import {
     FIXTURE_ACTIONS,
     FIXTURE_SEMANTIC_BADGE,
     FIXTURE_CONTENT,
-} from '@sourcegraph/shared/src/hover/HoverOverlay.story'
+} from '@sourcegraph/shared/src/hover/HoverOverlay.fixtures'
 
 import { WebStory } from '../WebStory'
 
 import { WebHoverOverlay } from './WebHoverOverlay'
+import {
+    FIXTURE_CONTENT_LONG_CODE,
+    FIXTURE_CONTENT_LONG_TEXT_ONLY,
+    FIXTURE_PARTIAL_BADGE,
+    FIXTURE_SMALL_TEXT_MARKDOWN_ALERT,
+    FIXTURE_WARNING_MARKDOWN_ALERT,
+} from './WebHoverOverlay.fixtures'
 
 registerHighlightContributions()
 
 const { add } = storiesOf('web/WebHoverOverlay', module).addDecorator(story => <WebStory>{() => story()}</WebStory>)
-
-const FIXTURE_CONTENT_LONG_CODE = {
-    ...FIXTURE_CONTENT,
-    value:
-        '```typescript\nexport interface LongTestInterface<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z>\n```\n\n' +
-        '---\n\nNisi id deserunt culpa dolore aute pariatur ut amet veniam. Proident id Lorem reprehenderit veniam sunt velit.\n',
-}
-
-const FIXTURE_CONTENT_LONG_TEXT_ONLY = {
-    ...FIXTURE_CONTENT,
-    value:
-        'WebAssembly (sometimes abbreviated Wasm) is an open standard that defines a portable binary-code format for executable programs, and a corresponding textual assembly language, as well as interfaces for facilitating interactions between such programs and their host environment. The main goal of WebAssembly is to enable high-performance applications on web pages, but the format is designed to be executed and integrated in other environments as well, including standalone ones.  WebAssembly (i.e. WebAssembly Core Specification (then version 1.0, 1.1 is in draft) and WebAssembly JavaScript Interface) became a World Wide Web Consortium recommendation on 5 December 2019, alongside HTML, CSS, and JavaScript. WebAssembly can support (at least in theory) any language (e.g. compiled or interpreted) on any operating system (with help of appropriate tools), and in practice all of the most popular languages already have at least some level of support.  The Emscripten SDK can compile any LLVM-supported languages (such as C, C++ or Rust, among others) source code into a binary file which runs in the same sandbox as JavaScript code. Emscripten provides bindings for several commonly used environment interfaces like WebGL. There is no direct Document Object Model (DOM) access; however, it is possible to create proxy functions for this, for example through stdweb, web_sys, and js_sys when using the Rust language.  WebAssembly implementations usually use either ahead-of-time (AOT) or just-in-time (JIT) compilation, but may also use an interpreter. While the currently best-known implementations may be in web browsers, there are also non-browser implementations for general-purpose use, including WebAssembly Micro Runtime, a Bytecode Alliance project (with subproject iwasm code VM supporting "interpreter, ahead of time compilation (AoT) and Just-in-Time compilation (JIT)"), Wasmtime, and Wasmer.',
-}
-
-const FIXTURE_PARITAL_BADGE: AggregableBadge = {
-    ...FIXTURE_SEMANTIC_BADGE,
-    text: 'partial semantic',
-}
-
-const FIXTURE_SMALL_TEXT_MARKDOWN_ALERT: HoverAlert = {
-    summary: {
-        kind: MarkupKind.Markdown,
-        value:
-            '<small>This is an info alert wrapped into a \\<small\\> element. Enim esse quis commodo ex. Pariatur tempor laborum officiairure est do est laborum nostrud cillum. Cupidatat id consectetur et eiusmod Loremproident cupidatat ullamco dolor nostrud. Cupidatat sit do dolor aliqua labore adlaboris cillum deserunt dolor. Sunt labore veniam Lorem reprehenderit quis occaecatsint do mollit aliquip. Consectetur mollit mollit magna eiusmod duis ex. Sint nisilabore labore nulla laboris.</small>',
-    },
-    type: 'test-alert-type',
-}
-
-const FIXTURE_WARNING_MARKDOWN_ALERT: HoverAlert = {
-    summary: {
-        kind: MarkupKind.Markdown,
-        value:
-            'This is a warning alert. [It uses Markdown.](https://sourcegraph.com) `To render things easily`. *Cool!*',
-    },
-    type: 'test-alert-type',
-    iconKind: 'warning',
-}
 
 add('Loading', () => <WebHoverOverlay {...commonProps()} hoverOrError="loading" actionsOrError={FIXTURE_ACTIONS} />)
 
@@ -210,7 +179,7 @@ add('With long markdown text dismissible alert with icon.', () => (
         hoverOrError={{
             contents: [FIXTURE_CONTENT],
             alerts: [FIXTURE_WARNING_MARKDOWN_ALERT],
-            aggregatedBadges: [FIXTURE_PARITAL_BADGE, FIXTURE_SEMANTIC_BADGE],
+            aggregatedBadges: [FIXTURE_PARTIAL_BADGE, FIXTURE_SEMANTIC_BADGE],
         }}
         actionsOrError={FIXTURE_ACTIONS}
         onAlertDismissed={action('onAlertDismissed')}

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback, useEffect } from 'react'
+
+import { HoverOverlay, HoverOverlayProps } from '@sourcegraph/shared/src/hover/HoverOverlay'
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
+
+import { HoverThresholdProps } from '../../repo/RepoContainer'
+
+export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps & HoverThresholdProps> = props => {
+    const [dismissedAlerts, setDismissedAlerts] = useLocalStorage<string[]>('WebHoverOverlay.dismissedAlerts', [])
+    const onAlertDismissed = useCallback(
+        (alertType: string) => {
+            if (!dismissedAlerts.includes(alertType)) {
+                setDismissedAlerts([...dismissedAlerts, alertType])
+            }
+        },
+        [dismissedAlerts, setDismissedAlerts]
+    )
+
+    let propsToUse = props
+    if (props.hoverOrError && props.hoverOrError !== 'loading' && !isErrorLike(props.hoverOrError)) {
+        const filteredAlerts = (props.hoverOrError?.alerts || []).filter(
+            alert => !alert.type || !dismissedAlerts.includes(alert.type)
+        )
+        propsToUse = { ...props, hoverOrError: { ...props.hoverOrError, alerts: filteredAlerts } }
+    }
+
+    const { hoverOrError } = propsToUse
+    const { onHoverShown, hoveredToken } = props
+
+    /** Whether the hover has actual content (that provides value to the user) */
+    const hoverHasValue = hoverOrError !== 'loading' && !isErrorLike(hoverOrError) && !!hoverOrError?.contents?.length
+
+    useEffect(() => {
+        if (hoverHasValue) {
+            onHoverShown?.()
+        }
+    }, [hoveredToken?.filePath, hoveredToken?.line, hoveredToken?.character, onHoverShown, hoverHasValue])
+
+    return (
+        <HoverOverlay
+            {...propsToUse}
+            className="card"
+            iconClassName="icon-inline"
+            iconButtonClassName="btn btn-icon"
+            actionItemClassName="btn btn-secondary"
+            infoAlertClassName="alert alert-secondary" // #18931
+            errorAlertClassName="alert alert-danger"
+            onAlertDismissed={onAlertDismissed}
+        />
+    )
+}
+
+WebHoverOverlay.displayName = 'WebHoverOverlay'

--- a/client/web/src/components/WebHoverOverlay/index.ts
+++ b/client/web/src/components/WebHoverOverlay/index.ts
@@ -1,0 +1,1 @@
+export * from './WebHoverOverlay'

--- a/client/web/src/components/shared.tsx
+++ b/client/web/src/components/shared.tsx
@@ -1,65 +1,16 @@
 import classNames from 'classnames'
-import React, { useCallback, useEffect } from 'react'
+import React from 'react'
 
 import { ActionsNavItems, ActionsNavItemsProps } from '@sourcegraph/shared/src/actions/ActionsNavItems'
 import {
     CommandListPopoverButton,
     CommandListPopoverButtonProps,
 } from '@sourcegraph/shared/src/commandPalette/CommandList'
-import { HoverOverlay, HoverOverlayProps } from '@sourcegraph/shared/src/hover/HoverOverlay'
-import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
-import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
-
-import { HoverThresholdProps } from '../repo/RepoContainer'
 
 // Components from shared with web-styling class names applied
 
-export const WebHoverOverlay: React.FunctionComponent<HoverOverlayProps & HoverThresholdProps> = props => {
-    const [dismissedAlerts, setDismissedAlerts] = useLocalStorage<string[]>('WebHoverOverlay.dismissedAlerts', [])
-    const onAlertDismissed = useCallback(
-        (alertType: string) => {
-            if (!dismissedAlerts.includes(alertType)) {
-                setDismissedAlerts([...dismissedAlerts, alertType])
-            }
-        },
-        [dismissedAlerts, setDismissedAlerts]
-    )
-
-    let propsToUse = props
-    if (props.hoverOrError && props.hoverOrError !== 'loading' && !isErrorLike(props.hoverOrError)) {
-        const filteredAlerts = (props.hoverOrError?.alerts || []).filter(
-            alert => !alert.type || !dismissedAlerts.includes(alert.type)
-        )
-        propsToUse = { ...props, hoverOrError: { ...props.hoverOrError, alerts: filteredAlerts } }
-    }
-
-    const { hoverOrError } = propsToUse
-    const { onHoverShown, hoveredToken } = props
-
-    /** Whether the hover has actual content (that provides value to the user) */
-    const hoverHasValue = hoverOrError !== 'loading' && !isErrorLike(hoverOrError) && !!hoverOrError?.contents?.length
-
-    useEffect(() => {
-        if (hoverHasValue) {
-            onHoverShown?.()
-        }
-    }, [hoveredToken?.filePath, hoveredToken?.line, hoveredToken?.character, onHoverShown, hoverHasValue])
-
-    return (
-        <HoverOverlay
-            {...propsToUse}
-            className="card"
-            iconClassName="icon-inline"
-            iconButtonClassName="btn btn-icon"
-            actionItemClassName="btn btn-secondary"
-            infoAlertClassName="alert alert-secondary" // #18931
-            errorAlertClassName="alert alert-danger"
-            onAlertDismissed={onAlertDismissed}
-        />
-    )
-}
-WebHoverOverlay.displayName = 'WebHoverOverlay'
+export { WebHoverOverlay } from './WebHoverOverlay'
 
 export const WebCommandListPopoverButton: React.FunctionComponent<CommandListPopoverButtonProps> = props => {
     const [isRedesignEnabled] = useRedesignToggle()


### PR DESCRIPTION
## Description

This PR is a preparation for the [Code Intel redesign](https://github.com/sourcegraph/sourcegraph/issues/19633) work.

## Changes

- Extracted `WebHoverOverlay` stories into a separate file and moved them into the `web` package.
- New story uses the `WebHoverOverlay` component directly instead of using `HoverOverlay` and providing web props. It's handy because now we have one source of truth for web props. 
- Fixed inconsistent `infoAlertClassName` prop in `WebHoverOverlay` story.
- Extracted fixtures into separate files.