### PR TITLE
frontend: add hierarchical repo rank scoring option.

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -161,17 +161,18 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 
 func repoRankFromConfig(siteConfig schema.SiteConfiguration, repoName string) float64 {
 	val := 0.0
-	if len(siteConfig.RepoRankScores) > 0 {
-		// try every "directory" in the repo name to assign it a value, so a repoName like
-		// "github.com/sourcegraph/zoekt" will have "github.com", "github.com/sourcegraph",
-		// and "github.com/sourcegraph/zoekt" tested.
-		for i := 0; i < len(repoName); i++ {
-			if repoName[i] == '/' {
-				val += siteConfig.RepoRankScores[repoName[:i]]
-			}
-		}
-		val += siteConfig.RepoRankScores[repoName]
+	if len(siteConfig.RepoRankScores) == 0 {
+		return val
 	}
+	// try every "directory" in the repo name to assign it a value, so a repoName like
+	// "github.com/sourcegraph/zoekt" will have "github.com", "github.com/sourcegraph",
+	// and "github.com/sourcegraph/zoekt" tested.
+	for i := 0; i < len(repoName); i++ {
+		if repoName[i] == '/' {
+			val += siteConfig.RepoRankScores[repoName[:i]]
+		}
+	}
+	val += siteConfig.RepoRankScores[repoName]
 	return val
 }
 

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -161,7 +161,11 @@ func serveConfiguration(w http.ResponseWriter, r *http.Request) error {
 
 func repoRankFromConfig(siteConfig schema.SiteConfiguration, repoName string) float64 {
 	val := 0.0
-	if len(siteConfig.RepoRankScores) == 0 {
+	if siteConfig.ExperimentalFeatures == nil || siteConfig.ExperimentalFeatures.Ranking == nil {
+		return val
+	}
+	scores := siteConfig.ExperimentalFeatures.Ranking.RepoScores
+	if len(scores) == 0 {
 		return val
 	}
 	// try every "directory" in the repo name to assign it a value, so a repoName like
@@ -169,10 +173,10 @@ func repoRankFromConfig(siteConfig schema.SiteConfiguration, repoName string) fl
 	// and "github.com/sourcegraph/zoekt" tested.
 	for i := 0; i < len(repoName); i++ {
 		if repoName[i] == '/' {
-			val += siteConfig.RepoRankScores[repoName[:i]]
+			val += scores[repoName[:i]]
 		}
 	}
-	val += siteConfig.RepoRankScores[repoName]
+	val += scores[repoName]
 	return val
 }
 

--- a/cmd/frontend/internal/httpapi/internal_test.go
+++ b/cmd/frontend/internal/httpapi/internal_test.go
@@ -214,7 +214,12 @@ func TestRepoRankFromConfig(t *testing.T) {
 		{"gh.test/sg/ex", map[string]float64{"gh.test": 100, "gh.test/sg": 50, "gh.test/sg/sg": -20}, 150},
 	}
 	for _, tc := range cases {
-		got := repoRankFromConfig(schema.SiteConfiguration{RepoRankScores: tc.rankScores}, tc.name)
+		config := schema.SiteConfiguration{ExperimentalFeatures: &schema.ExperimentalFeatures{
+			Ranking: &schema.Ranking{
+				RepoScores: tc.rankScores,
+			},
+		}}
+		got := repoRankFromConfig(config, tc.name)
 		if got != tc.want {
 			t.Errorf("got score %v, want %v, repo %q config %v", got, tc.want, tc.name, tc.rankScores)
 		}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -1484,6 +1484,8 @@ type SiteConfiguration struct {
 	RepoConcurrentExternalServiceSyncers int `json:"repoConcurrentExternalServiceSyncers,omitempty"`
 	// RepoListUpdateInterval description: Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.
 	RepoListUpdateInterval int `json:"repoListUpdateInterval,omitempty"`
+	// RepoRankScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.
+	RepoRankScores map[string]float64 `json:"repoRankScores,omitempty"`
 	// SearchIndexEnabled description: Whether indexed search is enabled. If unset Sourcegraph detects the environment to decide if indexed search is enabled. Indexed search is RAM heavy, and is disabled by default in the single docker image. All other environments will have it enabled by default. The size of all your repository working copies is the amount of additional RAM required.
 	SearchIndexEnabled *bool `json:"search.index.enabled,omitempty"`
 	// SearchIndexSymbolsEnabled description: Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -535,6 +535,8 @@ type ExperimentalFeatures struct {
 	EventLogging string `json:"eventLogging,omitempty"`
 	// Perforce description: Allow adding Perforce code host connections
 	Perforce string `json:"perforce,omitempty"`
+	// Ranking description: Experimental search result ranking options.
+	Ranking *Ranking `json:"ranking,omitempty"`
 	// RateLimitAnonymous description: Configures the hourly rate limits for anonymous calls to the GraphQL API. Setting limit to 0 disables the limiter. This is only relevant if unauthenticated calls to the API are permitted.
 	RateLimitAnonymous int `json:"rateLimitAnonymous,omitempty"`
 	// SearchIndexBranches description: A map from repository name to a list of extra revs (branch, ref, tag, commit sha, etc) to index for a repository. We always index the default branch ("HEAD") and revisions in version contexts. This allows specifying additional revisions. Sourcegraph can index up to 64 branches per repository.
@@ -1136,6 +1138,12 @@ type QuickLink struct {
 	// Url description: The URL of this quick link (absolute or relative)
 	Url string `json:"url"`
 }
+
+// Ranking description: Experimental search result ranking options.
+type Ranking struct {
+	// RepoScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.
+	RepoScores map[string]float64 `json:"repoScores,omitempty"`
+}
 type Repos struct {
 	// Callsign description: The unique Phabricator identifier for the repository, like 'MUX'.
 	Callsign string `json:"callsign"`
@@ -1484,8 +1492,6 @@ type SiteConfiguration struct {
 	RepoConcurrentExternalServiceSyncers int `json:"repoConcurrentExternalServiceSyncers,omitempty"`
 	// RepoListUpdateInterval description: Interval (in minutes) for checking code hosts (such as GitHub, Gitolite, etc.) for new repositories.
 	RepoListUpdateInterval int `json:"repoListUpdateInterval,omitempty"`
-	// RepoRankScores description: a map of URI directories to numeric scores for specifying search result importance, like {"github.com": 500, "github.com/sourcegraph": 300, "github.com/sourcegraph/sourcegraph": 100}. Would rank "github.com/sourcegraph/sourcegraph" as 500+300+100=900, and "github.com/other/foo" as 500.
-	RepoRankScores map[string]float64 `json:"repoRankScores,omitempty"`
 	// SearchIndexEnabled description: Whether indexed search is enabled. If unset Sourcegraph detects the environment to decide if indexed search is enabled. Indexed search is RAM heavy, and is disabled by default in the single docker image. All other environments will have it enabled by default. The size of all your repository working copies is the amount of additional RAM required.
 	SearchIndexEnabled *bool `json:"search.index.enabled,omitempty"`
 	// SearchIndexSymbolsEnabled description: Whether indexed symbol search is enabled. This is contingent on the indexed search configuration, and is true by default for instances with indexed search enabled. Enabling this will cause every repository to re-index, which is a time consuming (several hours) operation. Additionally, it requires more storage and ram to accommodate the added symbols information in the search index.

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -456,6 +456,15 @@
       "default": 1,
       "group": "External services"
     },
+    "repoRankScores": {
+      "description": "a map of URI directories to numeric scores for specifying search result importance, like {\"github.com\": 500, \"github.com/sourcegraph\": 300, \"github.com/sourcegraph/sourcegraph\": 100}. Would rank \"github.com/sourcegraph/sourcegraph\" as 500+300+100=900, and \"github.com/other/foo\" as 500.",
+      "type": "object",
+      "default": {},
+      "group": "Search",
+      "additionalProperties": {
+        "type": "number"
+      }
+    },
     "repoConcurrentExternalServiceSyncers": {
       "description": "The number of concurrent external service syncers that can run.",
       "type": "integer",

--- a/schema/site.schema.json
+++ b/schema/site.schema.json
@@ -246,6 +246,21 @@
           "type": "boolean",
           "default": false,
           "!go": { "pointer": false }
+        },
+        "ranking": {
+          "description": "Experimental search result ranking options.",
+          "type": "object",
+          "properties": {
+            "repoScores": {
+              "description": "a map of URI directories to numeric scores for specifying search result importance, like {\"github.com\": 500, \"github.com/sourcegraph\": 300, \"github.com/sourcegraph/sourcegraph\": 100}. Would rank \"github.com/sourcegraph/sourcegraph\" as 500+300+100=900, and \"github.com/other/foo\" as 500.",
+              "type": "object",
+              "default": {},
+              "group": "Search",
+              "additionalProperties": {
+                "type": "number"
+              }
+            }
+          }
         }
       },
       "examples": [
@@ -455,15 +470,6 @@
       "type": "integer",
       "default": 1,
       "group": "External services"
-    },
-    "repoRankScores": {
-      "description": "a map of URI directories to numeric scores for specifying search result importance, like {\"github.com\": 500, \"github.com/sourcegraph\": 300, \"github.com/sourcegraph/sourcegraph\": 100}. Would rank \"github.com/sourcegraph/sourcegraph\" as 500+300+100=900, and \"github.com/other/foo\" as 500.",
-      "type": "object",
-      "default": {},
-      "group": "Search",
-      "additionalProperties": {
-        "type": "number"
-      }
     },
     "repoConcurrentExternalServiceSyncers": {
       "description": "The number of concurrent external service syncers that can run.",


### PR DESCRIPTION
This allows site admins to manually specify which repositories should
have high priority in rankings, by directly modifying the scores given
to different subpaths. Entire services can be prioritized
("github.com"), specific users or orgs ("github.com/sourcegraph"), or
specific repos ("github.com/sourcegraph/sourcegraph").

Config looks like:

![image](https://user-images.githubusercontent.com/211868/120703252-4b164a80-c472-11eb-8e2e-e23902cf823f.png)
