### PR TITLE
batches: document how to ignore templating delimiters

### DIFF
--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -360,7 +360,7 @@ body > #sidebar .external a, body > #page > footer .external a {
         /* Note: all ancestors up to <html> (the scrolling element) must be overflow: visible (default) for this to work. */
 		position: sticky;
 		top: calc(2*var(--spacing));
-		max-height: 100vh;
+		max-height: calc(100vh - 2*var(--spacing));
 		padding: var(--spacing);
         border: solid 1px var(--border-color);
 	}

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -360,7 +360,7 @@ body > #sidebar .external a, body > #page > footer .external a {
         /* Note: all ancestors up to <html> (the scrolling element) must be overflow: visible (default) for this to work. */
 		position: sticky;
 		top: calc(2*var(--spacing));
-		max-height: calc(100vh - 2*var(--spacing));
+		max-height: calc(100vh - 4*var(--spacing));
 		padding: var(--spacing);
         border: solid 1px var(--border-color);
 	}

--- a/doc/_resources/assets/docsite.css
+++ b/doc/_resources/assets/docsite.css
@@ -519,11 +519,15 @@ body > #page > main > #content {
   opacity: 1;
 }
 .markdown-body .anchor {
+  height: 100%;
   position: relative;
   opacity: 0;
 }
 .markdown-body .anchor::before {
   content: "#";
+  height: 100%;
+  display: flex;
+  align-items: center;
   position: absolute;
   padding-left: 10px;
   padding-right: 5px;

--- a/doc/batch_changes/references/batch_spec_cheat_sheet.md
+++ b/doc/batch_changes/references/batch_spec_cheat_sheet.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-There are some common patterns that we reuse all the time when writing [batch specs](batch_spec_yaml_reference.md). In this document we collect these patterns to make it easy for others to copy and reuse them.
+There are some common patterns that we reuse all the time when writing [batch specs](batch_spec_yaml_reference.md). In this document we collect these patterns to make it easy for others to copy and reuse them. See our own curated collection of [batch change examples](https://github.com/sourcegraph/batch-change-examples) for even more complete batch change examples.
 
 Since most of the examples here make use of [batch spec templating](batch_spec_templating.md), be sure to also take a look at that page.
 

--- a/doc/batch_changes/references/batch_spec_cheat_sheet.md
+++ b/doc/batch_changes/references/batch_spec_cheat_sheet.md
@@ -211,6 +211,6 @@ steps:
       EOF
 ```
 
-Since GitHub expression syntax conflicts with Sourcegraph's own template expression syntax, the quotes indicate to Sourcegraph to ignore the sequence contained within them when evaluating the template. However, to avoid the shell also interpreting the GitHub expression as a variable when executing the script, we need to escape the quoted `$` twice: once for the shell script itself, and once to escape `\` for initially parsing the spec in Go.
+Since GitHub expression syntax conflicts with Sourcegraph's own template expression syntax, including the expression again as a quoted string within a template expression means that the inner expression will be output as a string (effectively, "ignoring" the contents of the inner expression). For `run:` fields specifically, to avoid the shell also interpreting the GitHub expression as a variable when executing the script, we need to escape the quoted `$` with two backslashes: firstly for the shell script itself, and secondly to escape the backslash within the template expression string.
 
-To use the literal sequence `${{ }}` in another field of the batch spec that [supports templating](batch_spec_templating.md#fields-with-template-support), quotes are normally sufficient: `${{ "${{ leave me alone! }}" }}`
+To use the literal sequence `${{ }}` in non-`run:` fields of the batch spec that [supports templating](batch_spec_templating.md#fields-with-template-support), quoted strings are normally sufficient: `${{ "${{ leave me alone! }}" }}`

--- a/doc/batch_changes/references/batch_spec_cheat_sheet.md
+++ b/doc/batch_changes/references/batch_spec_cheat_sheet.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-There are some common patterns that we reuse all the time when writing [batch specs](batch_spec_yaml_reference.md). In this document we collect these patterns to make it easy for others to copy and reuse them. See our own curated collection of [batch change examples](https://github.com/sourcegraph/batch-change-examples) for even more complete batch change examples.
+There are some common patterns that we reuse all the time when writing [batch specs](batch_spec_yaml_reference.md). In this document we collect these patterns to make it easy for others to copy and reuse them. See our own curated collection of [batch change examples](https://github.com/sourcegraph/batch-change-examples) for even more complete examples of batch specs.
 
 Since most of the examples here make use of [batch spec templating](batch_spec_templating.md), be sure to also take a look at that page.
 

--- a/doc/batch_changes/references/batch_spec_templating.md
+++ b/doc/batch_changes/references/batch_spec_templating.md
@@ -127,6 +127,7 @@ They are evaluated after the execution of all entries in `steps`.
 - `${{ replace "a/b/c/d" "/" "-" }}` - replaces occurrences of second argument in the first one with the last one.
 - `${{ split repository.name "/" }}` - splits the first argument into a list of strings at each occurrence of the last argument.
 - `${{ matches repository.name "github.com/my-org/terra*" }}` - matches the first argument against the glob pattern in the second argument, returning true/false.
+- `${{ "${{ repository.name }}" }}` - outputs the inner expression as a literal string, for example, to [ignore the inner set of `${{ }}`](faq.md#how-can-i-use-github-expression-syntax-literally-in-my-batch-spec)
 
 The features of Go's [`text/template`](https://golang.org/pkg/text/template/) package are also available, including conditionals and loops, since it is the underlying templating engine.
 

--- a/doc/batch_changes/references/batch_spec_yaml_reference.md
+++ b/doc/batch_changes/references/batch_spec_yaml_reference.md
@@ -5,7 +5,7 @@
 
 /* The sidebar on this page contains a lot of long identifiers without
 whitespace. In order to make them more readable we increase the width of the
-sidebar. /*
+sidebar. */
 @media (min-width: 1200px) {
   body > #page > main > #index {
     width: 35%;

--- a/doc/batch_changes/references/faq.md
+++ b/doc/batch_changes/references/faq.md
@@ -58,3 +58,13 @@ Common language agnostic starting points:
 
 - `sed`, [`yq`](https://github.com/mikefarah/yq), `awk` are common utilities for changing text
 - [comby](https://comby.dev/docs/overview) is a language-aware structural code search and replace tool. It can match expressions and function blocks, and is great for more complex changes.
+
+### How can I use [GitHub expression syntax](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions) (`${{ }}` literally) in my batch spec?
+
+To tell Sourcegraph not to evaluate `${{ }}` like a normal [template delimiter](batch_spec_templating.md), you can quote it and wrap it in a second set of `${{ }}` like so:
+
+```
+${{ "${{ leave me alone! }}" }}
+```
+
+Keep in mind the context in which the inner `${{ }}` will be evaluated and be sure to escape characters as is appropriate. Check out the cheatsheet for an [example](batch_spec_cheat_sheet.md#write-a-github-actions-workflow-that-includes-github-expression-syntax) within a shell script.


### PR DESCRIPTION
Adds an FAQ + cheatsheet example of writing a batch spec and ignoring the GitHub expressions syntax used in a step, as well as some explanation of how to escape characters when necessary. Double-checked that the example spec runs correctly 😉 (thanks to Adam + Erik again for helping me work that out).

I also noticed + fixed two couple minor visual things:

1. When the right nav menu had enough entries, or the window was short enough, the bottom of the menu would get cut off:

    **Before**
    ![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/8942601/120873850-b20e2f00-c558-11eb-8af5-faf4b198644e.gif)


    **After**
    ![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/8942601/120873862-ba666a00-c558-11eb-8756-1f9dfbe2530a.gif)

2. The page header `#` anchor that would appear on hover looked awfully mis-aligned with bigger headers:

    **Before**
    <img width="400" alt="Screen Shot 2021-06-04 at 5 12 49 PM" src="https://user-images.githubusercontent.com/8942601/120873885-dcf88300-c558-11eb-99f9-52d0012227c0.png">

    **After**
    ![ezgif com-gif-maker](https://user-images.githubusercontent.com/8942601/120873895-e681eb00-c558-11eb-8208-25f0f293d2e9.gif)
