### PR TITLE
eventLogger: redact repo, filenames and search queries from firstSourceURLs

### DIFF
--- a/client/web/src/tracking/analyticsUtils.tsx
+++ b/client/web/src/tracking/analyticsUtils.tsx
@@ -7,6 +7,7 @@ import { asError } from '@sourcegraph/shared/src/util/errors'
 import { IS_CHROME } from '../marketing/util'
 
 import { eventLogger } from './eventLogger'
+import { stripURLParameters } from './util'
 
 interface EventQueryParameters {
     utm_campaign?: string
@@ -113,17 +114,4 @@ export function handleQueryEvents(url: string): void {
     }
 
     stripURLParameters(url, ['utm_campaign', 'utm_source', 'utm_medium', 'badge'])
-}
-
-/**
- * Strip provided URL parameters and update window history
- */
-export function stripURLParameters(url: string, parametersToRemove: string[] = []): void {
-    const parsedUrl = new URL(url)
-    for (const key of parametersToRemove) {
-        if (parsedUrl.searchParams.has(key)) {
-            parsedUrl.searchParams.delete(key)
-        }
-    }
-    window.history.replaceState(window.history.state, window.document.title, parsedUrl.href)
 }

--- a/client/web/src/tracking/eventLogger.ts
+++ b/client/web/src/tracking/eventLogger.ts
@@ -103,19 +103,17 @@ export class EventLogger implements TelemetryService {
 
         // Use cookies instead of localStorage so that the ID can be shared with subdomains (about.sourcegraph.com).
         // Always set to renew expiry and migrate from localStorage
-        {
-            cookies.set(FIRST_SOURCE_URL_KEY, redactedURL, {
-                // 365 days expiry, but renewed on activity.
-                expires: 365,
-                // Enforce HTTPS
-                secure: true,
-                // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
-                sameSite: 'Strict',
-                // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
-                // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
-                domain: location.hostname,
-            })
-        }
+        cookies.set(FIRST_SOURCE_URL_KEY, redactedURL, {
+            // 365 days expiry, but renewed on activity.
+            expires: 365,
+            // Enforce HTTPS
+            secure: true,
+            // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
+            sameSite: 'Strict',
+            // Specify the Domain attribute to ensure subdomains (about.sourcegraph.com) can receive this cookie.
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
+            domain: location.hostname,
+        })
 
         this.firstSourceURL = firstSourceURL
         return firstSourceURL

--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -1,6 +1,6 @@
 import { redactSensitiveInfoFromURL } from './util'
 
-describe('tracking/analyticsUtils', () => {
+describe('tracking/util', () => {
     describe(`${redactSensitiveInfoFromURL.name}()`, () => {
         it('removes search queries from URLs', () => {
             expect(redactSensitiveInfoFromURL('https://sourcegraph.com/search?q=test+query')).toEqual(
@@ -8,12 +8,22 @@ describe('tracking/analyticsUtils', () => {
             )
         })
 
-        it('removes search queries from URLs but maintains other query params', () => {
+        it('removes search queries from URLs but maintains marketing query params', () => {
             expect(
                 redactSensitiveInfoFromURL(
                     'https://sourcegraph.com/search?q=test+query&utm_source=test&utm_campaign=test'
                 )
             ).toEqual('https://sourcegraph.com/redacted?q=redacted&utm_source=test&utm_campaign=test')
+        })
+
+        it('removes all query params from URLs but maintains marketing query params', () => {
+            expect(
+                redactSensitiveInfoFromURL(
+                    'https://sourcegraph.com/search?some_query_param=test+query&utm_source=test&utm_campaign=test&utm_content=test&utm_medium=test&utm_medium=test'
+                )
+            ).toEqual(
+                'https://sourcegraph.com/redacted?some_query_param=redacted&utm_source=test&utm_campaign=test&utm_content=test&utm_medium=test&utm_medium=test'
+            )
         })
 
         it('removes repo information from URLs', () => {

--- a/client/web/src/tracking/util.test.ts
+++ b/client/web/src/tracking/util.test.ts
@@ -1,0 +1,35 @@
+import { redactSensitiveInfoFromURL } from './util'
+
+describe('tracking/analyticsUtils', () => {
+    describe(`${redactSensitiveInfoFromURL.name}()`, () => {
+        it('removes search queries from URLs', () => {
+            expect(redactSensitiveInfoFromURL('https://sourcegraph.com/search?q=test+query')).toEqual(
+                'https://sourcegraph.com/redacted?q=redacted'
+            )
+        })
+
+        it('removes search queries from URLs but maintains other query params', () => {
+            expect(
+                redactSensitiveInfoFromURL(
+                    'https://sourcegraph.com/search?q=test+query&utm_source=test&utm_campaign=test'
+                )
+            ).toEqual('https://sourcegraph.com/redacted?q=redacted&utm_source=test&utm_campaign=test')
+        })
+
+        it('removes repo information from URLs', () => {
+            expect(
+                redactSensitiveInfoFromURL(
+                    'https://sourcegraph.com/github.com/test/test?utm_source=test&utm_campaign=test'
+                )
+            ).toEqual('https://sourcegraph.com/redacted?utm_source=test&utm_campaign=test')
+        })
+
+        it('removes repo and file information from URLs', () => {
+            expect(
+                redactSensitiveInfoFromURL(
+                    'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/test?utm_source=test&utm_campaign=test'
+                )
+            ).toEqual('https://sourcegraph.com/redacted?utm_source=test&utm_campaign=test')
+        })
+    })
+})

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -1,0 +1,33 @@
+/**
+ * Strip provided URL parameters and update window history
+ */
+export function stripURLParameters(url: string, parametersToRemove: string[] = []): void {
+    const parsedUrl = new URL(url)
+    for (const key of parametersToRemove) {
+        if (parsedUrl.searchParams.has(key)) {
+            parsedUrl.searchParams.delete(key)
+        }
+    }
+    window.history.replaceState(window.history.state, window.document.title, parsedUrl.href)
+}
+
+/**
+ * Redact the pathname and search query from URLs to avoid
+ * leaking sensitive information, while maintaining
+ * non-sensitive query parameters used for attribution tracking.
+ *
+ * @param url the original, full URL
+ */
+export function redactSensitiveInfoFromURL(url: string): string {
+    // Ensure we do not leak repo and file names in the URL
+    const sourceURL = new URL(url)
+    sourceURL.pathname = '/redacted'
+
+    // Ensure we do not leak search queries in the URL
+    const searchQuery = sourceURL.searchParams.get('q')
+    if (searchQuery) {
+        sourceURL.searchParams.set('q', 'redacted')
+    }
+
+    return sourceURL.href
+}

--- a/client/web/src/tracking/util.ts
+++ b/client/web/src/tracking/util.ts
@@ -19,14 +19,17 @@ export function stripURLParameters(url: string, parametersToRemove: string[] = [
  * @param url the original, full URL
  */
 export function redactSensitiveInfoFromURL(url: string): string {
+    const marketingQueryParameters = new Set(['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content'])
     // Ensure we do not leak repo and file names in the URL
     const sourceURL = new URL(url)
     sourceURL.pathname = '/redacted'
 
-    // Ensure we do not leak search queries in the URL
-    const searchQuery = sourceURL.searchParams.get('q')
-    if (searchQuery) {
-        sourceURL.searchParams.set('q', 'redacted')
+    // Ensure we do not leak search queries or other sensitive info in the URL
+    // by only maintaining UTM parameters for attribution.
+    for (const [parameter] of sourceURL.searchParams) {
+        if (!marketingQueryParameters.has(parameter)) {
+            sourceURL.searchParams.set(parameter, 'redacted')
+        }
     }
 
     return sourceURL.href


### PR DESCRIPTION
This updates our logic for tracking firstSourceURLs, which we use for marketing attribution. Currently, we will store the first sourcegraph URL a user has ever visited in a cookie, and associate that with their profile in HubSpot when they create one. However, with private code coming onto Cloud, we want to make sure we don't leak any private info like repo or file names, or the contents of search queries. 

This PR makes it so we replace these parts of the URL with `redacted`. For attribution, we only need the query parameters, which we maintain. So, with this change, we remove the risk of storing private information in a third-party tool, while ensuring our attribution remains effective. 



<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
