### PR TITLE
Revert "RFC 393: Disable e2e tests until they're not flaky anymore (#…

### DIFF
--- a/.buildkite/pipeline.e2e.yml
+++ b/.buildkite/pipeline.e2e.yml
@@ -1,0 +1,9 @@
+env:
+  VAGRANT_RUN_ENV: 'CI'
+steps:
+  - label: ':chromium: Sourcegraph E2E'
+    artifact_paths: ./*.png;./*.mp4;./ffmpeg.log
+    command:
+      - .buildkite/vagrant-run.sh sourcegraph-e2e
+    agents:
+      queue: 'baremetal'

--- a/enterprise/dev/ci/internal/ci/pipeline-steps.go
+++ b/enterprise/dev/ci/internal/ci/pipeline-steps.go
@@ -301,6 +301,16 @@ func triggerE2EandQA(c Config, commonEnv map[string]string) func(*bk.Pipeline) {
 			return
 		}
 
+		pipeline.AddTrigger(":chromium: Trigger E2E",
+			bk.Trigger("sourcegraph-e2e"),
+			bk.Async(async),
+			bk.Build(bk.BuildOptions{
+				Message: os.Getenv("BUILDKITE_MESSAGE"),
+				Commit:  c.commit,
+				Branch:  c.branch,
+				Env:     env,
+			}),
+		)
 		pipeline.AddTrigger(":chromium: Trigger QA",
 			bk.Trigger("qa"),
 			bk.Async(async),


### PR DESCRIPTION
…21448)"

This reverts commit c7257dc00511387e93da317e16fb0eaac4c547dc.

This pipeline has had status updates disabled, so this will no longer cause failed e2e test to mark the main status as failed. 
