### PR TITLE
Add new template helper function

### DIFF
--- a/doc/batch_changes/references/batch_spec_templating.md
+++ b/doc/batch_changes/references/batch_spec_templating.md
@@ -127,6 +127,7 @@ They are evaluated after the execution of all entries in `steps`.
 - `${{ replace "a/b/c/d" "/" "-" }}` - replaces occurrences of second argument in the first one with the last one.
 - `${{ split repository.name "/" }}` - splits the first argument into a list of strings at each occurrence of the last argument.
 - `${{ matches repository.name "github.com/my-org/terra*" }}` - matches the first argument against the glob pattern in the second argument, returning true/false.
+- `${{ “${{ repository.name }}” }}` - instructs Sourcegraph to ignore the specified argument
 
 The features of Go's [`text/template`](https://golang.org/pkg/text/template/) package are also available, including conditionals and loops, since it is the underlying templating engine.
 


### PR DESCRIPTION
Add a new template helper function - ${{ "${{ repo.name }}" }} that instructs sourcegraph not to process the included argument
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
