### PR TITLE
gomod: zoekt uses different import for lumberjack

### DIFF
--- a/dev/zoekt/update
+++ b/dev/zoekt/update
@@ -4,6 +4,9 @@ set -e
 
 export GO111MODULE=on
 
+# Disable proxy since it can cache the value of master
+export GOPROXY="${GOPROXY:-direct}"
+
 # Can specify a SHA pushed to our fork instead of master
 version="${1:-master}"
 

--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,7 @@ require (
 // or intentional forks.
 replace (
 	// We maintain our own fork of Zoekt. Update with ./dev/zoekt/update
-	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210527101435-38a21ddacc0a
+	github.com/google/zoekt => github.com/sourcegraph/zoekt v0.0.0-20210527123026-8b830279b96c
 	// We use a fork of Alertmanager to allow prom-wrapper to better manipulate Alertmanager configuration.
 	// See https://docs.sourcegraph.com/dev/background-information/observability/prometheus
 	github.com/prometheus/alertmanager => github.com/sourcegraph/alertmanager v0.21.1-0.20200727091526-3e856a90b534

--- a/go.sum
+++ b/go.sum
@@ -1350,6 +1350,8 @@ github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9 h1:2Dwc8R4X8RWHc
 github.com/sourcegraph/zoekt v0.0.0-20210526144326-2e9cf0ff1cc9/go.mod h1:YC1B28chsKPWXpYC//ZnaG3u7Zskipp6JlgmHxiz59U=
 github.com/sourcegraph/zoekt v0.0.0-20210527101435-38a21ddacc0a h1:HOHf6CpZ/42VNmdlhuv55bGgBpI71iTMZUva25affI8=
 github.com/sourcegraph/zoekt v0.0.0-20210527101435-38a21ddacc0a/go.mod h1:qoo9akQ7UrtoRYxnr0XqhScENQyq2UYufhiMFsRdGfU=
+github.com/sourcegraph/zoekt v0.0.0-20210527123026-8b830279b96c h1:MgxyktiWqcEAPUpWAza4JKJ+s5HAog6ENhxzOUrkVqk=
+github.com/sourcegraph/zoekt v0.0.0-20210527123026-8b830279b96c/go.mod h1:pDBF9tbOklLIUC7TSViRTWpYwckP8UYTEnSYPw5qts8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=


### PR DESCRIPTION
This is a bump to fix a problem we are facing in CI when building zoekt
for the server image.

Co-authored-by: @stefanhengl 