### PR TITLE
Fix code monitoring search query

### DIFF
--- a/cmd/query-runner/graphql.go
+++ b/cmd/query-runner/graphql.go
@@ -34,7 +34,6 @@ const gqlSearchQuery = `query Search(
 			results {
 				__typename
 				... on FileMatch {
-					resource
 					limitHit
 					lineMatches {
 						preview

--- a/enterprise/internal/codemonitors/background/graphql.go
+++ b/enterprise/internal/codemonitors/background/graphql.go
@@ -34,7 +34,6 @@ const gqlSearchQuery = `query Search(
 			results {
 				__typename
 				... on FileMatch {
-					resource
 					limitHit
 					lineMatches {
 						preview


### PR DESCRIPTION
This fixes an error I got locally after creating a code monitor:
```
Marked record as errored, name: code_monitors_trigger_jobs_worker, id: 25, err: graphql: errors: [map[locations:[map[column:6 line:13]] message:Cannot query field "resource" on type "FileMatch".]]
```
It also happens in Cloud, so I think(?) that code monitoring is broken currently? Should we have proper monitoring for errors in the query runner? Also, I think we should add a test running this query against the backend, to validate it is a valid graphql query. 

Log graph on Could:
![image](https://user-images.githubusercontent.com/19534377/119970131-a72f2980-bfaf-11eb-90e3-85240b984901.png)
