### PR TITLE
Add redesign work for some user settings pages

### DIFF
--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionPage.tsx
@@ -70,7 +70,7 @@ export const UserSubscriptionsProductSubscriptionPage: React.FunctionComponent<P
                 {productSubscription !== LOADING &&
                     !isErrorLike(productSubscription) &&
                     productSubscription.urlForSiteAdmin && (
-                        <SiteAdminAlert className="small m-0 p-1">
+                        <SiteAdminAlert className="small m-0">
                             <Link to={productSubscription.urlForSiteAdmin} className="mt-2 d-block">
                                 View subscription
                             </Link>

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -87,8 +87,8 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
                 }
                 description={
                     <>
-                        A subscription gives you a license key to run a self-hosted Sourcegraph instance. See{' '}
-                        <a href="https://about.sourcegraph.com/pricing">Sourcegraph pricing</a> for more information.
+                        Purchase a subscription for a self-hosted Sourcegraph instance.{' '}
+                        <a href="https://about.sourcegraph.com/pricing">pricing</a> for more information.
                     </>
                 }
                 className="mb-3"

--- a/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
+++ b/client/web/src/enterprise/user/productSubscriptions/UserSubscriptionsProductSubscriptionsPage.tsx
@@ -7,6 +7,7 @@ import { map } from 'rxjs/operators'
 import { gql } from '@sourcegraph/shared/src/graphql/graphql'
 import * as GQL from '@sourcegraph/shared/src/graphql/schema'
 import { createAggregateError } from '@sourcegraph/shared/src/util/errors'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { queryGraphQL } from '../../../backend/graphql'
 import { FilteredConnection } from '../../../components/FilteredConnection'
@@ -76,30 +77,40 @@ export const UserSubscriptionsProductSubscriptionsPage: React.FunctionComponent<
     return (
         <div className="user-subscriptions-product-subscriptions-page">
             <PageTitle title="Subscriptions" />
-            <div className="d-flex justify-content-between align-items-center mb-3">
-                <h2 className="mb-0">Subscriptions</h2>
-                <Link to={`${props.match.path}/new`} className="btn btn-primary">
-                    New subscription
-                </Link>
-            </div>
-            <p>
-                A subscription gives you a license key to run a self-hosted Sourcegraph instance. See{' '}
-                <a href="https://about.sourcegraph.com/pricing">Sourcegraph pricing</a> for more information.
-            </p>
-            <FilteredProductSubscriptionConnection
-                className="mt-3"
-                listComponent="table"
-                listClassName="table"
-                noun="subscription"
-                pluralNoun="subscriptions"
-                queryConnection={queryLicenses}
-                headComponent={ProductSubscriptionNodeHeader}
-                nodeComponent={ProductSubscriptionNode}
-                hideSearch={true}
-                noSummaryIfAllNodesVisible={true}
-                history={props.history}
-                location={props.location}
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'Subscriptions' }]}
+                actions={
+                    <Link to={`${props.match.path}/new`} className="btn btn-primary text-nowrap">
+                        New subscription
+                    </Link>
+                }
+                description={
+                    <>
+                        A subscription gives you a license key to run a self-hosted Sourcegraph instance. See{' '}
+                        <a href="https://about.sourcegraph.com/pricing">Sourcegraph pricing</a> for more information.
+                    </>
+                }
+                className="mb-3"
             />
+            <Container className="mb-3">
+                <FilteredProductSubscriptionConnection
+                    listComponent="table"
+                    listClassName="table mb-0"
+                    noun="subscription"
+                    pluralNoun="subscriptions"
+                    queryConnection={queryLicenses}
+                    headComponent={ProductSubscriptionNodeHeader}
+                    nodeComponent={ProductSubscriptionNode}
+                    hideSearch={true}
+                    noSummaryIfAllNodesVisible={true}
+                    history={props.history}
+                    location={props.location}
+                    emptyElement={
+                        <p className="w-100 mb-0 text-muted text-center">You have not purchased a subscription yet.</p>
+                    }
+                />
+            </Container>
         </div>
     )
 }

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.module.scss
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.module.scss
@@ -1,0 +1,7 @@
+.user-settings-permissions-page {
+    &__sync-container {
+        :global(.theme-redesign) & {
+            margin: 0;
+        }
+    }
+}

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { PageTitle } from '../../../../components/PageTitle'
 import { Timestamp } from '../../../../components/time/Timestamp'
@@ -11,6 +12,7 @@ import { ActionContainer } from '../../../../repo/settings/components/ActionCont
 import { eventLogger } from '../../../../tracking/eventLogger'
 
 import { scheduleUserPermissionsSync, userPermissionsInfo } from './backend'
