### PR TITLE
extensibility: add padding to blob for status bar

### DIFF
--- a/client/web/src/repo/blob/Blob.scss
+++ b/client/web/src/repo/blob/Blob.scss
@@ -23,7 +23,7 @@
                 &::after {
                     content: '';
                     display: inline-block;
-                    padding-bottom: calc(var(--blob-status-bar-height) + var(--blob-status-bar-bottom) + 0.5rem);
+                    padding-bottom: calc(var(--blob-status-bar-height) + var(--blob-status-bar-vertical-gap) + 0.5rem);
                     // Extra 0.5rem padding on top of the minimum required to expose code;
                 }
             }


### PR DESCRIPTION
Prevent the status bar from covering code.

#### Before

![Screenshot from 2021-05-27 15-14-12](https://user-images.githubusercontent.com/37420160/119884067-3e3ba900-befe-11eb-8d2a-aba4c31d7e39.png)


#### After

![Screenshot from 2021-05-27 15-13-54](https://user-images.githubusercontent.com/37420160/119884077-409e0300-befe-11eb-84a6-2e41de574bc3.png)
