### PR TITLE
web: update secondary alert border-color

### DIFF
--- a/client/branded/src/global-styles/alert-redesign.scss
+++ b/client/branded/src/global-styles/alert-redesign.scss
@@ -29,14 +29,15 @@
     }
 
     .alert-secondary {
-        --alert-border-color: var(--gray-06);
         --alert-icon-background-color: var(--secondary-4);
 
         @include theme-light-rules {
+            --alert-border-color: var(--secondary-3);
             --alert-icon-color: var(--gray-06);
         }
 
         @include theme-dark-rules {
+            --alert-border-color: var(--secondary);
             --alert-icon-color: var(--gray-05);
         }
     }

--- a/client/shared/src/hover/HoverOverlay.scss
+++ b/client/shared/src/hover/HoverOverlay.scss
@@ -130,7 +130,6 @@
     &__alert-dismiss {
         float: right;
         margin-left: 0.75rem;
-        line-height: 1;
     }
 
     &__actions {
@@ -294,6 +293,10 @@
             border-top: 1px solid var(--hover-overlay-separator-color);
             padding-top: 0.75rem;
             padding-bottom: 0.75rem;
+        }
+
+        &__alert-dismiss {
+            line-height: 1;
         }
 
         &__alert-redesign {

--- a/client/shared/src/hover/HoverOverlay.scss
+++ b/client/shared/src/hover/HoverOverlay.scss
@@ -130,6 +130,7 @@
     &__alert-dismiss {
         float: right;
         margin-left: 0.75rem;
+        line-height: 1;
     }
 
     &__actions {

--- a/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
+++ b/client/web/src/components/WebHoverOverlay/WebHoverOverlay.story.tsx
@@ -180,7 +180,8 @@ add('With dismissible alert with icon', () => (
                 {
                     summary: {
                         kind: MarkupKind.Markdown,
-                        value: 'This is a test alert.',
+                        value:
+                            'Search based result.<br /> [Learn more about precise code intelligence](https://sourcegraph.com/github.com/sourcegraph/code-intel-extensions/-/blob/shared/indicators.ts#L67)',
                     },
                     type: 'test-alert-type',
                     iconKind: 'info',


### PR DESCRIPTION
## Changes

- Updated secondary alert border-color according to the [design QA](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw?node-id=3958:10#84777153).

Related to https://github.com/sourcegraph/sourcegraph/issues/19662.