### PR TITLE
codeintel: Add associated upload and index records to UI

### DIFF
--- a/client/web/src/components/Timeline.tsx
+++ b/client/web/src/components/Timeline.tsx
@@ -21,57 +21,53 @@ export interface TimelineProps {
 }
 
 export const Timeline: FunctionComponent<TimelineProps> = ({ stages, now, className }) => (
-    <>
-        <h3>Timeline</h3>
+    <div className={className}>
+        {stages.map((stage, stageIndex) => {
+            if (!stage.date) {
+                return null
+            }
 
-        <div className={className}>
-            {stages.map((stage, stageIndex) => {
-                if (!stage.date) {
-                    return null
-                }
+            const previousDate = stages.map(stage => stage.date).find((date, index) => !!date && index < stageIndex)
 
-                const previousDate = stages.map(stage => stage.date).find((date, index) => !!date && index < stageIndex)
+            const meta = <TimelineMeta stage={{ ...stage, date: stage.date }} now={now} />
 
-                const meta = <TimelineMeta stage={{ ...stage, date: stage.date }} now={now} />
-
-                return (
-                    // Use index as key because the values in each step may not be unique. This is
-                    // OK here because this list will not be updated during this component's lifetime.
-                    /* eslint-disable react/no-array-index-key */
-                    <div key={stageIndex}>
-                        {previousDate && (
-                            <div className="d-flex align-items-center">
-                                <div className="flex-0">
-                                    <div className="timeline__executor-task-separator" />
-                                </div>
-                                <div className="flex-1">
-                                    <span className="text-muted ml-4">
-                                        {formatDistance(new Date(stage.date), new Date(previousDate))}
-                                    </span>
-                                </div>
+            return (
+                // Use index as key because the values in each step may not be unique. This is
+                // OK here because this list will not be updated during this component's lifetime.
+                /* eslint-disable react/no-array-index-key */
+                <div key={stageIndex}>
+                    {previousDate && (
+                        <div className="d-flex align-items-center">
+                            <div className="flex-0">
+                                <div className="timeline__executor-task-separator" />
                             </div>
-                        )}
+                            <div className="flex-1">
+                                <span className="text-muted ml-4">
+                                    {formatDistance(new Date(stage.date), new Date(previousDate))}
+                                </span>
+                            </div>
+                        </div>
+                    )}
 
-                        {stage.details ? (
-                            <>
-                                <Collapsible
-                                    title={meta}
-                                    className="p-0 font-weight-normal"
-                                    buttonClassName="mb-0"
-                                    titleAtStart={true}
-                                    defaultExpanded={stage.expanded}
-                                >
-                                    <div className="timeline__executor-task-details">{stage.details}</div>
-                                </Collapsible>
-                            </>
-                        ) : (
-                            meta
-                        )}
-                    </div>
-                )
-            })}
-        </div>
-    </>
+                    {stage.details ? (
+                        <>
+                            <Collapsible
+                                title={meta}
+                                className="p-0 font-weight-normal"
+                                buttonClassName="mb-0"
+                                titleAtStart={true}
+                                defaultExpanded={stage.expanded}
+                            >
+                                <div className="timeline__executor-task-details">{stage.details}</div>
+                            </Collapsible>
+                        </>
+                    ) : (
+                        meta
+                    )}
+                </div>
+            )
+        })}
+    </div>
 )
 
 export interface TimelineMetaProps {

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedIndex.scss
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedIndex.scss
@@ -1,0 +1,30 @@
+.codeintel-associated-index {
+    &__grid {
+        display: grid;
+        grid-template-columns: [info] minmax(auto, 1fr) [state] min-content [caret] min-content [end];
+        row-gap: 1rem;
+        column-gap: 1rem;
+        align-items: center;
+        @media (--sm-breakpoint-down) {
+            row-gap: 0.5rem;
+            column-gap: 0.5rem;
+        }
+    }
+
+    &__separator {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+        border-top: 1px solid var(--border-color-2);
+        @media (--xs-breakpoint-down) {
+            margin-top: 1rem;
+            padding-bottom: 1rem;
+        }
+    }
+
+    &__state,
+    &__information {
+        @media (--xs-breakpoint-down) {
+            grid-column: 1 / -1;
+        }
+    }
+}

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedIndex.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedIndex.tsx
@@ -1,0 +1,54 @@
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import React, { FunctionComponent } from 'react'
+
+import { Link } from '@sourcegraph/shared/src/components/Link'
+
+import { LsifUploadFields } from '../../../graphql-operations'
+import { CodeIntelState } from '../shared/CodeIntelState'
+import { CodeIntelUploadOrIndexLastActivity } from '../shared/CodeIntelUploadOrIndexLastActivity'
+
+export interface CodeIntelAssociatedIndexProps {
+    node: LsifUploadFields
+    now?: () => Date
+}
+
+export const CodeIntelAssociatedIndex: FunctionComponent<CodeIntelAssociatedIndexProps> = ({ node, now }) =>
+    node.associatedIndex && node.projectRoot ? (
+        <>
+            <div className="list-group position-relative">
+                <div className="codeintel-associated-index__grid mb-3">
+                    <span className="codeintel-associated-index__separator" />
+
+                    <div className="d-flex flex-column codeintel-associated-index__information">
+                        <div className="m-0">
+                            <h3 className="m-0 d-block d-md-inline">This upload was created by an auto-indexing job</h3>
+                        </div>
+
+                        <div>
+                            <small className="text-mute">
+                                <CodeIntelUploadOrIndexLastActivity
+                                    node={{ ...node.associatedIndex, uploadedAt: null }}
+                                    now={now}
+                                />
+                            </small>
+                        </div>
+                    </div>
+
+                    <span className="d-none d-md-inline codeintel-associated-index__state">
+                        <CodeIntelState node={node.associatedIndex} className="d-flex flex-column align-items-center" />
+                    </span>
+                    <span>
+                        <Link
+                            to={`/${node.projectRoot.repository.name}/-/settings/code-intelligence/indexes/${node.associatedIndex.id}`}
+                        >
+                            <ChevronRightIcon />
+                        </Link>
+                    </span>
+
+                    <span className="codeintel-associated-index__separator" />
+                </div>
+            </div>
+        </>
+    ) : (
+        <></>
+    )

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedUpload.scss
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedUpload.scss
@@ -1,0 +1,30 @@
+.codeintel-associated-upload {
+    &__grid {
+        display: grid;
+        grid-template-columns: [info] minmax(auto, 1fr) [state] min-content [caret] min-content [end];
+        row-gap: 1rem;
+        column-gap: 1rem;
+        align-items: center;
+        @media (--sm-breakpoint-down) {
+            row-gap: 0.5rem;
+            column-gap: 0.5rem;
+        }
+    }
+
+    &__separator {
+        // Make it full width in the current row.
+        grid-column: 1 / -1;
+        border-top: 1px solid var(--border-color-2);
+        @media (--xs-breakpoint-down) {
+            margin-top: 1rem;
+            padding-bottom: 1rem;
+        }
+    }
+
+    &__state,
+    &__information {
+        @media (--xs-breakpoint-down) {
+            grid-column: 1 / -1;
+        }
+    }
+}

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedUpload.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelAssociatedUpload.tsx
@@ -1,0 +1,61 @@
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import React, { FunctionComponent } from 'react'
+
+import { Link } from '@sourcegraph/shared/src/components/Link'
+
+import { Timestamp } from '../../../components/time/Timestamp'
+import { LsifIndexFields } from '../../../graphql-operations'
+import { CodeIntelState } from '../shared/CodeIntelState'
+import { CodeIntelUploadOrIndexLastActivity } from '../shared/CodeIntelUploadOrIndexLastActivity'
+
+export interface CodeIntelAssociatedUploadProps {
+    node: LsifIndexFields
+    now?: () => Date
+}
+
+export const CodeIntelAssociatedUpload: FunctionComponent<CodeIntelAssociatedUploadProps> = ({ node, now }) =>
+    node.associatedUpload && node.projectRoot ? (
+        <>
+            <div className="list-group position-relative">
+                <div className="codeintel-associated-upload__grid mb-3">
+                    <span className="codeintel-associated-upload__separator" />
+
+                    <div className="d-flex flex-column codeintel-associated-upload__information">
+                        <div className="m-0">
+                            <h3 className="m-0 d-block d-md-inline">
+                                This job uploaded an index{' '}
+                                <Timestamp date={node.associatedUpload.uploadedAt} now={now} />
+                            </h3>
+                        </div>
+
+                        <div>
+                            <small className="text-mute">
+                                <CodeIntelUploadOrIndexLastActivity
+                                    node={{ ...node.associatedUpload, queuedAt: null }}
+                                    now={now}
+                                />
+                            </small>
+                        </div>
+                    </div>
+
+                    <span className="d-none d-md-inline codeintel-associated-upload__state">
+                        <CodeIntelState
+                            node={node.associatedUpload}
+                            className="d-flex flex-column align-items-center"
+                        />
+                    </span>
+                    <span>
+                        <Link
+                            to={`/${node.projectRoot.repository.name}/-/settings/code-intelligence/uploads/${node.associatedUpload.id}`}
+                        >
+                            <ChevronRightIcon />
+                        </Link>
+                    </span>
+
+                    <span className="codeintel-associated-upload__separator" />
+                </div>
+            </div>
+        </>
+    ) : (
+        <></>
+    )

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelIndexMeta.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelIndexMeta.tsx
@@ -13,22 +13,24 @@ export interface CodeIntelIndexMetaProps {
 }
 
 export const CodeIntelIndexMeta: FunctionComponent<CodeIntelIndexMetaProps> = ({ node, now }) => (
-    <>
-        <div className="card border-0">
-            <div className="card-body">
-                <h3 className="card-title">
-                    <CodeIntelUploadOrIndexRepository node={node} />
-                </h3>
+    <div className="card mb-3">
+        <div className="card-body">
+            <div className="card border-0">
+                <div className="card-body">
+                    <h3 className="card-title">
+                        <CodeIntelUploadOrIndexRepository node={node} />
+                    </h3>
 
-                <p className="card-subtitle mb-2 text-muted">
-                    <CodeIntelUploadOrIndexLastActivity node={{ ...node, uploadedAt: null }} now={now} />
-                </p>
+                    <p className="card-subtitle mb-2 text-muted">
+                        <CodeIntelUploadOrIndexLastActivity node={{ ...node, uploadedAt: null }} now={now} />
+                    </p>
 
-                <p className="card-text">
-                    Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
-                    <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
-                </p>
+                    <p className="card-text">
+                        Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
+                        <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
+                    </p>
+                </div>
             </div>
         </div>
-    </>
+    </div>
 )

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelIndexPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelIndexPage.story.tsx
@@ -2,6 +2,8 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { Observable, of } from 'rxjs'
 
+import { LSIFUploadState } from '@sourcegraph/shared/src/graphql/schema'
+
 import {
     ExecutionLogEntryFields,
     LsifIndexFields,
@@ -32,6 +34,7 @@ add('Queued', () => (
                     finishedAt: null,
                     placeInQueue: 3,
                     failure: null,
+                    associatedUpload: null,
                     steps,
                 })}
                 now={now}
@@ -52,6 +55,7 @@ add('Processing', () => (
                     finishedAt: null,
                     failure: null,
                     placeInQueue: null,
+                    associatedUpload: null,
                     steps,
                 })}
                 now={now}
