### PR TITLE
web: show upload icon on code-intel uploads page

### DIFF
--- a/client/web/src/enterprise/codeintel/shared/CodeIntelStateBanner.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelStateBanner.tsx
@@ -25,7 +25,7 @@ export const CodeIntelStateBanner: FunctionComponent<CodeIntelStateBannerProps> 
 }) => (
     <div className={classNames('alert', className)}>
         <span className="icon-inline">
-            <CodeIntelStateIcon className="mr-2" state={state} />
+            <CodeIntelStateIcon className="mr-2 redesign-d-none" state={state} />
         </span>
         <span>
             <CodeIntelStateDescription

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelStateIcon.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelStateIcon.tsx
@@ -16,15 +16,15 @@ export interface CodeIntelStateIconProps {
 
 export const CodeIntelStateIcon: FunctionComponent<CodeIntelStateIconProps> = ({ state, className }) =>
     state === LSIFUploadState.UPLOADING ? (
-        <FileUploadIcon className={classNames('redesign-d-none', className)} />
+        <FileUploadIcon className={className} />
     ) : state === LSIFUploadState.QUEUED || state === LSIFIndexState.QUEUED ? (
-        <TimerSandIcon className={classNames('redesign-d-none', className)} />
+        <TimerSandIcon className={className} />
     ) : state === LSIFUploadState.PROCESSING || state === LSIFIndexState.PROCESSING ? (
-        <LoadingSpinner className={classNames('redesign-d-none', className)} />
+        <LoadingSpinner className={className} />
     ) : state === LSIFUploadState.COMPLETED || state === LSIFIndexState.COMPLETED ? (
-        <CheckCircleIcon className={classNames('redesign-d-none text-success', className)} />
+        <CheckCircleIcon className={classNames('text-success', className)} />
     ) : state === LSIFUploadState.ERRORED || state === LSIFIndexState.ERRORED ? (
-        <ErrorIcon className={classNames('redesign-d-none text-danger', className)} />
+        <ErrorIcon className={classNames('text-danger', className)} />
     ) : (
         <></>
     )


### PR DESCRIPTION
## Changes

- Hide `CodeIntelStateIcon` only in `CodeIntelStateBanner` to avoid hiding upload icon on code-intel uploads page.

Fixes https://github.com/sourcegraph/sourcegraph/issues/21404.