### PR TITLE
auth: Prompt and allow re-authenticating with GitHub

### DIFF
--- a/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
+++ b/client/web/src/components/externalServices/ExternalServicesPage.story.tsx
@@ -35,6 +35,7 @@ const queryExternalServices: typeof _queryExternalServices = () =>
                 updatedAt: '2021-03-15T19:39:11Z',
                 createdAt: '2021-03-15T19:39:11Z',
                 namespace: null,
+                grantedScopes: [],
             },
             {
                 id: 'service2',
@@ -53,6 +54,7 @@ const queryExternalServices: typeof _queryExternalServices = () =>
                     namespaceName: 'johndoe',
                     url: '/users/johndoe',
                 },
+                grantedScopes: [],
             },
         ],
     })

--- a/client/web/src/components/externalServices/backend.ts
+++ b/client/web/src/components/externalServices/backend.ts
@@ -203,6 +203,7 @@ export const listExternalServiceFragment = gql`
             namespaceName
             url
         }
+        grantedScopes
     }
 `
 

--- a/client/web/src/user/settings/cloud-ga.ts
+++ b/client/web/src/user/settings/cloud-ga.ts
@@ -37,4 +37,11 @@ export const externalServiceUserModeFromTags = (tags: string[]): 'disabled' | 'p
     return siteMode
 }
 
+export const githubRepoScopeRequired = (tags: string[], scopes: string[]): boolean => {
+    const allowedPrivate = externalServiceUserModeFromTags(tags) === 'all'
+    // If the user is allowed to add private code but they don't have the 'repo' scope
+    // then we need to request it.
+    return allowedPrivate && !scopes.includes('repo')
+}
+
 const modeEnabled = (mode: string): boolean => mode === 'all' || mode === 'public'

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -85,7 +85,7 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                 {service?.id ? (
                     <button
                         type="button"
-                        className="btn btn-link btn-sm text-danger px-0 shadow-none"
+                        className="btn btn-link btn-sm text-danger shadow-none"
                         onClick={toggleRemoveConnectionModal}
                     >
                         Remove
@@ -96,14 +96,12 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                         {oauthInFlight && <LoadingSpinner className="icon-inline ml-2 theme-dark" />}
                     </button>
                 )}
-            </div>
-            <div className="align-self-center">
                 {updateAuthRequired && (
                     <button type="button" className="btn btn-secondary" onClick={toAuthProvider}>
                         Update
                         {oauthInFlight && <LoadingSpinner className="icon-inline ml-2 theme-dark" />}
                     </button>
-            )}
+                )}
             </div>
         </div>
     )

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -10,6 +10,7 @@ import { Scalars, ExternalServiceKind, ListExternalServiceFields } from '../../.
 
 import { RemoveCodeHostConnectionModal } from './RemoveCodeHostConnectionModal'
 import { ifNotNavigated } from './UserAddCodeHostsPage'
+import { githubRepoScopeRequired } from '../cloud-ga'
 
 interface CodeHostItemProps {
     user: { id: Scalars['ID']; tags: string[] }
@@ -27,6 +28,7 @@ interface CodeHostItemProps {
 }
 
 export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
+    user,
     service,
     kind,
     name,
@@ -50,6 +52,8 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
         })
         navigateToAuthProvider(kind)
     }, [kind, navigateToAuthProvider])
+
+    const updateAuthRequired = service?.kind === 'GITHUB' && githubRepoScopeRequired(user.tags, service.grantedScopes)
 
     return (
         <div className="p-2 d-flex align-items-start">
@@ -92,6 +96,14 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                         {oauthInFlight && <LoadingSpinner className="icon-inline ml-2 theme-dark" />}
                     </button>
                 )}
+            </div>
+            <div className="align-self-center">
+                {updateAuthRequired && (
+                    <button type="button" className="btn btn-secondary" onClick={toAuthProvider}>
+                        Update
+                        {oauthInFlight && <LoadingSpinner className="icon-inline ml-2 theme-dark" />}
+                    </button>
+            )}
             </div>
         </div>
     )

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -90,16 +90,23 @@ export const CodeHostItem: React.FunctionComponent<CodeHostItemProps> = ({
                     >
                         Remove
                     </button>
+                ) : oauthInFlight ? (
+                    <button type="button" className="btn btn-primary disabled" onClick={toAuthProvider}>
+                        <LoadingSpinner className="icon-inline ml-2 theme-dark" />
+                    </button>
                 ) : (
                     <button type="button" className="btn btn-primary" onClick={toAuthProvider}>
                         Connect
-                        {oauthInFlight && <LoadingSpinner className="icon-inline ml-2 theme-dark" />}
                     </button>
                 )}
