### PR TITLE
batches: fix malformed links in deprecation banner

### DIFF
--- a/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangesListIntro.tsx
@@ -55,27 +55,39 @@ const BatchChangesChangelogAlert: React.FunctionComponent = () => (
                 <ul className="text-muted mb-0 pl-3">
                     <li>
                         Commenting on changesets{' '}
-                        <Link to="https://docs.sourcegraph.com/batch_changes/how-tos/bulk_operations_on_changesets">
+                        <a
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://docs.sourcegraph.com/batch_changes/how-tos/bulk_operations_on_changesets"
+                        >
                             is now supported
-                        </Link>
+                        </a>
                         .
                     </li>
                 </ul>
                 <ul className="text-muted mb-0 pl-3">
                     <li>
                         Steps in batch specs can be run conditionally using{' '}
-                        <Link to="https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#steps-if">
+                        <a
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#steps-if"
+                        >
                             the `if:` property
-                        </Link>
+                        </a>
                         .
                     </li>
                 </ul>
                 <ul className="text-muted mb-0 pl-3">
                     <li>
                         User and site credentials can be encrypted in the database by adding a key to{' '}
-                        <Link to="https://docs.sourcegraph.com/admin/config/encryption">
+                        <a
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href="https://docs.sourcegraph.com/admin/config/encryption"
+                        >
                             the `batchChangesCredentialKey` property
-                        </Link>{' '}
+                        </a>{' '}
                         of `encryption.keys` in the site configuration.
                     </li>
                 </ul>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21710.

This banner is likely going away in the next release anyway, but the links were malformed on managed instances and produced URLs like this:

```
https://sourcegraph.com/https://docs.sourcegraph.com/batch_changes/how-tos/bulk_operations_on_changesets
```

This just fixes that by switching them from `Link`s to regular `<a>`s, since we want to keep the full, absolute link URL!
