### PR TITLE
extensibility: update action item styles

### DIFF
--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -32,10 +32,6 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
 
         .theme-redesign & {
             background-color: var(--body-bg);
-
-            svg {
-                color: var(--icon-color);
-            }
         }
 
         &--open {
@@ -166,6 +162,13 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
                     background-color: nth($default-icon-colors, $i);
                 }
             }
+        }
+    }
+
+    // e.g. "close extensions panel", "add extensions"
+    &__aux-icon {
+        .theme-redesign & {
+            color: var(--icon-color);
         }
     }
 

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -294,7 +294,10 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(props => {
                     <li className="action-items__list-item">
                         <Link
                             to="/extensions"
-                            className={classNames(actionItemClassName, 'action-items__list-item')}
+                            className={classNames(
+                                actionItemClassName,
+                                'action-items__list-item action-items__aux-icon'
+                            )}
                             data-tooltip="Add extensions"
                         >
                             <PlusIcon className="icon-inline" />
@@ -334,7 +337,7 @@ export const ActionItemsToggle: React.FunctionComponent<ActionItemsToggleProps> 
                     )}
                 >
                     <ButtonLink
-                        className={classNames(actionItemClassName)}
+                        className={classNames(actionItemClassName, 'action-items__aux-icon')}
                         onSelect={toggle}
                         buttonLinkRef={toggleReference}
                     >

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -255,11 +255,15 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(props => {
                                     'action-items__action--inactive',
                                     !hasIconURL && 'action-items__action--no-icon-inactive'
                                 )
+                                const listItemClassName = classNames(
+                                    'action-items__list-item',
+                                    index !== items.length - 1 && 'mb-1'
+                                )
 
                                 const dataContent = !hasIconURL ? item.action.category?.slice(0, 1) : undefined
 
                                 return (
-                                    <li key={item.action.id} className="action-items__list-item">
+                                    <li key={item.action.id} className={listItemClassName}>
                                         <ActionItem
                                             {...props}
                                             {...item}


### PR DESCRIPTION
Update action items (not bar) styles for refresh:
- use `--icon-color` for "auxillary icons" (e.g. add extensions button)
- add m-1 between action items

![Screenshot from 2021-05-27 16-22-34](https://user-images.githubusercontent.com/37420160/119892392-15b8ac80-bf08-11eb-90ee-bfd9895e67fd.png)
