### PR TITLE
graphql: Use GithubSource instead of raw client

### DIFF
--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -172,5 +172,5 @@ func (r *externalServiceResolver) NextSyncAt() *DateTime {
 var scopeCache = rcache.New("extsvc_token_scope")
 
 func (r *externalServiceResolver) GrantedScopes(ctx context.Context) ([]string, error) {
-	return repos.GrantedScopes(ctx, scopeCache, r.externalService.Kind, r.externalService.Config)
+	return repos.GrantedScopes(ctx, scopeCache, r.externalService)
 }

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/inconshreveable/log15"
 	"github.com/pkg/errors"
 
 	"github.com/sourcegraph/sourcegraph/internal/conf"
@@ -172,5 +173,12 @@ func (r *externalServiceResolver) NextSyncAt() *DateTime {
 var scopeCache = rcache.New("extsvc_token_scope")
 
 func (r *externalServiceResolver) GrantedScopes(ctx context.Context) ([]string, error) {
-	return repos.GrantedScopes(ctx, scopeCache, r.externalService)
+	scope, err := repos.GrantedScopes(ctx, scopeCache, r.externalService)
+	if err != nil {
+		// It's possible that we fail to fetch scope from the code host, in this case we
+		// don't want the entire resolver to fail.
+		log15.Error("Getting service scope", "id", r.externalService.ID, "error", err)
+		return []string{}, nil
+	}
+	return scope, nil
 }

--- a/internal/repos/types_test.go
+++ b/internal/repos/types_test.go
@@ -277,9 +277,10 @@ func TestGrantedScopes(t *testing.T) {
 		return want, nil
 	}
 
+	svc := &types.ExternalService{Kind: extsvc.KindGitHub, Config: `{"token": "abc"}`}
 	// Run twice to use cache
 	for i := 0; i < 2; i++ {
-		have, err := GrantedScopes(ctx, cache, extsvc.KindGitHub, `{"token": "abc"}`)
+		have, err := GrantedScopes(ctx, cache, svc)
 		if err != nil {
 			t.Fatal(i, err)
 		}


### PR DESCRIPTION
This ensures that we set up the correct API routes for both github.com
and enterprise instances.
