### PR TITLE
extensibility: stabilize status bar items

### DIFF
--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -452,7 +452,12 @@ export function createExtensionHostAPI(state: ExtensionHostState): FlatExtension
                 return proxySubscribable(EMPTY)
             }
 
-            return proxySubscribable(viewer.mergedStatusBarItems.pipe(debounceTime(0)))
+            return proxySubscribable(
+                viewer.mergedStatusBarItems.pipe(
+                    debounceTime(0),
+                    map(statusBarItems => statusBarItems.sort((a, b) => a.text.charCodeAt(0) - b.text.charCodeAt(0)))
+                )
+            )
         },
 
         // Content

--- a/client/shared/src/api/extension/extensionHostApi.ts
+++ b/client/shared/src/api/extension/extensionHostApi.ts
@@ -455,7 +455,11 @@ export function createExtensionHostAPI(state: ExtensionHostState): FlatExtension
             return proxySubscribable(
                 viewer.mergedStatusBarItems.pipe(
                     debounceTime(0),
-                    map(statusBarItems => statusBarItems.sort((a, b) => a.text.charCodeAt(0) - b.text.charCodeAt(0)))
+                    map(statusBarItems =>
+                        statusBarItems.sort(
+                            (a, b) => a.text[0].toLowerCase().charCodeAt(0) - b.text[0].toLowerCase().charCodeAt(0)
+                        )
+                    )
                 )
             )
         },


### PR DESCRIPTION
Sort status bar items by text in extension host to close #20824. 

I considered sorting in each component that calls `getStatusBarItems`, but they are all satisfied by status bar items sorted alphabetically by text. In other words, this is a good default than components can override if needed later.