### PR TITLE
insights: added rate limiters for better control over code insights performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Added
 
 - Code Insights queries can now run concurrently up to a limit set by the `insights.query.worker.concurrency` site config. [#21219](https://github.com/sourcegraph/sourcegraph/pull/21219)
+- Code Insights workers now support a rate limit for query execution and historical data frame analysis using the `insights.query.worker.rateLimit` and `insights.historical.worker.rateLimit` site configurations. [#21533](https://github.com/sourcegraph/sourcegraph/pull/21533)
 
 ### Changed
 

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -214,10 +214,6 @@ type historicalEnqueuer struct {
 	limiter          *rate.Limiter
 }
 
-func (h *historicalEnqueuer) timeSince(t time.Time) time.Duration {
-	return h.now().Sub(t)
-}
-
 func (h *historicalEnqueuer) Handler(ctx context.Context) error {
 	// Discover all insights on the instance.
 	insights, err := discovery.Discover(ctx, h.settingStore)

--- a/enterprise/internal/insights/background/historical_enqueuer.go
+++ b/enterprise/internal/insights/background/historical_enqueuer.go
@@ -89,7 +89,6 @@ func newInsightHistoricalEnqueuer(ctx context.Context, workerBaseStore *basestor
 
 	historicalEnqueuer := &historicalEnqueuer{
 		now:           time.Now,
-		sleep:         time.Sleep,
 		settingStore:  settingStore,
 		insightsStore: insightsStore,
 		repoStore:     database.Repos(workerBaseStore.Handle().DB()),
@@ -197,7 +196,6 @@ type RepoStore interface {
 type historicalEnqueuer struct {
 	// Required fields used for mocking in tests.
 	now                   func() time.Time
-	sleep                 func(t time.Duration)
 	settingStore          discovery.SettingStore
 	insightsStore         store.Interface
 	repoStore             RepoStore

--- a/enterprise/internal/insights/background/queryrunner/worker.go
+++ b/enterprise/internal/insights/background/queryrunner/worker.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/sourcegraph/sourcegraph/internal/conf"
 
 	"github.com/keegancsmith/sqlf"
@@ -42,9 +44,14 @@ func NewWorker(ctx context.Context, workerBaseStore *basestore.Store, insightsSt
 		Interval:    5 * time.Second,
 		Metrics:     metrics,
 	}
+
+	//TODO: add a setting for this rate limiter
+	limiter := rate.NewLimiter(2, 1)
+
 	return dbworker.NewWorker(ctx, workerStore, &workHandler{
 		workerBaseStore: workerBaseStore,
 		insightsStore:   insightsStore,
+		limiter:         limiter,
 	}, options)
 }
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1452,6 +1452,8 @@ type SiteConfiguration struct {
 	InsightsHistoricalSpeedFactor *float64 `json:"insights.historical.speedFactor,omitempty"`
 	// InsightsQueryWorkerConcurrency description: Number of concurrent executions of a code insight query on a worker node
 	InsightsQueryWorkerConcurrency int `json:"insights.query.worker.concurrency,omitempty"`
+	// InsightsQueryWorkerRateLimit description: Maximum number of Code Insights queries initiated per second on a worker node.
+	InsightsQueryWorkerRateLimit *float64 `json:"insights.query.worker.rateLimit,omitempty"`
 	// LicenseKey description: The license key associated with a Sourcegraph product subscription, which is necessary to activate Sourcegraph Enterprise functionality. To obtain this value, contact Sourcegraph to purchase a subscription. To escape the value into a JSON string, you may want to use a tool like https://json-escape-text.now.sh.
 	LicenseKey string `json:"licenseKey,omitempty"`
 	// Log description: Configuration for logging and alerting, including to external services.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1450,6 +1450,8 @@ type SiteConfiguration struct {
 	InsightsHistoricalFrames int `json:"insights.historical.frames,omitempty"`
 	// InsightsHistoricalSpeedFactor description: (debug) Speed factor for building historical insights data. A value like 1.5 indicates approximately to use 1.5x as much repo-updater and gitserver resources.
 	InsightsHistoricalSpeedFactor *float64 `json:"insights.historical.speedFactor,omitempty"`
+	// InsightsHistoricalWorkerRateLimit description: Maximum number of historical Code Insights data frames that may be analyzed per second.
+	InsightsHistoricalWorkerRateLimit *float64 `json:"insights.historical.worker.rateLimit,omitempty"`
 	// InsightsQueryWorkerConcurrency description: Number of concurrent executions of a code insight query on a worker node
 	InsightsQueryWorkerConcurrency int `json:"insights.query.worker.concurrency,omitempty"`
 	// InsightsQueryWorkerRateLimit description: Maximum number of Code Insights queries initiated per second on a worker node.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -877,6 +877,14 @@
       "examples": [10.0, 0.5],
       "!go": { "pointer": true }
     },
+    "insights.historical.worker.rateLimit": {
+      "description": "Maximum number of historical Code Insights data frames that may be analyzed per second.",
+      "type": "number",
+      "group": "CodeInsights",
+      "default": 10,
+      "examples": [50.0, 0.5],
+      "!go": { "pointer": true }
+    },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",
       "type": "string",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -869,6 +869,14 @@
       "default": 1,
       "examples": [10]
     },
+    "insights.query.worker.rateLimit": {
+      "description": "Maximum number of Code Insights queries initiated per second on a worker node.",
+      "type": "number",
+      "group": "CodeInsights",
+      "default": 2,
+      "examples": [10.0, 0.5],
+      "!go": { "pointer": true }
+    },
     "htmlHeadTop": {
       "description": "HTML to inject at the top of the `<head>` element on each page, for analytics scripts",
       "type": "string",


### PR DESCRIPTION
Added rate limiters to the code insights jobs that do a significant amount of work, and site settings to control them. This will allow us to have better control over the insights backend and reduce the operational load on other services (searcher and gitserver) when necessary.

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
