### PR TITLE
web: `Definition` and `History` sections Code Intel panel redesign 

### DIFF
--- a/client/branded/src/components/panel/Panel.scss
+++ b/client/branded/src/components/panel/Panel.scss
@@ -52,5 +52,13 @@
         [data-reach-tab]:first-child {
             margin-left: 0;
         }
+
+        [data-reach-tab-panels] {
+            padding: 0.25rem 1rem;
+        }
+
+        &__empty {
+            padding-top: 0.5rem;
+        }
     }
 }

--- a/client/branded/src/components/panel/Panel.tsx
+++ b/client/branded/src/components/panel/Panel.tsx
@@ -224,17 +224,20 @@ export const Panel = React.memo<Props>(props => {
     }, [items, hash, currentTabID])
 
     const [isRedesignEnabled] = useRedesignToggle()
-    const EmptyPanelWrapper = isRedesignEnabled ? React.Fragment : 'div'
 
     if (!areExtensionsReady) {
-        return (
-            <EmptyPanelWrapper {...(!isRedesignEnabled && { className: 'panel' })}>
-                <ExtensionsLoadingPanelView />
-            </EmptyPanelWrapper>
-        )
+        return <ExtensionsLoadingPanelView />
     }
 
     if (!items) {
+        if (isRedesignEnabled) {
+            return (
+                <div className="panel">
+                    <EmptyPanelView />
+                </div>
+            )
+        }
+
         return <EmptyPanelView />
     }
 

--- a/client/branded/src/components/panel/views/EmptyPanelView.tsx
+++ b/client/branded/src/components/panel/views/EmptyPanelView.tsx
@@ -16,7 +16,7 @@ export const EmptyPanelView: React.FunctionComponent<EmptyPanelViewProps> = prop
     return (
         <EmptyPanelWrapper {...(!isRedesignEnabled && { className: 'panel' })}>
             <div className={classNames('panel__empty', className)}>
-                <CancelIcon className="icon-inline" /> Nothing to show here
+                <CancelIcon className="icon-inline mr-2" /> Nothing to show here
             </div>
         </EmptyPanelWrapper>
     )

--- a/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
+++ b/client/branded/src/components/panel/views/ExtensionsLoadingView.tsx
@@ -4,9 +4,11 @@ import React from 'react'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 
 export const ExtensionsLoadingPanelView: React.FunctionComponent = () => (
-    <div className="panel__empty">
-        <LoadingSpinner />
-        <span className="mx-2">Loading Sourcegraph extensions</span>
-        <PuzzleIcon className="icon-inline" />
+    <div className="panel">
+        <div className="panel__empty">
+            <LoadingSpinner />
+            <span className="mx-2">Loading Sourcegraph extensions</span>
+            <PuzzleIcon className="icon-inline" />
+        </div>
     </div>
 )

