### PR TITLE
dev: Disable flaky ioutil lint check

### DIFF
--- a/dev/check/all.sh
+++ b/dev/check/all.sh
@@ -19,7 +19,8 @@ CHECKS=(
   ./go-dbconn-import.sh
   ./go-generate.sh
   ./go-lint.sh
-  ./ioutil.sh
+  # Disabled until we can figure out why it's flaky
+  #./ioutil.sh
   ./go-mod-tidy.sh
   ./no-alpine-guard.sh
   ./no-localhost-guard.sh


### PR DESCRIPTION
We're occasionally seeing this error:
./slack.go:105:19: undefined: io.ReadAll

It appears to be related to the internal/cmd/resources-report command
being compiled against an older version of Go that doesn't have the
io.ReadAll function yet.
