### PR TITLE
repos: Cache GrantedScopes

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/repos"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
@@ -168,6 +169,8 @@ func (r *externalServiceResolver) NextSyncAt() *DateTime {
 	return &DateTime{Time: r.externalService.NextSyncAt}
 }
 
+var scopeCache = rcache.New("extsvc_token_scope")
+
 func (r *externalServiceResolver) GrantedScopes(ctx context.Context) ([]string, error) {
-	return repos.GrantedScopes(ctx, r.externalService.Kind, r.externalService.Config)
+	return repos.GrantedScopes(ctx, scopeCache, r.externalService.Kind, r.externalService.Config)
 }

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -270,6 +270,7 @@ func (m MockExternalServicesLister) List(ctx context.Context, args database.Exte
 func TestGrantedScopes(t *testing.T) {
 	rcache.SetupForTest(t)
 	cache := rcache.New("TestGrantedScopes")
+	ctx := context.Background()
 
 	want := []string{"repo"}
 	github.MockGetAuthenticatedUserOAuthScopes = func(ctx context.Context) ([]string, error) {
@@ -278,7 +279,6 @@ func TestGrantedScopes(t *testing.T) {
 
 	// Run twice to use cache
 	for i := 0; i < 2; i++ {
-		ctx := context.Background()
 		have, err := GrantedScopes(ctx, cache, extsvc.KindGitHub, `{"token": "abc"}`)
 		if err != nil {
 			t.Fatal(i, err)

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sourcegraph/sourcegraph/internal/rcache"
-
 	"github.com/google/go-cmp/cmp"
 	"golang.org/x/time/rate"
 
@@ -17,6 +15,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/ratelimit"
+	"github.com/sourcegraph/sourcegraph/internal/rcache"
 	"github.com/sourcegraph/sourcegraph/internal/types"
 	"github.com/sourcegraph/sourcegraph/schema"
 )


### PR DESCRIPTION
Since fetching scopes needs to hit the code host but code host tokens
are immutable it makes sense to cache them. This allows us to treat the
GrantedScopes API query as cheap so that we don't need to consider any
client side caching.

Caching on the client side would be difficult since we don't actually
have access to the tokens there.

For security we cache a hashed version of the token so that it continues
to only be stored in one place, an encrypted blob in the config column
of the external_services table.

Part of: https://github.com/sourcegraph/sourcegraph/issues/20229