### PR TITLE
web: Allow filtering repos by failure on site admin page

### DIFF
--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -100,6 +100,12 @@ const FILTERS: FilteredConnectionFilter[] = [
                 tooltip: 'Show only repositories that need to be indexed',
                 args: { indexed: false },
             },
+            {
+                label: 'Failed fetch/clone',
+                value: 'failed-fetch',
+                tooltip: 'Show only repositories that have failed to fetch or clone',
+                args: { failedFetch: true },
+            }
         ],
     },
 ]

--- a/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
+++ b/client/web/src/site-admin/SiteAdminRepositoriesPage.tsx
@@ -105,7 +105,7 @@ const FILTERS: FilteredConnectionFilter[] = [
                 value: 'failed-fetch',
                 tooltip: 'Show only repositories that have failed to fetch or clone',
                 args: { failedFetch: true },
-            }
+            },
         ],
     },
 ]

--- a/client/web/src/site-admin/backend.ts
+++ b/client/web/src/site-admin/backend.ts
@@ -252,6 +252,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                 $notCloned: Boolean
                 $indexed: Boolean
                 $notIndexed: Boolean
+                $failedFetch: Boolean
             ) {
                 repositories(
                     first: $first
@@ -260,6 +261,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
                     notCloned: $notCloned
                     indexed: $indexed
                     notIndexed: $notIndexed
+                    failedFetch: $failedFetch
                 ) {
                     nodes {
                         ...SiteAdminRepositoryFields
@@ -278,6 +280,7 @@ function fetchAllRepositories(args: Partial<RepositoriesVariables>): Observable<
             notCloned: args.notCloned ?? true,
             indexed: args.indexed ?? true,
             notIndexed: args.notIndexed ?? true,
+            failedFetch: args.failedFetch ?? false,
             first: args.first ?? null,
             query: args.query ?? null,
         }

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/types"
 )
 
-func (r *schemaResolver) Repositories(args *struct {
+type RepositoryArgs struct {
 	graphqlutil.ConnectionArgs
 	Query       *string
 	Names       *[]string
@@ -29,7 +29,9 @@ func (r *schemaResolver) Repositories(args *struct {
 	OrderBy     string
 	Descending  bool
 	After       *string
-}) (*repositoryConnectionResolver, error) {
+}
+
+func (r *schemaResolver) Repositories(args *RepositoryArgs) (*repositoryConnectionResolver, error) {
 	opt := database.ReposListOptions{
 		OrderBy: database.RepoListOrderBy{{
 			Field:      toDBRepoListColumn(args.OrderBy),
@@ -59,8 +61,10 @@ func (r *schemaResolver) Repositories(args *struct {
 			opt.CursorDirection = "next"
 		}
 	}
+
 	opt.FailedFetch = args.FailedFetch
 	args.ConnectionArgs.Set(&opt.LimitOffset)
+
 	return &repositoryConnectionResolver{
 		db:          r.db,
 		opt:         opt,

--- a/cmd/frontend/graphqlbackend/repositories.go
+++ b/cmd/frontend/graphqlbackend/repositories.go
@@ -59,6 +59,7 @@ func (r *schemaResolver) Repositories(args *struct {
 			opt.CursorDirection = "next"
 		}
 	}
+	opt.FailedFetch = args.FailedFetch
 	args.ConnectionArgs.Set(&opt.LimitOffset)
 	return &repositoryConnectionResolver{
 		db:          r.db,

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -997,6 +997,10 @@ type Query {
         """
         notIndexed: Boolean = true
         """
+        Include repositories that have encountered errors when cloning or fetching
+        """
+        failedFetch: Boolean = false
+        """
         Sort field.
         """
         orderBy: RepositoryOrderBy = REPOSITORY_NAME


### PR DESCRIPTION
When listing repos on the site admin page it is now possible to filter
to only repos that have failed to clone or fetch.

Closes: https://github.com/sourcegraph/sourcegraph/issues/19865