### PR TITLE
web: External service mode cleanup

### DIFF
--- a/client/web/dev/utils/create-js-context.ts
+++ b/client/web/dev/utils/create-js-context.ts
@@ -26,7 +26,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
         allowSignup: true,
         batchChangesEnabled: true,
         codeIntelAutoIndexingEnabled: false,
-        externalServicesUserModeEnabled: true,
+        externalServicesUserMode: 'public',
         productResearchPageEnabled: true,
         csrfToken: 'qwerty',
         assetsRoot: '/.assets',

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -18,7 +18,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     allowSignup: false,
     batchChangesEnabled: true,
     codeIntelAutoIndexingEnabled: true,
-    externalServicesUserModeEnabled: false,
+    externalServicesUserMode: false,
     productResearchPageEnabled: true,
     csrfToken: 'test-csrf-token',
     assetsRoot: new URL('/.assets', sourcegraphBaseUrl).href,

--- a/client/web/src/integration/jscontext.ts
+++ b/client/web/src/integration/jscontext.ts
@@ -18,7 +18,7 @@ export const createJsContext = ({ sourcegraphBaseUrl }: { sourcegraphBaseUrl: st
     allowSignup: false,
     batchChangesEnabled: true,
     codeIntelAutoIndexingEnabled: true,
-    externalServicesUserMode: false,
+    externalServicesUserMode: 'disabled',
     productResearchPageEnabled: true,
     csrfToken: 'test-csrf-token',
     assetsRoot: new URL('/.assets', sourcegraphBaseUrl).href,

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -89,7 +89,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     /** Whether the code intel auto-indexer feature is enabled on the site. */
     codeIntelAutoIndexingEnabled: boolean
 
-    /** Whether user is allowed to add external services. */
+    /** Whether users are allowed to add their own code and at what permission level. */
     externalServicesUserMode: 'disabled' | 'public' | 'all' | 'unknown'
 
     /** Authentication provider instances in site config. */

--- a/client/web/src/jscontext.ts
+++ b/client/web/src/jscontext.ts
@@ -90,7 +90,7 @@ export interface SourcegraphContext extends Pick<Required<SiteConfiguration>, 'e
     codeIntelAutoIndexingEnabled: boolean
 
     /** Whether user is allowed to add external services. */
-    externalServicesUserModeEnabled: boolean
+    externalServicesUserMode: 'disabled' | 'public' | 'all' | 'unknown'
 
     /** Authentication provider instances in site config. */
     authProviders: {

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -52,6 +52,7 @@ import {
 import { QueryState } from '../search/helpers'
 import { SearchNavbarItem } from '../search/input/SearchNavbarItem'
 import { ThemePreferenceProps } from '../theme'
+import { userExternalServicesEnabledFromTags } from '../user/settings/cloud-ga'
 import { UserSettingsSidebarItems } from '../user/settings/UserSettingsSidebar'
 import { showDotComMarketing } from '../util/features'
 
@@ -303,13 +304,8 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                             />
                         </NavAction>
                         {props.authenticatedUser &&
-                            (window.context?.externalServicesUserMode ||
-                                props.authenticatedUser?.siteAdmin ||
-                                props.authenticatedUser?.tags?.some(
-                                    tag =>
-                                        tag === 'AllowUserExternalServicePublic' ||
-                                        tag === 'AllowUserExternalServicePrivate'
-                                )) && (
+                            (props.authenticatedUser.siteAdmin ||
+                                userExternalServicesEnabledFromTags(props.authenticatedUser.tags)) && (
                                 <NavAction>
                                     <StatusMessagesNavItem
                                         isSiteAdmin={props.authenticatedUser?.siteAdmin || false}

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -303,7 +303,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                             />
                         </NavAction>
                         {props.authenticatedUser &&
-                            (window.context?.externalServicesUserModeEnabled ||
+                            (window.context?.externalServicesUserMode ||
                                 props.authenticatedUser?.siteAdmin ||
                                 props.authenticatedUser?.tags?.some(
                                     tag =>

--- a/client/web/src/nav/NavLinks.tsx
+++ b/client/web/src/nav/NavLinks.tsx
@@ -28,6 +28,7 @@ import { LayoutRouteProps } from '../routes'
 import { Settings } from '../schema/settings.schema'
 import { SearchContextProps } from '../search'
 import { ThemePreferenceProps } from '../theme'
+import { userExternalServicesEnabledFromTags } from '../user/settings/cloud-ga'
 import { getReactElements } from '../util/getReactElements'
 
 import { FeedbackPrompt } from './Feedback/FeedbackPrompt'
@@ -161,11 +162,7 @@ export const NavLinks: React.FunctionComponent<Props> = props => {
                 ))}
             {/* show status messages if user is logged in and either: user added code is enabled, user is admin or opted-in with a user tag  */}
             {authenticatedUser &&
-                (window.context?.externalServicesUserMode ||
-                    authenticatedUser?.siteAdmin ||
-                    authenticatedUser?.tags?.some(
-                        tag => tag === 'AllowUserExternalServicePublic' || tag === 'AllowUserExternalServicePrivate'
-                    )) && (
+                (authenticatedUser.siteAdmin || userExternalServicesEnabledFromTags(authenticatedUser.tags)) && (
                     <li className="nav-item">
                         <StatusMessagesNavItem isSiteAdmin={authenticatedUser.siteAdmin} history={history} />
                     </li>

--- a/client/web/src/nav/NavLinks.tsx
+++ b/client/web/src/nav/NavLinks.tsx
@@ -161,7 +161,7 @@ export const NavLinks: React.FunctionComponent<Props> = props => {
                 ))}
             {/* show status messages if user is logged in and either: user added code is enabled, user is admin or opted-in with a user tag  */}
             {authenticatedUser &&
-                (window.context?.externalServicesUserModeEnabled ||
+                (window.context?.externalServicesUserMode ||
                     authenticatedUser?.siteAdmin ||
                     authenticatedUser?.tags?.some(
                         tag => tag === 'AllowUserExternalServicePublic' || tag === 'AllowUserExternalServicePrivate'

--- a/client/web/src/user/settings/cloud-ga.ts
+++ b/client/web/src/user/settings/cloud-ga.ts
@@ -7,31 +7,34 @@ export interface UserProps {
 }
 
 export const externalServiceUserMode = (props: UserProps): 'disabled' | 'public' | 'all' | 'unknown' =>
-{
-    const siteMode = window.context.externalServicesUserMode
-    if (siteMode === 'all') {
-        // Site mode already allows all repo types, no need to check user tags
-        return siteMode
-    }
-    if (props.user.tags?.some(tag => tag === 'AllowUserExternalServicePrivate')) {
-        return 'all'
-    }
-    if (props.user.tags?.some(tag => tag === 'AllowUserExternalServicePublic')) {
-        return 'public'
-    }
-    return siteMode
-}
+    externalServiceUserModeFromTags(props.user.tags)
 
-export const userExternalServicesEnabled = (props: UserProps): boolean => {
-    const mode = externalServiceUserMode(props)
-    return mode === 'all' || mode === 'public'
-}
+export const userExternalServicesEnabled = (props: UserProps): boolean => modeEnabled(externalServiceUserMode(props))
 
-export const showPasswordsPage = (props: UserProps): boolean =>
-{
+export const userExternalServicesEnabledFromTags = (tags: string[]): boolean =>
+    modeEnabled(externalServiceUserModeFromTags(tags))
+
+export const showPasswordsPage = (props: UserProps): boolean => {
     // user is signed-in with builtin Auth and External Service is not public
     const mode = externalServiceUserMode(props)
     return props.user.builtinAuth && (mode === 'disabled' || mode === 'unknown')
 }
 
 export const showAccountSecurityPage = (props: UserProps): boolean => !showPasswordsPage(props)
+
+export const externalServiceUserModeFromTags = (tags: string[]): 'disabled' | 'public' | 'all' | 'unknown' => {
+    const siteMode = window.context.externalServicesUserMode
+    if (siteMode === 'all') {
+        // Site mode already allows all repo types, no need to check user tags
+        return siteMode
+    }
+    if (tags?.includes('AllowUserExternalServicePrivate')) {
+        return 'all'
+    }
+    if (tags?.includes('AllowUserExternalServicePublic')) {
+        return 'public'
+    }
+    return siteMode
+}
+
+const modeEnabled = (mode: string): boolean => mode === 'all' || mode === 'public'

--- a/client/web/src/user/settings/cloud-ga.ts
+++ b/client/web/src/user/settings/cloud-ga.ts
@@ -6,16 +6,32 @@ export interface UserProps {
     authenticatedUser: Pick<AuthenticatedUser, 'id' | 'tags'>
 }
 
-export const allowUserExternalServicePublic = (props: UserProps): boolean =>
-    window.context.externalServicesUserModeEnabled ||
-    (props.user.id === props.authenticatedUser.id &&
-        props.authenticatedUser.tags.some(
-            tag => tag === 'AllowUserExternalServicePublic' || tag === 'AllowUserExternalServicePrivate'
-        )) ||
-    props.user.tags?.some(tag => tag === 'AllowUserExternalServicePublic' || tag === 'AllowUserExternalServicePrivate')
+export const externalServiceUserMode = (props: UserProps): 'disabled' | 'public' | 'all' | 'unknown' =>
+{
+    const siteMode = window.context.externalServicesUserMode
+    if (siteMode === 'all') {
+        // Site mode already allows all repo types, no need to check user tags
+        return siteMode
+    }
+    if (props.user.tags?.some(tag => tag === 'AllowUserExternalServicePrivate')) {
+        return 'all'
+    }
+    if (props.user.tags?.some(tag => tag === 'AllowUserExternalServicePublic')) {
+        return 'public'
+    }
+    return siteMode
+}
+
+export const userExternalServicesEnabled = (props: UserProps): boolean => {
+    const mode = externalServiceUserMode(props)
+    return mode === 'all' || mode === 'public'
+}
 
 export const showPasswordsPage = (props: UserProps): boolean =>
+{
     // user is signed-in with builtin Auth and External Service is not public
-    props.user.builtinAuth && !allowUserExternalServicePublic(props)
+    const mode = externalServiceUserMode(props)
+    return props.user.builtinAuth && (mode === 'disabled' || mode === 'unknown')
+}
 
 export const showAccountSecurityPage = (props: UserProps): boolean => !showPasswordsPage(props)

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -31,6 +31,7 @@ import { eventLogger } from '../../../tracking/eventLogger'
 import { UserRepositoriesUpdateProps } from '../../../util'
 
 import { CheckboxRepositoryNode } from './RepositoryNode'
+import { externalServiceUserModeFromTags } from '../cloud-ga'
 
 interface authenticatedUser {
     id: string
@@ -150,7 +151,8 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
     }, [telemetryService])
 
     // if we should tweak UI messaging and copy
-    const ALLOW_PRIVATE_CODE = authenticatedUser.tags.includes('AllowUserExternalServicePrivate')
+    const ALLOW_PRIVATE_CODE = externalServiceUserModeFromTags(authenticatedUser.tags) === 'all'
+
     // if 'sync all' radio button is enabled and users can sync all repos from code hosts
     const ALLOW_SYNC_ALL = authenticatedUser.tags.includes('AllowUserExternalServiceSyncAll')
 

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -54,6 +54,7 @@ interface GitHubConfig {
     token: 'REDACTED'
     url: string
 }
+
 interface GitLabConfig {
     projectQuery: string[]
     projects: { name: string }[]

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -29,9 +29,9 @@ import {
 import { queryUserPublicRepositories, setUserPublicRepositories } from '../../../site-admin/backend'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { UserRepositoriesUpdateProps } from '../../../util'
+import { externalServiceUserModeFromTags } from '../cloud-ga'
 
 import { CheckboxRepositoryNode } from './RepositoryNode'
-import { externalServiceUserModeFromTags } from '../cloud-ga'
 
 interface authenticatedUser {
     id: string

--- a/client/web/src/user/settings/routes.tsx
+++ b/client/web/src/user/settings/routes.tsx
@@ -5,7 +5,7 @@ import { Scalars } from '../../graphql-operations'
 import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
 import { lazyComponent } from '../../util/lazyComponent'
 
-import { showPasswordsPage, showAccountSecurityPage, allowUserExternalServicePublic } from './cloud-ga'
+import { showPasswordsPage, showAccountSecurityPage, userExternalServicesEnabled } from './cloud-ga'
 import type { UserAddCodeHostsPageContainerProps } from './UserAddCodeHostsPageContainer'
 import { UserSettingsAreaRoute, UserSettingsAreaRouteContext } from './UserSettingsArea'
 
@@ -95,7 +95,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
             />
         ),
         exact: true,
-        condition: allowUserExternalServicePublic,
+        condition: userExternalServicesEnabled,
     },
     {
         path: '/repositories/manage',
@@ -111,7 +111,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
             />
         ),
         exact: true,
-        condition: allowUserExternalServicePublic,
+        condition: userExternalServicesEnabled,
     },
     {
         path: '/code-hosts',
@@ -124,7 +124,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
             />
         ),
         exact: true,
-        condition: allowUserExternalServicePublic,
+        condition: userExternalServicesEnabled,
     },
     {
         path: '/external-services/:id',
@@ -136,7 +136,7 @@ export const userSettingsAreaRoutes: readonly UserSettingsAreaRoute[] = [
             />
         ),
         exact: true,
-        condition: allowUserExternalServicePublic,
+        condition: userExternalServicesEnabled,
     },
     {
         path: '/product-research',

--- a/client/web/src/user/settings/sidebaritems.ts
+++ b/client/web/src/user/settings/sidebaritems.ts
@@ -1,4 +1,4 @@
-import { showAccountSecurityPage, showPasswordsPage, allowUserExternalServicePublic } from './cloud-ga'
+import { showAccountSecurityPage, showPasswordsPage, userExternalServicesEnabled } from './cloud-ga'
 import { UserSettingsSidebarItems } from './UserSettingsSidebar'
 
 export const userSettingsSideBarItems: UserSettingsSidebarItems = {
@@ -40,12 +40,12 @@ export const userSettingsSideBarItems: UserSettingsSidebarItems = {
         {
             label: 'Code host connections',
             to: '/code-hosts',
-            condition: allowUserExternalServicePublic,
+            condition: userExternalServicesEnabled,
         },
         {
             label: 'Repositories',
             to: '/repositories',
-            condition: allowUserExternalServicePublic,
+            condition: userExternalServicesEnabled,
         },
         {
             label: 'Product research',

--- a/cmd/frontend/internal/app/jscontext/jscontext.go
+++ b/cmd/frontend/internal/app/jscontext/jscontext.go
@@ -78,7 +78,7 @@ type JSContext struct {
 
 	ResetPasswordEnabled bool `json:"resetPasswordEnabled"`
 
-	ExternalServicesUserModeEnabled bool `json:"externalServicesUserModeEnabled"`
+	ExternalServicesUserMode string `json:"externalServicesUserMode"`
 
 	AuthProviders []authProviderInfo `json:"authProviders"`
 
@@ -180,7 +180,7 @@ func NewJSContextFromRequest(req *http.Request) JSContext {
 
 		ResetPasswordEnabled: userpasswd.ResetPasswordEnabled(),
 
-		ExternalServicesUserModeEnabled: conf.ExternalServiceUserMode() != conf.ExternalServiceModeDisabled,
+		ExternalServicesUserMode: conf.ExternalServiceUserMode().String(),
 
 		AllowSignup: conf.AuthAllowSignup(),
 

--- a/internal/conf/computed.go
+++ b/internal/conf/computed.go
@@ -360,6 +360,19 @@ const (
 	ExternalServiceModeAll      ExternalServiceMode = 2
 )
 
+func (e ExternalServiceMode) String() string {
+	switch e {
+	case ExternalServiceModeDisabled:
+		return "disabled"
+	case ExternalServiceModePublic:
+		return "public"
+	case ExternalServiceModeAll:
+		return "all"
+	default:
+		return "unknown"
+	}
+}
+
 // ExternalServiceUserMode returns the site level mode describing if users are
 // allowed to add external services for public and private repositories. It does
 // NOT take into account permissions granted to the current user.


### PR DESCRIPTION
The logic used to check whether user external services are allowed was spread
over many places. It also didn't consistently check both user tags and site
settings.

This change centralises all the logic in one place.