### PR TITLE
repositories: do not request `totalCount` field

### DIFF
--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -190,7 +190,6 @@ export function listUserRepositories(
                             nodes {
                                 ...SiteAdminRepositoryFields
                             }
-                            totalCount(precise: true)
                             pageInfo {
                                 hasNextPage
                             }

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -23,7 +23,6 @@ import {
 } from '../../../components/FilteredConnection'
 import { PageTitle } from '../../../components/PageTitle'
 import {
-    RepositoriesResult,
     SiteAdminRepositoryFields,
     UserRepositoriesResult,
     ListExternalServiceFields,
@@ -193,7 +192,9 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
         ) || emptyFilters
 
     const queryRepositories = useCallback(
-        (args: FilteredConnectionQueryArguments): Observable<RepositoriesResult['repositories']> =>
+        (
+            args: FilteredConnectionQueryArguments
+        ): Observable<NonNullable<UserRepositoriesResult['node']>['repositories']> =>
             listUserRepositories({ ...args, id: userID }).pipe(
                 repeatUntil(
                     (result): boolean => {


### PR DESCRIPTION
Do not request repositories `totalCount` field since it returns an error for non-site admin users and it's not used anywhere.