### PR TITLE
worker: Add common initialize methods for external services

### DIFF
--- a/cmd/worker/shared/db.go
+++ b/cmd/worker/shared/db.go
@@ -1,0 +1,27 @@
+package shared
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+)
+
+// InitDatabase initializes and returns a connection to the frontend database.
+func InitDatabase() (*sql.DB, error) {
+	conn, err := initDatabaseMemo.Init()
+	return conn.(*sql.DB), err
+}
+
+var initDatabaseMemo = NewMemoizedConstructor(func() (interface{}, error) {
+	postgresDSN := WatchServiceConnectionValue(func(serviceConnections conftypes.ServiceConnections) string {
+		return serviceConnections.PostgresDSN
+	})
+
+	if err := dbconn.SetupGlobalConnection(postgresDSN); err != nil {
+		return nil, fmt.Errorf("failed to connect to frontend database: %s", err)
+	}
+
+	return dbconn.Global, nil
+})

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/goroutine"
 	"github.com/sourcegraph/sourcegraph/internal/httpserver"
 	"github.com/sourcegraph/sourcegraph/internal/logging"
+	"github.com/sourcegraph/sourcegraph/internal/profiler"
 	"github.com/sourcegraph/sourcegraph/internal/trace"
 	"github.com/sourcegraph/sourcegraph/internal/tracer"
 )
