### PR TITLE
zoekt: update to include star ranking and heap observability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210525134535-f669d63e86d5
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1336,6 +1336,8 @@ github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152 h1:z/MpntplPaW6
 github.com/sourcegraph/yaml v1.0.1-0.20200714132230-56936252f152/go.mod h1:GIjDIg/heH5DOkXY3YJ/wNhfHsQHoXGjl8G8amsYQ1I=
 github.com/sourcegraph/zoekt v0.0.0-20210525134535-f669d63e86d5 h1:omlazpgJMdAOxOAv6cTZ273qcQIkayUUYnw4LlgLZp4=
 github.com/sourcegraph/zoekt v0.0.0-20210525134535-f669d63e86d5/go.mod h1:YC1B28chsKPWXpYC//ZnaG3u7Zskipp6JlgmHxiz59U=
+github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9 h1:2Dwc8R4X8RWHckW6pvGe4ZjzRtbWGA1U4q6ykzlYdMM=
+github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9/go.mod h1:YC1B28chsKPWXpYC//ZnaG3u7Zskipp6JlgmHxiz59U=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Our zoekt fork now has some better heap observability we want to observe
in production. It also includes functionality to store priorities for
what order we search shards (ie ranking!)

- https://github.com/sourcegraph/zoekt/commit/2e9cf0f index: read in ngrams in own function
- https://github.com/sourcegraph/zoekt/commit/8dc126b shards: call searchOneShard even if ctx is canceled
- https://github.com/sourcegraph/zoekt/commit/965d233 Add prometheus metrics for priority.json.
- https://github.com/sourcegraph/zoekt/commit/d720674 address review comments
- https://github.com/sourcegraph/zoekt/commit/8451765 make sourcegraph-indexserver store priorities and shardedsearcher sort by them
