### PR TITLE
codeintel: Remove redundant MarkComplete call

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -165,10 +165,6 @@ func (h *handler) handle(ctx context.Context, workerStore dbworkerstore.Store, d
 			}()
 		}
 
-		if _, err := workerStore.MarkComplete(ctx, upload.ID); err != nil {
-			return errors.Wrap(err, "store.MarkComplete")
-		}
-
 		return nil
 	})
 }


### PR DESCRIPTION
This call is redundant as it's made again by the worker abstraction once the handler returns a non-error.