### PR TITLE
sg: Simplify squashed down migration

### DIFF
--- a/dev/sg/migration.go
+++ b/dev/sg/migration.go
@@ -101,12 +101,7 @@ func generateSquashedMigrations(databaseName string, migrationIndex int) (up, do
 		return "", "", err
 	}
 
-	downMigration, err := generateSquashedDownMigration(databaseName)
-	if err != nil {
-		return "", "", err
-	}
-
-	return upMigration, downMigration, nil
+	return upMigration, "-- Nothing\n", nil
 }
 
 // removeMigrationFilesUpToIndex removes migration files for the given database falling on
@@ -419,22 +414,6 @@ func generateSquashedUpMigration(databaseName, postgresDSN string) (_ string, er
 	}
 
 	return sanitizePgDumpOutput(pgDumpOutput), nil
-}
-
-const squashedDownMigrationTemplate = `
-DROP SCHEMA IF EXISTS public CASCADE;
-CREATE SCHEMA public;
-
-CREATE TABLE IF NOT EXISTS %s (
-	version bigint NOT NULL PRIMARY KEY,
-	dirty boolean NOT NULL
-);
-`
-
-// generateSquashedDownMigration returns the contents of a down migration file containing the
-// canned down migration for this database.
-func generateSquashedDownMigration(databaseName string) (string, error) {
-	return strings.TrimSpace(fmt.Sprintf(squashedDownMigrationTemplate, migrationsTableForDatabase(databaseName))) + "\n", nil
 }
 
 var (


### PR DESCRIPTION
The last squash down migration is no longer necessary to appease tests after https://github.com/sourcegraph/sourcegraph/pull/21711.