### PR TITLE
codeintel: Add more repository ids to the dependency index allowlist

### DIFF
--- a/enterprise/cmd/frontend/internal/codeintel/background/indexing/dependency_indexing_scheduler.go
+++ b/enterprise/cmd/frontend/internal/codeintel/background/indexing/dependency_indexing_scheduler.go
@@ -100,7 +100,10 @@ func (h *dependencyIndexingSchedulerHandler) Handle(ctx context.Context, tx dbwo
 }
 
 var dependencyIndexingRepositoryIDs = []int{
-	36809250, // sg/sg on cloud
+	35703861, // github.com/sourcegraph/jsonx on cloud
+	36146693, // github.com/sourcegraph/src-clion cloud
+	36809250, // github.com/sourcegraph/sourcegraph on cloud
+	38967070, // github.com/sourcegraph/lsif-go on cloud
 }
 
 // shouldIndexDependencies returns true if the given upload should undergo dependency


### PR DESCRIPTION
Adding a few smaller dependency index targets so that we have a simple repository to index/upload in order to test out in cloud environment.