### PR TITLE
web: add correct DOCTYPE to the web-server index.html 🤦

### DIFF
--- a/client/web/dev/server/development.server.ts
+++ b/client/web/dev/server/development.server.ts
@@ -37,7 +37,9 @@ export async function startDevelopmentServer(): Promise<void> {
         hot: IS_HOT_RELOAD_ENABLED,
         // TODO: resolve https://github.com/webpack/webpack-dev-server/issues/2313 and enable HTTPS.
         https: false,
-        historyApiFallback: true,
+        historyApiFallback: {
+            disableDotRule: true,
+        },
         port: SOURCEGRAPH_HTTPS_PORT,
         publicPath: STATIC_ASSETS_URL,
         contentBase: STATIC_ASSETS_PATH,

--- a/client/web/dev/webpack/get-html-webpack-plugins.ts
+++ b/client/web/dev/webpack/get-html-webpack-plugins.ts
@@ -13,8 +13,10 @@ export const getHTMLWebpackPlugins = (): Plugin[] => {
 
     // TODO: use `cmd/frontend/internal/app/ui/app.html` template to be consistent with the default production setup.
     const templateContent = ({ htmlWebpackPlugin }: TemplateParameter): string => `
-        <html>
+        <!DOCTYPE html>
+        <html lang="en">
             <head>
+                <meta charset="UTF-8">
                 <title>Sourcegraph Development build</title>
                 ${htmlWebpackPlugin.tags.headTags.toString()}
             </head>


### PR DESCRIPTION
## Changes

- Added a document type declaration to the `index.html` served by the web server. Missing `DOCTYPE` caused incorrect styles. This change also fixes [this issue](https://github.com/sourcegraph/sourcegraph/pull/20126#issuecomment-831112999).
- Set `disableDotRule: true` in the web server config to avoid falling back to static files when the `.` symbol is present in the path, which is a frequent case because of the file search.

Closes #20745.