### PR TITLE
graphql: Allow users count their own repos

### DIFF
--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -205,9 +205,17 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*Repository
 }
 
 func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *TotalCountArgs) (countptr *int32, err error) {
-	// 🚨 SECURITY: Only site admins can do this, because a total repository count does not respect repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
-		return nil, err
+	if r.opt.UserID != 0 {
+		// 🚨 SECURITY: If filtering by user, restrict to that user
+		if err := backend.CheckSameUser(ctx, r.opt.UserID); err != nil {
+			return nil, err
+		}
+	} else {
+		// 🚨 SECURITY: Only site admins can list all repos, because a total repository
+		// count does not respect repository permissions.
+		if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+			return nil, err
+		}
 	}
 
 	i32ptr := func(v int32) *int32 {


### PR DESCRIPTION
Instead of limiting TotalCount to site admins only, we will also allow a
user to count the total number of repos they have access to.
