### PR TITLE
sg: Improve doctor checks

### DIFF
--- a/sg.config.yaml
+++ b/sg.config.yaml
@@ -426,11 +426,11 @@ commands:
 
 checks:
   docker:
-    cmd: docker -v
-    failMessage: "Failed to run 'docker -v'. Please make sure Docker is running."
+    cmd: docker version
+    failMessage: "Failed to run 'docker version'. Please make sure Docker is running."
 
   redis:
-    cmd: echo "PING" | nc localhost 6379
+    cmd: redis-cli -p 6379 PING
     failMessage: 'Failed to connect to Redis on port 6379. Please make sure Redis is running.'
 
   postgres:


### PR DESCRIPTION
This PR improves the doctor sub command checks.

- We now use `docker version` which actually checks the connection to the Docker daemon.
- We use `redis-cli` to test Redis connectivity instead of relying on netcat being installed.