@@ -72,6 +76,7 @@ add('Completed', () => (
                     finishedAt: '2020-06-15T12:30:30+00:00',
                     failure: null,
                     placeInQueue: null,
+                    associatedUpload: null,
                     steps,
                 })}
                 now={now}
@@ -96,6 +101,7 @@ add('Errored', () => {
                         finishedAt: '2020-06-15T12:30:30+00:00',
                         failure: 'Whoops! The server encountered a boo-boo handling this input.',
                         placeInQueue: null,
+                        associatedUpload: null,
                         steps: { ...steps, index: { ...steps.index, logEntry } },
                     })}
                     now={now}
@@ -105,10 +111,38 @@ add('Errored', () => {
     )
 })
 
+add('Associated upload', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CodeIntelIndexPage
+                {...props}
+                fetchLsifIndex={fetch({
+                    state: LSIFIndexState.COMPLETED,
+                    queuedAt: '2020-06-15T12:20:30+00:00',
+                    startedAt: '2020-06-15T12:25:30+00:00',
+                    finishedAt: '2020-06-15T12:30:30+00:00',
+                    failure: null,
+                    placeInQueue: null,
+                    associatedUpload: {
+                        id: '6789',
+                        state: LSIFUploadState.QUEUED,
+                        uploadedAt: '2020-06-15T12:28:30+00:00',
+                        startedAt: null,
+                        finishedAt: null,
+                        placeInQueue: 5,
+                    },
+                    steps,
+                })}
+                now={now}
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
 const fetch = (
     index: Pick<
         LsifIndexFields,
-        'state' | 'queuedAt' | 'startedAt' | 'finishedAt' | 'failure' | 'placeInQueue' | 'steps'
+        'state' | 'queuedAt' | 'startedAt' | 'finishedAt' | 'failure' | 'placeInQueue' | 'associatedUpload' | 'steps'
     >
 ): (() => Observable<LsifIndexFields>) => () =>
     of({

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelIndexPage.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelIndexPage.tsx
@@ -17,6 +17,7 @@ import { LsifIndexFields } from '../../../graphql-operations'
 import { CodeIntelStateBanner } from '../shared/CodeIntelStateBanner'
 
 import { deleteLsifIndex, fetchLsifIndex as defaultFetchLsifIndex } from './backend'
+import { CodeIntelAssociatedUpload } from './CodeIntelAssociatedUpload'
 import { CodeIntelIndexMeta } from './CodeIntelIndexMeta'
 import { CodeIntelIndexTimeline } from './CodeIntelIndexTimeline'
 
@@ -110,6 +111,7 @@ export const CodeIntelIndexPage: FunctionComponent<CodeIntelIndexPageProps> = ({
                         actions={<CodeIntelDeleteIndex deleteIndex={deleteIndex} deletionOrError={deletionOrError} />}
                         className="mb-3"
                     />
+
                     <CodeIntelStateBanner
                         state={indexOrError.state}
                         placeInQueue={indexOrError.placeInQueue}
@@ -118,11 +120,10 @@ export const CodeIntelIndexPage: FunctionComponent<CodeIntelIndexPageProps> = ({
                         pluralTypeName="indexes"
                         className={classNamesByState.get(indexOrError.state)}
                     />
-                    <div className="card mb-3">
-                        <div className="card-body">
-                            <CodeIntelIndexMeta node={indexOrError} now={now} />
-                        </div>
-                    </div>
+                    <CodeIntelIndexMeta node={indexOrError} now={now} />
+                    <CodeIntelAssociatedUpload node={indexOrError} now={now} />
+
+                    <h3>Timeline</h3>
                     <CodeIntelIndexTimeline index={indexOrError} now={now} className="mb-3" />
                 </>
             )}

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadMeta.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadMeta.tsx
@@ -13,22 +13,24 @@ export interface CodeIntelUploadMetaProps {
 }
 
 export const CodeIntelUploadMeta: FunctionComponent<CodeIntelUploadMetaProps> = ({ node, now }) => (
-    <>
-        <div className="card border-0">
-            <div className="card-body">
-                <h3 className="card-title">
-                    <CodeIntelUploadOrIndexRepository node={node} />
-                </h3>
+    <div className="card mb-3">
+        <div className="card-body">
+            <div className="card border-0">
+                <div className="card-body">
+                    <h3 className="card-title">
+                        <CodeIntelUploadOrIndexRepository node={node} />
+                    </h3>
 
-                <p className="card-subtitle mb-2 text-muted">
-                    <CodeIntelUploadOrIndexLastActivity node={{ ...node, queuedAt: null }} now={now} />
-                </p>
+                    <p className="card-subtitle mb-2 text-muted">
+                        <CodeIntelUploadOrIndexLastActivity node={{ ...node, queuedAt: null }} now={now} />
+                    </p>
 
-                <p className="card-text">
-                    Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
-                    <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
-                </p>
+                    <p className="card-text">
+                        Directory <CodeIntelUploadOrIndexRoot node={node} /> indexed at commit{' '}
+                        <CodeIntelUploadOrIndexCommit node={node} /> by <CodeIntelUploadOrIndexIndexer node={node} />
+                    </p>
+                </div>
             </div>
         </div>
-    </>
+    </div>
 )

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.story.tsx
@@ -2,6 +2,8 @@ import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { Observable, of } from 'rxjs'
 
+import { LSIFIndexState } from '@sourcegraph/shared/src/graphql/schema'
+
 import { LsifUploadFields, LSIFUploadState } from '../../../graphql-operations'
 import { EnterpriseWebStory } from '../../components/EnterpriseWebStory'
 
@@ -27,6 +29,7 @@ add('Uploading', () => (
                     finishedAt: null,
                     failure: null,
                     placeInQueue: null,
+                    associatedIndex: null,
                 })}
                 now={now}
             />
@@ -46,6 +49,7 @@ add('Queued', () => (
                     finishedAt: null,
                     placeInQueue: 3,
                     failure: null,
+                    associatedIndex: null,
                 })}
                 now={now}
             />
@@ -65,6 +69,7 @@ add('Processing', () => (
                     finishedAt: null,
                     failure: null,
                     placeInQueue: null,
+                    associatedIndex: null,
                 })}
                 now={now}
             />
@@ -84,6 +89,7 @@ add('Completed', () => (
                     finishedAt: '2020-06-15T12:30:30+00:00',
                     failure: null,
                     placeInQueue: null,
+                    associatedIndex: null,
                 })}
                 now={now}
             />
@@ -104,6 +110,7 @@ add('Errored', () => (
                     failure:
                         'Upload failed to complete: dial tcp: lookup gitserver-8.gitserver on 10.165.0.10:53: no such host',
                     placeInQueue: null,
+                    associatedIndex: null,
                 })}
                 now={now}
             />
