### PR TITLE
extensibility: hide site admin toggle for global settings file users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Code Insights queries can now run concurrently up to a limit set by the `insights.query.worker.concurrency` site config. [#21219](https://github.com/sourcegraph/sourcegraph/pull/21219)
 - Code Insights workers now support a rate limit for query execution and historical data frame analysis using the `insights.query.worker.rateLimit` and `insights.historical.worker.rateLimit` site configurations. [#21533](https://github.com/sourcegraph/sourcegraph/pull/21533)
+- The GraphQL `Site` `SettingsSubject` type now has an `allowSiteSettingsEdits` field to allow clients to determine whether the instance uses the `GLOBAL_SETTINGS_FILE` environment variable. [#21827](https://github.com/sourcegraph/sourcegraph/pull/21827)
 
 ### Changed
 

--- a/client/shared/src/settings/settings.ts
+++ b/client/shared/src/settings/settings.ts
@@ -41,7 +41,7 @@ export type SettingsSubject = Pick<GQL.ISettingsSubject, 'id' | 'viewerCanAdmini
         | Pick<IClient, '__typename' | 'displayName'>
         | Pick<GQL.IUser, '__typename' | 'username' | 'displayName'>
         | Pick<GQL.IOrg, '__typename' | 'name' | 'displayName'>
-        | Pick<GQL.ISite, '__typename'>
+        | Pick<GQL.ISite, '__typename' | 'allowSiteSettingsEdits'>
         | Pick<GQL.IDefaultSettings, '__typename'>
     )
 

--- a/client/web/src/extensions/ExtensionCard.test.tsx
+++ b/client/web/src/extensions/ExtensionCard.test.tsx
@@ -52,6 +52,7 @@ describe('ExtensionCard', () => {
                                 __typename: 'Site',
                                 id: 's',
                                 viewerCanAdminister: true,
+                                allowSiteSettingsEdits: true,
                             }}
                             settingsCascade={{ final: null, subjects: null }}
                             platformContext={NOOP_PLATFORM_CONTEXT}

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -68,7 +68,7 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
         }
         for (const subject of settingsCascade.subjects) {
             if (subject.subject.__typename === 'Site') {
-                // Even if the user has permission to admister Site settings, changes cannot be made
+                // Even if the user has permission to administer Site settings, changes cannot be made
                 // through the API if global settings are configured through the GLOBAL_SETTINGS_FILE envvar.
                 if (subject.subject.allowSiteSettingsEdits) {
                     return subject

--- a/client/web/src/extensions/ExtensionsList.tsx
+++ b/client/web/src/extensions/ExtensionsList.tsx
@@ -62,10 +62,22 @@ export const ExtensionsList: React.FunctionComponent<Props> = ({
         () => settingsCascade.subjects?.find(settingsSubject => settingsSubject.subject.id === subject.id),
         [settingsCascade, subject.id]
     )
-    const siteSubject = useMemo(
-        () => settingsCascade.subjects?.find(settingsSubject => settingsSubject.subject.__typename === 'Site'),
-        [settingsCascade]
-    )
+    const siteSubject = useMemo(() => {
+        if (!settingsCascade.subjects) {
+            return undefined
+        }
+        for (const subject of settingsCascade.subjects) {
+            if (subject.subject.__typename === 'Site') {
+                // Even if the user has permission to admister Site settings, changes cannot be made
+                // through the API if global settings are configured through the GLOBAL_SETTINGS_FILE envvar.
+                if (subject.subject.allowSiteSettingsEdits) {
+                    return subject
+                }
+                break
+            }
+        }
+        return undefined
+    }, [settingsCascade])
 
     if (!data || data === LOADING) {
         return <LoadingSpinner className="icon-inline mt-2" />

--- a/client/web/src/integration/code-monitoring.test.ts
+++ b/client/web/src/integration/code-monitoring.test.ts
@@ -62,6 +62,7 @@ describe('Code monitoring', () => {
                             },
                             settingsURL: '/site-admin/global-settings',
                             viewerCanAdminister: true,
+                            allowSiteSettingsEdits: true,
                         },
                     ],
                     final: JSON.stringify({}),

--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -154,6 +154,7 @@ describe('Extension Registry', () => {
                             },
                             settingsURL: '/site-admin/global-settings',
                             viewerCanAdminister: true,
+                            allowSiteSettingsEdits: true,
                         },
                         {
                             __typename: 'User',

--- a/client/web/src/integration/graphQlResults.ts
+++ b/client/web/src/integration/graphQlResults.ts
@@ -50,6 +50,7 @@ export const commonWebGraphQlResults: Partial<WebGraphQlOperations & SharedGraph
                     },
                     settingsURL: '/site-admin/global-settings',
                     viewerCanAdminister: true,
+                    allowSiteSettingsEdits: true,
                 },
             ],
             final: JSON.stringify({}),

--- a/client/web/src/integration/insights/utils/override-graphql-with-extensions.ts
+++ b/client/web/src/integration/insights/utils/override-graphql-with-extensions.ts
@@ -182,6 +182,7 @@ export function overrideGraphQLExtensions(props: OverrideGraphQLExtensionsProps)
                         },
                         settingsURL: '/site-admin/global-settings',
                         viewerCanAdminister: true,
+                        allowSiteSettingsEdits: true,
                     },
                     {
                         __typename: 'Org',

--- a/client/web/src/integration/search-contexts.test.ts
+++ b/client/web/src/integration/search-contexts.test.ts
@@ -92,6 +92,7 @@ describe('Search contexts', () => {
                         },
                         settingsURL: '/site-admin/global-settings',
                         viewerCanAdminister: true,
+                        allowSiteSettingsEdits: true,
                     },
                 ],
                 final: JSON.stringify({}),

--- a/client/web/src/integration/search-onboarding.test.ts
+++ b/client/web/src/integration/search-onboarding.test.ts
@@ -57,6 +57,7 @@ describe('Search onboarding', () => {
                             },
                             settingsURL: '/site-admin/global-settings',
                             viewerCanAdminister: true,
+                            allowSiteSettingsEdits: true,
                         },
                     ],
                     final: JSON.stringify({}),

