### PR TITLE
Try to get Chromatic components to react to theme changes

### DIFF
--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -44,8 +44,8 @@ export const BrandedStory: React.FunctionComponent<
         const listener = ((event: CustomEvent<boolean>): void => {
             setIsLightTheme(event.detail)
         }) as EventListener
-        window.addEventListener('theme-changed', listener)
-        return () => window.removeEventListener('theme-changed', listener)
+        document.body.addEventListener('chromatic-light-theme-toggled', listener)
+        return () => document.body.removeEventListener('chromatic-light-theme-toggled', listener)
     }, [])
 
     return (

--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -46,7 +46,7 @@ export const BrandedStory: React.FunctionComponent<
         }) as EventListener
         window.addEventListener('theme-changed', listener)
         return () => window.removeEventListener('theme-changed', listener)
-    })
+    }, [])
 
     return (
         <MemoryRouter {...memoryRouterProps}>

--- a/client/branded/src/components/BrandedStory.tsx
+++ b/client/branded/src/components/BrandedStory.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react'
+import React, { useLayoutEffect, useState } from 'react'
 import { MemoryRouter, MemoryRouterProps } from 'react-router'
 import { useDarkMode } from 'storybook-dark-mode'
 
@@ -30,7 +30,7 @@ export const BrandedStory: React.FunctionComponent<
         styles?: string
     }
 > = ({ children: Children, styles = brandedStyles, ...memoryRouterProps }) => {
-    const isLightTheme = !useDarkMode()
+    const [isLightTheme, setIsLightTheme] = useState(!useDarkMode())
 
     useLayoutEffect(() => {
         const styleTag = prependCSSToDocumentHead(styles)
@@ -39,6 +39,14 @@ export const BrandedStory: React.FunctionComponent<
             styleTag.remove()
         }
     }, [styles])
+
+    useLayoutEffect(() => {
+        const listener = ((event: CustomEvent<boolean>): void => {
+            setIsLightTheme(event.detail)
+        }) as EventListener
+        window.addEventListener('theme-changed', listener)
+        return () => window.removeEventListener('theme-changed', listener)
+    })
 
     return (
         <MemoryRouter {...memoryRouterProps}>

--- a/client/storybook/src/RedesignToggleDecorator.tsx
+++ b/client/storybook/src/RedesignToggleDecorator.tsx
@@ -1,6 +1,6 @@
 import { DecoratorFunction } from '@storybook/addons'
 import isChromatic from 'chromatic/isChromatic'
-import React, { ReactElement, useEffect } from 'react'
+import { ReactElement, useEffect } from 'react'
 
 import { useRedesignToggle, REDESIGN_CLASS_NAME } from '@sourcegraph/shared/src/util/useRedesignToggle'
 

--- a/client/storybook/src/RedesignToggleDecorator.tsx
+++ b/client/storybook/src/RedesignToggleDecorator.tsx
@@ -44,5 +44,7 @@ export const RedesignToggleDecorator: DecoratorFunction<ReactElement> = (Story, 
         updateManager(isRedesignEnabled)
     }, [isRedesignEnabled])
 
-    return <Story {...context} />
+    // Required instead of the <Story {...context} /> until the issue below is resolved
+    // https://github.com/storybookjs/storybook/issues/12255#issuecomment-697956943
+    return Story(context)
 }

--- a/client/storybook/src/chromatic-story/create-chromatic-story.tsx
+++ b/client/storybook/src/chromatic-story/create-chromatic-story.tsx
@@ -28,8 +28,7 @@ export const createChromaticStory = (options: CreateChromaticStoryOptions): Stor
         // 'storybook-dark-mode' doesn't expose any API to toggle dark/light theme programmatically, so we do it manually.
         document.body.classList.toggle(THEME_DARK_CLASS, isDarkModeEnabled)
         document.body.classList.toggle(THEME_LIGHT_CLASS, !isDarkModeEnabled)
