### PR TITLE
codeintel: Add migration to normalize casing in lsif_uploads.state

### DIFF
--- a/migrations/frontend/1528395824_fix_lsif_upload_state_casing.down.sql
+++ b/migrations/frontend/1528395824_fix_lsif_upload_state_casing.down.sql
@@ -1,0 +1,1 @@
+-- Nothing to do

--- a/migrations/frontend/1528395824_fix_lsif_upload_state_casing.up.sql
+++ b/migrations/frontend/1528395824_fix_lsif_upload_state_casing.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+UPDATE lsif_uploads SET state = 'deleted' WHERE state = 'DELETED';
+
+COMMIT;


### PR DESCRIPTION
Following up from https://github.com/sourcegraph/sourcegraph/pull/21450