### PR TITLE
web: add Chromatic delay to the `OptionsPage` story

### DIFF
--- a/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
+++ b/client/browser/src/browser-extension/options-menu/OptionsPage.story.tsx
@@ -30,6 +30,9 @@ const requestPermissionsHandler = action('requestPermission')
 
 storiesOf('browser/Options/OptionsPage', module)
     .addDecorator(story => <BrandedStory styles={brandedStyles}>{() => story()}</BrandedStory>)
+    .addParameters({
+        chromatic: { delay: 500 },
+    })
     .add('Default', () => (
         <OptionsPage
             {...commonProps()}


### PR DESCRIPTION
## Changes

- Added Chromatic delay to the `OptionsPage` story to wait for the URL validation to make snapshots stable.

Example of the flaky changeset: [link](https://www.chromatic.com/pullrequest?activeElementId=comparison-test-key-6082923b961ff8dfc1a2e8f3-1200&appId=5f0f381c0e50750022dc6bf7&number=21455&view=changes).
