### PR TITLE
zoekt: update to log shard lifecycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210527101435-38a21ddacc0a
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1093,6 +1093,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
+github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/nats-server/v2 v2.1.2/go.mod h1:Afk+wRZqkMQs/p45uXdrVLuab3gwv3Z8C4HTBu8GD/k=
@@ -1347,6 +1348,8 @@ github.com/sourcegraph/zoekt v0.0.0-20210525134535-f669d63e86d5 h1:omlazpgJMdAOx
 github.com/sourcegraph/zoekt v0.0.0-20210525134535-f669d63e86d5/go.mod h1:YC1B28chsKPWXpYC//ZnaG3u7Zskipp6JlgmHxiz59U=
 github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9 h1:2Dwc8R4X8RWHckW6pvGe4ZjzRtbWGA1U4q6ykzlYdMM=
 github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9/go.mod h1:YC1B28chsKPWXpYC//ZnaG3u7Zskipp6JlgmHxiz59U=
+github.com/sourcegraph/zoekt v0.0.0-20210527101435-38a21ddacc0a h1:HOHf6CpZ/42VNmdlhuv55bGgBpI71iTMZUva25affI8=
+github.com/sourcegraph/zoekt v0.0.0-20210527101435-38a21ddacc0a/go.mod h1:qoo9akQ7UrtoRYxnr0XqhScENQyq2UYufhiMFsRdGfU=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
Also includes a heap usage optimization:

- 38a21dd indexserver: log shard lifecycle to disk
- cc569f0 index: pre-allocate size of ngram map