### PR TITLE
internal/database: Sanitize error string before writing to last_error column in gitserver_repo 

### DIFF
--- a/internal/database/gitserver_repos_test.go
+++ b/internal/database/gitserver_repos_test.go
@@ -265,8 +265,11 @@ func TestSetLastError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Set error
-	err = GitserverRepos(db).SetLastError(ctx, gitserverRepo.RepoID, "oops", shardID)
+	// Set error.
+	//
+	// We are using a null terminated string for the last_error column. See
+	// https://stackoverflow.com/a/38008565/1773961 on how to set null terminated strings in Go.
+	err = GitserverRepos(db).SetLastError(ctx, gitserverRepo.RepoID, "oops\x00", shardID)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
