### PR TITLE
Add a method for validation of graphql queries

### DIFF
--- a/cmd/frontend/graphqlbackend/graphqlbackend.go
+++ b/cmd/frontend/graphqlbackend/graphqlbackend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"os"
 	"strconv"
@@ -399,6 +400,38 @@ func NewSchema(db dbutil.DB, batchChanges BatchChangesResolver, codeIntel CodeIn
 		graphql.Tracer(&prometheusTracer{db: db}),
 		graphql.UseStringDescriptions(),
 	)
+}
+
+var queryValidationSchema = func() *graphql.Schema {
+	schemas := []string{
+		mainSchema,
+		batchesSchema,
+		codeIntelSchema,
+		insightsSchema,
+		authzSchema,
+		codeMonitorsSchema,
+		licenseSchema,
+		dotcomSchema,
+	}
+	return graphql.MustParseSchema(strings.Join(schemas, "\n"), nil)
+}()
+
+// ValidatedQuery takes a query string and returns the validated query.
+// If query validation fails, it will panic.
+func ValidatedQuery(s string) string {
+	if errs := queryValidationSchema.Validate(s); len(errs) > 0 {
+		panic(fmt.Sprintf("query does not pass schema validation: %s", errs))
+	}
+	return s
+}
+
+// ValidatedQuery takes a query string and an example set of variables and returns
+// the validated query.  If query validation fails, it will panic.
+func ValidatedQueryWithVariables(s string, vars map[string]interface{}) string {
+	if errs := queryValidationSchema.ValidateWithVariables(s, vars); len(errs) > 0 {
+		panic(fmt.Sprintf("query does not pass schema validation: %s", errs))
+	}
+	return s
 }
 
 // schemaResolver handles all GraphQL queries for Sourcegraph. To do this, it

--- a/cmd/query-runner/graphql.go
+++ b/cmd/query-runner/graphql.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend"
 	"github.com/sourcegraph/sourcegraph/internal/api"
 
 	"golang.org/x/net/context/ctxhttp"
@@ -22,86 +23,88 @@ type graphQLQuery struct {
 	Variables interface{} `json:"variables"`
 }
 
-const gqlSearchQuery = `query Search(
-	$query: String!,
-) {
-	search(query: $query) {
-		results {
-			approximateResultCount
-			limitHit
-			cloning { name }
-			timedout { name }
+var gqlSearchQuery = graphqlbackend.ValidatedQueryWithVariables(`
+	query Search(
+		$query: String!,
+	) {
+		search(query: $query) {
 			results {
-				__typename
-				... on FileMatch {
-					limitHit
-					lineMatches {
-						preview
-						lineNumber
-						offsetAndLengths
+				approximateResultCount
+				limitHit
+				cloning { name }
+				timedout { name }
+				results {
+					__typename
+					... on FileMatch {
+						resource
+						limitHit
+						lineMatches {
+							preview
+							lineNumber
+							offsetAndLengths
+						}
 					}
-				}
-				... on CommitSearchResult {
-					refs {
-						name
-						displayName
-						prefix
-						repository {
+					... on CommitSearchResult {
+						refs {
 							name
-						}
-					}
-					sourceRefs {
-						name
-						displayName
-						prefix
-						repository {
-							name
-						}
-					}
-					messagePreview {
-						value
-						highlights {
-							line
-							character
-							length
-						}
-					}
-					diffPreview {
-						value
-						highlights {
-							line
-							character
-							length
-						}
-					}
-					commit {
-						repository {
-							name
-						}
-						oid
-						abbreviatedOID
-						author {
-							person {
-								displayName
-								avatarURL
+							displayName
+							prefix
+							repository {
+								name
 							}
-							date
 						}
-						message
+						sourceRefs {
+							name
+							displayName
+							prefix
+							repository {
+								name
+							}
+						}
+						messagePreview {
+							value
+							highlights {
+								line
+								character
+								length
+							}
+						}
+						diffPreview {
+							value
+							highlights {
+								line
+								character
+								length
+							}
+						}
+						commit {
+							repository {
+								name
+							}
+							oid
+							abbreviatedOID
+							author {
+								person {
+									displayName
+									avatarURL
+								}
+								date
+							}
+							message
+						}
 					}
 				}
-			}
-			alert {
-				title
-				description
-				proposedQueries {
+				alert {
+					title
 					description
-					query
+					proposedQueries {
+						description
+						query
+					}
 				}
 			}
 		}
-	}
-}`
+	}`, map[string]interface{}{"query": "test"})
 
 type gqlSearchVars struct {
 	Query string `json:"query"`


### PR DESCRIPTION
This commit adds `graphqlbackend.ValidatedQuery` and
`graphqlbackend.ValidatedQueryWithVariables`, which are intended to help
ensure that our GraphQL queries are up to date with the schema.

Motivation: This is meant to help mitigate situations like those that caused #21494.
The GraphQL query used a field that was removed, and we didn't catch it for a month
since it was just exposed in log messages. If we'd been using a validated query, this
would catch that situation. This PR adds validation to the query that was failing. If this is
accepted, I'll likely make some followup PRs adding it to other queries in the codebase. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
