### PR TITLE
codeintel: Expose associated upload id on index records

### DIFF
--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -443,7 +443,7 @@ var indexColumnsWithNullRank = []*sqlf.Query{
 	sqlf.Sprintf(`u.execution_logs`),
 	sqlf.Sprintf("NULL"),
 	sqlf.Sprintf(`u.local_steps`),
-	sqlf.Sprintf(`` + indexAssociatedUploadIDQueryFragment + ``),
+	sqlf.Sprintf(indexAssociatedUploadIDQueryFragment),
 }
 
 var IndexColumnsWithNullRank = indexColumnsWithNullRank

--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -20,26 +20,27 @@ import (
 // Index is a subset of the lsif_indexes table and stores both processed and unprocessed
 // records.
 type Index struct {
-	ID             int                            `json:"id"`
-	Commit         string                         `json:"commit"`
-	QueuedAt       time.Time                      `json:"queuedAt"`
-	State          string                         `json:"state"`
-	FailureMessage *string                        `json:"failureMessage"`
-	StartedAt      *time.Time                     `json:"startedAt"`
-	FinishedAt     *time.Time                     `json:"finishedAt"`
-	ProcessAfter   *time.Time                     `json:"processAfter"`
-	NumResets      int                            `json:"numResets"`
-	NumFailures    int                            `json:"numFailures"`
-	RepositoryID   int                            `json:"repositoryId"`
-	LocalSteps     []string                       `json:"local_steps"`
-	RepositoryName string                         `json:"repositoryName"`
-	DockerSteps    []DockerStep                   `json:"docker_steps"`
-	Root           string                         `json:"root"`
-	Indexer        string                         `json:"indexer"`
-	IndexerArgs    []string                       `json:"indexer_args"` // TODO - convert this to `IndexCommand string`
-	Outfile        string                         `json:"outfile"`
-	ExecutionLogs  []workerutil.ExecutionLogEntry `json:"execution_logs"`
-	Rank           *int                           `json:"placeInQueue"`
+	ID                 int                            `json:"id"`
+	Commit             string                         `json:"commit"`
+	QueuedAt           time.Time                      `json:"queuedAt"`
+	State              string                         `json:"state"`
+	FailureMessage     *string                        `json:"failureMessage"`
+	StartedAt          *time.Time                     `json:"startedAt"`
+	FinishedAt         *time.Time                     `json:"finishedAt"`
+	ProcessAfter       *time.Time                     `json:"processAfter"`
+	NumResets          int                            `json:"numResets"`
+	NumFailures        int                            `json:"numFailures"`
+	RepositoryID       int                            `json:"repositoryId"`
+	LocalSteps         []string                       `json:"local_steps"`
+	RepositoryName     string                         `json:"repositoryName"`
+	DockerSteps        []DockerStep                   `json:"docker_steps"`
+	Root               string                         `json:"root"`
+	Indexer            string                         `json:"indexer"`
+	IndexerArgs        []string                       `json:"indexer_args"` // TODO - convert this to `IndexCommand string`
+	Outfile            string                         `json:"outfile"`
+	ExecutionLogs      []workerutil.ExecutionLogEntry `json:"execution_logs"`
+	Rank               *int                           `json:"placeInQueue"`
+	AssociatedUploadID *int                           `json:"associatedUpload"`
 }
 
 func (i Index) RecordID() int {
@@ -79,6 +80,7 @@ func scanIndexes(rows *sql.Rows, queryErr error) (_ []Index, err error) {
 			pq.Array(&executionLogs),
 			&index.Rank,
 			pq.Array(&index.LocalSteps),
+			&index.AssociatedUploadID,
 		); err != nil {
 			return nil, err
 		}
@@ -124,6 +126,12 @@ func (s *Store) GetIndexByID(ctx context.Context, id int) (_ Index, _ bool, err 
 	return scanFirstIndex(s.Store.Query(ctx, sqlf.Sprintf(getIndexByIDQuery, id, authzConds)))
 }
 
+const indexAssociatedUploadIDQueryFragment = `
+(
+	SELECT MAX(id) FROM lsif_uploads WHERE associated_index_id = u.id
+) as associated_upload_id
+`
+
 const indexRankQueryFragment = `
 SELECT
 	r.id,
@@ -154,7 +162,8 @@ SELECT
 	u.outfile,
 	u.execution_logs,
 	s.rank,
-	u.local_steps
+	u.local_steps,
+	` + indexAssociatedUploadIDQueryFragment + `
 FROM lsif_indexes_with_repository_name u
 LEFT JOIN (` + indexRankQueryFragment + `) s
 ON u.id = s.id
@@ -209,7 +218,8 @@ SELECT
 	u.outfile,
 	u.execution_logs,
 	s.rank,
-	u.local_steps
+	u.local_steps,
+	` + indexAssociatedUploadIDQueryFragment + `
 FROM lsif_indexes_with_repository_name u
 LEFT JOIN (` + indexRankQueryFragment + `) s
 ON u.id = s.id
@@ -307,7 +317,8 @@ SELECT
 	u.outfile,
 	u.execution_logs,
 	s.rank,
-	u.local_steps
+	u.local_steps,
+	` + indexAssociatedUploadIDQueryFragment + `
 FROM lsif_indexes_with_repository_name u
 LEFT JOIN (` + indexRankQueryFragment + `) s
 ON u.id = s.id
@@ -432,6 +443,7 @@ var indexColumnsWithNullRank = []*sqlf.Query{
 	sqlf.Sprintf(`u.execution_logs`),
 	sqlf.Sprintf("NULL"),
 	sqlf.Sprintf(`u.local_steps`),
+	sqlf.Sprintf(`` + indexAssociatedUploadIDQueryFragment + ``),
 }
 
 var IndexColumnsWithNullRank = indexColumnsWithNullRank

--- a/enterprise/internal/codeintel/stores/dbstore/indexes.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes.go
@@ -129,7 +129,7 @@ func (s *Store) GetIndexByID(ctx context.Context, id int) (_ Index, _ bool, err 
 const indexAssociatedUploadIDQueryFragment = `
 (
 	SELECT MAX(id) FROM lsif_uploads WHERE associated_index_id = u.id
-) as associated_upload_id
+) AS associated_upload_id
 `
 
 const indexRankQueryFragment = `

--- a/enterprise/internal/codeintel/stores/dbstore/indexes_test.go
+++ b/enterprise/internal/codeintel/stores/dbstore/indexes_test.go
@@ -31,6 +31,7 @@ func TestGetIndexByID(t *testing.T) {
 		t.Fatal("unexpected record")
 	}
 
+	uploadID := 5
 	queuedAt := time.Unix(1587396557, 0).UTC()
 	startedAt := queuedAt.Add(time.Minute)
 	expected := Index{
@@ -58,10 +59,12 @@ func TestGetIndexByID(t *testing.T) {
 			{Command: []string{"op", "1"}, Out: "Indexing\nUploading\nDone with 1.\n"},
 			{Command: []string{"op", "2"}, Out: "Indexing\nUploading\nDone with 2.\n"},
 		},
-		Rank: nil,
+		Rank:               nil,
+		AssociatedUploadID: &uploadID,
 	}
 
 	insertIndexes(t, db, expected)
+	insertUploads(t, db, Upload{ID: uploadID, AssociatedIndexID: &expected.ID})
 
 	if index, exists, err := store.GetIndexByID(ctx, 1); err != nil {
 		t.Fatalf("unexpected error getting index: %s", err)
@@ -149,17 +152,26 @@ func TestGetIndexesByIDs(t *testing.T) {
 	store := testStore(db)
 	ctx := context.Background()
 
+	indexID1, indexID2, indexID3, indexID4 := 1, 3, 5, 5 // note the duplication
+	uploadID1, uploadID2, uploadID3, uploadID4 := 10, 11, 12, 13
+
 	insertIndexes(t, db,
-		Index{ID: 1},
+		Index{ID: 1, AssociatedUploadID: &uploadID1},
 		Index{ID: 2},
-		Index{ID: 3},
+		Index{ID: 3, AssociatedUploadID: &uploadID1},
 		Index{ID: 4},
-		Index{ID: 5},
+		Index{ID: 5, AssociatedUploadID: &uploadID1},
 		Index{ID: 6},
 		Index{ID: 7},
 		Index{ID: 8},
 		Index{ID: 9},
 		Index{ID: 10},
+	)
+	insertUploads(t, db,
+		Upload{ID: uploadID1, AssociatedIndexID: &indexID1},
+		Upload{ID: uploadID2, AssociatedIndexID: &indexID2},
+		Upload{ID: uploadID3, AssociatedIndexID: &indexID3},
+		Upload{ID: uploadID4, AssociatedIndexID: &indexID4},
 	)
 
 	t.Run("fetch", func(t *testing.T) {
@@ -217,17 +229,26 @@ func TestGetIndexes(t *testing.T) {
 	t10 := t1.Add(-time.Minute * 9)
 	failureMessage := "unlucky 333"
 
+	indexID1, indexID2, indexID3, indexID4 := 1, 3, 5, 5 // note the duplication
+	uploadID1, uploadID2, uploadID3, uploadID4 := 10, 11, 12, 13
+
 	insertIndexes(t, db,
-		Index{ID: 1, Commit: makeCommit(3331), QueuedAt: t1, State: "queued"},
+		Index{ID: 1, Commit: makeCommit(3331), QueuedAt: t1, State: "queued", AssociatedUploadID: &uploadID1},
 		Index{ID: 2, QueuedAt: t2, State: "errored", FailureMessage: &failureMessage},
-		Index{ID: 3, Commit: makeCommit(3333), QueuedAt: t3, State: "queued"},
+		Index{ID: 3, Commit: makeCommit(3333), QueuedAt: t3, State: "queued", AssociatedUploadID: &uploadID1},
 		Index{ID: 4, QueuedAt: t4, State: "queued", RepositoryID: 51, RepositoryName: "foo bar x"},
-		Index{ID: 5, Commit: makeCommit(3333), QueuedAt: t5, State: "processing"},
+		Index{ID: 5, Commit: makeCommit(3333), QueuedAt: t5, State: "processing", AssociatedUploadID: &uploadID1},
 		Index{ID: 6, QueuedAt: t6, State: "processing", RepositoryID: 52, RepositoryName: "foo bar y"},
 		Index{ID: 7, QueuedAt: t7},
 		Index{ID: 8, QueuedAt: t8},
 		Index{ID: 9, QueuedAt: t9, State: "queued"},
 		Index{ID: 10, QueuedAt: t10},
+	)
+	insertUploads(t, db,
+		Upload{ID: uploadID1, AssociatedIndexID: &indexID1},
+		Upload{ID: uploadID2, AssociatedIndexID: &indexID2},
+		Upload{ID: uploadID3, AssociatedIndexID: &indexID3},
+		Upload{ID: uploadID4, AssociatedIndexID: &indexID4},
 	)
 
 	testCases := []struct {

--- a/internal/database/schema.md
+++ b/internal/database/schema.md
@@ -1008,6 +1008,7 @@ Associates an upload with the set of packages they require within a given packag
 Indexes:
     "lsif_uploads_pkey" PRIMARY KEY, btree (id)
     "lsif_uploads_repository_id_commit_root_indexer" UNIQUE, btree (repository_id, commit, root, indexer) WHERE state = 'completed'::text
+    "lsif_uploads_associated_index_id" btree (associated_index_id)
     "lsif_uploads_commit_last_checked_at" btree (commit_last_checked_at) WHERE state <> 'deleted'::text
     "lsif_uploads_committed_at" btree (committed_at) WHERE state = 'completed'::text
     "lsif_uploads_state" btree (state)

--- a/migrations/frontend/1528395830_index_associated_index_id.down.sql
+++ b/migrations/frontend/1528395830_index_associated_index_id.down.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP INDEX lsif_uploads_associated_index_id;
+
+COMMIT;

--- a/migrations/frontend/1528395830_index_associated_index_id.up.sql
+++ b/migrations/frontend/1528395830_index_associated_index_id.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+CREATE INDEX lsif_uploads_associated_index_id ON lsif_uploads(associated_index_id);
+
+COMMIT;


### PR DESCRIPTION
We expose `associated_index_id` on `lsif_uploads`. This adds the reverse relationship on the index model.