### PR TITLE
web: mock `_.uniqueId()` in tests

### DIFF
--- a/client/browser/src/shared/code-hosts/shared/__snapshots__/codeHost.test.tsx.snap
+++ b/client/browser/src/shared/code-hosts/shared/__snapshots__/codeHost.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`codeHost handleCodeHost() Decorations decorates a diff code view 1`] = `
 <div
-  class="test test-6 sg-mounted"
+  class="test test-test-id sg-mounted"
   id="code"
 >
   <div
@@ -91,7 +91,7 @@ exports[`codeHost handleCodeHost() Decorations decorates a diff code view 1`] = 
 
 exports[`codeHost handleCodeHost() Decorations decorates a diff code view 2`] = `
 <div
-  class="test test-6 sg-mounted"
+  class="test test-test-id sg-mounted"
   id="code"
 >
   <div
@@ -173,7 +173,7 @@ exports[`codeHost handleCodeHost() Decorations decorates a diff code view 2`] = 
 
 exports[`codeHost handleCodeHost() Decorations decorates a diff code view 3`] = `
 <div
-  class="test test-6 sg-mounted"
+  class="test test-test-id sg-mounted"
   id="code"
 >
   <div

--- a/client/shared/dev/mockUniqueId.ts
+++ b/client/shared/dev/mockUniqueId.ts
@@ -1,0 +1,7 @@
+// The value returned by the `_.uniqueId()` function depends on the number of previous calls
+// because it maintains an internal variable that increments on each call.
+// Mock `_.uniqueId()` to avoid updating snapshots once the sequence or number of tests using this helper changes.
+
+// The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables
+// eslint-disable-next-line unicorn/consistent-function-scoping
+jest.mock('lodash/uniqueId', () => (prefix = '') => `${prefix}test-id`)

--- a/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
+++ b/client/web/src/nav/__snapshots__/NavLinks.test.tsx.snap
@@ -538,7 +538,7 @@ exports[`NavLinks authed Sourcegraph.com /foo 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-7"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg
@@ -1328,7 +1328,7 @@ exports[`NavLinks authed Sourcegraph.com /search 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-8"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg
@@ -2128,7 +2128,7 @@ exports[`NavLinks authed self-hosted /foo 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-5"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg
@@ -2899,7 +2899,7 @@ exports[`NavLinks authed self-hosted /search 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-6"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg
@@ -3439,7 +3439,7 @@ exports[`NavLinks unauthed Sourcegraph.com /foo 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-3"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg
@@ -3776,7 +3776,7 @@ exports[`NavLinks unauthed Sourcegraph.com /search 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-4"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg
@@ -4080,7 +4080,7 @@ exports[`NavLinks unauthed self-hosted /foo 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-1"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg
@@ -4374,7 +4374,7 @@ exports[`NavLinks unauthed self-hosted /search 1`] = `
   >
     <span
       class="test-command-list-button command-list__popover-button btn btn-link"
-      id="command-list-popover-button-2"
+      id="command-list-popover-button-test-id"
       role="button"
     >
       <svg

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -57,6 +57,7 @@ const config = {
     require.resolve('abort-controller/polyfill'),
     path.join(__dirname, 'client/shared/dev/fetch'),
     path.join(__dirname, 'client/shared/dev/setLinkComponentForTest.ts'),
+    path.join(__dirname, 'client/shared/dev/mockUniqueId.ts'),
     // Enzyme setup file
     path.join(__dirname, 'client/shared/dev/enzymeSetup.js'),
   ],


### PR DESCRIPTION
## Changes

- Mocked `_.uniqueId()` in tests to avoid updating snapshots once the sequence or number of tests using this helper changes. The value returned by `_.uniqueId()` depends on the number of previous calls because it maintains an internal variable that increments on each call.
- Updated snapshots with mocked values.

Encountered this issue in the PR: https://github.com/sourcegraph/sourcegraph/pull/21347.