### PR TITLE
Properly center “Show more matches” button

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -14,7 +14,7 @@
     .mdi-icon {
         margin-right: 0.125rem;
 
-        .theme-redesign & {
+        &:only-child {
             margin-right: 0;
         }
     }

--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -13,6 +13,10 @@
 
     .mdi-icon {
         margin-right: 0.125rem;
+
+        .theme-redesign & {
+            margin-right: 0;
+        }
     }
 
     &__row {

--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -13,10 +13,6 @@
 
     .mdi-icon {
         margin-right: 0.125rem;
-
-        &:only-child {
-            margin-right: 0;
-        }
     }
 
     &__row {

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -208,14 +208,14 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                                 >
                                     {props.allExpanded ? (
                                         isRedesignEnabled ? (
-                                            <ArrowCollapseUpIcon className="icon-inline" />
+                                            <ArrowCollapseUpIcon className="icon-inline mr-0" />
                                         ) : (
-                                            <ArrowCollapseVerticalIcon className="icon-inline" />
+                                            <ArrowCollapseVerticalIcon className="icon-inline mr-0" />
                                         )
                                     ) : isRedesignEnabled ? (
-                                        <ArrowExpandDownIcon className="icon-inline" />
+                                        <ArrowExpandDownIcon className="icon-inline mr-0" />
                                     ) : (
-                                        <ArrowExpandVerticalIcon className="icon-inline" />
+                                        <ArrowExpandVerticalIcon className="icon-inline mr-0" />
                                     )}
                                 </button>
                             </li>

--- a/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
+++ b/client/web/src/search/results/__snapshots__/SearchResultsInfoBar.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag disabled 1`] = `
           type="button"
         >
           <svg
-            className="mdi-icon icon-inline"
+            className="mdi-icon icon-inline mr-0"
             fill="currentColor"
             height={24}
             viewBox="0 0 24 24"
@@ -154,7 +154,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
           type="button"
         >
           <svg
-            className="mdi-icon icon-inline"
+            className="mdi-icon icon-inline mr-0"
             fill="currentColor"
             height={24}
             viewBox="0 0 24 24"
@@ -200,7 +200,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, can create m
           type="button"
         >
           <svg
-            className="mdi-icon icon-inline"
+            className="mdi-icon icon-inline mr-0"
             fill="currentColor"
             height={24}
             viewBox="0 0 24 24"
@@ -302,7 +302,7 @@ exports[`SearchResultsInfoBar code monitoring feature flag enabled, cannot creat
           type="button"
         >
           <svg
-            className="mdi-icon icon-inline"
+            className="mdi-icon icon-inline mr-0"
             fill="currentColor"
             height={24}
             viewBox="0 0 24 24"


### PR DESCRIPTION
Under the redesign, the "Show more matches" button on the search page has no text, only an icon. Remove the margin from the icon so that that it is centered horizontally on the button.

<img width="455" alt="CleanShot 2021-05-31 at 17 22 57@2x" src="https://user-images.githubusercontent.com/17293/120214518-defad300-c234-11eb-9949-911df7ecb8f4.png">