+import styles from './UserSettingsPermissionsPage.module.scss'
 
 /**
  * The user settings permissions page.
@@ -29,7 +31,7 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: UserAr
     return (
         <div className="w-100">
             <PageTitle title="Permissions" />
-            <h2>Permissions</h2>
+            <PageHeader headingElement="h2" path={[{ text: 'Permissions' }]} className="mb-3" />
             {user.siteAdmin && !window.context.site['authz.enforceForSiteAdmins'] ? (
                 <div className="alert alert-info">
                     Site admin can access all repositories in the Sourcegraph instance.
@@ -40,15 +42,15 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: UserAr
                     is finished.
                 </div>
             ) : (
-                <div>
+                <Container className="mb-3">
                     <table className="table">
                         <tbody>
                             <tr>
-                                <th>Last complete sync</th>
-                                <td>
+                                <th className="border-0">Last complete sync</th>
+                                <td className="border-0">
                                     {permissionsInfo.syncedAt ? <Timestamp date={permissionsInfo.syncedAt} /> : 'Never'}
                                 </td>
-                                <td className="text-muted">Updated by user permissions syncing</td>
+                                <td className="text-muted border-0">Updated by user permissions syncing</td>
                             </tr>
                             <tr>
                                 <th>Last incremental sync</th>
@@ -60,11 +62,13 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: UserAr
                         </tbody>
                     </table>
                     <ScheduleUserPermissionsSyncActionContainer user={user} history={history} />
-                </div>
+                </Container>
             )}
-            <a href="/help/admin/repo/permissions#background-permissions-syncing">
-                Learn more about background permissions syncing.
-            </a>
+            <p>
+                <a href="/help/admin/repo/permissions#background-permissions-syncing">
+                    Learn more about background permissions syncing.
+                </a>
+            </p>
         </div>
     )
 }
@@ -84,6 +88,7 @@ class ScheduleUserPermissionsSyncActionContainer extends React.PureComponent<Sch
                 flashText="Added to queue"
                 run={this.scheduleUserPermissions}
                 history={this.props.history}
+                className={styles.userSettingsPermissionsPageSyncContainer}
             />
         )
     }

--- a/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
+++ b/client/web/src/enterprise/user/settings/auth/UserSettingsPermissionsPage.tsx
@@ -31,44 +31,58 @@ export const UserSettingsPermissionsPage: React.FunctionComponent<{ user: UserAr
     return (
         <div className="w-100">
             <PageTitle title="Permissions" />
-            <PageHeader headingElement="h2" path={[{ text: 'Permissions' }]} className="mb-3" />
-            {user.siteAdmin && !window.context.site['authz.enforceForSiteAdmins'] ? (
-                <div className="alert alert-info">
-                    Site admin can access all repositories in the Sourcegraph instance.
-                </div>
-            ) : !permissionsInfo ? (
-                <div className="alert alert-info">
-                    This user is queued to sync permissions, it can only access non-private repositories until syncing
-                    is finished.
-                </div>
-            ) : (
-                <Container className="mb-3">
-                    <table className="table">
-                        <tbody>
-                            <tr>
-                                <th className="border-0">Last complete sync</th>
-                                <td className="border-0">
-                                    {permissionsInfo.syncedAt ? <Timestamp date={permissionsInfo.syncedAt} /> : 'Never'}
-                                </td>
-                                <td className="text-muted border-0">Updated by user permissions syncing</td>
-                            </tr>
-                            <tr>
-                                <th>Last incremental sync</th>
-                                <td>
-                                    <Timestamp date={permissionsInfo.updatedAt} />
-                                </td>
-                                <td className="text-muted">Updated by repository permissions syncing</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <ScheduleUserPermissionsSyncActionContainer user={user} history={history} />
-                </Container>
-            )}
-            <p>
-                <a href="/help/admin/repo/permissions#background-permissions-syncing">
-                    Learn more about background permissions syncing.
-                </a>
-            </p>
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'Permissions' }]}
+                description={
+                    <>
+                        Learn more about{' '}
+                        <a href="/help/admin/repo/permissions#background-permissions-syncing">
+                            background permissions syncing
+                        </a>
+                        .
+                    </>
+                }
+                className="mb-3"
+            />
+            <Container className="mb-3">
+                {user.siteAdmin && !window.context.site['authz.enforceForSiteAdmins'] ? (
+                    <div className="alert alert-info mb-0">
+                        Site admin can access all repositories in the Sourcegraph instance.
+                    </div>
+                ) : !permissionsInfo ? (
+                    <div className="alert alert-info mb-0">
+                        This user is queued to sync permissions, it can only access non-private repositories until
+                        syncing is finished.
+                    </div>
+                ) : (
+                    <>
+                        <table className="table">
+                            <tbody>
+                                <tr>
+                                    <th className="border-0">Last complete sync</th>
+                                    <td className="border-0">
+                                        {permissionsInfo.syncedAt ? (
+                                            <Timestamp date={permissionsInfo.syncedAt} />
+                                        ) : (
+                                            'Never'
+                                        )}
+                                    </td>
+                                    <td className="text-muted border-0">Updated by user permissions syncing</td>
+                                </tr>
+                                <tr>
+                                    <th>Last incremental sync</th>
+                                    <td>
+                                        <Timestamp date={permissionsInfo.updatedAt} />
+                                    </td>
+                                    <td className="text-muted">Updated by repository permissions syncing</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <ScheduleUserPermissionsSyncActionContainer user={user} history={history} />
+                    </>
+                )}
+            </Container>
         </div>
     )
 }

--- a/client/web/src/repo/settings/components/ActionContainer.tsx
+++ b/client/web/src/repo/settings/components/ActionContainer.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import * as React from 'react'
 
@@ -10,8 +11,9 @@ export const BaseActionContainer: React.FunctionComponent<{
     description: React.ReactFragment
     action: React.ReactFragment
     details?: React.ReactFragment
-}> = ({ title, description, action, details }) => (
-    <div className="action-container">
+    className?: string
+}> = ({ title, description, action, details, className }) => (
+    <div className={classNames('action-container', className)}>
         <div className="action-container__row">
             <div className="action-container__description">
                 <h4 className="action-container__title">{title}</h4>
@@ -31,6 +33,7 @@ interface Props {
     buttonSubtitle?: string
     buttonDisabled?: boolean
     info?: React.ReactNode
+    className?: string
 
     /** The message to briefly display below the button when the action is successful. */
     flashText?: string
