### PR TITLE
Unify + standardize code insights terms

### DIFF
--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -26,8 +26,8 @@ const DEFAULT_FINAL_SETTINGS = {}
 
 export interface LangStatsInsightCreationPageProps
     extends PlatformContextProps<'updateSettings'>,
-        SettingsCascadeProps,
-        TelemetryProps {
+    SettingsCascadeProps,
+    TelemetryProps {
     /**
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organization dashboard (public)
@@ -55,7 +55,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
                 values.visibility === 'personal'
                     ? userID
                     : // If this is not a 'personal' value than we are dealing with org id
-                      values.visibility
+                    values.visibility
 
             try {
                 const settings = await getSubjectSettings(subjectID).toPromise()
@@ -94,7 +94,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
             <PageTitle title="Create new code insight" />
 
             <div className="mb-5">
-                <h2>Set up new language usage insight</h2>
+                <h2>Create new language usage insight</h2>
 
                 <p className="text-muted">
                     Shows language usage in your repository based on number of lines of code.{' '}

--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -26,8 +26,8 @@ const DEFAULT_FINAL_SETTINGS = {}
 
 export interface LangStatsInsightCreationPageProps
     extends PlatformContextProps<'updateSettings'>,
-    SettingsCascadeProps,
-    TelemetryProps {
+        SettingsCascadeProps,
+        TelemetryProps {
     /**
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organization dashboard (public)
@@ -55,7 +55,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
                 values.visibility === 'personal'
                     ? userID
                     : // If this is not a 'personal' value than we are dealing with org id
-                    values.visibility
+                      values.visibility
 
             try {
                 const settings = await getSubjectSettings(subjectID).toPromise()

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -24,8 +24,8 @@ import { getSanitizedSearchInsight } from './utils/insight-sanitizer'
 
 export interface SearchInsightCreationPageProps
     extends PlatformContextProps<'updateSettings'>,
-    SettingsCascadeProps,
-    TelemetryProps {
+        SettingsCascadeProps,
+        TelemetryProps {
     /**
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
@@ -55,7 +55,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
                 values.visibility === 'personal'
                     ? userID
                     : // If this is not a 'personal' value than we are dealing with org id
-                    values.visibility
+                      values.visibility
 
             try {
                 const settings = await getSubjectSettings(subjectID).toPromise()

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -24,8 +24,8 @@ import { getSanitizedSearchInsight } from './utils/insight-sanitizer'
 
 export interface SearchInsightCreationPageProps
     extends PlatformContextProps<'updateSettings'>,
-        SettingsCascadeProps,
-        TelemetryProps {
+    SettingsCascadeProps,
+    TelemetryProps {
     /**
      * Authenticated user info, Used to decide where code insight will appears
      * in personal dashboard (private) or in organisation dashboard (public)
@@ -55,7 +55,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
                 values.visibility === 'personal'
                     ? userID
                     : // If this is not a 'personal' value than we are dealing with org id
-                      values.visibility
+                    values.visibility
 
             try {
                 const settings = await getSubjectSettings(subjectID).toPromise()
@@ -94,7 +94,7 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
             <PageTitle title="Create new code insight" />
 
             <div className="mb-5">
-                <h2>Create new code insight</h2>
+                <h2>Create new search-based insight</h2>
 
                 <p className="text-muted">
                     Search-based code insights analyze your code based on any search query.{' '}

--- a/doc/code_insights/language_insight_quickstart.md
+++ b/doc/code_insights/language_insight_quickstart.md
@@ -22,7 +22,7 @@ This creates a code insight tracking how many lines of code you have in each lan
 
 If you are more interested tracking the historical or future result count of an arbitrary Sourcegraph search, [follow this tutorial](quickstart.md) instead. 
 
-### 3. Once on the "Set up new language usage insight" form fields page, enter the repository you want to analyze. 
+### 3. Once on the "Create new language usage insight" form fields page, enter the repository you want to analyze. 
 
 Enter repositories in the repository URL format, like `github.com/Sourcegraph/Sourcegraph`. 
 


### PR DESCRIPTION
"Create" rather than "Set up." 

Specify the type of insight equally. 
