### PR TITLE
Fix example story for PageHeader component

### DIFF
--- a/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
+++ b/client/wildcard/src/components/PageHeader/PageHeader.story.tsx
@@ -66,7 +66,7 @@ add(
                     <Link to="/page" className="btn btn-secondary mr-2">
                         Secondary
                     </Link>
-                    <Link to="/page" className="btn btn-primary mr-2">
+                    <Link to="/page" className="btn btn-primary text-nowrap">
                         <PlusIcon className="icon-inline" /> Create
                     </Link>
                 </div>


### PR DESCRIPTION
Remove unnecessary margin on the right and prevent the button to split into two lines at certain sizes. 