### PR TITLE
COREAPP-43: initialize GitLab OAuth client based on the token type

### DIFF
--- a/internal/authz/gitlab/oauth_test.go
+++ b/internal/authz/gitlab/oauth_test.go
@@ -153,8 +153,9 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 	t.Run("token type PAT", func(t *testing.T) {
 		p := newOAuthProvider(
 			OAuthProviderOp{
-				BaseURL: mustURL(t, "https://gitlab.com"),
-				Token:   "admin_token",
+				BaseURL:   mustURL(t, "https://gitlab.com"),
+				Token:     "admin_token",
+				TokenType: gitlab.TokenTypePAT,
 			},
 			&mockDoer{
 				do: func(r *http.Request) (*http.Response, error) {

--- a/internal/authz/gitlab/oauth_test.go
+++ b/internal/authz/gitlab/oauth_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/extsvc/gitlab"
 	"github.com/sourcegraph/sourcegraph/internal/rcache"
 )
 
@@ -149,56 +150,114 @@ func TestOAuthProvider_FetchRepoPerms(t *testing.T) {
 	// We need to clear the cache before we run the tests
 	rcache.SetupForTest(t)
 
-	p := newOAuthProvider(
-		OAuthProviderOp{
-			BaseURL: mustURL(t, "https://gitlab.com"),
-			Token:   "admin_token",
-		},
-		&mockDoer{
-			do: func(r *http.Request) (*http.Response, error) {
-				want := "https://gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
-				if r.URL.String() != want {
-					return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
-				}
+	t.Run("token type PAT", func(t *testing.T) {
+		p := newOAuthProvider(
+			OAuthProviderOp{
+				BaseURL: mustURL(t, "https://gitlab.com"),
+				Token:   "admin_token",
+			},
+			&mockDoer{
+				do: func(r *http.Request) (*http.Response, error) {
+					want := "https://gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
+					if r.URL.String() != want {
+						return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
+					}
 
-				want = "admin_token"
-				got := r.Header.Get("Private-Token")
-				if got != want {
-					return nil, fmt.Errorf("HTTP Private-Token: want %q but got %q", want, got)
-				}
+					want = "admin_token"
+					got := r.Header.Get("Private-Token")
+					if got != want {
+						return nil, fmt.Errorf("HTTP Private-Token: want %q but got %q", want, got)
+					}
 
-				body := `
+					body := `
 [
 	{"id": 1, "access_level": 10},
 	{"id": 2, "access_level": 20},
 	{"id": 3, "access_level": 30}
 ]`
-				return &http.Response{
-					Status:     http.StatusText(http.StatusOK),
-					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
-				}, nil
+					return &http.Response{
+						Status:     http.StatusText(http.StatusOK),
+						StatusCode: http.StatusOK,
+						Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+					}, nil
+				},
 			},
-		},
-	)
+		)
 
-	accountIDs, err := p.FetchRepoPerms(context.Background(),
-		&extsvc.Repository{
-			URI: "gitlab.com/user/repo",
-			ExternalRepoSpec: api.ExternalRepoSpec{
-				ServiceType: "gitlab",
-				ServiceID:   "https://gitlab.com/",
-				ID:          "gitlab_project_id",
+		accountIDs, err := p.FetchRepoPerms(context.Background(),
+			&extsvc.Repository{
+				URI: "gitlab.com/user/repo",
+				ExternalRepoSpec: api.ExternalRepoSpec{
+					ServiceType: "gitlab",
+					ServiceID:   "https://gitlab.com/",
+					ID:          "gitlab_project_id",
+				},
 			},
-		},
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// 1 should not be included because of "access_level" < 20
-	expAccountIDs := []extsvc.AccountID{"2", "3"}
-	if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
-		t.Fatal(diff)
-	}
+		// 1 should not be included because of "access_level" < 20
+		expAccountIDs := []extsvc.AccountID{"2", "3"}
+		if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
+			t.Fatal(diff)
+		}
+	})
+
+	t.Run("token type OAuth", func(t *testing.T) {
+		p := newOAuthProvider(
+			OAuthProviderOp{
+				BaseURL:   mustURL(t, "https://gitlab.com"),
+				Token:     "admin_token",
+				TokenType: gitlab.TokenTypeOAuth,
+			},
+			&mockDoer{
+				do: func(r *http.Request) (*http.Response, error) {
+					want := "https://gitlab.com/api/v4/projects/gitlab_project_id/members/all?per_page=100"
+					if r.URL.String() != want {
+						return nil, fmt.Errorf("URL: want %q but got %q", want, r.URL)
+					}
+
+					want = "Bearer admin_token"
+					got := r.Header.Get("Authorization")
+					if got != want {
+						return nil, fmt.Errorf("HTTP Private-Token: want %q but got %q", want, got)
+					}
+
+					body := `
+[
+	{"id": 1, "access_level": 10},
+	{"id": 2, "access_level": 20},
+	{"id": 3, "access_level": 30}
+]`
+					return &http.Response{
+						Status:     http.StatusText(http.StatusOK),
+						StatusCode: http.StatusOK,
+						Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
+					}, nil
+				},
+			},
+		)
+
+		accountIDs, err := p.FetchRepoPerms(context.Background(),
+			&extsvc.Repository{
+				URI: "gitlab.com/user/repo",
+				ExternalRepoSpec: api.ExternalRepoSpec{
+					ServiceType: "gitlab",
+					ServiceID:   "https://gitlab.com/",
+					ID:          "gitlab_project_id",
+				},
+			},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// 1 should not be included because of "access_level" < 20
+		expAccountIDs := []extsvc.AccountID{"2", "3"}
+		if diff := cmp.Diff(expAccountIDs, accountIDs); diff != "" {
+			t.Fatal(diff)
+		}
+	})
 }

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -60,8 +60,8 @@ func trace(msg string, ctx ...interface{}) {
 type TokenType string
 
 const (
-	TokenTypePAT   TokenType = "pat"
-	TokenTypeOAuth TokenType = "oauth"
+	TokenTypePAT   TokenType = "pat"   // "pat" represents personal access token.
+	TokenTypeOAuth TokenType = "oauth" // "oauth" represents OAuth token.
 )
 
 // ClientProvider creates GitLab API clients. Each client has separate authentication creds and a

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -56,6 +56,14 @@ func trace(msg string, ctx ...interface{}) {
 	}
 }
 
+// TokenType is the type of an access token.
+type TokenType string
+
+const (
+	TokenTypePAT   TokenType = "pat"
+	TokenTypeOAuth TokenType = "oauth"
+)
+
 // ClientProvider creates GitLab API clients. Each client has separate authentication creds and a
 // separate cache, but they share an underlying HTTP client and rate limiter. Callers who want a simple
 // unauthenticated API client should use `NewClientProvider(baseURL, transport).GetClient()`.

--- a/internal/repos/gitlab.go
+++ b/internal/repos/gitlab.go
@@ -3,7 +3,6 @@ package repos
 import (
 	"context"
 	"fmt"
-
 	"net/url"
 	"strconv"
 	"strings"
@@ -102,8 +101,8 @@ func newGitLabSource(svc *types.ExternalService, c *schema.GitLabConnection, cf 
 	provider := gitlab.NewClientProvider(baseURL, cli)
 
 	var client *gitlab.Client
-	switch c.TokenType {
-	case "oauth":
+	switch gitlab.TokenType(c.TokenType) {
+	case gitlab.TokenTypeOAuth:
 		client = provider.GetOAuthClient(c.Token)
 	default:
 		client = provider.GetPATClient(c.Token, "")


### PR DESCRIPTION
This PR fixes the repo permissions syncing for GitLab is not initializing OAuth client when the access token is an OAuth token not a PAT.

COREAPP-43 #done