### PR TITLE
Refresh: Deprecate old `border-radius` values

### DIFF
--- a/client/branded/src/global-styles/border-radius.scss
+++ b/client/branded/src/global-styles/border-radius.scss
@@ -1,15 +1,4 @@
 :root {
-    --border-radius: 2px;
-    --border-radius-sm: 1px;
-    --border-radius-lg: 4px;
-    --popover-border-radius: 4px;
-}
-
-.theme-redesign {
     --border-radius: 3px;
     --popover-border-radius: 5px;
-
-    // TODO: Remove usage of these, replace with --border-radius: https://github.com/sourcegraph/sourcegraph/issues/21106
-    --border-radius-sm: 3px;
-    --border-radius-lg: 3px;
 }

--- a/client/branded/src/global-styles/index.scss
+++ b/client/branded/src/global-styles/index.scss
@@ -3,8 +3,8 @@
 
 // Bootstrap configuration before Bootstrap is imported
 $border-radius: var(--border-radius);
-$border-radius-sm: var(--border-radius-sm);
-$border-radius-lg: var(--border-radius-lg);
+$border-radius-sm: var(--border-radius);
+$border-radius-lg: var(--border-radius);
 $popover-border-radius: var(--popover-border-radius);
 
 $font-size-base: 0.875rem;

--- a/client/browser/src/app.scss
+++ b/client/browser/src/app.scss
@@ -2,8 +2,8 @@
 
 // Bootstrap configuration before Bootstrap is imported
 $border-radius: var(--border-radius);
-$border-radius-sm: var(--border-radius-sm);
-$border-radius-lg: var(--border-radius-lg);
+$border-radius-sm: var(--border-radius);
+$border-radius-lg: var(--border-radius);
 
 $font-size-base: 0.875rem;
 $line-height-base: (20/14);


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21106

SCSS variables are still required for Bootstrap configuration