-        const channel = addons.getChannel()
-        channel.emit(DARK_MODE_EVENT_NAME, isDarkModeEnabled)
+        window.dispatchEvent(new CustomEvent('theme-changed', { detail: !isDarkModeEnabled }))
 
         return () => {
             // Do not enable redesign theme if it was disabled before this story was opened.
@@ -40,7 +39,7 @@ export const createChromaticStory = (options: CreateChromaticStoryOptions): Stor
             // Always toggle dark mode back to the previous value because otherwise, it might be out of sync with the toolbar toggle.
             document.body.classList.toggle(THEME_DARK_CLASS, isDarkModeEnabledInitially)
             document.body.classList.toggle(THEME_LIGHT_CLASS, !isDarkModeEnabledInitially)
-            channel.emit(DARK_MODE_EVENT_NAME, !isDarkModeEnabled)
+            window.dispatchEvent(new CustomEvent('theme-changed', { detail: isDarkModeEnabled }))
         }
         // We need to execute `useEffect` callback once to take snapshot in Chromatic, so we can omit dependencies here.
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/storybook/src/chromatic-story/create-chromatic-story.tsx
+++ b/client/storybook/src/chromatic-story/create-chromatic-story.tsx
@@ -39,7 +39,7 @@ export const createChromaticStory = (options: CreateChromaticStoryOptions): Stor
             // Always toggle dark mode back to the previous value because otherwise, it might be out of sync with the toolbar toggle.
             document.body.classList.toggle(THEME_DARK_CLASS, isDarkModeEnabledInitially)
             document.body.classList.toggle(THEME_LIGHT_CLASS, !isDarkModeEnabledInitially)
-            window.dispatchEvent(new CustomEvent('theme-changed', { detail: isDarkModeEnabled }))
+            window.dispatchEvent(new CustomEvent('theme-changed', { detail: !isDarkModeEnabledInitially }))
         }
         // We need to execute `useEffect` callback once to take snapshot in Chromatic, so we can omit dependencies here.
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/storybook/src/chromatic-story/create-chromatic-story.tsx
+++ b/client/storybook/src/chromatic-story/create-chromatic-story.tsx
@@ -1,6 +1,6 @@
-import addons, { StoryFn } from '@storybook/addons'
+import { StoryFn } from '@storybook/addons'
 import React, { ReactElement, useEffect } from 'react'
-import { DARK_MODE_EVENT_NAME, useDarkMode } from 'storybook-dark-mode'
+import { useDarkMode } from 'storybook-dark-mode'
 
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 

--- a/client/storybook/src/chromatic-story/create-chromatic-story.tsx
+++ b/client/storybook/src/chromatic-story/create-chromatic-story.tsx
@@ -1,6 +1,6 @@
-import { StoryFn } from '@storybook/addons'
+import addons, { StoryFn } from '@storybook/addons'
 import React, { ReactElement, useEffect } from 'react'
-import { useDarkMode } from 'storybook-dark-mode'
+import { DARK_MODE_EVENT_NAME, useDarkMode } from 'storybook-dark-mode'
 
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
@@ -28,6 +28,8 @@ export const createChromaticStory = (options: CreateChromaticStoryOptions): Stor
         // 'storybook-dark-mode' doesn't expose any API to toggle dark/light theme programmatically, so we do it manually.
         document.body.classList.toggle(THEME_DARK_CLASS, isDarkModeEnabled)
         document.body.classList.toggle(THEME_LIGHT_CLASS, !isDarkModeEnabled)
+        const channel = addons.getChannel()
+        channel.emit(DARK_MODE_EVENT_NAME, isDarkModeEnabled)
 
         return () => {
             // Do not enable redesign theme if it was disabled before this story was opened.
@@ -38,6 +40,7 @@ export const createChromaticStory = (options: CreateChromaticStoryOptions): Stor
             // Always toggle dark mode back to the previous value because otherwise, it might be out of sync with the toolbar toggle.
             document.body.classList.toggle(THEME_DARK_CLASS, isDarkModeEnabledInitially)
             document.body.classList.toggle(THEME_LIGHT_CLASS, !isDarkModeEnabledInitially)
+            channel.emit(DARK_MODE_EVENT_NAME, !isDarkModeEnabled)
         }
         // We need to execute `useEffect` callback once to take snapshot in Chromatic, so we can omit dependencies here.
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/storybook/src/chromatic-story/create-chromatic-story.tsx
+++ b/client/storybook/src/chromatic-story/create-chromatic-story.tsx
@@ -28,7 +28,7 @@ export const createChromaticStory = (options: CreateChromaticStoryOptions): Stor
         // 'storybook-dark-mode' doesn't expose any API to toggle dark/light theme programmatically, so we do it manually.
         document.body.classList.toggle(THEME_DARK_CLASS, isDarkModeEnabled)
         document.body.classList.toggle(THEME_LIGHT_CLASS, !isDarkModeEnabled)
