### PR TITLE
search contexts: add CTA prompt tracking

### DIFF
--- a/client/web/src/search/input/SearchBox.story.tsx
+++ b/client/web/src/search/input/SearchBox.story.tsx
@@ -2,6 +2,8 @@ import { storiesOf } from '@storybook/react'
 import { createMemoryHistory } from 'history'
 import React from 'react'
 
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
 import { WebStory } from '../../components/WebStory'
 import { SearchPatternType } from '../../graphql-operations'
 import {
@@ -18,6 +20,7 @@ const { add } = storiesOf('web/search/input/SearchBox', module)
 
 const history = createMemoryHistory()
 const defaultProps: SearchBoxProps = {
+    telemetryService: NOOP_TELEMETRY_SERVICE,
     location: history.location,
     history,
     settingsCascade: {

--- a/client/web/src/search/input/SearchBox.tsx
+++ b/client/web/src/search/input/SearchBox.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { KeyboardShortcut } from '@sourcegraph/shared/src/keyboardShortcuts'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { SearchContextInputProps } from '..'
@@ -15,7 +16,11 @@ import { SearchButton } from './SearchButton'
 import { SearchContextDropdown } from './SearchContextDropdown'
 import { Toggles, TogglesProps } from './toggles/Toggles'
 
-export interface SearchBoxProps extends Omit<TogglesProps, 'navbarSearchQuery'>, ThemeProps, SearchContextInputProps {
+export interface SearchBoxProps
+    extends Omit<TogglesProps, 'navbarSearchQuery'>,
+        ThemeProps,
+        SearchContextInputProps,
+        TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     isSourcegraphDotCom: boolean // significant for query suggestions
     queryState: QueryState

--- a/client/web/src/search/input/SearchContextCtaPrompt.story.tsx
+++ b/client/web/src/search/input/SearchContextCtaPrompt.story.tsx
@@ -1,6 +1,8 @@
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
+
 import { AuthenticatedUser } from '../../auth'
 import { WebStory } from '../../components/WebStory'
 
@@ -39,7 +41,13 @@ add(
     'not authenticated',
     () => (
         <WebStory>
-            {() => <SearchContextCtaPrompt authenticatedUser={null} hasUserAddedExternalServices={false} />}
+            {() => (
+                <SearchContextCtaPrompt
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    authenticatedUser={null}
+                    hasUserAddedExternalServices={false}
+                />
+            )}
         </WebStory>
     ),
     {}
@@ -49,7 +57,13 @@ add(
     'authenticated without added external services',
     () => (
         <WebStory>
-            {() => <SearchContextCtaPrompt authenticatedUser={authUser} hasUserAddedExternalServices={false} />}
+            {() => (
+                <SearchContextCtaPrompt
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    authenticatedUser={authUser}
+                    hasUserAddedExternalServices={false}
+                />
+            )}
         </WebStory>
     ),
     {}
@@ -59,7 +73,13 @@ add(
     'authenticated with added external services',
     () => (
         <WebStory>
-            {() => <SearchContextCtaPrompt authenticatedUser={authUser} hasUserAddedExternalServices={true} />}
+            {() => (
+                <SearchContextCtaPrompt
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
+                    authenticatedUser={authUser}
+                    hasUserAddedExternalServices={true}
+                />
+            )}
         </WebStory>
     ),
     {}
@@ -71,6 +91,7 @@ add(
         <WebStory>
             {() => (
                 <SearchContextCtaPrompt
+                    telemetryService={NOOP_TELEMETRY_SERVICE}
                     authenticatedUser={{ ...authUser, tags: ['AllowUserExternalServicePrivate'] }}
                     hasUserAddedExternalServices={false}
                 />

--- a/client/web/src/search/input/SearchContextCtaPrompt.tsx
+++ b/client/web/src/search/input/SearchContextCtaPrompt.tsx
@@ -1,14 +1,15 @@
 import classNames from 'classnames'
-import React from 'react'
+import React, { useCallback } from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 
 import { AuthenticatedUser } from '../../auth'
 import { Badge } from '../../components/Badge'
 
 import styles from './SearchContextCtaPrompt.module.scss'
 
-export interface SearchContextCtaPromptProps {
+export interface SearchContextCtaPromptProps extends TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     hasUserAddedExternalServices: boolean
 }
@@ -16,6 +17,7 @@ export interface SearchContextCtaPromptProps {
 export const SearchContextCtaPrompt: React.FunctionComponent<SearchContextCtaPromptProps> = ({
     authenticatedUser,
     hasUserAddedExternalServices,
+    telemetryService,
 }) => {
     const repositoriesVisibility =
         window.context.externalServicesUserMode === 'all' ||
@@ -38,6 +40,15 @@ export const SearchContextCtaPrompt: React.FunctionComponent<SearchContextCtaPro
             : `/users/${authenticatedUser.username}/settings/code-hosts`
         : '/sign-up'
 
+    const onClick = useCallback(() => {
+        const actionKind = authenticatedUser
+            ? hasUserAddedExternalServices
+                ? 'AddRepositories'
+                : 'ConnectCodeHost'
+            : 'SignUp'
+        telemetryService.log(`SearchContextCtaPrompt${actionKind}Click`)
+    }, [authenticatedUser, hasUserAddedExternalServices, telemetryService])
+
     return (
         <div className={styles.searchContextCtaPrompt}>
             <div className={styles.searchContextCtaPromptTitle}>
@@ -45,7 +56,11 @@ export const SearchContextCtaPrompt: React.FunctionComponent<SearchContextCtaPro
                 <span>Search the code you care about</span>
             </div>
             <div className="text-muted">{copyText}</div>
-            <Link className={classNames('btn btn-primary', styles.searchContextCtaPromptButton)} to={linkTo}>
+            <Link
+                className={classNames('btn btn-primary', styles.searchContextCtaPromptButton)}
+                to={linkTo}
+                onClick={onClick}
+            >
                 {buttonText}
             </Link>
         </div>

--- a/client/web/src/search/input/SearchContextCtaPrompt.tsx
+++ b/client/web/src/search/input/SearchContextCtaPrompt.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { useCallback } from 'react'
+import React from 'react'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
@@ -40,14 +40,11 @@ export const SearchContextCtaPrompt: React.FunctionComponent<SearchContextCtaPro
             : `/users/${authenticatedUser.username}/settings/code-hosts`
         : '/sign-up'
 
-    const onClick = useCallback(() => {
-        const actionKind = authenticatedUser
-            ? hasUserAddedExternalServices
-                ? 'AddRepositories'
-                : 'ConnectCodeHost'
-            : 'SignUp'
+    const onClick = (): void => {
+        const authenticatedActionKind = hasUserAddedExternalServices ? 'AddRepositories' : 'ConnectCodeHost'
+        const actionKind = authenticatedUser ? authenticatedActionKind : 'SignUp'
         telemetryService.log(`SearchContextCtaPrompt${actionKind}Click`)
-    }, [authenticatedUser, hasUserAddedExternalServices, telemetryService])
+    }
 
     return (
         <div className={styles.searchContextCtaPrompt}>

--- a/client/web/src/search/input/SearchContextDropdown.test.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react-dom/test-utils'
 import { Dropdown, DropdownItem, DropdownToggle } from 'reactstrap'
 import sinon from 'sinon'
 
+import { NOOP_TELEMETRY_SERVICE } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { MockIntersectionObserver } from '@sourcegraph/shared/src/util/MockIntersectionObserver'
 
 import { SearchPatternType } from '../../graphql-operations'
@@ -18,6 +19,7 @@ import { SearchContextDropdown, SearchContextDropdownProps } from './SearchConte
 
 describe('SearchContextDropdown', () => {
     const defaultProps: SearchContextDropdownProps = {
+        telemetryService: NOOP_TELEMETRY_SERVICE,
         query: '',
         showSearchContextManagement: false,
         fetchAutoDefinedSearchContexts: mockFetchAutoDefinedSearchContexts(1),

--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -7,6 +7,7 @@ import Shepherd from 'shepherd.js'
 import { FilterType } from '@sourcegraph/shared/src/search/query/filters'
 import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
 import { CaseSensitivityProps, PatternTypeProps, SearchContextInputProps } from '..'
@@ -21,7 +22,8 @@ export interface SearchContextDropdownProps
     extends Omit<SearchContextInputProps, 'showSearchContext'>,
         Pick<PatternTypeProps, 'patternType'>,
         Pick<CaseSensitivityProps, 'caseSensitive'>,
-        VersionContextProps {
+        VersionContextProps,
+        TelemetryProps {
     isSourcegraphDotCom: boolean
     authenticatedUser: AuthenticatedUser | null
     submitSearch: (args: SubmitSearchParameters) => void
@@ -233,6 +235,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
             <DropdownMenu positionFixed={true} className="search-context-dropdown__menu">
                 {isSourcegraphDotCom && (!hasUserAddedExternalServices || !hasUserAddedRepositories) ? (
                     <SearchContextCtaPrompt
+                        telemetryService={props.telemetryService}
                         authenticatedUser={authenticatedUser}
                         hasUserAddedExternalServices={hasUserAddedExternalServices}
                     />

--- a/client/web/src/search/input/SearchNavbarItem.tsx
+++ b/client/web/src/search/input/SearchNavbarItem.tsx
@@ -5,6 +5,7 @@ import { Form } from '@sourcegraph/branded/src/components/Form'
 import { ActivationProps } from '@sourcegraph/shared/src/components/activation/Activation'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
+import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { ThemeProps } from '@sourcegraph/shared/src/theme'
 
 import { PatternTypeProps, CaseSensitivityProps, OnboardingTourProps, SearchContextInputProps } from '..'
@@ -22,7 +23,8 @@ interface Props
         ThemeProps,
         SearchContextInputProps,
         VersionContextProps,
-        OnboardingTourProps {
+        OnboardingTourProps,
+        TelemetryProps {
     authenticatedUser: AuthenticatedUser | null
     location: H.Location
     history: H.History


### PR DESCRIPTION
PR adds CTA prompt button tracking for all 3 possible options: Sign up, Connect code host and Add repositories.