### PR TITLE
codeintel: Fix error on worker reprocessing

### DIFF
--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -284,7 +284,7 @@ func isUniqueConstraintViolation(err error) bool {
 	if errors.As(err, &pgErr) {
 		return pgErr.Code == "23505"
 	}
-	
+
 	return false
 }
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -280,12 +280,11 @@ func writeData(ctx context.Context, lsifStore LSIFStore, id int, groupedBundleDa
 }
 
 func isUniqueConstraintViolation(err error) bool {
-	for ex := err; ex != nil; ex = errors.Unwrap(ex) {
-		if pgErr, ok := ex.(*pgconn.PgError); ok {
-			return pgErr.Code == "23505"
-		}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "23505"
 	}
-
+	
 	return false
 }
 

--- a/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
+++ b/enterprise/cmd/precise-code-intel-worker/internal/worker/handler.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/honeycombio/libhoney-go"
 	"github.com/inconshreveable/log15"
+	"github.com/jackc/pgconn"
 	"github.com/keegancsmith/sqlf"
 	"github.com/pkg/errors"
 
@@ -103,10 +104,18 @@ func (h *handler) handle(ctx context.Context, workerStore dbworkerstore.Store, d
 			return errors.Wrap(err, "conversion.Correlate")
 		}
 
-		// Note: this is writing to a different database than the block below, so the same comments
-		// do not apply here.
+		// Note: this is writing to a different database than the block below, so we need to use a
+		// different transaction context (managed by the writeData function).
 		if err := writeData(ctx, h.lsifStore, upload.ID, groupedBundleData); err != nil {
-			return err
+			if isUniqueConstraintViolation(err) {
+				// If this is a unique constraint violation, then we've previously processed this same
+				// upload record up to this point, but failed to perform the transaction below. We can
+				// safely assume that the entire index's data is in the codeintel database, as it's
+				// parsed determinstically and written atomically.
+				log15.Warn("LSIF data already exists for upload record")
+			} else {
+				return err
+			}
 		}
 
 		// Start a nested transaction with Postgres savepoints. In the event that something after this
@@ -268,6 +277,16 @@ func writeData(ctx context.Context, lsifStore LSIFStore, id int, groupedBundleDa
 	}
 
 	return nil
+}
+
+func isUniqueConstraintViolation(err error) bool {
+	for ex := err; ex != nil; ex = errors.Unwrap(ex) {
+		if pgErr, ok := ex.(*pgconn.PgError); ok {
+			return pgErr.Code == "23505"
+		}
+	}
+
+	return false
 }
 
 func createHoneyEvent(ctx context.Context, upload store.Upload, err error, duration time.Duration) *libhoney.Event {


### PR DESCRIPTION
Ignore unique constraint violations from `writeData`. This error occurring means that we've half-processed a record (we write to two different datastores, so it's possible to have lsif data but no completed metadata), but when we try to reprocess it we hit a duplicate data error from the lsifstore (which is the only part that previously succeeded).

Currently these records should only go into the `errored` state, which is why we haven't seen it before. We may introduce different error retry/resetting schemes, in which case this condition needs to not be a fatal error (otherwise all retries are destined to fail unconditionally).