### PR TITLE
web: remove `text-primary` class from links under the redesign theme

### DIFF
--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -54,9 +54,7 @@ export const ExternalAccount: React.FunctionComponent<Props> = ({ account, authP
                         <>
                             {account.external.userName} (
                             <Link to={account.external.userUrl} target="_blank" rel="noopener noreferrer">
-                                <span className={classNames(!isRedesignEnabled && 'text-primary')}>
-                                    @{account.external.userLogin}
-                                </span>
+                                @{account.external.userLogin}
                             </Link>
                             )
                         </>

--- a/client/web/src/user/settings/auth/ExternalAccount.tsx
+++ b/client/web/src/user/settings/auth/ExternalAccount.tsx
@@ -54,7 +54,9 @@ export const ExternalAccount: React.FunctionComponent<Props> = ({ account, authP
                         <>
                             {account.external.userName} (
                             <Link to={account.external.userUrl} target="_blank" rel="noopener noreferrer">
-                                <span className="text-primary">@{account.external.userLogin}</span>
+                                <span className={classNames(!isRedesignEnabled && 'text-primary')}>
+                                    @{account.external.userLogin}
+                                </span>
                             </Link>
                             )
                         </>

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -1,9 +1,11 @@
+import classNames from 'classnames'
 import React, { useCallback, useState, useEffect } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isDefined, keyExistsIn } from '@sourcegraph/shared/src/util/types'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../../components/alerts'
@@ -65,6 +67,7 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
 }) => {
     const [statusOrError, setStatusOrError] = useState<Status>()
     const [updateAuthRequired, setUpdateAuthRequired] = useState(false)
+    const [isRedesignEnabled] = useRedesignToggle()
 
     const fetchExternalServices = useCallback(async () => {
         setStatusOrError('loading')
@@ -216,7 +219,10 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                 description={
                     <>
                         Connect with your code hosts. Then,{' '}
-                        <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
+                        <Link
+                            className={classNames(!isRedesignEnabled && 'text-primary')}
+                            to={`${routingPrefix}/repositories/manage`}
+                        >
                             add repositories
                         </Link>{' '}
                         to search with Sourcegraph.

--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -1,11 +1,9 @@
-import classNames from 'classnames'
 import React, { useCallback, useState, useEffect } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { Link } from '@sourcegraph/shared/src/components/Link'
 import { asError, ErrorLike, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 import { isDefined, keyExistsIn } from '@sourcegraph/shared/src/util/types'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 import { Container, PageHeader } from '@sourcegraph/wildcard'
 
 import { ErrorAlert } from '../../../components/alerts'
@@ -67,7 +65,6 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
 }) => {
     const [statusOrError, setStatusOrError] = useState<Status>()
     const [updateAuthRequired, setUpdateAuthRequired] = useState(false)
-    const [isRedesignEnabled] = useRedesignToggle()
 
     const fetchExternalServices = useCallback(async () => {
         setStatusOrError('loading')
@@ -219,13 +216,8 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
                 description={
                     <>
                         Connect with your code hosts. Then,{' '}
-                        <Link
-                            className={classNames(!isRedesignEnabled && 'text-primary')}
-                            to={`${routingPrefix}/repositories/manage`}
-                        >
-                            add repositories
-                        </Link>{' '}
-                        to search with Sourcegraph.
+                        <Link to={`${routingPrefix}/repositories/manage`}>add repositories</Link> to search with
+                        Sourcegraph.
                     </>
                 }
                 className="mb-3"

--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -1,7 +1,9 @@
+import classNames from 'classnames'
 import React, { useState, FunctionComponent } from 'react'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { asError, ErrorLike } from '@sourcegraph/shared/src/util/errors'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import {
@@ -34,6 +36,7 @@ export const UserEmail: FunctionComponent<Props> = ({
     onEmailResendVerification,
 }) => {
     const [isLoading, setIsLoading] = useState(false)
+    const [isRedesignEnabled] = useRedesignToggle()
 
     const handleError = (error: ErrorLike): void => {
         onError(asError(error))
@@ -127,6 +130,8 @@ export const UserEmail: FunctionComponent<Props> = ({
         }
     }
 
+    const buttonLinkClassName = classNames('btn btn-link p-0', !isRedesignEnabled && 'text-primary ')
+
     return (
         <>
             <div className="d-flex align-items-center justify-content-between">
@@ -142,7 +147,7 @@ export const UserEmail: FunctionComponent<Props> = ({
                             <span className="user-settings-emails-page__dot">&bull;&nbsp;</span>
                             <button
                                 type="button"
-                                className="btn btn-link text-primary p-0"
+                                className={buttonLinkClassName}
                                 onClick={() => resendEmailVerification(email)}
                                 disabled={isLoading}
                             >
@@ -155,7 +160,7 @@ export const UserEmail: FunctionComponent<Props> = ({
                     {viewerCanManuallyVerify && (
                         <button
                             type="button"
-                            className="btn btn-link text-primary p-0"
+                            className={buttonLinkClassName}
                             onClick={() => updateEmailVerification(!verified)}
                             disabled={isLoading}
                         >

--- a/client/web/src/user/settings/emails/UserEmail.tsx
+++ b/client/web/src/user/settings/emails/UserEmail.tsx
@@ -1,9 +1,7 @@
-import classNames from 'classnames'
 import React, { useState, FunctionComponent } from 'react'
 
 import { dataOrThrowErrors, gql } from '@sourcegraph/shared/src/graphql/graphql'
 import { asError, ErrorLike } from '@sourcegraph/shared/src/util/errors'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { requestGraphQL } from '../../../backend/graphql'
 import {
@@ -36,7 +34,6 @@ export const UserEmail: FunctionComponent<Props> = ({
     onEmailResendVerification,
 }) => {
     const [isLoading, setIsLoading] = useState(false)
-    const [isRedesignEnabled] = useRedesignToggle()
 
     const handleError = (error: ErrorLike): void => {
         onError(asError(error))
@@ -130,8 +127,6 @@ export const UserEmail: FunctionComponent<Props> = ({
         }
     }
 
-    const buttonLinkClassName = classNames('btn btn-link p-0', !isRedesignEnabled && 'text-primary ')
-
     return (
         <>
             <div className="d-flex align-items-center justify-content-between">
@@ -147,7 +142,7 @@ export const UserEmail: FunctionComponent<Props> = ({
                             <span className="user-settings-emails-page__dot">&bull;&nbsp;</span>
                             <button
                                 type="button"
-                                className={buttonLinkClassName}
+                                className="btn btn-link p-0"
                                 onClick={() => resendEmailVerification(email)}
                                 disabled={isLoading}
                             >
@@ -160,7 +155,7 @@ export const UserEmail: FunctionComponent<Props> = ({
                     {viewerCanManuallyVerify && (
                         <button
                             type="button"
-                            className={buttonLinkClassName}
+                            className="btn btn-link p-0"
                             onClick={() => updateEmailVerification(!verified)}
                             disabled={isLoading}
                         >

--- a/client/web/src/user/settings/repositories/RepositoryNode.tsx
+++ b/client/web/src/user/settings/repositories/RepositoryNode.tsx
@@ -128,12 +128,7 @@ export const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({
                         {prefixComponent && prefixComponent}
                         <StatusIcon mirrorInfo={mirrorInfo} />
                         <CodeHostIcon hostType={serviceType} />
-                        <RepoLink
-                            className="text-muted"
-                            repoClassName={classNames(!isRedesignEnabled && 'text-primary')}
-                            repoName={name}
-                            to={null}
-                        />
+                        <RepoLink className="text-muted" repoName={name} to={null} />
                     </div>
                     <div>
                         {isPrivate && <div className="badge badge-secondary text-muted">Private</div>}

--- a/client/web/src/user/settings/repositories/RepositoryNode.tsx
+++ b/client/web/src/user/settings/repositories/RepositoryNode.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames'
 import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import CloudOutlineIcon from 'mdi-react/CloudOutlineIcon'
@@ -10,7 +9,6 @@ import React, { useCallback } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
-import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { ExternalServiceKind } from '../../../graphql-operations'
 
@@ -104,8 +102,6 @@ export const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({
     isPrivate,
     prefixComponent,
 }) => {
-    const [isRedesignEnabled] = useRedesignToggle()
-
     const handleOnClick = useCallback(
         (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
             if (onClick !== undefined) {

--- a/client/web/src/user/settings/repositories/RepositoryNode.tsx
+++ b/client/web/src/user/settings/repositories/RepositoryNode.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import BitbucketIcon from 'mdi-react/BitbucketIcon'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import CloudOutlineIcon from 'mdi-react/CloudOutlineIcon'
@@ -9,6 +10,7 @@ import React, { useCallback } from 'react'
 
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { RepoLink } from '@sourcegraph/shared/src/components/RepoLink'
+import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
 import { ExternalServiceKind } from '../../../graphql-operations'
 
@@ -102,6 +104,8 @@ export const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({
     isPrivate,
     prefixComponent,
 }) => {
+    const [isRedesignEnabled] = useRedesignToggle()
+
     const handleOnClick = useCallback(
         (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>): void => {
             if (onClick !== undefined) {
@@ -111,6 +115,7 @@ export const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({
         },
         [onClick]
     )
+
     return (
         <tr className="user-settings-repos__repositorynode">
             <td className="border-color">
@@ -123,7 +128,12 @@ export const RepositoryNode: React.FunctionComponent<RepositoryNodeProps> = ({
                         {prefixComponent && prefixComponent}
                         <StatusIcon mirrorInfo={mirrorInfo} />
                         <CodeHostIcon hostType={serviceType} />
-                        <RepoLink className="text-muted" repoClassName="text-primary" repoName={name} to={null} />
+                        <RepoLink
+                            className="text-muted"
+                            repoClassName={classNames(!isRedesignEnabled && 'text-primary')}
+                            repoName={name}
+                            to={null}
+                        />
                     </div>
                     <div>
                         {isPrivate && <div className="badge badge-secondary text-muted">Private</div>}

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -176,11 +176,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
     const [affiliateRepoProblems, setAffiliateRepoProblems] = useState<affiliateRepoProblemType>()
     const [otherPublicRepoError, setOtherPublicRepoError] = useState<undefined | ErrorLike>()
 
-    const ExternalServiceProblemHint = (
-        <Link className={classNames(!isRedesignEnabled && 'text-primary')} to={`${routingPrefix}/code-hosts`}>
-            Check code host connections
-        </Link>
-    )
+    const ExternalServiceProblemHint = <Link to={`${routingPrefix}/code-hosts`}>Check code host connections</Link>
 
     const toggleTextArea = useCallback(
         () => setPublicRepoState({ ...publicRepoState, enabled: !publicRepoState.enabled }),
@@ -736,12 +732,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                             <h3>Your repositories</h3>
                             <p className="text-muted">
                                 Repositories you own or collaborate on from your{' '}
-                                <Link
-                                    className={classNames(!isRedesignEnabled && 'text-primary')}
-                                    to={`${routingPrefix}/code-hosts`}
-                                >
-                                    connected code hosts
-                                </Link>
+                                <Link to={`${routingPrefix}/code-hosts`}>connected code hosts</Link>
                             </p>
                             {!ALLOW_PRIVATE_CODE && hasCodeHosts && (
                                 <div className="alert alert-primary">

--- a/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsManageRepositoriesPage.tsx
@@ -177,7 +177,7 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
     const [otherPublicRepoError, setOtherPublicRepoError] = useState<undefined | ErrorLike>()
 
     const ExternalServiceProblemHint = (
-        <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
+        <Link className={classNames(!isRedesignEnabled && 'text-primary')} to={`${routingPrefix}/code-hosts`}>
             Check code host connections
         </Link>
     )
@@ -736,7 +736,10 @@ export const UserSettingsManageRepositoriesPage: React.FunctionComponent<Props> 
                             <h3>Your repositories</h3>
                             <p className="text-muted">
                                 Repositories you own or collaborate on from your{' '}
-                                <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
+                                <Link
+                                    className={classNames(!isRedesignEnabled && 'text-primary')}
+                                    to={`${routingPrefix}/code-hosts`}
+                                >
                                     connected code hosts
                                 </Link>
                             </p>

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -123,18 +123,27 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
 
             {externalServices?.length === 0 ? (
                 <small>
-                    <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
+                    <Link
+                        className={classNames(!isRedesignEnabled && 'text-primary')}
+                        to={`${routingPrefix}/code-hosts`}
+                    >
                         Connect code hosts
                     </Link>{' '}
                     to start searching your own repositories, or{' '}
-                    <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
+                    <Link
+                        className={classNames(!isRedesignEnabled && 'text-primary')}
+                        to={`${routingPrefix}/repositories/manage`}
+                    >
                         add public repositories
                     </Link>{' '}
                     from GitHub or GitLab.
                 </small>
             ) : (
                 <small>
-                    <Link className="text-primary" to={`${routingPrefix}/repositories/manage`}>
+                    <Link
+                        className={classNames(!isRedesignEnabled && 'text-primary')}
+                        to={`${routingPrefix}/repositories/manage`}
+                    >
                         Add repositories
                     </Link>{' '}
                     to start searching your code with Sourcegraph.
@@ -406,7 +415,10 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 description={
                     <>
                         All repositories synced with Sourcegraph from{' '}
-                        <Link className="text-primary" to={`${routingPrefix}/code-hosts`}>
+                        <Link
+                            className={classNames(!isRedesignEnabled && 'text-primary')}
+                            to={`${routingPrefix}/code-hosts`}
+                        >
                             connected code hosts
                         </Link>
                     </>

--- a/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
+++ b/client/web/src/user/settings/repositories/UserSettingsRepositoriesPage.tsx
@@ -123,30 +123,14 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
 
             {externalServices?.length === 0 ? (
                 <small>
-                    <Link
-                        className={classNames(!isRedesignEnabled && 'text-primary')}
-                        to={`${routingPrefix}/code-hosts`}
-                    >
-                        Connect code hosts
-                    </Link>{' '}
-                    to start searching your own repositories, or{' '}
-                    <Link
-                        className={classNames(!isRedesignEnabled && 'text-primary')}
-                        to={`${routingPrefix}/repositories/manage`}
-                    >
-                        add public repositories
-                    </Link>{' '}
+                    <Link to={`${routingPrefix}/code-hosts`}>Connect code hosts</Link> to start searching your own
+                    repositories, or <Link to={`${routingPrefix}/repositories/manage`}>add public repositories</Link>{' '}
                     from GitHub or GitLab.
                 </small>
             ) : (
                 <small>
-                    <Link
-                        className={classNames(!isRedesignEnabled && 'text-primary')}
-                        to={`${routingPrefix}/repositories/manage`}
-                    >
-                        Add repositories
-                    </Link>{' '}
-                    to start searching your code with Sourcegraph.
+                    <Link to={`${routingPrefix}/repositories/manage`}>Add repositories</Link> to start searching your
+                    code with Sourcegraph.
                 </small>
             )}
         </Container>
@@ -415,12 +399,7 @@ export const UserSettingsRepositoriesPage: React.FunctionComponent<Props> = ({
                 description={
                     <>
                         All repositories synced with Sourcegraph from{' '}
-                        <Link
-                            className={classNames(!isRedesignEnabled && 'text-primary')}
-                            to={`${routingPrefix}/code-hosts`}
-                        >
-                            connected code hosts
-                        </Link>
+                        <Link to={`${routingPrefix}/code-hosts`}>connected code hosts</Link>
                     </>
                 }
                 actions={


### PR DESCRIPTION
## Changes

- Removed `text-primary` class from links under the redesign theme.

Closes https://github.com/sourcegraph/sourcegraph/issues/21780.
