### PR TITLE
search: fix flakey negated filter integration test

### DIFF
--- a/client/web/src/integration/search.test.ts
+++ b/client/web/src/integration/search.test.ts
@@ -166,16 +166,16 @@ describe('Search', () => {
             await driver.page.waitForSelector('#monaco-query-input')
             await driver.replaceText({
                 selector: '#monaco-query-input',
-                newText: '-repo',
+                newText: '-file',
                 enterTextMethod: 'type',
             })
             await driver.page.waitForSelector('.monaco-query-input .suggest-widget.visible')
-            await driver.findElementWithText('-repo', {
+            await driver.findElementWithText('-file', {
                 action: 'click',
                 wait: { timeout: 5000 },
                 selector: '.monaco-query-input .suggest-widget.visible span',
             })
-            expect(await getSearchFieldValue(driver)).toStrictEqual('-repo:')
+            expect(await getSearchFieldValue(driver)).toStrictEqual('-file:')
         })
     })
 


### PR DESCRIPTION
Negated filter autocomplete test sometimes fails because `-repo` is autocompleted as `-repohasfile:` instead of `-repo:`. [Example failure](https://buildkite.com/sourcegraph/sourcegraph/builds/97298#cbe81f47-e741-4114-b726-412be07998b2). Changing to `-file` to stabilize.

Build 1 https://buildkite.com/sourcegraph/sourcegraph/builds/97306
Build 2 https://buildkite.com/sourcegraph/sourcegraph/builds/97311