### PR TITLE
search frontend: modify console to use streaming

### DIFF
--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -149,6 +149,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const isSearchRelatedPage = (routeMatch === '/:repoRevAndRest+' || routeMatch?.startsWith('/search')) ?? false
     const minimalNavLinks = routeMatch === '/cncf'
     const isSearchHomepage = props.location.pathname === '/search' && !parseSearchURLQuery(props.location.search)
+    const isSearchConsolePage = routeMatch?.startsWith('/search/console')
 
     // Update parsedSearchQuery, patternType, caseSensitivity, versionContext, and selectedSearchContextSpec based on current URL
     const {
@@ -291,7 +292,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                 <GlobalNavbar
                     {...props}
                     authRequired={!!authRequired}
-                    showSearchBox={isSearchRelatedPage && !isSearchHomepage && !isRepogroupPage}
+                    showSearchBox={isSearchRelatedPage && !isSearchHomepage && !isRepogroupPage && !isSearchConsolePage}
                     variant={
                         hideGlobalSearchInput
                             ? 'no-search-input'

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -107,14 +107,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         path: '/search/console',
         render: props =>
             props.showMultilineSearchConsole ? (
-                <SearchConsolePage
-                    {...props}
-                    isMacPlatform={isMacPlatform}
-                    allExpanded={false}
-                    showSavedQueryModal={false}
-                    deployType={window.context.deployType}
-                    showSavedQueryButton={false}
-                />
+                <SearchConsolePage {...props} isMacPlatform={isMacPlatform} />
             ) : (
                 <Redirect to="/search" />
             ),

--- a/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
@@ -25,7 +25,7 @@ import { StreamingSearchResultFooter } from './StreamingSearchResultsFooter'
 const initialItemsToShow = 15
 const incrementalItemsToShow = 10
 
-interface StreamingSearchResultsListProps extends ThemeProps, SettingsCascadeProps, TelemetryProps {
+export interface StreamingSearchResultsListProps extends ThemeProps, SettingsCascadeProps, TelemetryProps {
     results?: AggregateStreamingSearchResults
 
     location: H.Location


### PR DESCRIPTION
We need to remove this use of graphql search so we can remove all graphql search components for #21267.
This is just the bare minimum to get this checked in in a working state. This page obviously needs a lot of polish as we decide to experiment with it more.

Note that #21485 makes it so `type:` filter does not work as the console page uses `patternType:structural` by default.

![image](https://user-images.githubusercontent.com/206864/119912863-2588be80-bf11-11eb-8e56-cad3cc1ec394.png)
