### PR TITLE
Adjust meter colors based on Felix's feedback

### DIFF
--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -1,11 +1,8 @@
 meter {
-    --meter-background: var(--border-color-2);
+    --meter-background: var(--gray-04);
 
     .theme-dark.theme-redesign & {
         --meter-background: var(--gray-07);
-    }
-    .theme-light.theme-redesign & {
-        --meter-background: var(--gray-05);
     }
 
     /* Reset the default appearence */

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -1,11 +1,11 @@
 meter {
     --meter-background: var(--border-color-2);
 
-    .theme-light.theme-redesign & {
-        --meter-background: var(--gray-04);
-    }
     .theme-dark.theme-redesign & {
         --meter-background: var(--gray-07);
+    }
+    .theme-light.theme-redesign & {
+        --meter-background: var(--gray-04);
     }
 
     /* Reset the default appearence */

--- a/client/branded/src/global-styles/meter.scss
+++ b/client/branded/src/global-styles/meter.scss
@@ -1,6 +1,9 @@
 meter {
-    --meter-background: var(--gray-04);
+    --meter-background: var(--border-color-2);
 
+    .theme-light.theme-redesign & {
+        --meter-background: var(--gray-04);
+    }
     .theme-dark.theme-redesign & {
         --meter-background: var(--gray-07);
     }

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -37,9 +37,9 @@
             color: $white;
         }
 
-        .theme-redesign.theme-light &--active,
-        .theme-redesign.theme-light &--selected,
-        .theme-redesign.theme-light &:hover {
+        .theme-light.theme-redesign &--active,
+        .theme-light.theme-redesign &--selected,
+        .theme-light.theme-redesign &:hover {
             meter {
                 --meter-background: var(--gray-05);
             }

--- a/client/web/src/tree/Tree.scss
+++ b/client/web/src/tree/Tree.scss
@@ -36,6 +36,14 @@
             background-color: var(--primary);
             color: $white;
         }
+
+        .theme-redesign.theme-light &--active,
+        .theme-redesign.theme-light &--selected,
+        .theme-redesign.theme-light &:hover {
+            meter {
+                --meter-background: var(--gray-05);
+            }
+        }
     }
 
     &__row-alert {


### PR DESCRIPTION
- Fixes #21558
- Changes the meter colors as follows —

    **Light theme:**
    - `gray-04` by default (same as before the refresh)
    - `gray-05` for selected, active, hover states

    <img width="312" alt="CleanShot 2021-06-01 at 09 58 26@2x" src="https://user-images.githubusercontent.com/17293/120287855-ee732e00-c2bf-11eb-9f4d-c666b47d4f40.png">

    **Dark theme:**
    - `gray-07` by default; unchanged in selected, active, hover states

    <img width="308" alt="CleanShot 2021-06-01 at 09 58 09@2x" src="https://user-images.githubusercontent.com/17293/120287865-f03cf180-c2bf-11eb-9b2a-06d26dccf75e.png">
