### PR TITLE
codeintel: Fix casing of upload state

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/janitor.go
+++ b/enterprise/internal/codeintel/stores/dbstore/janitor.go
@@ -135,7 +135,7 @@ func (s *Store) RefreshCommitResolvability(ctx context.Context, repositoryID int
 		sqlf.Sprintf("commit_last_checked_at = %s", now),
 	}
 	if delete {
-		assignmentExpressions = append(assignmentExpressions, sqlf.Sprintf("state = 'DELETED'"))
+		assignmentExpressions = append(assignmentExpressions, sqlf.Sprintf("state = 'deleted'"))
 	}
 	assignmentExpression := sqlf.Join(assignmentExpressions, ", ")
 


### PR DESCRIPTION
Noticed we were accumulating non-deleted records due to mismatch in state casing. Fixing the writes now and will introduce a migration later to move all the `DELETED` records to `deleted`.