### PR TITLE
web: `HoverOverlay` remove extra content margin if close button is not present

### DIFF
--- a/client/shared/src/hover/HoverOverlay.scss
+++ b/client/shared/src/hover/HoverOverlay.scss
@@ -164,8 +164,7 @@
     .theme-redesign & {
         --hover-overlay-vertical-padding: 0.25rem;
         --hover-overlay-horizontal-padding: 1rem;
-        // Required to avoid close button and text content overlap on scroll.
-        --hover-overlay-contents-right-padding: 2rem;
+        --hover-overlay-contents-right-padding: 1rem;
         --hover-overlay-content-margin-top: 0.5rem;
         --hover-overlay-separator-color: var(--border-color);
 
@@ -220,6 +219,11 @@
             padding-bottom: 0;
             padding-right: var(--hover-overlay-contents-right-padding);
             border-bottom: none;
+
+            &--with-close-button {
+                // Required to avoid close button and text content overlap on scroll.
+                --hover-overlay-contents-right-padding: 2rem;
+            }
 
             // To center loader-icon relative to whole overlay block make horizontal paddings equal.
             &--loading {
@@ -305,7 +309,7 @@
         }
 
         &__actions {
-            padding-top: 0.5rem;
+            padding-top: 0.75rem;
             padding-bottom: 0.5rem;
             border-top: 1px solid var(--hover-overlay-separator-color);
         }

--- a/client/shared/src/hover/HoverOverlay.tsx
+++ b/client/shared/src/hover/HoverOverlay.tsx
@@ -105,7 +105,8 @@ export const HoverOverlay: React.FunctionComponent<HoverOverlayProps> = props =>
             <div
                 className={classNames(
                     'hover-overlay__contents',
-                    hoverOrError === LOADING && 'hover-overlay__contents--loading'
+                    hoverOrError === LOADING && 'hover-overlay__contents--loading',
+                    showCloseButton && 'hover-overlay__contents--with-close-button'
                 )}
             >
                 {showCloseButton && (


### PR DESCRIPTION
## Description

This PR addresses issues from the [design QA](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=3958%3A10).

## Changes

1. Changed top padding of the actions container.
2. Removed extra content padding in case if `showCloseButton` is `false`.

## Screenshots

Before:

<img width="567" alt="Screenshot 2021-06-02 at 18 48 43" src="https://user-images.githubusercontent.com/3846380/120511607-2469fc80-c3fd-11eb-994f-a0dc3c9aad1b.png">

After:

<img width="567" alt="Screenshot 2021-06-02 at 18 48 55" src="https://user-images.githubusercontent.com/3846380/120511626-27fd8380-c3fd-11eb-83b7-0cac6eec2b61.png">
