### PR TITLE
Improve contrast in file tree decorations

### DIFF
--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -5,7 +5,7 @@ meter {
 
     /* We can directly style the meter's background for Firefox */
     background: none;
-    background-color: var(--text-disabled);
+    background-color: var(--gray-05);
     border-radius: 1px;
     height: 0.375rem;
 

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -1,11 +1,20 @@
 meter {
+    --meter-background: var(--border-color-2);
+
+    .theme-dark.theme-redesign & {
+        --meter-background: var(--gray-07);
+    }
+    .theme-light.theme-redesign & {
+        --meter-background: var(--gray-05);
+    }
+
     /* Reset the default appearence */
     -moz-appearance: none;
     // Don't reset -webkit-appearance: https://bugs.chromium.org/p/chromium/issues/detail?id=632510
 
     /* We can directly style the meter's background for Firefox */
     background: none;
-    background-color: var(--border-color-2);
+    background-color: var(--meter-background);
     border-radius: 1px;
     height: 0.375rem;
 
@@ -19,7 +28,7 @@ meter {
         height: 0.375rem;
         border: none;
         border-radius: 1px;
-        background-color: var(--border-color-2);
+        background-color: var(--meter-background);
     }
 
     // Optimum value styles

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -5,7 +5,7 @@ meter {
 
     /* We can directly style the meter's background for Firefox */
     background: none;
-    background-color: var(--text-disabled);
+    background-color: var(--border-color-2);
     border-radius: 1px;
     height: 0.375rem;
 
@@ -19,7 +19,7 @@ meter {
         height: 0.375rem;
         border: none;
         border-radius: 1px;
-        background-color: var(--text-disabled);
+        background-color: var(--border-color-2);
     }
 
     // Optimum value styles

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -5,7 +5,7 @@ meter {
 
     /* We can directly style the meter's background for Firefox */
     background: none;
-    background-color: var(--gray-05);
+    background-color: var(--text-disabled);
     border-radius: 1px;
     height: 0.375rem;
 

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -5,7 +5,7 @@ meter {
 
     /* We can directly style the meter's background for Firefox */
     background: none;
-    background-color: var(--border-color-2);
+    background-color: var(--text-disabled);
     border-radius: 1px;
     height: 0.375rem;
 
@@ -19,7 +19,7 @@ meter {
         height: 0.375rem;
         border: none;
         border-radius: 1px;
-        background-color: var(--border-color-2);
+        background-color: var(--text-disabled);
     }
 
     // Optimum value styles

--- a/client/web/src/tree/FileDecorator.scss
+++ b/client/web/src/tree/FileDecorator.scss
@@ -2,10 +2,6 @@
     &__after {
         margin-bottom: -0.125rem;
         color: var(--text-muted);
-
-        &--active {
-            color: $white;
-        }
     }
 
     &__meter {

--- a/client/web/src/tree/FileDecorator.scss
+++ b/client/web/src/tree/FileDecorator.scss
@@ -2,6 +2,10 @@
     &__after {
         margin-bottom: -0.125rem;
         color: var(--text-muted);
+
+        &--active {
+            color: $white;
+        }
     }
 
     &__meter {

--- a/client/web/src/tree/FileDecorator.scss
+++ b/client/web/src/tree/FileDecorator.scss
@@ -6,6 +6,10 @@
         &--active {
             color: $white;
         }
+
+        .theme-redesign &--active {
+            color: var(--text-muted);
+        }
     }
 
     &__meter {


### PR DESCRIPTION
Fixes #21330:
- Text should always be `--text-muted`, never `white`
- Meter background should be `--gray-05` in light theme, `--gray-07` in dark

**Before:**
![CleanShot 2021-05-26 at 14 13 53@2x](https://user-images.githubusercontent.com/17293/119658054-fd279400-be2c-11eb-9dc9-825ed00e2ec8.png)

**After:**
![Frame 5 (1)](https://user-images.githubusercontent.com/17293/119671687-429e8e00-be3a-11eb-9565-1d9aaf2fe153.png)
