### PR TITLE
internal/cmd: Add jsonc-validate

### DIFF
--- a/internal/cmd/jsonc-validate/main.go
+++ b/internal/cmd/jsonc-validate/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/sourcegraph/sourcegraph/internal/jsonc"
+)
+
+func main() {
+	in, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bs, err := jsonc.Parse(string(in))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Stdout.Write(bs)
+}


### PR DESCRIPTION
Updating site config in production requires manual fiddling with JSONC.
To prevent updating that value with invalid JSON, we introduce this
small command that sanitizes JSONC to JSON, which confirms the input
payload was valid JSONC.



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