--- a/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
+++ b/client/branded/src/components/panel/views/HierarchicalLocationsView.scss
@@ -45,7 +45,7 @@
     }
 
     .theme-redesign & {
-        padding: 0.25rem 1rem;
+        overflow-x: hidden;
 
         &__content {
             margin-right: -1rem;

--- a/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
+++ b/client/web/src/components/FilteredConnection/ConnectionNodes.tsx
@@ -60,6 +60,9 @@ export interface ConnectionNodesDisplayProps {
     /** CSS class name for the list element (<ul>, <table>, or <div>). */
     listClassName?: string
 
+    /** CSS class name for the summary container element. */
+    summaryClassName?: string
+
     /** CSS class name for the "Show more" button. */
     showMoreClassName?: string
 
@@ -117,6 +120,7 @@ export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
     nodeComponentProps,
     listComponent: ListComponent = 'ul',
     listClassName,
+    summaryClassName,
     headComponent: HeadComponent,
     headComponentProps,
     footComponent: FootComponent,
@@ -158,9 +162,11 @@ export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
         <NodeComponent key={hasID(node) ? node.id : index} node={node} {...nodeComponentProps!} />
     ))
 
+    const summaryContainerClassName = classNames(summaryClassName, 'filtered-connection__summary-container')
+
     return (
         <>
-            <div className="filtered-connection__summary-container">{connectionQuery && summary}</div>
+            <div className={summaryContainerClassName}>{connectionQuery && summary}</div>
             {connection.nodes.length > 0 && (
                 <ListComponent className={classNames('filtered-connection__nodes', listClassName)} data-testid="nodes">
                     {HeadComponent && (
@@ -175,7 +181,7 @@ export const ConnectionNodes = <C extends Connection<N>, N, NP = {}, HP = {}>({
                 </ListComponent>
             )}
             {!loading && (
-                <div className="filtered-connection__summary-container">
+                <div className={summaryContainerClassName}>
                     {!connectionQuery && summary}
                     {!noShowMore && hasNextPage && (
                         <button

--- a/client/web/src/components/FilteredConnection/FilteredConnection.scss
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.scss
@@ -33,7 +33,7 @@ $compact-summary-min-height: 2.75rem;
         padding: var(--popover-item-padding-v) var(--popover-item-padding-h);
         flex: 0 0;
 
-        .theme-redesign & {
+        :where(.theme-redesign) & {
             // Consistent with the summary to avoid layout shifting
             border-top: $compact-summary-divider;
             padding: $compact-summary-padding;
@@ -64,7 +64,7 @@ $compact-summary-min-height: 2.75rem;
         }
     }
     &--compact &__summary-container {
-        .theme-redesign & {
+        :where(.theme-redesign) & {
             padding: $compact-summary-padding;
             border-top: $compact-summary-divider;
             min-height: $compact-summary-min-height;

--- a/client/web/src/components/FilteredConnection/FilteredConnection.tsx
+++ b/client/web/src/components/FilteredConnection/FilteredConnection.tsx
@@ -41,6 +41,9 @@ interface FilteredConnectionDisplayProps extends ConnectionNodesDisplayProps {
     /** CSS class name for the root element. */
     className?: string
 
+    /** CSS class name for the loader element. */
+    loaderClassName?: string
+
     /** Whether to display it more compactly. */
     compact?: boolean
 
@@ -572,6 +575,7 @@ export class FilteredConnection<
                         pluralNoun={this.props.pluralNoun}
                         listComponent={this.props.listComponent}
                         listClassName={this.props.listClassName}
+                        summaryClassName={this.props.summaryClassName}
                         headComponent={this.props.headComponent}
                         headComponentProps={this.props.headComponentProps}
                         footComponent={this.props.footComponent}
@@ -587,7 +591,12 @@ export class FilteredConnection<
                     />
                 )}
                 {this.state.loading && (
-                    <span className="filtered-connection__loader test-filtered-connection__loader">
+                    <span
+                        className={classNames(
+                            'filtered-connection__loader test-filtered-connection__loader',
+                            this.props.loaderClassName
+                        )}
+                    >
                         <LoadingSpinner className="icon-inline" />
                     </span>
                 )}
@@ -649,6 +658,7 @@ export class FilteredConnection<
 
 /**
  * Resets the `FilteredConnection` URL query string parameters to the defaults
+ *
  * @param parameters the current URL search parameters
  */
 export const resetFilteredConnectionURLQuery = (parameters: URLSearchParams): void => {

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -856,7 +856,7 @@ describe('e2e test suite', () => {
                 await retry(async () =>
                     expect(
                         await driver.page.evaluate(() =>
-                            document.querySelectorAll('.git-commit-node-byline')[3].textContent!.trim()
+                            document.querySelectorAll('[data-testid="git-commit-node-byline"]')[3].textContent!.trim()
                         )
                     ).toContain('Dmitri Shuralyov')
                 )

--- a/client/web/src/repo/RepoRevisionSidebarCommits.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.module.scss
@@ -1,0 +1,27 @@
+:global(.theme-redesign) .repo-revision-sidebar-commits {
+    &__list {
+        padding-top: 0.5rem;
+    }
+
+    &__commit-container {
+        border: none;
+        border-bottom: 1px solid var(--border-color-2);
+    }
+
+    &__commit-node {
+        padding: 0.25rem 0;
+    }
+
+    &__loader {
+        border-top: none;
+    }
+
+    &__summary {
+        padding: 0;
+        border-top: none;
+    }
+
+    &__file-icon {
+        color: var(--icon-color);
+    }
+}

--- a/client/web/src/repo/RepoRevisionSidebarCommits.module.scss
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.module.scss
@@ -1,27 +1,27 @@
-:global(.theme-redesign) .repo-revision-sidebar-commits {
-    &__list {
+:global(.theme-redesign) {
+    .list {
         padding-top: 0.5rem;
     }
 
-    &__commit-container {
+    .commit-container {
         border: none;
         border-bottom: 1px solid var(--border-color-2);
     }
 
-    &__commit-node {
+    .commit-node {
         padding: 0.25rem 0;
     }
 
-    &__loader {
+    .loader {
         border-top: none;
     }
 
-    &__summary {
+    .summary {
         padding: 0;
         border-top: none;
     }
 
-    &__file-icon {
+    .file-icon {
         color: var(--icon-color);
     }
 }

--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as H from 'history'
 import FileIcon from 'mdi-react/FileIcon'
 import * as React from 'react'
@@ -21,6 +22,7 @@ import { replaceRevisionInURL } from '../util/url'
 
 import { GitCommitNode } from './commits/GitCommitNode'
 import { gitCommitFragment } from './commits/RepositoryCommitsPage'
+import styles from './RepoRevisionSidebarCommits.module.scss'
 
 interface CommitNodeProps {
     node: GitCommitFields
@@ -28,15 +30,16 @@ interface CommitNodeProps {
 }
 
 const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, location }) => (
-    <li className="list-group-item p-0">
+    <li className={classNames(styles.repoRevisionSidebarCommitsCommitContainer, 'list-group-item p-0')}>
         <GitCommitNode
+            className={styles.repoRevisionSidebarCommitsCommitNode}
             compact={true}
             node={node}
             hideExpandCommitMessageBody={true}
             afterElement={
                 <Link
                     to={replaceRevisionInURL(location.pathname + location.search + location.hash, node.oid)}
-                    className="ml-2"
+                    className={classNames(styles.repoRevisionSidebarCommitsFileIcon, 'ml-2')}
                     title="View current file at this commit"
                 >
                     <FileIcon className="icon-inline" />
@@ -57,6 +60,9 @@ export class RepoRevisionSidebarCommits extends React.PureComponent<Props> {
         return (
             <FilteredConnection<GitCommitFields, Pick<CommitNodeProps, 'location'>, CommitAncestorsConnectionFields>
                 className="list-group list-group-flush"
+                listClassName={styles.repoRevisionSidebarCommitsList}
+                summaryClassName={styles.repoRevisionSidebarCommitsSummary}
+                loaderClassName={styles.repoRevisionSidebarCommitsLoader}
                 compact={true}
                 noun="commit"
                 pluralNoun="commits"

--- a/client/web/src/repo/RepoRevisionSidebarCommits.tsx
+++ b/client/web/src/repo/RepoRevisionSidebarCommits.tsx
@@ -30,16 +30,16 @@ interface CommitNodeProps {
 }
 
 const CommitNode: React.FunctionComponent<CommitNodeProps> = ({ node, location }) => (
-    <li className={classNames(styles.repoRevisionSidebarCommitsCommitContainer, 'list-group-item p-0')}>
+    <li className={classNames(styles.commitContainer, 'list-group-item p-0')}>
         <GitCommitNode
-            className={styles.repoRevisionSidebarCommitsCommitNode}
+            className={styles.commitNode}
             compact={true}
             node={node}
             hideExpandCommitMessageBody={true}
             afterElement={
                 <Link
                     to={replaceRevisionInURL(location.pathname + location.search + location.hash, node.oid)}
-                    className={classNames(styles.repoRevisionSidebarCommitsFileIcon, 'ml-2')}
+                    className={classNames(styles.fileIcon, 'ml-2')}
                     title="View current file at this commit"
                 >
                     <FileIcon className="icon-inline" />
@@ -60,9 +60,9 @@ export class RepoRevisionSidebarCommits extends React.PureComponent<Props> {
         return (
             <FilteredConnection<GitCommitFields, Pick<CommitNodeProps, 'location'>, CommitAncestorsConnectionFields>
                 className="list-group list-group-flush"
-                listClassName={styles.repoRevisionSidebarCommitsList}
-                summaryClassName={styles.repoRevisionSidebarCommitsSummary}
-                loaderClassName={styles.repoRevisionSidebarCommitsLoader}
+                listClassName={styles.list}
+                summaryClassName={styles.summary}
+                loaderClassName={styles.loader}
                 compact={true}
                 noun="commit"
                 pluralNoun="commits"

--- a/client/web/src/repo/commits/GitCommitNode.scss
+++ b/client/web/src/repo/commits/GitCommitNode.scss
@@ -94,11 +94,20 @@
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+
+        .theme-redesign & {
+            display: flex;
+            align-items: center;
+        }
     }
     &--compact &__message {
         flex: 1;
         min-width: 0;
         padding-right: 1rem;
+
+        .theme-redesign & {
+            line-height: 1;
+        }
     }
     &--compact &__message-subject {
         font-weight: normal;

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import copy from 'copy-to-clipboard'
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon'
 import DotsHorizontalIcon from 'mdi-react/DotsHorizontalIcon'
@@ -7,6 +8,7 @@ import React, { useState, useCallback } from 'react'
 import { Tooltip } from '@sourcegraph/branded/src/components/tooltip/Tooltip'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { pluralize } from '@sourcegraph/shared/src/util/strings'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { Timestamp } from '../../components/time/Timestamp'
 import { GitCommitFields } from '../../graphql-operations'
@@ -48,6 +50,7 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
 }) => {
     const [showCommitMessageBody, setShowCommitMessageBody] = useState<boolean>(false)
     const [flashCopiedToClipboardMessage, setFlashCopiedToClipboardMessage] = useState<boolean>(false)
+    const [isRedesignEnabled] = useRedesignToggle()
 
     const toggleShowCommitMessageBody = useCallback((): void => {
         eventLogger.log('CommitBodyToggled')
@@ -73,10 +76,12 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
             compact={Boolean(compact)}
         />
     )
+
+    const MessageWrapper = isRedesignEnabled ? 'small' : React.Fragment
     const messageElement = (
         <div className="git-commit-node__message flex-grow-1">
             <Link to={node.canonicalURL} className="git-commit-node__message-subject" title={node.message}>
-                {node.subject}
+                <MessageWrapper>{node.subject}</MessageWrapper>
             </Link>
             {node.body && !hideExpandCommitMessageBody && !expandCommitMessageBody && (
                 <button
@@ -96,11 +101,13 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
     )
     const oidElement = <code className="git-commit-node__oid">{node.abbreviatedOID}</code>
     return (
-        <div
-            key={node.id}
-            className={`git-commit-node ${compact ? 'git-commit-node--compact' : ''} ${className || ''}`}
-        >
-            <div className="w-100 d-flex justify-content-between align-items-start flex-wrap-reverse">
+        <div key={node.id} className={classNames('git-commit-node', compact && 'git-commit-node--compact', className)}>
+            <div
+                className={classNames(
+                    'w-100 d-flex justify-content-between flex-wrap-reverse',
+                    isRedesignEnabled ? 'align-items-center' : 'align-items-start '
+                )}
+            >
                 {!compact ? (
                     <>
                         <div className="git-commit-node__signature">

--- a/client/web/src/repo/commits/GitCommitNode.tsx
+++ b/client/web/src/repo/commits/GitCommitNode.tsx
@@ -77,7 +77,7 @@ export const GitCommitNode: React.FunctionComponent<GitCommitNodeProps> = ({
         />
     )
 
-    const MessageWrapper = isRedesignEnabled ? 'small' : React.Fragment
+    const MessageWrapper = isRedesignEnabled && compact ? 'small' : React.Fragment
     const messageElement = (
         <div className="git-commit-node__message flex-grow-1">
             <Link to={node.canonicalURL} className="git-commit-node__message-subject" title={node.message}>

--- a/client/web/src/repo/commits/GitCommitNodeByLine.module.scss
+++ b/client/web/src/repo/commits/GitCommitNodeByLine.module.scss
@@ -1,0 +1,12 @@
+.git-commit-node-byline {
+    &__avatar--compact {
+        min-height: 1.5rem;
+        min-width: 1.5rem;
+    }
+
+    &__person--compact {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+}

--- a/client/web/src/repo/commits/GitCommitNodeByLine.module.scss
+++ b/client/web/src/repo/commits/GitCommitNodeByLine.module.scss
@@ -1,10 +1,10 @@
-:global(.theme-redesign) .git-commit-node-byline {
-    &__avatar--compact {
+:global(.theme-redesign) {
+    .avatar--compact {
         min-height: 1.5rem;
         min-width: 1.5rem;
     }
 
-    &__person--compact {
+    .person--compact {
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;

--- a/client/web/src/repo/commits/GitCommitNodeByLine.module.scss
+++ b/client/web/src/repo/commits/GitCommitNodeByLine.module.scss
@@ -1,4 +1,4 @@
-.git-commit-node-byline {
+:global(.theme-redesign) .git-commit-node-byline {
     &__avatar--compact {
         min-height: 1.5rem;
         min-width: 1.5rem;

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -23,7 +23,7 @@ interface Props {
 export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, committer, className = '', compact }) => {
     const [isRedesignEnabled] = useRedesignToggle()
 
-    const avatarMarginClass = isRedesignEnabled ? 'mr-2' : 'mr-1'
+    const avatarMarginClass = isRedesignEnabled && compact ? 'mr-2' : 'mr-1'
     const avatarClassName = classNames('icon-inline mr-1', compact && styles.gitCommitNodeBylineAvatarCompact)
 
     // Omit GitHub as committer to reduce noise. (Edits and squash commits made in the GitHub UI

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -24,7 +24,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, co
     const [isRedesignEnabled] = useRedesignToggle()
 
     const avatarMarginClass = isRedesignEnabled && compact ? 'mr-2' : 'mr-1'
-    const avatarClassName = classNames('icon-inline mr-1', compact && styles.gitCommitNodeBylineAvatarCompact)
+    const avatarClassName = classNames('icon-inline mr-1', compact && styles.avatarCompact)
 
     // Omit GitHub as committer to reduce noise. (Edits and squash commits made in the GitHub UI
     // include GitHub as a committer.)
@@ -50,7 +50,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, co
                     user={committer.person}
                     data-tooltip={`${formatPersonName(committer.person)} (committer)`}
                 />
-                <span className={classNames(compact && styles.gitCommitNodeBylinePersonCompact)}>
+                <span className={classNames(compact && styles.personCompact)}>
                     <PersonLink person={author.person} className="font-weight-bold" /> {!compact && 'authored'} and{' '}
                     <PersonLink person={committer.person} className="font-weight-bold" />{' '}
                     {!compact && (
@@ -70,7 +70,7 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, co
                 user={author.person}
                 data-tooltip={formatPersonName(author.person)}
             />{' '}
-            <span className={classNames(compact && styles.gitCommitNodeBylinePersonCompact)}>
+            <span className={classNames(compact && styles.personCompact)}>
                 <PersonLink person={author.person} className="font-weight-bold" />{' '}
                 {!compact && (
                     <>

--- a/client/web/src/repo/commits/GitCommitNodeByline.tsx
+++ b/client/web/src/repo/commits/GitCommitNodeByline.tsx
@@ -1,9 +1,14 @@
+import classNames from 'classnames'
 import React from 'react'
+
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { Timestamp } from '../../components/time/Timestamp'
 import { SignatureFields } from '../../graphql-operations'
 import { formatPersonName, PersonLink } from '../../person/PersonLink'
 import { UserAvatar } from '../../user/UserAvatar'
+
+import styles from './GitCommitNodeByLine.module.scss'
 
 interface Props {
     author: SignatureFields
@@ -16,6 +21,11 @@ interface Props {
  * Displays a Git commit's author and committer (with avatars if available) and the dates.
  */
 export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, committer, className = '', compact }) => {
+    const [isRedesignEnabled] = useRedesignToggle()
+
+    const avatarMarginClass = isRedesignEnabled ? 'mr-2' : 'mr-1'
+    const avatarClassName = classNames('icon-inline mr-1', compact && styles.gitCommitNodeBylineAvatarCompact)
+
     // Omit GitHub as committer to reduce noise. (Edits and squash commits made in the GitHub UI
     // include GitHub as a committer.)
     if (committer && committer.person.name === 'GitHub' && committer.person.email === 'noreply@github.com') {
@@ -29,41 +39,45 @@ export const GitCommitNodeByline: React.FunctionComponent<Props> = ({ author, co
     ) {
         // The author and committer both exist and are different people.
         return (
-            <small className={`git-commit-node-byline git-commit-node-byline--has-committer ${className}`}>
+            <small data-testid="git-commit-node-byline" className={className}>
                 <UserAvatar
-                    className="icon-inline"
+                    className={avatarClassName}
                     user={author.person}
                     data-tooltip={`${formatPersonName(author.person)} (author)`}
-                />{' '}
+                />
                 <UserAvatar
-                    className="icon-inline mr-1"
+                    className={classNames(avatarClassName, avatarMarginClass)}
                     user={committer.person}
                     data-tooltip={`${formatPersonName(committer.person)} (committer)`}
-                />{' '}
-                <PersonLink person={author.person} className="font-weight-bold" /> {!compact && 'authored'} and{' '}
-                <PersonLink person={committer.person} className="font-weight-bold" />{' '}
-                {!compact && (
-                    <>
-                        committed <Timestamp date={committer.date} />
-                    </>
-                )}
+                />
+                <span className={classNames(compact && styles.gitCommitNodeBylinePersonCompact)}>
+                    <PersonLink person={author.person} className="font-weight-bold" /> {!compact && 'authored'} and{' '}
+                    <PersonLink person={committer.person} className="font-weight-bold" />{' '}
+                    {!compact && (
+                        <>
+                            committed <Timestamp date={committer.date} />
+                        </>
+                    )}
+                </span>
             </small>
         )
     }
 
     return (
-        <small className={`git-commit-node-byline git-commit-node-byline--no-committer ${className}`}>
+        <small data-testid="git-commit-node-byline" className={className}>
             <UserAvatar
-                className="icon-inline mr-1"
+                className={classNames(avatarClassName, avatarMarginClass)}
                 user={author.person}
                 data-tooltip={formatPersonName(author.person)}
             />{' '}
-            <PersonLink person={author.person} className="font-weight-bold" />{' '}
-            {!compact && (
-                <>
-                    committed <Timestamp date={author.date} />
-                </>
-            )}
+            <span className={classNames(compact && styles.gitCommitNodeBylinePersonCompact)}>
+                <PersonLink person={author.person} className="font-weight-bold" />{' '}
+                {!compact && (
+                    <>
+                        committed <Timestamp date={author.date} />
+                    </>
+                )}
+            </span>
         </small>
     )
 }

--- a/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
+++ b/client/web/src/repo/commits/__snapshots__/GitCommitNodeByline.test.tsx.snap
@@ -2,212 +2,238 @@
 
 exports[`GitCommitNodeByline author (compact) 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className=""
+  data-testid="git-commit-node-byline"
 >
   <img
     alt=""
-    className="user-avatar icon-inline mr-1"
+    className="user-avatar icon-inline mr-1 mr-1"
     data-tooltip="Alice Zhao"
     role="presentation"
     src="http://example.com/alice.png"
   />
    
   <span
-    className="font-weight-bold "
-    data-tooltip="alice@example.com"
+    className=""
   >
-    Alice Zhao
-  </span>
-   
-  committed 
-  <span
-    className="timestamp"
-    data-tooltip="1990-01-01"
-  >
-    about 16 years ago
+    <span
+      className="font-weight-bold "
+      data-tooltip="alice@example.com"
+    >
+      Alice Zhao
+    </span>
+     
+    committed 
+    <span
+      className="timestamp"
+      data-tooltip="1990-01-01"
+    >
+      about 16 years ago
+    </span>
   </span>
 </small>
 `;
 
 exports[`GitCommitNodeByline author 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className=""
+  data-testid="git-commit-node-byline"
 >
   <img
     alt=""
-    className="user-avatar icon-inline mr-1"
+    className="user-avatar icon-inline mr-1 mr-1"
     data-tooltip="Alice Zhao"
     role="presentation"
     src="http://example.com/alice.png"
   />
    
   <span
-    className="font-weight-bold "
-    data-tooltip="alice@example.com"
+    className=""
   >
-    Alice Zhao
-  </span>
-   
-  committed 
-  <span
-    className="timestamp"
-    data-tooltip="1990-01-01"
-  >
-    about 16 years ago
+    <span
+      className="font-weight-bold "
+      data-tooltip="alice@example.com"
+    >
+      Alice Zhao
+    </span>
+     
+    committed 
+    <span
+      className="timestamp"
+      data-tooltip="1990-01-01"
+    >
+      about 16 years ago
+    </span>
   </span>
 </small>
 `;
 
 exports[`GitCommitNodeByline different author and committer (compact) 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--has-committer "
+  className=""
+  data-testid="git-commit-node-byline"
 >
   <img
     alt=""
-    className="user-avatar icon-inline"
+    className="user-avatar icon-inline mr-1"
     data-tooltip="Alice Zhao (author)"
     role="presentation"
     src="http://example.com/alice.png"
   />
-   
   <img
     alt=""
-    className="user-avatar icon-inline mr-1"
+    className="user-avatar icon-inline mr-1 mr-1"
     data-tooltip="bYang (committer)"
     role="presentation"
     src="http://example.com/bob.png"
   />
-   
   <span
-    className="font-weight-bold "
-    data-tooltip="alice@example.com"
+    className=""
   >
-    Alice Zhao
-  </span>
-   
-  authored
-   and
-   
-  <a
-    className="font-weight-bold "
-    data-tooltip="Bob Yang <bob@example.com>"
-    href="https://example.com/bobyang"
-  >
-    bYang
-  </a>
-   
-  committed 
-  <span
-    className="timestamp"
-    data-tooltip="1991-01-01"
-  >
-    about 15 years ago
+    <span
+      className="font-weight-bold "
+      data-tooltip="alice@example.com"
+    >
+      Alice Zhao
+    </span>
+     
+    authored
+     and
+     
+    <a
+      className="font-weight-bold "
+      data-tooltip="Bob Yang <bob@example.com>"
+      href="https://example.com/bobyang"
+    >
+      bYang
+    </a>
+     
+    committed 
+    <span
+      className="timestamp"
+      data-tooltip="1991-01-01"
+    >
+      about 15 years ago
+    </span>
   </span>
 </small>
 `;
 
 exports[`GitCommitNodeByline different author and committer 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--has-committer "
+  className=""
+  data-testid="git-commit-node-byline"
 >
   <img
     alt=""
-    className="user-avatar icon-inline"
+    className="user-avatar icon-inline mr-1"
     data-tooltip="Alice Zhao (author)"
     role="presentation"
     src="http://example.com/alice.png"
   />
-   
   <img
     alt=""
-    className="user-avatar icon-inline mr-1"
+    className="user-avatar icon-inline mr-1 mr-1"
     data-tooltip="bYang (committer)"
     role="presentation"
     src="http://example.com/bob.png"
   />
-   
   <span
-    className="font-weight-bold "
-    data-tooltip="alice@example.com"
+    className=""
   >
-    Alice Zhao
-  </span>
-   
-  authored
-   and
-   
-  <a
-    className="font-weight-bold "
-    data-tooltip="Bob Yang <bob@example.com>"
-    href="https://example.com/bobyang"
-  >
-    bYang
-  </a>
-   
-  committed 
-  <span
-    className="timestamp"
-    data-tooltip="1991-01-01"
-  >
-    about 15 years ago
+    <span
+      className="font-weight-bold "
+      data-tooltip="alice@example.com"
+    >
+      Alice Zhao
+    </span>
+     
+    authored
+     and
+     
+    <a
+      className="font-weight-bold "
+      data-tooltip="Bob Yang <bob@example.com>"
+      href="https://example.com/bobyang"
+    >
+      bYang
+    </a>
+     
+    committed 
+    <span
+      className="timestamp"
+      data-tooltip="1991-01-01"
+    >
+      about 15 years ago
+    </span>
   </span>
 </small>
 `;
 
 exports[`GitCommitNodeByline omit GitHub committer 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className=""
+  data-testid="git-commit-node-byline"
 >
   <img
     alt=""
-    className="user-avatar icon-inline mr-1"
+    className="user-avatar icon-inline mr-1 mr-1"
     data-tooltip="Alice Zhao"
     role="presentation"
     src="http://example.com/alice.png"
   />
    
   <span
-    className="font-weight-bold "
-    data-tooltip="alice@example.com"
+    className=""
   >
-    Alice Zhao
-  </span>
-   
-  committed 
-  <span
-    className="timestamp"
-    data-tooltip="1990-01-01"
-  >
-    about 16 years ago
+    <span
+      className="font-weight-bold "
+      data-tooltip="alice@example.com"
+    >
+      Alice Zhao
+    </span>
+     
+    committed 
+    <span
+      className="timestamp"
+      data-tooltip="1990-01-01"
+    >
+      about 16 years ago
+    </span>
   </span>
 </small>
 `;
 
 exports[`GitCommitNodeByline same author and committer 1`] = `
 <small
-  className="git-commit-node-byline git-commit-node-byline--no-committer "
+  className=""
+  data-testid="git-commit-node-byline"
 >
   <img
     alt=""
-    className="user-avatar icon-inline mr-1"
+    className="user-avatar icon-inline mr-1 mr-1"
     data-tooltip="Alice Zhao"
     role="presentation"
     src="http://example.com/alice.png"
   />
    
   <span
-    className="font-weight-bold "
-    data-tooltip="alice@example.com"
+    className=""
   >
-    Alice Zhao
-  </span>
-   
-  committed 
-  <span
-    className="timestamp"
-    data-tooltip="1990-01-01"
-  >
-    about 16 years ago
+    <span
+      className="font-weight-bold "
+      data-tooltip="alice@example.com"
+    >
+      Alice Zhao
+    </span>
+     
+    committed 
+    <span
+      className="timestamp"
+      data-tooltip="1990-01-01"
+    >
+      about 16 years ago
+    </span>
   </span>
 </small>
 `;

--- a/client/web/src/user/UserAvatar.scss
+++ b/client/web/src/user/UserAvatar.scss
@@ -2,7 +2,7 @@
     border-radius: 50%;
 }
 
-:where(.theme-redesign) {
+.theme-redesign {
     .user-avatar {
         display: inline-flex;
         border-radius: 50%;

--- a/client/web/src/user/UserAvatar.scss
+++ b/client/web/src/user/UserAvatar.scss
@@ -2,7 +2,7 @@
     border-radius: 50%;
 }
 
-.theme-redesign {
+:where(.theme-redesign) {
     .user-avatar {
         display: inline-flex;
         border-radius: 50%;


### PR DESCRIPTION
## Description

Definition and History sections Code Intel panel redesign: https://github.com/sourcegraph/sourcegraph/issues/21045.
[Figma mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=3008%3A501).

## Changes

- Added redesign styles for Definition and History sections.
- Updated snapshots accordingly.

## Screenshots

### History section

<img width="1021" alt="Screenshot 2021-06-02 at 14 53 24" src="https://user-images.githubusercontent.com/3846380/120505541-a3f4cd00-c3f7-11eb-907e-41d4ff54ddb1.png">

### Definition section

<img width="1021" alt="Screenshot 2021-06-02 at 14 53 36" src="https://user-images.githubusercontent.com/3846380/120505558-a7885400-c3f7-11eb-8d3e-bb390815b5ca.png">

## Notes

1. Alignment of the file icon in the History section is different from the design. It can be changed easily. I want to double-check that we don't want to align it with the close icon in the header row. See [thread](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw?node-id=3008:501#84632333).

<p align="center">
  <img  height="100px" alt="Screenshot 2021-06-02 at 13 52 50" src="https://user-images.githubusercontent.com/3846380/120506634-af94c380-c3f8-11eb-9cfa-cc7d2148277d.png">
&nbsp; &nbsp;
  <img  height="100px" alt="Screenshot 2021-06-02 at 13 49 08" src="https://user-images.githubusercontent.com/3846380/120506638-b15e8700-c3f8-11eb-9e81-32c5a88da4ca.png">
</p>

2. Left padding in the History section is different from the design according to this [thread](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw?node-id=3008:501#84466972).