### PR TITLE
web: update the web app docs

### DIFF
--- a/doc/dev/background-information/web/styling.md
+++ b/doc/dev/background-information/web/styling.md
@@ -56,6 +56,7 @@ They can however utilize environment-agnostic components by passing our Bootstra
 - Prefer classes over descendent/child selectors. It decouples styles from the DOM structure of the component, ensures encapsulation and avoids CSS specificity issues.
 - Create utility classes for styles that should be shared horizontally between components.
 - Avoid hardcoding colors, use CSS variables if they are available / the color makes sense to share.
+- If possible, prefer CSS variables to SCSS variables.
 - Try to _minimize_ the usage of advanced SCSS features. They can lead to bugs and complicate styles.
   - Encouraged features are nesting and imports (which is the intersection of Less', SCSS' and PostCSS' feature set).
 - Think about mobile at least so much that no feature breaks when the browser window is resized.
@@ -101,7 +102,7 @@ This file should not contain any real CSS rules so that it can be included in mu
 @import 'branded/src/global-styles/breakpoints';
 ```
 
-If possible, prefer CSS variables to SCSS variables.
+Do not use BEM convention in CSS modules. Use short descriptive classes specific only for the corresponding component because CSS modules provide scoping out of the box. It outputs shorter classes that are more readable in the component markup.
 
 #### BEM convention
 

--- a/doc/dev/background-information/web/styling.md
+++ b/doc/dev/background-information/web/styling.md
@@ -50,6 +50,19 @@ They can however utilize environment-agnostic components by passing our Bootstra
 
 ## Our approach to styling
 
+### General guidelines
+
+- Colocate styles with the corresponding component. Stylesheet file should be named like the `.tsx` component file.
+- Prefer classes over descendent/child selectors. It decouples styles from the DOM structure of the component, ensures encapsulation and avoids CSS specificity issues.
+- Create utility classes for styles that should be shared horizontally between components.
+- Avoid hardcoding colors, use CSS variables if they are available / the color makes sense to share.
+- Try to _minimize_ the usage of advanced SCSS features. They can lead to bugs and complicate styles.
+  - Encouraged features are nesting and imports (which is the intersection of Less', SCSS' and PostCSS' feature set).
+- Think about mobile at least so much that no feature breaks when the browser window is resized.
+- Prefer flexbox over absolute positioning.
+- Avoid styling the children of your components. This couples your component to the implementation of the child.
+- Order your rules so that layout rules (that describe how the component is laid out to its parents) come first, then rules that describe the layout of its children, and finally visual details.
+
 ### Structuring style sheets
 
 A component may need styles that are common to all environments, like internal layout.
@@ -118,30 +131,30 @@ Example:
 
 Please note that there is no hierarchy in _elements_, as that would couple the styling to the DOM structure. Element names should be unambiguous within their component/_block_, or be split into a separate component/_block_.
 
-We colocate stylesheets next to the component using the same file name.
-This approach ensures styles are easy to find and makes it easy to tell which styles apply to which elements (by putting them side-by-side in an editor, or through a simple text search).
-
-Using classes, as opposed to child and descendant selectors, decouples styles from the DOM structure of the component, ensures encapsulation and avoids CSS specificity issues.
-Descendant selectors can still be useful in rare cases though, like styling in the browser extension, or styling markdown content.
-
 ### Typography
 
 Avoid ever overriding font family, text sizes or text colors.
 These are set globally by the host environment for semantic HTML elements, e.g. `<h1>`, `<a>`, `<code>` or `<small>`.
 
-### Colors and theming
+### Theming
+
+Theming is done through toggling top-level CSS classes `theme-light` and `theme-dark`.
+Any style can be made different on either theme by scoping it to one of those two classes.
+Where possible, we use CSS variables, but unfortunately they don't work with compile-time color manipulation (`darken()` etc)
+and runtime color manipulation is not yet implemented in CSS (coming in CSS Color Level 4).
+
+### Colors
 
 The brand color palette is [OpenColor](https://yeun.github.io/open-color/).
 In addition to these, we define a blueish grayscale palette for backgrounds, text and borders.
-These colors are all available as SCSS and CSS variables.
+These colors are all available as CSS and SCSS variables.
+
 However, directly referencing these may not work well in both light and dark themes, and may not match code host themes (if the component is shared).
 The best approach is to not reference colors at all and use building blocks that have borders, text colors etc defined.
 This saves code and makes it easy to maintain design consistency even if we want to change colors in the future.
 When that is not possible (for example UI contributed by extensions), prefer to reference CSS variables with semantic colors like `var(--danger)`, `var(--success)`, `var(--border-color)`, `var(--body-bg)` etc.
 The values of these variables are changed globally when the theme changes.
 Be aware that this means our stylesheets for each host environment need to define these variables too.
-
-Defining different styles in the webapp depending on the `theme-dark` and `theme-light` classes predates CSS variables and is discouraged.
 
 ### Spacing
 

--- a/doc/dev/background-information/web/styling.md
+++ b/doc/dev/background-information/web/styling.md
@@ -53,7 +53,7 @@ They can however utilize environment-agnostic components by passing our Bootstra
 ### General guidelines
 
 - Colocate styles with the corresponding component. Stylesheet file should be named like the `.tsx` component file.
-- Prefer classes over descendent/child selectors. It decouples styles from the DOM structure of the component, ensures encapsulation and avoids CSS specificity issues.
+- Prefer classes over descendant/child selectors. It decouples styles from the DOM structure of the component, ensures encapsulation and avoids CSS specificity issues.
 - Create utility classes for styles that should be shared horizontally between components.
 - Avoid hardcoding colors, use CSS variables if they are available / the color makes sense to share.
 - If possible, prefer CSS variables to SCSS variables.

--- a/doc/dev/background-information/web/web_app.md
+++ b/doc/dev/background-information/web/web_app.md
@@ -80,25 +80,6 @@ Their purpose is to reexport symbols from a number of other files to make import
 - Try to do one component per file. This makes it easy to encapsulate corresponding styles.
 - Don't pass arrow functions as React bindings unless unavoidable
 
-## Styles
-
-- Styles are written in SCSS
-- Every component .tsx file should have a corresponding stylesheet named like the .tsx file
-  - The stylesheet must contain a top-level selector to scope it to a class that is the kebab-case version of the component name.
-    The component must apply that class to its top-level element.
-- Use [BEM](http://getbem.com/). "Block" here is the component name, element a non-component child of the component.
-- Only use descendent/child selectors where unavoidable. Prefer BEM-style class names that are nested in SCSS through the `&` operator
-- Create utility classes for styles that should be shared horizontally between components
-- Always use `rem` units (when converting designs, `1rem` = `16px`). This allows us to scale the whole UI by modifying the root font size.
-- Avoid hardcoding colors, use SCSS variables if they are available / the color makes sense to share.
-- Try to _minimize_ the usage of advanced SCSS features. They can lead to bugs and complicate styles.
-  - Encouraged features are nesting and imports (which is the intersection of Less', SCSS' and PostCSS' feature set)
-- Think about mobile at least so much that no feature breaks when the browser window is resized
-- Don't couple the styles to the DOM structure. It should be possible to change the structure without changing the styles and vice versa.
-- Prefer flexbox over absolute positioning
-- Avoid styling the children of your components. This couples your component to the implementation of the child
-- Order your rules so that layout rules (that describe how the component is laid out to its parents) come first, then rules that describe the layout of its children, and finally visual details.
-
 ## Code splitting
 
 [Code splitting](https://reactjs.org/docs/code-splitting.html) refers to the practice of bundling the frontend code into multiple JavaScript files, each with a subset of the frontend code, so that the client only needs to download and parse/run the code necessary for the page they are viewing. We use the [react-router code splitting technique](https://reactjs.org/docs/code-splitting.html#route-based-code-splitting) to accomplish this.
@@ -114,13 +95,6 @@ const MyComponent = React.lazy(async () => ({
 If you don't do this (and just use a normal `import`), it will still work, but it will increase the initial bundle size for all users.
 
 (It is necessary to return the component as the `default` property of an object because `React.lazy` is hard-coded to look there for it. We could avoid this extra work by using default exports, but we chose not to use default exports ([reasons](https://blog.neufund.org/why-we-have-banned-default-exports-and-you-should-do-the-same-d51fdc2cf2ad)).)
-
-### Theming
-
-Theming is done through toggling top-level CSS classes `theme-light` and `theme-dark`.
-Any style can be made different on either theme by scoping it to one of those two classes.
-Where possible, we use CSS variables, but unfortunately they don't work with compile-time color manipulation (`darken()` etc)
-and runtime color manipulation is not yet implemented in CSS (coming in CSS Color Level 4).
 
 ## Formatting
 

--- a/doc/dev/background-information/web/web_app.md
+++ b/doc/dev/background-information/web/web_app.md
@@ -1,6 +1,59 @@
 # Developing the Sourcegraph web app
 
-Guide to contribute to the Sourcegraph webapp. Please also see our general [TypeScript documentation](https://about.sourcegraph.com/handbook/engineering/languages/typescript).
+Guide to contribute to the Sourcegraph web app. Please also see our general [TypeScript documentation](https://about.sourcegraph.com/handbook/engineering/languages/typescript).
+
+## Local development
+
+Common commands for local development are located [here](../../getting-started/quickstart_6_start_server.md).
+Commands specifically useful for the web team can be found in the root [package.json](https://github.com/sourcegraph/sourcegraph/blob/main/package.json).
+Also, check out the web app [README](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/README.md).
+
+### Prerequisites
+
+The `sg` CLI tool is required for key local development commands. Check out the `sg` [README](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md).
+To install it, use the following command.
+
+```sh
+./dev/sg/install.sh
+```
+
+### Commands
+
+1. Start the web server and point it to any deployed API instance. See more info in the web app [README](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/README.md).
+
+    ```sh
+    sg run web-standalone
+    ```
+
+    For the enterprise version:
+
+    ```sh
+    sg run enterprise-web-standalone
+    ```
+
+2. Start all backend services with the frontend server.
+
+    ```sh
+    ./dev/start.sh
+    ```
+
+    For the enterprise version:
+
+    ```sh
+    ./enterprise/dev/start.sh
+    ```
+
+3. Regenerate GraphQL schema, Typescript types for GraphQL operations and CSS Modules.
+
+    ```sh
+    yarn generate
+    ```
+
+    To regenerate on file change:
+
+    ```sh
+    yarn watch-generate
+    ```
 
 ## Naming files
 
@@ -89,39 +142,3 @@ You can run unit tests via `yarn test` (to run all) or `yarn test --watch` (to r
 ### E2E tests
 
 See [testing.md](../../how-to/testing.md).
-
-### Local development
-
-Basic commands for local development can be found [here](../../getting-started/quickstart_6_start_server.md).
-Commands specifically useful for the web team can be found in the root [package.json](https://github.com/sourcegraph/sourcegraph/blob/main/package.json).
-Also, check out the web app [README](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/README.md).
-
-1. Regenerate GraphQL schema, Typescript types for GraphQL operations, and start a development server for the web app.
-
-   ```sh
-   yarn dev-web
-   ```
-
-2. Same as the previous one, but skip initial code generation task.
-
-   ```sh
-   yarn unsafeDev-web
-   ```
-
-3. Start all backend services and the frontend server with enterprise functionality.
-
-   ```sh
-   ./enterprise/dev/start.sh
-   ```
-
-4. Start the web server only and point it to any deployed API instance. See more info in the web app [README](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/README.md).
-
-  ```sh
-  sg run web-standalone
-  ```
-
-  For enterprise version:
-
-  ```sh
-  sg run enterprise-web-standalone
-  ```


### PR DESCRIPTION
## Changes

- Moved the "Local Development" section to the top of the `web_app.md`.
- Moved the "Styling" section content from the `web_app.md` to `styling.md`.
- Added note about BEM convention usage CSS modules. 

## Notes

Usage of BEM convention in CSS modules has been discussed in multiple PRs and we have both approaches currently in the codebase. Having shorter classes provides [better readability](https://github.com/sourcegraph/sourcegraph/pull/21631#discussion_r644198772) in the component markup, so let's default to _not_ using BEM in CSS modules. If you see any downsides to this decision, please leave a comment.