### PR TITLE
frontend: Repair broken startup when reading first_version

### DIFF
--- a/cmd/frontend/backend/versions.go
+++ b/cmd/frontend/backend/versions.go
@@ -71,7 +71,6 @@ func UpdateServiceVersion(ctx context.Context, service, version string) error {
 			upsertVersionQuery,
 			service,
 			version,
-			version,
 			time.Now().UTC(),
 			prev,
 		)
@@ -84,8 +83,8 @@ func UpdateServiceVersion(ctx context.Context, service, version string) error {
 const getVersionQuery = `SELECT version FROM versions WHERE service = %s`
 
 const upsertVersionQuery = `
-INSERT INTO versions (service, version, first_version, updated_at)
-VALUES (%s, %s, %s, %s) ON CONFLICT (service) DO
+INSERT INTO versions (service, version, updated_at)
+VALUES (%s, %s, %s) ON CONFLICT (service) DO
 UPDATE SET (version, updated_at) =
 	(excluded.version, excluded.updated_at)
 WHERE versions.version = %s`

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1777,6 +1777,8 @@ Triggers:
  first_version | text                     |           | not null | 
 Indexes:
     "versions_pkey" PRIMARY KEY, btree (service)
+Triggers:
+    versions_insert BEFORE INSERT ON versions FOR EACH ROW EXECUTE FUNCTION versions_insert_row_trigger()
 
 ```
 

--- a/migrations/frontend/1528395829_first_version_trigger.down.sql
+++ b/migrations/frontend/1528395829_first_version_trigger.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TRIGGER versions_insert ON versions;
+DROP FUNCTION versions_insert_row_trigger;
+
+COMMIT;

--- a/migrations/frontend/1528395829_first_version_trigger.up.sql
+++ b/migrations/frontend/1528395829_first_version_trigger.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION versions_insert_row_trigger() RETURNS trigger LANGUAGE plpgsql AS $lang$
+BEGIN
+    NEW.first_version = NEW.version;
+    RETURN NEW;
+END $lang$;
+
+CREATE TRIGGER versions_insert BEFORE INSERT ON versions FOR EACH ROW EXECUTE PROCEDURE versions_insert_row_trigger();
+
+COMMIT;


### PR DESCRIPTION
https://github.com/sourcegraph/sourcegraph/pull/20967 introduced an issue because we try to read/write our version from the database *prior* to a migration attempt. The following error can occur when the database has a version table, but does not have the most up-to-date columns.

```
│ ERROR: ERROR: column "first_version" of relation "versions" does not exist (SQLSTATE 42703)                                                                                                          ```

This PR fixes the issue by instead of referencing the column directly on write, we can just populate it with a trigger. Since this value is populated only once (on insert), a trigger seems like an appropriate solution.