### PR TITLE
Remove fuzzy finder cache storage.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,4 +5,3 @@ shfmt 3.2.0
 shellcheck 0.7.1
 kubectl 1.17.3
 github-cli 1.8.0
-nodejs 14.15.4

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,3 +5,4 @@ shfmt 3.2.0
 shellcheck 0.7.1
 kubectl 1.17.3
 github-cli 1.8.0
+nodejs 14.15.4


### PR DESCRIPTION
Previously, it was slow to download files in larger repositories so the
fuzzy finder used the cache storage to speed up subsequent loads. This
commit removes that caching because

- downloading files has gotten faster https://github.com/sourcegraph/sourcegraph/pull/21422
- filenames are already cached by the SPA as the user navigates between
  files. Files only need to be re-downloaded when refreshing the
  browser. The original implementation used raw `<a href=` links, which trigger
  a cold refresh.