-                {updateAuthRequired && (
+                {updateAuthRequired && !oauthInFlight && (
                     <button type="button" className="btn btn-secondary" onClick={toAuthProvider}>
                         Update
-                        {oauthInFlight && <LoadingSpinner className="icon-inline ml-2 theme-dark" />}
+                    </button>
+                )}
+                {updateAuthRequired && oauthInFlight && (
+                    <button type="button" className="btn btn-secondary disabled" onClick={toAuthProvider}>
+                        <LoadingSpinner className="icon-inline ml-2 theme-dark" />
                     </button>
                 )}
             </div>

--- a/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
+++ b/client/web/src/user/settings/codeHosts/CodeHostItem.tsx
@@ -7,10 +7,10 @@ import { ErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { CircleDashedIcon } from '../../../components/CircleDashedIcon'
 import { Scalars, ExternalServiceKind, ListExternalServiceFields } from '../../../graphql-operations'
+import { githubRepoScopeRequired } from '../cloud-ga'
 
 import { RemoveCodeHostConnectionModal } from './RemoveCodeHostConnectionModal'
 import { ifNotNavigated } from './UserAddCodeHostsPage'
-import { githubRepoScopeRequired } from '../cloud-ga'
 
 interface CodeHostItemProps {
     user: { id: Scalars['ID']; tags: string[] }

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -13,9 +13,9 @@ import { Scalars, ExternalServiceKind, ListExternalServiceFields } from '../../.
 import { SourcegraphContext } from '../../../jscontext'
 import { eventLogger } from '../../../tracking/eventLogger'
 import { UserExternalServicesOrRepositoriesUpdateProps } from '../../../util'
+import { githubRepoScopeRequired } from '../cloud-ga'
 
 import { CodeHostItem } from './CodeHostItem'
-import { githubRepoScopeRequired } from '../cloud-ga'
 
 type AuthProvider = SourcegraphContext['authProviders'][0]
 type AuthProvidersByKind = Partial<Record<ExternalServiceKind, AuthProvider>>

--- a/cmd/frontend/graphqlbackend/external_services.go
+++ b/cmd/frontend/graphqlbackend/external_services.go
@@ -171,7 +171,7 @@ type repoupdaterClient interface {
 // timeout as an argument which is recommended to be 5 seconds unless the caller
 // has special requirements for it to be larger or smaller.
 func syncExternalService(ctx context.Context, svc *types.ExternalService, timeout time.Duration, client repoupdaterClient) error {
-	// Set a timeouut to validate external service sync. It usually fails in
+	// Set a timeout to validate external service sync. It usually fails in
 	// under 5s if there is a problem.
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
+++ b/enterprise/cmd/frontend/internal/auth/githuboauth/session_test.go
@@ -15,14 +15,13 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 
-	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
-	"github.com/sourcegraph/sourcegraph/internal/types"
-
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth"
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/auth/providers"
 	"github.com/sourcegraph/sourcegraph/internal/actor"
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	githubsvc "github.com/sourcegraph/sourcegraph/internal/extsvc/github"
+	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
 func init() {

--- a/internal/database/basestore/handle.go
+++ b/internal/database/basestore/handle.go
@@ -52,7 +52,7 @@ func (h *TransactableHandle) InTransaction() bool {
 // Note that it is not valid to call Transact or Done on the same database handle from distinct goroutines.
 // Because we support properly nested transactions via savepoints, calling Transact from two different
 // goroutines on the same handle will not be deterministic: either transaction could nest the other one,
-// and callaing Done in one goroutine may not finalize the expected unit of work.
+// and calling Done in one goroutine may not finalize the expected unit of work.
 func (h *TransactableHandle) Transact(ctx context.Context) (*TransactableHandle, error) {
 	if h.InTransaction() {
 		savepoint, err := newSavepoint(ctx, h.db)

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -53,6 +53,17 @@ type ExternalServiceStore struct {
 	mu sync.Mutex
 }
 
+func (e *ExternalServiceStore) copy() *ExternalServiceStore {
+	return &ExternalServiceStore{
+		Store:                     e.Store,
+		key:                       e.key,
+		GitHubValidators:          e.GitHubValidators,
+		GitLabValidators:          e.GitLabValidators,
+		BitbucketServerValidators: e.BitbucketServerValidators,
+		PerforceValidators:        e.PerforceValidators,
+	}
+}
+
 // ExternalServices instantiates and returns a new ExternalServicesStore with prepared statements.
 func ExternalServices(db dbutil.DB) *ExternalServiceStore {
 	return &ExternalServiceStore{Store: basestore.NewWithDB(db, sql.TxOptions{})}
@@ -64,11 +75,15 @@ func ExternalServicesWith(other basestore.ShareableStore) *ExternalServiceStore 
 }
 
 func (e *ExternalServiceStore) With(other basestore.ShareableStore) *ExternalServiceStore {
-	return &ExternalServiceStore{Store: e.Store.With(other), key: e.key}
+	s := e.copy()
+	s.Store = e.Store.With(other)
+	return s
 }
 
 func (e *ExternalServiceStore) WithEncryptionKey(key encryption.Key) *ExternalServiceStore {
-	return &ExternalServiceStore{Store: e.Store, key: key}
+	s := e.copy()
+	s.key = key
+	return s
 }
 
 func (e *ExternalServiceStore) Transact(ctx context.Context) (*ExternalServiceStore, error) {
@@ -76,14 +91,9 @@ func (e *ExternalServiceStore) Transact(ctx context.Context) (*ExternalServiceSt
 		return Mocks.ExternalServices.Transact(ctx)
 	}
 	txBase, err := e.Store.Transact(ctx)
-	return &ExternalServiceStore{
-		Store:                     txBase,
-		key:                       e.key,
-		GitHubValidators:          e.GitHubValidators,
-		GitLabValidators:          e.GitLabValidators,
-		BitbucketServerValidators: e.BitbucketServerValidators,
-		PerforceValidators:        e.PerforceValidators,
-	}, err
+	s := e.copy()
+	s.Store = txBase
+	return s, err
 }
 
 func (e *ExternalServiceStore) Done(err error) error {

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -72,6 +72,9 @@ func (e *ExternalServiceStore) WithEncryptionKey(key encryption.Key) *ExternalSe
 }
 
 func (e *ExternalServiceStore) Transact(ctx context.Context) (*ExternalServiceStore, error) {
+	if Mocks.ExternalServices.Transact != nil {
+		return Mocks.ExternalServices.Transact(ctx)
+	}
 	txBase, err := e.Store.Transact(ctx)
 	return &ExternalServiceStore{
 		Store:                     txBase,
@@ -81,6 +84,13 @@ func (e *ExternalServiceStore) Transact(ctx context.Context) (*ExternalServiceSt
 		BitbucketServerValidators: e.BitbucketServerValidators,
 		PerforceValidators:        e.PerforceValidators,
 	}, err
+}
+
+func (e *ExternalServiceStore) Done(err error) error {
+	if Mocks.ExternalServices.Done != nil {
+		return Mocks.ExternalServices.Done(err)
+	}
+	return e.Store.Done(err)
 }
 
 // ensureStore instantiates a basestore.Store if necessary, using the dbconn.Global handle.
@@ -1288,4 +1298,6 @@ type MockExternalServices struct {
 	Update           func(ctx context.Context, ps []schema.AuthProviders, id int64, update *ExternalServiceUpdate) error
 	Count            func(ctx context.Context, opt ExternalServicesListOptions) (int, error)
 	Upsert           func(ctx context.Context, services ...*types.ExternalService) error
+	Transact         func(ctx context.Context) (*ExternalServiceStore, error)
+	Done             func(error) error
 }

--- a/internal/database/external_services.go
+++ b/internal/database/external_services.go
@@ -73,7 +73,14 @@ func (e *ExternalServiceStore) WithEncryptionKey(key encryption.Key) *ExternalSe
 
 func (e *ExternalServiceStore) Transact(ctx context.Context) (*ExternalServiceStore, error) {
 	txBase, err := e.Store.Transact(ctx)
-	return &ExternalServiceStore{Store: txBase, key: e.key}, err
+	return &ExternalServiceStore{
+		Store:                     txBase,
+		key:                       e.key,
+		GitHubValidators:          e.GitHubValidators,
+		GitLabValidators:          e.GitLabValidators,
+		BitbucketServerValidators: e.BitbucketServerValidators,
+		PerforceValidators:        e.PerforceValidators,
+	}, err
 }
 
 // ensureStore instantiates a basestore.Store if necessary, using the dbconn.Global handle.

--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -116,10 +116,11 @@ type ScopeCache interface {
 // GrantedScopes returns a slice of scopes granted by the service based on the token
 // provided in the config. It makes a request to the code host.
 //
-// Currently only GitHub is supported.
+// Currently only GitHub is supported, other code hosts will simply return an
+// empty slice
 func GrantedScopes(ctx context.Context, cache ScopeCache, kind string, rawConfig string) ([]string, error) {
 	if kind != extsvc.KindGitHub {
-		return nil, fmt.Errorf("only GitHub supported")
+		return nil, nil
 	}
 	config, err := extsvc.ParseConfig(kind, rawConfig)
 	if err != nil {


### PR DESCRIPTION
This change will prompt a user who has been opted in to private code after already being part of the public code trial. In this case, we need to prompt them to re-authenticate with GitHub to request the additional `repo` scope. 

This change only updates the code host page and does not yet add a global banner.

https://user-images.githubusercontent.com/25610/119990169-4eb85600-bfc8-11eb-9409-90421aa9fe1e.mov

Part of https://github.com/sourcegraph/sourcegraph/issues/20229