### PR TITLE
Refactor auth helpers to receive DB as param

### DIFF
--- a/cmd/frontend/backend/orgs.go
+++ b/cmd/frontend/backend/orgs.go
@@ -35,7 +35,7 @@ func checkOrgAccess(ctx context.Context, db dbutil.DB, orgID int32, allowAdmin b
 	if hasAuthzBypass(ctx) {
 		return nil
 	}
-	currentUser, err := CurrentUser(ctx)
+	currentUser, err := CurrentUser(ctx, db)
 	if err != nil {
 		return err
 	}

--- a/cmd/frontend/graphqlbackend/access_token.go
+++ b/cmd/frontend/graphqlbackend/access_token.go
@@ -35,7 +35,7 @@ func accessTokenByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*accessT
 		return nil, err
 	}
 	// 🚨 SECURITY: Only the user (token owner) and site admins may retrieve the token.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, accessToken.SubjectUserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, db, accessToken.SubjectUserID); err != nil {
 		return nil, err
 	}
 	return &accessTokenResolver{db: db, accessToken: *accessToken}, nil

--- a/cmd/frontend/graphqlbackend/access_tokens.go
+++ b/cmd/frontend/graphqlbackend/access_tokens.go
@@ -44,7 +44,7 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 	case conf.AccessTokensAdmin:
 		// 🚨 SECURITY: The site has opted in to only allow site admins to create access
 		// tokens. In this case, they can create a token for any user.
-		if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 			return nil, errors.New("Access token creation has been restricted to admin users. Contact an admin user to create a new access token.")
 		}
 	case conf.AccessTokensNone:
