### PR TITLE
Fix modify calls over user/org settings. 

### DIFF
--- a/client/web/src/insights/core/jsonc-operation.ts
+++ b/client/web/src/insights/core/jsonc-operation.ts
@@ -8,6 +8,21 @@ export const defaultFormattingOptions: jsonc.FormattingOptions = {
     tabSize: 2,
 }
 
+/**
+ * Simplified jsonc API method to modify jsonc object.
+ *
+ * @param originContent Origin content (settings)
+ * @param path - path to the field which will be modified
+ * @param value - new value for modify field
+ */
+export const modify = (originContent: string, path: jsonc.JSONPath, value: unknown): string => {
+    const addingExtensionKeyEdits = jsonc.modify(originContent, path, value, {
+        formattingOptions: defaultFormattingOptions,
+    })
+
+    return jsonc.applyEdits(originContent, addingExtensionKeyEdits)
+}
+
 const getExtensionNameByInsight = (insight: Insight): string => {
     if (isSearchBasedInsight(insight)) {
         return 'sourcegraph/search-insights'
@@ -25,14 +40,10 @@ export const addInsightToCascadeSetting = (settings: string, insight: Insight): 
 
     const extensionName = getExtensionNameByInsight(insight)
     // Turn on extension if user in creation code insight.
-    const addingExtensionKeyEdits = jsonc.modify(settings, ['extensions', extensionName], true, {
-        formattingOptions: defaultFormattingOptions,
-    })
-    const addingInsightEdits = jsonc.modify(settings, [id], originInsight, {
-        formattingOptions: defaultFormattingOptions,
-    })
+    const settingsWithExtension = modify(settings, ['extensions', extensionName], true)
 
-    return jsonc.applyEdits(settings, [...addingExtensionKeyEdits, ...addingInsightEdits])
+    // Add insight to the user settings
+    return modify(settingsWithExtension, [id], originInsight)
 }
 
 export const removeInsightFromSetting = (settings: string, insightID: string): string => {

--- a/client/web/src/insights/pages/dashboard/hooks/use-delete-insight.ts
+++ b/client/web/src/insights/pages/dashboard/hooks/use-delete-insight.ts
@@ -52,31 +52,11 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
                 // Fetch the settings of particular subject which the insight belongs to
                 const settings = await getSubjectSettings(subjectID).toPromise()
 
-                let editedSettings = settings.contents
-
-                if (isOldCodeStatsInsight) {
-                    editedSettings = modify(
-                        editedSettings,
-                        // According to our naming convention <type>.insight.<name>
-                        ['codeStatsInsights.query'],
-                        undefined
-                    )
-
-                    editedSettings = modify(
-                        editedSettings,
-                        // According to our naming convention <type>.insight.<name>
-                        ['codeStatsInsights.otherThreshold'],
-                        undefined
-                    )
-                } else {
-                    // Remove insight settings from subject (user/org settings)
-                    editedSettings = modify(
-                        editedSettings,
-                        // According to our naming convention <type>.insight.<name>
-                        [insightID],
-                        undefined
-                    )
-                }
+                const editedSettings = getEditedSettings({
+                    originSettings: settings.contents,
+                    insightID,
+                    isOldCodeStatsInsight,
+                })
 
                 // Update local settings of application with new settings without insight
                 await updateSubjectSettings(platformContext, subjectID, editedSettings).toPromise()
@@ -89,4 +69,41 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
     )
 
     return { handleDelete }
+}
+
+interface GetEditedSettingsProps {
+    originSettings: string
+    isOldCodeStatsInsight: boolean
+    insightID: string
+}
+
+/**
+ * Return edited settings without deleted insight settings section
+ */
+function getEditedSettings(props: GetEditedSettingsProps): string {
+    const { originSettings, isOldCodeStatsInsight, insightID } = props
+
+    if (isOldCodeStatsInsight) {
+        const editedSettings = modify(
+            originSettings,
+            // According to our naming convention <type>.insight.<name>
+            ['codeStatsInsights.query'],
+            undefined
+        )
+
+        return modify(
+            editedSettings,
+            // According to our naming convention <type>.insight.<name>
+            ['codeStatsInsights.otherThreshold'],
+            undefined
+        )
+    }
+
+    // Remove insight settings from subject (user/org settings)
+    return modify(
+        originSettings,
+        // According to our naming convention <type>.insight.<name>
+        [insightID],
+        undefined
+    )
 }

