### PR TITLE
Add cloneable error object for error handlers insights providers 

### DIFF
--- a/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
+++ b/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
@@ -2,7 +2,7 @@ import { from, Observable, of } from 'rxjs'
 import { catchError, defaultIfEmpty, map, mergeMap, scan, startWith, switchMap } from 'rxjs/operators'
 import sourcegraph from 'sourcegraph'
 
-import { asError, ErrorLike } from '../../../util/errors'
+import { ErrorLike } from '../../../util/errors'
 import { allOf, isDefined, isExactly, isNot, property } from '../../../util/types'
 import { ContributableViewContainer } from '../../protocol'
 import { RegisteredViewProvider, ViewContexts, ViewProviderResult } from '../extensionHostApi'
@@ -62,7 +62,10 @@ export function callViewProvidersInParallel<W extends ContributableViewContainer
                                   defaultIfEmpty<sourcegraph.View | null | undefined>(null),
                                   catchError((error): [ErrorLike] => {
                                       console.error('View provider errored:', error)
-                                      return [asError(error)]
+
+                                      // Pass only primitive copied values because Error object is not
+                                      // cloneable in Firefox and Safari
+                                      return [{ message: error.message, name: error.name }]
                                   }),
                                   // Add index to view to put response in right position of result views array below in scan operator
                                   map(view => ({ id: provider.id, view, index }))

--- a/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
+++ b/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
@@ -60,12 +60,12 @@ export function callViewProvidersInParallel<W extends ContributableViewContainer
                               // calling provideView on null value
                               providerResultToObservable(provider.viewProvider.provideView(context)).pipe(
                                   defaultIfEmpty<sourcegraph.View | null | undefined>(null),
-                                  catchError((error): [ErrorLike] => {
+                                  catchError((error: Error): [ErrorLike] => {
                                       console.error('View provider errored:', error)
 
                                       // Pass only primitive copied values because Error object is not
                                       // cloneable in Firefox and Safari
-                                      return [{ message: error.message, name: error.name }]
+                                      return [{ message: error.message, name: error.name, stack: error.stack }]
                                   }),
                                   // Add index to view to put response in right position of result views array below in scan operator
                                   map(view => ({ id: provider.id, view, index }))

--- a/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
+++ b/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
@@ -2,7 +2,7 @@ import { from, Observable, of } from 'rxjs'
 import { catchError, defaultIfEmpty, map, mergeMap, scan, startWith, switchMap } from 'rxjs/operators'
 import sourcegraph from 'sourcegraph'
 
-import { ErrorLike } from '../../../util/errors'
+import { asError, ErrorLike } from '../../../util/errors'
 import { allOf, isDefined, isExactly, isNot, property } from '../../../util/types'
 import { ContributableViewContainer } from '../../protocol'
 import { RegisteredViewProvider, ViewContexts, ViewProviderResult } from '../extensionHostApi'
@@ -60,12 +60,13 @@ export function callViewProvidersInParallel<W extends ContributableViewContainer
                               // calling provideView on null value
                               providerResultToObservable(provider.viewProvider.provideView(context)).pipe(
                                   defaultIfEmpty<sourcegraph.View | null | undefined>(null),
-                                  catchError((error: Error): [ErrorLike] => {
+                                  catchError((error: unknown): [ErrorLike] => {
                                       console.error('View provider errored:', error)
 
                                       // Pass only primitive copied values because Error object is not
                                       // cloneable in Firefox and Safari
-                                      return [{ message: error.message, name: error.name, stack: error.stack } as ErrorLike]
+                                      const { message, name, stack } = asError(error)
+                                      return [{ message, name, stack } as ErrorLike]
                                   }),
                                   // Add index to view to put response in right position of result views array below in scan operator
                                   map(view => ({ id: provider.id, view, index }))

--- a/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
+++ b/client/shared/src/api/extension/api/callViewProvidersInParallel.ts
@@ -65,7 +65,7 @@ export function callViewProvidersInParallel<W extends ContributableViewContainer
 
                                       // Pass only primitive copied values because Error object is not
                                       // cloneable in Firefox and Safari
-                                      return [{ message: error.message, name: error.name, stack: error.stack }]
+                                      return [{ message: error.message, name: error.name, stack: error.stack } as ErrorLike]
                                   }),
                                   // Add index to view to put response in right position of result views array below in scan operator
                                   map(view => ({ id: provider.id, view, index }))

--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -657,11 +657,11 @@ function callViewProviders<W extends ContributableViewContainer>(
                         [undefined],
                         providerResultToObservable(viewProvider.provideView(context)).pipe(
                             defaultIfEmpty<sourcegraph.View | null | undefined>(null),
-                            catchError((error): [ErrorLike] => {
+                            catchError((error: Error): [ErrorLike] => {
                                 console.error('View provider errored:', error)
                                 // Pass only primitive copied values because Error object is not
                                 // cloneable in Firefox and Safari
-                                return [{ message: error.message, name: error.name }]
+                                return [{ message: error.message, name: error.name, stack: error.stack }]
                             })
                         )
                     ).pipe(map(view => ({ id, view })))

--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -16,7 +16,7 @@ import { LOADING, MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import * as clientType from '@sourcegraph/extension-api-types'
 
 import { getModeFromPath } from '../../languages'
-import { asError, ErrorLike } from '../../util/errors'
+import { ErrorLike } from '../../util/errors'
 import { combineLatestOrDefault } from '../../util/rxjs/combineLatestOrDefault'
 import { allOf, isDefined, isExactly, isNot, property } from '../../util/types'
 import { parseRepoURI } from '../../util/url'
@@ -659,7 +659,9 @@ function callViewProviders<W extends ContributableViewContainer>(
                             defaultIfEmpty<sourcegraph.View | null | undefined>(null),
                             catchError((error): [ErrorLike] => {
                                 console.error('View provider errored:', error)
-                                return [asError(error)]
+                                // Pass only primitive copied values because Error object is not
+                                // cloneable in Firefox and Safari
+                                return [{ message: error.message, name: error.name }]
                             })
                         )
                     ).pipe(map(view => ({ id, view })))

--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -661,7 +661,7 @@ function callViewProviders<W extends ContributableViewContainer>(
                                 console.error('View provider errored:', error)
                                 // Pass only primitive copied values because Error object is not
                                 // cloneable in Firefox and Safari
-                                return [{ message: error.message, name: error.name, stack: error.stack }]
+                                return [{ message: error.message, name: error.name, stack: error.stack } as ErrorLike]
                             })
                         )
                     ).pipe(map(view => ({ id, view })))

--- a/client/shared/src/util/errors.ts
+++ b/client/shared/src/util/errors.ts
@@ -1,6 +1,7 @@
 export interface ErrorLike {
     message: string
     name?: string
+    stack?: string
 }
 
 export const isErrorLike = (value: unknown): value is ErrorLike =>

--- a/client/shared/src/util/errors.ts
+++ b/client/shared/src/util/errors.ts
@@ -1,7 +1,6 @@
 export interface ErrorLike {
     message: string
     name?: string
-    stack?: string
 }
 
 export const isErrorLike = (value: unknown): value is ErrorLike =>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/20336

This PR adds a `cloneable` error object in order to support error handling for browsers that don't support native Error objects as a cloneable object from the web worker thread.

As a result of this problem we had failed loading for insight which returned an error from insight extension and also that ruined all loading insight pipeline which means if you have one error-producing insight, it blocks the others. 

You could see this problem only in Safari and Firefox but not in Chrome. Now all browsers should work as expected (don't block the loading of other insights in case if they got an error from the web worker thread)



