### PR TITLE
extensibility: use hover styles for all interactive status bar items

### DIFF
--- a/client/web/src/extensions/components/StatusBar.scss
+++ b/client/web/src/extensions/components/StatusBar.scss
@@ -50,7 +50,7 @@
             padding-right: 0.5rem !important;
         }
 
-        &--tooltipped {
+        &--interactive {
             &:hover {
                 background-color: var(--link-hover-bg-color);
                 color: var(--link-hover-color);

--- a/client/web/src/extensions/components/StatusBar.tsx
+++ b/client/web/src/extensions/components/StatusBar.tsx
@@ -180,11 +180,13 @@ const StatusBarItem: React.FunctionComponent<
 
     const noop = !command
 
+    const interactive = Boolean(command || statusBarItem.tooltip)
+
     return (
         <ButtonLink
             className={classNames(
                 `${className}__item h-100 d-flex align-items-center px-1 text-decoration-none`,
-                statusBarItem.tooltip && `${className}__item--tooltipped`,
+                interactive && `${className}__item--interactive`,
                 noop && `${className}__item--noop`
             )}
             data-tooltip={statusBarItem.tooltip}

--- a/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
+++ b/client/web/src/extensions/components/__snapshots__/StatusBar.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`StatusBar renders correctly 1`] = `
         </a>
         <a
           aria-label="Code owners: @felixbecker, @beyang"
-          class="status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none status-bar__item--tooltipped status-bar__item--noop"
+          class="status-bar__item h-100 d-flex align-items-center px-1 text-decoration-none status-bar__item--interactive status-bar__item--noop"
           data-tooltip="Code owners: @felixbecker, @beyang"
           href=""
           role="button"


### PR DESCRIPTION
Fix #21571.

Use hover styles for all interactive status bar items, not just those with tooltips.