### PR TITLE
batches: revise query for changeset spec expiry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to Sourcegraph are documented in this file.
 ### Fixed
 
 - Stricter validation of structural search queries. The `type:` parameter is not supported for structural searches and returns an appropriate alert. [#21487](https://github.com/sourcegraph/sourcegraph/pull/21487)
+- Batch changeset specs that are not attached to changesets will no longer prematurely expire before the batch specs that they are associated with. [#21678](https://github.com/sourcegraph/sourcegraph/pull/21678)
 
 ### Removed
 

--- a/enterprise/internal/batches/store/changeset_specs_test.go
+++ b/enterprise/internal/batches/store/changeset_specs_test.go
@@ -374,6 +374,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 	t.Run("DeleteExpiredChangesetSpecs", func(t *testing.T) {
 		underTTL := clock.Now().Add(-btypes.ChangesetSpecTTL + 24*time.Hour)
 		overTTL := clock.Now().Add(-btypes.ChangesetSpecTTL - 24*time.Hour)
+		overBatchSpecTTL := clock.Now().Add(-btypes.BatchSpecTTL - 24*time.Hour)
 
 		type testCase struct {
 			createdAt time.Time
@@ -389,7 +390,7 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 
 		printTestCase := func(tc testCase) string {
 			var tooOld bool
-			if tc.createdAt.Equal(overTTL) {
+			if tc.createdAt.Equal(overTTL) || tc.createdAt.Equal(overBatchSpecTTL) {
 				tooOld = true
 			}
 
@@ -417,7 +418,8 @@ func testStoreChangesetSpecs(t *testing.T, ctx context.Context, s *Store, clock 
 			// anymore, and the ChangesetSpec is neither the current, nor the
 			// previous spec.
 			{hasBatchSpec: true, createdAt: underTTL, wantDeleted: false},
-			{hasBatchSpec: true, createdAt: overTTL, wantDeleted: true},
+			{hasBatchSpec: true, createdAt: overTTL, wantDeleted: false},
+			{hasBatchSpec: true, createdAt: overBatchSpecTTL, wantDeleted: true},
 		}
 
 		for _, tc := range tests {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/20170, _maybe_.

Modifies the query for deleting changeset specs so that it will only flag a changeset spec that isn't attached to a changeset but is attached to an un-applied batch spec **IF** that changeset spec is also older than `BatchSpecTTL`.

I say this _maybe_ closes that issue because I'm not sure if checking the age of the changeset spec is enough, or if I should actually be checking whether or not the associated _batch spec_ is older than `BatchSpecTTL`. 😅 Would those more or less be equivalent checks in this case?

Since the batch spec deletion happens after the changeset deletion, I believe no action is needed to preserve the existing behavior for also deleting the batch specs associated with these changeset specs after `BatchSpecTTL` elapses.
