### PR TITLE
web: code intel panel header + references section redesign

### DIFF
--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -36,4 +36,21 @@
             overflow: auto;
         }
     }
+
+    .theme-redesign & {
+        border-top: 2px solid var(--border-color-2);
+
+        &__header {
+            padding: 0 1rem;
+            background-color: var(--color-bg-1);
+        }
+
+        &__dismiss {
+            color: var(--icon-color);
+        }
+
+        [data-reach-tab]:first-child {
+            margin-left: 0;
+        }
+    }
 }

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -1,10 +1,10 @@
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@reach/tabs'
+import classNames from 'classnames'
 import CloseIcon from 'mdi-react/CloseIcon'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useHistory, useLocation } from 'react-router'
 import { BehaviorSubject, from, Observable } from 'rxjs'
 import { map, switchMap } from 'rxjs/operators'
-import classNames from 'classnames'
 
 import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { Location } from '@sourcegraph/extension-api-types'
@@ -25,12 +25,12 @@ import { ThemeProps } from '@sourcegraph/shared/src/theme'
 import { combineLatestOrDefault } from '@sourcegraph/shared/src/util/rxjs/combineLatestOrDefault'
 import { isDefined } from '@sourcegraph/shared/src/util/types'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { registerPanelToolbarContributions } from './views/contributions'
 import { EmptyPanelView } from './views/EmptyPanelView'
 import { ExtensionsLoadingPanelView } from './views/ExtensionsLoadingView'
 import { PanelView } from './views/PanelView'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 interface Props
     extends ExtensionsControllerProps,

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -228,7 +228,7 @@ export const Panel = React.memo<Props>(props => {
 
     if (!areExtensionsReady) {
         return (
-            <EmptyPanelWrapper {...(isRedesignEnabled && { className: 'panel' })}>
+            <EmptyPanelWrapper {...(!isRedesignEnabled && { className: 'panel' })}>
                 <ExtensionsLoadingPanelView />
             </EmptyPanelWrapper>
         )
@@ -236,7 +236,7 @@ export const Panel = React.memo<Props>(props => {
 
     if (!items) {
         return (
-            <EmptyPanelWrapper {...(isRedesignEnabled && { className: 'panel' })}>
+            <EmptyPanelWrapper {...(!isRedesignEnabled && { className: 'panel' })}>
                 <EmptyPanelView />
             </EmptyPanelWrapper>
         )

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -235,11 +235,7 @@ export const Panel = React.memo<Props>(props => {
     }
 
     if (!items) {
-        return (
-            <EmptyPanelWrapper {...(!isRedesignEnabled && { className: 'panel' })}>
-                <EmptyPanelView />
-            </EmptyPanelWrapper>
-        )
+        return <EmptyPanelView />
     }
 
     const activeTab: PanelItem | undefined = items[tabIndex]

--- a/client/branded/src/components/panel/views/EmptyPanelView.tsx
+++ b/client/branded/src/components/panel/views/EmptyPanelView.tsx
@@ -2,16 +2,22 @@ import classNames from 'classnames'
 import CancelIcon from 'mdi-react/CancelIcon'
 import React from 'react'
 
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+
 interface EmptyPanelViewProps {
     className?: string
 }
 
 export const EmptyPanelView: React.FunctionComponent<EmptyPanelViewProps> = props => {
     const { className } = props
+    const [isRedesignEnabled] = useRedesignToggle()
+    const EmptyPanelWrapper = isRedesignEnabled ? React.Fragment : 'div'
 
     return (
-        <div className={classNames('panel__empty', className)}>
-            <CancelIcon className="icon-inline" /> Nothing to show here
-        </div>
+        <EmptyPanelWrapper {...(!isRedesignEnabled && { className: 'panel' })}>
+            <div className={classNames('panel__empty', className)}>
+                <CancelIcon className="icon-inline" /> Nothing to show here
+            </div>
+        </EmptyPanelWrapper>
     )
 }

--- a/client/branded/src/components/panel/views/EmptyPanelView.tsx
+++ b/client/branded/src/components/panel/views/EmptyPanelView.tsx
@@ -2,13 +2,16 @@ import classNames from 'classnames'
 import CancelIcon from 'mdi-react/CancelIcon'
 import React from 'react'
 
-/**
- * An empty panel view.
- */
-export const EmptyPanelView: React.FunctionComponent<{ className?: string }> = ({ className = '' }) => (
-    <div className="panel">
+interface EmptyPanelViewProps {
+    className?: string
+}
+
+export const EmptyPanelView: React.FunctionComponent<EmptyPanelViewProps> = props => {
+    const { className } = props
+
+    return (
         <div className={classNames('panel__empty', className)}>
             <CancelIcon className="icon-inline" /> Nothing to show here
         </div>
-    </div>
-)
+    )
+}

--- a/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
+++ b/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
@@ -1,15 +1,12 @@
-import classNames from 'classnames'
 import PuzzleIcon from 'mdi-react/PuzzleIcon'
 import React from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
-export const ExtensionsLoadingPanelView: React.FunctionComponent<{ className?: string }> = ({ className = '' }) => (
-    <div className="panel">
-        <div className={classNames('panel__empty', className)}>
-            <LoadingSpinner />
-            <span className="mx-2">Loading Sourcegraph extensions</span>
-            <PuzzleIcon className="icon-inline" />
-        </div>
+export const ExtensionsLoadingPanelView: React.FunctionComponent = () => (
+    <div className="panel__empty">
+        <LoadingSpinner />
+        <span className="mx-2">Loading Sourcegraph extensions</span>
+        <PuzzleIcon className="icon-inline" />
     </div>
 )

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
@@ -43,4 +43,47 @@
         flex: 1;
         width: 100%;
     }
+
+    .theme-redesign & {
+        &__resizable {
+            padding: 0.75rem 1rem;
+            overflow-y: auto;
+        }
+
+        &__list {
+            border-right: none;
+            // Move overflow-y to the parent element to avoid cutting down box-shadow on focus.
+            overflow-y: visible;
+        }
+
+        &__item {
+            border-radius: var(--border-radius);
+            font-size: 0.75rem;
+            line-height: (16/12);
+            border: none;
+            outline: none;
+
+            &:focus-visible {
+                // Show item outline over the active item background instead of cutting it.
+                z-index: 2;
+            }
+
+            &-badge {
+                opacity: 1;
+                color: var(--primary);
+            }
+
+            &.active {
+                background-color: var(--primary);
+
+                &:hover {
+                    color: var(--light-text);
+                }
+
+                .hierarchical-locations-view__item-badge {
+                    color: var(--light-text);
+                }
+            }
+        }
+    }
 }

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
@@ -102,6 +102,7 @@
 
             &.active {
                 background-color: var(--primary);
+                margin-top: 0;
 
                 &:hover {
                     color: var(--light-text);

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
@@ -45,9 +45,36 @@
     }
 
     .theme-redesign & {
+        padding: 0.25rem 1rem;
+
+        &__content {
+            margin-right: -1rem;
+        }
+
         &__resizable {
-            padding: 0.75rem 1rem;
+            padding: 0.5rem;
             overflow-y: auto;
+
+            &:first-child {
+                padding-left: 0;
+            }
+
+            &:last-of-type {
+                margin-right: 0.5rem;
+            }
+
+            .resizable__handle {
+                border-right: 1px solid var(--border-color-2);
+                margin: 0;
+                margin-right: 0.5rem;
+                width: 0;
+                padding-left: 0.5rem;
+                transition: opacity 150ms;
+
+                &:hover {
+                    opacity: 1;
+                }
+            }
         }
 
         &__list {

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
@@ -81,6 +81,7 @@
             border-right: none;
             // Move overflow-y to the parent element to avoid cutting down box-shadow on focus.
             overflow-y: visible;
+            overflow-x: hidden;
         }
 
         &__item {

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.tsx
@@ -8,7 +8,6 @@ import { MaybeLoadingResult } from '@sourcegraph/codeintellify'
 import { Location } from '@sourcegraph/extension-api-types'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { FetchFileParameters } from '@sourcegraph/shared/src/components/CodeExcerpt'
-import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
 import { Resizable } from '@sourcegraph/shared/src/components/Resizable'
 import { ExtensionsControllerProps } from '@sourcegraph/shared/src/extensions/controller'
 import { VersionContextProps } from '@sourcegraph/shared/src/search/util'
@@ -17,6 +16,7 @@ import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/er
 import { parseRepoURI } from '@sourcegraph/shared/src/util/url'
 
 import { FileLocations, FileLocationsError, FileLocationsNotFound } from './FileLocations'
+import { HierarchicalLocationsViewButton } from './HierarchicalLocationsViewButton'
 import { groupLocations } from './locations'
 
 /** The maximum number of results we'll receive from a provider before we truncate and display a banner. */
@@ -241,28 +241,15 @@ export class HierarchicalLocationsView extends React.PureComponent<HierarchicalL
                                         element={
                                             <div className="list-group list-group-flush hierarchical-locations-view__list test-hierarchical-locations-view-list">
                                                 {groups[index].map((group, innerIndex) => (
-                                                    <button
+                                                    <HierarchicalLocationsViewButton
                                                         key={innerIndex}
-                                                        type="button"
-                                                        className={`list-group-item list-group-item-action hierarchical-locations-view__item ${
-                                                            selectedGroups[index] === group.key ? 'active' : ''
-                                                        }`}
+                                                        groupKey={group.key}
+                                                        groupCount={group.count}
+                                                        isActive={selectedGroups[index] === group.key}
                                                         onClick={event =>
                                                             this.onSelectTree(event, selectedGroups, index, group.key)
                                                         }
-                                                    >
-                                                        <span
-                                                            className="hierarchical-locations-view__item-name"
-                                                            title={group.key}
-                                                        >
-                                                            <span className="hierarchical-locations-view__item-name-text">
-                                                                <RepoLink to={null} repoName={group.key} />
-                                                            </span>
-                                                        </span>
-                                                        <span className="badge badge-secondary badge-pill hierarchical-locations-view__item-badge">
-                                                            {group.count}
-                                                        </span>
-                                                    </button>
+                                                    />
                                                 ))}
                                                 {this.state.locationsOrError.isLoading && (
                                                     <LoadingSpinner className="icon-inline m-2 flex-shrink-0 test-loading-spinner" />

--- a/client/branded/src/components/panel/views/HierarchicalLocationsViewButton.tsx
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsViewButton.tsx
@@ -1,0 +1,44 @@
+import classNames from 'classnames'
+import React from 'react'
+
+import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
+
+interface HierarchicalLocationsViewButtonProps {
+    groupKey: string
+    groupCount: number
+    isActive: boolean
+    onClick: (event: React.MouseEvent<HTMLElement>) => void
+}
+
+export const HierarchicalLocationsViewButton: React.FunctionComponent<HierarchicalLocationsViewButtonProps> = props => {
+    const { groupKey, groupCount, isActive, onClick } = props
+
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    return (
+        <button
+            type="button"
+            className={classNames(
+                'list-group-item list-group-item-action hierarchical-locations-view__item',
+                isActive && 'active'
+            )}
+            onClick={onClick}
+        >
+            <span className="hierarchical-locations-view__item-name" title={groupKey}>
+                <span className="hierarchical-locations-view__item-name-text">
+                    <RepoLink to={null} repoName={groupKey} />
+                </span>
+            </span>
+            <span
+                className={classNames(
+                    'hierarchical-locations-view__item-badge',
+                    !isRedesignEnabled && 'badge badge-secondary badge-pill ',
+                    isRedesignEnabled && 'ml-1'
+                )}
+            >
+                {groupCount}
+            </span>
+        </button>
+    )
+}

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
               className="result-container__header"
             >
               <svg
-                className="mdi-icon icon-inline"
+                className="mdi-icon icon-inline flex-shrink-0"
                 fill="currentColor"
                 height={24}
                 viewBox="0 0 24 24"
@@ -195,13 +195,13 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
             </span>
           </span>
           <span
-            className="badge badge-secondary badge-pill hierarchical-locations-view__item-badge"
+            className="hierarchical-locations-view__item-badge badge badge-secondary badge-pill "
           >
             2
           </span>
         </button>
         <button
-          className="list-group-item list-group-item-action hierarchical-locations-view__item "
+          className="list-group-item list-group-item-action hierarchical-locations-view__item"
           onClick={[Function]}
           type="button"
         >
@@ -223,7 +223,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
             </span>
           </span>
           <span
-            className="badge badge-secondary badge-pill hierarchical-locations-view__item-badge"
+            className="hierarchical-locations-view__item-badge badge badge-secondary badge-pill "
           >
             3
           </span>
@@ -251,7 +251,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
               className="result-container__header"
             >
               <svg
-                className="mdi-icon icon-inline"
+                className="mdi-icon icon-inline flex-shrink-0"
                 fill="currentColor"
                 height={24}
                 viewBox="0 0 24 24"
@@ -429,7 +429,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
               className="result-container__header"
             >
               <svg
-                className="mdi-icon icon-inline"
+                className="mdi-icon icon-inline flex-shrink-0"
                 fill="currentColor"
                 height={24}
                 viewBox="0 0 24 24"

--- a/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
+++ b/client/branded/src/components/panel/views/__snapshots__/HierarchicalLocationsView.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<HierarchicalLocationsView /> displays a single location when complete 
                   </a>
                 </div>
                 <span
-                  className="ml-2"
+                  className="result-container__header-description ml-2"
                 />
               </div>
               <button
@@ -285,7 +285,7 @@ exports[`<HierarchicalLocationsView /> displays multiple locations grouped by fi
                   </a>
                 </div>
                 <span
-                  className="ml-2"
+                  className="result-container__header-description ml-2"
                 />
               </div>
               <button
@@ -463,7 +463,7 @@ exports[`<HierarchicalLocationsView /> displays partial locations before complet
                   </a>
                 </div>
                 <span
-                  className="ml-2"
+                  className="result-container__header-description ml-2"
                 />
               </div>
               <button

--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -39,7 +39,7 @@
         letter-spacing: normal;
         font-size: 0.75rem;
         margin: 0 0.375rem;
-        padding: 0;
+        padding: 0 2px;
         color: var(--body-color);
         text-transform: none;
         display: inline-flex;
@@ -84,7 +84,7 @@
 
     .tablist-wrapper {
         min-height: 2rem;
-        border-bottom: 1px solid var(--border-color);
+        border-bottom: 1px solid var(--border-color-2);
         padding-bottom: 0;
         display: flex;
         align-items: stretch;

--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -39,7 +39,7 @@
         letter-spacing: normal;
         font-size: 0.75rem;
         margin: 0 0.375rem;
-        padding: 0 2px;
+        padding: 0 0.125rem;
         color: var(--body-color);
         text-transform: none;
         display: inline-flex;

--- a/client/shared/src/components/FileMatch.tsx
+++ b/client/shared/src/components/FileMatch.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import React, { useEffect, useState } from 'react'
 import { Observable } from 'rxjs'
@@ -133,7 +134,10 @@ export const FileMatch: React.FunctionComponent<Props> = props => {
                         target="_blank"
                         rel="noopener noreferrer"
                         data-tooltip={badge.hoverMessage}
-                        className="badge badge-secondary text-muted text-uppercase file-match__badge"
+                        className={classNames(
+                            'badge badge-secondary text-muted text-uppercase file-match__badge',
+                            isRedesignEnabled && 'badge-sm'
+                        )}
                     >
                         {badge.text}
                     </LinkOrSpan>

--- a/client/shared/src/components/FileMatchChildren.scss
+++ b/client/shared/src/components/FileMatchChildren.scss
@@ -1,7 +1,7 @@
 .file-match-children {
     .theme-redesign & {
         background-color: var(--code-bg);
-        border: 1px solid var(--border-color-2);
+        border: 1px solid var(--border-color);
         border-radius: var(--border-radius);
         padding: 0.25rem 0;
     }
@@ -30,6 +30,10 @@
             overflow-x: auto;
             &:not(:first-child) {
                 border-top: 1px solid var(--border-color);
+
+                .theme-redesign & {
+                    border-color: var(--border-color-2);
+                }
             }
         }
     }

--- a/client/shared/src/components/ResultContainer.scss
+++ b/client/shared/src/components/ResultContainer.scss
@@ -10,7 +10,7 @@
         margin-right: 1rem;
 
         &:not(:last-of-type) {
-            margin-bottom: 0.25rem;
+            margin-bottom: 0.5rem;
         }
     }
 

--- a/client/shared/src/components/ResultContainer.scss
+++ b/client/shared/src/components/ResultContainer.scss
@@ -51,6 +51,10 @@
             background-color: transparent;
             padding: 0.5rem 0;
 
+            &-description {
+                line-height: (14/11);
+            }
+
             &:not(:only-of-type) {
                 border-bottom: none;
             }

--- a/client/shared/src/components/ResultContainer.tsx
+++ b/client/shared/src/components/ResultContainer.tsx
@@ -1,4 +1,5 @@
 /* eslint jsx-a11y/click-events-have-key-events: warn, jsx-a11y/no-static-element-interactions: warn */
+import classNames from 'classnames'
 import ArrowCollapseUpIcon from 'mdi-react/ArrowCollapseUpIcon'
 import ArrowExpandDownIcon from 'mdi-react/ArrowExpandDownIcon'
 import ChevronDownIcon from 'mdi-react/ChevronDownIcon'
@@ -110,11 +111,11 @@ export const ResultContainer: React.FunctionComponent<Props> = ({
                 <Icon className="icon-inline flex-shrink-0" />
                 <div className="result-container__header-divider" />
                 <div
-                    className={`result-container__header-title ${titleClassName || ''}`}
+                    className={classNames('result-container__header-title', titleClassName)}
                     data-testid="result-container-header"
                 >
                     {title}
-                    {description && <span className="ml-2">{description}</span>}
+                    {description && <span className="result-container__header-description ml-2">{description}</span>}
                 </div>
                 {matchCountLabel && isRedesignEnabled && (
                     <>

--- a/client/shared/src/components/ResultContainer.tsx
+++ b/client/shared/src/components/ResultContainer.tsx
@@ -107,7 +107,7 @@ export const ResultContainer: React.FunctionComponent<Props> = ({
     return (
         <div className="test-search-result result-container" data-testid="result-container">
             <div className="result-container__header">
-                <Icon className="icon-inline" />
+                <Icon className="icon-inline flex-shrink-0" />
                 <div className="result-container__header-divider" />
                 <div
                     className={`result-container__header-title ${titleClassName || ''}`}


### PR DESCRIPTION
## Description

The redesign of the Code Intel bottom panel header and references section: https://github.com/sourcegraph/sourcegraph/issues/21045.
[Figma mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=3008%3A501).

## Changes

- Added redesign styles to the panel header.
- Added redesign styles to the references panel.
- Extracted the `HierarchicalLocationsViewButton` component.
- Added minor tweaks to the tabs components to match redesign styles.
- Fixed file match icon size.
- Fixed margin between file matches to be 16px.
- Added basic styles to the resizable handler.

[The resizable handle](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw?node-id=3008:501#84194351), empty and loading states will be updated in a separate PR.

## Screenshots

Before: 

<img width="940" alt="Screenshot 2021-05-31 at 18 41 50" src="https://user-images.githubusercontent.com/3846380/120218009-b93cf080-c26b-11eb-883a-8234c0b4e9b0.png">

After:

<img width="903" alt="Screenshot 2021-06-01 at 11 24 25" src="https://user-images.githubusercontent.com/3846380/120291424-dfa76e00-c2f5-11eb-8317-356b60d1ae60.png">
