### PR TITLE
extensibility: add feedback modal for our extensions

### DIFF
--- a/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
+++ b/client/web/src/extensions/extension/RegistryExtensionOverviewPage.tsx
@@ -5,6 +5,7 @@ import GithubIcon from 'mdi-react/GithubIcon'
 import React, { useMemo, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 
+import { splitExtensionID } from '@sourcegraph/shared/src/extensions/extension'
 import { ExtensionCategory, ExtensionManifest } from '@sourcegraph/shared/src/schema/extensionSchema'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isEncodedImage } from '@sourcegraph/shared/src/util/icon'
@@ -17,6 +18,7 @@ import { DefaultExtensionIcon, DefaultSourcegraphExtensionIcon } from '../icons'
 import { extensionIDPrefix, extensionsQuery, urlToExtensionsQuery, validCategories } from './extension'
 import { ExtensionAreaRouteContext } from './ExtensionArea'
 import { ExtensionReadme } from './RegistryExtensionReadme'
+import { SourcegraphExtensionFeedback } from './SourcegraphExtensionFeedback'
 
 interface Props extends Pick<ExtensionAreaRouteContext, 'extension' | 'telemetryService' | 'isLightTheme'> {}
 
@@ -91,6 +93,8 @@ export const RegistryExtensionOverviewPage: React.FunctionComponent<Props> = ({
             categories = validatedCategories
         }
     }
+
+    const { isSourcegraphExtension } = splitExtensionID(extension.id)
 
     return (
         <div className="registry-extension-overview-page d-flex flex-wrap">
@@ -216,6 +220,11 @@ export const RegistryExtensionOverviewPage: React.FunctionComponent<Props> = ({
                                 </div>
                             )}
                         </dd>
+                        {isSourcegraphExtension && (
+                            <dd className="mt-2 py-2">
+                                <SourcegraphExtensionFeedback extensionID={extension.id} />
+                            </dd>
+                        )}
                     </dl>
                 </small>
             </aside>

--- a/client/web/src/extensions/extension/SourcegraphExtensionFeedback.tsx
+++ b/client/web/src/extensions/extension/SourcegraphExtensionFeedback.tsx
@@ -19,8 +19,8 @@ export const SourcegraphExtensionFeedback: React.FunctionComponent<SourcegraphEx
 
     return (
         <>
-            <button type="button" className="btn btn-sm btn-link p-0" onClick={toggleIsOpen}>
-                Message the author
+            <button type="button" className="btn btn-link p-0" onClick={toggleIsOpen}>
+                <small>Message the author</small>
             </button>
             {isOpen && (
                 <Dialog

--- a/client/web/src/extensions/extension/SourcegraphExtensionFeedback.tsx
+++ b/client/web/src/extensions/extension/SourcegraphExtensionFeedback.tsx
@@ -1,0 +1,36 @@
+import Dialog from '@reach/dialog'
+import React, { useState } from 'react'
+
+import { FeedbackPromptContent } from '../../nav/Feedback/FeedbackPrompt'
+
+interface SourcegraphExtensionFeedbackProps {
+    extensionID: string
+}
+
+export const SourcegraphExtensionFeedback: React.FunctionComponent<SourcegraphExtensionFeedbackProps> = ({
+    extensionID,
+}) => {
+    const [isOpen, setIsOpen] = useState(false)
+
+    const toggleIsOpen = (): void => setIsOpen(!isOpen)
+    const onClose = (): void => setIsOpen(false)
+    const textPrefix = `Sourcegraph extension ${extensionID}: `
+    const labelId = 'sourcegraph-extension-feedback-modal'
+
+    return (
+        <>
+            <button type="button" className="btn btn-sm btn-link p-0" onClick={toggleIsOpen}>
+                Message the author
+            </button>
+            {isOpen && (
+                <Dialog
+                    className="modal-body modal-body--top-third p-4 rounded border"
+                    onDismiss={onClose}
+                    aria-labelledby={labelId}
+                >
+                    <FeedbackPromptContent closePrompt={onClose} textPrefix={textPrefix} />
+                </Dialog>
+            )}
+        </>
+    )
+}

--- a/client/web/src/nav/Feedback/FeedbackPrompt.tsx
+++ b/client/web/src/nav/Feedback/FeedbackPrompt.tsx
@@ -55,12 +55,18 @@ const SUBMIT_HAPPINESS_FEEDBACK_QUERY = gql`
 interface ContentProps {
     closePrompt: () => void
     routeMatch?: string
+    /** Text to be prepended to user input on submission. */
+    textPrefix?: string
 }
 
 const LOCAL_STORAGE_KEY_RATING = 'feedbackPromptRating'
 const LOCAL_STORAGE_KEY_TEXT = 'feedbackPromptText'
 
-const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePrompt, routeMatch }) => {
+export const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({
+    closePrompt,
+    routeMatch,
+    textPrefix = '',
+}) => {
     const [rating, setRating] = useLocalStorage<number | undefined>(LOCAL_STORAGE_KEY_RATING, undefined)
     const [text, setText] = useLocalStorage<string>(LOCAL_STORAGE_KEY_TEXT, '')
     const handleRateChange = useCallback((value: number) => setRating(value), [setRating])
@@ -78,11 +84,11 @@ const FeedbackPromptContent: React.FunctionComponent<ContentProps> = ({ closePro
             event.preventDefault()
             if (rating) {
                 return submitFeedback({
-                    input: { score: rating, feedback: text, currentPath: routeMatch },
+                    input: { score: rating, feedback: `${textPrefix}${text}`, currentPath: routeMatch },
                 })
             }
         },
-        [rating, submitFeedback, text, routeMatch]
+        [rating, submitFeedback, text, routeMatch, textPrefix]
     )
 
     useEffect(() => {


### PR DESCRIPTION
Closes #21151. Add feedback modal for Sourcegraph-authored extensions. Prepend feedback with the extension ID for which the user has provided feedback.

![sgExtFeedback](https://user-images.githubusercontent.com/37420160/119899814-a3e56080-bf11-11eb-85f6-796e52335f45.gif)

Uses the same `<FeedbackPromptContent>` as the global nav's `<FeedbackPrompt>`. @sourcegraph/frontend-platform I think this could be confusing since they share the same `localStorage` key for partially-completed feedback. Should we parameterize the key, or is this not likely to be an issue?