### PR TITLE
#21605 document the DISABLE_CODE_INSIGHTS flag

### DIFF
--- a/doc/dev/background-information/insights/backend.md
+++ b/doc/dev/background-information/insights/backend.md
@@ -34,6 +34,13 @@ The following architecture diagram shows how the backend fits into the two Sourc
 
 [![](diagrams/architecture.svg)](https://raw.githubusercontent.com/sourcegraph/sourcegraph/main/doc/dev/background-information/insights/diagrams/architecture.svg)
 
+## Feature Flags
+Code Insights is currently an experimental feature, and ships with an "escape hatch" feature flag that will completely disable the dependency on TimescaleDB (named `codeinsights-db`). This feature flag is implemented as an environment variable that if set true `DISABLE_CODE_INSIGHTS=true` will disable the dependency and will not start the Code Insights background workers or GraphQL resolvers. This variable must be set on both the `repo-updater` and `frontend` services to remove the dependency. If the flag is not set on both services, the `codeinsights-db` dependency will be required.
+
+Implementation of this environment variable can be found in the [`frontend`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/insights/insights.go#L43) and [`repo-updater`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/enterprise/internal/insights/background/background.go#L30) services.
+
+This flag should be used judiciously and should generally be considered a last resort for Sourcegraph installations that need to disable Code Insights or remove the database dependency.
+
 ## Life of an insight
 
 ### (1) User defines insight in settings


### PR DESCRIPTION
Resolves #21605

Adds documentation to the Code Insights experimental backend page around the usage of the environment variable DISABLE_CODE_INSIGHTS



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