-        window.dispatchEvent(new CustomEvent('theme-changed', { detail: !isDarkModeEnabled }))
+        document.body.dispatchEvent(new CustomEvent('chromatic-light-theme-toggled', { detail: !isDarkModeEnabled }))
 
         return () => {
             // Do not enable redesign theme if it was disabled before this story was opened.
@@ -39,7 +39,9 @@ export const createChromaticStory = (options: CreateChromaticStoryOptions): Stor
             // Always toggle dark mode back to the previous value because otherwise, it might be out of sync with the toolbar toggle.
             document.body.classList.toggle(THEME_DARK_CLASS, isDarkModeEnabledInitially)
             document.body.classList.toggle(THEME_LIGHT_CLASS, !isDarkModeEnabledInitially)
-            window.dispatchEvent(new CustomEvent('theme-changed', { detail: !isDarkModeEnabledInitially }))
+            document.body.dispatchEvent(
+                new CustomEvent('chromatic-light-theme-toggled', { detail: !isDarkModeEnabledInitially })
+            )
         }
         // We need to execute `useEffect` callback once to take snapshot in Chromatic, so we can omit dependencies here.
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -44,7 +44,7 @@ export const WebStory: React.FunctionComponent<
         }) as EventListener
         window.addEventListener('theme-changed', listener)
         return () => window.removeEventListener('theme-changed', listener)
-    })
+    }, [])
 
     return (
         <MemoryRouter {...memoryRouterProps}>

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -42,8 +42,8 @@ export const WebStory: React.FunctionComponent<
         const listener = ((event: CustomEvent<boolean>): void => {
             setIsLightTheme(event.detail)
         }) as EventListener
-        window.addEventListener('theme-changed', listener)
-        return () => window.removeEventListener('theme-changed', listener)
+        document.body.addEventListener('chromatic-light-theme-toggled', listener)
+        return () => document.body.removeEventListener('chromatic-light-theme-toggled', listener)
     }, [])
 
     return (

--- a/client/web/src/components/WebStory.tsx
+++ b/client/web/src/components/WebStory.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useMemo } from 'react'
+import React, { useLayoutEffect, useMemo, useState } from 'react'
 import { MemoryRouter, MemoryRouterProps, RouteComponentProps, withRouter } from 'react-router'
 import { useDarkMode } from 'storybook-dark-mode'
 
@@ -26,7 +26,7 @@ export const WebStory: React.FunctionComponent<
         webStyles?: string
     }
 > = ({ children, webStyles = _webStyles, ...memoryRouterProps }) => {
-    const isLightTheme = !useDarkMode()
+    const [isLightTheme, setIsLightTheme] = useState(!useDarkMode())
     const breadcrumbSetters = useBreadcrumbs()
     const Children = useMemo(() => withRouter(children), [children])
 
@@ -37,6 +37,14 @@ export const WebStory: React.FunctionComponent<
             styleTag.remove()
         }
     }, [webStyles])
+
+    useLayoutEffect(() => {
+        const listener = ((event: CustomEvent<boolean>): void => {
+            setIsLightTheme(event.detail)
+        }) as EventListener
+        window.addEventListener('theme-changed', listener)
+        return () => window.removeEventListener('theme-changed', listener)
+    })
 
     return (
         <MemoryRouter {...memoryRouterProps}>


### PR DESCRIPTION
@limitedmage, I've created a separate PR because your previous commits work great, and I didn't want to overwrite the history in your branch. Events didn't work properly because decorators and stories were mounted twice. This behavior is caused by [the bug](https://github.com/storybookjs/storybook/issues/12255), which should be addressed in the next Storybook release. 

Double mount didn't affect the Chromatic decorator, so the event was emitted only once for the first mount. On the second mount `isLightTheme` value was set based on the initial value and was never updated after that.

Moves https://github.com/sourcegraph/sourcegraph/pull/21000 forward via [this commit](https://github.com/sourcegraph/sourcegraph/commit/d548730dd0759f0b067e561f43817a18ee7e99a9).
Fixes #20687