### PR TITLE
Template testing DB followup

### DIFF
--- a/internal/database/dbtest/dbtest.go
+++ b/internal/database/dbtest/dbtest.go
@@ -113,11 +113,11 @@ func initTemplateDB(t testing.TB, config *url.URL) {
 			if err != nil {
 				t.Fatalf("failed to construct migrations: %s", err)
 			}
+			defer m.Close()
 			if err = dbconn.DoMigrate(m); err != nil {
 				t.Fatalf("failed to apply migrations: %s", err)
 			}
 		}
-		dbExec(t, db, killClientConnsQuery, templateName)
 	})
 }
 


### PR DESCRIPTION
This is a followup PR on #21300 

It:
- Closes migrations instead of manually killing connections (thanks @unknwon!) 
- Re-uses an existing template database if it exists rather than dropping and re-migrating every run (thanks @mrnugget for confirming that this isn't as straightforward as I was hoping)

Reusing the template database package helps lower startup cost of running tests, so we don't pay the few seconds required to migrate the template database on the front end of every test run. This helps with fast feedback when only running a few tests.

Before:
```
❯ go clean -testcache && go test ./internal/database/ -run TestSearchContexts
ok      github.com/sourcegraph/sourcegraph/internal/database    7.018s
```

After:
```
❯ go clean -testcache && go test ./internal/database/ -run TestSearchContexts
ok      github.com/sourcegraph/sourcegraph/internal/database    4.026s
```

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
