### PR TITLE
Add current limitations page to code insights docs

### DIFF
--- a/doc/code_insights/explanations/current_limitations_of_code_insights.md
+++ b/doc/code_insights/explanations/current_limitations_of_code_insights.md
@@ -1,0 +1,21 @@
+# Current limitations of Code Insights
+
+Because code insights is currently a [prototype feature](../../admin/beta_and_prototype_features.md#prototype-features), there are some limitations that we have not finished building solutions for yet. 
+
+If you have strong feedback, please do [let us know](mailto:feedback@sourcegraph.com).
+
+## The number of repositories in a search-based insight must be less than 50
+
+Code Insights currently depends on frontend API calls to Sourcegraph searches, so it can't run historical searches over more than 50 repositories due to that search limitation. 
+
+We're currently developing a scalable backend service that fixes this and are planning to release it by September 2021. 
+
+## Search-based Code Insights may run slowly for large numbers of repositories or data series
+
+Because Code Insights runs on the frontend, it may run slowly (or possibly timeout) if you're using it over very many repositories or with very many data series for each insight. That said, a code insight caches locally after you've run it the first time. 
+
+We're currently working on both backend and frontend improvements to increase the speed at which code insights returns data, and you can expect significant improvement by September 2021. 
+
+## Known bugs
+
+Known bugs we plan to fix are tracked in our [GitHub repository here](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Abug+label%3Ateam%2Fcode-insights). 

--- a/doc/code_insights/explanations/index.md
+++ b/doc/code_insights/explanations/index.md
@@ -6,4 +6,5 @@ The following articles explain different parts of [Sourcegraph Code Insights](..
 <!-- - [Types of Code Insights](types_of_code_insights.md) -->
 <!-- - [User viewing permissions of Code Insights](explanations/user_viewing_permissions_of_code_insights.md) -->
 - [Administration and Security of Code Insights](administration_and_security_of_code_insights.md)
+- [Current limitations of Code Insights](current_limitations_of_code_insights.md)
 <!-- - [How Code Insights work](explanations/how_code_insights_work.md) -->

--- a/doc/code_insights/index.md
+++ b/doc/code_insights/index.md
@@ -10,3 +10,4 @@ Work-in-progress table of contents:
 - [Language Insight Quickstart](language_insight_quickstart.md)
 - [Explanations](explanations/index.md)
     - [Administration and security of Code Insights](explanations/administration_and_security_of_code_insights.md)
+    - [Current limitations of Code Insights](explanations/current_limitations_of_code_insights.md)


### PR DESCRIPTION
The purpose of this page is to pre-empt disappointment and support requests. It's essentially the docs.sourcegraph version of the "considerations" section of our [original gist](https://gist.github.com/Joelkw/f0582b164578aabc3ac936dee43f23e0). 

When communicating with customers we haven't spoken to directly before about code insights (so they haven't heard about the limitations from me or a member of the team), this page will help set expectations in a clear and consistent way. 
