### PR TITLE
web redesign: fix spacing under search box

### DIFF
--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -69,6 +69,10 @@
             font-weight: 700;
         }
 
+        &:first-of-type {
+            margin-left: 0;
+        }
+
         &:focus-visible {
             outline: none;
             box-shadow: none;

--- a/client/web/src/components/Breadcrumbs.tsx
+++ b/client/web/src/components/Breadcrumbs.tsx
@@ -7,6 +7,7 @@ import { Unsubscribable } from 'sourcegraph'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { isDefined } from '@sourcegraph/shared/src/util/types'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import styles from './Breadcrumbs.module.scss'
 
@@ -153,38 +154,49 @@ export const useBreadcrumbs = (): BreadcrumbsProps & BreadcrumbSetters => {
 export const Breadcrumbs: React.FunctionComponent<{ breadcrumbs: BreadcrumbAtDepth[]; location: H.Location }> = ({
     breadcrumbs,
     location,
-}) => (
-    <nav className="d-flex p-2 container-fluid flex-nowrap flex-shrink-past-contents" aria-label="Breadcrumbs">
-        {sortBy(breadcrumbs, 'depth')
-            .map(({ breadcrumb }) => breadcrumb)
-            .filter(isDefined)
-            .map((breadcrumb, index, validBreadcrumbs) => {
-                const divider = breadcrumb.divider ?? (
-                    <ChevronRightIcon className={classNames('icon-inline', styles.divider)} />
-                )
-                // When the last breadcrumbs is a link and the hash is empty (to allow user to reset hash),
-                // render link breadcrumbs as plain text
-                return (
-                    <span
-                        key={breadcrumb.key}
-                        className={classNames(
-                            'text-muted d-flex align-items-center test-breadcrumb',
-                            breadcrumb.className
-                        )}
-                    >
-                        {index !== 0 && <span className="font-weight-medium">{divider}</span>}
-                        {isElementBreadcrumb(breadcrumb) ? (
-                            breadcrumb.element
-                        ) : index === validBreadcrumbs.length - 1 && !location.hash ? (
-                            breadcrumb.link.label
-                        ) : (
-                            <Link to={breadcrumb.link.to}>{breadcrumb.link.label}</Link>
-                        )}
-                    </span>
-                )
-            })}
-    </nav>
-)
+}) => {
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    return (
+        <nav
+            className={classNames(
+                'd-flex container-fluid flex-nowrap flex-shrink-past-contents',
+                !isRedesignEnabled && 'p-2',
+                isRedesignEnabled && 'pl-3 pr-2'
+            )}
+            aria-label="Breadcrumbs"
+        >
+            {sortBy(breadcrumbs, 'depth')
+                .map(({ breadcrumb }) => breadcrumb)
+                .filter(isDefined)
+                .map((breadcrumb, index, validBreadcrumbs) => {
+                    const divider = breadcrumb.divider ?? (
+                        <ChevronRightIcon className={classNames('icon-inline', styles.divider)} />
+                    )
+                    // When the last breadcrumbs is a link and the hash is empty (to allow user to reset hash),
+                    // render link breadcrumbs as plain text
+                    return (
+                        <span
+                            key={breadcrumb.key}
+                            className={classNames(
+                                'text-muted d-flex align-items-center test-breadcrumb',
+                                breadcrumb.className
+                            )}
+                        >
+                            {index !== 0 && <span className="font-weight-medium">{divider}</span>}
+                            {isElementBreadcrumb(breadcrumb) ? (
+                                breadcrumb.element
+                            ) : index === validBreadcrumbs.length - 1 && !location.hash ? (
+                                breadcrumb.link.label
+                            ) : (
+                                <Link to={breadcrumb.link.to}>{breadcrumb.link.label}</Link>
+                            )}
+                        </span>
+                    )
+                })}
+        </nav>
+    )
+}
 
 /**
  * To be used in unit tests, it minimally fulfills the BreadcrumbSetters interface.

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -105,13 +105,19 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
         height: 2rem;
 
         .theme-redesign & {
-            width: 2rem;
             margin-left: 0.25rem;
             border-radius: 0.1875rem;
         }
 
         &:hover {
             background-color: var(--link-hover-bg-color);
+        }
+
+        &--toggle {
+            .theme-redesign & {
+                height: auto;
+                padding: 0.25rem;
+            }
         }
 
         &--pressed {

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -32,6 +32,8 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
 
         .theme-redesign & {
             background-color: var(--body-bg);
+            padding-top: 0;
+            padding-bottom: 0;
         }
 
         &--open {

--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -79,6 +79,12 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
 
         border-radius: 2px;
         background-color: var(--border-color);
+
+        .theme-redesign & {
+            position: static;
+            transform: none;
+            align-self: center;
+        }
     }
 
     &__list {
@@ -105,6 +111,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
         height: 2rem;
 
         .theme-redesign & {
+            width: 2rem;
             margin-left: 0.25rem;
             border-radius: 0.1875rem;
         }

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -341,7 +341,11 @@ export const ActionItemsToggle: React.FunctionComponent<ActionItemsToggleProps> 
                     )}
                 >
                     <ButtonLink
-                        className={classNames(actionItemClassName, 'action-items__aux-icon')}
+                        className={classNames(
+                            actionItemClassName,
+                            'action-items__aux-icon',
+                            'action-items__action--toggle'
+                        )}
                         onSelect={toggle}
                         buttonLinkRef={toggleReference}
                     >

--- a/client/web/src/nav/GlobalNavbar.tsx
+++ b/client/web/src/nav/GlobalNavbar.tsx
@@ -356,7 +356,7 @@ export const GlobalNavbar: React.FunctionComponent<Props> = ({
                     </NavActions>
                 </NavBar>
                 {showSearchBox && (
-                    <div className="w-100 px-3 py-2">
+                    <div className="w-100 px-3 pt-2">
                         <div className="pb-2 border-bottom">{searchNavBar}</div>
                     </div>
                 )}

--- a/client/web/src/repo/RepoHeader.scss
+++ b/client/web/src/repo/RepoHeader.scss
@@ -12,6 +12,7 @@
     .theme-redesign & {
         border: none;
         align-items: center;
+        margin-top: 0.5rem;
         margin-bottom: 0.5rem;
     }
 

--- a/client/web/src/repo/RepoHeader.scss
+++ b/client/web/src/repo/RepoHeader.scss
@@ -11,6 +11,8 @@
 
     .theme-redesign & {
         border: none;
+        align-items: center;
+        margin-bottom: 0.5rem;
     }
 
     &--alert {
@@ -44,6 +46,11 @@
     &__action {
         margin: 0.5rem 0.625rem 0.5rem 0;
         padding: 0.25rem;
+
+        .theme-redesign & {
+            margin-top: 0;
+            margin-bottom: 0;
+        }
     }
 
     .navbar-nav {

--- a/client/web/src/repo/actions/CopyLinkAction.tsx
+++ b/client/web/src/repo/actions/CopyLinkAction.tsx
@@ -40,7 +40,7 @@ export const CopyLinkAction: React.FunctionComponent = () => {
     return (
         <button
             type="button"
-            className={classNames('btn btn-icon my-2', isRedesignEnabled && 'btn-sm')}
+            className={classNames('btn btn-icon', isRedesignEnabled && 'btn-sm p-2', !isRedesignEnabled && 'my-2')}
             data-tooltip={copied ? 'Copied!' : 'Copy link to clipboard'}
             aria-label="Copy link"
             onClick={onClick}

--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -5,7 +5,10 @@
     align-self: stretch;
     color: #93a9c8;
     padding: 0.25rem 0.5rem;
-    // TODO(tj): might need to remove this for action items toggle
+
+    .theme-redesign & {
+        padding-top: 0;
+    }
 
     .alert {
         margin-bottom: 0.5rem;

--- a/client/web/src/search/results/SearchResultsInfoBar.scss
+++ b/client/web/src/search/results/SearchResultsInfoBar.scss
@@ -8,6 +8,7 @@
 
     .theme-redesign & {
         padding-top: 0;
+        padding-left: 0;
     }
 
     .alert {
@@ -62,9 +63,5 @@
             flex-grow: 1;
             margin-right: 0; // Reset gap
         }
-    }
-
-    .theme-redesign & {
-        padding-left: 0;
     }
 }

--- a/client/web/src/search/results/streaming/StreamingSearchResults.module.scss
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.module.scss
@@ -10,6 +10,7 @@
         grid-template-columns: auto 1fr;
         grid-template-rows: auto 1fr;
         height: min-content;
+        padding-top: 0.5rem;
 
         @media (--md-breakpoint-down) {
             grid-template-columns: auto;

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.module.scss
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.module.scss
@@ -1,7 +1,7 @@
 @import 'wildcard/src/global-styles/breakpoints';
 
 .search-sidebar {
-    padding: 0.5rem 1rem;
+    padding: 0 1rem;
     width: 17.5rem;
     flex-shrink: 0;
 

--- a/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
+++ b/client/web/src/search/results/streaming/sidebar/SearchSidebar.tsx
@@ -47,7 +47,7 @@ export const SearchSidebar: React.FunctionComponent<SearchSidebarProps> = props 
 
     return (
         <div className={classNames(styles.searchSidebar, props.className)}>
-            <StickyBox offsetTop={8} offsetBottom={8} className={styles.searchSidebarStickyBox}>
+            <StickyBox className={styles.searchSidebarStickyBox}>
                 <SearchSidebarSection className={styles.searchSidebarItem} header="Search types">
                     {getSearchTypeLinks(props)}
                 </SearchSidebarSection>


### PR DESCRIPTION
- Fixes #21512, margin under search box is now uniform 0.5rem across search results and file pages
- Tweaked spacing in repo header component to match designs
- Reduced the height of the extension button toggle to fit it into the bar
- Remove spacing to the left of the first tab in a tab bar

![image](https://user-images.githubusercontent.com/206864/120508651-c0075880-c37c-11eb-8264-234e254bb854.png)

![image](https://user-images.githubusercontent.com/206864/120508120-4ff8d280-c37c-11eb-80c0-4bdb933d39cc.png)
