### PR TITLE
Update Monoco redesign theme colors

### DIFF
--- a/client/web/src/components/MonacoEditor.tsx
+++ b/client/web/src/components/MonacoEditor.tsx
@@ -142,8 +142,35 @@ monaco.editor.defineTheme(SOURCEGRAPH_DARK_REDESIGN, {
         ...darkColors,
         background: '#181b26',
         'editor.background': '#181b26',
+        'editorSuggestWidget.border': '#343a4d',
+        'editorHoverWidget.border': '#343a4d',
     },
-    rules: darkRules,
+    rules: [
+        ...darkRules,
+        // Sourcegraph base language tokens
+        { token: 'identifier', foreground: '#f9fafb' },
+        { token: 'field', foreground: '#4393e7' },
+        { token: 'keyword', foreground: '#d68cf3' },
+        { token: 'openingParen', foreground: '#d68cf3' },
+        { token: 'closingParen', foreground: '#d68cf3' },
+        // Sourcegraph decorated language tokens
+        { token: 'metaRepoRevisionSeparator', foreground: '#569cd9' },
+        { token: 'metaContextPrefix', foreground: '#d68cf3' },
+        { token: 'metaPredicateNameAccess', foreground: '#d68cf3' },
+        { token: 'metaPredicateDot', foreground: '#f9fafb' },
+        // Regexp pattern highlighting
+        { token: 'metaRegexpCharacterSet', foreground: '#d68cf3' },
+        { token: 'metaRegexpCharacterClass', foreground: '#d68cf3' },
+        { token: 'metaRegexpCharacterClassMember', foreground: '#f9fafb' },
+        { token: 'metaRegexpCharacterClassRange', foreground: '#f9fafb' },
+        { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#d68cf3' },
+        // Structural pattern highlighting
+        { token: 'metaStructuralVariable', foreground: '#f9fafb' },
+        // Revision highlighting
+        { token: 'metaRevisionCommitHash', foreground: '#f9fafb' },
+        { token: 'metaRevisionLabel', foreground: '#f9fafb' },
+        { token: 'metaRevisionReferencePath', foreground: '#f9fafb' },
+    ],
 })
 
 monaco.editor.defineTheme(SOURCEGRAPH_DARK, {
@@ -163,8 +190,42 @@ monaco.editor.defineTheme(SOURCEGRAPH_LIGHT, {
 monaco.editor.defineTheme(SOURCEGRAPH_LIGHT_REDESIGN, {
     base: 'vs',
     inherit: true,
-    colors: lightColors,
-    rules: lightRules,
+    colors: {
+        ...lightColors,
+        'editor.foreground': '#14171f',
+        'editorCursor.foreground': '#14171f',
+        'editorSuggestWidget.foreground': '#14171f',
+        'editorSuggestWidget.border': '#dbe2f0',
+        'editorHoverWidget.foreground': '#14171f',
+        'editorHoverWidget.border': '#dbe2f0',
+        'editor.hoverHighlightBackground': '#343a4d',
+    },
+    rules: [
+        ...lightRules,
+        // Sourcegraph base language tokens
+        { token: 'identifier', foreground: '#14171f' },
+        { token: 'field', foreground: '#0b70db' },
+        { token: 'keyword', foreground: '#a305e1' },
+        { token: 'openingParen', foreground: '#a305e1' },
+        { token: 'closingParen', foreground: '#a305e1' },
+        // Sourcegraph decorated language tokens
+        { token: 'metaRepoRevisionSeparator', foreground: '#0b70db' },
+        { token: 'metaContextPrefix', foreground: '#a305e1' },
+        { token: 'metaPredicateNameAccess', foreground: '#a305e1' },
+        { token: 'metaPredicateDot', foreground: '#14171f' },
+        // Regexp pattern highlighting
+        { token: 'metaRegexpCharacterSet', foreground: '#a305e1' },
+        { token: 'metaRegexpCharacterClass', foreground: '#a305e1' },
+        { token: 'metaRegexpCharacterClassMember', foreground: '#14171f' },
+        { token: 'metaRegexpCharacterClassRange', foreground: '#14171f' },
+        { token: 'metaRegexpCharacterClassRangeHyphen', foreground: '#a305e1' },
+        // Structural pattern highlighting
+        { token: 'metaStructuralVariable', foreground: '#14171f' },
+        // Revision highlighting
+        { token: 'metaRevisionCommitHash', foreground: '#14171f' },
+        { token: 'metaRevisionLabel', foreground: '#14171f' },
+        { token: 'metaRevisionReferencePath', foreground: '#14171f' },
+    ],
 })
 
 interface Props extends ThemeProps {


### PR DESCRIPTION
Resolves: #20946 

This commit updates the Monoco color values to match redesign changes.
This was done by finding the color values and variable names in `colors.scss` or
`open-colors.css` and find the corresponding new color in
`colors-redesign.scss`.

I found the following color mappings (including which variables I used
to determine the mapping):

Light theme:

```
2b3750 -> 14171f (--search-query-text-color -> --gray-12)
268bd2 -> 0b70db (--search-filter-keyword-color -> --primary -> --blue -> $redesign-blue)
ae3ec9 -> a305e1 ($oc-grape-7 -> --search-keyword-color -> --purple -> $redesign-purple)
cad2e2 -> dbe2f0 ($gray-04 -> --gray-04)
dee2e6 -> 343a4d ($oc-gray-3 -> --disabled-action-bg-color -> --color-bg-3 -> --gray-08 -> $redesign-gray-08)
```

Dark theme:

```
f2f4f8 -> f9fafb (--search-query-text-color -> --gray-04)
569cd6 -> 4393e7 (--search-filter-keyword-color)
da77f2 -> d68cf3 ($oc-grape-4 -> --search-keyword-color -> --pink -> $redesign-pink)
2b3750 -> 343a4d ($secondary -> --secondary -> --gray-08 -> --redesign-gray-08)
```

I used my best judgement to map the colors, but I don't know if all these mappings are correct. I spot checked some of them to make sure that they are picked up (see screenshot)

![Screenshot of developers tools verifying search input color values](https://user-images.githubusercontent.com/179026/121022093-533bf600-c7a2-11eb-821e-d8f575eb8cc9.png)

