### PR TITLE
searcher: run comby tests in parallel

### DIFF
--- a/cmd/searcher/search/search_structural_test.go
+++ b/cmd/searcher/search/search_structural_test.go
@@ -31,11 +31,6 @@ func foo(go string) {}
 `,
 	}
 
-	p := &protocol.PatternInfo{
-		Pattern:         "foo(:[args])",
-		IncludePatterns: []string{"file_without_extension"},
-	}
-
 	cases := []struct {
 		Name      string
 		Languages []string
@@ -73,7 +68,13 @@ func foo(go string) {}
 			tt := tt
 			t.Run(tt.Name, func(t *testing.T) {
 				t.Parallel()
-				p.Languages = tt.Languages
+
+				p := &protocol.PatternInfo{
+					Pattern:         "foo(:[args])",
+					IncludePatterns: []string{"file_without_extension"},
+					Languages:       tt.Languages,
+				}
+
 				matches, _, err := structuralSearch(context.Background(), zf, Subset(p.IncludePatterns), "", p.Pattern, p.CombyRule, p.Languages, "repo_foo")
 				if err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
We noticed that searcher tests took a few seconds locally. This was
surprising, so we investigated and it seems it is dominated by the cost
of starting comby multiple times. This PR moves to using parallel
testing to hide some of the costs. Part of this was moving away from
autogold in one test to allow parallel subtests.

Co-authored-by: @stefanhengl 