### PR TITLE
Fuzzy finder: add new `fileNames` GraphQL property

### DIFF
--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -6,7 +6,7 @@ import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
 import { requestGraphQL } from '../../backend/graphql'
 import { FuzzySearch, SearchIndexing } from '../../fuzzyFinder/FuzzySearch'
-import { FilesResult, FilesVariables } from '../../graphql-operations'
+import { FileNamesResult, FileNamesVariables } from '../../graphql-operations'
 import {
     KEYBOARD_SHORTCUT_CLOSE_FUZZY_FINDER,
     KEYBOARD_SHORTCUT_FUZZY_FINDER,
@@ -128,15 +128,13 @@ export interface Failed {
 }
 
 async function downloadFilenames(props: FuzzyFinderProps): Promise<string[]> {
-    const gqlResult = await requestGraphQL<FilesResult, FilesVariables>(
+    const gqlResult = await requestGraphQL<FileNamesResult, FileNamesVariables>(
         gql`
-            query Files($repository: String!, $commit: String!) {
+            query FileNames($repository: String!, $commit: String!) {
                 repository(name: $repository) {
                     commit(rev: $commit) {
                         tree(recursive: true) {
-                            files(first: 1000000, recursive: true) {
-                                path
-                            }
+                            fileNames
                         }
                     }
                 }
@@ -147,7 +145,7 @@ async function downloadFilenames(props: FuzzyFinderProps): Promise<string[]> {
             commit: props.commitID,
         }
     ).toPromise()
-    const filenames = gqlResult.data?.repository?.commit?.tree?.files?.map(file => file.path)
+    const filenames = gqlResult.data?.repository?.commit?.tree?.fileNames
     if (!filenames) {
         throw new Error(JSON.stringify(gqlResult))
     }

--- a/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyFinder.tsx
@@ -133,9 +133,7 @@ async function downloadFilenames(props: FuzzyFinderProps): Promise<string[]> {
             query FileNames($repository: String!, $commit: String!) {
                 repository(name: $repository) {
                     commit(rev: $commit) {
-                        tree(recursive: true) {
-                            fileNames
-                        }
+                        fileNames
                     }
                 }
             }
@@ -145,7 +143,7 @@ async function downloadFilenames(props: FuzzyFinderProps): Promise<string[]> {
             commit: props.commitID,
         }
     ).toPromise()
-    const filenames = gqlResult.data?.repository?.commit?.tree?.fileNames
+    const filenames = gqlResult.data?.repository?.commit?.fileNames
     if (!filenames) {
         throw new Error(JSON.stringify(gqlResult))
     }

--- a/cmd/frontend/graphqlbackend/git_commit.go
+++ b/cmd/frontend/graphqlbackend/git_commit.go
@@ -232,6 +232,10 @@ func (r *GitCommitResolver) File(ctx context.Context, args *struct {
 	return r.Blob(ctx, args)
 }
 
+func (r *GitCommitResolver) FileNames(ctx context.Context) ([]string, error) {
+	return git.LsFiles(ctx, r.gitRepo, api.CommitID(r.oid))
+}
+
 func (r *GitCommitResolver) Languages(ctx context.Context) ([]string, error) {
 	repo, err := r.repoResolver.repo(ctx)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/git_commit_test.go
+++ b/cmd/frontend/graphqlbackend/git_commit_test.go
@@ -7,8 +7,11 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/graph-gophers/graphql-go/gqltesting"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/backend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
+	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
@@ -106,5 +109,49 @@ func TestGitCommitResolver(t *testing.T) {
 				}
 			})
 		}
+	})
+}
+
+func TestGitCommitFileNames(t *testing.T) {
+	resetMocks()
+	database.Mocks.ExternalServices.List = func(opt database.ExternalServicesListOptions) ([]*types.ExternalService, error) {
+		return nil, nil
+	}
+	database.Mocks.Repos.MockGetByName(t, "github.com/gorilla/mux", 2)
+	backend.Mocks.Repos.ResolveRev = func(ctx context.Context, repo *types.Repo, rev string) (api.CommitID, error) {
+		if repo.ID != 2 || rev != exampleCommitSHA1 {
+			t.Error("wrong arguments to Repos.ResolveRev")
+		}
+		return exampleCommitSHA1, nil
+	}
+	backend.Mocks.Repos.MockGetCommit_Return_NoCheck(t, &git.Commit{ID: exampleCommitSHA1})
+	git.Mocks.LsFiles = func(repo api.RepoName, commit api.CommitID) ([]string, error) {
+		return []string{"a", "b"}, nil
+	}
+
+	defer git.ResetMocks()
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: mustParseGraphQLSchema(t),
+			Query: `
+				{
+					repository(name: "github.com/gorilla/mux") {
+						commit(rev: "` + exampleCommitSHA1 + `") {
+							fileNames
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+{
+  "repository": {
+    "commit": {
+		"fileNames": ["a", "b"]
+    }
+  }
+}
+			`,
+		},
 	})
 }

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -181,6 +181,14 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 	return nil
 }
 
+func (r *GitTreeEntryResolver) FileNames(ctx context.Context) ([]string, error) {
+	return git.LsFiles(
+		ctx,
+		r.commit.repoResolver.RepoName(),
+		api.CommitID(r.commit.OID()),
+	)
+}
+
 func cloneURLToRepoName(ctx context.Context, cloneURL string) (string, error) {
 	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, cloneURL)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/git_tree_entry.go
+++ b/cmd/frontend/graphqlbackend/git_tree_entry.go
@@ -181,14 +181,6 @@ func (r *GitTreeEntryResolver) Submodule() *gitSubmoduleResolver {
 	return nil
 }
 
-func (r *GitTreeEntryResolver) FileNames(ctx context.Context) ([]string, error) {
-	return git.LsFiles(
-		ctx,
-		r.commit.repoResolver.RepoName(),
-		api.CommitID(r.commit.OID()),
-	)
-}
-
 func cloneURLToRepoName(ctx context.Context, cloneURL string) (string, error) {
 	repoName, err := cloneurls.ReposourceCloneURLToRepoName(ctx, cloneURL)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3782,6 +3782,10 @@ type GitTree implements TreeEntry {
         recursive: Boolean = false
     ): [File!]!
     """
+    A list of file names in this repository.
+    """
+    fileNames: [String!]!
+    """
     A list of entries in this tree.
     """
     entries(

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -3509,6 +3509,10 @@ type GitCommit implements Node {
         recursive: Boolean = false
     ): GitTree
     """
+    A list of file names in this repository.
+    """
+    fileNames: [String!]!
+    """
     The Git blob in this commit at the given path.
     """
     blob(path: String!): GitBlob
@@ -3781,10 +3785,6 @@ type GitTree implements TreeEntry {
         """
         recursive: Boolean = false
     ): [File!]!
-    """
-    A list of file names in this repository.
-    """
-    fileNames: [String!]!
     """
     A list of entries in this tree.
     """

--- a/internal/vcs/git/mocks.go
+++ b/internal/vcs/git/mocks.go
@@ -19,6 +19,7 @@ var Mocks, emptyMocks struct {
 	NewFileReader    func(commit api.CommitID, name string) (io.ReadCloser, error)
 	ReadFile         func(commit api.CommitID, name string) ([]byte, error)
 	ReadDir          func(commit api.CommitID, name string, recurse bool) ([]os.FileInfo, error)
+	LsFiles          func(repo api.RepoName, commit api.CommitID) ([]string, error)
 	ResolveRevision  func(spec string, opt ResolveRevisionOptions) (api.CommitID, error)
 	Stat             func(commit api.CommitID, name string) (os.FileInfo, error)
 	GetObject        func(objectName string) (OID, ObjectType, error)

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -132,6 +132,23 @@ var (
 	lsTreeRootCache   = lru.New(5)
 )
 
+// LsFiles returns the output of `git ls-files`
+func LsFiles(ctx context.Context, repo api.RepoName, commit api.CommitID) ([]string, error) {
+	args := []string{
+		"ls-files",
+		"-z",
+		"--with-tree",
+		string(commit),
+	}
+	cmd := gitserver.DefaultClient.Command("git", args...)
+	cmd.Repo = repo
+	out, err := cmd.CombinedOutput(ctx)
+	if err != nil {
+		return nil, errors.WithMessage(err, fmt.Sprintf("git command %v failed (output: %q)", cmd.Args, out))
+	}
+	return strings.Split(string(out), "\x00"), nil
+}
+
 // lsTree returns ls of tree at path.
 func lsTree(ctx context.Context, repo api.RepoName, commit api.CommitID, path string, recurse bool) ([]os.FileInfo, error) {
 	if path != "" || !recurse {

--- a/internal/vcs/git/tree.go
+++ b/internal/vcs/git/tree.go
@@ -134,6 +134,9 @@ var (
 
 // LsFiles returns the output of `git ls-files`
 func LsFiles(ctx context.Context, repo api.RepoName, commit api.CommitID) ([]string, error) {
+	if Mocks.LsFiles != nil {
+		return Mocks.LsFiles(repo, commit)
+	}
 	args := []string{
 		"ls-files",
 		"-z",


### PR DESCRIPTION
Previously, the fuzzy finder used the existing `files()` GraphQL method
to list all the filenames in the repo. This solution was slow in very
large repositories because it uses `git ls-tree` to support more
functionality than what the fuzzy finder needs. This commit adds a new
`fileNames: string[]` property that should have better performance.