--- a/client/web/src/insights/pages/dashboard/hooks/use-delete-insight.ts
+++ b/client/web/src/insights/pages/dashboard/hooks/use-delete-insight.ts
@@ -1,4 +1,3 @@
-import * as jsonc from '@sqs/jsonc-parser'
 import { useCallback, useContext } from 'react'
 
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
@@ -6,7 +5,7 @@ import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
 import { InsightsApiContext } from '../../../core/backend/api-provider'
-import { defaultFormattingOptions } from '../../../core/jsonc-operation'
+import { modify } from '../../../core/jsonc-operation'
 import { InsightTypePrefix } from '../../../core/types'
 
 export interface UseDeleteInsightProps extends SettingsCascadeProps, PlatformContextProps<'updateSettings'> {}
@@ -53,40 +52,32 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
                 // Fetch the settings of particular subject which the insight belongs to
                 const settings = await getSubjectSettings(subjectID).toPromise()
 
-                const edits = []
+                let editedSettings = settings.contents
 
                 if (isOldCodeStatsInsight) {
-                    const queryDeleteEdits = jsonc.modify(
-                        settings.contents,
+                    editedSettings = modify(
+                        editedSettings,
                         // According to our naming convention <type>.insight.<name>
                         ['codeStatsInsights.query'],
                         undefined,
-                        { formattingOptions: defaultFormattingOptions }
                     )
 
-                    const otherThresholdDeleteEdits = jsonc.modify(
-                        settings.contents,
+                    editedSettings = modify(
+                        editedSettings,
                         // According to our naming convention <type>.insight.<name>
                         ['codeStatsInsights.otherThreshold'],
                         undefined,
-                        { formattingOptions: defaultFormattingOptions }
                     )
 
-                    edits.push(...queryDeleteEdits, ...otherThresholdDeleteEdits)
                 } else {
                     // Remove insight settings from subject (user/org settings)
-                    const insightDeleteEdits = jsonc.modify(
-                        settings.contents,
+                    editedSettings = modify(
+                        editedSettings,
                         // According to our naming convention <type>.insight.<name>
                         [insightID],
                         undefined,
-                        { formattingOptions: defaultFormattingOptions }
                     )
-
-                    edits.push(...insightDeleteEdits)
                 }
-
-                const editedSettings = jsonc.applyEdits(settings.contents, edits)
 
                 // Update local settings of application with new settings without insight
                 await updateSubjectSettings(platformContext, subjectID, editedSettings).toPromise()

--- a/client/web/src/insights/pages/dashboard/hooks/use-delete-insight.ts
+++ b/client/web/src/insights/pages/dashboard/hooks/use-delete-insight.ts
@@ -59,23 +59,22 @@ export function useDeleteInsight(props: UseDeleteInsightProps): UseDeleteInsight
                         editedSettings,
                         // According to our naming convention <type>.insight.<name>
                         ['codeStatsInsights.query'],
-                        undefined,
+                        undefined
                     )
 
                     editedSettings = modify(
                         editedSettings,
                         // According to our naming convention <type>.insight.<name>
                         ['codeStatsInsights.otherThreshold'],
-                        undefined,
+                        undefined
                     )
-
                 } else {
                     // Remove insight settings from subject (user/org settings)
                     editedSettings = modify(
                         editedSettings,
                         // According to our naming convention <type>.insight.<name>
                         [insightID],
-                        undefined,
+                        undefined
                     )
                 }
 


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21623

You can see this problem If you try to edit insight and you have an empty `extension` object below this insight config in a user or org settings.

Example 

```jsonc
{
  "experimentalFeatures": {
    "codeInsights": true
  },
   // [2] attempt edit insight but we will produce bad jsonc
   // because we shift all document on the first step 
  "searchInsights.insight.migrationToNewGraphQlTsTypes2Dfd23": {
    "title": "Migration to new GraphQL TS types #2dfd23",
    "repositories": [
      "github.com/sourcegraph/sourcegraph"
    ],
    "series": [
      {
        "name": "Imports of old GQL.* types",
        "stroke": "var(--oc-grape-7)",
        "query": "patternType:regex case:yes \\*\\sas\\sGQL"
      }
    ],
    "step": {
      "months": 2
    }
  },
   // [1] First modification of extensions object shifts all documents by at least one line
  "extensions": {},
}
```

If you edit the extension object first you change the document length and indexes of all symbols below the extension field (shift by one line since we're adding a new extension to the extension object).
Then we try to edit insight by ID but the indexes/place of this insight in a user document has already been changed by extension edit operation so we just will produce an illegal JSON object by this operation.

As a result, we have this problem. 