### PR TITLE
extensibility: add patternType to search bar action items

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -144,7 +144,10 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
         )
     }, [buttonClass, props.authenticatedUser, props.onSaveQueryClick, props.showSavedQueryButton])
 
-    const extraContext = useMemo(() => ({ searchQuery: props.query || null }), [props.query])
+    const extraContext = useMemo(() => ({ searchQuery: props.query || null, patternType: props.patternType }), [
+        props.query,
+        props.patternType,
+    ])
 
     const [showFilters, setShowFilters] = useState(false)
     const onShowFiltersClicked = (): void => {


### PR DESCRIPTION
Closes #21569 (sibling PR of sourcegraph/sourcegraph-search-export#6).

Add `patternType` to search toolbar context so that extensions can read it through context key expression interpolation.