### PR TITLE
Sidebar redesign

### DIFF
--- a/client/shared/src/util/useRedesignToggle.ts
+++ b/client/shared/src/util/useRedesignToggle.ts
@@ -5,6 +5,7 @@ import { useObservable } from './useObservable'
 
 export const REDESIGN_TOGGLE_KEY = 'isRedesignEnabled'
 export const REDESIGN_CLASS_NAME = 'theme-redesign'
+export const NOT_REDESIGN_CLASS_NAME = 'theme-classic'
 
 export const getIsRedesignEnabled = (): boolean => localStorage.getItem(REDESIGN_TOGGLE_KEY) === 'true'
 

--- a/client/web/src/SourcegraphWebApp.tsx
+++ b/client/web/src/SourcegraphWebApp.tsx
@@ -25,6 +25,7 @@ import { filterExists } from '@sourcegraph/shared/src/search/query/validate'
 import { EMPTY_SETTINGS_CASCADE, SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import {
+    NOT_REDESIGN_CLASS_NAME,
     REDESIGN_CLASS_NAME,
     getIsRedesignEnabled,
     REDESIGN_TOGGLE_KEY,
@@ -451,6 +452,7 @@ class ColdSourcegraphWebApp extends React.Component<SourcegraphWebAppProps, Sour
         }
 
         document.documentElement.classList.toggle(REDESIGN_CLASS_NAME, getIsRedesignEnabled())
+        document.documentElement.classList.toggle(NOT_REDESIGN_CLASS_NAME, !getIsRedesignEnabled())
     }
 
     public render(): React.ReactFragment | null {

--- a/client/web/src/components/Sidebar.scss
+++ b/client/web/src/components/Sidebar.scss
@@ -1,8 +1,22 @@
 .sidebar {
     isolation: isolate;
     width: 12rem;
+    .theme-redesign & {
+        display: flex;
+        flex-direction: column;
+    }
 
     &__chevron {
         color: var(--color-bg-6);
+    }
+
+    &__link {
+        &--inactive {
+            .theme-redesign & {
+                &:hover {
+                    background-color: var(--color-bg-2);
+                }
+            }
+        }
     }
 }

--- a/client/web/src/components/Sidebar.tsx
+++ b/client/web/src/components/Sidebar.tsx
@@ -5,7 +5,9 @@ import React, { useCallback, useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import { Collapse } from 'reactstrap'
 
-export const SIDEBAR_BUTTON_CLASS = 'btn btn-secondary d-block w-100 my-2'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+
+export const SIDEBAR_BUTTON_CLASS = 'btn text-left sidebar__link--inactive w-100'
 
 /**
  * Item of `SideBarGroupItems`.
@@ -16,31 +18,50 @@ export const SidebarNavItem: React.FunctionComponent<{
     className?: string
     exact?: boolean
     source?: string
-}> = ({ icon: Icon, children, className, to, exact, source }) =>
-    source === 'server' ? (
-        <a href={to} className={classNames('list-group-item list-group-item-action py-2', className)}>
-            {Icon && <Icon className="icon-inline mr-2" />}
-            {children}
-        </a>
-    ) : (
-        <NavLink to={to} exact={exact} className={classNames('list-group-item list-group-item-action py-2', className)}>
-            {Icon && <Icon className="icon-inline mr-2" />}
+}> = ({ icon: Icon, children, className, to, exact, source }) => {
+    const [isRedesign] = useRedesignToggle()
+    const buttonClassNames = isRedesign
+        ? 'btn text-left sidebar__link--inactive d-flex sidebar-nav-link'
+        : 'list-group-item list-group-item-action py-2'
+    if (source === 'server') {
+        return (
+            <a href={to} className={classNames(buttonClassNames, className)}>
+                {Icon && <Icon className="icon-inline mr-2" />}
+                {children}
+            </a>
+        )
+    }
+    return (
+        <NavLink
+            to={to}
+            exact={exact}
+            className={classNames(buttonClassNames, className)}
+            activeClassName={isRedesign ? 'btn-primary' : undefined}
+        >
+            {Icon && <Icon className="redesign-d-none icon-inline mr-2" />}
             {children}
         </NavLink>
     )
-
+}
 /**
+ *
  * Header of a `SideBarGroup`
  */
 export const SidebarGroupHeader: React.FunctionComponent<{
     icon?: React.ComponentType<{ className?: string }>
     label: string
     children?: undefined
-}> = ({ icon: Icon, label }) => (
-    <div className="card-header">
-        {Icon && <Icon className="icon-inline mr-1" />} {label}
-    </div>
-)
+}> = ({ icon: Icon, label }) => {
+    const [isRedesign] = useRedesignToggle()
+    if (isRedesign) {
+        return <h3>{label}</h3>
+    }
+    return (
+        <div className="card-header">
+            {Icon && <Icon className="icon-inline mr-1" />} {label}
+        </div>
+    )
+}
 
 /**
  * Sidebar with collapsible items
@@ -81,13 +102,18 @@ export const SidebarCollapseItems: React.FunctionComponent<{
 /**
  * A box of items in the side bar. Use `SideBarGroupHeader` and `SideBarGroupItems` as children.
  */
-export const SidebarGroup: React.FunctionComponent<{}> = ({ children }) => (
-    <div className="card mb-3 sidebar">{children}</div>
-)
+export const SidebarGroup: React.FunctionComponent<{}> = ({ children }) => {
+    const [isRedesign] = useRedesignToggle()
+    return <div className={classNames('mb-3 sidebar', !isRedesign && 'card')}>{children}</div>
+}
 
 /**
  * Container for all `SideBarNavItem` in a `SideBarGroup`.
  */
-export const SidebarGroupItems: React.FunctionComponent<{}> = ({ children }) => (
-    <div className="list-group list-group-flush">{children}</div>
-)
+export const SidebarGroupItems: React.FunctionComponent<{}> = ({ children }) => {
+    const [isRedesign] = useRedesignToggle()
+    if (isRedesign) {
+        return <>{children}</>
+    }
+    return <div className="list-group list-group-flush">{children}</div>
+}

--- a/client/web/src/enterprise/user/settings/sidebaritems.ts
+++ b/client/web/src/enterprise/user/settings/sidebaritems.ts
@@ -3,40 +3,35 @@ import { UserSettingsSidebarItems } from '../../../user/settings/UserSettingsSid
 import { SHOW_BUSINESS_FEATURES } from '../../dotcom/productSubscriptions/features'
 import { authExp } from '../../site-admin/SiteAdminAuthenticationProvidersPage'
 
-export const enterpriseUserSettingsSideBarItems: UserSettingsSidebarItems = {
-    ...userSettingsSideBarItems,
-    account: [
-        ...userSettingsSideBarItems.account.slice(0, 2),
-        {
-            label: 'Subscriptions',
-            to: '/subscriptions',
-            condition: ({ user }) => SHOW_BUSINESS_FEATURES && user.viewerCanAdminister,
-        },
-        {
-            label: 'External accounts',
-            to: '/external-accounts',
-            exact: true,
-            condition: () => authExp,
-        },
-        {
-            to: '/batch-changes',
-            label: 'Batch Changes',
-            condition: ({ isSourcegraphDotCom, user: { viewerCanAdminister } }) =>
-                !isSourcegraphDotCom && window.context.batchChangesEnabled && viewerCanAdminister,
-        },
-        ...userSettingsSideBarItems.account.slice(2),
-        {
-            label: 'Permissions',
-            to: '/permissions',
-            exact: true,
-            condition: ({ authenticatedUser }) => !!authenticatedUser.siteAdmin,
-        },
-    ],
-    misc: [
-        {
-            to: '/event-log',
-            label: 'Event log',
-            condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
-        },
-    ],
-}
+export const enterpriseUserSettingsSideBarItems: UserSettingsSidebarItems = [
+    ...userSettingsSideBarItems.slice(0, 2),
+    {
+        label: 'Subscriptions',
+        to: '/subscriptions',
+        condition: ({ user }) => SHOW_BUSINESS_FEATURES && user.viewerCanAdminister,
+    },
+    {
+        label: 'External accounts',
+        to: '/external-accounts',
+        exact: true,
+        condition: () => authExp,
+    },
+    {
+        to: '/batch-changes',
+        label: 'Batch Changes',
+        condition: ({ isSourcegraphDotCom, user: { viewerCanAdminister } }) =>
+            !isSourcegraphDotCom && window.context.batchChangesEnabled && viewerCanAdminister,
+    },
+    ...userSettingsSideBarItems.slice(2),
+    {
+        label: 'Permissions',
+        to: '/permissions',
+        exact: true,
+        condition: ({ authenticatedUser }) => !!authenticatedUser.siteAdmin,
+    },
+    {
+        to: '/event-log',
+        label: 'Event log',
+        condition: ({ user: { viewerCanAdminister } }) => viewerCanAdminister,
+    },
+]

--- a/client/web/src/extensions/ExtensionRegistrySidenav.module.scss
+++ b/client/web/src/extensions/ExtensionRegistrySidenav.module.scss
@@ -10,12 +10,6 @@
     border-color: var(--border-color-2);
 }
 
