### PR TITLE
web: update branch selector icon padding

### DIFF
--- a/client/web/src/repo/RepoRevisionContainer.scss
+++ b/client/web/src/repo/RepoRevisionContainer.scss
@@ -59,6 +59,11 @@
         }
     }
 
+    &__breadcrumb-icon {
+        margin-left: 0.125rem;
+        margin-right: -0.25rem;
+    }
+
     &__divider {
         margin-right: 0.25rem;
 

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -127,7 +127,7 @@ const RepoRevisionContainerBreadcrumb: React.FunctionComponent<RepoRevisionBread
         return (
             <button
                 type="button"
-                className="btn btn-sm btn-outline-secondary d-flex align-items-center text-nowrap "
+                className="btn btn-sm btn-outline-secondary d-flex align-items-center text-nowrap"
                 key="repo-revision"
                 id="repo-revision-popover"
                 aria-label="Change revision"

--- a/client/web/src/repo/RepoRevisionContainer.tsx
+++ b/client/web/src/repo/RepoRevisionContainer.tsx
@@ -127,7 +127,7 @@ const RepoRevisionContainerBreadcrumb: React.FunctionComponent<RepoRevisionBread
         return (
             <button
                 type="button"
-                className="btn btn-sm btn-outline-secondary d-flex align-items-center text-nowrap"
+                className="btn btn-sm btn-outline-secondary d-flex align-items-center text-nowrap "
                 key="repo-revision"
                 id="repo-revision-popover"
                 aria-label="Change revision"
@@ -137,7 +137,7 @@ const RepoRevisionContainerBreadcrumb: React.FunctionComponent<RepoRevisionBread
                     : revision) ||
                     resolvedRevisionOrError.defaultBranch ||
                     'HEAD'}
-                <ChevronDownIcon className="icon-inline" />
+                <ChevronDownIcon className="icon-inline repo-revision-container__breadcrumb-icon" />
                 <RepoRevisionContainerPopover
                     repo={repo}
                     resolvedRevisionOrError={resolvedRevisionOrError}


### PR DESCRIPTION
## Changes

- Update branch selector icon padding to match [the latest mockups](https://www.figma.com/file/NIsN34NH7lPu04olBzddTw/Design-Refresh-Systemization-source-of-truth?node-id=3008%3A9804).

Closes https://github.com/sourcegraph/sourcegraph/issues/21806.

## Screenshots

### Before

<img width="908" alt="Screenshot 2021-06-07 at 19 08 07" src="https://user-images.githubusercontent.com/3846380/121053147-a25b4880-c7ed-11eb-9ca5-6a25bea3b850.png">

### After

<img width="908" alt="Screenshot 2021-06-07 at 19 07 36" src="https://user-images.githubusercontent.com/3846380/121053071-8f487880-c7ed-11eb-8a57-5d9d9a48ff7d.png">
