### PR TITLE
search: send public field back to zoekt indexserver

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -197,6 +197,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 
 		return &searchbackend.RepoIndexOptions{
 			RepoID:      int32(repo.ID),
+			Public:      !repo.Private,
 			GetVersion:  getVersion,
 			GetPriority: getPriority,
 		}, nil

--- a/internal/search/backend/index_options.go
+++ b/internal/search/backend/index_options.go
@@ -19,6 +19,10 @@ type zoektIndexOptions struct {
 	// RepoID is the Sourcegraph Repository ID.
 	RepoID int32
 
+	// Public is true if the repository is public and does not require auth
+	// filtering.
+	Public bool
+
 	// LargeFiles is a slice of glob patterns where matching file paths should
 	// be indexed regardless of their size. The pattern syntax can be found
 	// here: https://golang.org/pkg/path/filepath/#Match.
@@ -42,6 +46,10 @@ type zoektIndexOptions struct {
 type RepoIndexOptions struct {
 	// RepoID is the Sourcegraph Repository ID.
 	RepoID int32
+
+	// Public is true if the repository is public and does not require auth
+	// filtering.
+	Public bool
 
 	// GetVersion is used to resolve revisions for a repo. If it fails, the
 	// error is encoded in the body. If the revision is missing, an empty
@@ -95,6 +103,7 @@ func getIndexOptions(
 
 	o := &zoektIndexOptions{
 		RepoID:     opts.RepoID,
+		Public:     opts.Public,
 		LargeFiles: c.SearchLargeFiles,
 		Symbols:    getBoolPtr(c.SearchIndexSymbolsEnabled, true),
 	}

--- a/internal/search/backend/index_options_test.go
+++ b/internal/search/backend/index_options_test.go
@@ -51,6 +51,18 @@ func TestGetIndexOptions(t *testing.T) {
 			},
 		},
 	}, {
+		name: "public",
+		conf: schema.SiteConfiguration{},
+		repo: "public",
+		want: zoektIndexOptions{
+			RepoID:  5,
+			Public:  true,
+			Symbols: true,
+			Branches: []zoekt.RepositoryBranch{
+				{Name: "HEAD", Version: "!HEAD"},
+			},
+		},
+	}, {
 		name: "nosymbols",
 		conf: schema.SiteConfiguration{
 			SearchIndexSymbolsEnabled: boolPtr(false)},
@@ -209,7 +221,7 @@ func TestGetIndexOptions(t *testing.T) {
 
 	getRepoIndexOptions := func(repo string) (*RepoIndexOptions, error) {
 		repoID := int32(1)
-		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority"} {
+		for _, r := range []string{"repo", "foo", "not_in_version_context", "priority", "public"} {
 			if r == repo {
 				break
 			}
@@ -221,6 +233,7 @@ func TestGetIndexOptions(t *testing.T) {
 		}
 		return &RepoIndexOptions{
 			RepoID: repoID,
+			Public: repo == "public",
 			GetVersion: func(branch string) (string, error) {
 				return "!" + branch, nil
 			},


### PR DESCRIPTION
We want zoekt to start recording if a repository is private or
public. So we add public to the list of index options we return for a
repository.

Note: the repo table stores "private", but we chose to call the field
"public". This is done in case a mistake is made and the field is
unset. Then go defaults to false => privacy leak.