--- a/client/web/src/platform/context.ts
+++ b/client/web/src/platform/context.ts
@@ -102,6 +102,7 @@ const settingsCascadeFragment = gql`
             ... on Site {
                 id
                 siteID
+                allowSiteSettingsEdits
             }
             latestSettings {
                 id

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5067,7 +5067,7 @@ type Site implements SettingsSubject {
         days: Int
     ): MonitoringStatistics!
     """
-    Whether changes can be made to site settings. When global settings are configured through
+    Whether changes can be made to site settings through the API. When global settings are configured through
     the GLOBAL_SETTINGS_FILE environment variable, site settings edits cannot be made through the API.
     """
     allowSiteSettingsEdits: Boolean!

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -5066,6 +5066,11 @@ type Site implements SettingsSubject {
         """
         days: Int
     ): MonitoringStatistics!
+    """
+    Whether changes can be made to site settings. When global settings are configured through
+    the GLOBAL_SETTINGS_FILE environment variable, site settings edits cannot be made through the API.
+    """
+    allowSiteSettingsEdits: Boolean!
 }
 
 """

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -119,10 +119,8 @@ func (r *siteResolver) ProductSubscription() *productSubscriptionStatus {
 	return &productSubscriptionStatus{}
 }
 
-var allowSiteSettingsEdits = os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits
-
 func (r *siteResolver) AllowSiteSettingsEdits() bool {
-	return allowSiteSettingsEdits
+	return canUpdateSiteConfiguration()
 }
 
 type siteConfigurationResolver struct {
@@ -156,8 +154,6 @@ func (r *siteConfigurationResolver) ValidationMessages(ctx context.Context) ([]s
 	return conf.ValidateSite(string(contents))
 }
 
-var siteConfigAllowEdits, _ = strconv.ParseBool(env.Get("SITE_CONFIG_ALLOW_EDITS", "false", "When SITE_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
-
 func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *struct {
 	LastID int32
 	Input  string
@@ -167,7 +163,7 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 	if err := backend.CheckCurrentUserIsSiteAdmin(ctx, r.db); err != nil {
 		return false, err
 	}
-	if os.Getenv("SITE_CONFIG_FILE") != "" && !siteConfigAllowEdits {
+	if !canUpdateSiteConfiguration() {
 		return false, errors.New("updating site configuration not allowed when using SITE_CONFIG_FILE")
 	}
 	if strings.TrimSpace(args.Input) == "" {
@@ -187,4 +183,10 @@ func (r *schemaResolver) UpdateSiteConfiguration(ctx context.Context, args *stru
 		return false, err
 	}
 	return globals.ConfigurationServerFrontendOnly.NeedServerRestart(), nil
+}
+
+var siteConfigAllowEdits, _ = strconv.ParseBool(env.Get("SITE_CONFIG_ALLOW_EDITS", "false", "When SITE_CONFIG_FILE is in use, allow edits in the application to be made which will be overwritten on next process restart"))
+
+func canUpdateSiteConfiguration() bool {
+	return os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits
 }

--- a/cmd/frontend/graphqlbackend/site.go
+++ b/cmd/frontend/graphqlbackend/site.go
@@ -119,6 +119,12 @@ func (r *siteResolver) ProductSubscription() *productSubscriptionStatus {
 	return &productSubscriptionStatus{}
 }
 
+var allowSiteSettingsEdits = os.Getenv("SITE_CONFIG_FILE") == "" || siteConfigAllowEdits
+
+func (r *siteResolver) AllowSiteSettingsEdits() bool {
+	return allowSiteSettingsEdits
+}
+
 type siteConfigurationResolver struct {
 	db dbutil.DB
 }


### PR DESCRIPTION
Fix #21573. We added a toggle for site admins to enable/disable and extension for all users, but settings set through a global settings file cannot be mutated.

- Add `allowSiteSettingsEdits` field to `Site` settings subject type (GraphQL API).
- Hide "enable/disable extension for all" toggle for site admins who use a global settings file.

#### Questions

- When we add new fields to the GraphQL API, how do we handle the case where users are on the latest browser extension version, but point it towards a Sourcegraph instance running an older version? I'm not using this field in the browser extension for now, or probably ever since we don't mutate settings from it, but I wonder how we prevent bugs while iterating on the API (cc @felixfbecker).