### PR TITLE
Refresh: Add badge outline support

### DIFF
--- a/client/branded/src/global-styles/GlobalStylesStory/BadgeVariants/BadgeVariants.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/BadgeVariants/BadgeVariants.tsx
@@ -9,10 +9,11 @@ import styles from './BadgeVariants.module.scss'
 
 interface BadgeProps {
     variant?: string
+    small?: boolean
 }
 
-const Badge: React.FunctionComponent<BadgeProps> = ({ variant }) => {
-    const className = classNames('badge', variant && `badge-${variant}`)
+const Badge: React.FunctionComponent<BadgeProps> = ({ variant, small }) => {
+    const className = classNames('badge', small && 'badge-sm', variant && `badge-${variant}`)
     return (
         <>
             <span className={className}>{startCase(variant || 'Default')}</span>
@@ -25,14 +26,15 @@ const Badge: React.FunctionComponent<BadgeProps> = ({ variant }) => {
 }
 
 interface BadgeVariantProps {
-    variants: readonly typeof SEMANTIC_COLORS[number][]
+    variants?: readonly (typeof SEMANTIC_COLORS[number] | 'outline-secondary')[]
+    small?: boolean
 }
 
-export const BadgeVariants: React.FunctionComponent<BadgeVariantProps> = ({ variants }) => (
+export const BadgeVariants: React.FunctionComponent<BadgeVariantProps> = ({ variants, small }) => (
     <div className={styles.grid}>
-        <Badge />
-        {variants.map(variant => (
-            <Badge key={variant} variant={variant} />
+        <Badge small={small} />
+        {variants?.map(variant => (
+            <Badge key={variant} small={small} variant={variant} />
         ))}
     </div>
 )

--- a/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -375,7 +375,10 @@ add(
             </table>
 
             <h2>Reference</h2>
-            <BadgeVariants variants={SEMANTIC_COLORS} />
+            <BadgeVariants variants={[...SEMANTIC_COLORS, 'outline-secondary']} />
+            <h3>Size</h3>
+            <p>We can also make our badges smaller.</p>
+            <BadgeVariants small={true} variants={['primary', 'secondary']} />
             <h2>Pill badges</h2>
             <p>Pill badges are commonly used to display counts.</p>
             <div className="mb-4">

--- a/client/branded/src/global-styles/badge.scss
+++ b/client/branded/src/global-styles/badge.scss
@@ -15,7 +15,7 @@
     --badge-font-weight: 600;
     --badge-padding-y: 0.34em;
     --badge-padding-x: 0.6em;
-    --badge-border-radius: 2px;
+    --badge-border-radius: 3px;
 }
 
 .theme-redesign {
@@ -40,6 +40,7 @@
         --badge-font-size: #{(11/16)}rem;
         --badge-padding-y: 0;
         --badge-padding-x: 0.25rem;
+        --badge-border-radius: 2px;
     }
 
     a.badge {
@@ -54,9 +55,11 @@
     .badge-danger,
     .badge-info,
     .badge-warning,
-    .badge-merged {
+    .badge-merged,
+    .badge-outline-secondary {
         background-color: var(--badge-base);
         color: var(--badge-text);
+        border: var(--badge-border, none);
 
         @at-root #{selector-unify('a', &)} {
             background-color: var(--badge-base);
@@ -131,21 +134,38 @@
         --badge-dark: var(--merged-3);
         --badge-text: var(--light-text);
     }
+
+    .badge-outline-secondary {
+        --badge-base: transparent;
+        --badge-light: var(--secondary-2);
+        --badge-dark: var(--secondary-3);
+        --badge-text: var(--text-muted);
+        --badge-border: 1px solid var(--secondary);
+    }
 }
 
 .theme-light.theme-redesign,
 .theme-dark.theme-redesign {
     // Update secondary text color and focus state for better contrast
+    a.badge-secondary,
+    a.badge-outline-secondary {
+        &:focus,
+        &.focus {
+            box-shadow: var(--focus-box-shadow);
+        }
+    }
     a.badge-secondary {
         &:hover,
         &:focus,
         &.focus {
             color: var(--body-color);
         }
-
+    }
+    a.badge-outline-secondary {
+        &:hover,
         &:focus,
         &.focus {
-            box-shadow: var(--focus-box-shadow);
+            background-color: var(--color-bg-1);
         }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/sourcegraph/sourcegraph/issues/21442

This PR:
- Adds support for outline badges through `badge-outline-secondary`
- Fixes the button radius on large badges, maintains 2px for smaller badges as per designs
- Updates storybook documentation to support small and outline badges