### PR TITLE
backend: log repo lengths in ListDefault tracing

### DIFF
--- a/cmd/frontend/backend/repos.go
+++ b/cmd/frontend/backend/repos.go
@@ -177,7 +177,7 @@ func (s *repos) ListIndexable(ctx context.Context) (repos []types.RepoName, err 
 // It lists all public default repos and also any private repos added by the
 // current user.
 func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err error) {
-	ctx, done := trace(ctx, "Repos", "ListDefaultPublic", nil, &err)
+	ctx, done := trace(ctx, "Repos", "ListDefault", nil, &err)
 	defer func() {
 		if err == nil {
 			span := opentracing.SpanFromContext(ctx)
@@ -187,26 +187,22 @@ func (s *repos) ListDefault(ctx context.Context) (repos []types.RepoName, err er
 	}()
 
 	span := opentracing.SpanFromContext(ctx)
-	span.LogFields(otlog.String("ListPublic", "start"))
 	repos, err = s.cache.ListPublic(ctx)
 	if err != nil {
-		span.LogFields(otlog.String("ListPublic", "failed"))
 		return nil, errors.Wrap(err, "listing default public repos")
 	}
-	span.LogFields(otlog.String("ListPublic", "done"))
+	span.LogFields(otlog.Int("public.len", len(repos)))
 
 	// For authenticated users we also want to include any private repos they may have added
 	if a := actor.FromContext(ctx); a.IsAuthenticated() {
-		span.LogFields(otlog.String("ListRepoNames", "start"))
 		privateRepos, err := database.GlobalRepos.ListRepoNames(ctx, database.ReposListOptions{
 			UserID:      a.UID,
 			OnlyPrivate: true,
 		})
 		if err != nil {
-			span.LogFields(otlog.String("ListRepoNames", "failed"))
 			return nil, errors.Wrap(err, "getting user private repos")
 		}
-		span.LogFields(otlog.String("ListRepoNames", "done"))
+		span.LogFields(otlog.Int("private.len", len(privateRepos)))
 		repos = append(repos, privateRepos...)
 	}
 


### PR DESCRIPTION
We log the individual lengths of public vs private. Additionally we
remove the start and fail events. Start events are implicit, while fail
events are handled by the trace logger capturing the returned error.

Additionally the trace had the incorrect name.

Co-authored-by: @stefanhengl 