### PR TITLE
Move middleware to featureflag package

### DIFF
--- a/cmd/frontend/internal/cli/http.go
+++ b/cmd/frontend/internal/cli/http.go
@@ -27,7 +27,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
-	ffmiddleware "github.com/sourcegraph/sourcegraph/internal/featureflag/middleware"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
 	tracepkg "github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/trace/ot"
 	"github.com/sourcegraph/sourcegraph/internal/version"
@@ -50,7 +50,7 @@ func newExternalHTTPHandler(db dbutil.DB, schema *graphql.Schema, gitHubWebhook 
 	apiHandler = authMiddlewares.API(apiHandler) // 🚨 SECURITY: auth middleware
 	// 🚨 SECURITY: The HTTP API should not accept cookies as authentication (except those with the
 	// X-Requested-With header). Doing so would open it up to CSRF attacks.
-	apiHandler = ffmiddleware.Middleware(database.FeatureFlags(db), apiHandler)
+	apiHandler = featureflag.Middleware(database.FeatureFlags(db), apiHandler)
 	apiHandler = session.CookieMiddlewareWithCSRFSafety(apiHandler, corsAllowHeader, isTrustedOrigin) // API accepts cookies with special header
 	apiHandler = internalhttpapi.AccessTokenAuthMiddleware(db, apiHandler)                            // API accepts access tokens
 	apiHandler = gziphandler.GzipHandler(apiHandler)

--- a/internal/featureflag/middleware.go
+++ b/internal/featureflag/middleware.go
@@ -9,7 +9,7 @@ import (
 
 type flagContextKey struct{}
 
-type FeatureFlagStorer interface {
+type FeatureFlagStore interface {
 	GetUserFlags(context.Context, int32) (map[string]bool, error)
 	GetAnonymousUserFlags(context.Context, string) (map[string]bool, error)
 	GetGlobalFeatureFlags(context.Context) (map[string]bool, error)
@@ -17,14 +17,14 @@ type FeatureFlagStorer interface {
 
 // Middleware evaluates the feature flags for the current user and adds the
 // feature flags to the current context.
-func Middleware(ffs FeatureFlagStorer, next http.Handler) http.Handler {
+func Middleware(ffs FeatureFlagStore, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Cookie")
 		next.ServeHTTP(w, r.WithContext(contextWithFeatureFlags(ffs, r)))
 	})
 }
 
-func contextWithFeatureFlags(ffs FeatureFlagStorer, r *http.Request) context.Context {
+func contextWithFeatureFlags(ffs FeatureFlagStore, r *http.Request) context.Context {
 	if a := actor.FromContext(r.Context()); a.IsAuthenticated() {
 		flags, err := ffs.GetUserFlags(r.Context(), a.UID)
 		if err == nil {

--- a/internal/featureflag/middleware.go
+++ b/internal/featureflag/middleware.go
@@ -1,30 +1,34 @@
-package middleware
+package featureflag
 
 import (
 	"context"
 	"net/http"
 
 	"github.com/sourcegraph/sourcegraph/internal/actor"
-	"github.com/sourcegraph/sourcegraph/internal/database"
-	ff "github.com/sourcegraph/sourcegraph/internal/featureflag"
 )
 
 type flagContextKey struct{}
 
+type FeatureFlagStorer interface {
+	GetUserFlags(context.Context, int32) (map[string]bool, error)
+	GetAnonymousUserFlags(context.Context, string) (map[string]bool, error)
+	GetGlobalFeatureFlags(context.Context) (map[string]bool, error)
+}
+
 // Middleware evaluates the feature flags for the current user and adds the
 // feature flags to the current context.
-func Middleware(ffs *database.FeatureFlagStore, next http.Handler) http.Handler {
+func Middleware(ffs FeatureFlagStorer, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Vary", "Cookie")
 		next.ServeHTTP(w, r.WithContext(contextWithFeatureFlags(ffs, r)))
 	})
 }
 
-func contextWithFeatureFlags(ffs *database.FeatureFlagStore, r *http.Request) context.Context {
+func contextWithFeatureFlags(ffs FeatureFlagStorer, r *http.Request) context.Context {
 	if a := actor.FromContext(r.Context()); a.IsAuthenticated() {
 		flags, err := ffs.GetUserFlags(r.Context(), a.UID)
 		if err == nil {
-			return context.WithValue(r.Context(), flagContextKey{}, ff.FlagSet(flags))
+			return context.WithValue(r.Context(), flagContextKey{}, FlagSet(flags))
 		}
 		// Continue if err != nil
 	}
@@ -32,7 +36,7 @@ func contextWithFeatureFlags(ffs *database.FeatureFlagStore, r *http.Request) co
 	if cookie, err := r.Cookie("sourcegraphAnonymousUid"); err == nil {
 		flags, err := ffs.GetAnonymousUserFlags(r.Context(), cookie.Value)
 		if err == nil {
-			return context.WithValue(r.Context(), flagContextKey{}, ff.FlagSet(flags))
+			return context.WithValue(r.Context(), flagContextKey{}, FlagSet(flags))
 		}
 		// Continue if err != nil
 	}
@@ -41,14 +45,14 @@ func contextWithFeatureFlags(ffs *database.FeatureFlagStore, r *http.Request) co
 	if err != nil {
 		return r.Context()
 	}
-	return context.WithValue(r.Context(), flagContextKey{}, ff.FlagSet(flags))
+	return context.WithValue(r.Context(), flagContextKey{}, FlagSet(flags))
 }
 
 // FromContext retrieves the current set of flags from the current
 // request's context.
-func FromContext(ctx context.Context) ff.FlagSet {
+func FromContext(ctx context.Context) FlagSet {
 	if flags := ctx.Value(flagContextKey{}); flags != nil {
-		return flags.(ff.FlagSet)
+		return flags.(FlagSet)
 	}
 	return nil
 }


### PR DESCRIPTION
Removes the dedicated package for feature flag middleware by making a lightweight interface for the feature flag store so we can avoid cyclical dependencies. 

Based on discussion in #21308 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
