### PR TITLE
Create GraphQL CRUD methods for feature flags

### DIFF
--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -1,0 +1,119 @@
+package graphqlbackend
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/database"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
+	"github.com/sourcegraph/sourcegraph/internal/featureflag"
+)
+
+type FeatureFlagResolver struct {
+	db    dbutil.DB
+	inner *featureflag.FeatureFlag
+}
+
+func (f *FeatureFlagResolver) ToFeatureFlagBooleanResolver() (*FeatureFlagBooleanResolver, bool) {
+	if f.inner.Bool != nil {
+		return &FeatureFlagBooleanResolver{f.db, f.inner}, true
+	}
+	return nil, false
+}
+
+func (f *FeatureFlagResolver) ToFeatureFlagRolloutResolver() (*FeatureFlagRolloutResolver, bool) {
+	if f.inner.Rollout != nil {
+		return &FeatureFlagRolloutResolver{f.db, f.inner}, true
+	}
+	return nil, false
+}
+
+type FeatureFlagBooleanResolver struct {
+	db dbutil.DB
+	// Invariant: inner.Bool is non-nil
+	inner *featureflag.FeatureFlag
+}
+
+func (f *FeatureFlagBooleanResolver) Name() string { return f.inner.Name }
+func (f *FeatureFlagBooleanResolver) Value() bool  { return f.inner.Bool.Value }
+func (f *FeatureFlagBooleanResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
+	overrides, err := database.FeatureFlags(f.db).GetOverridesForFlag(ctx, f.inner.Name)
+	if err != nil {
+		return nil, err
+	}
+	return overridesToResolvers(overrides), nil
+}
+
+type FeatureFlagRolloutResolver struct {
+	db dbutil.DB
+	// Invariant: inner.Rollout is non-nil
+	inner *featureflag.FeatureFlag
+}
+
+func (f *FeatureFlagRolloutResolver) Name() string { return f.inner.Name }
+func (f *FeatureFlagRolloutResolver) Rollout() int { return f.inner.Rollout.Rollout }
+func (f *FeatureFlagRolloutResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
+	overrides, err := database.FeatureFlags(f.db).GetOverridesForFlag(ctx, f.inner.Name)
+	if err != nil {
+		return nil, err
+	}
+	return overridesToResolvers(overrides), nil
+}
+
+func overridesToResolvers(input []*featureflag.Override) []*FeatureFlagOverrideResolver {
+	res := make([]*FeatureFlagOverrideResolver, 0, len(input))
+	for _, flag := range input {
+		res = append(res, &FeatureFlagOverrideResolver{flag})
+	}
+	return res
+}
+
+type FeatureFlagOverrideResolver struct {
+	inner *featureflag.Override
+}
+
+func (f *FeatureFlagOverrideResolver) Name() string   { return f.inner.FlagName }
+func (f *FeatureFlagOverrideResolver) Value() bool    { return f.inner.Value }
+func (f *FeatureFlagOverrideResolver) UserID() *int32 { return f.inner.UserID }
+func (f *FeatureFlagOverrideResolver) OrgID() *int32  { return f.inner.OrgID }
+
+type EvaluatedFeatureFlagResolver struct {
+	name  string
+	value bool
+}
+
+func (e *EvaluatedFeatureFlagResolver) Name() string {
+	return e.name
+}
+
+func (e *EvaluatedFeatureFlagResolver) Value() bool {
+	return e.value
+}
+
+func (r *schemaResolver) ViewerFeatureFlags(ctx context.Context) []*EvaluatedFeatureFlagResolver {
+	f := featureflag.FromContext(ctx)
+	return evaluatedFlagsToResolvers(f)
+}
+
+func evaluatedFlagsToResolvers(input map[string]bool) []*EvaluatedFeatureFlagResolver {
+	res := make([]*EvaluatedFeatureFlagResolver, 0, len(input))
+	for k, v := range input {
+		res = append(res, &EvaluatedFeatureFlagResolver{name: k, value: v})
+	}
+	return res
+}
+
+func (r *schemaResolver) FeatureFlags(ctx context.Context) ([]FeatureFlagResolver, error) {
+	flags, err := database.FeatureFlags(r.db).GetFeatureFlags(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return flagsToResolvers(r.db, flags), nil
+}
+
+func flagsToResolvers(db dbutil.DB, flags []*featureflag.FeatureFlag) []FeatureFlagResolver {
+	res := make([]FeatureFlagResolver, 0, len(flags))
+	for _, flag := range flags {
+		res = append(res, FeatureFlagResolver{db, flag})
+	}
+	return res
+}

--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -238,38 +238,14 @@ func (r *schemaResolver) DeleteFeatureFlagOverride(ctx context.Context, args str
 }
 
 func (r *schemaResolver) UpdateFeatureFlagOverride(ctx context.Context, args struct {
-	ID       graphql.ID
-	UserID   *graphql.ID
-	OrgID    *graphql.ID
-	FlagName string
-	Value    bool
+	ID    graphql.ID
+	Value bool
 }) (*FeatureFlagOverrideResolver, error) {
 	spec, err := unmarshalOverrideID(args.ID)
 	if err != nil {
 		return nil, err
 	}
 
-	var uid, oid *int32
-	if args.UserID != nil {
-		u, err := UnmarshalUserID(*args.UserID)
-		if err != nil {
-			return nil, err
-		}
-		uid = &u
-	} else if args.OrgID != nil {
-		o, err := UnmarshalOrgID(*args.OrgID)
-		if err != nil {
-			return nil, err
-		}
-		oid = &o
-	}
-
-	fo := &featureflag.Override{
-		UserID:   uid,
-		OrgID:    oid,
-		FlagName: args.FlagName,
-		Value:    args.Value,
-	}
-	res, err := database.FeatureFlags(r.db).UpdateOverride(ctx, spec.OrgID, spec.UserID, spec.FlagName, fo)
+	res, err := database.FeatureFlags(r.db).UpdateOverride(ctx, spec.OrgID, spec.UserID, spec.FlagName, args.Value)
 	return &FeatureFlagOverrideResolver{r.db, res}, err
 }

--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -53,7 +53,7 @@ type FeatureFlagRolloutResolver struct {
 }
 
 func (f *FeatureFlagRolloutResolver) Name() string   { return f.inner.Name }
-func (f *FeatureFlagRolloutResolver) Rollout() int32 { return int32(f.inner.Rollout.Rollout) }
+func (f *FeatureFlagRolloutResolver) Rollout() int32 { return f.inner.Rollout.Rollout }
 func (f *FeatureFlagRolloutResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
 	overrides, err := database.FeatureFlags(f.db).GetOverridesForFlag(ctx, f.inner.Name)
 	if err != nil {

--- a/cmd/frontend/graphqlbackend/feature_flags.go
+++ b/cmd/frontend/graphqlbackend/feature_flags.go
@@ -53,8 +53,8 @@ type FeatureFlagRolloutResolver struct {
 	inner *featureflag.FeatureFlag
 }
 
-func (f *FeatureFlagRolloutResolver) Name() string   { return f.inner.Name }
-func (f *FeatureFlagRolloutResolver) Rollout() int32 { return f.inner.Rollout.Rollout }
+func (f *FeatureFlagRolloutResolver) Name() string              { return f.inner.Name }
+func (f *FeatureFlagRolloutResolver) RolloutBasisPoints() int32 { return f.inner.Rollout.Rollout }
 func (f *FeatureFlagRolloutResolver) Overrides(ctx context.Context) ([]*FeatureFlagOverrideResolver, error) {
 	overrides, err := database.FeatureFlags(f.db).GetOverridesForFlag(ctx, f.inner.Name)
 	if err != nil {
@@ -161,9 +161,9 @@ func flagsToResolvers(db dbutil.DB, flags []*featureflag.FeatureFlag) []*Feature
 }
 
 func (r *schemaResolver) CreateFeatureFlag(ctx context.Context, args struct {
-	Name    string
-	Value   *bool
-	Rollout *int32
+	Name               string
+	Value              *bool
+	RolloutBasisPoints *int32
 }) (*FeatureFlagResolver, error) {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
@@ -175,8 +175,8 @@ func (r *schemaResolver) CreateFeatureFlag(ctx context.Context, args struct {
 	var err error
 	if args.Value != nil {
 		res, err = ff.CreateBool(ctx, args.Name, *args.Value)
-	} else if args.Rollout != nil {
-		res, err = ff.CreateRollout(ctx, args.Name, *args.Rollout)
+	} else if args.RolloutBasisPoints != nil {
+		res, err = ff.CreateRollout(ctx, args.Name, *args.RolloutBasisPoints)
 	}
 
 	return &FeatureFlagResolver{r.db, res}, err
@@ -192,9 +192,9 @@ func (r *schemaResolver) DeleteFeatureFlag(ctx context.Context, args struct {
 }
 
 func (r *schemaResolver) UpdateFeatureFlag(ctx context.Context, args struct {
-	Name    string
-	Value   *bool
-	Rollout *int32
+	Name               string
+	Value              *bool
+	RolloutBasisPoints *int32
 }) (*FeatureFlagResolver, error) {
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return nil, err
@@ -202,8 +202,8 @@ func (r *schemaResolver) UpdateFeatureFlag(ctx context.Context, args struct {
 	ff := &featureflag.FeatureFlag{Name: args.Name}
 	if args.Value != nil {
 		ff.Bool = &featureflag.FeatureFlagBool{Value: *args.Value}
-	} else if args.Rollout != nil {
-		ff.Rollout = &featureflag.FeatureFlagRollout{Rollout: *args.Rollout}
+	} else if args.RolloutBasisPoints != nil {
+		ff.Rollout = &featureflag.FeatureFlagRollout{Rollout: *args.RolloutBasisPoints}
 	}
 
 	res, err := database.FeatureFlags(r.db).UpdateFeatureFlag(ctx, ff)

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -614,77 +614,67 @@ type Mutation {
         repositories: [SearchContextRepositoryRevisionsInput!]!
     ): SearchContext!
 
-	"""
-	(experimental) Create a new feature flag
-	"""
-	createFeatureFlag(
-			"""
-			The name of the feature flag
-			"""
-			name: String!
-			
-			"""
-			The value of the feature flag. Only set if the new feature flag
-			will be a concrete boolean flag. Mutually exclusive with rollout.
-			"""
-			value: Boolean
+    """
+    (experimental) Create a new feature flag
+    """
+    createFeatureFlag(
+        """
+        The name of the feature flag
+        """
+        name: String!
 
-			"""
-			The proportion of users the feature flag will be applied to in increments
-			of 0.01%. Only set if the new feature flag will be a rollout flag. 
-			Mutually exclusive with value.
-			"""
-			rollout: Int
-	): FeatureFlag!
-	   
-	"""
-	(experimental) Delete a feature flag
-	"""
-	deleteFeatureFlag(
-			"""
-			The name of the feature flag
-			"""
-			name: String!
-	): EmptyResponse!
+        """
+        The value of the feature flag. Only set if the new feature flag
+        will be a concrete boolean flag. Mutually exclusive with rollout.
+        """
+        value: Boolean
 
-	"""
-	(experimental) Update a feature flag
-	"""
-	updateFeatureFlag(
-			"""
-			The name of the feature flag
-			"""
-			name: String!
-			
-			"""
-			The value of the feature flag. Only set if the new feature flag
-			will be a concrete boolean flag. Mutually exclusive with rollout.
-			"""
-			value: Boolean
+        """
+        The proportion of users the feature flag will be applied to in increments
+        of 0.01%. Only set if the new feature flag will be a rollout flag.
+        Mutually exclusive with value.
+        """
+        rollout: Int
+    ): FeatureFlag!
 
-			"""
-			The proportion of users the feature flag will be applied to in increments
-			of 0.01%. Only set if the new feature flag will be a rollout flag. 
-			Mutually exclusive with value.
-			"""
-			rollout: Int
-	): FeatureFlag!
+    """
+    (experimental) Delete a feature flag
+    """
+    deleteFeatureFlag(
+        """
+        The name of the feature flag
+        """
+        name: String!
+    ): EmptyResponse!
 
-	createFeatureFlagOverride(
-		orgID: ID
-		userID: ID
-		flagName: String!
-		value: Boolean!
-	): FeatureFlagOverride!
+    """
+    (experimental) Update a feature flag
+    """
+    updateFeatureFlag(
+        """
+        The name of the feature flag
+        """
+        name: String!
 
-	deleteFeatureFlagOverride(
-		id: ID!
-	): EmptyResponse!
+        """
+        The value of the feature flag. Only set if the new feature flag
+        will be a concrete boolean flag. Mutually exclusive with rollout.
+        """
+        value: Boolean
 
-	updateFeatureFlagOverride(
-		id: ID!
-		value: Boolean!
-	): FeatureFlagOverride!
+        """
+        The proportion of users the feature flag will be applied to in increments
+        of 0.01%. Only set if the new feature flag will be a rollout flag.
+        Mutually exclusive with value.
+        """
+        rollout: Int
+    ): FeatureFlag!
+
+    createFeatureFlagOverride(orgID: ID, userID: ID, flagName: String!, value: Boolean!): FeatureFlagOverride!
+
+    deleteFeatureFlagOverride(id: ID!): EmptyResponse!
+
+    updateFeatureFlagOverride(id: ID!, value: Boolean!): FeatureFlagOverride!
 }
 
 """
@@ -1356,7 +1346,7 @@ type Query {
     """
     Retrieve the list of defined feature flags
     """
-	featureFlags: [FeatureFlag!]!
+    featureFlags: [FeatureFlag!]!
 }
 
 """
@@ -1381,7 +1371,7 @@ type FeatureFlagBoolean {
     """
     Overrides that apply to the feature flag
     """
-	overrides: [FeatureFlagOverride!]!
+    overrides: [FeatureFlagOverride!]!
 }
 
 """
@@ -1402,16 +1392,16 @@ type FeatureFlagRollout {
     """
     Overrides that apply to the feature flag
     """
-	overrides: [FeatureFlagOverride!]!
+    overrides: [FeatureFlagOverride!]!
 }
 
 """
 A feature flag override is an override of a feature flag's value for a specific org or user
 """
 type FeatureFlagOverride {
-	id: ID!
-	user: User
-	org: Org
+    id: ID!
+    user: User
+    org: Org
     """
     The name of the feature flag being overridden
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -674,16 +674,9 @@ type Mutation {
     """
     createFeatureFlagOverride(
         """
-        The orgID for the org this override will apply to.
-        Mutually exclusive with userID.
+        The namespace for this feature flag. Must be either a user ID or an org ID.
         """
-        orgID: ID
-
-        """
-        The userID for the user this override will apply to.
-        Mutually exclusive with orgID.
-        """
-        userID: ID
+        namespace: ID!
 
         """
         The name of the feature flag this override applies to
@@ -1450,16 +1443,9 @@ type FeatureFlagOverride {
     id: ID!
 
     """
-    The user this feature flag override applies to, if set.
-    Mutually exclusive with Org
+    The namespace for this override. Will always be a user or org.
     """
-    user: User
-
-    """
-    The org this feature flag override applies to, if set.
-    Mutually exclusive with User
-    """
-    org: Org
+    namespace: Namespace!
 
     """
     The name of the feature flag being overridden

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -670,11 +670,57 @@ type Mutation {
         rollout: Int
     ): FeatureFlag!
 
-    createFeatureFlagOverride(orgID: ID, userID: ID, flagName: String!, value: Boolean!): FeatureFlagOverride!
+    """
+    (experimental) Create a new feature flag override for the given org or user
+    """
+    createFeatureFlagOverride(
+        """
+        The orgID for the org this override will apply to.
+        Mutually exclusive with userID.
+        """
+        orgID: ID
 
-    deleteFeatureFlagOverride(id: ID!): EmptyResponse!
+        """
+        The userID for the user this override will apply to.
+        Mutually exclusive with orgID.
+        """
+        userID: ID
 
-    updateFeatureFlagOverride(id: ID!, value: Boolean!): FeatureFlagOverride!
+        """
+        The name of the feature flag this override applies to
+        """
+        flagName: String!
+
+        """
+        The overridden value
+        """
+        value: Boolean!
+    ): FeatureFlagOverride!
+
+    """
+    Delete a feature flag override
+    """
+    deleteFeatureFlagOverride(
+        """
+        The ID of the feature flag override to delete
+        """
+        id: ID!
+    ): EmptyResponse!
+
+    """
+    Update a feature flag override
+    """
+    updateFeatureFlagOverride(
+        """
+        The ID of the feature flag override to update
+        """
+        id: ID!
+
+        """
+        The updated value of the feature flag override
+        """
+        value: Boolean!
+    ): FeatureFlagOverride!
 }
 
 """
@@ -1399,9 +1445,23 @@ type FeatureFlagRollout {
 A feature flag override is an override of a feature flag's value for a specific org or user
 """
 type FeatureFlagOverride {
+    """
+    A unique ID for this feature flag override
+    """
     id: ID!
+
+    """
+       The user this feature flag override applies to, if set.
+    Mutually exclusive with Org
+    """
     user: User
+
+    """
+       The org this feature flag override applies to, if set.
+    Mutually exclusive with User
+    """
     org: Org
+
     """
     The name of the feature flag being overridden
     """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1474,22 +1474,6 @@ type FeatureFlagOverride {
 }
 
 """
-An evaluated feature flag is any feature flag (static or random) that has been evaluated to
-a concrete value for a given viewer.
-"""
-type EvaluatedFeatureFlag {
-    """
-    The name of the feature flag
-    """
-    name: String!
-
-    """
-    The concrete evaluated value of the feature flag
-    """
-    value: Boolean!
-}
-
-"""
 An out-of-band migration is a process that runs in the background of the instance that moves
 data from one format into another format. Out-of-band migrations
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -671,8 +671,8 @@ type Mutation {
 	): FeatureFlag!
 
 	createFeatureFlagOverride(
-		userID: ID
 		orgID: ID
+		userID: ID
 		flagName: String!
 		value: Boolean!
 	): FeatureFlagOverride!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -683,9 +683,6 @@ type Mutation {
 
 	updateFeatureFlagOverride(
 		id: ID!
-		userID: ID
-		orgID: ID
-		flagName: String!
 		value: Boolean!
 	): FeatureFlagOverride!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -631,7 +631,7 @@ type Mutation {
 
         """
         The ratio of users the feature flag will apply to, expressed in basis points (0.01%).
-		Only set if the new feature flag will be a rollout flag.
+        Only set if the new feature flag will be a rollout flag.
         Mutually exclusive with value.
         """
         rolloutBasisPoints: Int
@@ -663,7 +663,7 @@ type Mutation {
         value: Boolean
 
         """
-		The ratio of users the feasture flag will apply to, expressed in basis points (0.01%).
+        The ratio of users the feature flag will apply to, expressed in basis points (0.01%).
         Mutually exclusive with value.
         """
         rolloutBasisPoints: Int
@@ -1429,8 +1429,8 @@ type FeatureFlagRollout {
     name: String!
 
     """
-    The ratio of users that will be assigned this this feature flag, expressed in 
-	basis points (0.01%).
+    The ratio of users that will be assigned this this feature flag, expressed in
+    basis points (0.01%).
     """
     rolloutBasisPoints: Int!
 
@@ -1467,7 +1467,7 @@ type FeatureFlagOverride {
     targetFlag: FeatureFlag!
 
     """
-    The overriden value of hte feature flag
+    The overridden value of hte feature flag
     """
     value: Boolean!
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -625,16 +625,16 @@ type Mutation {
 
         """
         The value of the feature flag. Only set if the new feature flag
-        will be a concrete boolean flag. Mutually exclusive with rollout.
+        will be a concrete boolean flag. Mutually exclusive with rolloutBasisPoints.
         """
         value: Boolean
 
         """
-        The proportion of users the feature flag will be applied to in increments
-        of 0.01%. Only set if the new feature flag will be a rollout flag.
+        The ratio of users the feature flag will apply to, expressed in basis points (0.01%).
+		Only set if the new feature flag will be a rollout flag.
         Mutually exclusive with value.
         """
-        rollout: Int
+        rolloutBasisPoints: Int
     ): FeatureFlag!
 
     """
@@ -663,11 +663,10 @@ type Mutation {
         value: Boolean
 
         """
-        The proportion of users the feature flag will be applied to in increments
-        of 0.01%. Only set if the new feature flag will be a rollout flag.
+		The ratio of users the feasture flag will apply to, expressed in basis points (0.01%).
         Mutually exclusive with value.
         """
-        rollout: Int
+        rolloutBasisPoints: Int
     ): FeatureFlag!
 
     """
@@ -1430,10 +1429,10 @@ type FeatureFlagRollout {
     name: String!
 
     """
-    The proportion of users who will be randomly assigned a value of true for this
-    feature flag. It is interpreted as increments of 0.01%
+    The ratio of users that will be assigned this this feature flag, expressed in 
+	basis points (0.01%).
     """
-    rollout: Int!
+    rolloutBasisPoints: Int!
 
     """
     Overrides that apply to the feature flag

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -669,6 +669,25 @@ type Mutation {
 			"""
 			rollout: Int
 	): FeatureFlag!
+
+	createFeatureFlagOverride(
+		userID: ID
+		orgID: ID
+		flagName: String!
+		value: Boolean!
+	): FeatureFlagOverride!
+
+	deleteFeatureFlagOverride(
+		id: ID!
+	): EmptyResponse!
+
+	updateFeatureFlagOverride(
+		id: ID!
+		userID: ID
+		orgID: ID
+		flagName: String!
+		value: Boolean!
+	): FeatureFlagOverride!
 }
 
 """
@@ -1393,10 +1412,13 @@ type FeatureFlagRollout {
 A feature flag override is an override of a feature flag's value for a specific org or user
 """
 type FeatureFlagOverride {
+	id: ID!
+	user: User
+	org: Org
     """
     The name of the feature flag being overridden
     """
-    flagName: String!
+    targetFlag: FeatureFlag!
 
     """
     The overriden value of hte feature flag

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -613,6 +613,62 @@ type Mutation {
         """
         repositories: [SearchContextRepositoryRevisionsInput!]!
     ): SearchContext!
+
+	"""
+	(experimental) Create a new feature flag
+	"""
+	createFeatureFlag(
+			"""
+			The name of the feature flag
+			"""
+			name: String!
+			
+			"""
+			The value of the feature flag. Only set if the new feature flag
+			will be a concrete boolean flag. Mutually exclusive with rollout.
+			"""
+			value: Boolean
+
+			"""
+			The proportion of users the feature flag will be applied to in increments
+			of 0.01%. Only set if the new feature flag will be a rollout flag. 
+			Mutually exclusive with value.
+			"""
+			rollout: Int
+	): FeatureFlag!
+	   
+	"""
+	(experimental) Delete a feature flag
+	"""
+	deleteFeatureFlag(
+			"""
+			The name of the feature flag
+			"""
+			name: String!
+	): EmptyResponse!
+
+	"""
+	(experimental) Update a feature flag
+	"""
+	updateFeatureFlag(
+			"""
+			The name of the feature flag
+			"""
+			name: String!
+			
+			"""
+			The value of the feature flag. Only set if the new feature flag
+			will be a concrete boolean flag. Mutually exclusive with rollout.
+			"""
+			value: Boolean
+
+			"""
+			The proportion of users the feature flag will be applied to in increments
+			of 0.01%. Only set if the new feature flag will be a rollout flag. 
+			Mutually exclusive with value.
+			"""
+			rollout: Int
+	): FeatureFlag!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1280,6 +1280,88 @@ type Query {
     Retrieve all registered out-of-band migrations.
     """
     outOfBandMigrations: [OutOfBandMigration!]!
+
+    """
+    Retrieve the list of defined feature flags
+    """
+	featureFlags: [FeatureFlag!]!
+}
+
+"""
+A defined feature flag
+"""
+union FeatureFlag = FeatureFlagBoolean | FeatureFlagRollout
+
+"""
+A feature flag that has a statically configured value
+"""
+type FeatureFlagBoolean {
+    """
+    The name of the feature flag
+    """
+    name: String!
+
+    """
+    The static value of the feature flag
+    """
+    value: Boolean!
+
+    """
+    Overrides that apply to the feature flag
+    """
+	overrides: [FeatureFlagOverride!]!
+}
+
+"""
+A feature flag that is randomly evaluated to a boolean based on the rollout parameter
+"""
+type FeatureFlagRollout {
+    """
+    The name of the feature flag
+    """
+    name: String!
+
+    """
+    The proportion of users who will be randomly assigned a value of true for this
+    feature flag. It is interpreted as increments of 0.01%
+    """
+    rollout: Int!
+
+    """
+    Overrides that apply to the feature flag
+    """
+	overrides: [FeatureFlagOverride!]!
+}
+
+"""
+A feature flag override is an override of a feature flag's value for a specific org or user
+"""
+type FeatureFlagOverride {
+    """
+    The name of the feature flag being overridden
+    """
+    flagName: String!
+
+    """
+    The overriden value of hte feature flag
+    """
+    value: Boolean!
+}
+
+"""
+An evaluated feature flag is any feature flag (static or random) that has been evaluated to
+a concrete value for a given viewer.
+"""
+type EvaluatedFeatureFlag {
+    """
+    The name of the feature flag
+    """
+    name: String!
+
+    """
+    The concrete evaluated value of the feature flag
+    """
+    value: Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1450,13 +1450,13 @@ type FeatureFlagOverride {
     id: ID!
 
     """
-       The user this feature flag override applies to, if set.
+    The user this feature flag override applies to, if set.
     Mutually exclusive with Org
     """
     user: User
 
     """
-       The org this feature flag override applies to, if set.
+    The org this feature flag override applies to, if set.
     Mutually exclusive with User
     """
     org: Org

--- a/dev/gqltest/feature_flag_test.go
+++ b/dev/gqltest/feature_flag_test.go
@@ -251,12 +251,11 @@ func TestFeatureFlags(t *testing.T) {
 		})
 	})
 
-	createOverride := func(orgID *string, userID *string, flagName string, value bool) (featureFlagOverrideResult, error) {
+	createOverride := func(namespace string, flagName string, value bool) (featureFlagOverrideResult, error) {
 		m := featureFlagOverrideFragment + `
-		mutation CreateFeatureFlagOverride($orgID: ID, $userID: ID, $flagName: String!, $value: Boolean!) {
+		mutation CreateFeatureFlagOverride($namespace: ID!, $flagName: String!, $value: Boolean!) {
 			createFeatureFlagOverride(
-				orgID: $orgID,
-				userID: $userID,
+				namespace: $namespace,
 				flagName: $flagName,
 				value: $value,
 			) {
@@ -269,7 +268,7 @@ func TestFeatureFlags(t *testing.T) {
 				CreateFeatureFlagOverride featureFlagOverrideResult
 			}
 		}
-		params := map[string]interface{}{"orgID": orgID, "userID": userID, "flagName": flagName, "value": value}
+		params := map[string]interface{}{"namespace": namespace, "flagName": flagName, "value": value}
 		err := client.GraphQL("", m, params, &res)
 		return res.Data.CreateFeatureFlagOverride, err
 	}
@@ -332,7 +331,7 @@ func TestFeatureFlags(t *testing.T) {
 		overrideT := t
 		t.Run("Create", func(t *testing.T) {
 			t.Run("OrgOverride", func(t *testing.T) {
-				res, err := createOverride(&orgID, nil, flag.Name, false)
+				res, err := createOverride(orgID, flag.Name, false)
 				require.NoError(t, err)
 				overrideT.Cleanup(func() {
 					deleteOverride(res.ID)
@@ -351,7 +350,7 @@ func TestFeatureFlags(t *testing.T) {
 			})
 
 			t.Run("UserOverride", func(t *testing.T) {
-				res, err := createOverride(nil, &userID, flag.Name, false)
+				res, err := createOverride(userID, flag.Name, false)
 				require.NoError(t, err)
 				overrideT.Cleanup(func() {
 					deleteOverride(res.ID)
@@ -363,19 +362,19 @@ func TestFeatureFlags(t *testing.T) {
 			})
 
 			t.Run("NonextantFlag", func(t *testing.T) {
-				_, err = createOverride(&orgID, nil, "test_nonextant", true)
+				_, err = createOverride(orgID, "test_nonextant", true)
 				require.Error(t, err)
 			})
 
 			t.Run("NonextantUser", func(t *testing.T) {
 				userString := "nonextant"
-				_, err := createOverride(nil, &userString, "test_nonextant", true)
+				_, err := createOverride(userString, "test_nonextant", true)
 				require.Error(t, err)
 			})
 
 			t.Run("NonextantOrg", func(t *testing.T) {
 				orgID := "nonextant"
-				_, err := createOverride(&orgID, nil, "test_nonextant", true)
+				_, err := createOverride(orgID, "test_nonextant", true)
 				require.Error(t, err)
 			})
 		})

--- a/dev/gqltest/feature_flag_test.go
+++ b/dev/gqltest/feature_flag_test.go
@@ -50,7 +50,7 @@ func TestFeatureFlags(t *testing.T) {
 		}
 		...on FeatureFlagRollout {
 		  name
-		  rollout
+		  rolloutBasisPoints
 		  overrides {
 			...FeatureFlagOverrideData
 		  }
@@ -58,19 +58,19 @@ func TestFeatureFlags(t *testing.T) {
 	}`
 
 	type featureFlagResult struct {
-		Name      string
-		Value     *bool
-		Rollout   *int
-		Overrides []featureFlagOverrideResult
+		Name               string
+		Value              *bool
+		RolloutBasisPoints *int
+		Overrides          []featureFlagOverrideResult
 	}
 
-	createFeatureFlag := func(name string, value *bool, rollout *int) (featureFlagResult, error) {
+	createFeatureFlag := func(name string, value *bool, rolloutBasisPoints *int) (featureFlagResult, error) {
 		m := featureFlagFragment + featureFlagOverrideFragment + `
 		mutation CreateFeatureFlag($name: String!, $value: Boolean, $rollout: Int) {
 			createFeatureFlag(
 				name: $name,
 				value: $value,
-				rollout: $rollout,
+				rolloutBasisPoints: $rollout,
 			) {
 				...FeatureFlagData
 			}
@@ -81,18 +81,18 @@ func TestFeatureFlags(t *testing.T) {
 				CreateFeatureFlag featureFlagResult
 			}
 		}
-		params := map[string]interface{}{"name": name, "value": value, "rollout": rollout}
+		params := map[string]interface{}{"name": name, "value": value, "rollout": rolloutBasisPoints}
 		err := client.GraphQL("", m, params, &res)
 		return res.Data.CreateFeatureFlag, err
 	}
 
-	updateFeatureFlag := func(name string, value *bool, rollout *int) (featureFlagResult, error) {
+	updateFeatureFlag := func(name string, value *bool, rolloutBasisPoints *int) (featureFlagResult, error) {
 		m := featureFlagFragment + featureFlagOverrideFragment + `
 		mutation UpdateFeatureFlag($name: String!, $value: Boolean, $rollout: Int) {
 			updateFeatureFlag(
 				name: $name,
 				value: $value,
-				rollout: $rollout
+				rolloutBasisPoints: $rollout
 			) {
 				...FeatureFlagData
 			}
@@ -103,7 +103,7 @@ func TestFeatureFlags(t *testing.T) {
 				UpdateFeatureFlag featureFlagResult
 			}
 		}
-		params := map[string]interface{}{"name": name, "value": value, "rollout": rollout}
+		params := map[string]interface{}{"name": name, "value": value, "rollout": rolloutBasisPoints}
 		err := client.GraphQL("", m, params, &res)
 		return res.Data.UpdateFeatureFlag, err
 	}
@@ -160,9 +160,9 @@ func TestFeatureFlags(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := featureFlagResult{
-				Name:      "test_rollout",
-				Rollout:   &int343,
-				Overrides: []featureFlagOverrideResult{},
+				Name:               "test_rollout",
+				RolloutBasisPoints: &int343,
+				Overrides:          []featureFlagOverrideResult{},
 			}
 			require.Equal(t, expected, res)
 		})
@@ -195,9 +195,9 @@ func TestFeatureFlags(t *testing.T) {
 			require.NoError(t, err)
 
 			expected := featureFlagResult{
-				Name:      "test_rollout",
-				Rollout:   &int344,
-				Overrides: []featureFlagOverrideResult{},
+				Name:               "test_rollout",
+				RolloutBasisPoints: &int344,
+				Overrides:          []featureFlagOverrideResult{},
 			}
 			require.Equal(t, expected, res)
 		})

--- a/dev/gqltest/feature_flag_test.go
+++ b/dev/gqltest/feature_flag_test.go
@@ -232,6 +232,7 @@ func TestFeatureFlags(t *testing.T) {
 			// Create a feature flag first
 			boolTrue := true
 			_, err := createFeatureFlag("test_concrete", &boolTrue, nil)
+			require.NoError(t, err)
 			t.Cleanup(func() {
 				err := deleteFeatureFlag("test_concrete")
 				require.NoError(t, err)

--- a/dev/gqltest/feature_flag_test.go
+++ b/dev/gqltest/feature_flag_test.go
@@ -9,11 +9,8 @@ import (
 func TestFeatureFlags(t *testing.T) {
 	const featureFlagOverrideFragment = `fragment FeatureFlagOverrideData on FeatureFlagOverride {
 		id
-		user {
-			username 
-		}
-		org {
-			id
+		namespace {
+			id 
 		}
 		targetFlag {
 			...on FeatureFlagBoolean {
@@ -27,11 +24,8 @@ func TestFeatureFlags(t *testing.T) {
 	}`
 
 	type featureFlagOverrideResult struct {
-		ID   string
-		User struct {
-			Username string
-		}
-		Org struct {
+		ID        string
+		Namespace struct {
 			ID string
 		}
 		TargetFlag struct {
@@ -337,7 +331,7 @@ func TestFeatureFlags(t *testing.T) {
 					deleteOverride(res.ID)
 				})
 
-				require.Equal(t, res.Org.ID, orgID)
+				require.Equal(t, res.Namespace.ID, orgID)
 				require.Equal(t, res.TargetFlag.Name, flag.Name)
 				require.Equal(t, res.Value, false)
 
@@ -356,7 +350,7 @@ func TestFeatureFlags(t *testing.T) {
 					deleteOverride(res.ID)
 				})
 
-				require.Equal(t, res.User.Username, "testuseroverrides")
+				require.Equal(t, res.Namespace.ID, userID)
 				require.Equal(t, res.TargetFlag.Name, flag.Name)
 				require.Equal(t, res.Value, false)
 			})
@@ -388,8 +382,8 @@ func TestFeatureFlags(t *testing.T) {
 
 			o1 := res[0].Overrides[0]
 			o2 := res[0].Overrides[1]
-			require.Equal(t, o1.Org.ID, orgID)
-			require.Equal(t, o2.User.Username, "testuseroverrides")
+			require.Equal(t, o1.Namespace.ID, orgID)
+			require.Equal(t, o2.Namespace.ID, userID)
 			require.Equal(t, o1.TargetFlag.Name, "test_override")
 			require.Equal(t, o2.TargetFlag.Name, "test_override")
 			require.Equal(t, o1.Value, true)

--- a/dev/gqltest/feature_flag_test.go
+++ b/dev/gqltest/feature_flag_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFeatureFlags(t *testing.T) {
+	const featureFlagOverrideFragment = `fragment FeatureFlagOverrideData on FeatureFlagOverride {
+		id
+		user {
+			username 
+		}
+		org {
+			id
+		}
+		targetFlag {
+			...on FeatureFlagBoolean {
+				name
+			}
+			...on FeatureFlagRollout{
+				name
+			}
+		}
+		value
+	}`
+
+	type featureFlagOverrideResult struct {
+		ID   string
+		User struct {
+			Username string
+		}
+		Org struct {
+			ID string
+		}
+		TargetFlag struct {
+			Name string
+		}
+		Value bool
+	}
+
+	const featureFlagFragment = `fragment FeatureFlagData on FeatureFlag {
+		...on FeatureFlagBoolean{
+		  name
+		  value
+		  overrides {
+			...FeatureFlagOverrideData
+		  }
+		}
+		...on FeatureFlagRollout {
+		  name
+		  rollout
+		  overrides {
+			...FeatureFlagOverrideData
+		  }
+		}
+	}`
+
+	type featureFlagResult struct {
+		Name      string
+		Value     *bool
+		Rollout   *int
+		Overrides []featureFlagOverrideResult
+	}
+
+	createFeatureFlag := func(name string, value *bool, rollout *int) (featureFlagResult, error) {
+		m := featureFlagFragment + featureFlagOverrideFragment + `
+		mutation CreateFeatureFlag($name: String!, $value: Boolean, $rollout: Int) {
+			createFeatureFlag(
+				name: $name,
+				value: $value,
+				rollout: $rollout,
+			) {
+				...FeatureFlagData
+			}
+		}`
+
+		var res struct {
+			Data struct {
+				CreateFeatureFlag featureFlagResult
+			}
+		}
+		params := map[string]interface{}{"name": name, "value": value, "rollout": rollout}
+		err := client.GraphQL("", m, params, &res)
+		return res.Data.CreateFeatureFlag, err
+	}
+
+	updateFeatureFlag := func(name string, value *bool, rollout *int) (featureFlagResult, error) {
+		m := featureFlagFragment + featureFlagOverrideFragment + `
+		mutation UpdateFeatureFlag($name: String!, $value: Boolean, $rollout: Int) {
+			updateFeatureFlag(
+				name: $name,
+				value: $value,
+				rollout: $rollout
+			) {
+				...FeatureFlagData
+			}
+		}`
+
+		var res struct {
+			Data struct {
+				UpdateFeatureFlag featureFlagResult
+			}
+		}
+		params := map[string]interface{}{"name": name, "value": value, "rollout": rollout}
+		err := client.GraphQL("", m, params, &res)
+		return res.Data.UpdateFeatureFlag, err
+	}
+
+	deleteFeatureFlag := func(name string) error {
+		m := `mutation DeleteFeatureFlag($name: String!){
+			deleteFeatureFlag(
+				name: $name,
+			) {
+				alwaysNil		
+			}
+		}`
+		params := map[string]interface{}{"name": name}
+		return client.GraphQL("", m, params, nil)
+	}
+
+	listFeatureFlags := func() ([]featureFlagResult, error) {
+		m := featureFlagFragment + featureFlagOverrideFragment + `
+		query ListFeatureFlags{
+			featureFlags{
+				...FeatureFlagData
+			}
+		}`
+
+		var res struct {
+			Data struct {
+				FeatureFlags []featureFlagResult
+			}
+		}
+		err := client.GraphQL("", m, nil, &res)
+		return res.Data.FeatureFlags, err
+	}
+
+	t.Run("Create", func(t *testing.T) {
+		t.Run("Concrete", func(t *testing.T) {
+			boolTrue := true
+			res, err := createFeatureFlag("test_concrete", &boolTrue, nil)
+			require.NoError(t, err)
+
+			expected := featureFlagResult{
+				Name:      "test_concrete",
+				Value:     &boolTrue,
+				Overrides: []featureFlagOverrideResult{},
+			}
+			require.Equal(t, expected, res)
+		})
+
+		t.Run("Rollout", func(t *testing.T) {
+			int343 := 343
+			res, err := createFeatureFlag("test_rollout", nil, &int343)
+			require.NoError(t, err)
+
+			expected := featureFlagResult{
+				Name:      "test_rollout",
+				Rollout:   &int343,
+				Overrides: []featureFlagOverrideResult{},
+			}
+			require.Equal(t, expected, res)
+		})
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Run("Concrete", func(t *testing.T) {
+			boolFalse := false
+			res, err := updateFeatureFlag("test_concrete", &boolFalse, nil)
+			require.NoError(t, err)
+
+			expected := featureFlagResult{
+				Name:      "test_concrete",
+				Value:     &boolFalse,
+				Overrides: []featureFlagOverrideResult{},
+			}
+			require.Equal(t, expected, res)
+		})
+
+		t.Run("Rollout", func(t *testing.T) {
+			int344 := 344
+			res, err := updateFeatureFlag("test_rollout", nil, &int344)
+			require.NoError(t, err)
+
+			expected := featureFlagResult{
+				Name:      "test_rollout",
+				Rollout:   &int344,
+				Overrides: []featureFlagOverrideResult{},
+			}
+			require.Equal(t, expected, res)
+		})
+	})
+
+	t.Run("Delete", func(t *testing.T) {
+		t.Run("Concrete", func(t *testing.T) {
+			err := deleteFeatureFlag("test_concrete")
+			require.NoError(t, err)
+		})
+
+		t.Run("Rollout", func(t *testing.T) {
+			err := deleteFeatureFlag("test_rollout")
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("List", func(t *testing.T) {
+		t.Run("None", func(t *testing.T) {
+			res, err := listFeatureFlags()
+			require.NoError(t, err)
+			require.Len(t, res, 0)
+		})
+
+		t.Run("Some", func(t *testing.T) {
+			// Create a feature flag first
+			boolTrue := true
+			_, err := createFeatureFlag("test_concrete", &boolTrue, nil)
+			require.NoError(t, err)
+
+			// Then see if it shows up when we list it
+			res, err := listFeatureFlags()
+			require.NoError(t, err)
+
+			expected := []featureFlagResult{{
+				Name:      "test_concrete",
+				Value:     &boolTrue,
+				Overrides: []featureFlagOverrideResult{},
+			}}
+			require.Equal(t, res, expected)
+		})
+	})
+
+	t.Run("Overrides", func(t *testing.T) {
+
+	})
+}

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -129,7 +129,7 @@ func (f *FeatureFlagStore) DeleteFeatureFlag(ctx context.Context, name string) e
 	const deleteFeatureFlagFmtStr = `
 		UPDATE feature_flags
 		SET 
-			flag_name = flag_name || '-DELETED-' || TRUNC(EXTRACT(epoch FROM now()))::varchar(255),
+			flag_name = flag_name || '-DELETED-' || TRUNC(random() * 1000000)::varchar(255),
 			deleted_at = now()
 		WHERE flag_name = %s;
 	`

--- a/internal/database/feature_flags.go
+++ b/internal/database/feature_flags.go
@@ -305,10 +305,12 @@ func (f *FeatureFlagStore) DeleteOverride(ctx context.Context, orgID, userID *in
 	))
 }
 
-func (f *FeatureFlagStore) UpdateOverride(ctx context.Context, userID, orgID *int32, flagName string, newOverride *ff.Override) (*ff.Override, error) {
+func (f *FeatureFlagStore) UpdateOverride(ctx context.Context, orgID, userID *int32, flagName string, newValue bool) (*ff.Override, error) {
 	const newFeatureFlagOverrideFmtStr = `
-		DELETE FROM feature_flag_overrides 
-		WHERE %s AND flag_name = %s
+		UPDATE feature_flag_overrides 
+		SET flag_value = %s
+		WHERE %s -- namespace condition
+			AND flag_name = %s
 		RETURNING
 			namespace_org_id,
 			namespace_user_id,
@@ -328,6 +330,7 @@ func (f *FeatureFlagStore) UpdateOverride(ctx context.Context, userID, orgID *in
 
 	row := f.QueryRow(ctx, sqlf.Sprintf(
 		newFeatureFlagOverrideFmtStr,
+		newValue,
 		cond,
 		flagName,
 	))

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -375,8 +375,8 @@ func testUserFlags(t *testing.T) {
 		return res
 	}
 
-	mkFFBoolVar := func(name string, rollout int) *ff.FeatureFlag {
-		res, err := flagStore.CreateBoolVar(ctx, name, rollout)
+	mkFFBoolVar := func(name string, rollout int32) *ff.FeatureFlag {
+		res, err := flagStore.CreateRollout(ctx, name, rollout)
 		require.NoError(t, err)
 		return res
 	}
@@ -505,8 +505,8 @@ func testAnonymousUserFlags(t *testing.T) {
 		return res
 	}
 
-	mkFFBoolVar := func(name string, rollout int) *ff.FeatureFlag {
-		res, err := flagStore.CreateBoolVar(ctx, name, rollout)
+	mkFFBoolVar := func(name string, rollout int32) *ff.FeatureFlag {
+		res, err := flagStore.CreateRollout(ctx, name, rollout)
 		require.NoError(t, err)
 		return res
 	}
@@ -549,8 +549,8 @@ func testUserlessFeatureFlags(t *testing.T) {
 		return res
 	}
 
-	mkFFBoolVar := func(name string, rollout int) *ff.FeatureFlag {
-		res, err := flagStore.CreateBoolVar(ctx, name, rollout)
+	mkFFBoolVar := func(name string, rollout int32) *ff.FeatureFlag {
+		res, err := flagStore.CreateRollout(ctx, name, rollout)
 		require.NoError(t, err)
 		return res
 	}

--- a/internal/database/feature_flags_test.go
+++ b/internal/database/feature_flags_test.go
@@ -153,22 +153,22 @@ func testNewOverrideRoundtrip(t *testing.T) {
 	invalidUserID := int32(38535)
 
 	cases := []struct {
-		override  *ff.FeatureFlagOverride
+		override  *ff.Override
 		assertErr require.ErrorAssertionFunc
 	}{
 		{
-			override: &ff.FeatureFlagOverride{UserID: &u1.ID, FlagName: ff1.Name, Value: false},
+			override: &ff.Override{UserID: &u1.ID, FlagName: ff1.Name, Value: false},
 		},
 		{
-			override:  &ff.FeatureFlagOverride{UserID: &invalidUserID, FlagName: ff1.Name, Value: false},
+			override:  &ff.Override{UserID: &invalidUserID, FlagName: ff1.Name, Value: false},
 			assertErr: errorContains(`violates foreign key constraint "feature_flag_overrides_namespace_user_id_fkey"`),
 		},
 		{
-			override:  &ff.FeatureFlagOverride{UserID: &u1.ID, FlagName: "invalid-flag-name", Value: false},
+			override:  &ff.Override{UserID: &u1.ID, FlagName: "invalid-flag-name", Value: false},
 			assertErr: errorContains(`violates foreign key constraint "feature_flag_overrides_flag_name_fkey"`),
 		},
 		{
-			override:  &ff.FeatureFlagOverride{FlagName: ff1.Name, Value: false},
+			override:  &ff.Override{FlagName: ff1.Name, Value: false},
 			assertErr: errorContains(`violates check constraint "feature_flag_overrides_has_org_or_user_id"`),
 		},
 	}
@@ -205,8 +205,8 @@ func testListUserOverrides(t *testing.T) {
 		return res
 	}
 
-	mkOverride := func(user int32, flag string, val bool) *ff.FeatureFlagOverride {
-		ffo, err := flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{UserID: &user, FlagName: flag, Value: val})
+	mkOverride := func(user int32, flag string, val bool) *ff.Override {
+		ffo, err := flagStore.CreateOverride(ctx, &ff.Override{UserID: &user, FlagName: flag, Value: val})
 		require.NoError(t, err)
 		return ffo
 	}
@@ -227,7 +227,7 @@ func testListUserOverrides(t *testing.T) {
 		o1 := mkOverride(u1.ID, f1.Name, false)
 		got, err := flagStore.GetUserOverrides(ctx, u1.ID)
 		require.NoError(t, err)
-		require.Equal(t, got, []*ff.FeatureFlagOverride{o1})
+		require.Equal(t, got, []*ff.Override{o1})
 	})
 
 	t.Run("overrides for other users", func(t *testing.T) {
@@ -239,7 +239,7 @@ func testListUserOverrides(t *testing.T) {
 		mkOverride(u2.ID, f1.Name, true)
 		got, err := flagStore.GetUserOverrides(ctx, u1.ID)
 		require.NoError(t, err)
-		require.Equal(t, got, []*ff.FeatureFlagOverride{o1})
+		require.Equal(t, got, []*ff.Override{o1})
 	})
 
 	t.Run("deleted override", func(t *testing.T) {
@@ -258,9 +258,9 @@ func testListUserOverrides(t *testing.T) {
 		t.Cleanup(cleanup(t, db))
 		u1 := mkUser("u1")
 		f1 := mkFFBool("f", true)
-		_, err := flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{UserID: &u1.ID, FlagName: f1.Name, Value: true})
+		_, err := flagStore.CreateOverride(ctx, &ff.Override{UserID: &u1.ID, FlagName: f1.Name, Value: true})
 		require.NoError(t, err)
-		_, err = flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{UserID: &u1.ID, FlagName: f1.Name, Value: true})
+		_, err = flagStore.CreateOverride(ctx, &ff.Override{UserID: &u1.ID, FlagName: f1.Name, Value: true})
 		require.Error(t, err)
 	})
 }
@@ -290,8 +290,8 @@ func testListOrgOverrides(t *testing.T) {
 		return res
 	}
 
-	mkOverride := func(org int32, flag string, val bool) *ff.FeatureFlagOverride {
-		ffo, err := flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{OrgID: &org, FlagName: flag, Value: val})
+	mkOverride := func(org int32, flag string, val bool) *ff.Override {
+		ffo, err := flagStore.CreateOverride(ctx, &ff.Override{OrgID: &org, FlagName: flag, Value: val})
 		require.NoError(t, err)
 		return ffo
 	}
@@ -321,7 +321,7 @@ func testListOrgOverrides(t *testing.T) {
 
 		got, err := flagStore.GetOrgOverridesForUser(ctx, u1.ID)
 		require.NoError(t, err)
-		require.Equal(t, got, []*ff.FeatureFlagOverride{o1})
+		require.Equal(t, got, []*ff.Override{o1})
 	})
 
 	t.Run("deleted overrides", func(t *testing.T) {
@@ -343,9 +343,9 @@ func testListOrgOverrides(t *testing.T) {
 		org1 := mkOrg("org1")
 		f1 := mkFFBool("f", true)
 
-		_, err := flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{OrgID: &org1.ID, FlagName: f1.Name, Value: true})
+		_, err := flagStore.CreateOverride(ctx, &ff.Override{OrgID: &org1.ID, FlagName: f1.Name, Value: true})
 		require.NoError(t, err)
-		_, err = flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{OrgID: &org1.ID, FlagName: f1.Name, Value: false})
+		_, err = flagStore.CreateOverride(ctx, &ff.Override{OrgID: &org1.ID, FlagName: f1.Name, Value: false})
 		require.Error(t, err)
 	})
 }
@@ -381,14 +381,14 @@ func testUserFlags(t *testing.T) {
 		return res
 	}
 
-	mkUserOverride := func(user int32, flag string, val bool) *ff.FeatureFlagOverride {
-		ffo, err := flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{UserID: &user, FlagName: flag, Value: val})
+	mkUserOverride := func(user int32, flag string, val bool) *ff.Override {
+		ffo, err := flagStore.CreateOverride(ctx, &ff.Override{UserID: &user, FlagName: flag, Value: val})
 		require.NoError(t, err)
 		return ffo
 	}
 
-	mkOrgOverride := func(org int32, flag string, val bool) *ff.FeatureFlagOverride {
-		ffo, err := flagStore.CreateOverride(ctx, &ff.FeatureFlagOverride{OrgID: &org, FlagName: flag, Value: val})
+	mkOrgOverride := func(org int32, flag string, val bool) *ff.Override {
+		ffo, err := flagStore.CreateOverride(ctx, &ff.Override{OrgID: &org, FlagName: flag, Value: val})
 		require.NoError(t, err)
 		return ffo
 	}

--- a/internal/featureflag/featureflag.go
+++ b/internal/featureflag/featureflag.go
@@ -78,7 +78,7 @@ type FeatureFlagRollout struct {
 	Rollout int
 }
 
-type FeatureFlagOverride struct {
+type Override struct {
 	UserID   *int32
 	OrgID    *int32
 	FlagName string

--- a/internal/featureflag/featureflag.go
+++ b/internal/featureflag/featureflag.go
@@ -75,7 +75,7 @@ type FeatureFlagRollout struct {
 	// Rollout is an integer between 0 and 10000, representing the percent of
 	// users for which this feature flag will evaluate to 'true' in increments
 	// of 0.01%
-	Rollout int
+	Rollout int32
 }
 
 type Override struct {


### PR DESCRIPTION
This creates the GraphQL CRUD interface for managing feature flags.
This constitutes most of the remaining work left for feature flags. 

<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
