### PR TITLE
Revert "Include the skeleton worker as a default OSS command"

### DIFF
--- a/dev/go-install.sh
+++ b/dev/go-install.sh
@@ -6,7 +6,7 @@
 # This will install binaries into the `.bin` directory under the repository root.
 #
 
-all_oss_commands=" gitserver query-runner github-proxy searcher frontend repo-updater symbols worker "
+all_oss_commands=" gitserver query-runner github-proxy searcher frontend repo-updater symbols "
 all_commands="${all_oss_commands}${ENTERPRISE_ONLY_COMMANDS}"
 
 # handle options


### PR DESCRIPTION
Reverts sourcegraph/sourcegraph#21792

Reverting because builds are failing on main.