### PR TITLE
graphql: On error, return nil scopes

### DIFF
--- a/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
+++ b/client/web/src/user/settings/codeHosts/UserAddCodeHostsPage.tsx
@@ -87,7 +87,8 @@ export const UserAddCodeHostsPage: React.FunctionComponent<UserAddCodeHostsPageP
         // update their scope
         const gitHubService = services.GITHUB
         if (gitHubService) {
-            setUpdateAuthRequired(githubRepoScopeRequired(user.tags, gitHubService.grantedScopes))
+            const scopes = gitHubService.grantedScopes || []
+            setUpdateAuthRequired(githubRepoScopeRequired(user.tags, scopes))
         }
 
         const repoCount = fetchedServices.reduce((sum, codeHost) => sum + codeHost.repoCount, 0)

--- a/cmd/frontend/graphqlbackend/external_service.go
+++ b/cmd/frontend/graphqlbackend/external_service.go
@@ -172,13 +172,16 @@ func (r *externalServiceResolver) NextSyncAt() *DateTime {
 
 var scopeCache = rcache.New("extsvc_token_scope")
 
-func (r *externalServiceResolver) GrantedScopes(ctx context.Context) ([]string, error) {
-	scope, err := repos.GrantedScopes(ctx, scopeCache, r.externalService)
+func (r *externalServiceResolver) GrantedScopes(ctx context.Context) (*[]string, error) {
+	scopes, err := repos.GrantedScopes(ctx, scopeCache, r.externalService)
 	if err != nil {
 		// It's possible that we fail to fetch scope from the code host, in this case we
 		// don't want the entire resolver to fail.
 		log15.Error("Getting service scope", "id", r.externalService.ID, "error", err)
-		return []string{}, nil
+		return nil, nil
 	}
-	return scope, nil
+	if scopes == nil {
+		return nil, nil
+	}
+	return &scopes, nil
 }

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -1951,7 +1951,7 @@ type ExternalService implements Node {
     NOTE: Currently only GitHub is supported and the request consumes rate limit tokens
     so it should be used sparingly.
     """
-    grantedScopes: [String!]!
+    grantedScopes: [String!]
 }
 
 """

--- a/internal/repos/types.go
+++ b/internal/repos/types.go
@@ -116,7 +116,7 @@ type ScopeCache interface {
 // empty slice
 func GrantedScopes(ctx context.Context, cache ScopeCache, svc *types.ExternalService) ([]string, error) {
 	if svc.Kind != extsvc.KindGitHub {
-		return []string{}, nil
+		return nil, nil
 	}
 	src, err := NewSource(svc, nil)
 	if err != nil {


### PR DESCRIPTION
Instead of an empty slice. This allows us to differentiate between an
error and a token without any scopes.
