### PR TITLE
Add local storage save logic for search based creation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights queries can now run concurrently up to a limit set by the `insights.query.worker.concurrency` site config. [#21219](https://github.com/sourcegraph/sourcegraph/pull/21219)
 - Code Insights workers now support a rate limit for query execution and historical data frame analysis using the `insights.query.worker.rateLimit` and `insights.historical.worker.rateLimit` site configurations. [#21533](https://github.com/sourcegraph/sourcegraph/pull/21533)
 - The GraphQL `Site` `SettingsSubject` type now has an `allowSiteSettingsEdits` field to allow clients to determine whether the instance uses the `GLOBAL_SETTINGS_FILE` environment variable. [#21827](https://github.com/sourcegraph/sourcegraph/pull/21827)
+- Code Insights creation UI now has auto-save logic and clear all fields functionality  [#21744](https://github.com/sourcegraph/sourcegraph/pull/21744)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Code Insights queries can now run concurrently up to a limit set by the `insights.query.worker.concurrency` site config. [#21219](https://github.com/sourcegraph/sourcegraph/pull/21219)
 - Code Insights workers now support a rate limit for query execution and historical data frame analysis using the `insights.query.worker.rateLimit` and `insights.historical.worker.rateLimit` site configurations. [#21533](https://github.com/sourcegraph/sourcegraph/pull/21533)
 - The GraphQL `Site` `SettingsSubject` type now has an `allowSiteSettingsEdits` field to allow clients to determine whether the instance uses the `GLOBAL_SETTINGS_FILE` environment variable. [#21827](https://github.com/sourcegraph/sourcegraph/pull/21827)
-- Code Insights creation UI now has auto-save logic and clear all fields functionality  [#21744](https://github.com/sourcegraph/sourcegraph/pull/21744)
+- Code Insights creation UI now has auto-save logic and clear all fields functionality [#21744](https://github.com/sourcegraph/sourcegraph/pull/21744)
 
 ### Changed
 

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -130,11 +130,12 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
         }
 
         if (async) {
-            // Due we call start async validation in useLayoutEffect
-            // we have to schedule async validation in the next tick
-            // to be able run observable pipeline validation.
-            // useAsyncValidation hook use useObservable hook internally
-            // which calls .subscribe in useEffect.
+            // Due the call of start async validation in useLayoutEffect we have to
+            // schedule the async validation event in the next tick to be able run
+            // observable pipeline validation since useAsyncValidation hook use
+            // useObservable hook internally which calls '.subscribe' in useEffect.
+            // In order to catch start async validation event we need until next
+            // tick.
             requestAnimationFrame(() => {
                 startAsyncValidation({ value: state.value, validity })
             })

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -130,7 +130,14 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
         }
 
         if (async) {
-            startAsyncValidation({ value: state.value, validity })
+            // Due we call start async validation in useLayoutEffect
+            // we have to schedule async validation in the next tick
+            // to be able run observable pipeline validation.
+            // useAsyncValidation hook use useObservable hook internally
+            // which calls .subscribe in useEffect.
+            requestAnimationFrame(() => {
+                startAsyncValidation({ value: state.value, validity })
+            })
         }
 
         return setState(state => ({

--- a/client/web/src/insights/components/form/hooks/useField.ts
+++ b/client/web/src/insights/components/form/hooks/useField.ts
@@ -134,8 +134,6 @@ export function useField<FormValues, FieldValueKey extends keyof FormAPI<FormVal
             // schedule the async validation event in the next tick to be able run
             // observable pipeline validation since useAsyncValidation hook use
             // useObservable hook internally which calls '.subscribe' in useEffect.
-            // In order to catch start async validation event we need until next
-            // tick.
             requestAnimationFrame(() => {
                 startAsyncValidation({ value: state.value, validity })
             })

--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -72,6 +72,8 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
 
                 await updateSubjectSettings(platformContext, subjectID, editedSettings).toPromise()
 
+                // Clear initial values if user successfully created search insight
+                setInitialFormValues(undefined)
                 telemetryService.log('CodeInsightsCodeStatsCreationPageSubmitClick')
                 history.push('/insights')
             } catch (error) {
@@ -80,10 +82,20 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
 
             return
         },
-        [telemetryService, history, updateSubjectSettings, getSubjectSettings, platformContext, authenticatedUser]
+        [
+            authenticatedUser,
+            getSubjectSettings,
+            updateSubjectSettings,
+            platformContext,
+            setInitialFormValues,
+            telemetryService,
+            history,
+        ]
     )
 
     const handleCancel = useCallback(() => {
+        // Clear initial values if user successfully created search insight
+        setInitialFormValues(undefined)
         telemetryService.log('CodeInsightsCodeStatsCreationPageCancelClick')
         history.push('/insights')
     }, [history, telemetryService])

--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -98,7 +98,7 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
         setInitialFormValues(undefined)
         telemetryService.log('CodeInsightsCodeStatsCreationPageCancelClick')
         history.push('/insights')
-    }, [history, telemetryService])
+    }, [history, setInitialFormValues, telemetryService])
 
     const handleChange = (event: FormChangeEvent<LangStatsCreationFormFields>): void => {
         setInitialFormValues(event.values)

--- a/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/LangStatsInsightCreationPage.tsx
@@ -7,11 +7,12 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError } from '@sourcegraph/shared/src/util/errors'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
 import { AuthenticatedUser } from '../../../../auth'
 import { Page } from '../../../../components/Page'
 import { PageTitle } from '../../../../components/PageTitle'
-import { FORM_ERROR } from '../../../components/form/hooks/useForm'
+import { FORM_ERROR, FormChangeEvent } from '../../../components/form/hooks/useForm'
 import { InsightsApiContext } from '../../../core/backend/api-provider'
 import { addInsightToCascadeSetting } from '../../../core/jsonc-operation'
 
@@ -20,6 +21,7 @@ import {
     LangStatsInsightCreationContentProps,
 } from './components/lang-stats-insight-creation-content/LangStatsInsightCreationContent'
 import styles from './LangStatsInsightCreationPage.module.scss'
+import { LangStatsCreationFormFields } from './types'
 import { getSanitizedLangStatsInsight } from './utils/insight-sanitizer'
 
 const DEFAULT_FINAL_SETTINGS = {}
@@ -39,6 +41,11 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
     const { authenticatedUser, settingsCascade, platformContext, telemetryService } = props
     const { getSubjectSettings, updateSubjectSettings } = useContext(InsightsApiContext)
     const history = useHistory()
+
+    const [initialFormValues, setInitialFormValues] = useLocalStorage<LangStatsCreationFormFields | undefined>(
+        'insights.code-stats-creation',
+        undefined
+    )
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsCodeStatsCreationPage')
@@ -81,6 +88,10 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
         history.push('/insights')
     }, [history, telemetryService])
 
+    const handleChange = (event: FormChangeEvent<LangStatsCreationFormFields>): void => {
+        setInitialFormValues(event.values)
+    }
+
     if (authenticatedUser === null) {
         return <Redirect to="/" />
     }
@@ -107,9 +118,11 @@ export const LangStatsInsightCreationPage: React.FunctionComponent<LangStatsInsi
             <LangStatsInsightCreationContent
                 className="pb-5"
                 settings={settingsCascade.final ?? DEFAULT_FINAL_SETTINGS}
+                initialValues={initialFormValues}
                 organizations={orgs}
                 onSubmit={handleSubmit}
                 onCancel={handleCancel}
+                onChange={handleChange}
             />
         </Page>
     )

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -22,6 +22,7 @@ export interface LangStatsInsightCreationFormProps {
     submitErrors: SubmissionErrors
     submitting: boolean
     className?: string
+    isFormClearActive?: boolean
 
     title: useFieldAPI<LangStatsCreationFormFields['title']>
     repository: useFieldAPI<LangStatsCreationFormFields['repository']>
@@ -30,6 +31,7 @@ export interface LangStatsInsightCreationFormProps {
     organizations: Organization[]
 
     onCancel: () => void
+    onFormReset: () => void
 }
 
 export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsightCreationFormProps> = props => {
@@ -46,6 +48,8 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
         visibility,
         organizations,
         onCancel,
+        onFormReset,
+        isFormClearActive,
     } = props
 
     const isEditMode = mode === 'edit'
@@ -105,7 +109,7 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
 
             <hr className={styles.formSeparator} />
 
-            <div>
+            <div className="d-flex">
                 {submitErrors?.[FORM_ERROR] && <ErrorAlert error={submitErrors[FORM_ERROR]} />}
 
                 <LoaderButton
@@ -120,6 +124,15 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
 
                 <button type="button" className="btn btn-outline-secondary" onClick={onCancel}>
                     Cancel
+                </button>
+
+                <button
+                    type="reset"
+                    disabled={!isFormClearActive}
+                    className="btn ml-auto btn-outline-secondary border-0"
+                    onClick={onFormReset}
+                >
+                    Clear all fields
                 </button>
             </div>
         </form>

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -61,6 +61,7 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
             noValidate={true}
             className={classnames(className, 'd-flex flex-column')}
             onSubmit={handleSubmit}
+            onReset={onFormReset}
         >
             <FormInput
                 required={true}
@@ -130,7 +131,6 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
                     type="reset"
                     disabled={!isFormClearActive}
                     className="btn ml-auto btn-outline-secondary border-0"
-                    onClick={onFormReset}
                 >
                     Clear all fields
                 </button>

--- a/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/lang-stats/components/lang-stats-insight-creation-form/LangStatsInsightCreationForm.tsx
@@ -110,7 +110,7 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
 
             <hr className={styles.formSeparator} />
 
-            <div className="d-flex">
+            <div className="d-flex flex-wrap align-items-baseline">
                 {submitErrors?.[FORM_ERROR] && <ErrorAlert error={submitErrors[FORM_ERROR]} />}
 
                 <LoaderButton
@@ -120,18 +120,14 @@ export const LangStatsInsightCreationForm: React.FunctionComponent<LangStatsInsi
                     label={submitting ? 'Submitting' : isEditMode ? 'Edit insight' : 'Create code insight'}
                     type="submit"
                     disabled={submitting}
-                    className="btn btn-primary mr-2"
+                    className="btn btn-primary mr-2 mb-2"
                 />
 
-                <button type="button" className="btn btn-outline-secondary" onClick={onCancel}>
+                <button type="button" className="btn btn-outline-secondary mb-2 mr-auto" onClick={onCancel}>
                     Cancel
                 </button>
 
-                <button
-                    type="reset"
-                    disabled={!isFormClearActive}
-                    className="btn ml-auto btn-outline-secondary border-0"
-                >
+                <button type="reset" disabled={!isFormClearActive} className="btn btn-outline-secondary border-0">
                     Clear all fields
                 </button>
             </div>

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -99,8 +99,9 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
 
     const handleCancel = useCallback(() => {
         telemetryService.log('CodeInsightsSearchBasedCreationPageCancelClick')
+        setInitialFormValues(undefined)
         history.push('/insights')
-    }, [history, telemetryService])
+    }, [history, setInitialFormValues, telemetryService])
 
     // TODO [VK] Move this logic to high order component to simplify logic here
     if (authenticatedUser === null) {

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -7,11 +7,12 @@ import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { asError } from '@sourcegraph/shared/src/util/errors'
+import { useLocalStorage } from '@sourcegraph/shared/src/util/useLocalStorage'
 
 import { AuthenticatedUser } from '../../../../auth'
 import { Page } from '../../../../components/Page'
 import { PageTitle } from '../../../../components/PageTitle'
-import { FORM_ERROR } from '../../../components/form/hooks/useForm'
+import { FORM_ERROR, FormChangeEvent } from '../../../components/form/hooks/useForm'
 import { InsightsApiContext } from '../../../core/backend/api-provider'
 import { addInsightToCascadeSetting } from '../../../core/jsonc-operation'
 
@@ -20,6 +21,7 @@ import {
     SearchInsightCreationContentProps,
 } from './components/search-insight-creation-content/SearchInsightCreationContent'
 import styles from './SearchInsightCreationPage.module.scss'
+import { CreateInsightFormFields } from './types'
 import { getSanitizedSearchInsight } from './utils/insight-sanitizer'
 
 export interface SearchInsightCreationPageProps
@@ -38,6 +40,11 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
     const { platformContext, authenticatedUser, settingsCascade, telemetryService } = props
     const { updateSubjectSettings, getSubjectSettings } = useContext(InsightsApiContext)
     const history = useHistory()
+
+    const [initialFormValues, setInitialFormValues] = useLocalStorage<CreateInsightFormFields | undefined>(
+        'insights.search-insight-creation',
+        undefined
+    )
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsSearchBasedCreationPage')
@@ -65,6 +72,9 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
                 await updateSubjectSettings(platformContext, subjectID, editedSettings).toPromise()
 
                 telemetryService.log('CodeInsightsSearchBasedCreationPageSubmitClick')
+
+                // Clear initial values if user successfully created search insight
+                setInitialFormValues(undefined)
                 history.push('/insights')
             } catch (error) {
                 return { [FORM_ERROR]: asError(error) }
@@ -72,8 +82,20 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
 
             return
         },