@@ -123,6 +130,34 @@ add('Failed Upload', () => (
                     finishedAt: '2020-06-15T12:30:30+00:00',
                     failure: 'Upload failed to complete: object store error:\n * XMinioStorageFull etc etc',
                     placeInQueue: null,
+                    associatedIndex: null,
+                })}
+                now={now}
+            />
+        )}
+    </EnterpriseWebStory>
+))
+
+add('Associated Index', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <CodeIntelUploadPage
+                {...props}
+                fetchLsifUpload={fetch({
+                    state: LSIFUploadState.PROCESSING,
+                    uploadedAt: '2020-06-15T12:20:30+00:00',
+                    startedAt: '2020-06-15T12:25:30+00:00',
+                    finishedAt: null,
+                    failure: null,
+                    placeInQueue: null,
+                    associatedIndex: {
+                        id: '6789',
+                        state: LSIFIndexState.COMPLETED,
+                        queuedAt: '2020-06-15T12:15:10+00:00',
+                        startedAt: '2020-06-15T12:20:20+00:00',
+                        finishedAt: '2020-06-15T12:25:30+00:00',
+                        placeInQueue: null,
+                    },
                 })}
                 now={now}
             />
@@ -131,7 +166,10 @@ add('Failed Upload', () => (
 ))
 
 const fetch = (
-    upload: Pick<LsifUploadFields, 'state' | 'uploadedAt' | 'startedAt' | 'finishedAt' | 'failure' | 'placeInQueue'>
+    upload: Pick<
+        LsifUploadFields,
+        'state' | 'uploadedAt' | 'startedAt' | 'finishedAt' | 'failure' | 'placeInQueue' | 'associatedIndex'
+    >
 ): (() => Observable<LsifUploadFields>) => () =>
     of({
         __typename: 'LSIFUpload',

--- a/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
+++ b/client/web/src/enterprise/codeintel/detail/CodeIntelUploadPage.tsx
@@ -18,6 +18,7 @@ import { LsifUploadFields } from '../../../graphql-operations'
 import { CodeIntelStateBanner } from '../shared/CodeIntelStateBanner'
 
 import { deleteLsifUpload, fetchLsifUpload as defaultFetchUpload } from './backend'
+import { CodeIntelAssociatedIndex } from './CodeIntelAssociatedIndex'
 import { CodeIntelUploadMeta } from './CodeIntelUploadMeta'
 import { CodeIntelUploadTimeline } from './CodeIntelUploadTimeline'
 
@@ -126,6 +127,7 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                         }
                         className="mb-3"
                     />
+
                     <CodeIntelStateBanner
                         state={uploadOrError.state}
                         placeInQueue={uploadOrError.placeInQueue}
@@ -140,11 +142,10 @@ export const CodeIntelUploadPage: FunctionComponent<CodeIntelUploadPageProps> = 
                             tip of the default branch and are targets of cross-repository find reference operations.
                         </div>
                     )}
