### PR TITLE
add case sensitivity to extension action context

### DIFF
--- a/client/web/src/search/results/SearchResultsInfoBar.test.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.test.tsx
@@ -24,6 +24,7 @@ const COMMON_PROPS: Omit<SearchResultsInfoBarProps, 'enableCodeMonitoring'> = {
     stats: <div />,
     telemetryService: NOOP_TELEMETRY_SERVICE,
     patternType: SearchPatternType.literal,
+    caseSensitive: false,
 }
 
 describe('SearchResultsInfoBar', () => {

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -19,7 +19,7 @@ import { FilterKind, findFilter } from '@sourcegraph/shared/src/search/query/val
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useRedesignToggle } from '@sourcegraph/shared/src/util/useRedesignToggle'
 
-import { PatternTypeProps } from '..'
+import { PatternTypeProps, CaseSensitivityProps } from '..'
 import { AuthenticatedUser } from '../../auth'
 import { CodeMonitoringProps } from '../../code-monitoring'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
@@ -31,6 +31,7 @@ export interface SearchResultsInfoBarProps
         PlatformContextProps<'forceUpdateTooltip' | 'settings'>,
         TelemetryProps,
         Pick<PatternTypeProps, 'patternType'>,
+        Pick<CaseSensitivityProps, 'caseSensitive'>,
         CodeMonitoringProps {
     history: H.History
     /** The currently authenticated user or null */
@@ -144,10 +145,14 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
         )
     }, [buttonClass, props.authenticatedUser, props.onSaveQueryClick, props.showSavedQueryButton])
 
-    const extraContext = useMemo(() => ({ searchQuery: props.query || null, patternType: props.patternType }), [
-        props.query,
-        props.patternType,
-    ])
+    const extraContext = useMemo(
+        () => ({
+            searchQuery: props.query || null,
+            patternType: props.patternType,
+            caseSensitive: props.caseSensitive,
+        }),
+        [props.query, props.patternType, props.caseSensitive]
+    )
 
     const [showFilters, setShowFilters] = useState(false)
     const onShowFiltersClicked = (): void => {


### PR DESCRIPTION
Ensure that all relevant search bar props are available to extensions (case sensitivity, pattern type, and the actual search query).
