### PR TITLE
codeintel: Expose associated index/upload id in graphql layer

### DIFF
--- a/cmd/frontend/graphqlbackend/codeintel.go
+++ b/cmd/frontend/graphqlbackend/codeintel.go
@@ -53,6 +53,7 @@ type LSIFUploadResolver interface {
 	FinishedAt() *DateTime
 	InputIndexer() string
 	PlaceInQueue() *int32
+	AssociatedIndex(ctx context.Context) (LSIFIndexResolver, error)
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
 }
 
@@ -86,6 +87,7 @@ type LSIFIndexResolver interface {
 	FinishedAt() *DateTime
 	Steps() IndexStepsResolver
 	PlaceInQueue() *int32
+	AssociatedUpload(ctx context.Context) (LSIFUploadResolver, error)
 	ProjectRoot(ctx context.Context) (*GitTreeEntryResolver, error)
 }
 

--- a/cmd/frontend/graphqlbackend/codeintel.graphql
+++ b/cmd/frontend/graphqlbackend/codeintel.graphql
@@ -425,7 +425,7 @@ type LSIFUpload implements Node {
     startedAt: DateTime
 
     """
-    The time the upload compelted or errored.
+    The time the upload completed or errored.
     """
     finishedAt: DateTime
 
@@ -446,6 +446,11 @@ type LSIFUpload implements Node {
     The rank of this upload in the queue. The value of this field is null if the upload has been processed.
     """
     placeInQueue: Int
+
+    """
+    The LSIF indexing job that created this upload record.
+    """
+    associatedIndex: LSIFIndex
 }
 
 """
@@ -538,7 +543,7 @@ type LSIFIndex implements Node {
     startedAt: DateTime
 
     """
-    The time the index compelted or errored.
+    The time the index completed or errored.
     """
     finishedAt: DateTime
 
@@ -556,6 +561,11 @@ type LSIFIndex implements Node {
     The rank of this index in the queue. The value of this field is null if the index has been processed.
     """
     placeInQueue: Int
+
+    """
+    The LSIF upload created as part of this indexing job.
+    """
+    associatedUpload: LSIFUpload
 }
 
 """

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/index_connection.go
@@ -10,12 +10,14 @@ import (
 
 type IndexConnectionResolver struct {
 	resolver         *resolvers.IndexesResolver
+	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
 }
 
-func NewIndexConnectionResolver(resolver *resolvers.IndexesResolver, locationResolver *CachedLocationResolver) gql.LSIFIndexConnectionResolver {
+func NewIndexConnectionResolver(resolver *resolvers.IndexesResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver) gql.LSIFIndexConnectionResolver {
 	return &IndexConnectionResolver{
 		resolver:         resolver,
+		prefetcher:       prefetcher,
 		locationResolver: locationResolver,
 	}
 }
@@ -27,7 +29,7 @@ func (r *IndexConnectionResolver) Nodes(ctx context.Context) ([]gql.LSIFIndexRes
 
 	resolvers := make([]gql.LSIFIndexResolver, 0, len(r.resolver.Indexes))
 	for i := range r.resolver.Indexes {
-		resolvers = append(resolvers, NewIndexResolver(r.resolver.Indexes[i], r.locationResolver))
+		resolvers = append(resolvers, NewIndexResolver(r.resolver.Indexes[i], r.prefetcher, r.locationResolver))
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/prefetcher.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/prefetcher.go
@@ -1,0 +1,135 @@
+package graphql
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers"
+	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+)
+
+// Prefetcher is a
+type Prefetcher struct {
+	sync.RWMutex
+	resolver    resolvers.Resolver
+	uploadIDs   []int
+	indexIDs    []int
+	uploadCache map[int]store.Upload
+	indexCache  map[int]store.Index
+}
+
+// NewPrefetcher returns a prefetcher with an empty cache.
+func NewPrefetcher(resolver resolvers.Resolver) *Prefetcher {
+	return &Prefetcher{
+		resolver:    resolver,
+		uploadCache: map[int]store.Upload{},
+		indexCache:  map[int]store.Index{},
+	}
+}
+
+// MarkUpload adds the given identifier to the next batch of uploads to fetch.
+func (p *Prefetcher) MarkUpload(id int) {
+	p.Lock()
+	p.uploadIDs = append(p.uploadIDs, id)
+	p.Unlock()
+}
+
+// GetUploadByID will return an upload with the given identifier as well as a boolean
+// flag indicating such a record's existence. If the given ID has already been fetched
+// by another call to GetUploadByID, that record is returned immediately. Otherwise,
+// the given identifier will be added to the current batch of identifiers constructed
+// via calls to MarkUpload. All uploads will in the current batch are requested at once
+// and the upload with the given identifier is returned from that result set.
+func (p *Prefetcher) GetUploadByID(ctx context.Context, id int) (store.Upload, bool, error) {
+	p.RLock()
+	upload, ok := p.uploadCache[id]
+	p.RUnlock()
+	if ok {
+		return upload, true, nil
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	if upload, ok := p.uploadCache[id]; ok {
+		return upload, true, nil
+	}
+
+	m := map[int]struct{}{}
+	for _, x := range append(p.uploadIDs, id) {
+		if _, ok := p.uploadCache[x]; !ok {
+			m[x] = struct{}{}
+		}
+	}
+	ids := make([]int, 0, len(m))
+	for x := range m {
+		ids = append(ids, x)
+	}
+	sort.Ints(ids)
+
+	uploads, err := p.resolver.GetUploadsByIDs(ctx, ids...)
+	if err != nil {
+		return store.Upload{}, false, err
+	}
+	for _, upload := range uploads {
+		p.uploadCache[upload.ID] = upload
+	}
+	p.uploadIDs = nil
+
+	upload, ok = p.uploadCache[id]
+	return upload, ok, nil
+}
+
+// MarkIndex adds the given identifier to the next batch of indexes to fetch.
+func (p *Prefetcher) MarkIndex(id int) {
+	p.Lock()
+	p.indexIDs = append(p.indexIDs, id)
+	p.Unlock()
+}
+
+// GetIndexByID will return an index with the given identifier as well as a boolean
+// flag indicating such a record's existence. If the given ID has already been fetched
+// by another call to GetIndexByID, that record is returned immediately. Otherwise,
+// the given identifier will be added to the current batch of identifiers constructed
+// via calls to MarkIndex. All indexes will in the current batch are requested at once
+// and the index with the given identifier is returned from that result set.
+func (p *Prefetcher) GetIndexByID(ctx context.Context, id int) (store.Index, bool, error) {
+	p.RLock()
+	index, ok := p.indexCache[id]
+	p.RUnlock()
+	if ok {
+		return index, true, nil
+	}
+
+	p.Lock()
+	defer p.Unlock()
+
+	if index, ok := p.indexCache[id]; ok {
+		return index, true, nil
+	}
+
+	m := map[int]struct{}{}
+	for _, x := range append(p.indexIDs, id) {
+		if _, ok := p.indexCache[x]; !ok {
+			m[x] = struct{}{}
+		}
+	}
+	ids := make([]int, 0, len(m))
+	for x := range m {
+		ids = append(ids, x)
+	}
+	sort.Ints(ids)
+
+	indexes, err := p.resolver.GetIndexesByIDs(ctx, ids...)
+	if err != nil {
+		return store.Index{}, false, err
+	}
+	for _, index := range indexes {
+		p.indexCache[index.ID] = index
+	}
+	p.indexIDs = nil
+
+	index, ok = p.indexCache[id]
+	return index, ok, nil
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/prefetcher.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/prefetcher.go
@@ -9,7 +9,10 @@ import (
 	store "github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
 )
 
-// Prefetcher is a
+// Prefetcher is a batch query utility and cache used to reduce the amount of database
+// queries made by a tree of upload and index resolvers. A single prefetcher instance
+// is shared by all sibling resolvers resulting from an upload or index connection, as
+// well as index records resulting from an upload resolver (and vice versa).
 type Prefetcher struct {
 	sync.RWMutex
 	resolver    resolvers.Resolver

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/prefetcher_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/prefetcher_test.go
@@ -1,0 +1,153 @@
+package graphql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	resolvermocks "github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend/internal/codeintel/resolvers/mocks"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+)
+
+func TestPrefetcherUploads(t *testing.T) {
+	mockResolver := resolvermocks.NewMockResolver()
+	prefetcher := NewPrefetcher(mockResolver)
+
+	uploads := map[int]dbstore.Upload{
+		1: {ID: 1},
+		2: {ID: 2},
+		3: {ID: 3},
+		4: {ID: 4},
+		5: {ID: 5},
+	}
+
+	mockResolver.GetUploadsByIDsFunc.SetDefaultHook(func(ctx context.Context, ids ...int) ([]dbstore.Upload, error) {
+		matching := make([]dbstore.Upload, 0, len(ids))
+		for _, id := range ids {
+			matching = append(matching, uploads[id])
+		}
+
+		return matching, nil
+	})
+
+	// Bare fetch
+	if upload, exists, err := prefetcher.GetUploadByID(context.Background(), 1); err != nil {
+		t.Fatalf("unexpected error fetching upload: %s", err)
+	} else if !exists {
+		t.Fatalf("expected upload to exist")
+	} else if diff := cmp.Diff(uploads[1], upload); diff != "" {
+		t.Fatalf("unexpected upload (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetUploadsByIDsFunc.History()); callCount != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, callCount)
+	}
+
+	// Re-fetch cached
+	if upload, exists, err := prefetcher.GetUploadByID(context.Background(), 1); err != nil {
+		t.Fatalf("unexpected error fetching upload: %s", err)
+	} else if !exists {
+		t.Fatalf("expected upload to exist")
+	} else if diff := cmp.Diff(uploads[1], upload); diff != "" {
+		t.Fatalf("unexpected upload (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetUploadsByIDsFunc.History()); callCount != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, callCount)
+	}
+
+	// Fetch batch
+	prefetcher.MarkUpload(2)
+	prefetcher.MarkUpload(3)
+	prefetcher.MarkUpload(4)
+	prefetcher.MarkUpload(6) // unknown id
+
+	if upload, exists, err := prefetcher.GetUploadByID(context.Background(), 2); err != nil {
+		t.Fatalf("unexpected error fetching upload: %s", err)
+	} else if !exists {
+		t.Fatalf("expected upload to exist")
+	} else if diff := cmp.Diff(uploads[2], upload); diff != "" {
+		t.Fatalf("unexpected upload (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetUploadsByIDsFunc.History()); callCount != 2 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 2, callCount)
+	}
+
+	// Cached from earlier
+	if upload, exists, err := prefetcher.GetUploadByID(context.Background(), 4); err != nil {
+		t.Fatalf("unexpected error fetching upload: %s", err)
+	} else if !exists {
+		t.Fatalf("expected upload to exist")
+	} else if diff := cmp.Diff(uploads[4], upload); diff != "" {
+		t.Fatalf("unexpected upload (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetUploadsByIDsFunc.History()); callCount != 2 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 2, callCount)
+	}
+}
+
+func TestPrefetcherIndexes(t *testing.T) {
+	mockResolver := resolvermocks.NewMockResolver()
+	prefetcher := NewPrefetcher(mockResolver)
+
+	indexes := map[int]dbstore.Index{
+		1: {ID: 1},
+		2: {ID: 2},
+		3: {ID: 3},
+		4: {ID: 4},
+		5: {ID: 5},
+	}
+
+	mockResolver.GetIndexesByIDsFunc.SetDefaultHook(func(ctx context.Context, ids ...int) ([]dbstore.Index, error) {
+		matching := make([]dbstore.Index, 0, len(ids))
+		for _, id := range ids {
+			matching = append(matching, indexes[id])
+		}
+
+		return matching, nil
+	})
+
+	// Bare fetch
+	if index, exists, err := prefetcher.GetIndexByID(context.Background(), 1); err != nil {
+		t.Fatalf("unexpected error fetching index: %s", err)
+	} else if !exists {
+		t.Fatalf("expected index to exist")
+	} else if diff := cmp.Diff(indexes[1], index); diff != "" {
+		t.Fatalf("unexpected index (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetIndexesByIDsFunc.History()); callCount != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, callCount)
+	}
+
+	// Re-fetch cached
+	if index, exists, err := prefetcher.GetIndexByID(context.Background(), 1); err != nil {
+		t.Fatalf("unexpected error fetching index: %s", err)
+	} else if !exists {
+		t.Fatalf("expected index to exist")
+	} else if diff := cmp.Diff(indexes[1], index); diff != "" {
+		t.Fatalf("unexpected index (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetIndexesByIDsFunc.History()); callCount != 1 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 1, callCount)
+	}
+
+	// Fetch batch
+	prefetcher.MarkIndex(2)
+	prefetcher.MarkIndex(3)
+	prefetcher.MarkIndex(4)
+	prefetcher.MarkIndex(6) // unknown id
+
+	if index, exists, err := prefetcher.GetIndexByID(context.Background(), 2); err != nil {
+		t.Fatalf("unexpected error fetching index: %s", err)
+	} else if !exists {
+		t.Fatalf("expected index to exist")
+	} else if diff := cmp.Diff(indexes[2], index); diff != "" {
+		t.Fatalf("unexpected index (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetIndexesByIDsFunc.History()); callCount != 2 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 2, callCount)
+	}
+
+	// Cached from earlier
+	if index, exists, err := prefetcher.GetIndexByID(context.Background(), 4); err != nil {
+		t.Fatalf("unexpected error fetching index: %s", err)
+	} else if !exists {
+		t.Fatalf("expected index to exist")
+	} else if diff := cmp.Diff(indexes[4], index); diff != "" {
+		t.Fatalf("unexpected index (-want +got):\n%s", diff)
+	} else if callCount := len(mockResolver.GetIndexesByIDsFunc.History()); callCount != 2 {
+		t.Fatalf("unexpected call count. want=%d have=%d", 2, callCount)
+	}
+}

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/resolver.go
@@ -57,12 +57,16 @@ func (r *Resolver) LSIFUploadByID(ctx context.Context, id graphql.ID) (gql.LSIFU
 		return nil, err
 	}
 
-	upload, exists, err := r.resolver.GetUploadByID(ctx, int(uploadID))
+	// Create a new prefetcher here as we only want to cache upload and index records in
+	// the same graphQL request, not across different request.
+	prefetcher := NewPrefetcher(r.resolver)
+
+	upload, exists, err := prefetcher.GetUploadByID(ctx, int(uploadID))
 	if err != nil || !exists {
 		return nil, err
 	}
 
-	return NewUploadResolver(upload, r.locationResolver), nil
+	return NewUploadResolver(upload, prefetcher, r.locationResolver), nil
 }
 
 func (r *Resolver) LSIFUploads(ctx context.Context, args *gql.LSIFUploadsQueryArgs) (gql.LSIFUploadConnectionResolver, error) {
@@ -76,7 +80,11 @@ func (r *Resolver) LSIFUploadsByRepo(ctx context.Context, args *gql.LSIFReposito
 		return nil, err
 	}
 
-	return NewUploadConnectionResolver(r.resolver.UploadConnectionResolver(opts), r.locationResolver), nil
+	// Create a new prefetcher here as we only want to cache upload and index records in
+	// the same graphQL request, not across different request.
+	prefetcher := NewPrefetcher(r.resolver)
+
+	return NewUploadConnectionResolver(r.resolver.UploadConnectionResolver(opts), prefetcher, r.locationResolver), nil
 }
 
 func (r *Resolver) DeleteLSIFUpload(ctx context.Context, args *struct{ ID graphql.ID }) (*gql.EmptyResponse, error) {
@@ -109,12 +117,16 @@ func (r *Resolver) LSIFIndexByID(ctx context.Context, id graphql.ID) (gql.LSIFIn
 		return nil, err
 	}
 
-	index, exists, err := r.resolver.GetIndexByID(ctx, int(indexID))
+	// Create a new prefetcher here as we only want to cache upload and index records in
+	// the same graphQL request, not across different request.
+	prefetcher := NewPrefetcher(r.resolver)
+
+	index, exists, err := prefetcher.GetIndexByID(ctx, int(indexID))
 	if err != nil || !exists {
 		return nil, err
 	}
 
-	return NewIndexResolver(index, r.locationResolver), nil
+	return NewIndexResolver(index, prefetcher, r.locationResolver), nil
 }
 
 func (r *Resolver) LSIFIndexes(ctx context.Context, args *gql.LSIFIndexesQueryArgs) (gql.LSIFIndexConnectionResolver, error) {
@@ -136,7 +148,11 @@ func (r *Resolver) LSIFIndexesByRepo(ctx context.Context, args *gql.LSIFReposito
 		return nil, err
 	}
 
-	return NewIndexConnectionResolver(r.resolver.IndexConnectionResolver(opts), r.locationResolver), nil
+	// Create a new prefetcher here as we only want to cache upload and index records in
+	// the same graphQL request, not across different request.
+	prefetcher := NewPrefetcher(r.resolver)
+
+	return NewIndexConnectionResolver(r.resolver.IndexConnectionResolver(opts), prefetcher, r.locationResolver), nil
 }
 
 func (r *Resolver) DeleteLSIFIndex(ctx context.Context, args *struct{ ID graphql.ID }) (*gql.EmptyResponse, error) {

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/graphql/upload_connection.go
@@ -10,12 +10,14 @@ import (
 
 type UploadConnectionResolver struct {
 	resolver         *resolvers.UploadsResolver
+	prefetcher       *Prefetcher
 	locationResolver *CachedLocationResolver
 }
 
-func NewUploadConnectionResolver(resolver *resolvers.UploadsResolver, locationResolver *CachedLocationResolver) gql.LSIFUploadConnectionResolver {
+func NewUploadConnectionResolver(resolver *resolvers.UploadsResolver, prefetcher *Prefetcher, locationResolver *CachedLocationResolver) gql.LSIFUploadConnectionResolver {
 	return &UploadConnectionResolver{
 		resolver:         resolver,
+		prefetcher:       prefetcher,
 		locationResolver: locationResolver,
 	}
 }
@@ -27,7 +29,7 @@ func (r *UploadConnectionResolver) Nodes(ctx context.Context) ([]gql.LSIFUploadR
 
 	resolvers := make([]gql.LSIFUploadResolver, 0, len(r.resolver.Uploads))
 	for i := range r.resolver.Uploads {
-		resolvers = append(resolvers, NewUploadResolver(r.resolver.Uploads[i], r.locationResolver))
+		resolvers = append(resolvers, NewUploadResolver(r.resolver.Uploads[i], r.prefetcher, r.locationResolver))
 	}
 	return resolvers, nil
 }

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/iface.go
@@ -22,6 +22,7 @@ type DBStore interface {
 	gitserver.DBStore
 
 	GetUploadByID(ctx context.Context, id int) (dbstore.Upload, bool, error)
+	GetUploadsByIDs(ctx context.Context, ids ...int) ([]dbstore.Upload, error)
 	GetUploads(ctx context.Context, opts dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error)
 	DeleteUploadByID(ctx context.Context, id int) (bool, error)
 	GetDumpsByIDs(ctx context.Context, ids []int) ([]dbstore.Dump, error)
@@ -34,6 +35,7 @@ type DBStore interface {
 	MarkRepositoryAsDirty(ctx context.Context, repositoryID int) error
 	CommitGraphMetadata(ctx context.Context, repositoryID int) (stale bool, updatedAt *time.Time, _ error)
 	GetIndexByID(ctx context.Context, id int) (dbstore.Index, bool, error)
+	GetIndexesByIDs(ctx context.Context, ids ...int) ([]dbstore.Index, error)
 	GetIndexes(ctx context.Context, opts dbstore.GetIndexesOptions) ([]dbstore.Index, int, error)
 	DeleteIndexByID(ctx context.Context, id int) (bool, error)
 	GetIndexConfigurationByRepositoryID(ctx context.Context, repositoryID int) (store.IndexConfiguration, bool, error)

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/mock_iface_test.go
@@ -56,12 +56,18 @@ type MockDBStore struct {
 	// GetIndexesFunc is an instance of a mock function object controlling
 	// the behavior of the method GetIndexes.
 	GetIndexesFunc *DBStoreGetIndexesFunc
+	// GetIndexesByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetIndexesByIDs.
+	GetIndexesByIDsFunc *DBStoreGetIndexesByIDsFunc
 	// GetUploadByIDFunc is an instance of a mock function object
 	// controlling the behavior of the method GetUploadByID.
 	GetUploadByIDFunc *DBStoreGetUploadByIDFunc
 	// GetUploadsFunc is an instance of a mock function object controlling
 	// the behavior of the method GetUploads.
 	GetUploadsFunc *DBStoreGetUploadsFunc
+	// GetUploadsByIDsFunc is an instance of a mock function object
+	// controlling the behavior of the method GetUploadsByIDs.
+	GetUploadsByIDsFunc *DBStoreGetUploadsByIDsFunc
 	// HasCommitFunc is an instance of a mock function object controlling
 	// the behavior of the method HasCommit.
 	HasCommitFunc *DBStoreHasCommitFunc
@@ -137,6 +143,11 @@ func NewMockDBStore() *MockDBStore {
 				return nil, 0, nil
 			},
 		},
+		GetIndexesByIDsFunc: &DBStoreGetIndexesByIDsFunc{
+			defaultHook: func(context.Context, ...int) ([]dbstore.Index, error) {
+				return nil, nil
+			},
+		},
 		GetUploadByIDFunc: &DBStoreGetUploadByIDFunc{
 			defaultHook: func(context.Context, int) (dbstore.Upload, bool, error) {
 				return dbstore.Upload{}, false, nil
@@ -145,6 +156,11 @@ func NewMockDBStore() *MockDBStore {
 		GetUploadsFunc: &DBStoreGetUploadsFunc{
 			defaultHook: func(context.Context, dbstore.GetUploadsOptions) ([]dbstore.Upload, int, error) {
 				return nil, 0, nil
+			},
+		},
+		GetUploadsByIDsFunc: &DBStoreGetUploadsByIDsFunc{
+			defaultHook: func(context.Context, ...int) ([]dbstore.Upload, error) {
+				return nil, nil
 			},
 		},
 		HasCommitFunc: &DBStoreHasCommitFunc{
@@ -214,11 +230,17 @@ func NewMockDBStoreFrom(i DBStore) *MockDBStore {
 		GetIndexesFunc: &DBStoreGetIndexesFunc{
 			defaultHook: i.GetIndexes,
 		},
+		GetIndexesByIDsFunc: &DBStoreGetIndexesByIDsFunc{
+			defaultHook: i.GetIndexesByIDs,
+		},
 		GetUploadByIDFunc: &DBStoreGetUploadByIDFunc{
 			defaultHook: i.GetUploadByID,
 		},
 		GetUploadsFunc: &DBStoreGetUploadsFunc{
 			defaultHook: i.GetUploads,
+		},
+		GetUploadsByIDsFunc: &DBStoreGetUploadsByIDsFunc{
+			defaultHook: i.GetUploadsByIDs,
 		},
 		HasCommitFunc: &DBStoreHasCommitFunc{
 			defaultHook: i.HasCommit,
@@ -1378,6 +1400,122 @@ func (c DBStoreGetIndexesFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
 }
 
+// DBStoreGetIndexesByIDsFunc describes the behavior when the
+// GetIndexesByIDs method of the parent MockDBStore instance is invoked.
+type DBStoreGetIndexesByIDsFunc struct {
+	defaultHook func(context.Context, ...int) ([]dbstore.Index, error)
+	hooks       []func(context.Context, ...int) ([]dbstore.Index, error)
+	history     []DBStoreGetIndexesByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetIndexesByIDs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDBStore) GetIndexesByIDs(v0 context.Context, v1 ...int) ([]dbstore.Index, error) {
+	r0, r1 := m.GetIndexesByIDsFunc.nextHook()(v0, v1...)
+	m.GetIndexesByIDsFunc.appendCall(DBStoreGetIndexesByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetIndexesByIDs
+// method of the parent MockDBStore instance is invoked and the hook queue
+// is empty.
+func (f *DBStoreGetIndexesByIDsFunc) SetDefaultHook(hook func(context.Context, ...int) ([]dbstore.Index, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetIndexesByIDs method of the parent MockDBStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *DBStoreGetIndexesByIDsFunc) PushHook(hook func(context.Context, ...int) ([]dbstore.Index, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DBStoreGetIndexesByIDsFunc) SetDefaultReturn(r0 []dbstore.Index, r1 error) {
+	f.SetDefaultHook(func(context.Context, ...int) ([]dbstore.Index, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DBStoreGetIndexesByIDsFunc) PushReturn(r0 []dbstore.Index, r1 error) {
+	f.PushHook(func(context.Context, ...int) ([]dbstore.Index, error) {
+		return r0, r1
+	})
+}
+
+func (f *DBStoreGetIndexesByIDsFunc) nextHook() func(context.Context, ...int) ([]dbstore.Index, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreGetIndexesByIDsFunc) appendCall(r0 DBStoreGetIndexesByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreGetIndexesByIDsFuncCall objects
+// describing the invocations of this function.
+func (f *DBStoreGetIndexesByIDsFunc) History() []DBStoreGetIndexesByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreGetIndexesByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreGetIndexesByIDsFuncCall is an object that describes an invocation
+// of method GetIndexesByIDs on an instance of MockDBStore.
+type DBStoreGetIndexesByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []dbstore.Index
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
+func (c DBStoreGetIndexesByIDsFuncCall) Args() []interface{} {
+	trailing := []interface{}{}
+	for _, val := range c.Arg1 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0}, trailing...)
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreGetIndexesByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
+}
+
 // DBStoreGetUploadByIDFunc describes the behavior when the GetUploadByID
 // method of the parent MockDBStore instance is invoked.
 type DBStoreGetUploadByIDFunc struct {
@@ -1599,6 +1737,122 @@ func (c DBStoreGetUploadsFuncCall) Args() []interface{} {
 // invocation.
 func (c DBStoreGetUploadsFuncCall) Results() []interface{} {
 	return []interface{}{c.Result0, c.Result1, c.Result2}
+}
+
+// DBStoreGetUploadsByIDsFunc describes the behavior when the
+// GetUploadsByIDs method of the parent MockDBStore instance is invoked.
+type DBStoreGetUploadsByIDsFunc struct {
+	defaultHook func(context.Context, ...int) ([]dbstore.Upload, error)
+	hooks       []func(context.Context, ...int) ([]dbstore.Upload, error)
+	history     []DBStoreGetUploadsByIDsFuncCall
+	mutex       sync.Mutex
+}
+
+// GetUploadsByIDs delegates to the next hook function in the queue and
+// stores the parameter and result values of this invocation.
+func (m *MockDBStore) GetUploadsByIDs(v0 context.Context, v1 ...int) ([]dbstore.Upload, error) {
+	r0, r1 := m.GetUploadsByIDsFunc.nextHook()(v0, v1...)
+	m.GetUploadsByIDsFunc.appendCall(DBStoreGetUploadsByIDsFuncCall{v0, v1, r0, r1})
+	return r0, r1
+}
+
+// SetDefaultHook sets function that is called when the GetUploadsByIDs
+// method of the parent MockDBStore instance is invoked and the hook queue
+// is empty.
+func (f *DBStoreGetUploadsByIDsFunc) SetDefaultHook(hook func(context.Context, ...int) ([]dbstore.Upload, error)) {
+	f.defaultHook = hook
+}
+
+// PushHook adds a function to the end of hook queue. Each invocation of the
+// GetUploadsByIDs method of the parent MockDBStore instance invokes the
+// hook at the front of the queue and discards it. After the queue is empty,
+// the default hook function is invoked for any future action.
+func (f *DBStoreGetUploadsByIDsFunc) PushHook(hook func(context.Context, ...int) ([]dbstore.Upload, error)) {
+	f.mutex.Lock()
+	f.hooks = append(f.hooks, hook)
+	f.mutex.Unlock()
+}
+
+// SetDefaultReturn calls SetDefaultDefaultHook with a function that returns
+// the given values.
+func (f *DBStoreGetUploadsByIDsFunc) SetDefaultReturn(r0 []dbstore.Upload, r1 error) {
+	f.SetDefaultHook(func(context.Context, ...int) ([]dbstore.Upload, error) {
+		return r0, r1
+	})
+}
+
+// PushReturn calls PushDefaultHook with a function that returns the given
+// values.
+func (f *DBStoreGetUploadsByIDsFunc) PushReturn(r0 []dbstore.Upload, r1 error) {
+	f.PushHook(func(context.Context, ...int) ([]dbstore.Upload, error) {
+		return r0, r1
+	})
+}
+
+func (f *DBStoreGetUploadsByIDsFunc) nextHook() func(context.Context, ...int) ([]dbstore.Upload, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if len(f.hooks) == 0 {
+		return f.defaultHook
+	}
+
+	hook := f.hooks[0]
+	f.hooks = f.hooks[1:]
+	return hook
+}
+
+func (f *DBStoreGetUploadsByIDsFunc) appendCall(r0 DBStoreGetUploadsByIDsFuncCall) {
+	f.mutex.Lock()
+	f.history = append(f.history, r0)
+	f.mutex.Unlock()
+}
+
+// History returns a sequence of DBStoreGetUploadsByIDsFuncCall objects
+// describing the invocations of this function.
+func (f *DBStoreGetUploadsByIDsFunc) History() []DBStoreGetUploadsByIDsFuncCall {
+	f.mutex.Lock()
+	history := make([]DBStoreGetUploadsByIDsFuncCall, len(f.history))
+	copy(history, f.history)
+	f.mutex.Unlock()
+
+	return history
+}
+
+// DBStoreGetUploadsByIDsFuncCall is an object that describes an invocation
+// of method GetUploadsByIDs on an instance of MockDBStore.
+type DBStoreGetUploadsByIDsFuncCall struct {
+	// Arg0 is the value of the 1st argument passed to this method
+	// invocation.
+	Arg0 context.Context
+	// Arg1 is a slice containing the values of the variadic arguments
+	// passed to this method invocation.
+	Arg1 []int
+	// Result0 is the value of the 1st result returned from this method
+	// invocation.
+	Result0 []dbstore.Upload
+	// Result1 is the value of the 2nd result returned from this method
+	// invocation.
+	Result1 error
+}
+
+// Args returns an interface slice containing the arguments of this
+// invocation. The variadic slice argument is flattened in this array such
+// that one positional argument and three variadic arguments would result in
+// a slice of four, not two.
+func (c DBStoreGetUploadsByIDsFuncCall) Args() []interface{} {
+	trailing := []interface{}{}
+	for _, val := range c.Arg1 {
+		trailing = append(trailing, val)
+	}
+
+	return append([]interface{}{c.Arg0}, trailing...)
+}
+
+// Results returns an interface slice containing the results of this
+// invocation.
+func (c DBStoreGetUploadsByIDsFuncCall) Results() []interface{} {
+	return []interface{}{c.Result0, c.Result1}
 }
 
 // DBStoreHasCommitFunc describes the behavior when the HasCommit method of

--- a/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
+++ b/enterprise/cmd/frontend/internal/codeintel/resolvers/resolver.go
@@ -22,6 +22,8 @@ import (
 type Resolver interface {
 	GetUploadByID(ctx context.Context, id int) (store.Upload, bool, error)
 	GetIndexByID(ctx context.Context, id int) (store.Index, bool, error)
+	GetUploadsByIDs(ctx context.Context, ids ...int) ([]store.Upload, error)
+	GetIndexesByIDs(ctx context.Context, ids ...int) ([]store.Index, error)
 	UploadConnectionResolver(opts store.GetUploadsOptions) *UploadsResolver
 	IndexConnectionResolver(opts store.GetIndexesOptions) *IndexesResolver
 	DeleteUploadByID(ctx context.Context, uploadID int) error
@@ -78,6 +80,14 @@ func (r *resolver) GetUploadByID(ctx context.Context, id int) (store.Upload, boo
 
 func (r *resolver) GetIndexByID(ctx context.Context, id int) (store.Index, bool, error) {
 	return r.dbStore.GetIndexByID(ctx, id)
+}
+
+func (r *resolver) GetUploadsByIDs(ctx context.Context, ids ...int) ([]store.Upload, error) {
+	return r.dbStore.GetUploadsByIDs(ctx, ids...)
+}
+
+func (r *resolver) GetIndexesByIDs(ctx context.Context, ids ...int) ([]store.Index, error) {
+	return r.dbStore.GetIndexesByIDs(ctx, ids...)
 }
 
 func (r *resolver) UploadConnectionResolver(opts store.GetUploadsOptions) *UploadsResolver {


### PR DESCRIPTION
This adds `AssociatedIndex` to `Upload` resolvers and `AssociatedUploads` to `Index` resolvers.

In order to make sure that we don't have a common n+1 query path when dealing with these objects, I've added a prefetcher layer. To best illustrate how this works, suppose that we have the following query:

```graphql
query Uploads {
  lsifUploads {
    nodes {
      id
      associatedIndex {
        id
      }
    }
  }
}

```

When we hit the `LSIFUploadsConnection` resolver, we create a distinct resolver for each upload. In order to communicate between sibling resolvers, we pass in a `prefetcher` instance that is shared between the siblings. Whenever an upload record resolver is created, it will stash any associated index identifier in the prefetcher (and symmetrically with index records). When the resolver actually wants to resolve the index, it asks the prefetcher for an object by id, which will perform a batch database query with all stashed identifiers and cache the result.

This reduces the number of queries for the query above from `n+1` to two.