### PR TITLE
extensibility: add action items bar to compare page

### DIFF
--- a/client/web/src/repo/routes.tsx
+++ b/client/web/src/repo/routes.tsx
@@ -77,9 +77,18 @@ export const repoContainerRoutes: readonly RepoContainerRoute[] = [
     {
         path: '/-/compare/:spec*',
         render: context => (
-            <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
-                <RepositoryCompareArea {...context} />
-            </RepositoryGitDataContainer>
+            <div className="repo-revision-container">
+                <RepositoryGitDataContainer {...context} repoName={context.repo.name}>
+                    <RepositoryCompareArea {...context} />
+                </RepositoryGitDataContainer>
+                <ActionItemsBar
+                    extensionsController={context.extensionsController}
+                    platformContext={context.platformContext}
+                    useActionItemsBar={context.useActionItemsBar}
+                    location={context.location}
+                    telemetryService={context.telemetryService}
+                />
+            </div>
         ),
     },
     {


### PR DESCRIPTION
It's essentially the same as the commit page, so there's no reason to _not_ include the action items bar here.

![Screenshot from 2021-05-25 12-35-43](https://user-images.githubusercontent.com/37420160/119535188-bfa40780-bd55-11eb-8489-532c824cec31.png)