-                    <div className="card mb-3">
-                        <div className="card-body">
-                            <CodeIntelUploadMeta node={uploadOrError} now={now} />
-                        </div>
-                    </div>
+                    <CodeIntelUploadMeta node={uploadOrError} now={now} />
+                    <CodeIntelAssociatedIndex node={uploadOrError} now={now} />
+
+                    <h3>Timeline</h3>
                     <CodeIntelUploadTimeline now={now} upload={uploadOrError} className="mb-3" />
                 </>
             )}

--- a/client/web/src/enterprise/codeintel/index.scss
+++ b/client/web/src/enterprise/codeintel/index.scss
@@ -1,3 +1,5 @@
+@import './detail/CodeIntelAssociatedIndex';
+@import './detail/CodeIntelAssociatedUpload';
 @import './detail/CodeIntelIndexTimeline';
 @import './list/CodeIntelIndexesPage';
 @import './list/CodeIntelUploadsPage';

--- a/client/web/src/enterprise/codeintel/list/CodeIntelIndexNode.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelIndexNode.tsx
@@ -40,7 +40,7 @@ export const CodeIntelIndexNode: FunctionComponent<CodeIntelIndexNodeProps> = ({
         </div>
 
         <span className="d-none d-md-inline codeintel-index-node__state">
-            <CodeIntelState node={node} />
+            <CodeIntelState node={node} className="d-flex flex-column align-items-center" />
         </span>
         <span>
             <Link to={`./indexes/${node.id}`}>

--- a/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelIndexesPage.story.tsx
@@ -26,6 +26,7 @@ add('Page', () => {
             finishedAt: null,
             placeInQueue: 3,
             failure: null,
+            associatedUpload: null,
         },
         {
             id: '2',
@@ -35,6 +36,7 @@ add('Page', () => {
             finishedAt: null,
             failure: null,
             placeInQueue: null,
+            associatedUpload: null,
         },
         {
             id: '3',
@@ -44,6 +46,7 @@ add('Page', () => {
             finishedAt: '2020-06-15T12:30:30+00:00',
             failure: null,
             placeInQueue: null,
+            associatedUpload: null,
         },
         {
             id: '4',
@@ -53,6 +56,7 @@ add('Page', () => {
             finishedAt: '2020-06-15T12:30:30+00:00',
             failure: 'Whoops! The server encountered a boo-boo handling this input.',
             placeInQueue: null,
+            associatedUpload: null,
         }
     )
 

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadNode.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadNode.tsx
@@ -40,7 +40,7 @@ export const CodeIntelUploadNode: FunctionComponent<CodeIntelUploadNodeProps> = 
         </div>
 
         <span className="d-none d-md-inline codeintel-upload-node__state">
-            <CodeIntelState node={node} />
+            <CodeIntelState node={node} className="d-flex flex-column align-items-center" />
         </span>
         <span>
             <Link to={`./uploads/${node.id}`}>

--- a/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
+++ b/client/web/src/enterprise/codeintel/list/CodeIntelUploadsPage.story.tsx
@@ -123,6 +123,7 @@ const fetchLsifUploads = fetch(
         finishedAt: null,
         failure: null,
         placeInQueue: null,
+        associatedIndex: null,
     },
     {
         id: '2',
@@ -132,6 +133,7 @@ const fetchLsifUploads = fetch(
         finishedAt: null,
         placeInQueue: 3,
         failure: null,
+        associatedIndex: null,
     },
     {
         id: '3',
@@ -141,6 +143,7 @@ const fetchLsifUploads = fetch(
         finishedAt: null,
         failure: null,
         placeInQueue: null,
+        associatedIndex: null,
     },
     {
         id: '4',
@@ -150,6 +153,7 @@ const fetchLsifUploads = fetch(
         finishedAt: '2020-06-15T12:30:30+00:00',
         failure: null,
         placeInQueue: null,
+        associatedIndex: null,
     },
     {
         id: '5',
@@ -159,6 +163,7 @@ const fetchLsifUploads = fetch(
         finishedAt: '2020-06-15T12:30:30+00:00',
         failure: 'Whoops! The server encountered a boo-boo handling this input.',
         placeInQueue: null,
+        associatedIndex: null,
     }
 )
 

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelState.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelState.tsx
@@ -7,15 +7,15 @@ import { CodeIntelStateIcon } from './CodeIntelStateIcon'
 import { CodeIntelStateLabel } from './CodeIntelStateLabel'
 
 export interface CodeIntelStateProps {
-    node: LsifUploadFields | LsifIndexFields
+    node: Pick<LsifUploadFields | LsifIndexFields, 'state' | 'placeInQueue'>
     className?: string
 }
 
-const iconClassNames = 'm-0 text-nowrap d-flex flex-column align-items-center justify-content-center'
+const iconClassNames = 'm-0 text-nowrap justify-content-center'
 
 export const CodeIntelState: React.FunctionComponent<CodeIntelStateProps> = ({ node, className }) => (
     <div className={classNames(iconClassNames, className)}>
         <CodeIntelStateIcon state={node.state} />
-        <CodeIntelStateLabel state={node.state} placeInQueue={node.placeInQueue} className="mt-2" />
+        <CodeIntelStateLabel state={node.state} placeInQueue={node.placeInQueue} className="mt-2 ml-2" />
     </div>
 )

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexCommit.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexCommit.tsx
@@ -5,7 +5,7 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { LsifIndexFields, LsifUploadFields } from '../../../graphql-operations'
 
 export interface CodeIntelUploadOrIndexCommitProps {
-    node: LsifUploadFields | LsifIndexFields
+    node: Pick<LsifUploadFields | LsifIndexFields, 'projectRoot' | 'inputCommit'>
     abbreviated?: boolean
 }
 

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexIndexer.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexIndexer.tsx
@@ -1,7 +1,9 @@
 import React, { FunctionComponent } from 'react'
 
+import { LsifIndexFields } from '../../../graphql-operations'
+
 export interface CodeIntelUploadOrIndexIndexerProps {
-    node: { inputIndexer?: string }
+    node: Partial<Pick<LsifIndexFields, 'inputIndexer'>>
 }
 
 export const CodeIntelUploadOrIndexIndexer: FunctionComponent<CodeIntelUploadOrIndexIndexerProps> = ({ node }) => (

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexLastActivity.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexLastActivity.tsx
@@ -4,7 +4,10 @@ import { Timestamp } from '../../../components/time/Timestamp'
 import { LsifIndexFields, LsifUploadFields } from '../../../graphql-operations'
 
 export interface CodeIntelUploadOrIndexLastActivityProps {
-    node: (LsifUploadFields & { queuedAt: null }) | (LsifIndexFields & { uploadedAt: null })
+    node: Pick<
+        (LsifUploadFields & { queuedAt: null }) | (LsifIndexFields & { uploadedAt: null }),
+        'queuedAt' | 'uploadedAt' | 'startedAt' | 'finishedAt'
+    >
     now?: () => Date
 }
 

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexRoot.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexRoot.tsx
@@ -5,7 +5,7 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { LsifIndexFields, LsifUploadFields } from '../../../graphql-operations'
 
 export interface CodeIntelUploadOrIndexRootProps {
-    node: LsifUploadFields | LsifIndexFields
+    node: Pick<LsifUploadFields | LsifIndexFields, 'projectRoot' | 'inputRoot'>
 }
 
 export const CodeIntelUploadOrIndexRoot: FunctionComponent<CodeIntelUploadOrIndexRootProps> = ({ node }) =>

--- a/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexerRepository.tsx
+++ b/client/web/src/enterprise/codeintel/shared/CodeIntelUploadOrIndexerRepository.tsx
@@ -5,7 +5,7 @@ import { Link } from '@sourcegraph/shared/src/components/Link'
 import { LsifIndexFields, LsifUploadFields } from '../../../graphql-operations'
 
 export interface CodeIntelUploadOrIndexRepositoryProps {
-    node: LsifUploadFields | LsifIndexFields
+    node: Pick<LsifUploadFields | LsifIndexFields, 'projectRoot'>
 }
 
 export const CodeIntelUploadOrIndexRepository: FunctionComponent<CodeIntelUploadOrIndexRepositoryProps> = ({ node }) =>

--- a/client/web/src/enterprise/codeintel/shared/backend.ts
+++ b/client/web/src/enterprise/codeintel/shared/backend.ts
@@ -27,6 +27,14 @@ export const lsifUploadFieldsFragment = gql`
         startedAt
         finishedAt
         placeInQueue
+        associatedIndex {
+            id
+            state
+            queuedAt
+            startedAt
+            finishedAt
+            placeInQueue
+        }
     }
 `
 
@@ -59,6 +67,14 @@ export const lsifIndexFieldsFragment = gql`
         startedAt
         finishedAt
         placeInQueue
+        associatedUpload {
+            id
+            state
+            uploadedAt
+            startedAt
+            finishedAt
+            placeInQueue
+        }
     }
     fragment LsifIndexStepsFields on IndexSteps {
         setup {


### PR DESCRIPTION
Expose associated upload and indexes in the UI. Fixes #21609.

Summary of code changes:

- Started fetching associatedIndex/associatedUpload when querying upload and index records
- Added and displayed `CodeIntelAssociatedUpload` and `CodeIntelAssociatedIndex` components
- Cleanup/drive-by:
  - Moved `<h3>` from timeline into where it's called
  - Moved `card` and `card-body` classes into `CodeIntelUploadMeta` and `CodeIntelIndexMeta` for consistency
  - Moved `d-flex flex-column align-items-center` classes out from `CodeIntelState`
  - Made types in shared code intel components more specific to its use of the types

<img width="1037" alt="Screen Shot 2021-06-04 at 12 28 25 PM" src="https://user-images.githubusercontent.com/103087/120840884-68a9e980-c530-11eb-9964-b342c0e3c367.png">

<img width="1037" alt="Screen Shot 2021-06-04 at 12 26 36 PM" src="https://user-images.githubusercontent.com/103087/120840883-6778bc80-c530-11eb-8ce5-303909103b05.png">
