### PR TITLE
Fix navbar jitter in redesign

### DIFF
--- a/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -391,7 +391,7 @@ add(
                             <span>
                                 <span className="text-content" data-test-tab="Comments">
                                     Comments
-                                </span>
+                                </span>{' '}
                                 <span className="badge badge-pill badge-secondary">14</span>
                             </span>
                         </a>
@@ -401,7 +401,7 @@ add(
                             <span>
                                 <span className="text-content" data-test-tab="Changed files">
                                     Changed files
-                                </span>
+                                </span>{' '}
                                 <span className="badge badge-pill badge-secondary">6</span>
                             </span>
                         </a>

--- a/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
+++ b/client/branded/src/global-styles/GlobalStylesStory/GlobalStyles.story.tsx
@@ -388,12 +388,22 @@ add(
                 <ul className="nav nav-tabs mb-2">
                     <li className="nav-item">
                         <a className="nav-link active" href="/" onClick={preventDefault}>
-                            Comments <span className="badge badge-pill badge-secondary">14</span>
+                            <span>
+                                <span className="text-content" data-test-tab="Comments">
+                                    Comments
+                                </span>
+                                <span className="badge badge-pill badge-secondary">14</span>
+                            </span>
                         </a>
                     </li>
                     <li className="nav-item">
                         <a className="nav-link" href="/" onClick={preventDefault}>
-                            Changed files <span className="badge badge-pill badge-secondary">6</span>
+                            <span>
+                                <span className="text-content" data-test-tab="Changed files">
+                                    Changed files
+                                </span>
+                                <span className="badge badge-pill badge-secondary">6</span>
+                            </span>
                         </a>
                     </li>
                 </ul>

--- a/client/branded/src/global-styles/nav.scss
+++ b/client/branded/src/global-styles/nav.scss
@@ -14,8 +14,13 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
 .nav-tabs > .nav-item > .nav-link {
     height: 100%;
     .theme-redesign & {
-        color: var(--text-muted);
+        display: inline-flex;
+        align-items: center;
+        flex-direction: column;
+        justify-content: center;
         border: none;
+        border-bottom: 2px solid transparent;
+        color: var(--text-muted);
         &:focus-visible {
             border-radius: var(--border-radius);
             // Add this new stacking context in order to show the focus ring without cutting any edge.
@@ -27,13 +32,30 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
             margin-top: 0;
             color: var(--body-color);
         }
+        // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
+        .text-content {
+            display: inline-flex;
+            align-items: center;
+            flex-direction: column;
+            justify-content: center;
+            &::after {
+                content: attr(data-test-tab);
+                height: 0;
+                text-transform: capitalize;
+                visibility: hidden; // a11y: avoid detection for voice over
+                overflow: hidden;
+                user-select: none;
+                pointer-events: none;
+                font-weight: 700;
+            }
+        }
     }
 }
 
 .nav-tabs > .nav-item > .nav-link.active {
     .theme-redesign & {
         color: var(--body-color);
-        font-weight: 600;
+        font-weight: 700;
         border-bottom: 2px solid var(--brand-secondary);
     }
 }

--- a/client/branded/src/global-styles/nav.scss
+++ b/client/branded/src/global-styles/nav.scss
@@ -39,7 +39,7 @@ $nav-tabs-link-active-border-color: var(--border-color) var(--border-color) tran
             flex-direction: column;
             justify-content: center;
             &::after {
-                content: attr(data-test-tab);
+                content: attr(data-tab-content);
                 height: 0;
                 text-transform: capitalize;
                 visibility: hidden; // a11y: avoid detection for voice over

--- a/client/branded/src/global-styles/tabs.scss
+++ b/client/branded/src/global-styles/tabs.scss
@@ -59,7 +59,7 @@
         }
         // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
         &::after {
-            content: attr(data-test-tab);
+            content: attr(data-tab-content);
             height: 0;
             text-transform: capitalize;
             visibility: hidden; // a11y: avoid detection for voice over

--- a/client/shared/src/extensions/devtools/index.tsx
+++ b/client/shared/src/extensions/devtools/index.tsx
@@ -38,7 +38,7 @@ const ExtensionDevelopmentTools: React.FunctionComponent<ExtensionsDevelopmentTo
             <div className="tablist-wrapper w-100 align-items-center">
                 <TabList>
                     {TABS.map(({ label, id }) => (
-                        <Tab className="d-flex flex-1 justify-content-around" key={id} data-test-tab={id}>
+                        <Tab className="d-flex flex-1 justify-content-around" key={id} data-tab-content={id}>
                             {label}
                         </Tab>
                     ))}

--- a/client/web/src/end-to-end/end-to-end.test.ts
+++ b/client/web/src/end-to-end/end-to-end.test.ts
@@ -729,7 +729,7 @@ describe('e2e test suite', () => {
                 test(symbolTest.name, async () => {
                     await driver.page.goto(sourcegraphBaseUrl + symbolTest.filePath)
 
-                    await (await driver.page.waitForSelector('[data-test-tab="symbols"]')).click()
+                    await (await driver.page.waitForSelector('[data-tab-content="symbols"]')).click()
 
                     await driver.page.waitForSelector('.test-symbol-name', { visible: true })
 
@@ -785,7 +785,7 @@ describe('e2e test suite', () => {
 
                     await driver.page.goto(repoBaseURL + navigationTest.filePath)
 
-                    await (await driver.page.waitForSelector('[data-test-tab="symbols"]')).click()
+                    await (await driver.page.waitForSelector('[data-tab-content="symbols"]')).click()
 
                     await driver.page.waitForSelector('.test-symbol-name', { visible: true })
 
@@ -818,8 +818,8 @@ describe('e2e test suite', () => {
             for (const { name, filePath, index, line } of highlightSymbolTests) {
                 test(name, async () => {
                     await driver.page.goto(sourcegraphBaseUrl + filePath)
-                    await driver.page.waitForSelector('[data-test-tab="symbols"]')
-                    await driver.page.click('[data-test-tab="symbols"]')
+                    await driver.page.waitForSelector('[data-tab-content="symbols"]')
+                    await driver.page.click('[data-tab-content="symbols"]')
                     await driver.page.waitForSelector('.test-symbol-name', { visible: true })
                     await driver.page.click(`.filtered-connection__nodes li:nth-child(${index + 1}) a`)
 
@@ -933,7 +933,7 @@ describe('e2e test suite', () => {
                 await driver.page.waitForSelector('#repo-revision-popover', { visible: true })
                 await driver.page.click('#repo-revision-popover')
                 // Click "Tags" tab
-                const popoverSelector = '.revisions-popover [data-test-tab="tags"]'
+                const popoverSelector = '.revisions-popover [data-tab-content="tags"]'
                 await driver.page.waitForSelector(popoverSelector, { visible: true })
                 await clickAnchorElement(popoverSelector)
                 const gitReferenceNodeSelector = 'a.git-ref-node[href*="0.5.0"]'

--- a/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
@@ -11,11 +11,10 @@
             margin: 0;
             color: var(--text-muted);
         }
-    }
-
-    [data-reach-tab][data-selected] {
-        color: var(--body-color);
-        font-weight: 700;
+        [data-reach-tab][data-selected] {
+            color: var(--body-color);
+            font-weight: 700;
+        }
     }
 
     [data-reach-tab],

--- a/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
@@ -1,19 +1,57 @@
 // unsets the defaults; can probably go away with the redesign
 .batch-change-tabs {
     .nav-link {
-        color: var(--link-color);
+        :global(.theme-classic) & {
+            color: var(--link-color);
+        }
+    }
+
+    :global(.theme-redesign) & {
+        [data-reach-tab] {
+            margin: 0;
+            color: var(--text-muted);
+        }
+    }
+
+    [data-reach-tab][data-selected] {
+        color: var(--body-color);
+        font-weight: 700;
     }
 
     [data-reach-tab],
     [data-reach-tab]:hover,
     [data-reach-tab][data-selected] {
-        // stylelint-disable-next-line declaration-property-unit-whitelist
-        margin-bottom: -1px;
-        border-bottom: 0;
         padding: 0.5rem 1rem;
         font-size: 0.875rem;
-        font-weight: normal;
-        text-transform: none;
-        letter-spacing: normal;
+        :global(.theme-classic) & {
+            // stylelint-disable-next-line declaration-property-unit-whitelist
+            margin-bottom: -1px;
+            border-bottom: 0;
+            font-weight: normal;
+            text-transform: none;
+            letter-spacing: normal;
+        }
+        :global(.theme-redesign) & {
+            border-top: none;
+            border-left: none;
+            border-right: none;
+            :global(.text-content) {
+                display: inline-flex;
+                align-items: center;
+                flex-direction: column;
+                justify-content: center;
+                // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
+                &::after {
+                    content: attr(data-test-tab);
+                    height: 0;
+                    text-transform: capitalize;
+                    visibility: hidden; // a11y: avoid detection for voice over
+                    overflow: hidden;
+                    user-select: none;
+                    pointer-events: none;
+                    font-weight: 700;
+                }
+            }
+        }
     }
 }

--- a/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
@@ -2,7 +2,9 @@
 .batch-change-tabs {
     .nav-link {
         :global(.theme-classic) & {
-            color: var(--link-color);
+            &:not(:global(.active)) {
+                color: var(--link-color);
+            }
         }
     }
 

--- a/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
+++ b/client/web/src/enterprise/batches/BatchChangeTabs.module.scss
@@ -41,7 +41,7 @@
                 justify-content: center;
                 // ::after used here for avoids the CLS when the font-weight change (see: https://css-tricks.com/bold-on-hover-without-the-layout-shift/)
                 &::after {
-                    content: attr(data-test-tab);
+                    content: attr(data-tab-content);
                     height: 0;
                     text-transform: capitalize;
                     visibility: hidden; // a11y: avoid detection for voice over

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -78,25 +78,53 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
     <BatchChangeTabs history={history} location={location}>
         <BatchChangeTabList>
             <BatchChangeTab index={0} name={TabName.Changesets}>
-                <SourceBranchIcon className="icon-inline text-muted mr-1" />
-                Changesets{' '}
-                <span className="badge badge-pill badge-secondary ml-1">
-                    {batchChange.changesetsStats.total - batchChange.changesetsStats.archived}
+                <span>
+                    <SourceBranchIcon className="icon-inline text-muted mr-1" />
+                    <span className="text-content" data-test-tab="Changesets">
+                        Changesets
+                    </span>{' '}
+                    <span className="badge badge-pill badge-secondary ml-1">
+                        {batchChange.changesetsStats.total - batchChange.changesetsStats.archived}
+                    </span>
                 </span>
             </BatchChangeTab>
             <BatchChangeTab index={1} name={TabName.Chart}>
-                <ChartLineVariantIcon className="icon-inline text-muted mr-1" /> Burndown chart
+                <span>
+                    <ChartLineVariantIcon className="icon-inline text-muted mr-1" />{' '}
+                    <span className="text-content" data-test-tab="Burndown chart">
+                        Burndown chart
+                    </span>
+                </span>
             </BatchChangeTab>
             <BatchChangeTab index={2} name={TabName.Spec}>
-                <FileDocumentIcon className="icon-inline text-muted mr-1" /> Spec
+                <span>
+                    <FileDocumentIcon className="icon-inline text-muted mr-1" />{' '}
+                    <span className="text-content" data-test-tab="Spec">
+                        Spec
+                    </span>
+                </span>
             </BatchChangeTab>
             <BatchChangeTab index={3} name={TabName.Archived}>
-                <ArchiveIcon className="icon-inline text-muted mr-1" /> Archived{' '}
-                <span className="badge badge-pill badge-secondary ml-1">{batchChange.changesetsStats.archived}</span>
+                <span>
+                    <ArchiveIcon className="icon-inline text-muted mr-1" />{' '}
+                    <span className="text-content" data-test-tab="Archived">
+                        Archived
+                    </span>{' '}
+                    <span className="badge badge-pill badge-secondary ml-1">
+                        {batchChange.changesetsStats.archived}
+                    </span>
+                </span>
             </BatchChangeTab>
             <BatchChangeTab index={4} name={TabName.BulkOperations}>
-                <MonitorStarIcon className="icon-inline text-muted mr-1" /> Bulk operations{' '}
-                <span className="badge badge-pill badge-secondary ml-1">{batchChange.bulkOperations.totalCount}</span>
+                <span>
+                    <MonitorStarIcon className="icon-inline text-muted mr-1" />{' '}
+                    <span className="text-content" data-test-tab="Bulk operations">
+                        Bulk operations
+                    </span>{' '}
+                    <span className="badge badge-pill badge-secondary ml-1">
+                        {batchChange.bulkOperations.totalCount}
+                    </span>
+                </span>
             </BatchChangeTab>
         </BatchChangeTabList>
         <BatchChangeTabPanels>

--- a/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
+++ b/client/web/src/enterprise/batches/detail/BatchChangeDetailsTabs.tsx
@@ -80,7 +80,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
             <BatchChangeTab index={0} name={TabName.Changesets}>
                 <span>
                     <SourceBranchIcon className="icon-inline text-muted mr-1" />
-                    <span className="text-content" data-test-tab="Changesets">
+                    <span className="text-content" data-tab-content="Changesets">
                         Changesets
                     </span>{' '}
                     <span className="badge badge-pill badge-secondary ml-1">
@@ -91,7 +91,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
             <BatchChangeTab index={1} name={TabName.Chart}>
                 <span>
                     <ChartLineVariantIcon className="icon-inline text-muted mr-1" />{' '}
-                    <span className="text-content" data-test-tab="Burndown chart">
+                    <span className="text-content" data-tab-content="Burndown chart">
                         Burndown chart
                     </span>
                 </span>
@@ -99,7 +99,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
             <BatchChangeTab index={2} name={TabName.Spec}>
                 <span>
                     <FileDocumentIcon className="icon-inline text-muted mr-1" />{' '}
-                    <span className="text-content" data-test-tab="Spec">
+                    <span className="text-content" data-tab-content="Spec">
                         Spec
                     </span>
                 </span>
@@ -107,7 +107,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
             <BatchChangeTab index={3} name={TabName.Archived}>
                 <span>
                     <ArchiveIcon className="icon-inline text-muted mr-1" />{' '}
-                    <span className="text-content" data-test-tab="Archived">
+                    <span className="text-content" data-tab-content="Archived">
                         Archived
                     </span>{' '}
                     <span className="badge badge-pill badge-secondary ml-1">
@@ -118,7 +118,7 @@ export const BatchChangeDetailsTabs: React.FunctionComponent<BatchChangeDetailsT
             <BatchChangeTab index={4} name={TabName.BulkOperations}>
                 <span>
                     <MonitorStarIcon className="icon-inline text-muted mr-1" />{' '}
-                    <span className="text-content" data-test-tab="Bulk operations">
+                    <span className="text-content" data-tab-content="Bulk operations">
                         Bulk operations
                     </span>{' '}
                     <span className="badge badge-pill badge-secondary ml-1">

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -229,7 +229,7 @@ const BatchChangeListTabHeader: React.FunctionComponent<{
                         className={classNames('nav-link', selectedTab === 'batchChanges' && 'active')}
                         role="button"
                     >
-                        <span className="text-content" data-test-tab="All batch changes">
+                        <span className="text-content" data-tab-content="All batch changes">
                             All batch changes
                         </span>
                     </a>
@@ -242,7 +242,7 @@ const BatchChangeListTabHeader: React.FunctionComponent<{
                         className={classNames('nav-link', selectedTab === 'gettingStarted' && 'active')}
                         role="button"
                     >
-                        <span className="text-content" data-test-tab="Getting started">
+                        <span className="text-content" data-tab-content="Getting started">
                             Getting started
                         </span>
                     </a>

--- a/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
+++ b/client/web/src/enterprise/batches/list/BatchChangeListPage.tsx
@@ -229,7 +229,9 @@ const BatchChangeListTabHeader: React.FunctionComponent<{
                         className={classNames('nav-link', selectedTab === 'batchChanges' && 'active')}
                         role="button"
                     >
-                        All batch changes
+                        <span className="text-content" data-test-tab="All batch changes">
+                            All batch changes
+                        </span>
                     </a>
                 </li>
                 <li className="nav-item">
@@ -240,7 +242,9 @@ const BatchChangeListTabHeader: React.FunctionComponent<{
                         className={classNames('nav-link', selectedTab === 'gettingStarted' && 'active')}
                         role="button"
                     >
-                        Getting started
+                        <span className="text-content" data-test-tab="Getting started">
+                            Getting started
+                        </span>
                     </a>
                 </li>
             </ul>

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
@@ -57,7 +57,7 @@ export const BatchChangePreviewTabs: React.FunctionComponent<BatchChangePreviewT
             <BatchChangeTab index={0} name="previewchangesets">
                 <span>
                     <SourceBranchIcon className="icon-inline text-muted mr-1" />
-                    <span className="text-content" data-test-tab="Preview changesets">
+                    <span className="text-content" data-tab-content="Preview changesets">
                         Preview changesets
                     </span>{' '}
                     <span className="badge badge-pill badge-secondary ml-1">{spec.applyPreview.totalCount}</span>
@@ -66,7 +66,7 @@ export const BatchChangePreviewTabs: React.FunctionComponent<BatchChangePreviewT
             <BatchChangeTab index={1} name="spec">
                 <span>
                     <FileDocumentIcon className="icon-inline text-muted mr-1" />{' '}
-                    <span className="text-content" data-test-tab="Spec">
+                    <span className="text-content" data-tab-content="Spec">
                         Spec
                     </span>
                 </span>

--- a/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
+++ b/client/web/src/enterprise/batches/preview/BatchChangePreviewTabs.tsx
@@ -55,12 +55,21 @@ export const BatchChangePreviewTabs: React.FunctionComponent<BatchChangePreviewT
     <BatchChangeTabs history={history} location={location}>
         <BatchChangeTabList>
             <BatchChangeTab index={0} name="previewchangesets">
-                <SourceBranchIcon className="icon-inline text-muted mr-1" />
-                Preview changesets{' '}
-                <span className="badge badge-pill badge-secondary ml-1">{spec.applyPreview.totalCount}</span>
+                <span>
+                    <SourceBranchIcon className="icon-inline text-muted mr-1" />
+                    <span className="text-content" data-test-tab="Preview changesets">
+                        Preview changesets
+                    </span>{' '}
+                    <span className="badge badge-pill badge-secondary ml-1">{spec.applyPreview.totalCount}</span>
+                </span>
             </BatchChangeTab>
             <BatchChangeTab index={1} name="spec">
-                <FileDocumentIcon className="icon-inline text-muted mr-1" /> Spec
+                <span>
+                    <FileDocumentIcon className="icon-inline text-muted mr-1" />{' '}
+                    <span className="text-content" data-test-tab="Spec">
+                        Spec
+                    </span>
+                </span>
             </BatchChangeTab>
         </BatchChangeTabList>
         <BatchChangeTabPanels>

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.module.scss
@@ -43,7 +43,6 @@ $changeset-backdrop: #f3faff;
     &__tab-link {
         &--active {
             background-color: $changeset-backdrop !important;
-            border-bottom: 1px solid $changeset-backdrop !important;
         }
     }
     &__change-indicator {
@@ -67,7 +66,6 @@ $changeset-backdrop: #f3faff;
         &__tab-link {
             &--active {
                 background-color: var(--oc-gray-7) !important;
-                border-bottom: 1px solid var(--oc-gray-7) !important;
             }
         }
     }

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -252,7 +252,7 @@ const ExpandedSection: React.FunctionComponent<
                                 selectedTab === 'diff' && 'active'
                             )}
                         >
-                            <span className="text-content" data-test-tab="Changed files">
+                            <span className="text-content" data-tab-content="Changed files">
                                 Changed files
                             </span>
                             {node.delta.diffChanged && (
@@ -279,7 +279,7 @@ const ExpandedSection: React.FunctionComponent<
                                 selectedTab === 'description' && 'active'
                             )}
                         >
-                            <span className="text-content" data-test-tab="Description">
+                            <span className="text-content" data-tab-content="Description">
                                 Description
                             </span>
                             {(node.delta.titleChanged || node.delta.bodyChanged) && (
@@ -306,7 +306,7 @@ const ExpandedSection: React.FunctionComponent<
                                 selectedTab === 'commits' && 'active'
                             )}
                         >
-                            <span className="text-content" data-test-tab="Commits">
+                            <span className="text-content" data-tab-content="Commits">
                                 Commits
                             </span>
                             {(node.delta.authorEmailChanged ||

--- a/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
+++ b/client/web/src/enterprise/batches/preview/list/VisibleChangesetApplyPreviewNode.tsx
@@ -252,7 +252,9 @@ const ExpandedSection: React.FunctionComponent<
                                 selectedTab === 'diff' && 'active'
                             )}
                         >
-                            Changed files
+                            <span className="text-content" data-test-tab="Changed files">
+                                Changed files
+                            </span>
                             {node.delta.diffChanged && (
                                 <small className="text-warning ml-2" data-tooltip="Changes in this tab">
                                     <CheckboxBlankCircleIcon
@@ -277,7 +279,9 @@ const ExpandedSection: React.FunctionComponent<
                                 selectedTab === 'description' && 'active'
                             )}
                         >
-                            Description
+                            <span className="text-content" data-test-tab="Description">
+                                Description
+                            </span>
                             {(node.delta.titleChanged || node.delta.bodyChanged) && (
                                 <small className="text-warning ml-2" data-tooltip="Changes in this tab">
                                     <CheckboxBlankCircleIcon
@@ -302,7 +306,9 @@ const ExpandedSection: React.FunctionComponent<
                                 selectedTab === 'commits' && 'active'
                             )}
                         >
-                            Commits
+                            <span className="text-content" data-test-tab="Commits">
+                                Commits
+                            </span>
                             {(node.delta.authorEmailChanged ||
                                 node.delta.authorNameChanged ||
                                 node.delta.commitMessageChanged) && (

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -225,7 +225,7 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
                             <div className="nav nav-tabs">
                                 <div className="nav-item">
                                     <div className="nav-link active">
-                                        <span className="text-content" data-test-tab="Code monitors">
+                                        <span className="text-content" data-tab-content="Code monitors">
                                             Code monitors
                                         </span>
                                     </div>

--- a/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
+++ b/client/web/src/enterprise/code-monitoring/CodeMonitoringPage.tsx
@@ -221,10 +221,14 @@ export const CodeMonitoringPage: React.FunctionComponent<CodeMonitoringPageProps
             {userHasCodeMonitors && userHasCodeMonitors !== 'loading' && !isErrorLike(userHasCodeMonitors) && (
                 <>
                     <div className="d-flex flex-column">
-                        <div className="code-monitoring-page-tabs border-bottom mb-4">
-                            <div className="nav nav-tabs border-bottom-0">
+                        <div className="code-monitoring-page-tabs mb-4">
+                            <div className="nav nav-tabs">
                                 <div className="nav-item">
-                                    <div className="nav-link active">Code monitors</div>
+                                    <div className="nav-link active">
+                                        <span className="text-content" data-test-tab="Code monitors">
+                                            Code monitors
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -155,7 +155,7 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
             >
               <span
                 className="text-content"
-                data-test-tab="Code monitors"
+                data-tab-content="Code monitors"
               >
                 Code monitors
               </span>
@@ -2142,7 +2142,7 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
             >
               <span
                 className="text-content"
-                data-test-tab="Code monitors"
+                data-tab-content="Code monitors"
               >
                 Code monitors
               </span>
@@ -2960,7 +2960,7 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
             >
               <span
                 className="text-content"
-                data-test-tab="Code monitors"
+                data-tab-content="Code monitors"
               >
                 Code monitors
               </span>

--- a/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/__snapshots__/CodeMonitoringPage.test.tsx.snap
@@ -142,10 +142,10 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
       className="d-flex flex-column"
     >
       <div
-        className="code-monitoring-page-tabs border-bottom mb-4"
+        className="code-monitoring-page-tabs mb-4"
       >
         <div
-          className="nav nav-tabs border-bottom-0"
+          className="nav nav-tabs"
         >
           <div
             className="nav-item"
@@ -153,7 +153,12 @@ exports[`CodeMonitoringListPage Code monitoring page with 10 results 1`] = `
             <div
               className="nav-link active"
             >
-              Code monitors
+              <span
+                className="text-content"
+                data-test-tab="Code monitors"
+              >
+                Code monitors
+              </span>
             </div>
           </div>
         </div>
@@ -2124,10 +2129,10 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
       className="d-flex flex-column"
     >
       <div
-        className="code-monitoring-page-tabs border-bottom mb-4"
+        className="code-monitoring-page-tabs mb-4"
       >
         <div
-          className="nav nav-tabs border-bottom-0"
+          className="nav nav-tabs"
         >
           <div
             className="nav-item"
@@ -2135,7 +2140,12 @@ exports[`CodeMonitoringListPage Code monitoring page with less than 10 results 1
             <div
               className="nav-link active"
             >
-              Code monitors
+              <span
+                className="text-content"
+                data-test-tab="Code monitors"
+              >
+                Code monitors
+              </span>
             </div>
           </div>
         </div>
@@ -2937,10 +2947,10 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
       className="d-flex flex-column"
     >
       <div
-        className="code-monitoring-page-tabs border-bottom mb-4"
+        className="code-monitoring-page-tabs mb-4"
       >
         <div
-          className="nav nav-tabs border-bottom-0"
+          className="nav nav-tabs"
         >
           <div
             className="nav-item"
@@ -2948,7 +2958,12 @@ exports[`CodeMonitoringListPage Code monitoring page with more than 10 results 1
             <div
               className="nav-link active"
             >
-              Code monitors
+              <span
+                className="text-content"
+                data-test-tab="Code monitors"
+              >
+                Code monitors
+              </span>
             </div>
           </div>
         </div>

--- a/client/web/src/extensions/extension/ExtensionArea.tsx
+++ b/client/web/src/extensions/extension/ExtensionArea.tsx
@@ -216,12 +216,7 @@ export class ExtensionArea extends React.Component<ExtensionAreaProps> {
 
         return (
             <div className="registry-extension-area">
-                <ExtensionAreaHeader
-                    {...this.props}
-                    {...context}
-                    navItems={this.props.extensionAreaHeaderNavItems}
-                    className="border-bottom"
-                />
+                <ExtensionAreaHeader {...this.props} {...context} navItems={this.props.extensionAreaHeaderNavItems} />
                 <div className="container pt-3">
                     <ErrorBoundary location={this.props.location}>
                         <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -17,7 +17,7 @@ import { ExtensionStatusBadge } from './ExtensionStatusBadge'
 
 interface ExtensionAreaHeaderProps extends ExtensionAreaRouteContext, RouteComponentProps<{}> {
     navItems: readonly ExtensionAreaHeaderNavItem[]
-    className: string
+    className?: string
 }
 
 export type ExtensionAreaHeaderContext = Pick<ExtensionAreaHeaderProps, 'extension'>
@@ -191,7 +191,7 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                             }
                         />
                         <div className="mt-4">
-                            <ul className="nav nav-tabs border-bottom-0">
+                            <ul className="nav nav-tabs">
                                 {props.navItems.map(
                                     ({ to, label, exact, icon: Icon, condition = () => true }) =>
                                         condition(props) && (
@@ -202,7 +202,10 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                                                     activeClassName="active"
                                                     exact={exact}
                                                 >
-                                                    {Icon && <Icon className="icon-inline" />} {label}
+                                                    {Icon && <Icon className="icon-inline" />}{' '}
+                                                    <span className="text-content" data-test-tab={label}>
+                                                        {label}
+                                                    </span>
                                                 </NavLink>
                                             </li>
                                         )

--- a/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
+++ b/client/web/src/extensions/extension/ExtensionAreaHeader.tsx
@@ -203,7 +203,7 @@ export const ExtensionAreaHeader: React.FunctionComponent<ExtensionAreaHeaderPro
                                                     exact={exact}
                                                 >
                                                     {Icon && <Icon className="icon-inline" />}{' '}
-                                                    <span className="text-content" data-test-tab={label}>
+                                                    <span className="text-content" data-tab-content={label}>
                                                         {label}
                                                     </span>
                                                 </NavLink>

--- a/client/web/src/org/area/OrgArea.tsx
+++ b/client/web/src/org/area/OrgArea.tsx
@@ -241,12 +241,7 @@ export class OrgArea extends React.Component<Props> {
 
         return (
             <Page className="org-area">
-                <OrgHeader
-                    {...this.props}
-                    {...context}
-                    navItems={this.props.orgAreaHeaderNavItems}
-                    className="border-bottom"
-                />
+                <OrgHeader {...this.props} {...context} navItems={this.props.orgAreaHeaderNavItems} />
                 <div className="container mt-3">
                     <ErrorBoundary location={this.props.location}>
                         <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>

--- a/client/web/src/org/area/OrgHeader.tsx
+++ b/client/web/src/org/area/OrgHeader.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react'
+import classNames from 'classnames'
+import React from 'react'
 import { Link, NavLink, RouteComponentProps } from 'react-router-dom'
 
 import { PageHeader } from '@sourcegraph/wildcard'
@@ -7,7 +8,6 @@ import { NavItemWithIconDescriptor } from '../../util/contributions'
 import { OrgAvatar } from '../OrgAvatar'
 
 import { OrgAreaPageProps } from './OrgArea'
-import classNames from 'classnames'
 
 interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {
     isSourcegraphDotCom: boolean

--- a/client/web/src/org/area/OrgHeader.tsx
+++ b/client/web/src/org/area/OrgHeader.tsx
@@ -66,7 +66,7 @@ export const OrgHeader: React.FunctionComponent<Props> = ({
                                             >
                                                 <span>
                                                     {Icon && <Icon className="icon-inline" />}{' '}
-                                                    <span className="text-content" data-test-tab={label}>
+                                                    <span className="text-content" data-tab-content={label}>
                                                         {label}
                                                     </span>
                                                 </span>

--- a/client/web/src/org/area/OrgHeader.tsx
+++ b/client/web/src/org/area/OrgHeader.tsx
@@ -7,6 +7,7 @@ import { NavItemWithIconDescriptor } from '../../util/contributions'
 import { OrgAvatar } from '../OrgAvatar'
 
 import { OrgAreaPageProps } from './OrgArea'
+import classNames from 'classnames'
 
 interface Props extends OrgAreaPageProps, RouteComponentProps<{}> {
     isSourcegraphDotCom: boolean
@@ -28,7 +29,7 @@ export const OrgHeader: React.FunctionComponent<Props> = ({
     className = '',
     isSourcegraphDotCom,
 }) => (
-    <div className={`org-header ${className}`}>
+    <div className={classNames('org-header', className)}>
         <div className="container">
             {org && (
                 <>
@@ -52,7 +53,7 @@ export const OrgHeader: React.FunctionComponent<Props> = ({
                         className="mb-3"
                     />
                     <div className="d-flex align-items-end justify-content-between">
-                        <ul className="nav nav-tabs border-bottom-0">
+                        <ul className="nav nav-tabs w-100">
                             {navItems.map(
                                 ({ to, label, exact, icon: Icon, condition = () => true }) =>
                                     condition({ org, isSourcegraphDotCom }) && (
@@ -63,7 +64,12 @@ export const OrgHeader: React.FunctionComponent<Props> = ({
                                                 activeClassName="active"
                                                 exact={exact}
                                             >
-                                                {Icon && <Icon className="icon-inline" />} {label}
+                                                <span>
+                                                    {Icon && <Icon className="icon-inline" />}{' '}
+                                                    <span className="text-content" data-test-tab={label}>
+                                                        {label}
+                                                    </span>
+                                                </span>
                                             </NavLink>
                                         </li>
                                     )

--- a/client/web/src/repo/RepoRevisionSidebar.tsx
+++ b/client/web/src/repo/RepoRevisionSidebar.tsx
@@ -68,10 +68,10 @@ export const RepoRevisionSidebar: React.FunctionComponent<Props> = props => {
                     >
                         <div className={classnames('tablist-wrapper d-flex flex-1', isRedesignEnabled && 'mx-3')}>
                             <TabList>
-                                <Tab data-test-tab="files">
+                                <Tab data-tab-content="files">
                                     <span className="tablist-wrapper--tab-label">Files</span>
                                 </Tab>
-                                <Tab data-test-tab="symbols">
+                                <Tab data-tab-content="symbols">
                                     <span className="tablist-wrapper--tab-label">Symbols</span>
                                 </Tab>
                             </TabList>

--- a/client/web/src/repo/RevisionsPopover.tsx
+++ b/client/web/src/repo/RevisionsPopover.tsx
@@ -254,7 +254,7 @@ export const RevisionsPopover: React.FunctionComponent<Props> = props => {
             <div className="tablist-wrapper revisions-popover__tabs">
                 <TabList>
                     {TABS.map(({ label, id }) => (
-                        <Tab key={id} data-test-tab={id}>
+                        <Tab key={id} data-tab-content={id}>
                             <span className="tablist-wrapper--tab-label">{label}</span>
                         </Tab>
                     ))}

--- a/client/web/src/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/searchContexts/SearchContextsListPage.tsx
@@ -65,54 +65,58 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
 
     return (
         <div className="w-100">
-            <Page>
-                <div className="search-contexts-list-page">
-                    <PageHeader
-                        path={[
-                            {
-                                text: 'Search contexts',
-                            },
-                        ]}
-                        actions={
-                            <Link to="/contexts/new" className="btn btn-secondary">
-                                <PlusIcon className="icon-inline" />
-                                Create search context
-                            </Link>
-                        }
-                        className="mb-2"
-                    />
-                    <p className="text-muted">
-                        Search code you care about with search contexts.{' '}
-                        <a
-                            href="https://docs.sourcegraph.com/code_search/explanations/features#search-contexts"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            Learn more
-                        </a>
-                    </p>
-                    <div className="border-bottom my-4">
-                        <div className="nav nav-tabs border-bottom-0">
-                            <div className="nav-item">
-                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                <a
-                                    href=""
-                                    role="button"
-                                    onClick={onSelectSearchContextsList}
-                                    className={classNames('nav-link', selectedTab === 'list' && 'active')}
-                                >
+            <Page className="search-contexts-list-page">
+                <PageHeader
+                    path={[
+                        {
+                            text: 'Search contexts',
+                        },
+                    ]}
+                    actions={
+                        <Link to="/contexts/new" className="btn btn-secondary">
+                            <PlusIcon className="icon-inline" />
+                            Create search context
+                        </Link>
+                    }
+                    description={
+                        <span className="text-muted">
+                            Search code you care about with search contexts.{' '}
+                            <a
+                                href="https://docs.sourcegraph.com/code_search/explanations/features#search-contexts"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Learn more
+                            </a>
+                        </span>
+                    }
+                    className="mb-3"
+                />
+                <div className="mb-4">
+                    <div className="nav nav-tabs">
+                        <div className="nav-item">
+                            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                            <a
+                                href=""
+                                role="button"
+                                onClick={onSelectSearchContextsList}
+                                className={classNames('nav-link', selectedTab === 'list' && 'active')}
+                            >
+                                <span className="text-content" data-test-tab="Your search contexts">
                                     Your search contexts
-                                </a>
-                            </div>
-                            {props.authenticatedUser?.siteAdmin && (
-                                <div className="nav-item d-flex align-items-center ml-auto">
-                                    <Link to="/contexts/convert-version-contexts">Convert version contexts</Link>
-                                </div>
-                            )}
+                                </span>
+                            </a>
                         </div>
+                        {props.authenticatedUser?.siteAdmin && (
+                            <div className="nav-item d-flex align-items-center ml-auto">
+                                <Link className="nav-link" to="/contexts/convert-version-contexts">
+                                    Convert version contexts
+                                </Link>
+                            </div>
+                        )}
                     </div>
-                    {selectedTab === 'list' && <SearchContextsListTab {...props} />}
                 </div>
+                {selectedTab === 'list' && <SearchContextsListTab {...props} />}
             </Page>
         </div>
     )

--- a/client/web/src/searchContexts/SearchContextsListPage.tsx
+++ b/client/web/src/searchContexts/SearchContextsListPage.tsx
@@ -102,7 +102,7 @@ export const SearchContextsListPage: React.FunctionComponent<SearchContextsListP
                                 onClick={onSelectSearchContextsList}
                                 className={classNames('nav-link', selectedTab === 'list' && 'active')}
                             >
-                                <span className="text-content" data-test-tab="Your search contexts">
+                                <span className="text-content" data-tab-content="Your search contexts">
                                     Your search contexts
                                 </span>
                             </a>

--- a/client/web/src/user/area/UserArea.tsx
+++ b/client/web/src/user/area/UserArea.tsx
@@ -208,7 +208,7 @@ export const UserArea: React.FunctionComponent<UserAreaProps> = ({
 
     return (
         <Page className="user-area">
-            <UserAreaHeader {...props} {...context} navItems={props.userAreaHeaderNavItems} className="border-bottom" />
+            <UserAreaHeader {...props} {...context} navItems={props.userAreaHeaderNavItems} />
             <div className="container mt-3">
                 <ErrorBoundary location={props.location}>
                     <React.Suspense fallback={<LoadingSpinner className="icon-inline m-2" />}>

--- a/client/web/src/user/area/UserAreaHeader.tsx
+++ b/client/web/src/user/area/UserAreaHeader.tsx
@@ -54,7 +54,7 @@ export const UserAreaHeader: React.FunctionComponent<Props> = ({ url, navItems, 
                                     <NavLink to={url + to} className="nav-link" activeClassName="active" exact={exact}>
                                         <span>
                                             {Icon && <Icon className="icon-inline" />}{' '}
-                                            <span className="text-content" data-test-tab={label}>
+                                            <span className="text-content" data-tab-content={label}>
                                                 {label}
                                             </span>
                                         </span>

--- a/client/web/src/user/area/UserAreaHeader.tsx
+++ b/client/web/src/user/area/UserAreaHeader.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import * as React from 'react'
 import { NavLink } from 'react-router-dom'
 
@@ -23,50 +24,46 @@ export interface UserAreaHeaderNavItem extends NavItemWithIconDescriptor<UserAre
  * Header for the user area.
  */
 export const UserAreaHeader: React.FunctionComponent<Props> = ({ url, navItems, className = '', ...props }) => (
-    <div className={`user-area-header ${className}`}>
+    <div className={classNames('user-area-header', className)}>
         <div className="container">
-            {props.user && (
-                <>
-                    <PageHeader
-                        path={[
-                            {
-                                text: (
-                                    <span className="align-middle">
-                                        {props.user.displayName ? (
-                                            <>
-                                                {props.user.displayName} ({props.user.username})
-                                            </>
-                                        ) : (
-                                            props.user.username
-                                        )}
-                                    </span>
-                                ),
-                                icon: () => <UserAvatar className="user-area-header__avatar" user={props.user} />,
-                            },
-                        ]}
-                        className="mb-3"
-                    />
-                    <div className="d-flex align-items-end justify-content-between">
-                        <ul className="nav nav-tabs border-bottom-0">
-                            {navItems.map(
-                                ({ to, label, exact, icon: Icon, condition = () => true }) =>
-                                    condition(props) && (
-                                        <li key={label} className="nav-item">
-                                            <NavLink
-                                                to={url + to}
-                                                className="nav-link"
-                                                activeClassName="active"
-                                                exact={exact}
-                                            >
-                                                {Icon && <Icon className="icon-inline" />} {label}
-                                            </NavLink>
-                                        </li>
-                                    )
-                            )}
-                        </ul>
-                    </div>
-                </>
-            )}
+            <PageHeader
+                path={[
+                    {
+                        text: (
+                            <span className="align-middle">
+                                {props.user.displayName ? (
+                                    <>
+                                        {props.user.displayName} ({props.user.username})
+                                    </>
+                                ) : (
+                                    props.user.username
+                                )}
+                            </span>
+                        ),
+                        icon: () => <UserAvatar className="user-area-header__avatar" user={props.user} />,
+                    },
+                ]}
+                className="mb-3"
+            />
+            <div className="d-flex align-items-end justify-content-between">
+                <ul className="nav nav-tabs w-100">
+                    {navItems.map(
+                        ({ to, label, exact, icon: Icon, condition = () => true }) =>
+                            condition(props) && (
+                                <li key={label} className="nav-item">
+                                    <NavLink to={url + to} className="nav-link" activeClassName="active" exact={exact}>
+                                        <span>
+                                            {Icon && <Icon className="icon-inline" />}{' '}
+                                            <span className="text-content" data-test-tab={label}>
+                                                {label}
+                                            </span>
+                                        </span>
+                                    </NavLink>
+                                </li>
+                            )
+                    )}
+                </ul>
+            </div>
         </div>
     </div>
 )


### PR DESCRIPTION
### Before

https://user-images.githubusercontent.com/19534377/120830375-b76e7800-c55e-11eb-8c19-49fe5ed5d0f7.mov

### After

https://user-images.githubusercontent.com/19534377/120830662-087e6c00-c55f-11eb-87f5-ade50ff160be.mov

This isn't the nicest implementation and likely should be followed up on, but at least it polishes it a bit for the redesign launch. 

Nice side-effect: The border on the user/org pages of the navbar now aligns with the content below it. (See percy)