### PR TITLE
web: update redesign alert icon colors

### DIFF
--- a/client/branded/src/global-styles/alert-redesign.scss
+++ b/client/branded/src/global-styles/alert-redesign.scss
@@ -3,13 +3,14 @@
 .theme-redesign {
     .alert-info {
         --alert-border-color: var(--info);
-        --alert-icon-color: var(--info-3);
 
         @include theme-light-rules {
+            --alert-icon-color: var(--info-3);
             --alert-icon-background-color: var(--info-4);
         }
 
         @include theme-dark-rules {
+            --alert-icon-color: var(--info);
             --alert-icon-background-color: var(--info-3);
         }
     }
@@ -17,7 +18,14 @@
     .alert-primary {
         --alert-border-color: var(--primary);
         --alert-icon-background-color: var(--primary-4);
-        --alert-icon-color: var(--primary-3);
+
+        @include theme-light-rules {
+            --alert-icon-color: var(--primary-3);
+        }
+
+        @include theme-dark-rules {
+            --alert-icon-color: var(--primary);
+        }
     }
 
     .alert-secondary {
@@ -49,7 +57,14 @@
     .alert-warning {
         --alert-border-color: var(--warning);
         --alert-icon-background-color: var(--warning-4);
-        --alert-icon-color: var(--warning-3);
+
+        @include theme-light-rules {
+            --alert-icon-color: var(--warning-3);
+        }
+
+        @include theme-dark-rules {
+            --alert-icon-color: var(--warning);
+        }
 
         &::after {
             // Icon: mdi-react/Alert
@@ -62,7 +77,14 @@
     .alert-danger {
         --alert-border-color: var(--danger);
         --alert-icon-background-color: var(--danger-4);
-        --alert-icon-color: var(--danger-3);
+
+        @include theme-light-rules {
+            --alert-icon-color: var(--danger-3);
+        }
+
+        @include theme-dark-rules {
+            --alert-icon-color: var(--danger);
+        }
 
         &::after {
             // Icon: mdi-react/AlertCircle
@@ -75,7 +97,14 @@
     .alert-success {
         --alert-border-color: var(--success);
         --alert-icon-background-color: var(--success-4);
-        --alert-icon-color: var(--success-3);
+
+        @include theme-light-rules {
+            --alert-icon-color: var(--success-3);
+        }
+
+        @include theme-dark-rules {
+            --alert-icon-color: var(--success);
+        }
 
         &::after {
             // Icon: mdi-react/CheckCircle
@@ -88,7 +117,14 @@
     .alert-merged {
         --alert-border-color: var(--merged);
         --alert-icon-background-color: var(--merged-4);
-        --alert-icon-color: var(--merged-3);
+
+        @include theme-light-rules {
+            --alert-icon-color: var(--merged-3);
+        }
+
+        @include theme-dark-rules {
+            --alert-icon-color: var(--merged);
+        }
 
         &::after {
             // Icon: mdi-react/SourceMerge
@@ -137,7 +173,7 @@
 
         &::after {
             mask-repeat: no-repeat;
-            mask-size: 1.25rem;
+            mask-size: 1rem;
             mask-position: 50% 50%;
             // Applied as a fill color for SVG icon because of the mask-image.
             background-color: var(--alert-icon-color);

--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -69,7 +69,7 @@ $theme-colors-redesign: (
     --warning-2: #fbd999;
     --danger: var(--red);
     --danger-2: #e9aaaa;
-    --merged: var(--purple);
+    --merged: #7048e8;
     --merged-2: #c6b6f6;
     --merged-3: #6b47d6;
     --light-text: var(--white);


### PR DESCRIPTION
## Changes

- Updated redesign alert icon colors based on the discussion [here](https://github.com/sourcegraph/sourcegraph/issues/21041).
- Updated redesign alert icon size to match the latest mockups.
- Updated `--merged` color to match the latest mockups. 

[Figma mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=1563%3A196).
Fixes https://github.com/sourcegraph/sourcegraph/issues/21041.