### PR TITLE
search redesign: search box QA

### DIFF
--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -123,6 +123,7 @@ $theme-colors-redesign: (
     --code-bg: var(--white);
     --intel-bg: var(--white);
     --subtle-bg: var(--gray-02);
+    --search-input-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 
     // TODO: Remove from use, replace with the variables referenced here.
     // Issue: https://github.com/sourcegraph/sourcegraph/issues/19973
@@ -172,6 +173,7 @@ $theme-colors-redesign: (
     --code-bg: var(--gray-10);
     --intel-bg: var(--gray-12);
     --subtle-bg: var(--gray-09);
+    --search-input-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 
     // TODO: Remove from use, replace with the variables referenced here.
     // Issue: https://github.com/sourcegraph/sourcegraph/issues/19973

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -355,7 +355,11 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                         )}
                     </NavActions>
                 </NavBar>
-                {showSearchBox && <div className="d-flex w-100 flex-row px-3 py-2 border-bottom">{searchNavBar}</div>}
+                {showSearchBox && (
+                    <div className="w-100 px-3 py-2">
+                        <div className="pb-2 border-bottom">{searchNavBar}</div>
+                    </div>
+                )}
             </>
         )
     }

--- a/client/web/src/nav/VersionContextDropdown.scss
+++ b/client/web/src/nav/VersionContextDropdown.scss
@@ -23,8 +23,11 @@
         border-radius: 0;
 
         .theme-redesign & {
+            padding: 0.5rem 0.75rem;
+            border: none;
+
             @media (--xs-breakpoint-down) {
-                padding: 0 0.25rem;
+                padding: 0.2rem 0.25rem;
                 margin-right: 0.5rem;
                 border-radius: var(--border-radius);
             }

--- a/client/web/src/repogroups/RepogroupPage.scss
+++ b/client/web/src/repogroups/RepogroupPage.scss
@@ -69,6 +69,11 @@
         border-radius: 2px 0 0 2px;
     }
 
+    &__search-button {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+
     &__repo-item {
         white-space: nowrap;
         overflow: hidden;

--- a/client/web/src/repogroups/RepogroupPage.tsx
+++ b/client/web/src/repogroups/RepogroupPage.tsx
@@ -145,7 +145,7 @@ export const RepogroupPage: React.FunctionComponent<RepogroupPageProps> = (props
                                     </small>
                                     <div className="d-flex">
                                         <button
-                                            className="btn btn-primary btn-sm search-button__btn test-search-button btn-secondary"
+                                            className="btn btn-secondary btn-sm repogroup-page__search-button"
                                             type="button"
                                             aria-label="Search"
                                             onClick={onSubmitExample(

--- a/client/web/src/search/input/SearchBox.module.scss
+++ b/client/web/src/search/input/SearchBox.module.scss
@@ -11,6 +11,7 @@
         @media (--xs-breakpoint-down) {
             background-color: var(--color-bg-1);
             border: 1px solid var(--input-border-color);
+            border-radius: var(--border-radius);
             display: inline;
             padding: 0.5rem;
         }

--- a/client/web/src/search/input/SearchBox.module.scss
+++ b/client/web/src/search/input/SearchBox.module.scss
@@ -143,7 +143,7 @@
         :global(.theme-redesign) & {
             @media (--xs-breakpoint-down) {
                 display: inline-flex;
-                margin-top: 1rem;
+                margin-top: 0.75rem;
                 padding-left: 0;
             }
         }
@@ -155,7 +155,7 @@
             @media (--xs-breakpoint-down) {
                 display: inline-flex;
                 flex-direction: row-reverse;
-                margin-top: 0.75rem;
+                margin-top: 0.5rem;
                 float: right;
             }
         }

--- a/client/web/src/search/input/SearchBox.module.scss
+++ b/client/web/src/search/input/SearchBox.module.scss
@@ -8,6 +8,8 @@
     min-width: 12rem;
 
     :global(.theme-redesign) & {
+        box-shadow: var(--search-input-shadow);
+
         @media (--xs-breakpoint-down) {
             background-color: var(--color-bg-1);
             border: 1px solid var(--input-border-color);

--- a/client/web/src/search/input/SearchBox.module.scss
+++ b/client/web/src/search/input/SearchBox.module.scss
@@ -79,6 +79,7 @@
                 flex-wrap: wrap;
                 display: inline;
                 padding-left: 0;
+                margin-left: 0;
 
                 &:focus-within {
                     border: none;

--- a/client/web/src/search/input/SearchButton.scss
+++ b/client/web/src/search/input/SearchButton.scss
@@ -3,6 +3,7 @@
         // Left side is flush with QueryInput.
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
+        display: flex;
 
         .theme-redesign & {
             @media (--xs-breakpoint-down) {

--- a/client/web/src/search/input/SearchButton.scss
+++ b/client/web/src/search/input/SearchButton.scss
@@ -6,6 +6,9 @@
         display: flex;
 
         .theme-redesign & {
+            padding: 0.5rem 1rem;
+            border: none;
+
             @media (--xs-breakpoint-down) {
                 border-radius: var(--border-radius);
             }


### PR DESCRIPTION
Fixes #21318

- [x] search icon is too tall and icon should be centered
- [x] adjust top margin for search button and toggles in xs size
- [x] xs search box should have border radius
- [x] adjust search box bottom border when under navbar
- [x] add box shadow to search box
- [x] equalize search button and version context dropdown height
- [x] align xs search input with other elements

Not implemented:
- multiline, to be done in separately in #21215
- adding placeholder text, Monaco does not support this (see https://github.com/microsoft/monaco-editor/issues/1228) but we can hack around it. to be done separately in #21465
- modifying the autocomplete box position, this is handled automatically by Monaco and it would be quite expensive to hack around this.