### PR TITLE
Slap some redesign stuff onto saved searches pages

### DIFF
--- a/client/web/src/savedSearches/SavedSearchForm.scss
+++ b/client/web/src/savedSearches/SavedSearchForm.scss
@@ -1,10 +1,4 @@
 .saved-search-form {
-    &__header {
-        margin-bottom: 1rem;
-    }
-    &__input {
-        margin: 1rem 0;
-    }
     &__checkbox {
         margin-right: 0.25rem;
     }

--- a/client/web/src/savedSearches/SavedSearchForm.tsx
+++ b/client/web/src/savedSearches/SavedSearchForm.tsx
@@ -4,6 +4,7 @@ import { Omit } from 'utility-types'
 
 import { Form } from '@sourcegraph/branded/src/components/Form'
 import { Scalars } from '@sourcegraph/shared/src/graphql-operations'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../auth'
 import { ErrorAlert } from '../components/alerts'
@@ -79,100 +80,104 @@ export class SavedSearchForm extends React.Component<Props, State> {
 
         return (
             <div className="saved-search-form">
-                <div className="saved-search-form__header">
-                    <h2>{this.props.title}</h2>
-                    <div>Get notifications when there are new results for specific search queries</div>
-                </div>
+                <PageHeader
+                    path={[{ text: this.props.title }]}
+                    headingElement="h2"
+                    description="Get notifications when there are new results for specific search queries."
+                    className="mb-3"
+                />
                 <Form onSubmit={this.handleSubmit}>
-                    <div className="saved-search-form__input">
-                        <label className="saved-search-form__label" htmlFor="saved-search-form-input-description">
-                            Description:
-                        </label>
-                        <input
-                            id="saved-search-form-input-description"
-                            type="text"
-                            name="description"
-                            className="form-control test-saved-search-form-input-description"
-                            placeholder="Description"
-                            required={true}
-                            value={description}
-                            onChange={this.createInputChangeHandler('description')}
-                        />
-                    </div>
-                    <div className="saved-search-form__input">
-                        <label className="saved-search-form__label" htmlFor="saved-search-form-input-query">
-                            Query:
-                        </label>
-                        <input
-                            id="saved-search-form-input-query"
-                            type="text"
-                            name="query"
-                            className="form-control test-saved-search-form-input-query"
-                            placeholder="Query"
-                            required={true}
-                            value={query}
-                            onChange={this.createInputChangeHandler('query')}
-                        />
-                    </div>
-                    <div className="saved-search-form__input">
-                        {/* Label is for visual benefit, input has more specific label attached */}
-                        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-                        <label className="saved-search-form__label" id="saved-search-form-email-notifications">
-                            Email notifications:
-                        </label>
-                        <div aria-labelledby="saved-search-form-email-notifications">
-                            <label>
-                                <input
-                                    type="checkbox"
-                                    name="Notify owner"
-                                    className="saved-search-form__checkbox"
-                                    defaultChecked={notify}
-                                    onChange={this.createInputChangeHandler('notify')}
-                                />{' '}
-                                <span>
-                                    {this.props.namespace.__typename === 'Org'
-                                        ? 'Send email notifications to all members of this organization'
-                                        : this.props.namespace.__typename === 'User'
-                                        ? 'Send email notifications to my email'
-                                        : 'Email notifications'}
-                                </span>
-                            </label>
-                        </div>
-                    </div>
-                    {notifySlack && slackWebhookURL && (
-                        <div className="saved-search-form__input">
-                            <label className="saved-search-form__label" htmlFor="saved-search-form-input-slack">
-                                Slack notifications:
+                    <Container className="mb-3">
+                        <div className="form-group">
+                            <label className="saved-search-form__label" htmlFor="saved-search-form-input-description">
+                                Description
                             </label>
                             <input
-                                id="saved-search-form-input-slack"
+                                id="saved-search-form-input-description"
                                 type="text"
-                                name="Slack webhook URL"
-                                className="form-control"
-                                value={slackWebhookURL}
-                                disabled={true}
-                                onChange={this.createInputChangeHandler('slackWebhookURL')}
+                                name="description"
+                                className="form-control test-saved-search-form-input-description"
+                                placeholder="Description"
+                                required={true}
+                                value={description}
+                                onChange={this.createInputChangeHandler('description')}
                             />
-                            <small>
-                                Slack webhooks are deprecated and will be removed in a future Sourcegraph version.
-                            </small>
                         </div>
-                    )}
-                    {this.isUnsupportedNotifyQuery(this.state.values) && (
-                        <div className="alert alert-warning mb-3">
-                            <strong>Warning:</strong> non-commit searches do not currently support notifications.
-                            Consider adding <code>type:diff</code> or <code>type:commit</code> to your query.
+                        <div className="form-group">
+                            <label className="saved-search-form__label" htmlFor="saved-search-form-input-query">
+                                Query
+                            </label>
+                            <input
+                                id="saved-search-form-input-query"
+                                type="text"
+                                name="query"
+                                className="form-control test-saved-search-form-input-query"
+                                placeholder="Query"
+                                required={true}
+                                value={query}
+                                onChange={this.createInputChangeHandler('query')}
+                            />
                         </div>
-                    )}
-                    {notify && !window.context.emailEnabled && !this.isUnsupportedNotifyQuery(this.state.values) && (
-                        <div className="alert alert-warning mb-3">
-                            <strong>Warning:</strong> Sending emails is not currently configured on this Sourcegraph
-                            server.{' '}
-                            {this.props.authenticatedUser?.siteAdmin
-                                ? 'Use the email.smtp site configuration setting to enable sending emails.'
-                                : 'Contact your server admin for more information.'}
+                        <div className="form-group mb-0">
+                            {/* Label is for visual benefit, input has more specific label attached */}
+                            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                            <label className="saved-search-form__label" id="saved-search-form-email-notifications">
+                                Email notifications
+                            </label>
+                            <div aria-labelledby="saved-search-form-email-notifications">
+                                <label>
+                                    <input
+                                        type="checkbox"
+                                        name="Notify owner"
+                                        className="saved-search-form__checkbox"
+                                        defaultChecked={notify}
+                                        onChange={this.createInputChangeHandler('notify')}
+                                    />{' '}
+                                    <span>
+                                        {this.props.namespace.__typename === 'Org'
+                                            ? 'Send email notifications to all members of this organization'
+                                            : this.props.namespace.__typename === 'User'
+                                            ? 'Send email notifications to my email'
+                                            : 'Email notifications'}
+                                    </span>
+                                </label>
+                            </div>
                         </div>
-                    )}
+                        {notifySlack && slackWebhookURL && (
+                            <div className="form-group mt-3 mb-0">
+                                <label className="saved-search-form__label" htmlFor="saved-search-form-input-slack">
+                                    Slack notifications
+                                </label>
+                                <input
+                                    id="saved-search-form-input-slack"
+                                    type="text"
+                                    name="Slack webhook URL"
+                                    className="form-control"
+                                    value={slackWebhookURL}
+                                    disabled={true}
+                                    onChange={this.createInputChangeHandler('slackWebhookURL')}
+                                />
+                                <small>
+                                    Slack webhooks are deprecated and will be removed in a future Sourcegraph version.
+                                </small>
+                            </div>
+                        )}
+                        {this.isUnsupportedNotifyQuery(this.state.values) && (
+                            <div className="alert alert-warning mb-3">
+                                <strong>Warning:</strong> non-commit searches do not currently support notifications.
+                                Consider adding <code>type:diff</code> or <code>type:commit</code> to your query.
+                            </div>
+                        )}
+                        {notify && !window.context.emailEnabled && !this.isUnsupportedNotifyQuery(this.state.values) && (
+                            <div className="alert alert-warning mb-3">
+                                <strong>Warning:</strong> Sending emails is not currently configured on this Sourcegraph
+                                server.{' '}
+                                {this.props.authenticatedUser?.siteAdmin
+                                    ? 'Use the email.smtp site configuration setting to enable sending emails.'
+                                    : 'Contact your server admin for more information.'}
+                            </div>
+                        )}
+                    </Container>
                     <button
                         type="submit"
                         disabled={this.props.loading}

--- a/client/web/src/savedSearches/SavedSearchListPage.scss
+++ b/client/web/src/savedSearches/SavedSearchListPage.scss
@@ -1,10 +1,7 @@
 .saved-search-list-page {
     padding: 0 0.75rem;
-
-    &__title {
-        display: flex;
-        justify-content: space-between;
-        margin-bottom: 1rem;
+    .theme-redesign & {
+        padding: 0;
     }
 
     &__row {
@@ -13,6 +10,16 @@
         justify-content: space-between;
         padding: 0.75rem;
         font-weight: bold;
+
+        .theme-redesign & {
+            padding: 0;
+            &:not(:last-child) {
+                padding-bottom: 1rem;
+            }
+            + .saved-search-list-page__row {
+                padding-top: 1rem;
+            }
+        }
 
         &--icon {
             margin-right: 0.5rem;

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -169,22 +169,24 @@ const SavedSearchListPageContent: React.FunctionComponent<SavedSearchListPageCon
 }) => {
     if (savedSearchesOrError === undefined) {
         return <LoadingSpinner />
-    } else if (isErrorLike(savedSearchesOrError)) {
-        return <ErrorAlert className="mb-3" error={savedSearchesOrError} />
-    } else {
-        const namespaceSavedSearches = savedSearchesOrError.filter(search => namespace.id === search.namespace.id)
-        if (namespaceSavedSearches.length === 0) {
-            return <Container className="text-center text-muted">You haven't created a saved search yet.</Container>
-        } else {
-            return (
-                <Container>
-                    <div className="list-group list-group-flush">
-                        {namespaceSavedSearches.map(search => (
-                            <SavedSearchNode key={search.id} {...props} savedSearch={search} />
-                        ))}
-                    </div>
-                </Container>
-            )
-        }
     }
+
+    if (isErrorLike(savedSearchesOrError)) {
+        return <ErrorAlert className="mb-3" error={savedSearchesOrError} />
+    }
+
+    const namespaceSavedSearches = savedSearchesOrError.filter(search => namespace.id === search.namespace.id)
+    if (namespaceSavedSearches.length === 0) {
+        return <Container className="text-center text-muted">You haven't created a saved search yet.</Container>
+    }
+
+    return (
+        <Container>
+            <div className="list-group list-group-flush">
+                {namespaceSavedSearches.map(search => (
+                    <SavedSearchNode key={search.id} {...props} savedSearch={search} />
+                ))}
+            </div>
+        </Container>
+    )
 }

--- a/client/web/src/savedSearches/SavedSearchListPage.tsx
+++ b/client/web/src/savedSearches/SavedSearchListPage.tsx
@@ -132,34 +132,6 @@ export class SavedSearchListPage extends React.Component<Props, State> {
     }
 
     public render(): JSX.Element | null {
-        let body: JSX.Element
-        if (this.state.savedSearchesOrError === undefined) {
-            body = <LoadingSpinner />
-        } else if (isErrorLike(this.state.savedSearchesOrError)) {
-            body = <ErrorAlert className="mb-3" error={this.state.savedSearchesOrError} />
-        } else {
-            const namespaceSavedSearches = this.state.savedSearchesOrError.filter(
-                search => this.props.namespace.id === search.namespace.id
-            )
-            if (namespaceSavedSearches.length === 0) {
-                body = <Container className="text-center text-muted">You haven't created a saved search yet.</Container>
-            } else {
-                body = (
-                    <Container>
-                        <div className="list-group list-group-flush">
-                            {namespaceSavedSearches.map(search => (
-                                <SavedSearchNode
-                                    key={search.id}
-                                    {...this.props}
-                                    savedSearch={search}
-                                    onDelete={this.onDelete}
-                                />
-                            ))}
-                        </div>
-                    </Container>
-                )
-            }
-        }
         return (
             <div className="saved-search-list-page">
                 <PageHeader
@@ -176,12 +148,43 @@ export class SavedSearchListPage extends React.Component<Props, State> {
                     }
                     className="mb-3"
                 />
-                {body}
+                <SavedSearchListPageContent onDelete={this.onDelete} {...this.props} {...this.state} />
             </div>
         )
     }
 
     private onDelete = (): void => {
         this.refreshRequests.next()
+    }
+}
+
+interface SavedSearchListPageContentProps extends Props, State {
+    onDelete: () => void
+}
+
+const SavedSearchListPageContent: React.FunctionComponent<SavedSearchListPageContentProps> = ({
+    namespace,
+    savedSearchesOrError,
+    ...props
+}) => {
+    if (savedSearchesOrError === undefined) {
+        return <LoadingSpinner />
+    } else if (isErrorLike(savedSearchesOrError)) {
+        return <ErrorAlert className="mb-3" error={savedSearchesOrError} />
+    } else {
+        const namespaceSavedSearches = savedSearchesOrError.filter(search => namespace.id === search.namespace.id)
+        if (namespaceSavedSearches.length === 0) {
+            return <Container className="text-center text-muted">You haven't created a saved search yet.</Container>
+        } else {
+            return (
+                <Container>
+                    <div className="list-group list-group-flush">
+                        {namespaceSavedSearches.map(search => (
+                            <SavedSearchNode key={search.id} {...props} savedSearch={search} />
+                        ))}
+                    </div>
+                </Container>
+            )
+        }
     }
 }


### PR DESCRIPTION
- Makes the form a bit more consistent with what we do elsewhere
- Use `PageHeaders`
- Add a `Container` wrapper
- Add loading and empty state to list view

No storybooks for these components, so pasting some screenshots here:
|   **Before** | **After**   |
|---|---|
|![image](https://user-images.githubusercontent.com/19534377/119980446-93d68b00-bfbc-11eb-8c50-5d5457bcb6a9.png)   |  ![image](https://user-images.githubusercontent.com/19534377/119980310-6689dd00-bfbc-11eb-806a-7f28e87cf43a.png) |
| ![image](https://user-images.githubusercontent.com/19534377/119980427-8d481380-bfbc-11eb-9a5d-7b176e51109a.png)  | ![image](https://user-images.githubusercontent.com/19534377/119980327-6be72780-bfbc-11eb-9a47-da91b5da2512.png)  |
| ![image](https://user-images.githubusercontent.com/19534377/119980418-88835f80-bfbc-11eb-8e69-366803123d0f.png)  | ![image](https://user-images.githubusercontent.com/19534377/119980352-730e3580-bfbc-11eb-8d4c-ed12d37f2957.png)  |