@@ -35,6 +36,11 @@ func Start(additionalTasks map[string]Task) {
 
 	// Setup environment variables
 	loadConfigs(tasks)
+
+	// Set up Google Cloud Profiler when running in Cloud
+	if err := profiler.Init(); err != nil {
+		log.Fatalf("Failed to start profiler: %v", err)
+	}
 
 	env.Lock()
 	env.HandleHelpFlag()

--- a/cmd/worker/shared/main.go
+++ b/cmd/worker/shared/main.go
@@ -26,7 +26,7 @@ const addr = ":3189"
 // Start runs the worker. This method does not return.
 func Start(additionalTasks map[string]Task) {
 	tasks := map[string]Task{}
-	for name, task := range bultins {
+	for name, task := range builtins {
 		tasks[name] = task
 	}
 	for name, task := range additionalTasks {

--- a/cmd/worker/shared/memo.go
+++ b/cmd/worker/shared/memo.go
@@ -1,0 +1,26 @@
+package shared
+
+import "sync"
+
+// MemoizedConstructor wraps a function returning a value and an error
+// and memoizes its result. Multiple calls to Init will result in the
+// underlying constructor being called once. All callers will receive
+// the same return values.
+type MemoizedConstructor struct {
+	ctor  func() (interface{}, error)
+	value interface{}
+	err   error
+	once  sync.Once
+}
+
+// NewMemoizedConstructor memoizes the given constructor
+func NewMemoizedConstructor(ctor func() (interface{}, error)) *MemoizedConstructor {
+	return &MemoizedConstructor{ctor: ctor}
+}
+
+// Init ensures that the given constructor has been called exactly
+// once, then returns the constructor's result value and error.
+func (m *MemoizedConstructor) Init() (interface{}, error) {
+	m.once.Do(func() { m.value, m.err = m.ctor() })
+	return m.value, m.err
+}

--- a/cmd/worker/shared/service_connections.go
+++ b/cmd/worker/shared/service_connections.go
@@ -1,0 +1,25 @@
+package shared
+
+import (
+	"log"
+
+	"github.com/sourcegraph/sourcegraph/internal/conf"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+)
+
+// WatchServiceConnectionValue returns the value returned by the given function when passed the
+// current service connection configuration. If this function returns a different value in the
+// future for an updated service connection configuration, a fatal log will be emitted to
+// restart the service to pick up changes.
+//
+// This method should only be called for critical values like database connection config.
+func WatchServiceConnectionValue(f func(serviceConnections conftypes.ServiceConnections) string) string {
+	value := f(conf.Get().ServiceConnections)
+	conf.Watch(func() {
+		if newValue := f(conf.Get().ServiceConnections); value != newValue {
+			log.Fatalf("Detected settings change change, restarting to take effect: %s", newValue)
+		}
+	})
+
+	return value
+}

--- a/cmd/worker/shared/task.go
+++ b/cmd/worker/shared/task.go
@@ -26,6 +26,6 @@ type Task interface {
 	Routines(ctx context.Context) ([]goroutine.BackgroundRoutine, error)
 }
 
-var bultins = map[string]Task{
+var builtins = map[string]Task{
 	// Empty for now
 }

--- a/dev/check/go-dbconn-import.sh
+++ b/dev/check/go-dbconn-import.sh
@@ -13,11 +13,13 @@ cd "$(dirname "${BASH_SOURCE[0]}")"/../..
 allowed_prefix=(
   github.com/sourcegraph/sourcegraph/cmd/frontend
   github.com/sourcegraph/sourcegraph/cmd/gitserver
+  github.com/sourcegraph/sourcegraph/cmd/worker
   github.com/sourcegraph/sourcegraph/cmd/repo-updater
-  github.com/sourcegraph/sourcegraph/enterprise/cmd/executor-queue
   github.com/sourcegraph/sourcegraph/enterprise/cmd/frontend
-  github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-
+  github.com/sourcegraph/sourcegraph/enterprise/cmd/worker
   github.com/sourcegraph/sourcegraph/enterprise/cmd/repo-updater
+  github.com/sourcegraph/sourcegraph/enterprise/cmd/executor-queue
+  github.com/sourcegraph/sourcegraph/enterprise/cmd/precise-code-intel-
 )
 
 # Create regex ^(a|b|c)

--- a/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
+++ b/enterprise/cmd/worker/internal/codeintel/codeinteldb.go
@@ -1,0 +1,33 @@
+package codeintel
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/internal/conf/conftypes"
+	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
+)
+
+// InitCodeIntelDatabase initializes and returns a connection to the codeintel db.
+func InitCodeIntelDatabase() (*sql.DB, error) {
+	conn, err := initCodeIntelDatabaseMemo.Init()
+	return conn.(*sql.DB), err
+}
+
+var initCodeIntelDatabaseMemo = shared.NewMemoizedConstructor(func() (interface{}, error) {
+	postgresDSN := shared.WatchServiceConnectionValue(func(serviceConnections conftypes.ServiceConnections) string {
+		return serviceConnections.CodeIntelPostgresDSN
+	})
+
+	db, err := dbconn.New(postgresDSN, "_codeintel")
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to codeintel database: %s", err)
+	}
+
+	if err := dbconn.MigrateDB(db, dbconn.CodeIntel); err != nil {
+		return nil, fmt.Errorf("failed to perform codeintel database migration: %s", err)
+	}
+
+	return db, nil
+})

--- a/enterprise/cmd/worker/internal/codeintel/dbstore.go
+++ b/enterprise/cmd/worker/internal/codeintel/dbstore.go
@@ -1,0 +1,33 @@
+package codeintel
+
+import (
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/dbstore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+// InitDBStore initializes and returns a db store instance.
+func InitDBStore() (*dbstore.Store, error) {
+	conn, err := initDBStore.Init()
+	return conn.(*dbstore.Store), err
+}
+
+var initDBStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+	observationContext := &observation.Context{
+		Logger:     log15.Root(),
+		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+		Registerer: prometheus.DefaultRegisterer,
+	}
+
+	db, err := shared.InitDatabase()
+	if err != nil {
+		return nil, err
+	}
+
+	return dbstore.NewWithDB(db, observationContext), nil
+})

--- a/enterprise/cmd/worker/internal/codeintel/gitserver.go
+++ b/enterprise/cmd/worker/internal/codeintel/gitserver.go
@@ -1,0 +1,33 @@
+package codeintel
+
+import (
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/gitserver"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+// InitGitserverClient initializes and returns a gitserver client.
+func InitGitserverClient() (*gitserver.Client, error) {
+	conn, err := initGitserverClient.Init()
+	return conn.(*gitserver.Client), err
+}
+
+var initGitserverClient = shared.NewMemoizedConstructor(func() (interface{}, error) {
+	observationContext := &observation.Context{
+		Logger:     log15.Root(),
+		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+		Registerer: prometheus.DefaultRegisterer,
+	}
+
+	dbStore, err := InitDBStore()
+	if err != nil {
+		return nil, err
+	}
+
+	return gitserver.New(dbStore, observationContext), nil
+})

--- a/enterprise/cmd/worker/internal/codeintel/lsifstore.go
+++ b/enterprise/cmd/worker/internal/codeintel/lsifstore.go
@@ -1,0 +1,33 @@
+package codeintel
+
+import (
+	"github.com/inconshreveable/log15"
+	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/sourcegraph/sourcegraph/cmd/worker/shared"
+	"github.com/sourcegraph/sourcegraph/enterprise/internal/codeintel/stores/lsifstore"
+	"github.com/sourcegraph/sourcegraph/internal/observation"
+	"github.com/sourcegraph/sourcegraph/internal/trace"
+)
+
+// InitLSIFStore initializes and returns an LSIF store instance.
+func InitLSIFStore() (*lsifstore.Store, error) {
+	conn, err := initLSFIStore.Init()
+	return conn.(*lsifstore.Store), err
+}
+
+var initLSFIStore = shared.NewMemoizedConstructor(func() (interface{}, error) {
+	observationContext := &observation.Context{
+		Logger:     log15.Root(),
+		Tracer:     &trace.Tracer{Tracer: opentracing.GlobalTracer()},
+		Registerer: prometheus.DefaultRegisterer,
+	}
+
+	db, err := InitCodeIntelDatabase()
+	if err != nil {
+		return nil, err
+	}
+
+	return lsifstore.NewStore(db, observationContext), nil
+})


### PR DESCRIPTION
This PR:

- adds external service initialization methods for:
  - the frontend database
  - the codeintel-db
  - common code intelligence stores and clients (dbstore, lsifstore, gitserver client)
- sets up authz permissions

Nothing currently uses these, but there was some non-trivial memoization work I wanted to do separately before moving any actual behavior into this service.