### PR TITLE
Use cross-repo hover message instead of "partial semantic" label

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_definitions.go
@@ -80,7 +80,7 @@ func (r *queryResolver) Definitions(ctx context.Context, line, character int) (_
 
 	// Determine the set of uploads over which we need to perform a moniker search. This will
 	// include all all indexes which define one of the ordered monikers. This should not include
-	// any of the indexes we have already performed an LSIF graph traversal in.
+	// any of the indexes we have already performed an LSIF graph traversal in above.
 	uploads, err := r.definitionUploads(ctx, orderedMonikers)
 	if err != nil {
 		return nil, err

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover.go
@@ -28,22 +28,19 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ strin
 	})
 	defer endObservation()
 
-	for i := range r.uploads {
-		traceLog(log.Int("uploadID", r.uploads[i].ID))
+	adjustedUploads, err := r.adjustUploads(ctx, line, character)
+	if err != nil {
+		return "", lsifstore.Range{}, false, err
+	}
 
-		// Adjust the path and position for each visible upload based on its git difference to the target commit
-		adjustedUpload, ok, err := r.adjustUpload(ctx, line, character, r.uploads[i])
-		if err != nil {
-			return "", lsifstore.Range{}, false, err
-		}
-		if !ok {
-			continue
-		}
+	for i := range adjustedUploads {
+		adjustedUpload := adjustedUploads[i]
+		traceLog(log.Int("uploadID", adjustedUpload.Upload.ID))
 
 		// Fetch hover text from the index
 		text, rn, exists, err := r.lsifStore.Hover(
 			ctx,
-			r.uploads[i].ID,
+			adjustedUpload.Upload.ID,
 			adjustedUpload.AdjustedPathInBundle,
 			adjustedUpload.AdjustedPosition.Line,
 			adjustedUpload.AdjustedPosition.Character,
@@ -62,6 +59,59 @@ func (r *queryResolver) Hover(ctx context.Context, line, character int) (_ strin
 		}
 
 		return text, adjustedRange, true, nil
+	}
+
+	// Gather all import monikers attached to the ranges enclosing the requested position
+	orderedMonikers, err := r.orderedMonikers(ctx, adjustedUploads, "import")
+	if err != nil {
+		return "", lsifstore.Range{}, false, err
+	}
+	traceLog(
+		log.Int("numMonikers", len(orderedMonikers)),
+		log.String("monikers", monikersToString(orderedMonikers)),
+	)
+
+	// Determine the set of uploads over which we need to perform a moniker search. This will
+	// include all all indexes which define one of the ordered monikers. This should not include
+	// any of the indexes we have already performed an LSIF graph traversal in.
+	uploads, err := r.dbStore.DefinitionDumps(ctx, orderedMonikers)
+	if err != nil {
+		return "", lsifstore.Range{}, false, errors.Wrap(err, "dbStore.DefinitionDumps")
+	}
+	traceLog(
+		log.Int("numDefinitionUploads", len(uploads)),
+		log.String("definitionUploads", uploadIDsToString(uploads)),
+	)
+
+	locations, _, err := r.monikerLocations(ctx, uploads, orderedMonikers, "definitions", DefinitionsLimit, 0)
+	if err != nil {
+		return "", lsifstore.Range{}, false, err
+	}
+
+	for i := range locations {
+		text, _, exists, err := r.lsifStore.Hover(
+			ctx,
+			locations[i].DumpID,
+			locations[i].Path,
+			locations[i].Range.Start.Line,
+			locations[i].Range.Start.Character,
+		)
+		hoverPosition := lsifstore.Position{
+			Line:      line,
+			Character: character,
+		}
+		hoverRange := lsifstore.Range{
+			Start: hoverPosition,
+			End:   hoverPosition,
+		}
+		if err != nil {
+			return "", hoverRange, false, errors.Wrap(err, "lsifStore.Hover")
+		}
+		if !exists || text == "" {
+			continue
+		}
+
+		return text, lsifstore.Range{}, true, nil
 	}
 
 	return "", lsifstore.Range{}, false, nil

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/query_hover_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
 	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/lib/codeintel/semantic"
 )
 
 func TestHover(t *testing.T) {
@@ -52,6 +53,91 @@ func TestHover(t *testing.T) {
 	if text != "doctext" {
 		t.Errorf("unexpected text. want=%q have=%q", "doctext", text)
 	}
+	if diff := cmp.Diff(expectedRange, rn); diff != "" {
+		t.Errorf("unexpected range (-want +got):\n%s", diff)
+	}
+}
+
+func TestHoverRemote(t *testing.T) {
+	mockDBStore := NewMockDBStore()
+	mockLSIFStore := NewMockLSIFStore()
+	mockGitserverClient := NewMockGitserverClient()
+	mockPositionAdjuster := noopPositionAdjuster()
+
+	expectedRange := lsifstore.Range{
+		Start: lsifstore.Position{Line: 10, Character: 10},
+		End:   lsifstore.Position{Line: 15, Character: 25},
+	}
+	mockLSIFStore.HoverFunc.PushReturn("", lsifstore.Range{}, false, nil)
+	mockLSIFStore.HoverFunc.PushReturn("doctext", expectedRange, true, nil)
+
+	remoteUploads := []dbstore.Dump{
+		{ID: 150, Commit: "deadbeef1", Root: "sub1/"},
+		{ID: 151, Commit: "deadbeef2", Root: "sub2/"},
+		{ID: 152, Commit: "deadbeef3", Root: "sub3/"},
+		{ID: 153, Commit: "deadbeef4", Root: "sub4/"},
+	}
+	mockDBStore.DefinitionDumpsFunc.PushReturn(remoteUploads, nil)
+
+	// upload #150's commit no longer exists; all others do
+	mockGitserverClient.CommitExistsFunc.PushReturn(false, nil)
+	mockGitserverClient.CommitExistsFunc.SetDefaultReturn(true, nil)
+
+	monikers := []semantic.MonikerData{
+		{Kind: "import", Scheme: "tsc", Identifier: "padLeft", PackageInformationID: "51"},
+		{Kind: "export", Scheme: "tsc", Identifier: "pad_left", PackageInformationID: "52"},
+		{Kind: "import", Scheme: "tsc", Identifier: "pad-left", PackageInformationID: "53"},
+		{Kind: "import", Scheme: "tsc", Identifier: "left_pad"},
+	}
+	mockLSIFStore.MonikersByPositionFunc.PushReturn([][]semantic.MonikerData{{monikers[0]}}, nil)
+	mockLSIFStore.MonikersByPositionFunc.PushReturn([][]semantic.MonikerData{{monikers[1]}}, nil)
+	mockLSIFStore.MonikersByPositionFunc.PushReturn([][]semantic.MonikerData{{monikers[2]}}, nil)
+	mockLSIFStore.MonikersByPositionFunc.PushReturn([][]semantic.MonikerData{{monikers[3]}}, nil)
+
+	packageInformation1 := semantic.PackageInformationData{Name: "leftpad", Version: "0.1.0"}
+	packageInformation2 := semantic.PackageInformationData{Name: "leftpad", Version: "0.2.0"}
+	mockLSIFStore.PackageInformationFunc.PushReturn(packageInformation1, true, nil)
+	mockLSIFStore.PackageInformationFunc.PushReturn(packageInformation2, true, nil)
+
+	locations := []lsifstore.Location{
+		{DumpID: 151, Path: "a.go", Range: testRange1},
+		{DumpID: 151, Path: "b.go", Range: testRange2},
+		{DumpID: 151, Path: "a.go", Range: testRange3},
+		{DumpID: 151, Path: "b.go", Range: testRange4},
+		{DumpID: 151, Path: "c.go", Range: testRange5},
+	}
+	mockLSIFStore.BulkMonikerResultsFunc.PushReturn(locations, 0, nil)
+	mockLSIFStore.BulkMonikerResultsFunc.PushReturn(locations, len(locations), nil)
+
+	uploads := []dbstore.Dump{
+		{ID: 50, Commit: "deadbeef", Root: "sub1/"},
+		{ID: 51, Commit: "deadbeef", Root: "sub2/"},
+		{ID: 52, Commit: "deadbeef", Root: "sub3/"},
+		{ID: 53, Commit: "deadbeef", Root: "sub4/"},
+	}
+	resolver := newQueryResolver(
+		mockDBStore,
+		mockLSIFStore,
+		newCachedCommitChecker(mockGitserverClient),
+		mockPositionAdjuster,
+		42,
+		"deadbeef",
+		"s1/main.go",
+		uploads,
+		newOperations(&observation.TestContext),
+	)
+	text, rn, exists, err := resolver.Hover(context.Background(), 10, 20)
+	if err != nil {
+		t.Fatalf("unexpected error querying hover: %s", err)
+	}
+	if !exists {
+		t.Fatalf("expected hover to exist")
+	}
+
+	if text != "doctext" {
+		t.Errorf("unexpected text. want=%q have=%q", "doctext", text)
+	}
+
 	if diff := cmp.Diff(expectedRange, rn); diff != "" {
 		t.Errorf("unexpected range (-want +got):\n%s", diff)
 	}


### PR DESCRIPTION
Fixes #21057.  Previously, Sourcegraph would use search-based code intel
to populate the hover message in the following scenario:

* the call-site has LSIF, but no hover message for externally imported
  symbols
* the definition-site has LSIF, including hover messages for exported
  symbols (which are imported from call-site)

With this commit, Sourcegraph queries the LSIF store to find the hover
message that's attached to the definition location of the moniker.

cc/ @sourcegraph/code-intel 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
