### PR TITLE
Switch to dbtest.NewDB in batches codebase

### DIFF
--- a/enterprise/internal/batches/background/bulk_processor_test.go
+++ b/enterprise/internal/batches/background/bulk_processor_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 )
 
 func TestBulkProcessor(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	tx := dbtest.NewTx(t, db)
 	bstore := store.New(tx, nil)
 	user := ct.CreateTestUser(t, db, true)

--- a/enterprise/internal/batches/background/main_test.go
+++ b/enterprise/internal/batches/background/main_test.go
@@ -1,7 +1,0 @@
-package background
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "batchesbackgrounddb"
-}

--- a/enterprise/internal/batches/background/reconciler_worker_test.go
+++ b/enterprise/internal/batches/background/reconciler_worker_test.go
@@ -13,7 +13,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
@@ -22,9 +22,10 @@ func TestReconcilerWorkerView(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
+	t.Parallel()
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }

--- a/enterprise/internal/batches/background/site_credential_migrator_test.go
+++ b/enterprise/internal/batches/background/site_credential_migrator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -18,7 +18,7 @@ import (
 
 func TestSiteCredentialMigrator(t *testing.T) {
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, et.TestKey{})
 

--- a/enterprise/internal/batches/background/ssh_migrator_test.go
+++ b/enterprise/internal/batches/background/ssh_migrator_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -15,7 +15,7 @@ import (
 
 func TestSSHMigrator(t *testing.T) {
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	user := ct.CreateTestUser(t, db, false)
 
 	ct.MockRSAKeygen(t)

--- a/enterprise/internal/batches/background/user_credential_migrator_test.go
+++ b/enterprise/internal/batches/background/user_credential_migrator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -19,7 +19,7 @@ import (
 
 func TestUserCredentialMigrator(t *testing.T) {
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, et.TestKey{})
 

--- a/enterprise/internal/batches/reconciler/executor_test.go
+++ b/enterprise/internal/batches/reconciler/executor_test.go
@@ -17,6 +17,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
@@ -34,7 +35,7 @@ func TestExecutor_ExecutePlan(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	now := timeutil.Now()
 	clock := func() time.Time { return now }
@@ -591,7 +592,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, et.TestKey{})
 
@@ -632,7 +633,7 @@ func TestExecutor_ExecutePlan_PublishedChangesetDuplicateBranch(t *testing.T) {
 
 func TestLoadChangesetSource(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	token := &auth.OAuthBearerToken{Token: "abcdef"}
 
 	cstore := store.New(db, et.TestKey{})
@@ -796,7 +797,7 @@ func TestLoadChangesetSource(t *testing.T) {
 
 func TestExecutor_UserCredentialsForGitserver(t *testing.T) {
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, et.TestKey{})
 

--- a/enterprise/internal/batches/reconciler/main_test.go
+++ b/enterprise/internal/batches/reconciler/main_test.go
@@ -4,14 +4,9 @@ import (
 	"time"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "batchchangesreconcilerdb"
-}
 
 func buildGithubPR(now time.Time, externalState btypes.ChangesetExternalState) *github.PullRequest {
 	state := string(externalState)

--- a/enterprise/internal/batches/reconciler/reconciler_test.go
+++ b/enterprise/internal/batches/reconciler/reconciler_test.go
@@ -11,7 +11,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/repoupdater/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
@@ -22,7 +22,7 @@ func TestReconcilerProcess_IntegrationTest(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	store := store.New(db, nil)
 

--- a/enterprise/internal/batches/resolvers/batch_change_connection_test.go
+++ b/enterprise/internal/batches/resolvers/batch_change_connection_test.go
@@ -16,7 +16,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestBatchChangeConnectionResolver(t *testing.T) {
@@ -25,7 +25,7 @@ func TestBatchChangeConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 
@@ -177,7 +177,7 @@ func TestBatchChangesListing(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 	actorCtx := actor.WithActor(ctx, actor.FromUser(userID))

--- a/enterprise/internal/batches/resolvers/batch_change_test.go
+++ b/enterprise/internal/batches/resolvers/batch_change_test.go
@@ -15,7 +15,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -25,7 +25,7 @@ func TestBatchChangeResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 	orgName := "test-batch-change-resolver-org"

--- a/enterprise/internal/batches/resolvers/batch_spec_test.go
+++ b/enterprise/internal/batches/resolvers/batch_spec_test.go
@@ -17,7 +17,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 )
 
@@ -27,7 +27,7 @@ func TestBatchSpecResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, nil)
 	repoStore := database.ReposWith(cstore)

--- a/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation_connection_test.go
@@ -15,7 +15,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -25,7 +25,7 @@ func TestBulkOperationConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 	now := timeutil.Now()

--- a/enterprise/internal/batches/resolvers/bulk_operation_test.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation_test.go
@@ -13,7 +13,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -23,7 +23,7 @@ func TestBulkOperationResolver(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID
 

--- a/enterprise/internal/batches/resolvers/changeset_apply_preview_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_apply_preview_connection_test.go
@@ -16,7 +16,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -26,7 +26,7 @@ func TestChangesetApplyPreviewConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID
 

--- a/enterprise/internal/batches/resolvers/changeset_apply_preview_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_apply_preview_test.go
@@ -14,7 +14,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -24,7 +24,7 @@ func TestChangesetApplyPreviewResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID
 

--- a/enterprise/internal/batches/resolvers/changeset_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_connection_test.go
@@ -16,7 +16,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestChangesetConnectionResolver(t *testing.T) {
@@ -25,7 +25,7 @@ func TestChangesetConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID
 

--- a/enterprise/internal/batches/resolvers/changeset_counts_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_counts_test.go
@@ -20,7 +20,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/httptestutil"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
@@ -71,7 +71,7 @@ func TestChangesetCountsOverTimeIntegration(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	rcache.SetupForTest(t)
 
 	cf, save := httptestutil.NewGitHubRecorderFactory(t, *update, "test-changeset-counts-over-time")

--- a/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_event_connection_test.go
@@ -16,7 +16,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
@@ -27,7 +27,7 @@ func TestChangesetEventConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 

--- a/enterprise/internal/batches/resolvers/changeset_spec_connection_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec_connection_test.go
@@ -14,7 +14,7 @@ import (
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
@@ -24,7 +24,7 @@ func TestChangesetSpecConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID
 

--- a/enterprise/internal/batches/resolvers/changeset_spec_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_spec_test.go
@@ -15,7 +15,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 	"github.com/sourcegraph/sourcegraph/lib/batches"
 )
@@ -26,7 +26,7 @@ func TestChangesetSpecResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, false).ID
 

--- a/enterprise/internal/batches/resolvers/changeset_test.go
+++ b/enterprise/internal/batches/resolvers/changeset_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -28,7 +28,7 @@ func TestChangesetResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 

--- a/enterprise/internal/batches/resolvers/code_host_connection_test.go
+++ b/enterprise/internal/batches/resolvers/code_host_connection_test.go
@@ -16,7 +16,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 )
@@ -27,7 +27,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	pruneUserCredentials(t, db, nil)
 
@@ -154,7 +154,7 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 	})
 
 	t.Run("User.BatchChangesCodeHosts", func(t *testing.T) {
-		cred, err := cstore.UserCredentials().Create(ctx, database.UserCredentialScope{
+		userCred, err := cstore.UserCredentials().Create(ctx, database.UserCredentialScope{
 			Domain:              database.UserCredentialDomainBatches,
 			ExternalServiceID:   ghRepo.ExternalRepo.ServiceID,
 			ExternalServiceType: ghRepo.ExternalRepo.ServiceType,
@@ -188,10 +188,10 @@ func TestCodeHostConnectionResolver(t *testing.T) {
 				ExternalServiceURL:  ghRepo.ExternalRepo.ServiceID,
 				ExternalServiceKind: extsvc.TypeToKind(ghRepo.ExternalRepo.ServiceType),
 				Credential: apitest.BatchChangesCredential{
-					ID:                  string(marshalBatchChangesCredentialID(cred.ID, false)),
-					ExternalServiceKind: extsvc.TypeToKind(cred.ExternalServiceType),
-					ExternalServiceURL:  cred.ExternalServiceID,
-					CreatedAt:           cred.CreatedAt.Format(time.RFC3339),
+					ID:                  string(marshalBatchChangesCredentialID(userCred.ID, false)),
+					ExternalServiceKind: extsvc.TypeToKind(userCred.ExternalServiceType),
+					ExternalServiceURL:  userCred.ExternalServiceID,
+					CreatedAt:           userCred.CreatedAt.Format(time.RFC3339),
 					IsSiteCredential:    false,
 				},
 			},

--- a/enterprise/internal/batches/resolvers/main_test.go
+++ b/enterprise/internal/batches/resolvers/main_test.go
@@ -20,7 +20,6 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -28,10 +27,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "batchchangesresolversdb"
-}
 
 var update = flag.Bool("update", false, "update testdata")
 

--- a/enterprise/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/internal/batches/resolvers/permissions_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -36,7 +36,7 @@ func TestPermissionLevels(t *testing.T) {
 
 	ct.MockRSAKeygen(t)
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	key := et.TestKey{}
 
 	cstore := store.New(db, key)
@@ -925,7 +925,7 @@ func TestRepositoryPermissions(t *testing.T) {
 		t.Skip()
 	}
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	cstore := store.New(db, nil)
 	sr := &Resolver{store: cstore}

--- a/enterprise/internal/batches/resolvers/resolver_test.go
+++ b/enterprise/internal/batches/resolvers/resolver_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
@@ -35,7 +35,7 @@ import (
 func TestNullIDResilience(t *testing.T) {
 	ct.MockRSAKeygen(t)
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	sr := New(store.New(db, nil))
 
 	s, err := graphqlbackend.NewSchema(db, sr, nil, nil, nil, nil, nil, nil)
@@ -101,7 +101,7 @@ func TestCreateBatchSpec(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	user := ct.CreateTestUser(t, db, true)
 	userID := user.ID
@@ -282,7 +282,7 @@ func TestCreateChangesetSpec(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 
@@ -355,7 +355,7 @@ func TestApplyBatchChange(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	// Ensure our site configuration doesn't have rollout windows so we get a
 	// consistent initial state.
@@ -516,7 +516,7 @@ func TestCreateBatchChange(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	userID := ct.CreateTestUser(t, db, true).ID
 
@@ -578,7 +578,7 @@ func TestMoveBatchChange(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	user := ct.CreateTestUser(t, db, true)
 	userID := user.ID
@@ -843,7 +843,7 @@ func TestCreateBatchChangesCredential(t *testing.T) {
 	ct.MockRSAKeygen(t)
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	pruneUserCredentials(t, db, nil)
 
@@ -973,7 +973,7 @@ func TestDeleteBatchChangesCredential(t *testing.T) {
 	ct.MockRSAKeygen(t)
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	pruneUserCredentials(t, db, nil)
 
@@ -1062,7 +1062,7 @@ func TestCreateChangesetComments(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 	cstore := store.New(db, nil)
 
 	userID := ct.CreateTestUser(t, db, true).ID

--- a/enterprise/internal/batches/service/main_test.go
+++ b/enterprise/internal/batches/service/main_test.go
@@ -1,7 +1,0 @@
-package service
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "batchesservicedb"
-}

--- a/enterprise/internal/batches/service/service_apply_batch_change_test.go
+++ b/enterprise/internal/batches/service/service_apply_batch_change_test.go
@@ -14,7 +14,7 @@ import (
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/timeutil"
 )
 
@@ -24,7 +24,7 @@ func TestServiceApplyBatchChange(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	admin := ct.CreateTestUser(t, db, true)
 	adminCtx := actor.WithActor(context.Background(), actor.FromUser(admin.ID))

--- a/enterprise/internal/batches/service/service_test.go
+++ b/enterprise/internal/batches/service/service_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/database"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
@@ -33,7 +33,7 @@ func TestServicePermissionLevels(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	s := store.New(db, nil)
 	svc := New(s)
@@ -175,7 +175,7 @@ func TestService(t *testing.T) {
 	}
 
 	ctx := backend.WithAuthzBypass(context.Background())
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	admin := ct.CreateTestUser(t, db, true)
 	user := ct.CreateTestUser(t, db, false)

--- a/enterprise/internal/batches/store/integration_test.go
+++ b/enterprise/internal/batches/store/integration_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 	"github.com/sourcegraph/sourcegraph/internal/encryption"
 	et "github.com/sourcegraph/sourcegraph/internal/encryption/testing"
 )
@@ -15,7 +15,7 @@ func TestIntegration(t *testing.T) {
 
 	t.Parallel()
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	t.Run("Store", func(t *testing.T) {
 		t.Run("BatchChanges", storeTest(db, nil, testStoreBatchChanges))

--- a/enterprise/internal/batches/store/main_test.go
+++ b/enterprise/internal/batches/store/main_test.go
@@ -1,7 +1,0 @@
-package store
-
-import "github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
-
-func init() {
-	dbtesting.DBNameSuffix = "batchchangesstoredb"
-}

--- a/enterprise/internal/batches/webhooks/main_test.go
+++ b/enterprise/internal/batches/webhooks/main_test.go
@@ -11,14 +11,9 @@ import (
 	"testing"
 
 	btypes "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
-
-func init() {
-	dbtesting.DBNameSuffix = "batchchangesswebhooksdb"
-}
 
 var update = flag.Bool("update", false, "update testdata")
 

--- a/enterprise/internal/batches/webhooks/webhooks_integration_test.go
+++ b/enterprise/internal/batches/webhooks/webhooks_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	ct "github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing"
-	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbtest"
 )
 
 func TestWebhooksIntegration(t *testing.T) {
@@ -14,7 +14,7 @@ func TestWebhooksIntegration(t *testing.T) {
 
 	t.Parallel()
 
-	db := dbtesting.GetDB(t)
+	db := dbtest.NewDB(t, "")
 
 	user := ct.CreateTestUser(t, db, false)
 


### PR DESCRIPTION
Stacked on top of https://github.com/sourcegraph/sourcegraph/pull/21397, this PR refactors usages of `dbtesting.GetDB` to `dbtest.NewDB` after @camdencheek has improved its performance quite substantially. 

## After
```
?       github.com/sourcegraph/sourcegraph/enterprise/internal/batches  [no test files]
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/background       2.441s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/global   0.430s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/reconciler       4.023s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers        11.064s
?       github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest        [no test files]
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/rewirer  0.775s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/scheduler        0.299s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search   0.372s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search/syntax    0.238s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/service  4.880s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources  1.079s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/state    0.690s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store    3.266s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/syncer   1.471s
?       github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing  [no test files]
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types    0.770s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/config   0.248s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/window   0.205s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/webhooks 3.402s
```

## Before 
```
?       github.com/sourcegraph/sourcegraph/enterprise/internal/batches  [no test files]
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/background       6.593s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/global   0.941s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/reconciler       7.328s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers        14.464s
?       github.com/sourcegraph/sourcegraph/enterprise/internal/batches/resolvers/apitest        [no test files]
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/rewirer  0.634s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/scheduler        0.501s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search   0.284s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/search/syntax    0.135s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/service  6.907s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/sources  1.428s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/state    0.435s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store    5.897s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/syncer   0.694s
?       github.com/sourcegraph/sourcegraph/enterprise/internal/batches/testing  [no test files]
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types    1.108s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/config   0.317s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/types/scheduler/window   0.181s
ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/webhooks 6.586s
```

---

Single test performance also got a lot better: 
**After:** `ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store    1.725s`
**Before:** `ok      github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store    4.046s`