### PR TITLE
web: remove unused styles from the `Panel` component

### DIFF
--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -29,62 +29,11 @@
         opacity: 0.6;
     }
 
-    &__header {
-        flex: none;
-        padding: 0.25rem 0.25rem 0.25rem 0.5rem;
-        display: flex;
-        align-items: center;
-        &-icon {
-            flex: 0;
-            align-self: flex-start;
-            opacity: 0.6;
-        }
-    }
-
-    &__tab-bar {
-        flex-wrap: wrap;
-        position: relative;
-        overflow-x: hidden; /* We can rely on the tab bar breaking onto new lines */
-    }
-
-    &__tabs {
+    &__tabs-content {
         flex: 1;
-        min-height: 0; /* needed for Firefox for content scrolling to work properly; See sourcegraph/sourcegraph#12340 and https://codepen.io/slimsag/pen/mjPXyN */
-        &-content {
-            flex: 1;
-            &--scroll {
-                overflow: auto;
-            }
+
+        &--scroll {
+            overflow: auto;
         }
-    }
-
-    &__dismiss {
-        position: absolute;
-        right: 0.5rem;
-        top: 4px;
-        border: none;
-    }
-
-    &__actions {
-        padding-right: 2rem;
-
-        // Ensures the action border always completes the full line it breaks onto
-        &::after {
-            opacity: 0.6;
-            position: absolute;
-            content: '';
-            width: 100%;
-            top: calc(100% - 3px);
-            border-bottom: 3px solid var(--border-color);
-        }
-
-        li:first-child .panel__action {
-            padding-left: 0.5rem;
-        }
-    }
-
-    &__action {
-        // stylelint-disable-next-line declaration-property-unit-whitelist
-        padding: 0.25rem 0.75rem calc(0.25rem + 3px);
     }
 }

--- a/client/branded/src/components/panel/views/EmptyPanelView.tsx
+++ b/client/branded/src/components/panel/views/EmptyPanelView.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import CancelIcon from 'mdi-react/CancelIcon'
 import React from 'react'
 
@@ -6,7 +7,7 @@ import React from 'react'
  */
 export const EmptyPanelView: React.FunctionComponent<{ className?: string }> = ({ className = '' }) => (
     <div className="panel">
-        <div className={`panel__empty ${className}`}>
+        <div className={classNames('panel__empty', className)}>
             <CancelIcon className="icon-inline" /> Nothing to show here
         </div>
     </div>

--- a/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
+++ b/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import PuzzleIcon from 'mdi-react/PuzzleIcon'
 import React from 'react'
 
@@ -5,7 +6,7 @@ import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
 export const ExtensionsLoadingPanelView: React.FunctionComponent<{ className?: string }> = ({ className = '' }) => (
     <div className="panel">
-        <div className={`panel__empty ${className}`}>
+        <div className={classNames('panel__empty', className)}>
             <LoadingSpinner />
             <span className="mx-2">Loading Sourcegraph extensions</span>
             <PuzzleIcon className="icon-inline" />


### PR DESCRIPTION
## Description

The preparation PR for the Code Intel bottom panel redesign: https://github.com/sourcegraph/sourcegraph/issues/21045.

## Changes

- Removed unused styles from the `Panel` component.