-        [telemetryService, history, updateSubjectSettings, getSubjectSettings, platformContext, authenticatedUser]
+        [
+            authenticatedUser,
+            getSubjectSettings,
+            updateSubjectSettings,
+            platformContext,
+            telemetryService,
+            setInitialFormValues,
+            history,
+        ]
     )
+
+    const handleChange = (event: FormChangeEvent<CreateInsightFormFields>): void => {
+        setInitialFormValues(event.values)
+    }
 
     const handleCancel = useCallback(() => {
         telemetryService.log('CodeInsightsSearchBasedCreationPageCancelClick')
@@ -108,9 +130,11 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
                 className="pb-5"
                 dataTestId="search-insight-create-page-content"
                 settings={settingsCascade.final}
+                initialValue={initialFormValues}
                 organizations={orgs}
                 onSubmit={handleSubmit}
                 onCancel={handleCancel}
+                onChange={handleChange}
             />
         </Page>
     )

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -5,7 +5,7 @@ import { noop } from 'rxjs'
 import { Settings } from '@sourcegraph/shared/src/settings/settings'
 
 import { useField } from '../../../../../components/form/hooks/useField'
-import { SubmissionErrors, useForm } from '../../../../../components/form/hooks/useForm'
+import { FormChangeEvent, SubmissionErrors, useForm } from '../../../../../components/form/hooks/useForm'
 import { useTitleValidator } from '../../../../../components/form/hooks/useTitleValidator'
 import { Organization } from '../../../../../components/visibility-picker/VisibilityPicker'
 import { InsightTypePrefix } from '../../../../../core/types'
@@ -51,6 +51,8 @@ export interface SearchInsightCreationContentProps {
     onSubmit: (values: CreateInsightFormFields) => SubmissionErrors | Promise<SubmissionErrors> | void
     /** Cancel handler. */
     onCancel?: () => void
+    /** Change handlers is called every time when user changed any field within the form. */
+    onChange?: (event: FormChangeEvent<CreateInsightFormFields>) => void
 }
 
 export const SearchInsightCreationContent: React.FunctionComponent<SearchInsightCreationContentProps> = props => {
@@ -63,13 +65,15 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         dataTestId,
         onSubmit,
         onCancel = noop,
+        onChange = noop,
     } = props
 
     const isEditMode = mode === 'edit'
 
-    const { formAPI, ref, handleSubmit } = useForm<CreateInsightFormFields>({
+    const { values, formAPI, ref, handleSubmit } = useForm<CreateInsightFormFields>({
         initialValues: initialValue,
         onSubmit,
+        onChange,
         touched: isEditMode,
     })
 
@@ -91,6 +95,18 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         series,
     })
 
+    const handleFormReset = (): void => {
+        // TODO [VK] Change useForm API in order to implement form.reset method.
+        title.input.onChange('')
+        repositories.input.onChange('')
+        // Focus first element of the form
+        repositories.input.ref.current?.focus()
+        visibility.input.onChange('personal')
+        series.input.onChange([createDefaultEditSeries({ edit: true })])
+        stepValue.input.onChange('2')
+        step.input.onChange('months')
+    }
+
     const validEditSeries = editSeries.filter(series => series.valid)
 
     // If some fields that needed to run live preview  are invalid
@@ -99,6 +115,11 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         (repositories.meta.validState === 'VALID' || repositories.meta.validState === 'CHECKING') &&
         (series.meta.validState === 'VALID' || validEditSeries.length) &&
         stepValue.meta.validState === 'VALID'
+
+    const hasFilledValue =
+        values.series?.some(line => line.name !== '' || line.query !== '') ||
+        values.repositories !== '' ||
+        values.title !== ''
 
     return (
         <div data-testid={dataTestId} className={classnames(styles.content, className)}>
@@ -117,12 +138,14 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
                 series={series}
                 step={step}
                 stepValue={stepValue}
+                isFormClearActive={hasFilledValue}
                 onSeriesLiveChange={listen}
                 onCancel={onCancel}
                 onEditSeriesRequest={editRequest}
                 onEditSeriesCancel={cancelEdit}
                 onEditSeriesCommit={editCommit}
                 onSeriesRemove={deleteSeries}
+                onFormReset={handleFormReset}
             />
 
             <SearchInsightLivePreview

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -28,6 +28,7 @@ interface CreationSearchInsightFormProps {
     submitting: boolean
     submitted: boolean
     className?: string
+    isFormClearActive?: boolean
 
     title: useFieldAPI<CreateInsightFormFields['title']>
     repositories: useFieldAPI<CreateInsightFormFields['repositories']>
@@ -55,6 +56,8 @@ interface CreationSearchInsightFormProps {
     onEditSeriesCommit: (seriesIndex: number, editedSeries: EditableDataSeries) => void
     onEditSeriesCancel: (closedCardIndex: number) => void
     onSeriesRemove: (removedSeriesIndex: number) => void
+
+    onFormReset: () => void
 }
 
 /**
@@ -77,12 +80,14 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
         stepValue,
         step,
         className,
+        isFormClearActive,
         onCancel,
         onSeriesLiveChange,
         onEditSeriesRequest,
         onEditSeriesCommit,
         onEditSeriesCancel,
         onSeriesRemove,
+        onFormReset,
     } = props
 
     const isEditMode = mode === 'edit'
@@ -219,7 +224,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
 
             <hr className={styles.creationInsightFormSeparator} />
 
-            <div>
+            <div className="d-flex">
                 {submitErrors?.[FORM_ERROR] && <ErrorAlert error={submitErrors[FORM_ERROR]} />}
 
                 <LoaderButton
@@ -234,6 +239,15 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
 
                 <button type="button" className="btn btn-outline-secondary" onClick={onCancel}>
                     Cancel
+                </button>
+
+                <button
+                    type="reset"
+                    disabled={!isFormClearActive}
+                    className="btn ml-auto btn-outline-secondary border-0"
+                    onClick={onFormReset}
+                >
+                    Clear all fields
                 </button>
             </div>
         </form>

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -98,6 +98,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
             noValidate={true}
             ref={innerRef}
             onSubmit={handleSubmit}
+            onReset={onFormReset}
             className={classnames(className, 'd-flex flex-column')}
         >
             <FormGroup
@@ -245,7 +246,6 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                     type="reset"
                     disabled={!isFormClearActive}
                     className="btn ml-auto btn-outline-secondary border-0"
-                    onClick={onFormReset}
                 >
                     Clear all fields
                 </button>

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-form/SearchInsightCreationForm.tsx
@@ -225,7 +225,7 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
 
             <hr className={styles.creationInsightFormSeparator} />
 
-            <div className="d-flex">
+            <div className="d-flex flex-wrap align-items-baseline">
                 {submitErrors?.[FORM_ERROR] && <ErrorAlert error={submitErrors[FORM_ERROR]} />}
 
                 <LoaderButton
@@ -235,18 +235,14 @@ export const SearchInsightCreationForm: React.FunctionComponent<CreationSearchIn
                     type="submit"
                     disabled={submitting}
                     data-testid="insight-save-button"
-                    className="btn btn-primary mr-2"
+                    className="btn btn-primary mr-2 mb-2"
                 />
 
-                <button type="button" className="btn btn-outline-secondary" onClick={onCancel}>
+                <button type="button" className="btn btn-outline-secondary mb-2 mr-auto" onClick={onCancel}>
                     Cancel
                 </button>
 
-                <button
-                    type="reset"
-                    disabled={!isFormClearActive}
-                    className="btn ml-auto btn-outline-secondary border-0"
-                >
+                <button type="reset" disabled={!isFormClearActive} className="btn btn-outline-secondary border-0">
                     Clear all fields
                 </button>
             </div>


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21098

This PR adds autosave logic for search-based insight and code stats insight creation UI. 

if the user filled in some fields and left the page. When returning to the form page, it will see the last value of the filled fields.