### PR TITLE
Add sub directory support for test-integration command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "generate": "gulp generate",
     "watch-generate": "gulp watchGenerate",
     "test": "jest --testPathIgnorePatterns end-to-end regression integration storybook",
-    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=2 ./client/web/src/integration/**/*.test.ts",
+    "test-integration": "TS_NODE_PROJECT=client/web/src/integration/tsconfig.json NODE_NO_WARNINGS=1 mocha --parallel=$CI --retries=1 --jobs=2  \"./client/web/src/integration/**/*.test.ts\"",
     "cover-integration": "nyc --hook-require=false yarn test-integration",
     "test-e2e": "TS_NODE_PROJECT=client/web/src/end-to-end/tsconfig.json mocha ./client/web/src/end-to-end/end-to-end.test.ts",
     "cover-e2e": "nyc --hook-require=false --silent=true yarn test-e2e",


### PR DESCRIPTION

it seems like with just `./client/web/src/integration/**/*.test.ts` as a path argument for mocha does't work properly 
By this path we run only files that were placed in a sub directory in integration folder. 


But if wrap glob path for integration tests into quotes `"./client/web/src/integration/**/*.test.ts"` we select all files from top level and from sub levels as well.
