### PR TITLE
docs: Highlight workspaces as solution in monorepos

### DIFF
--- a/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
+++ b/doc/batch_changes/how-tos/creating_multiple_changesets_in_large_repositories.md
@@ -17,9 +17,11 @@
 
 ## Overview
 
-Batch Changes can produce a lot of changes in a single repository and in order to make reviewing and merging them easier, it might make sense to split the changes up into multiple changesets.
+Batch changes can produce a lot of changes in a single repository. In order to make reviewing and merging the changes easier, it can be helpful to split the changes up into multiple changesets.
 
 That can be done by using [`transformChanges`](../references/batch_spec_yaml_reference.md#transformchanges) in the batch spec to group the changes produced in one single repository by directory and create a changeset for each group.
+
+> NOTE: In some monorepos it makes more sense to run the batch spec [`steps`][steps] _per project_. Take a look at "[Creating changesets per project in monorepos](./creating_changesets_per_project_in_monorepos.md)" to find out how to use the [`workspaces`][workspaces] property to do that.
 
 ## Using `transformChanges`
 
@@ -78,3 +80,8 @@ In case no changes have been made in a `directory` specified in a `group`, no ad
 If the optional `repository` property is specified only the changes in that repository will be grouped.
 
 See the [batch spec YAML reference on `transformChanges`](../references/batch_spec_yaml_reference.md#transformchanges) for more details.
+
+<!-- References for easier reading of text above: -->
+
+[steps]: ../references/batch_spec_yaml_reference.md#steps
+[workspaces]: ../references/batch_spec_yaml_reference.md#workspaces

--- a/doc/batch_changes/how-tos/index.md
+++ b/doc/batch_changes/how-tos/index.md
@@ -11,6 +11,8 @@ The following is a list of how-tos that show how to use [Sourcegraph Batch Chang
 - [Site admin configuration for Batch Changes](site_admin_configuration.md)
 - [Configuring credentials for Batch Changes](configuring_credentials.md)
 - [Handling errored changesets](handling_errored_changesets.md)
-- <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)
-- [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)
 - [Opting out of batch changes](opting_out_of_batch_changes.md)
+- [Bulk operations on changesets](bulk_operations_on_changesets.md)
+- Batch changes in monorepos
+  - [Creating changesets per project in monorepos](creating_changesets_per_project_in_monorepos.md)
+  - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](creating_multiple_changesets_in_large_repositories.md)

--- a/doc/batch_changes/index.md
+++ b/doc/batch_changes/index.md
@@ -87,11 +87,12 @@ Create a batch change by specifying a search query to get a list of repositories
 - [Closing or deleting a batch change](how-tos/closing_or_deleting_a_batch_change.md)
 - [Site admin configuration for batch changes](how-tos/site_admin_configuration.md)
 - [Configuring credentials for Batch Changes](how-tos/configuring_credentials.md)
-- <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
 - [Handling errored changesets](how-tos/handling_errored_changesets.md)
-- [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)
 - [Opting out of batch changes](how-tos/opting_out_of_batch_changes.md)
 - [Bulk operations on changesets](how-tos/bulk_operations_on_changesets.md)
+- Batch changes in monorepos
+  - [Creating changesets per project in monorepos](how-tos/creating_changesets_per_project_in_monorepos.md)
+  - <span class="badge badge-experimental">Experimental</span> [Creating multiple changesets in large repositories](how-tos/creating_multiple_changesets_in_large_repositories.md)
 
 ## Tutorials
 


### PR DESCRIPTION

Not sure whether this fixes #20061 (I'll let @malomarrec decide), but
this is my attempt to.

It groups the two how-tos under a "monorepo" header and it provides a
backlink to the `workspaces:` how-to in the `transformChanges:` how-to.

#### Screenshots

![screenshot_2021-05-27_11 17 45@2x](https://user-images.githubusercontent.com/1185253/119800798-649d1c80-bedd-11eb-8842-44584391ca68.png)

![image](https://user-images.githubusercontent.com/1185253/119801209-c9587700-bedd-11eb-96a1-6fe8a7d17039.png)

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