@@ -63,7 +63,7 @@ func (r *schemaResolver) CreateAccessToken(ctx context.Context, args *createAcce
 			hasUserAllScope = true
 		case authz.ScopeSiteAdminSudo:
 			// 🚨 SECURITY: Only site admins may create a token with the "site-admin:sudo" scope.
-			if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+			if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 				return nil, err
 			} else if envvar.SourcegraphDotComMode() {
 				return nil, errors.New("creation of access tokens with sudo scope is disabled")
@@ -127,7 +127,7 @@ func (r *schemaResolver) DeleteAccessToken(ctx context.Context, args *deleteAcce
 		subjectUserID = token.SubjectUserID
 
 		// 🚨 SECURITY: Only site admins and the user can delete a user's access token.
-		if err := backend.CheckSiteAdminOrSameUser(ctx, token.SubjectUserID); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, token.SubjectUserID); err != nil {
 			return nil, err
 		}
 		if err := database.AccessTokens(r.db).DeleteByID(ctx, token.ID, token.SubjectUserID); err != nil {
@@ -163,7 +163,7 @@ func (r *siteResolver) AccessTokens(ctx context.Context, args *struct {
 }) (*accessTokenConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins can list all access tokens. This is safe as the
 	// token values themselves are not stored in our database.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -176,7 +176,7 @@ func (r *UserResolver) AccessTokens(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 }) (*accessTokenConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins and the user can list a user's access tokens.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/event_logs.go
+++ b/cmd/frontend/graphqlbackend/event_logs.go
@@ -14,7 +14,7 @@ func (r *UserResolver) EventLogs(ctx context.Context, args *struct {
 	EventName *string // return only event logs matching the event name
 }) (*userEventLogsConnectionResolver, error) {
 	// 🚨 SECURITY: Event logs can only be viewed by the user or site admin.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 		return nil, err
 	}
 	var opt database.EventLogsListOptions

--- a/cmd/frontend/graphqlbackend/external_account.go
+++ b/cmd/frontend/graphqlbackend/external_account.go
@@ -29,7 +29,7 @@ func externalAccountByID(ctx context.Context, db dbutil.DB, id graphql.ID) (*ext
 	}
 
 	// 🚨 SECURITY: Only the user and site admins should be able to see a user's external accounts.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, account.UserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, db, account.UserID); err != nil {
 		return nil, err
 	}
 
@@ -69,9 +69,9 @@ func (r *externalAccountResolver) AccountData(ctx context.Context) (*JSONValue, 
 	// GitLab, but only site admins can view account data for all other types.
 	var err error
 	if r.account.ServiceType == extsvc.TypeGitHub || r.account.ServiceType == extsvc.TypeGitLab {
-		err = backend.CheckSiteAdminOrSameUser(ctx, actor.FromContext(ctx).UID)
+		err = backend.CheckSiteAdminOrSameUser(ctx, r.db, actor.FromContext(ctx).UID)
 	} else {
-		err = backend.CheckUserIsSiteAdmin(ctx, actor.FromContext(ctx).UID)
+		err = backend.CheckUserIsSiteAdmin(ctx, r.db, actor.FromContext(ctx).UID)
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/frontend/graphqlbackend/external_accounts.go
+++ b/cmd/frontend/graphqlbackend/external_accounts.go
@@ -21,7 +21,7 @@ func (r *siteResolver) ExternalAccounts(ctx context.Context, args *struct {
 	ClientID    *string
 }) (*externalAccountConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins can list all external accounts.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -50,7 +50,7 @@ func (r *UserResolver) ExternalAccounts(ctx context.Context, args *struct {
 	graphqlutil.ConnectionArgs
 }) (*externalAccountConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins and the user can list a user's external accounts.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +128,7 @@ func (r *schemaResolver) DeleteExternalAccount(ctx context.Context, args *struct
 	}
 
 	// 🚨 SECURITY: Only the user and site admins should be able to see a user's external accounts.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, account.UserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, account.UserID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -40,7 +40,7 @@ func externalServiceByID(ctx context.Context, db dbutil.DB, gqlID graphql.ID) (*
 		return nil, err
 	}
 
-	if err := checkExternalServiceAccess(ctx, es.NamespaceUserID); err != nil {
+	if err := checkExternalServiceAccess(ctx, db, es.NamespaceUserID); err != nil {
 		return nil, err
 	}
 	return &externalServiceResolver{db: db, externalService: es}, nil

--- a/cmd/frontend/graphqlbackend/observability.go
+++ b/cmd/frontend/graphqlbackend/observability.go
@@ -25,7 +25,7 @@ func (r *schemaResolver) TriggerObservabilityTestAlert(ctx context.Context, args
 	Level string
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Do not allow arbitrary users to set off alerts.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/oobmigrations.go
+++ b/cmd/frontend/graphqlbackend/oobmigrations.go
@@ -13,7 +13,7 @@ import (
 // OutOfBandMigrationByID resolves a single out-of-band migration by its identifier.
 func (r *schemaResolver) OutOfBandMigrationByID(ctx context.Context, id graphql.ID) (*outOfBandMigrationResolver, error) {
 	// 🚨 SECURITY: Only site admins may view out-of-band migrations
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -33,7 +33,7 @@ func (r *schemaResolver) OutOfBandMigrationByID(ctx context.Context, id graphql.
 // OutOfBandMigrations resolves all registered single out-of-band migrations.
 func (r *schemaResolver) OutOfBandMigrations(ctx context.Context) ([]*outOfBandMigrationResolver, error) {
 	// 🚨 SECURITY: Only site admins may view out-of-band migrations
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -56,7 +56,7 @@ func (r *schemaResolver) SetMigrationDirection(ctx context.Context, args *struct
 	ApplyReverse bool
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins may modify out-of-band migrations
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/org.go
+++ b/cmd/frontend/graphqlbackend/org.go
@@ -268,7 +268,7 @@ func (r *schemaResolver) AddUserToOrganization(ctx context.Context, args *struct
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Must be a site admin to immediately add a user to an organization (bypassing the
 	// invitation step).
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/orgs.go
+++ b/cmd/frontend/graphqlbackend/orgs.go
@@ -28,7 +28,7 @@ type orgConnectionResolver struct {
 
 func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, error) {
 	// 🚨 SECURITY: Only site admins can list organisations.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -49,7 +49,7 @@ func (r *orgConnectionResolver) Nodes(ctx context.Context) ([]*OrgResolver, erro
 
 func (r *orgConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can count organisations.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -101,7 +101,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 
 		if envvar.SourcegraphDotComMode() {
 			// 🚨 SECURITY: Don't allow non-admins to perform huge queries on Sourcegraph.com.
-			if isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil; !isSiteAdmin {
+			if isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil; !isSiteAdmin {
 				if opt2.LimitOffset == nil {
 					opt2.LimitOffset = &database.LimitOffset{Limit: 1000}
 				}
@@ -213,7 +213,7 @@ func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *Tot
 	} else {
 		// 🚨 SECURITY: Only site admins can list all repos, because a total repository
 		// count does not respect repository permissions.
-		if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+		if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -128,7 +128,7 @@ func (r *RepositoryResolver) Description(ctx context.Context) (string, error) {
 }
 
 func (r *RepositoryResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		if err == backend.ErrMustBeSiteAdmin || err == backend.ErrNotAuthenticated {
 			return false, nil // not an error
 		}

--- a/cmd/frontend/graphqlbackend/repository_external.go
+++ b/cmd/frontend/graphqlbackend/repository_external.go
@@ -45,7 +45,7 @@ func (r *RepositoryResolver) ExternalServices(ctx context.Context, args *struct 
 	graphqlutil.ConnectionArgs
 }) (*computedExternalServiceConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins may read external services (they have secrets).
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/repository_stats.go
+++ b/cmd/frontend/graphqlbackend/repository_stats.go
@@ -22,7 +22,7 @@ func (r *repositoryStatsResolver) IndexedLinesCount() BigInt {
 
 func (r *schemaResolver) RepositoryStats(ctx context.Context) (*repositoryStatsResolver, error) {
 	// 🚨 SECURITY: Only site admins may query repository statistics for the site.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/saved_searches.go
+++ b/cmd/frontend/graphqlbackend/saved_searches.go
@@ -137,7 +137,7 @@ func (r *schemaResolver) SendSavedSearchTestNotification(ctx context.Context, ar
 	ID graphql.ID
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins should be able to send test notifications.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 	id, err := unmarshalSavedSearchID(args.ID)
@@ -169,7 +169,7 @@ func (r *schemaResolver) CreateSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 		userID = &u
-		if err := backend.CheckSiteAdminOrSameUser(ctx, u); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, u); err != nil {
 			return nil, err
 		}
 	} else if args.OrgID != nil {
@@ -221,7 +221,7 @@ func (r *schemaResolver) UpdateSavedSearch(ctx context.Context, args *struct {
 			return nil, err
 		}
 		userID = &u
-		if err := backend.CheckSiteAdminOrSameUser(ctx, u); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, u); err != nil {
 			return nil, err
 		}
 	} else if args.OrgID != nil {
@@ -275,7 +275,7 @@ func (r *schemaResolver) DeleteSavedSearch(ctx context.Context, args *struct {
 	}
 	// 🚨 SECURITY: Make sure the current user has permission to delete a saved search for the specified user or org.
 	if ss.Config.UserID != nil {
-		if err := backend.CheckSiteAdminOrSameUser(ctx, *ss.Config.UserID); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, *ss.Config.UserID); err != nil {
 			return nil, err
 		}
 	} else if ss.Config.OrgID != nil {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -319,7 +319,7 @@ func (r *searchResolver) alertForNoResolvedRepos(ctx context.Context) *searchAle
 		}
 
 	case len(repoGroupFilters) == 0 && len(repoFilters) == 1:
-		isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx) == nil
+		isSiteAdmin := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil
 		if !envvar.SourcegraphDotComMode() {
 			if needsRepoConfig, err := needsRepositoryConfiguration(ctx, r.db); err == nil && needsRepoConfig {
 				if isSiteAdmin {
@@ -426,7 +426,7 @@ func (r *searchResolver) alertForOverRepoLimit(ctx context.Context) *searchAlert
 	if envvar.SourcegraphDotComMode() {
 		description = "Use a 'repo:' or 'repogroup:' filter to narrow your search and see results or set up a self-hosted Sourcegraph instance to search an unlimited number of repositories."
 	}
-	if backend.CheckCurrentUserIsSiteAdmin(ctx) == nil {
+	if backend.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil {
 		description += " As a site admin, you can increase the limit by changing maxReposToSearch in site config."
 	}
 

--- a/cmd/frontend/graphqlbackend/search_contexts.go
+++ b/cmd/frontend/graphqlbackend/search_contexts.go
@@ -446,7 +446,7 @@ func resolveVersionContext(versionContext string) (*schema.VersionContext, error
 func (r *schemaResolver) ConvertVersionContextToSearchContext(ctx context.Context, args *struct {
 	Name string
 }) (*searchContextResolver, error) {
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, errors.New("converting a version context to a search context is limited to site admins")
 	}
 	versionContext, err := resolveVersionContext(args.Name)

--- a/cmd/frontend/graphqlbackend/set_external_service_repos.go
+++ b/cmd/frontend/graphqlbackend/set_external_service_repos.go
@@ -31,7 +31,7 @@ func (r *schemaResolver) SetExternalServiceRepos(ctx context.Context, args struc
 	}
 
 	// 🚨 SECURITY: make sure the user is either site admin or the same user being requested
-	if err := backend.CheckSiteAdminOrSameUser(ctx, es.NamespaceUserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, es.NamespaceUserID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/settings_subject.go
+++ b/cmd/frontend/graphqlbackend/settings_subject.go
@@ -39,7 +39,7 @@ func settingsSubjectForNode(ctx context.Context, n Node) (*settingsSubject, erro
 
 	case *UserResolver:
 		// 🚨 SECURITY: Only the user and site admins are allowed to view the user's settings.
-		if err := backend.CheckSiteAdminOrSameUser(ctx, s.user.ID); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, s.db, s.user.ID); err != nil {
 			return nil, err
 		}
 		return &settingsSubject{user: s}, nil

--- a/cmd/frontend/graphqlbackend/site_admin.go
+++ b/cmd/frontend/graphqlbackend/site_admin.go
@@ -18,7 +18,7 @@ func (r *schemaResolver) DeleteUser(ctx context.Context, args *struct {
 	Hard *bool
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can delete users.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -101,7 +101,7 @@ func (r *schemaResolver) DeleteOrganization(ctx context.Context, args *struct {
 	Organization graphql.ID
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can delete orgs.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -122,7 +122,7 @@ func (r *schemaResolver) SetUserIsSiteAdmin(ctx context.Context, args *struct {
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins can promote other users to site admin (or demote from site
 	// admin).
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +149,7 @@ func (r *schemaResolver) InvalidateSessionsByID(ctx context.Context, args *struc
 	UserID graphql.ID
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only the site admin can invalidate the sessions of a user
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 	userID, err := UnmarshalUserID(args.UserID)

--- a/cmd/frontend/graphqlbackend/site_alerts.go
+++ b/cmd/frontend/graphqlbackend/site_alerts.go
@@ -69,7 +69,7 @@ func (r *siteResolver) Alerts(ctx context.Context) ([]*Alert, error) {
 
 	args := AlertFuncArgs{
 		IsAuthenticated:     actor.FromContext(ctx).IsAuthenticated(),
-		IsSiteAdmin:         backend.CheckCurrentUserIsSiteAdmin(ctx) == nil,
+		IsSiteAdmin:         backend.CheckCurrentUserIsSiteAdmin(ctx, r.db) == nil,
 		ViewerFinalSettings: settings,
 	}
 

--- a/cmd/frontend/graphqlbackend/site_flags.go
+++ b/cmd/frontend/graphqlbackend/site_flags.go
@@ -18,7 +18,7 @@ func (r *siteResolver) NeedsRepositoryConfiguration(ctx context.Context) (bool, 
 
 	// 🚨 SECURITY: The site alerts may contain sensitive data, so only site
 	// admins may view them.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		// TODO(dax): This should return err once the site flags query is fixed for users
 		return false, nil
 	}

--- a/cmd/frontend/graphqlbackend/site_reload.go
+++ b/cmd/frontend/graphqlbackend/site_reload.go
@@ -20,7 +20,7 @@ var canReloadSite = processrestart.CanRestart()
 func (r *schemaResolver) ReloadSite(ctx context.Context) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Reloading the site is an interruptive action, so only admins
 	// may do it.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/site_update_check.go
+++ b/cmd/frontend/graphqlbackend/site_update_check.go
@@ -10,7 +10,7 @@ import (
 
 func (r *siteResolver) UpdateCheck(ctx context.Context) (*updateCheckResolver, error) {
 	// 🚨 SECURITY: Only site admins can check for updates.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		// TODO(dax): This should return err once the site flags query is fixed for users
 		return &updateCheckResolver{
 			last: &updatecheck.Status{

--- a/cmd/frontend/graphqlbackend/status_messages.go
+++ b/cmd/frontend/graphqlbackend/status_messages.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (r *schemaResolver) StatusMessages(ctx context.Context) ([]*statusMessageResolver, error) {
-	currentUser, err := backend.CurrentUser(ctx)
+	currentUser, err := backend.CurrentUser(ctx, r.db)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/survey_responses.go
+++ b/cmd/frontend/graphqlbackend/survey_responses.go
@@ -24,7 +24,7 @@ func (r *schemaResolver) SurveyResponses(args *struct {
 
 func (r *surveyResponseConnectionResolver) Nodes(ctx context.Context) ([]*surveyResponseResolver, error) {
 	// 🚨 SECURITY: Survey responses can only be viewed by site admins.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -43,7 +43,7 @@ func (r *surveyResponseConnectionResolver) Nodes(ctx context.Context) ([]*survey
 
 func (r *surveyResponseConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can count survey responses.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 
@@ -53,7 +53,7 @@ func (r *surveyResponseConnectionResolver) TotalCount(ctx context.Context) (int3
 
 func (r *surveyResponseConnectionResolver) AverageScore(ctx context.Context) (float64, error) {
 	// 🚨 SECURITY: Only site admins can see average scores.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 	return database.SurveyResponses(r.db).Last30DaysAverageScore(ctx)
@@ -61,7 +61,7 @@ func (r *surveyResponseConnectionResolver) AverageScore(ctx context.Context) (fl
 
 func (r *surveyResponseConnectionResolver) NetPromoterScore(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can see net promoter scores.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 	nps, err := database.SurveyResponses(r.db).Last30DaysNetPromoterScore(ctx)
@@ -70,7 +70,7 @@ func (r *surveyResponseConnectionResolver) NetPromoterScore(ctx context.Context)
 
 func (r *surveyResponseConnectionResolver) Last30DaysCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can count survey responses.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 	count, err := database.SurveyResponses(r.db).Last30DaysCount(ctx)

--- a/cmd/frontend/graphqlbackend/tags.go
+++ b/cmd/frontend/graphqlbackend/tags.go
@@ -16,7 +16,7 @@ func (r *schemaResolver) SetTag(ctx context.Context, args *struct {
 	Present bool
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins may set tags.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/user_emails.go
+++ b/cmd/frontend/graphqlbackend/user_emails.go
@@ -19,7 +19,7 @@ var timeNow = time.Now
 
 func (r *UserResolver) Emails(ctx context.Context) ([]*userEmailResolver, error) {
 	// 🚨 SECURITY: Only the self user and site admins can fetch a user's emails.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 		return nil, err
 	}
 
@@ -64,7 +64,7 @@ func (r *userEmailResolver) VerificationPending() bool {
 func (r *userEmailResolver) User() *UserResolver { return r.user }
 
 func (r *userEmailResolver) ViewerCanManuallyVerify(ctx context.Context) (bool, error) {
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err == backend.ErrNotAuthenticated || err == backend.ErrMustBeSiteAdmin {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err == backend.ErrNotAuthenticated || err == backend.ErrMustBeSiteAdmin {
 		return false, nil
 	} else if err != nil {
 		return false, err
@@ -80,7 +80,7 @@ func (r *schemaResolver) AddUserEmail(ctx context.Context, args *struct {
 	if err != nil {
 		return nil, err
 	}
-	if err := backend.UserEmails.Add(ctx, userID, args.Email); err != nil {
+	if err := backend.UserEmails.Add(ctx, r.db, userID, args.Email); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (r *schemaResolver) RemoveUserEmail(ctx context.Context, args *struct {
 	}
 
 	// 🚨 SECURITY: Only the user and site admins can remove an email address from a user.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, userID); err != nil {
 		return nil, err
 	}
 
@@ -135,7 +135,7 @@ func (r *schemaResolver) SetUserEmailPrimary(ctx context.Context, args *struct {
 	}
 
 	// 🚨 SECURITY: Only the user and site admins can set the primary email address from a user.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, userID); err != nil {
 		return nil, err
 	}
 
@@ -159,7 +159,7 @@ func (r *schemaResolver) SetUserEmailVerified(ctx context.Context, args *struct 
 }) (*EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins (NOT users themselves) can manually set email verification
 	// status. Users themselves must go through the normal email verification process.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -194,7 +194,7 @@ func (r *schemaResolver) ResendVerificationEmail(ctx context.Context, args *stru
 		return nil, err
 	}
 	// 🚨 SECURITY: Only the user and site admins can set the primary email address from a user.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, userID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, userID); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/user_usage_stats.go
+++ b/cmd/frontend/graphqlbackend/user_usage_stats.go
@@ -22,7 +22,7 @@ import (
 
 func (r *UserResolver) UsageStatistics(ctx context.Context) (*userUsageStatisticsResolver, error) {
 	if envvar.SourcegraphDotComMode() {
-		if err := backend.CheckSiteAdminOrSameUser(ctx, r.user.ID); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, r.db, r.user.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/frontend/graphqlbackend/users.go
+++ b/cmd/frontend/graphqlbackend/users.go
@@ -89,7 +89,7 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, in
 
 func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, error) {
 	// 🚨 SECURITY: Only site admins can list users.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -116,7 +116,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*UserResolver, er
 
 func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins can count users.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return 0, err
 	}
 

--- a/cmd/frontend/graphqlbackend/users_create.go
+++ b/cmd/frontend/graphqlbackend/users_create.go
@@ -20,7 +20,7 @@ func (r *schemaResolver) CreateUser(ctx context.Context, args *struct {
 	Email    *string
 }) (*createUserResult, error) {
 	// 🚨 SECURITY: Only site admins can create user accounts.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/graphqlbackend/users_randomize_password.go
+++ b/cmd/frontend/graphqlbackend/users_randomize_password.go
@@ -35,7 +35,7 @@ func (r *schemaResolver) RandomizeUserPassword(ctx context.Context, args *struct
 	User graphql.ID
 }) (*randomizeUserPasswordResult, error) {
 	// 🚨 SECURITY: Only site admins can randomize user passwords.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/cmd/frontend/internal/app/debug.go
+++ b/cmd/frontend/internal/app/debug.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/debugproxies"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	srcprometheus "github.com/sourcegraph/sourcegraph/internal/src-prometheus"
@@ -155,7 +156,7 @@ func addJaeger(r *mux.Router) {
 // adminOnly is a HTTP middleware which only allows requests by admins.
 func adminOnly(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), dbconn.Global); err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}

--- a/cmd/frontend/internal/app/debugproxies/handler.go
+++ b/cmd/frontend/internal/app/debugproxies/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/app/errorutil"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 )
@@ -145,7 +146,7 @@ func reverseProxyFromHost(host string, pathPrefix string) http.Handler {
 // adminOnly is a HTTP middleware which only allows requests by admins.
 func adminOnly(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), dbconn.Global); err != nil {
 			http.Error(w, err.Error(), http.StatusUnauthorized)
 			return
 		}

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/siteid"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/globalstatedb"
 	"github.com/sourcegraph/sourcegraph/internal/env"
 	"github.com/sourcegraph/sourcegraph/internal/lazyregexp"
@@ -140,7 +141,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 	// Check if batch changes are enabled for this user.
 	batchChangesEnabled := conf.BatchChangesEnabled()
-	if conf.BatchChangesRestrictedToAdmins() && backend.CheckCurrentUserIsSiteAdmin(req.Context()) != nil {
+	if conf.BatchChangesRestrictedToAdmins() && backend.CheckCurrentUserIsSiteAdmin(req.Context(), dbconn.Global) != nil {
 		batchChangesEnabled = false
 	}
 

--- a/cmd/frontend/internal/app/ping.go
+++ b/cmd/frontend/internal/app/ping.go
@@ -17,7 +17,7 @@ import (
 func latestPingHandler(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 🚨SECURITY: Only site admins may access ping data.
-		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}

--- a/cmd/frontend/internal/app/usage_stats.go
+++ b/cmd/frontend/internal/app/usage_stats.go
@@ -13,7 +13,7 @@ import (
 func usageStatsArchiveHandler(db dbutil.DB) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// 🚨SECURITY: Only site admins may get this archive.
-		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context()); err != nil {
+		if err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), db); err != nil {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}

--- a/cmd/frontend/internal/httpapi/auth.go
+++ b/cmd/frontend/internal/httpapi/auth.go
@@ -83,7 +83,7 @@ func AccessTokenAuthMiddleware(db dbutil.DB, next http.Handler) http.Handler {
 			} else {
 				// 🚨 SECURITY: Confirm that the sudo token's subject is still a site admin, to
 				// prevent users from retaining site admin privileges after being demoted.
-				if err := backend.CheckUserIsSiteAdmin(r.Context(), subjectUserID); err != nil {
+				if err := backend.CheckUserIsSiteAdmin(r.Context(), db, subjectUserID); err != nil {
 					log15.Error("Sudo access token's subject is not a site admin.", "subjectUserID", subjectUserID, "err", err)
 					http.Error(w, "The subject user of a sudo access token must be a site admin.", http.StatusForbidden)
 					return

--- a/enterprise/cmd/frontend/internal/authz/init.go
+++ b/enterprise/cmd/frontend/internal/authz/init.go
@@ -109,7 +109,7 @@ func Init(ctx context.Context, db dbutil.DB, outOfBandMigrationRunner *oobmigrat
 			// Site admins are exempt from license enforcement screens so that they can
 			// easily update the license key. Also ignore backend.ErrNotAuthenticated
 			// because we need to allow site admins to sign in.
-			err := backend.CheckCurrentUserIsSiteAdmin(r.Context())
+			err := backend.CheckCurrentUserIsSiteAdmin(r.Context(), db)
 			if err == nil || err == backend.ErrNotAuthenticated {
 				next.ServeHTTP(w, r)
 				return

--- a/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/repositories.go
@@ -76,7 +76,7 @@ func (r *repositoryConnectionResolver) compute(ctx context.Context) ([]*types.Re
 
 func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbackend.RepositoryResolver, error) {
 	// 🚨 SECURITY: Only site admins may access this method.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +93,7 @@ func (r *repositoryConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbac
 
 func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *graphqlbackend.TotalCountArgs) (*int32, error) {
 	// 🚨 SECURITY: Only site admins may access this method.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -103,7 +103,7 @@ func (r *repositoryConnectionResolver) TotalCount(ctx context.Context, args *gra
 
 func (r *repositoryConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
 	// 🚨 SECURITY: Only site admins may access this method.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver.go
@@ -73,7 +73,7 @@ func (r *Resolver) SetRepositoryPermissionsForUsers(ctx context.Context, args *g
 	}
 
 	// 🚨 SECURITY: Only site admins can mutate repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 
@@ -166,7 +166,7 @@ func (r *Resolver) ScheduleRepositoryPermissionsSync(ctx context.Context, args *
 	}
 
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 
@@ -190,7 +190,7 @@ func (r *Resolver) ScheduleUserPermissionsSync(ctx context.Context, args *graphq
 	}
 
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 
@@ -214,7 +214,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 	}
 
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 
@@ -275,7 +275,7 @@ func (r *Resolver) AuthorizedUserRepositories(ctx context.Context, args *graphql
 
 func (r *Resolver) UsersWithPendingPermissions(ctx context.Context) ([]string, error) {
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 
@@ -284,7 +284,7 @@ func (r *Resolver) UsersWithPendingPermissions(ctx context.Context) ([]string, e
 
 func (r *Resolver) AuthorizedUsers(ctx context.Context, args *graphqlbackend.RepoAuthorizedUserArgs) (graphqlbackend.UserConnectionResolver, error) {
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 
@@ -341,7 +341,7 @@ func (r *permissionsInfoResolver) UpdatedAt() graphqlbackend.DateTime {
 
 func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID) (graphqlbackend.PermissionsInfoResolver, error) {
 	// 🚨 SECURITY: Only site admins can query repository permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 
@@ -376,7 +376,7 @@ func (r *Resolver) RepositoryPermissionsInfo(ctx context.Context, id graphql.ID)
 
 func (r *Resolver) UserPermissionsInfo(ctx context.Context, id graphql.ID) (graphqlbackend.PermissionsInfoResolver, error) {
 	// 🚨 SECURITY: Only site admins can query user permissions.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB()); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/resolver_test.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -21,6 +22,8 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/authz"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/basestore"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
@@ -64,7 +67,7 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 		}()
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).SetRepositoryPermissionsForUsers(ctx, &graphqlbackend.RepoPermsArgs{})
+		result, err := (&Resolver{store: &edb.PermsStore{Store: basestore.NewWithDB(nil, sql.TxOptions{})}}).SetRepositoryPermissionsForUsers(ctx, &graphqlbackend.RepoPermsArgs{})
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -212,6 +215,8 @@ func TestResolver_SetRepositoryPermissionsForUsers(t *testing.T) {
 }
 
 func TestResolver_ScheduleRepositoryPermissionsSync(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return &types.User{}, nil
@@ -221,7 +226,7 @@ func TestResolver_ScheduleRepositoryPermissionsSync(t *testing.T) {
 		})
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).ScheduleRepositoryPermissionsSync(ctx, &graphqlbackend.RepositoryIDArgs{})
+		result, err := (&Resolver{store: edb.Perms(db, timeutil.Now)}).ScheduleRepositoryPermissionsSync(ctx, &graphqlbackend.RepositoryIDArgs{})
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -238,6 +243,7 @@ func TestResolver_ScheduleRepositoryPermissionsSync(t *testing.T) {
 	})
 
 	r := &Resolver{
+		store: edb.Perms(db, timeutil.Now),
 		repoupdaterClient: &fakeRepoupdaterClient{
 			mockSchedulePermsSync: func(ctx context.Context, args protocol.PermsSyncRequest) error {
 				if len(args.RepoIDs) != 1 {
@@ -256,6 +262,8 @@ func TestResolver_ScheduleRepositoryPermissionsSync(t *testing.T) {
 }
 
 func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return &types.User{}, nil
@@ -265,7 +273,7 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 		})
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).ScheduleUserPermissionsSync(ctx, &graphqlbackend.UserIDArgs{})
+		result, err := (&Resolver{store: edb.Perms(db, timeutil.Now)}).ScheduleUserPermissionsSync(ctx, &graphqlbackend.UserIDArgs{})
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -282,6 +290,7 @@ func TestResolver_ScheduleUserPermissionsSync(t *testing.T) {
 	})
 
 	r := &Resolver{
+		store: edb.Perms(db, timeutil.Now),
 		repoupdaterClient: &fakeRepoupdaterClient{
 			mockSchedulePermsSync: func(ctx context.Context, args protocol.PermsSyncRequest) error {
 				if len(args.UserIDs) != 1 {
@@ -308,6 +317,8 @@ func (c *fakeRepoupdaterClient) SchedulePermsSync(ctx context.Context, args prot
 }
 
 func TestResolver_AuthorizedUserRepositories(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return &types.User{}, nil
@@ -317,7 +328,7 @@ func TestResolver_AuthorizedUserRepositories(t *testing.T) {
 		}()
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).AuthorizedUserRepositories(ctx, &graphqlbackend.AuthorizedRepoArgs{})
+		result, err := (&Resolver{store: edb.Perms(db, timeutil.Now)}).AuthorizedUserRepositories(ctx, &graphqlbackend.AuthorizedRepoArgs{})
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -488,6 +499,8 @@ func TestResolver_AuthorizedUserRepositories(t *testing.T) {
 }
 
 func TestResolver_UsersWithPendingPermissions(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return &types.User{}, nil
@@ -497,7 +510,7 @@ func TestResolver_UsersWithPendingPermissions(t *testing.T) {
 		}()
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).UsersWithPendingPermissions(ctx)
+		result, err := (&Resolver{store: edb.Perms(db, timeutil.Now)}).UsersWithPendingPermissions(ctx)
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -551,6 +564,8 @@ func TestResolver_UsersWithPendingPermissions(t *testing.T) {
 }
 
 func TestResolver_AuthorizedUsers(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return &types.User{}, nil
@@ -560,7 +575,7 @@ func TestResolver_AuthorizedUsers(t *testing.T) {
 		}()
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).AuthorizedUsers(ctx, &graphqlbackend.RepoAuthorizedUserArgs{})
+		result, err := (&Resolver{store: edb.Perms(db, timeutil.Now)}).AuthorizedUsers(ctx, &graphqlbackend.RepoAuthorizedUserArgs{})
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -639,6 +654,8 @@ func TestResolver_AuthorizedUsers(t *testing.T) {
 }
 
 func TestResolver_RepositoryPermissionsInfo(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return &types.User{}, nil
@@ -648,7 +665,7 @@ func TestResolver_RepositoryPermissionsInfo(t *testing.T) {
 		})
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).RepositoryPermissionsInfo(ctx, graphqlbackend.MarshalRepositoryID(1))
+		result, err := (&Resolver{store: edb.Perms(db, timeutil.Now)}).RepositoryPermissionsInfo(ctx, graphqlbackend.MarshalRepositoryID(1))
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}
@@ -719,6 +736,8 @@ func TestResolver_RepositoryPermissionsInfo(t *testing.T) {
 }
 
 func TestResolver_UserPermissionsInfo(t *testing.T) {
+	db := dbtest.NewDB(t, "")
+
 	t.Run("authenticated as non-admin", func(t *testing.T) {
 		database.Mocks.Users.GetByCurrentAuthUser = func(context.Context) (*types.User, error) {
 			return &types.User{}, nil
@@ -728,7 +747,7 @@ func TestResolver_UserPermissionsInfo(t *testing.T) {
 		})
 
 		ctx := actor.WithActor(context.Background(), &actor.Actor{UID: 1})
-		result, err := (&Resolver{}).UserPermissionsInfo(ctx, graphqlbackend.MarshalRepositoryID(1))
+		result, err := (&Resolver{store: edb.Perms(db, timeutil.Now)}).UserPermissionsInfo(ctx, graphqlbackend.MarshalRepositoryID(1))
 		if want := backend.ErrMustBeSiteAdmin; err != want {
 			t.Errorf("err: want %q but got %v", want, err)
 		}

--- a/enterprise/cmd/frontend/internal/authz/resolvers/users.go
+++ b/enterprise/cmd/frontend/internal/authz/resolvers/users.go
@@ -76,7 +76,7 @@ func (r *userConnectionResolver) compute(ctx context.Context) ([]*types.User, *g
 
 func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbackend.UserResolver, error) {
 	// 🚨 SECURITY: Only site admins may access this method.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 
@@ -93,7 +93,7 @@ func (r *userConnectionResolver) Nodes(ctx context.Context) ([]*graphqlbackend.U
 
 func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) {
 	// 🚨 SECURITY: Only site admins may access this method.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return -1, err
 	}
 
@@ -102,7 +102,7 @@ func (r *userConnectionResolver) TotalCount(ctx context.Context) (int32, error) 
 
 func (r *userConnectionResolver) PageInfo(ctx context.Context) (*graphqlutil.PageInfo, error) {
 	// 🚨 SECURITY: Only site admins may access this method.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/execution_log_entry.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/execution_log_entry.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	gql "github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/workerutil"
 )
 
@@ -28,7 +29,7 @@ func (r *executionLogEntryResolver) DurationMilliseconds() int32 {
 
 func (r *executionLogEntryResolver) Out(ctx context.Context) (string, error) {
 	// 🚨 SECURITY: Only site admins can view executor log contents.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, dbconn.Global); err != nil {
 		if err != backend.ErrMustBeSiteAdmin {
 			return "", err
 		}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 )
 
@@ -80,7 +81,7 @@ func (r *Resolver) LSIFUploadsByRepo(ctx context.Context, args *gql.LSIFReposito
 
 func (r *Resolver) DeleteLSIFUpload(ctx context.Context, args *struct{ ID graphql.ID }) (*gql.EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins may delete LSIF data for now
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, dbconn.Global); err != nil {
 		return nil, err
 	}
 
@@ -144,7 +145,7 @@ func (r *Resolver) DeleteLSIFIndex(ctx context.Context, args *struct{ ID graphql
 	}
 
 	// 🚨 SECURITY: Only site admins may delete LSIF data for now
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, dbconn.Global); err != nil {
 		return nil, err
 	}
 
@@ -184,7 +185,7 @@ func (r *Resolver) UpdateRepositoryIndexConfiguration(ctx context.Context, args 
 	}
 
 	// 🚨 SECURITY: Only site admins may configure indexing jobs for now
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, dbconn.Global); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/dotcom/billing/customers_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/billing/customers_graphql.go
@@ -14,7 +14,7 @@ import (
 func (r BillingResolver) UserURLForSiteAdminBilling(ctx context.Context, userID int32) (*string, error) {
 	// 🚨 SECURITY: Only site admins may view the billing URL, because it may contain sensitive
 	// data or identifiers.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.DB); err != nil {
 		return nil, err
 	}
 	custID, err := dbBilling{db: r.DB}.getUserBillingCustomerID(ctx, userID)
@@ -30,7 +30,7 @@ func (r BillingResolver) UserURLForSiteAdminBilling(ctx context.Context, userID 
 
 func (r BillingResolver) SetUserBilling(ctx context.Context, args *graphqlbackend.SetUserBillingArgs) (*graphqlbackend.EmptyResponse, error) {
 	// 🚨 SECURITY: Only site admins may set a user's billing info.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.DB); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/invoices_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/invoices_graphql.go
@@ -74,7 +74,7 @@ func (r ProductSubscriptionLicensingResolver) PreviewProductSubscriptionInvoice(
 		}
 		// 🚨 SECURITY: Users may only preview invoices for their own product subscriptions. Site admins
 		// may preview invoices for all product subscriptions.
-		if err := backend.CheckSiteAdminOrSameUser(ctx, *accountUserID); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, r.DB, *accountUserID); err != nil {
 			return nil, err
 		}
 	} else {
@@ -132,7 +132,7 @@ func (r ProductSubscriptionLicensingResolver) PreviewProductSubscriptionInvoice(
 		}
 		// 🚨 SECURITY: Only site admins and the subscription's account owner may preview invoices
 		// for product subscriptions.
-		if err := backend.CheckSiteAdminOrSameUser(ctx, subToUpdate.v.UserID); err != nil {
+		if err := backend.CheckSiteAdminOrSameUser(ctx, r.DB, subToUpdate.v.UserID); err != nil {
 			return nil, err
 		}
 

--- a/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
+++ b/enterprise/cmd/frontend/internal/dotcom/productsubscription/licenses_graphql.go
@@ -52,7 +52,7 @@ func productLicenseByDBID(ctx context.Context, db dbutil.DB, id string) (*produc
 	if err != nil {
 		return nil, err
 	}
-	if err := backend.CheckSiteAdminOrSameUser(ctx, sub.v.UserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, db, sub.v.UserID); err != nil {
 		return nil, err
 	}
 
@@ -112,7 +112,7 @@ func generateProductLicenseForSubscription(ctx context.Context, db dbutil.DB, su
 
 func (r ProductSubscriptionLicensingResolver) GenerateProductLicenseForSubscription(ctx context.Context, args *graphqlbackend.GenerateProductLicenseForSubscriptionArgs) (graphqlbackend.ProductLicense, error) {
 	// 🚨 SECURITY: Only site admins may generate product licenses.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.DB); err != nil {
 		return nil, err
 	}
 	sub, err := productSubscriptionByID(ctx, r.DB, args.ProductSubscriptionID)
@@ -128,7 +128,7 @@ func (r ProductSubscriptionLicensingResolver) GenerateProductLicenseForSubscript
 
 func (r ProductSubscriptionLicensingResolver) ProductLicenses(ctx context.Context, args *graphqlbackend.ProductLicensesArgs) (graphqlbackend.ProductLicenseConnection, error) {
 	// 🚨 SECURITY: Only site admins may list product licenses.
-	if err := backend.CheckCurrentUserIsSiteAdmin(ctx); err != nil {
+	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.DB); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
+++ b/enterprise/cmd/frontend/internal/registry/publisher_graphql.go
@@ -140,7 +140,7 @@ func (p *registryPublisherID) viewerCanAdminister(ctx context.Context, db dbutil
 	switch {
 	case p.userID != 0:
 		// 🚨 SECURITY: Check that the current user is either the publisher or a site admin.
-		return backend.CheckSiteAdminOrSameUser(ctx, p.userID)
+		return backend.CheckSiteAdminOrSameUser(ctx, db, p.userID)
 	case p.orgID != 0:
 		// 🚨 SECURITY: Check that the current user is a member of the publisher org.
 		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, p.orgID)

--- a/enterprise/internal/batches/resolvers/batch_change.go
+++ b/enterprise/internal/batches/resolvers/batch_change.go
@@ -99,7 +99,7 @@ func (r *batchChangeResolver) SpecCreator(ctx context.Context) (*graphqlbackend.
 }
 
 func (r *batchChangeResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
-	return checkSiteAdminOrSameUser(ctx, r.batchChange.InitialApplierID)
+	return checkSiteAdminOrSameUser(ctx, r.store.DB(), r.batchChange.InitialApplierID)
 }
 
 func (r *batchChangeResolver) URL(ctx context.Context) (string, error) {

--- a/enterprise/internal/batches/resolvers/batch_spec.go
+++ b/enterprise/internal/batches/resolvers/batch_spec.go
@@ -196,7 +196,7 @@ func (r *batchSpecResolver) ExpiresAt() *graphqlbackend.DateTime {
 }
 
 func (r *batchSpecResolver) ViewerCanAdminister(ctx context.Context) (bool, error) {
-	return checkSiteAdminOrSameUser(ctx, r.batchSpec.UserID)
+	return checkSiteAdminOrSameUser(ctx, r.store.DB(), r.batchSpec.UserID)
 }
 
 type batchChangeDescriptionResolver struct {

--- a/enterprise/internal/batches/resolvers/changeset.go
+++ b/enterprise/internal/batches/resolvers/changeset.go
@@ -171,7 +171,7 @@ func (r *changesetResolver) BatchChanges(ctx context.Context, args *graphqlbacke
 		opts.Cursor = cursor
 	}
 
-	authErr := backend.CheckCurrentUserIsSiteAdmin(ctx)
+	authErr := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.DB())
 	if authErr != nil && authErr != backend.ErrMustBeSiteAdmin {
 		return nil, err
 	}

--- a/enterprise/internal/batches/service/service.go
+++ b/enterprise/internal/batches/service/service.go
@@ -262,7 +262,7 @@ func (s *Service) MoveBatchChange(ctx context.Context, opts MoveBatchChangeOpts)
 	}
 
 	// 🚨 SECURITY: Only the Author of the batch change can move it.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DB(), batchChange.InitialApplierID); err != nil {
 		return nil, err
 	}
 	// Check if current user has access to target namespace if set.
@@ -306,7 +306,7 @@ func (s *Service) CloseBatchChange(ctx context.Context, id int64, closeChangeset
 		return batchChange, nil
 	}
 
-	if err := backend.CheckSiteAdminOrSameUser(ctx, batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DB(), batchChange.InitialApplierID); err != nil {
 		return nil, err
 	}
 
@@ -352,7 +352,7 @@ func (s *Service) DeleteBatchChange(ctx context.Context, id int64) (err error) {
 		return err
 	}
 
-	if err := backend.CheckSiteAdminOrSameUser(ctx, batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DB(), batchChange.InitialApplierID); err != nil {
 		return err
 	}
 
@@ -394,7 +394,7 @@ func (s *Service) EnqueueChangesetSync(ctx context.Context, id int64) (err error
 	)
 
 	for _, c := range batchChanges {
-		err := backend.CheckSiteAdminOrSameUser(ctx, c.InitialApplierID)
+		err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DB(), c.InitialApplierID)
 		if err != nil {
 			authErr = err
 		} else {
@@ -449,7 +449,7 @@ func (s *Service) ReenqueueChangeset(ctx context.Context, id int64) (changeset *
 	)
 
 	for _, c := range attachedBatchChanges {
-		err := backend.CheckSiteAdminOrSameUser(ctx, c.InitialApplierID)
+		err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DB(), c.InitialApplierID)
 		if err != nil {
 			authErr = err
 		} else {
@@ -487,7 +487,7 @@ func checkNamespaceAccess(ctx context.Context, db dbutil.DB, namespaceUserID, na
 	if namespaceOrgID != 0 {
 		return backend.CheckOrgAccessOrSiteAdmin(ctx, db, namespaceOrgID)
 	} else if namespaceUserID != 0 {
-		return backend.CheckSiteAdminOrSameUser(ctx, namespaceUserID)
+		return backend.CheckSiteAdminOrSameUser(ctx, db, namespaceUserID)
 	} else {
 		return ErrNoNamespace
 	}
@@ -590,7 +590,7 @@ func (s *Service) CreateChangesetJobs(ctx context.Context, batchChangeID int64, 
 	}
 
 	// 🚨 SECURITY: Only the author of the batch change can create jobs.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, batchChange.InitialApplierID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DB(), batchChange.InitialApplierID); err != nil {
 		return bulkGroupID, err
 	}
 

--- a/enterprise/internal/batches/service/service_apply_batch_change.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change.go
@@ -60,7 +60,7 @@ func (s *Service) ApplyBatchChange(ctx context.Context, opts ApplyBatchChangeOpt
 	}
 
 	// 🚨 SECURITY: Only site-admins or the creator of batchSpec can apply it.
-	if err := backend.CheckSiteAdminOrSameUser(ctx, batchSpec.UserID); err != nil {
+	if err := backend.CheckSiteAdminOrSameUser(ctx, s.store.DB(), batchSpec.UserID); err != nil {
 		return nil, err
 	}
 

--- a/enterprise/internal/codemonitors/resolvers/resolvers.go
+++ b/enterprise/internal/codemonitors/resolvers/resolvers.go
@@ -204,7 +204,7 @@ func (r *Resolver) UpdateCodeMonitor(ctx context.Context, args *graphqlbackend.U
 // actions (emails, webhooks) immediately. This is useful during development and
 // troubleshooting. Only site admins can call this functions.
 func (r *Resolver) ResetTriggerQueryTimestamps(ctx context.Context, args *graphqlbackend.ResetTriggerQueryTimestampsArgs) (*graphqlbackend.EmptyResponse, error) {
-	err := backend.CheckCurrentUserIsSiteAdmin(ctx)
+	err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.store.Handle().DB())
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +424,7 @@ func (r *Resolver) isAllowedToCreate(ctx context.Context, owner graphql.ID) erro
 	}
 	switch kind := relay.UnmarshalKind(owner); kind {
 	case "User":
-		return backend.CheckSiteAdminOrSameUser(ctx, ownerInt32)
+		return backend.CheckSiteAdminOrSameUser(ctx, r.store.Handle().DB(), ownerInt32)
 	case "Org":
 		return backend.CheckOrgAccessOrSiteAdmin(ctx, r.store.Handle().DB(), ownerInt32)
 	default:

--- a/internal/search/searchcontexts/search_contexts.go
+++ b/internal/search/searchcontexts/search_contexts.go
@@ -84,7 +84,7 @@ func ValidateSearchContextWriteAccessForCurrentUser(ctx context.Context, db dbut
 		return errors.New("namespaceUserID and namespaceOrgID are mutually exclusive")
 	}
 
-	user, err := backend.CurrentUser(ctx)
+	user, err := backend.CurrentUser(ctx, db)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This makes the auth helpers not use `dbconn.Global` anymore, which is a prerequisite to running tests against functions using them with the `dbtest.NewDB` test helper (because it doesn't set that global variable). 