### PR TITLE
search: fix predicate extractor for multiple lines

### DIFF
--- a/internal/search/query/predicate.go
+++ b/internal/search/query/predicate.go
@@ -51,7 +51,7 @@ func (pr predicateRegistry) Get(field, name string) Predicate {
 }
 
 var (
-	predicateRegexp = regexp.MustCompile(`^(?P<name>[a-z\.]+)\((?P<params>.*)\)$`)
+	predicateRegexp = regexp.MustCompile(`^(?P<name>[a-z\.]+)\((?s:(?P<params>.*))\)$`)
 	nameIndex       = predicateRegexp.SubexpIndex("name")
 	paramsIndex     = predicateRegexp.SubexpIndex("params")
 )
@@ -62,7 +62,7 @@ var (
 func ParseAsPredicate(value string) (name, params string) {
 	match := predicateRegexp.FindStringSubmatch(value)
 	if match == nil {
-		panic("Invariant broken: attempt to parse a predicate value " + value + " that has not been validated")
+		panic("Invariant broken: attempt to parse a predicate value " + value + " which appears to have not been properly validated")
 	}
 	name = match[nameIndex]
 	params = match[paramsIndex]

--- a/internal/search/query/query_test.go
+++ b/internal/search/query/query_test.go
@@ -8,21 +8,21 @@ import (
 	"github.com/hexops/autogold"
 )
 
-func TestPipeline(t *testing.T) {
-	planToString := func(disjuncts [][]Node) string {
-		var plan Plan
-		for _, disjunct := range disjuncts {
-			parameters, pattern, _ := PartitionSearchPattern(disjunct)
-			plan = append(plan, Basic{Parameters: parameters, Pattern: pattern})
-		}
-
-		var result []string
-		for _, basic := range plan {
-			result = append(result, toString(basic.ToParseTree()))
-		}
-		return strings.Join(result, " ")
+func planToString(disjuncts [][]Node) string {
+	var plan Plan
+	for _, disjunct := range disjuncts {
+		parameters, pattern, _ := PartitionSearchPattern(disjunct)
+		plan = append(plan, Basic{Parameters: parameters, Pattern: pattern})
 	}
 
+	var result []string
+	for _, basic := range plan {
+		result = append(result, toString(basic.ToParseTree()))
+	}
+	return strings.Join(result, " ")
+}
+
+func TestPipeline_equivalence(t *testing.T) {
 	// The Pipeline must produce a value that is equivalent under DNF to parsing the query and processing it with DNF.
 	test := func(input string) string {
 		pipelinePlan, _ := Pipeline(InitLiteral(input))
@@ -40,4 +40,13 @@ func TestPipeline(t *testing.T) {
 	}
 
 	autogold.Want("equivalent or-expression", "equivalent").Equal(t, test("(repo:bob or repo:jim) ((rev:olga or rev:ham) demo123232)"))
+}
+
+func TestPipeline(t *testing.T) {
+	test := func(input string) string {
+		pipelinePlan, _ := Pipeline(InitStructural(input))
+		return planToString(Dnf(pipelinePlan.ToParseTree()))
+	}
+
+	autogold.Want("contains(...) spans newlines", `"repo:contains.file(\nfoo\n)"`).Equal(t, test("repo:contains.file(\nfoo\n)"))
 }


### PR DESCRIPTION
Previously, a query like:

```
repo:contains.file(
   foo
)
```

would panic because it breaks the [invariant on this line](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/internal/search/query/predicate.go#L65) because the regular expression we use to extract values does not handle newlines, while the parser does.

This fix is a stopgap. We should either reuse the predicate scanner when extracting values here (so that there is no difference between the parser behavior and the extraction) and/or expose the value in the query directly. 

Discovered by fuzzer https://github.com/sourcegraph/sourcegraph/pull/21379. 
For now this is OK--priority is to add a fix so that I can continue fuzzing and this was a very quick way to fix things. Realistically multiline queries are only reasonable in the experimental search console in the UI, and src-cli.