### PR TITLE
search redesign: add border under search sidebar section header

### DIFF
--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.module.scss
@@ -1,4 +1,6 @@
 .sidebar-section {
+    isolation: isolate; // Prevent the z-index below from leaking out of this container
+
     &__collapse-button {
         display: flex;
         align-items: center;
@@ -7,6 +9,10 @@
         border: none;
         padding: 0.25rem;
         margin: 0 -0.25rem;
+
+        // Force the button's box-shadow to always show over the sibling element's border
+        position: relative;
+        z-index: 1;
     }
 
     &__list {

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebarSection.tsx
@@ -31,8 +31,10 @@ export const SearchSidebarSection: React.FunctionComponent<{
 
     const [collapsed, setCollapsed] = useState(false)
 
+    const searchVisible = showSearch && children.length > 1
+
     return children.length > 0 ? (
-        <div className={className}>
+        <div className={classNames(styles.sidebarSection, className)}>
             <button
                 type="button"
                 className={classNames('btn btn-outline-secondary', styles.sidebarSectionCollapseButton)}
@@ -48,8 +50,8 @@ export const SearchSidebarSection: React.FunctionComponent<{
             </button>
 
             <Collapse isOpen={!collapsed}>
-                <div className="pb-4">
-                    {showSearch && children.length > 1 && (
+                <div className={classNames('pb-4', !searchVisible && 'border-top')}>
+                    {searchVisible && (
                         <input
                             type="search"
                             placeholder="Find..."


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/206864/120390123-2f7c3a00-c2e2-11eb-8d33-f25955461d32.png)

![image](https://user-images.githubusercontent.com/206864/120390684-e1b40180-c2e2-11eb-98f2-0e3873a10683.png)

Apologies in advance for the use of `z-index` :( Seems to be the only way to fix the issue where the border can show over the button's box shadow.