@@ -67,6 +70,7 @@ export class ActionContainer extends React.PureComponent<Props, State> {
             <BaseActionContainer
                 title={this.props.title}
                 description={this.props.description}
+                className={this.props.className}
                 action={
                     <>
                         <button

--- a/client/web/src/user/settings/UserSettingsArea.tsx
+++ b/client/web/src/user/settings/UserSettingsArea.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from '../../components/ErrorBoundary'
 import { HeroPage } from '../../components/HeroPage'
 import { CreateAccessTokenResult, UserAreaUserFields } from '../../graphql-operations'
 import { OnboardingTourProps } from '../../search'
+import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
 import { UserExternalServicesOrRepositoriesUpdateProps } from '../../util'
 import { RouteDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
@@ -76,37 +77,46 @@ export const UserSettingsArea = withAuthenticatedUser(
             const context: UserSettingsAreaRouteContext = {
                 ...props,
             }
+            const siteAdminViewingOtherUser = props.user.id !== props.authenticatedUser.id
 
             return (
-                <div className="d-flex">
-                    <UserSettingsSidebar
-                        items={this.props.sideBarItems}
-                        {...this.props}
-                        className="flex-0 mr-3 user-settings-sidebar"
-                    />
-                    <div className="flex-1">
-                        <ErrorBoundary location={this.props.location}>
-                            <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
-                                <Switch>
-                                    {this.props.routes.map(
-                                        ({ path, exact, render, condition = () => true }) =>
-                                            condition(context) && (
-                                                <Route
-                                                    render={routeComponentProps =>
-                                                        render({ ...context, ...routeComponentProps })
-                                                    }
-                                                    path={this.props.match.url + path}
-                                                    key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
-                                                    exact={exact}
-                                                />
-                                            )
-                                    )}
-                                    <Route component={NotFoundPage} key="hardcoded-key" />
-                                </Switch>
-                            </React.Suspense>
-                        </ErrorBoundary>
+                <>
+                    {/* Indicate when the site admin is viewing another user's account */}
+                    {siteAdminViewingOtherUser && (
+                        <SiteAdminAlert>
+                            Viewing account for <strong>{props.user.username}</strong>
+                        </SiteAdminAlert>
+                    )}
+                    <div className="d-flex">
+                        <UserSettingsSidebar
+                            items={this.props.sideBarItems}
+                            {...this.props}
+                            className="flex-0 mr-3 user-settings-sidebar"
+                        />
+                        <div className="flex-1">
+                            <ErrorBoundary location={this.props.location}>
+                                <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>
+                                    <Switch>
+                                        {this.props.routes.map(
+                                            ({ path, exact, render, condition = () => true }) =>
+                                                condition(context) && (
+                                                    <Route
+                                                        render={routeComponentProps =>
+                                                            render({ ...context, ...routeComponentProps })
+                                                        }
+                                                        path={this.props.match.url + path}
+                                                        key="hardcoded-key" // see https://github.com/ReactTraining/react-router/issues/4578#issuecomment-334489490
+                                                        exact={exact}
+                                                    />
+                                                )
+                                        )}
+                                        <Route component={NotFoundPage} key="hardcoded-key" />
+                                    </Switch>
+                                </React.Suspense>
+                            </ErrorBoundary>
+                        </div>
                     </div>
-                </div>
+                </>
             )
         }
     }

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -20,7 +20,6 @@ import { UserAreaUserFields } from '../../graphql-operations'
 import { OrgAvatar } from '../../org/OrgAvatar'
 import { OnboardingTourProps } from '../../search'
 import { HAS_CANCELLED_TOUR_KEY, HAS_COMPLETED_TOUR_KEY } from '../../search/input/SearchOnboardingTour'
-import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
 import { NavItemDescriptor } from '../../util/contributions'
 import { UserAreaRouteContext } from '../area/UserArea'
 
@@ -66,13 +65,6 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
 
     return (
         <div className={props.className}>
-            {/* Indicate when the site admin is viewing another user's account */}
-            {siteAdminViewingOtherUser && (
-                <SiteAdminAlert className="sidebar__alert">
-                    Viewing account for <strong>{props.user.username}</strong>
-                </SiteAdminAlert>
-            )}
-
             <SidebarGroup>
                 <SidebarGroupHeader label="User account" icon={AccountCircleIcon} />
                 <SidebarGroupItems>

--- a/client/web/src/user/settings/research/ProductResearch.tsx
+++ b/client/web/src/user/settings/research/ProductResearch.tsx
@@ -2,7 +2,7 @@ import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import React, { useEffect } from 'react'
 
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
-import { PageHeader } from '@sourcegraph/wildcard'
+import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 
@@ -23,21 +23,17 @@ export const ProductResearchPage: React.FunctionComponent<Props> = ({ telemetryS
 
     return (
         <>
-            <PageHeader
-                headingElement="h2"
-                path={[{ text: 'Product research and feedback' }]}
-                description={
-                    <>
-                        Our product team conducts occasional research to learn about how you use Sourcegraph and ask for
-                        feedback about upcoming ideas. Sign up to participate in our research and help us shape the
-                        future of our product!
-                    </>
-                }
-                className="mb-3"
-            />
-            <a href={signUpForm.href} className="btn btn-primary mt-2" target="_blank" rel="noopener noreferrer">
-                Sign up now <OpenInNewIcon className="icon-inline" />
-            </a>
+            <PageHeader headingElement="h2" path={[{ text: 'Product research and feedback' }]} className="mb-3" />
+            <Container>
+                <p>
+                    Our product team conducts occasional research to learn about how you use Sourcegraph and ask for
+                    feedback about upcoming ideas. Sign up to participate in our research and help us shape the future
+                    of our product!
+                </p>
+                <a href={signUpForm.href} className="btn btn-primary" target="_blank" rel="noopener noreferrer">
+                    Sign up now <OpenInNewIcon className="icon-inline" />
+                </a>
+            </Container>
         </>
     )
 }

--- a/client/web/src/user/settings/research/ProductResearch.tsx
+++ b/client/web/src/user/settings/research/ProductResearch.tsx
@@ -2,6 +2,7 @@ import OpenInNewIcon from 'mdi-react/OpenInNewIcon'
 import React, { useEffect } from 'react'
 
 import { TelemetryService } from '@sourcegraph/shared/src/telemetry/telemetryService'
+import { PageHeader } from '@sourcegraph/wildcard'
 
 import { AuthenticatedUser } from '../../../auth'
 
@@ -22,12 +23,18 @@ export const ProductResearchPage: React.FunctionComponent<Props> = ({ telemetryS
 
     return (
         <>
-            <h2 className="mb-3">Product research and feedback</h2>
-            <p>
-                Our product team conducts occasional research to learn about how you use Sourcegraph and ask for
-                feedback about upcoming ideas. Sign up to participate in our research and help us shape the future of
-                our product!
-            </p>
+            <PageHeader
+                headingElement="h2"
+                path={[{ text: 'Product research and feedback' }]}
+                description={
+                    <>
+                        Our product team conducts occasional research to learn about how you use Sourcegraph and ask for
+                        feedback about upcoming ideas. Sign up to participate in our research and help us shape the
+                        future of our product!
+                    </>
+                }
+                className="mb-3"
+            />
             <a href={signUpForm.href} className="btn btn-primary mt-2" target="_blank" rel="noopener noreferrer">
                 Sign up now <OpenInNewIcon className="icon-inline" />
             </a>


### PR DESCRIPTION
Aligns headers and adds containers to the three pages below:

![image](https://user-images.githubusercontent.com/19534377/119985510-05b1d300-bfc3-11eb-9289-a292cd7dc541.png)
![image](https://user-images.githubusercontent.com/19534377/119985519-09ddf080-bfc3-11eb-9644-5e53352bc56a.png)
![image](https://user-images.githubusercontent.com/19534377/119986111-bd46e500-bfc3-11eb-9c7d-eae16f3e2e33.png)
