### PR TITLE
search: add validation for type: and structural search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 ### Fixed
 
--
+- Stricter validation of structural search queries. The `type:` parameter is not supported for structural searches and returns an appropriate alert. [#21487](https://github.com/sourcegraph/sourcegraph/pull/21487)
 
 ### Removed
 

--- a/internal/search/query/validate_test.go
+++ b/internal/search/query/validate_test.go
@@ -95,6 +95,16 @@ func TestAndOrQuery_Validation(t *testing.T) {
 			input: "type:symbol select:symbol.timelime",
 			want:  "invalid field 'timelime' on select type 'symbol'",
 		},
+		{
+			input:      "nice try type:repo",
+			want:       "this structural search query specifies `type:` and is not supported. Structural search syntax only applies to searching file contents",
+			searchType: SearchTypeStructural,
+		},
+		{
+			input:      "type:diff nice try",
+			want:       "this structural search query specifies `type:` and is not supported. Structural search syntax only applies to searching file contents and is not currently supported for diff searches",
+			searchType: SearchTypeStructural,
+		},
 	}
 	for _, c := range cases {
 		t.Run("validate and/or query", func(t *testing.T) {


### PR DESCRIPTION
Fixes #21485. 

Also plugs a specific case of `type:diff` where users were surprised to see results. It isn't supported.