### PR TITLE
extensibility: prevent action item race conditions

### DIFF
--- a/client/web/src/extensions/components/ActionItemsBar.scss
+++ b/client/web/src/extensions/components/ActionItemsBar.scss
@@ -137,7 +137,7 @@ $default-icon-colors: $oc-grape-7, $oc-violet-7, $oc-cyan-9, $oc-indigo-7, $oc-p
         }
 
         &--inactive {
-            cursor: not-allowed;
+            cursor: default;
             filter: saturate(0%);
             opacity: 0.7;
         }

--- a/client/web/src/extensions/components/ActionItemsBar.tsx
+++ b/client/web/src/extensions/components/ActionItemsBar.tsx
@@ -276,6 +276,7 @@ export const ActionItemsBar = React.memo<ActionItemsBarProps>(props => {
                                             hideLabel={true}
                                             tabIndex={-1}
                                             hideExternalLinkIcon={true}
+                                            disabledDuringExecution={true}
                                         />
                                     </li>
                                 )


### PR DESCRIPTION
Fix #21516.

Prevent action item race conditions by forbidding execution while waiting for asynchronous commands to resolve (i.e. an action item can only have one command "in-flight" at a time).

<details>
<summary>Example: git-extras</summary>
<img src="https://user-images.githubusercontent.com/37420160/120850393-5f774780-c545-11eb-9ce9-35ccb6ff3544.gif" />
</details>