### PR TITLE
worker: Add task runner machinery

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -3,5 +3,5 @@ package main
 import "github.com/sourcegraph/sourcegraph/cmd/worker/shared"
 
 func main() {
-	shared.Main()
+	shared.Start(nil)
 }

--- a/cmd/worker/shared/config.go
+++ b/cmd/worker/shared/config.go
@@ -63,14 +63,14 @@ func (c *Config) Validate() error {
 
 // shouldRunTask returns true if the given task should be run.
 func shouldRunTask(name string) bool {
-	for _, rc := range config.TaskBlocklist {
-		if name == rc {
+	for _, candidate := range config.TaskBlocklist {
+		if name == candidate {
 			return false
 		}
 	}
 
-	for _, rc := range config.TaskAllowlist {
-		if rc == "all" || name == rc {
+	for _, candidate := range config.TaskAllowlist {
+		if candidate == "all" || name == candidate {
 			return true
 		}
 	}

--- a/cmd/worker/shared/config.go
+++ b/cmd/worker/shared/config.go
@@ -36,7 +36,7 @@ func (c *Config) Load() {
 	), ",")
 }
 
-// Validate returns an error indicating a valid environment read during Load.
+// Validate returns an error indicating if there was an invalid environment read during Load.
 // THe environment is invalid when a supplied task name is not recognized by
 // the set of names registered to the worker (at compile time).
 //

--- a/cmd/worker/shared/config.go
+++ b/cmd/worker/shared/config.go
@@ -1,0 +1,88 @@
+package shared
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+)
+
+// Config is the configuration that controls what tasks will be initialized
+// and monitored. By default, all tasks are enabled. Individual tasks can be
+// explicit allowed or blocked from running on a particular instance.
+type Config struct {
+	env.BaseConfig
+	names []string
+
+	TaskAllowlist []string
+	TaskBlocklist []string
+}
+
+var config = &Config{}
+
+// Load reads from the environment and stores the transformed data on the config
+// object for later retrieval.
+func (c *Config) Load() {
+	c.TaskAllowlist = safeSplit(c.Get(
+		"WORKER_TASK_ALLOWLIST",
+		"all",
+		`A comma-seprated list of names of tasks that should be enabled. The value "all" (the default) enables all tasks.`,
+	), ",")
+
+	c.TaskBlocklist = safeSplit(c.Get(
+		"WORKER_TASK_BLOCKLIST",
+		"",
+		"A comma-seprated list of names of tasks that should not be enabled. Values in this list take precedence over the allowlist.",
+	), ",")
+}
+
+// Validate returns an error indicating a valid environment read during Load.
+// THe environment is invalid when a supplied task name is not recognized by
+// the set of names registered to the worker (at compile time).
+//
+// This method assumes that the name field has been set externally.
+func (c *Config) Validate() error {
+	allowlist := map[string]struct{}{}
+	for _, name := range c.names {
+		allowlist[name] = struct{}{}
+	}
+
+	for _, name := range c.TaskAllowlist {
+		if _, ok := allowlist[name]; !ok && name != "all" {
+			return fmt.Errorf("unknown †ask %q", name)
+		}
+	}
+	for _, name := range c.TaskBlocklist {
+		if _, ok := allowlist[name]; !ok {
+			return fmt.Errorf("unknown †ask %q", name)
+		}
+	}
+
+	return nil
+}
+
+// shouldRunTask returns true if the given task should be run.
+func shouldRunTask(name string) bool {
+	for _, rc := range config.TaskBlocklist {
+		if name == rc {
+			return false
+		}
+	}
+
+	for _, rc := range config.TaskAllowlist {
+		if rc == "all" || name == rc {
+			return true
+		}
+	}
+
+	return false
+}
+
+// safeSplit is strings.Split but returns nil (not a []string{""}) on empty input.
+func safeSplit(text, sep string) []string {
+	if text == "" {
+		return nil
+	}
+
+	return strings.Split(text, sep)
+}

--- a/cmd/worker/shared/config.go
+++ b/cmd/worker/shared/config.go
@@ -36,9 +36,9 @@ func (c *Config) Load() {
 	), ",")
 }
 
-// Validate returns an error indicating if there was an invalid environment read during Load.
-// THe environment is invalid when a supplied task name is not recognized by
-// the set of names registered to the worker (at compile time).
+// Validate returns an error indicating if there was an invalid environment read
+// during Load. The environment is invalid when a supplied task name is not recognized
+// by the set of names registered to the worker (at compile time).
 //
 // This method assumes that the name field has been set externally.
 func (c *Config) Validate() error {

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -24,17 +24,17 @@ import (
 const addr = ":3189"
 
 // Start runs the worker. This method does not return.
-func Start(enterpriseTasks map[string]Task) {
-	allTasks := map[string]Task{}
-	for name, task := range tasks {
-		allTasks[name] = task
+func Start(additionalTasks map[string]Task) {
+	tasks := map[string]Task{}
+	for name, task := range bultins {
+		tasks[name] = task
 	}
-	for name, task := range enterpriseTasks {
-		allTasks[name] = task
+	for name, task := range additionalTasks {
+		tasks[name] = task
 	}
 
 	// Setup environment variables
-	loadConfigs(allTasks)
+	loadConfigs(tasks)
 
 	env.Lock()
 	env.HandleHelpFlag()
@@ -46,14 +46,13 @@ func Start(enterpriseTasks map[string]Task) {
 	ready := make(chan struct{})
 	go debugserver.NewServerRoutine(ready).Start()
 
-	// Validate environment variables. A validation error at this point will
-	// cause a fatal log message to be emitted.
-	validateConfigs(allTasks)
+	// Validate environment variables
+	mustValidateConfigs(tasks)
 
 	// Create the background routines that the worker will monitor for its
 	// lifetime. There may be a non-trivial startup time on this step as we
 	// connect to external databases, wait for migrations, etc.
-	allRoutines := createBackgroundRoutines(allTasks)
+	allRoutines := mustCreateBackgroundRoutines(tasks)
 
 	// Initialize health server
 	server := httpserver.NewFromAddr(addr, &http.Server{
@@ -79,33 +78,33 @@ func loadConfigs(tasks map[string]Task) {
 	config.Load()
 
 	// Load all other registered configs
-	for _, task := range tasks {
-		for _, config := range task.Config() {
-			config.Load()
+	for _, t := range tasks {
+		for _, c := range t.Config() {
+			c.Load()
 		}
 	}
 }
 
-// validateConfigs calls Validate on the configs of each of the tasks that will be run
-// by this instance of the worker. If any config has a validation error, a fatal log
-// message will be emitted.
-func validateConfigs(tasks map[string]Task) {
+// mustValidateConfigs calls Validate on the configs of each of the tasks that will be run
+// by this instance of the worker. If any config has a validation error, a fatal log message
+// will be emitted.
+func mustValidateConfigs(tasks map[string]Task) {
 	validationErrors := map[string][]error{}
 	if err := config.Validate(); err != nil {
 		log.Fatalf("Failed to load configuration: %s", err)
 	}
+
 	if len(validationErrors) == 0 {
-		// If the worker config is valid, validate the children configs.
-		// We guard this in the case of worker config errors because we
-		// don't want to spew validation errors for things that should
-		// be disabled.
-		for _, name := range taskNames(tasks) {
+		// If the worker config is valid, validate the children configs. We guard this
+		// in the case of worker config errors because we don't want to spew validation
+		// errors for things that should be disabled.
+		for name, task := range tasks {
 			if !shouldRunTask(name) {
 				continue
 			}
 
-			for _, config := range tasks[name].Config() {
-				if err := config.Validate(); err != nil {
+			for _, c := range task.Config() {
+				if err := c.Validate(); err != nil {
 					validationErrors[name] = append(validationErrors[name], err)
 				}
 			}
@@ -125,10 +124,10 @@ func validateConfigs(tasks map[string]Task) {
 	}
 }
 
-// createBackgroundRoutines runs the Routines function of each of the given tasks concurrently.
+// mustCreateBackgroundRoutines runs the Routines function of each of the given tasks concurrently.
 // If an error occurs from any of them, a fatal log message will be emitted. Otherwise, the set
 // of background routines from each task will be returned.
-func createBackgroundRoutines(tasks map[string]Task) []goroutine.BackgroundRoutine {
+func mustCreateBackgroundRoutines(tasks map[string]Task) []goroutine.BackgroundRoutine {
 	var (
 		allRoutines  []goroutine.BackgroundRoutine
 		descriptions []string
@@ -168,20 +167,25 @@ func runRoutinesConcurrently(tasks map[string]Task) chan routinesResult {
 	defer cancel()
 
 	for _, name := range taskNames(tasks) {
+		taskLoggr := log15.New("name", name)
+
 		if !shouldRunTask(name) {
-			log15.Info("Skipping task", "name", name)
+			taskLoggr.Info("Skipping task")
 			continue
 		}
 
-		log15.Info("Running task", "name", name)
 		wg.Add(1)
+		taskLoggr.Info("Running task")
 
 		go func(name string) {
 			defer wg.Done()
 
 			routines, err := tasks[name].Routines(ctx)
 			results <- routinesResult{name, routines, err}
-			if err != nil {
+
+			if err == nil {
+				taskLoggr.Info("Finished initializing task")
+			} else {
 				cancel()
 			}
 		}(name)

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -2,8 +2,15 @@ package shared
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net/http"
+	"sort"
+	"strings"
+	"sync"
 	"time"
+
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/debugserver"
 	"github.com/sourcegraph/sourcegraph/internal/env"
@@ -16,7 +23,19 @@ import (
 
 const addr = ":3189"
 
-func Main() {
+// Start runs the worker. This method does not return.
+func Start(enterpriseTasks map[string]Task) {
+	allTasks := map[string]Task{}
+	for name, task := range tasks {
+		allTasks[name] = task
+	}
+	for name, task := range enterpriseTasks {
+		allTasks[name] = task
+	}
+
+	// Setup environment variables
+	loadConfigs(allTasks)
+
 	env.Lock()
 	env.HandleHelpFlag()
 	logging.Init()
@@ -27,7 +46,14 @@ func Main() {
 	ready := make(chan struct{})
 	go debugserver.NewServerRoutine(ready).Start()
 
-	var allRoutines []goroutine.BackgroundRoutine
+	// Validate environment variables. A validation error at this point will
+	// cause a fatal log message to be emitted.
+	validateConfigs(allTasks)
+
+	// Create the background routines that the worker will monitor for its
+	// lifetime. There may be a non-trivial startup time on this step as we
+	// connect to external databases, wait for migrations, etc.
+	allRoutines := createBackgroundRoutines(allTasks)
 
 	// Initialize health server
 	server := httpserver.NewFromAddr(addr, &http.Server{
@@ -37,6 +63,141 @@ func Main() {
 	})
 	allRoutines = append(allRoutines, server)
 
+	// We're all set up now
+	// Respond positively to ready checks
 	close(ready)
+
 	goroutine.MonitorBackgroundRoutines(context.Background(), allRoutines...)
+}
+
+// loadConfigs calls Load on the configs of each of the tasks registered in this binary.
+// All configs will be loaded regardless if they would later be validated - this is the
+// best place we have to manipulate the environment before the call to env.Lock.
+func loadConfigs(tasks map[string]Task) {
+	// Load the worker config
+	config.names = taskNames(tasks)
+	config.Load()
+
+	// Load all other registered configs
+	for _, task := range tasks {
+		for _, config := range task.Config() {
+			config.Load()
+		}
+	}
+}
+
+// validateConfigs calls Validate on the configs of each of the tasks that will be run
+// by this instance of the worker. If any config has a validation error, a fatal log
+// message will be emitted.
+func validateConfigs(tasks map[string]Task) {
+	validationErrors := map[string][]error{}
+	if err := config.Validate(); err != nil {
+		log.Fatalf("Failed to load configuration: %s", err)
+	}
+	if len(validationErrors) == 0 {
+		// If the worker config is valid, validate the children configs.
+		// We guard this in the case of worker config errors because we
+		// don't want to spew validation errors for things that should
+		// be disabled.
+		for _, name := range taskNames(tasks) {
+			if !shouldRunTask(name) {
+				continue
+			}
+
+			for _, config := range tasks[name].Config() {
+				if err := config.Validate(); err != nil {
+					validationErrors[name] = append(validationErrors[name], err)
+				}
+			}
+		}
+	}
+
+	if len(validationErrors) != 0 {
+		var descriptions []string
+		for name, errs := range validationErrors {
+			for _, err := range errs {
+				descriptions = append(descriptions, fmt.Sprintf("  - %s: %s ", name, err))
+			}
+		}
+		sort.Strings(descriptions)
+
+		log.Fatalf("Failed to load configuration:\n%s", strings.Join(descriptions, "\n"))
+	}
+}
+
+// createBackgroundRoutines runs the Routines function of each of the given tasks concurrently.
+// If an error occurs from any of them, a fatal log message will be emitted. Otherwise, the set
+// of background routines from each task will be returned.
+func createBackgroundRoutines(tasks map[string]Task) []goroutine.BackgroundRoutine {
+	var (
+		allRoutines  []goroutine.BackgroundRoutine
+		descriptions []string
+	)
+
+	for result := range runRoutinesConcurrently(tasks) {
+		if result.err == nil {
+			allRoutines = append(allRoutines, result.routines...)
+		} else {
+			descriptions = append(descriptions, fmt.Sprintf("  - %s: %s", result.name, result.err))
+		}
+	}
+	sort.Strings(descriptions)
+
+	if len(descriptions) != 0 {
+		log.Fatalf("Failed to initialize worker:\n%s", strings.Join(descriptions, "\n"))
+	}
+
+	return allRoutines
+}
+
+type routinesResult struct {
+	name     string
+	routines []goroutine.BackgroundRoutine
+	err      error
+}
+
+// runRoutinesConcurrently returns a channel that will be populated with the return value of
+// the Routines function from each given task. Each function is called concurrently. If an
+// error occurs in one function, the context passed to all its siblings will be canceled.
+func runRoutinesConcurrently(tasks map[string]Task) chan routinesResult {
+	results := make(chan routinesResult, len(tasks))
+	defer close(results)
+
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, name := range taskNames(tasks) {
+		if !shouldRunTask(name) {
+			log15.Info("Skipping task", "name", name)
+			continue
+		}
+
+		log15.Info("Running task", "name", name)
+		wg.Add(1)
+
+		go func(name string) {
+			defer wg.Done()
+
+			routines, err := tasks[name].Routines(ctx)
+			results <- routinesResult{name, routines, err}
+			if err != nil {
+				cancel()
+			}
+		}(name)
+	}
+
+	wg.Wait()
+	return results
+}
+
+// taskNames returns an ordered slice of keys from the given map.
+func taskNames(tasks map[string]Task) []string {
+	names := make([]string, 0, len(tasks))
+	for name := range tasks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	return names
 }

--- a/cmd/worker/shared/task.go
+++ b/cmd/worker/shared/task.go
@@ -26,6 +26,6 @@ type Task interface {
 	Routines(ctx context.Context) ([]goroutine.BackgroundRoutine, error)
 }
 
-var tasks = map[string]Task{
+var bultins = map[string]Task{
 	// Empty for now
 }

--- a/cmd/worker/shared/task.go
+++ b/cmd/worker/shared/task.go
@@ -13,6 +13,8 @@ type Task interface {
 	// Config returns a set of configuration struct pointers that should be loaded
 	// and validated as part of application startup.
 	//
+	// If called multiple times, the same pointers should be returned.
+	//
 	// Note that the Load function of every config object is invoked even if the
 	// task is not enabled. It is assumed safe to call this method with an invalid
 	// configuration (and all configuration errors should be surfaced via Validate).

--- a/cmd/worker/shared/task.go
+++ b/cmd/worker/shared/task.go
@@ -1,0 +1,29 @@
+package shared
+
+import (
+	"context"
+
+	"github.com/sourcegraph/sourcegraph/internal/env"
+	"github.com/sourcegraph/sourcegraph/internal/goroutine"
+)
+
+// Task creates configuration struct and background routine instances to be run
+// as part of the worker process.
+type Task interface {
+	// Config returns a set of configuration struct pointers that should be loaded
+	// and validated as part of application startup.
+	//
+	// Note that the Load function of every config object is invoked even if the
+	// task is not enabled. It is assumed safe to call this method with an invalid
+	// configuration (and all configuration errors should be surfaced via Validate).
+	Config() []env.Config
+
+	// Routines constructs and returns the set of background routines that
+	// should run as part of the worker process. Service initialization should
+	// be shared between setup hooks when possible (e.g. sync.Once initialization).
+	Routines(ctx context.Context) ([]goroutine.BackgroundRoutine, error)
+}
+
+var tasks = map[string]Task{
+	// Empty for now
+}

--- a/enterprise/cmd/worker/main.go
+++ b/enterprise/cmd/worker/main.go
@@ -14,5 +14,5 @@ func main() {
 		log.Println("enterprise edition")
 	}
 
-	shared.Main()
+	shared.Start(nil)
 }

--- a/internal/env/baseconfig.go
+++ b/internal/env/baseconfig.go
@@ -13,7 +13,10 @@ type Config interface {
 	// read the values from the environment and store errors to be reported later.
 	Load()
 
-	// Validate returns errors about the environment that occurred during Load.
+	// Validate performs non-trivial validation and returns any resulting errors.
+	// This method should also return errors that occurred while reading values from
+	// the environment in Load. This method is called after the environment has been
+	// locked, so all environment variable reads must happen in Load.
 	Validate() error
 }
 

--- a/internal/env/baseconfig.go
+++ b/internal/env/baseconfig.go
@@ -13,7 +13,7 @@ type Config interface {
 	// read the values from the environment and store errors to be reported later.
 	Load()
 
-	// Validate returns errors about the environment that occurred durign Load.
+	// Validate returns errors about the environment that occurred during Load.
 	Validate() error
 }
 

--- a/internal/env/baseconfig.go
+++ b/internal/env/baseconfig.go
@@ -8,6 +8,15 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
+type Config interface {
+	// Load is called prior to env.Lock an application startup. This method should
+	// read the values from the environment and store errors to be reported later.
+	Load()
+
+	// Validate returns errors about the environment that occurred durign Load.
+	Validate() error
+}
+
 // BaseConfig is a base struct for configuration objects. The following is a minimal
 // example of declaring, loading, and validating configuration from the environment.
 //


### PR DESCRIPTION
This PR adds the machinery to register and run tasks in a worker instance. Fixes https://github.com/sourcegraph/sourcegraph/issues/21758.