### PR TITLE
web: prevent install browser extension alert from shrinking

### DIFF
--- a/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
+++ b/client/web/src/repo/actions/InstallBrowserExtensionAlert.tsx
@@ -41,7 +41,7 @@ export const InstallBrowserExtensionAlert: React.FunctionComponent<Props> = ({
     const Icon = icon || ExportIcon
 
     return (
-        <div className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert">
+        <div className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert">
             <div className="d-flex align-items-center">
                 <div className="redesign-d-none position-relative">
                     <div className="install-browser-extension-alert__icon-flash" />

--- a/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
+++ b/client/web/src/repo/actions/__snapshots__/InstallBrowserExtensionAlert.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -83,7 +83,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (native integration) 1`] =
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -155,7 +155,7 @@ exports[`InstallBrowserExtensionAlert BITBUCKETSERVER (non-Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -222,7 +222,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -290,7 +290,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (native integration) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -362,7 +362,7 @@ exports[`InstallBrowserExtensionAlert GITHUB (non-Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -429,7 +429,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -497,7 +497,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (native integration) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -569,7 +569,7 @@ exports[`InstallBrowserExtensionAlert GITLAB (non-Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -636,7 +636,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -730,7 +730,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (native integration) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"
@@ -831,7 +831,7 @@ exports[`InstallBrowserExtensionAlert PHABRICATOR (non-Chrome) 1`] = `
   onAlertDismissed={[Function]}
 >
   <div
-    className="alert alert-info m-2 d-flex justify-content-between install-browser-extension-alert"
+    className="alert alert-info m-2 d-flex justify-content-between flex-shrink-0 install-browser-extension-alert"
   >
     <div
       className="d-flex align-items-center"


### PR DESCRIPTION
## Changes

- Added `flex-shrink: 0` to browser extension alert to fix its size.

Local example [url](http://sourcegraph.test:3443/ghe.sgdev.org/sourcegraph/sourcegraph-sourcegraph/-/tree/web/src/components).

## Screenshots

Before:

<img width="1227" alt="Screenshot 2021-05-27 at 12 15 11" src="https://user-images.githubusercontent.com/3846380/119800101-47814180-bf0f-11eb-8e56-02d0cf7108a6.png">


After:

<img width="1227" alt="Screenshot 2021-05-27 at 12 14 50" src="https://user-images.githubusercontent.com/3846380/119800134-510aa980-bf0f-11eb-9a3f-137c5a6085f8.png">
