### PR TITLE
Move types.RepoCloneURL to repos.CloneURL

### DIFF
--- a/cmd/gitserver/main.go
+++ b/cmd/gitserver/main.go
@@ -12,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/internal/repos"
+
 	"github.com/sourcegraph/sourcegraph/internal/encryption/keyring"
 
 	"github.com/inconshreveable/log15"
@@ -34,7 +36,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
-	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )
 
@@ -103,7 +104,7 @@ func main() {
 					return "", err
 				}
 
-				return types.RepoCloneURL(svc.Kind, svc.Config, r)
+				return repos.CloneURL(svc.Kind, svc.Config, r)
 			}
 			return "", fmt.Errorf("no sources for %q", repo)
 		},

--- a/enterprise/internal/batches/sources/sources.go
+++ b/enterprise/internal/batches/sources/sources.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"sort"
 
+	"github.com/sourcegraph/sourcegraph/internal/repos"
+
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/enterprise/internal/batches/store"
@@ -387,7 +389,7 @@ func extractCloneURL(ctx context.Context, s *database.ExternalServiceStore, repo
 	for _, svc := range svcs {
 		// build the clone url using the external service config instead of using
 		// the source CloneURL field
-		cloneURL, err := types.RepoCloneURL(svc.Kind, svc.Config, repo)
+		cloneURL, err := repos.CloneURL(svc.Kind, svc.Config, repo)
 		if err != nil {
 			return "", err
 		}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -350,7 +350,7 @@ func scanRepo(rows *sql.Rows, r *types.Repo) (err error) {
 	case extsvc.TypePerforce:
 		r.Metadata = new(perforce.Depot)
 	case extsvc.TypeOther:
-		r.Metadata = new(types.OtherRepoMetadata)
+		r.Metadata = new(extsvc.OtherRepoMetadata)
 	default:
 		return nil
 	}

--- a/internal/extsvc/types.go
+++ b/internal/extsvc/types.go
@@ -415,3 +415,9 @@ func DecodeURN(urn string) (kind string, id int64) {
 	}
 	return fields[1], id
 }
+
+type OtherRepoMetadata struct {
+	// RelativePath is relative to ServiceID which is usually the host URL.
+	// Joining them gives you the clone url.
+	RelativePath string
+}

--- a/internal/repos/bitbucketcloud.go
+++ b/internal/repos/bitbucketcloud.go
@@ -131,7 +131,7 @@ func (s BitbucketCloudSource) makeRepo(r *bitbucketcloud.Repo) *types.Repo {
 // remoteURL returns the repository's Git remote URL
 //
 // note: this used to contain credentials but that is no longer the case
-// if you need to get an authenticated clone url use types.RepoCloneURL
+// if you need to get an authenticated clone url use repos.CloneURL
 func (s *BitbucketCloudSource) remoteURL(repo *bitbucketcloud.Repo) string {
 	if s.config.GitURLType == "ssh" {
 		return fmt.Sprintf("git@%s:%s.git", s.config.Url, repo.FullName)

--- a/internal/repos/clone_url_test.go
+++ b/internal/repos/clone_url_test.go
@@ -1,14 +1,10 @@
-package types
+package repos
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-
-	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/awscodecommit"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketcloud"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/bitbucketserver"
@@ -236,62 +232,5 @@ func TestPerforceCloneURL(t *testing.T) {
 	want := "perforce://admin:pa$$word@ssl:111.222.333.444:1666//Sourcegraph/"
 	if got != want {
 		t.Fatalf("wrong cloneURL, got: %q, want: %q", got, want)
-	}
-}
-
-func TestSetUserinfoBestEffort(t *testing.T) {
-	cases := []struct {
-		rawurl   string
-		username string
-		password string
-		want     string
-	}{
-		// no-op
-		{"https://foo.com/foo/bar", "", "", "https://foo.com/foo/bar"},
-		// invalid name is returned as is
-		{":/foo.com/foo/bar", "u", "p", ":/foo.com/foo/bar"},
-
-		// no user details in rawurl
-		{"https://foo.com/foo/bar", "u", "p", "https://u:p@foo.com/foo/bar"},
-		{"https://foo.com/foo/bar", "u", "", "https://u@foo.com/foo/bar"},
-		{"https://foo.com/foo/bar", "", "p", "https://foo.com/foo/bar"},
-
-		// user set already
-		{"https://x@foo.com/foo/bar", "u", "p", "https://x:p@foo.com/foo/bar"},
-		{"https://x@foo.com/foo/bar", "u", "", "https://x@foo.com/foo/bar"},
-		{"https://x@foo.com/foo/bar", "", "p", "https://x:p@foo.com/foo/bar"},
-
-		// user and password set already
-		{"https://x:y@foo.com/foo/bar", "u", "p", "https://x:y@foo.com/foo/bar"},
-		{"https://x:y@foo.com/foo/bar", "u", "", "https://x:y@foo.com/foo/bar"},
-		{"https://x:y@foo.com/foo/bar", "", "p", "https://x:y@foo.com/foo/bar"},
-
-		// empty password
-		{"https://x:@foo.com/foo/bar", "u", "p", "https://x:@foo.com/foo/bar"},
-		{"https://x:@foo.com/foo/bar", "u", "", "https://x:@foo.com/foo/bar"},
-		{"https://x:@foo.com/foo/bar", "", "p", "https://x:@foo.com/foo/bar"},
-	}
-	for _, c := range cases {
-		got := setUserinfoBestEffort(c.rawurl, c.username, c.password)
-		if got != c.want {
-			t.Errorf("setUserinfoBestEffort(%q, %q, %q): got %q want %q", c.rawurl, c.username, c.password, got, c.want)
-		}
-	}
-}
-
-func TestGrantedScopes(t *testing.T) {
-	want := []string{"repo"}
-	github.MockGetAuthenticatedUserOAuthScopes = func(ctx context.Context) ([]string, error) {
-		return want, nil
-	}
-
-	ctx := context.Background()
-	have, err := GrantedScopes(ctx, extsvc.KindGitHub, `{}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if diff := cmp.Diff(want, have); diff != "" {
-		t.Fatal(diff)
 	}
 }

--- a/internal/repos/github.go
+++ b/internal/repos/github.go
@@ -264,7 +264,7 @@ func (s GithubSource) makeRepo(r *github.Repository) *types.Repo {
 // remoteURL returns the repository's Git remote URL
 //
 // note: this used to contain credentials but that is no longer the case
-// if you need to get an authenticated clone url use types.RepoCloneURL
+// if you need to get an authenticated clone url use repos.CloneURL
 func (s *GithubSource) remoteURL(repo *github.Repository) string {
 	if s.config.GitURLType == "ssh" {
 		url := fmt.Sprintf("git@%s:%s.git", s.originalHostname, repo.NameWithOwner)

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -209,7 +209,7 @@ func (s GitLabSource) makeRepo(proj *gitlab.Project) *types.Repo {
 // remoteURL returns the GitLab projects's Git remote URL
 //
 // note: this used to contain credentials but that is no longer the case
-// if you need to get an authenticated clone url use types.RepoCloneURL
+// if you need to get an authenticated clone url use repos.CloneURL
 func (s *GitLabSource) remoteURL(proj *gitlab.Project) string {
 	if s.config.GitURLType == "ssh" {
 		return proj.SSHURLToRepo // SSH authentication must be provided out-of-band

--- a/internal/repos/other.go
+++ b/internal/repos/other.go
@@ -142,7 +142,7 @@ func (s OtherSource) otherRepoFromCloneURL(urn string, u *url.URL) (*types.Repo,
 				CloneURL: repoURL,
 			},
 		},
-		Metadata: &types.OtherRepoMetadata{
+		Metadata: &extsvc.OtherRepoMetadata{
 			RelativePath: strings.TrimPrefix(repoURL, serviceID),
 		},
 	}, nil
@@ -198,7 +198,7 @@ func (s OtherSource) srcExpose(ctx context.Context) ([]*types.Repo, error) {
 				CloneURL: cloneURL,
 			},
 		}
-		r.Metadata = &types.OtherRepoMetadata{
+		r.Metadata = &extsvc.OtherRepoMetadata{
 			RelativePath: strings.TrimPrefix(cloneURL, s.conn.Url),
 		}
 		// The only required field left is Name

--- a/internal/repos/other_test.go
+++ b/internal/repos/other_test.go
@@ -61,7 +61,7 @@ func TestSrcExpose(t *testing.T) {
 					CloneURL: s.URL + "/foo/.git",
 				},
 			},
-			Metadata: &types.OtherRepoMetadata{RelativePath: "/foo/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/foo/.git"},
 		}, {
 			URI:  "bar/baz",
 			Name: "bar/baz",
@@ -76,7 +76,7 @@ func TestSrcExpose(t *testing.T) {
 					CloneURL: s.URL + "/bar/baz/.git",
 				},
 			},
-			Metadata: &types.OtherRepoMetadata{RelativePath: "/bar/baz/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/bar/baz/.git"},
 		}},
 	}, {
 		name: "override",
@@ -96,7 +96,7 @@ func TestSrcExpose(t *testing.T) {
 					CloneURL: s.URL + "/repos/foo/.git",
 				},
 			},
-			Metadata: &types.OtherRepoMetadata{RelativePath: "/repos/foo/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/repos/foo/.git"},
 		}},
 	}, {
 		name: "immutable",
@@ -115,7 +115,7 @@ func TestSrcExpose(t *testing.T) {
 					CloneURL: s.URL + "/foo/.git",
 				},
 			},
-			Metadata: &types.OtherRepoMetadata{RelativePath: "/foo/.git"},
+			Metadata: &extsvc.OtherRepoMetadata{RelativePath: "/foo/.git"},
 		}},
 	}}
 

--- a/internal/repos/store_test.go
+++ b/internal/repos/store_test.go
@@ -130,7 +130,7 @@ func testStoreUpsertRepos(t *testing.T, store *repos.Store) func(*testing.T) {
 				ServiceID:   "https://git-host.com/",
 				ServiceType: extsvc.TypeOther,
 			},
-			Metadata: &types.OtherRepoMetadata{},
+			Metadata: &extsvc.OtherRepoMetadata{},
 			Sources: map[string]*types.SourceInfo{
 				servicesPerKind[extsvc.KindOther].URN(): {
 					ID:       servicesPerKind[extsvc.KindOther].URN(),

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -98,7 +98,7 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 			ServiceID:   "https://git-host.com/",
 			ServiceType: extsvc.TypeOther,
 		},
-		Metadata: &types.OtherRepoMetadata{},
+		Metadata: &extsvc.OtherRepoMetadata{},
 	}).With(
 		types.Opt.RepoSources(otherService.URN()),
 	)

--- a/internal/types/scopes.go
+++ b/internal/types/scopes.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/auth"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/schema"
+)
+
+// TODO: GrantedScopes doesn't feel like it should belong in this package. It
+// causes our internal/types package to pull in code host specific packages like
+// sourcegraph/sourcegraph/internal/extsvc/github. Ideally, they should belong in
+// the extsvc package but that also doesn't work since that package can't
+// imported from the code host specific sub-packages which as it leads to a
+// cyclic import.
+
+// GrantedScopes returns a slice of scopes granted by the service based on the token
+// provided in the config.
+//
+// Currently only GitHub is supported.
+func GrantedScopes(ctx context.Context, kind string, rawConfig string) ([]string, error) {
+	if kind != extsvc.KindGitHub {
+		return nil, fmt.Errorf("only GitHub supported")
+	}
+	config, err := extsvc.ParseConfig(kind, rawConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing config")
+	}
+	switch v := config.(type) {
+	case *schema.GitHubConnection:
+		u, err := url.Parse(v.Url)
+		if err != nil {
+			return nil, errors.Wrap(err, "parsing URL")
+		}
+		client := github.NewV3Client(u, &auth.OAuthBearerToken{Token: v.Token}, nil)
+		return client.GetAuthenticatedUserOAuthScopes(ctx)
+	default:
+		return nil, fmt.Errorf("unsupported config type: %T", v)
+	}
+}

--- a/internal/types/scopes_test.go
+++ b/internal/types/scopes_test.go
@@ -1,0 +1,28 @@
+package types
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+)
+
+func TestGrantedScopes(t *testing.T) {
+	want := []string{"repo"}
+	github.MockGetAuthenticatedUserOAuthScopes = func(ctx context.Context) ([]string, error) {
+		return want, nil
+	}
+
+	ctx := context.Background()
+	have, err := GrantedScopes(ctx, extsvc.KindGitHub, `{}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, have); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/internal/types/testing.go
+++ b/internal/types/testing.go
@@ -75,7 +75,7 @@ func MakeAWSCodeCommitRepo(services ...*ExternalService) *Repo {
 // MakeOtherRepo returns a configured repository from a custom host.
 func MakeOtherRepo(services ...*ExternalService) *Repo {
 	repo := MakeRepo("git-host.com/org/foo", "https://git-host.com/", extsvc.KindOther, services...)
-	repo.Metadata = new(OtherRepoMetadata)
+	repo.Metadata = new(extsvc.OtherRepoMetadata)
 	return repo
 }
 


### PR DESCRIPTION
The code is related to repos, it should belong in the repos pacakge.
Also, havning it in the types package causaed that package to pull in a
bunch of code host specific packages.
