### PR TITLE
search contexts: show CTA prompt only if user has not added any repositories

### DIFF
--- a/client/web/src/search/input/SearchContextDropdown.tsx
+++ b/client/web/src/search/input/SearchContextDropdown.tsx
@@ -233,7 +233,7 @@ export const SearchContextDropdown: React.FunctionComponent<SearchContextDropdow
                 </code>
             </DropdownToggle>
             <DropdownMenu positionFixed={true} className="search-context-dropdown__menu">
-                {isSourcegraphDotCom && (!hasUserAddedExternalServices || !hasUserAddedRepositories) ? (
+                {isSourcegraphDotCom && !hasUserAddedRepositories ? (
                     <SearchContextCtaPrompt
                         telemetryService={props.telemetryService}
                         authenticatedUser={authenticatedUser}


### PR DESCRIPTION
Fixes #21582

Currently, if user adds public repositories by URL without creating a code host, we still show the `Connect with code host` in the CTA prompt. Instead, we should not show the CTA prompt if user has added any repositories (by public URL or through code host connections) and display the dropdown list.