### PR TITLE
search: enable streaming permanently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ All notable changes to Sourcegraph are documented in this file.
 ### Changed
 
 - SSH public keys generated to access code hosts with batch changes now include a comment indicating they originated from Sourcegraph. [#20523](https://github.com/sourcegraph/sourcegraph/issues/20523)
-- The copy query button is now permanently enabled and the `copyQueryButton` experimental feature flag has been removed. [#21364](https://github.com/sourcegraph/sourcegraph/pull/21364)
+- The copy query button is now permanently enabled and `experimentalFeatures.copyQueryButton` setting has been deprecated. [#21364](https://github.com/sourcegraph/sourcegraph/pull/21364)
+- Search streaming is now permanently enabled and `experimentalFeatures.searchStreaming` setting has been deprecated. [#TODO](https://github.com/sourcegraph/sourcegraph/pull/TODO)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - SSH public keys generated to access code hosts with batch changes now include a comment indicating they originated from Sourcegraph. [#20523](https://github.com/sourcegraph/sourcegraph/issues/20523)
 - The copy query button is now permanently enabled and `experimentalFeatures.copyQueryButton` setting has been deprecated. [#21364](https://github.com/sourcegraph/sourcegraph/pull/21364)
-- Search streaming is now permanently enabled and `experimentalFeatures.searchStreaming` setting has been deprecated. [#TODO](https://github.com/sourcegraph/sourcegraph/pull/TODO)
+- Search streaming is now permanently enabled and `experimentalFeatures.searchStreaming` setting has been deprecated. [#21522](https://github.com/sourcegraph/sourcegraph/pull/21522)
 
 ### Fixed
 

--- a/client/web/src/Layout.tsx
+++ b/client/web/src/Layout.tsx
@@ -149,6 +149,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
     const isSearchRelatedPage = (routeMatch === '/:repoRevAndRest+' || routeMatch?.startsWith('/search')) ?? false
     const minimalNavLinks = routeMatch === '/cncf'
     const isSearchHomepage = props.location.pathname === '/search' && !parseSearchURLQuery(props.location.search)
+    const isSearchConsolePage = routeMatch?.startsWith('/search/console')
 
     // Update parsedSearchQuery, patternType, caseSensitivity, versionContext, and selectedSearchContextSpec based on current URL
     const {
@@ -291,7 +292,7 @@ export const Layout: React.FunctionComponent<LayoutProps> = props => {
                 <GlobalNavbar
                     {...props}
                     authRequired={!!authRequired}
-                    showSearchBox={isSearchRelatedPage && !isSearchHomepage && !isRepogroupPage}
+                    showSearchBox={isSearchRelatedPage && !isSearchHomepage && !isRepogroupPage && !isSearchConsolePage}
                     variant={
                         hideGlobalSearchInput
                             ? 'no-search-input'

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -22,25 +22,6 @@ const commonSearchGraphQLResults: Partial<WebGraphQlOperations & SharedGraphQlOp
             suggestions: [],
         },
     }),
-    Search: (): SearchResult => ({
-        search: {
-            results: {
-                __typename: 'SearchResults',
-                limitHit: true,
-                matchCount: 30,
-                approximateResultCount: '30+',
-                missing: [],
-                cloning: [],
-                repositoriesCount: 372,
-                timedout: [],
-                indexUnavailable: false,
-                dynamicFilters: [],
-                results: [],
-                alert: null,
-                elapsedMilliseconds: 103,
-            },
-        },
-    }),
     RepoGroups: (): RepoGroupsResult => ({
         repoGroups: [],
     }),
@@ -63,6 +44,7 @@ describe('Search contexts', () => {
             directory: __dirname,
         })
         testContext.overrideGraphQL(testContextForSearchContexts)
+        testContext.overrideSearchStreamEvents([{ type: 'done', data: {} }])
         const context = createJsContext({ sourcegraphBaseUrl: driver.sourcegraphBaseUrl })
         testContext.overrideJsContext({
             ...context,

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -8,7 +8,7 @@ import { ISearchContext } from '@sourcegraph/shared/src/graphql/schema'
 import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
-import { RepoGroupsResult, SearchSuggestionsResult, WebGraphQlOperations, SearchResult } from '../graphql-operations'
+import { RepoGroupsResult, SearchSuggestionsResult, WebGraphQlOperations } from '../graphql-operations'
 
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { createRepositoryRedirectResult } from './graphQlResponseHelpers'

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -5,8 +5,6 @@ import expect from 'expect'
 import { Driver, createDriverForTest } from '@sourcegraph/shared/src/testing/driver'
 import { afterEachSaveScreenshotIfFailed } from '@sourcegraph/shared/src/testing/screenshotReporter'
 
-import { SearchResult } from '../graphql-operations'
-
 import { WebIntegrationTestContext, createWebIntegrationTestContext } from './context'
 import { commonWebGraphQlResults } from './graphQlResults'
 import { siteID, siteGQLID } from './jscontext'
@@ -29,25 +27,6 @@ describe('Search onboarding', () => {
             SearchSuggestions: () => ({
                 search: {
                     suggestions: [{ __typename: 'Repository', name: '^github\\.com/sourcegraph/sourcegraph$' }],
-                },
-            }),
-            Search: (): SearchResult => ({
-                search: {
-                    results: {
-                        __typename: 'SearchResults',
-                        limitHit: true,
-                        matchCount: 30,
-                        approximateResultCount: '30+',
-                        missing: [],
-                        cloning: [],
-                        repositoriesCount: 372,
-                        timedout: [],
-                        indexUnavailable: false,
-                        dynamicFilters: [],
-                        results: [],
-                        alert: null,
-                        elapsedMilliseconds: 103,
-                    },
                 },
             }),
             RepoGroups: () => ({
@@ -84,6 +63,7 @@ describe('Search onboarding', () => {
                 },
             }),
         })
+        testContext.overrideSearchStreamEvents([{ type: 'done', data: {} }])
     })
     afterEachSaveScreenshotIfFailed(() => driver.page)
     afterEach(() => testContext?.dispose())

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -79,18 +79,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
     },
     {
         path: '/search',
-        render: props =>
-            props.parsedSearchQuery ? (
-                props.isRedesignEnabled || // Force streaming search if redesing is enabled
-                (!isErrorLike(props.settingsCascade.final) &&
-                    props.settingsCascade.final?.experimentalFeatures?.searchStreaming) ? (
-                    <StreamingSearchResults {...props} />
-                ) : (
-                    <SearchResults {...props} deployType={window.context.deployType} />
-                )
-            ) : (
-                <SearchPage {...props} />
-            ),
+        render: props => (props.parsedSearchQuery ? <StreamingSearchResults {...props} /> : <SearchPage {...props} />),
         exact: true,
     },
     {

--- a/client/web/src/routes.tsx
+++ b/client/web/src/routes.tsx
@@ -107,14 +107,7 @@ export const routes: readonly LayoutRouteProps<any>[] = [
         path: '/search/console',
         render: props =>
             props.showMultilineSearchConsole ? (
-                <SearchConsolePage
-                    {...props}
-                    isMacPlatform={isMacPlatform}
-                    allExpanded={false}
-                    showSavedQueryModal={false}
-                    deployType={window.context.deployType}
-                    showSavedQueryButton={false}
-                />
+                <SearchConsolePage {...props} isMacPlatform={isMacPlatform} />
             ) : (
                 <Redirect to="/search" />
             ),

--- a/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResultsList.tsx
@@ -25,7 +25,7 @@ import { StreamingSearchResultFooter } from './StreamingSearchResultsFooter'
 const initialItemsToShow = 15
 const incrementalItemsToShow = 10
 
-interface StreamingSearchResultsListProps extends ThemeProps, SettingsCascadeProps, TelemetryProps {
+export interface StreamingSearchResultsListProps extends ThemeProps, SettingsCascadeProps, TelemetryProps {
     results?: AggregateStreamingSearchResults
 
     location: H.Location

--- a/cmd/frontend/graphqlbackend/default_settings.go
+++ b/cmd/frontend/graphqlbackend/default_settings.go
@@ -62,10 +62,8 @@ func defaultSettings(db dbutil.DB) map[string]interface{} {
 	}
 
 	return map[string]interface{}{
-		"experimentalFeatures": map[string]interface{}{
-			"searchStreaming": true,
-		},
-		"extensions": extensions,
+		"experimentalFeatures": map[string]interface{}{},
+		"extensions":           extensions,
 	}
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1322,7 +1322,7 @@ type SettingsExperimentalFeatures struct {
 	FuzzyFinderCaseInsensitiveFileCountThreshold *float64 `json:"fuzzyFinderCaseInsensitiveFileCountThreshold,omitempty"`
 	// SearchStats description: Enables a new page that shows language statistics about the results for a search query.
 	SearchStats *bool `json:"searchStats,omitempty"`
-	// SearchStreaming description: Enables experimental streaming support.
+	// SearchStreaming description: DEPRECATED: This feature is now permanently enabled. Enables streaming search support.
 	SearchStreaming *bool `json:"searchStreaming,omitempty"`
 	// ShowCodeMonitoringTestEmailButton description: Enables the 'Send test email' debugging button for code monitoring.
 	ShowCodeMonitoringTestEmailButton *bool `json:"showCodeMonitoringTestEmailButton,omitempty"`

--- a/schema/settings.schema.json
+++ b/schema/settings.schema.json
@@ -53,7 +53,7 @@
           }
         },
         "searchStreaming": {
-          "description": "Enables experimental streaming support.",
+          "description": "DEPRECATED: This feature is now permanently enabled. Enables streaming search support.",
           "type": "boolean",
           "default": false,
           "!go": {


### PR DESCRIPTION
Part of #21267

Enables streaming search permanently and fixes any tests related to this change. The feature flag has now been deprecated.