-.inactive-category {
-    &:hover {
-        background-color: var(--color-bg-2);
-    }
-}
-
 .banner {
     margin-top: 2.25rem;
 }

--- a/client/web/src/extensions/ExtensionRegistrySidenav.tsx
+++ b/client/web/src/extensions/ExtensionRegistrySidenav.tsx
@@ -4,6 +4,8 @@ import { ButtonDropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reac
 
 import { EXTENSION_CATEGORIES } from '@sourcegraph/shared/src/schema/extensionSchema'
 
+import { SidebarGroup, SidebarGroupHeader, SidebarGroupItems } from '../components/Sidebar'
+
 import { ExtensionCategoryOrAll, ExtensionsEnablement } from './ExtensionRegistry'
 import styles from './ExtensionRegistrySidenav.module.scss'
 import { extensionBannerIconURL } from './icons'
@@ -49,24 +51,25 @@ export const ExtensionRegistrySidenav: React.FunctionComponent<
 
     return (
         <div className={classnames(styles.column, 'mr-4 flex-grow-0 flex-shrink-0')}>
-            <div className="d-flex flex-column">
-                <h3 className={classnames(styles.header, 'mb-3')}>Categories</h3>
-
-                {['All' as const, ...EXTENSION_CATEGORIES].map(category => (
-                    <button
-                        type="button"
-                        className={classnames(
-                            'btn text-left',
-                            selectedCategory === category ? 'btn-primary' : styles.inactiveCategory
-                        )}
-                        data-test-extension-category={category}
-                        key={category}
-                        onClick={() => onSelectCategory(category)}
-                    >
-                        {category}
-                    </button>
-                ))}
-            </div>
+            <SidebarGroup>
+                <SidebarGroupHeader label="Categories" />
+                <SidebarGroupItems>
+                    {['All' as const, ...EXTENSION_CATEGORIES].map(category => (
+                        <button
+                            type="button"
+                            className={classnames(
+                                'btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100',
+                                selectedCategory === category && 'btn-primary'
+                            )}
+                            data-test-extension-category={category}
+                            key={category}
+                            onClick={() => onSelectCategory(category)}
+                        >
+                            {category}
+                        </button>
+                    ))}
+                </SidebarGroupItems>
+            </SidebarGroup>
 
             <hr className={classnames('my-3', styles.divider)} />
 

--- a/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
+++ b/client/web/src/extensions/__snapshots__/ExtensionRegistrySidenav.test.tsx.snap
@@ -5,77 +5,82 @@ exports[`ExtensionsQueryInputToolbar renders 1`] = `
   className="column mr-4 flex-grow-0 flex-shrink-0"
 >
   <div
-    className="d-flex flex-column"
+    className="mb-3 sidebar card"
   >
-    <h3
-      className="header mb-3"
+    <div
+      className="card-header"
     >
+       
       Categories
-    </h3>
-    <button
-      className="btn text-left inactiveCategory"
-      data-test-extension-category="All"
-      onClick={[Function]}
-      type="button"
+    </div>
+    <div
+      className="list-group list-group-flush"
     >
-      All
-    </button>
-    <button
-      className="btn text-left inactiveCategory"
-      data-test-extension-category="External services"
-      onClick={[Function]}
-      type="button"
-    >
-      External services
-    </button>
-    <button
-      className="btn text-left inactiveCategory"
-      data-test-extension-category="Reports and stats"
-      onClick={[Function]}
-      type="button"
-    >
-      Reports and stats
-    </button>
-    <button
-      className="btn text-left inactiveCategory"
-      data-test-extension-category="Linters"
-      onClick={[Function]}
-      type="button"
-    >
-      Linters
-    </button>
-    <button
-      className="btn text-left inactiveCategory"
-      data-test-extension-category="Code editors"
-      onClick={[Function]}
-      type="button"
-    >
-      Code editors
-    </button>
-    <button
-      className="btn text-left btn-primary"
-      data-test-extension-category="Code analysis"
-      onClick={[Function]}
-      type="button"
-    >
-      Code analysis
-    </button>
-    <button
-      className="btn text-left inactiveCategory"
-      data-test-extension-category="Programming languages"
-      onClick={[Function]}
-      type="button"
-    >
-      Programming languages
-    </button>
-    <button
-      className="btn text-left inactiveCategory"
-      data-test-extension-category="Other"
-      onClick={[Function]}
-      type="button"
-    >
-      Other
-    </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+        data-test-extension-category="All"
+        onClick={[Function]}
+        type="button"
+      >
+        All
+      </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+        data-test-extension-category="External services"
+        onClick={[Function]}
+        type="button"
+      >
+        External services
+      </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+        data-test-extension-category="Reports and stats"
+        onClick={[Function]}
+        type="button"
+      >
+        Reports and stats
+      </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+        data-test-extension-category="Linters"
+        onClick={[Function]}
+        type="button"
+      >
+        Linters
+      </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+        data-test-extension-category="Code editors"
+        onClick={[Function]}
+        type="button"
+      >
+        Code editors
+      </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100 btn-primary"
+        data-test-extension-category="Code analysis"
+        onClick={[Function]}
+        type="button"
+      >
+        Code analysis
+      </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+        data-test-extension-category="Programming languages"
+        onClick={[Function]}
+        type="button"
+      >
+        Programming languages
+      </button>
+      <button
+        className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+        data-test-extension-category="Other"
+        onClick={[Function]}
+        type="button"
+      >
+        Other
+      </button>
+    </div>
   </div>
   <hr
     className="my-3 divider"

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -141,7 +141,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
     // Design Refresh will include repositories section as part of the user navigation bar
     // This filter makes sure repositories feature flag is active.
     const showRepositorySection = useMemo(
-        () => !!props.userSettingsSideBarItems?.account.find(item => item.label === 'Repositories'),
+        () => !!props.userSettingsSideBarItems?.find(item => item.label === 'Repositories'),
         [props.userSettingsSideBarItems]
     )
 

--- a/client/web/src/nav/RedesignToggle/RedesignToggle.tsx
+++ b/client/web/src/nav/RedesignToggle/RedesignToggle.tsx
@@ -1,7 +1,11 @@
 import React, { useCallback } from 'react'
 
 import { Toggle } from '@sourcegraph/branded/src/components/Toggle'
-import { useRedesignToggle, REDESIGN_CLASS_NAME } from '@sourcegraph/shared/src/util/useRedesignToggle'
+import {
+    useRedesignToggle,
+    NOT_REDESIGN_CLASS_NAME,
+    REDESIGN_CLASS_NAME,
+} from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { Badge } from '../../components/Badge'
 
@@ -11,6 +15,7 @@ export const RedesignToggle: React.FunctionComponent = () => {
     const handleRedesignToggle = useCallback((): void => {
         setIsRedesignEnabled(!isRedesignEnabled)
         document.documentElement.classList.toggle(REDESIGN_CLASS_NAME, !isRedesignEnabled)
+        document.documentElement.classList.toggle(NOT_REDESIGN_CLASS_NAME, isRedesignEnabled)
     }, [isRedesignEnabled, setIsRedesignEnabled])
 
     return (

--- a/client/web/src/org/settings/OrgSettingsSidebar.module.scss
+++ b/client/web/src/org/settings/OrgSettingsSidebar.module.scss
@@ -1,0 +1,3 @@
+.org-settings-sidebar {
+    width: 12.5rem;
+}

--- a/client/web/src/org/settings/OrgSettingsSidebar.tsx
+++ b/client/web/src/org/settings/OrgSettingsSidebar.tsx
@@ -1,12 +1,15 @@
+import classNames from 'classnames'
 import AccountMultipleIcon from 'mdi-react/AccountMultipleIcon'
 import ClipboardAccountOutlineIcon from 'mdi-react/ClipboardAccountOutlineIcon'
 import EarthIcon from 'mdi-react/EarthIcon'
 import * as React from 'react'
 import { RouteComponentProps } from 'react-router-dom'
 
-import { SidebarGroup, SidebarGroupItems, SidebarNavItem } from '../../components/Sidebar'
+import { SidebarGroup, SidebarGroupHeader, SidebarGroupItems, SidebarNavItem } from '../../components/Sidebar'
 import { SiteAdminAlert } from '../../site-admin/SiteAdminAlert'
 import { OrgAreaPageProps } from '../area/OrgArea'
+
+import styles from './OrgSettingsSidebar.module.scss'
 
 interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {
     className?: string
@@ -23,7 +26,7 @@ export const OrgSettingsSidebar: React.FunctionComponent<Props> = ({ org, authen
     const siteAdminViewingOtherOrg = authenticatedUser && org.viewerCanAdminister && !org.viewerIsMember
 
     return (
-        <div className={className}>
+        <div className={classNames(styles.orgSettingsSidebar, className)}>
             {/* Indicate when the site admin is viewing another org's settings */}
             {siteAdminViewingOtherOrg && (
                 <SiteAdminAlert className="sidebar__alert">
@@ -32,6 +35,7 @@ export const OrgSettingsSidebar: React.FunctionComponent<Props> = ({ org, authen
             )}
 
             <SidebarGroup>
+                <SidebarGroupHeader label="Organization" />
                 <SidebarGroupItems>
                     <SidebarNavItem icon={EarthIcon} to={match.url} exact={true}>
                         Organization Settings

--- a/client/web/src/user/settings/UserSettingsSidebar.scss
+++ b/client/web/src/user/settings/UserSettingsSidebar.scss
@@ -7,7 +7,7 @@
         }
     }
     &__new-org-btn {
-        html:not(.theme-redesign) & {
+        .theme-classic & {
             width: 100%;
             height: 100%;
         }

--- a/client/web/src/user/settings/UserSettingsSidebar.scss
+++ b/client/web/src/user/settings/UserSettingsSidebar.scss
@@ -1,3 +1,15 @@
 .user-settings-sidebar {
-    max-width: 12rem;
+    width: 12.5rem;
+
+    &__new-org-btn-wrapper {
+        .theme-redesign & {
+            margin-top: 0.25rem;
+        }
+    }
+    &__new-org-btn {
+        html:not(.theme-redesign) & {
+            width: 100%;
+            height: 100%;
+        }
+    }
 }

--- a/client/web/src/user/settings/UserSettingsSidebar.tsx
+++ b/client/web/src/user/settings/UserSettingsSidebar.tsx
@@ -9,13 +9,7 @@ import { Link, RouteComponentProps } from 'react-router-dom'
 
 import { AuthenticatedUser } from '../../auth'
 import { Badge, BadgeStatus } from '../../components/Badge'
-import {
-    SIDEBAR_BUTTON_CLASS,
-    SidebarGroup,
-    SidebarGroupHeader,
-    SidebarGroupItems,
-    SidebarNavItem,
-} from '../../components/Sidebar'
+import { SidebarGroup, SidebarGroupHeader, SidebarGroupItems, SidebarNavItem } from '../../components/Sidebar'
 import { UserAreaUserFields } from '../../graphql-operations'
 import { OrgAvatar } from '../../org/OrgAvatar'
 import { OnboardingTourProps } from '../../search'
@@ -34,10 +28,7 @@ type UserSettingsSidebarItem = NavItemDescriptor<UserSettingsSidebarItemConditio
     status?: BadgeStatus
 }
 
-export interface UserSettingsSidebarItems {
-    account: readonly UserSettingsSidebarItem[]
-    misc?: readonly UserSettingsSidebarItem[]
-}
+export type UserSettingsSidebarItems = readonly UserSettingsSidebarItem[]
 
 export interface UserSettingsSidebarProps extends UserAreaRouteContext, OnboardingTourProps, RouteComponentProps<{}> {
     items: UserSettingsSidebarItems
@@ -76,30 +67,16 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
             <SidebarGroup>
                 <SidebarGroupHeader label="User account" icon={AccountCircleIcon} />
                 <SidebarGroupItems>
-                    {props.items.account.map(
+                    {props.items.map(
                         ({ label, to, exact, status, condition = () => true }) =>
                             condition(context) && (
-                                <SidebarNavItem key={label} to={props.match.path + to} exact={exact} className="d-flex">
+                                <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
                                     {label} {status && <Badge className="ml-1" status={status} />}
                                 </SidebarNavItem>
                             )
                     )}
                 </SidebarGroupItems>
             </SidebarGroup>
-            {props.items.misc?.length && (
-                <SidebarGroup>
-                    <SidebarGroupItems>
-                        {props.items.misc.map(
-                            ({ label, to, exact, condition = () => true }) =>
-                                condition(context) && (
-                                    <SidebarNavItem key={label} to={props.match.path + to} exact={exact}>
-                                        {label}
-                                    </SidebarNavItem>
-                                )
-                        )}
-                    </SidebarGroupItems>
-                </SidebarGroup>
-            )}
             {(props.user.organizations.nodes.length > 0 || !siteAdminViewingOtherUser) && (
                 <SidebarGroup>
                     <SidebarGroupHeader label="Organizations" icon={DomainIcon} />
@@ -115,27 +92,42 @@ export const UserSettingsSidebar: React.FunctionComponent<UserSettingsSidebarPro
                         ))}
                     </SidebarGroupItems>
                     {!siteAdminViewingOtherUser && (
-                        <Link to="/organizations/new" className="btn btn-secondary btn-sm w-100">
-                            <AddIcon className="icon-inline" /> New organization
-                        </Link>
+                        <div className="user-settings-sidebar__new-org-btn-wrapper">
+                            <Link
+                                to="/organizations/new"
+                                className="user-settings-sidebar__new-org-btn btn btn-outline-secondary btn-sm"
+                            >
+                                <AddIcon className="icon-inline" /> New organization
+                            </Link>
+                        </div>
                     )}
                 </SidebarGroup>
             )}
-            {!siteAdminViewingOtherUser && (
-                <Link to="/api/console" className={SIDEBAR_BUTTON_CLASS}>
-                    <ConsoleIcon className="icon-inline" /> API console
-                </Link>
-            )}
-            {props.authenticatedUser.siteAdmin && (
-                <Link to="/site-admin" className={SIDEBAR_BUTTON_CLASS}>
-                    <ServerIcon className="icon-inline list-group-item-action-icon" /> Site admin
-                </Link>
-            )}
-            {props.showOnboardingTour && (
-                <button type="button" onClick={reEnableSearchTour} className={SIDEBAR_BUTTON_CLASS}>
-                    <MapSearchOutlineIcon className="icon-inline list-group-item-action-icon" /> Show search tour
-                </button>
-            )}
+            <SidebarGroup>
+                <SidebarGroupHeader label="Other actions" />
+                <SidebarGroupItems>
+                    {!siteAdminViewingOtherUser && (
+                        <SidebarNavItem to="/api/console" icon={ConsoleIcon}>
+                            API console
+                        </SidebarNavItem>
+                    )}
+                    {props.authenticatedUser.siteAdmin && (
+                        <SidebarNavItem to="/site-admin" icon={ServerIcon}>
+                            Site admin
+                        </SidebarNavItem>
+                    )}
+                    {props.showOnboardingTour && (
+                        <button
+                            type="button"
+                            className="btn text-left sidebar__link--inactive d-flex sidebar-nav-link w-100"
+                            onClick={reEnableSearchTour}
+                        >
+                            <MapSearchOutlineIcon className="icon-inline list-group-item-action-icon redesign-d-none" />{' '}
+                            Show search tour
+                        </button>
+                    )}
+                </SidebarGroupItems>
+            </SidebarGroup>
             <div>Version: {window.context.version}</div>
         </div>
     )

--- a/client/web/src/user/settings/sidebaritems.ts
+++ b/client/web/src/user/settings/sidebaritems.ts
@@ -1,57 +1,55 @@
 import { showAccountSecurityPage, showPasswordsPage, userExternalServicesEnabled } from './cloud-ga'
 import { UserSettingsSidebarItems } from './UserSettingsSidebar'
 
-export const userSettingsSideBarItems: UserSettingsSidebarItems = {
-    account: [
-        {
-            label: 'Settings',
-            to: '',
-            exact: true,
-        },
-        {
-            label: 'Profile',
-            to: '/profile',
-            exact: true,
-        },
-        {
-            label: 'Password',
-            to: '/password',
-            exact: true,
-            // Only the builtin auth provider has a password.
-            condition: showPasswordsPage,
-        },
-        {
-            label: 'Emails',
-            to: '/emails',
-            exact: true,
-        },
-        {
-            label: 'Access tokens',
-            to: '/tokens',
-            condition: () => window.context.accessTokensAllow !== 'none',
-        },
-        //  future GA Cloud nav items
-        {
-            label: 'Account security',
-            to: '/security',
-            exact: true,
-            condition: showAccountSecurityPage,
-        },
-        {
-            label: 'Code host connections',
-            to: '/code-hosts',
-            condition: userExternalServicesEnabled,
-        },
-        {
-            label: 'Repositories',
-            to: '/repositories',
-            condition: userExternalServicesEnabled,
-        },
-        {
-            label: 'Product research',
-            to: '/product-research',
-            condition: () => window.context.productResearchPageEnabled,
-            status: 'new',
-        },
-    ],
-}
+export const userSettingsSideBarItems: UserSettingsSidebarItems = [
+    {
+        label: 'Settings',
+        to: '',
+        exact: true,
+    },
+    {
+        label: 'Profile',
+        to: '/profile',
+        exact: true,
+    },
+    {
+        label: 'Password',
+        to: '/password',
+        exact: true,
+        // Only the builtin auth provider has a password.
+        condition: showPasswordsPage,
+    },
+    {
+        label: 'Emails',
+        to: '/emails',
+        exact: true,
+    },
+    {
+        label: 'Access tokens',
+        to: '/tokens',
+        condition: () => window.context.accessTokensAllow !== 'none',
+    },
+    //  future GA Cloud nav items
+    {
+        label: 'Account security',
+        to: '/security',
+        exact: true,
+        condition: showAccountSecurityPage,
+    },
+    {
+        label: 'Code host connections',
+        to: '/code-hosts',
+        condition: userExternalServicesEnabled,
+    },
+    {
+        label: 'Repositories',
+        to: '/repositories',
+        condition: userExternalServicesEnabled,
+    },
+    {
+        label: 'Product research',
+        to: '/product-research',
+        condition: () => window.context.productResearchPageEnabled,
+        status: 'new',
+    },
+]


### PR DESCRIPTION
Redesigns the sidebar in user and org settings. The design is the same as we use in the extension registry, so I went ahead and used the `Sidebar` components for all three of the use-cases.
Side-effect: The extensions registry will look "old-style" in the non-redesign version, too.

| **Before** | **After** |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/19534377/120245988-3322a900-c26f-11eb-8d3c-4c48a0446faa.png) | ![image](https://user-images.githubusercontent.com/19534377/120245550-d8d51880-c26d-11eb-8171-9890e4de3179.png) |
| ![image](https://user-images.githubusercontent.com/19534377/120245616-fd30f500-c26d-11eb-9a14-89e4ac1c2326.png) | ![image](https://user-images.githubusercontent.com/19534377/120245632-0ae67a80-c26e-11eb-8f3d-a2dc64b86ea9.png) |
| ![image](https://user-images.githubusercontent.com/19534377/120245671-2a7da300-c26e-11eb-8f99-92e438617ba8.png) | ![image](https://user-images.githubusercontent.com/19534377/120245647-19cd2d00-c26e-11eb-9e14-cce4c9ca9f39.png) |



