### PR TITLE
Contributors page: ensure name and avatar are vertically centered

### DIFF
--- a/client/web/src/repo/stats/RepositoryStatsContributorsPage.scss
+++ b/client/web/src/repo/stats/RepositoryStatsContributorsPage.scss
@@ -5,6 +5,8 @@
     flex-wrap: wrap;
 
     &__person {
+        display: flex;
+        align-items: center;
         min-width: 25%;
         flex: none;
         margin-right: 2rem;


### PR DESCRIPTION
Fix the contributors page ([example](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/stats/contributors)) to ensure that the user avatar and the full name are vertically aligned.

![Frame 7](https://user-images.githubusercontent.com/17293/121017423-8d56c900-c79d-11eb-90d5-b0f10541a8ed.png)
