### PR TITLE
Don't fetch unknown stargazerCount field on old GHE versions

### DIFF
--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1023,6 +1023,7 @@ const timelineItemTypesFmtStr = `ASSIGNED_EVENT, CLOSED_EVENT, ISSUE_COMMENT, RE
 
 var ghe220Semver, _ = semver.NewConstraint("~2.20.0")
 var ghe221PlusOrDotComSemver, _ = semver.NewConstraint(">= 2.21.0")
+var ghe300PlusOrDotComSemver, _ = semver.NewConstraint(">= 3.0.0")
 
 func timelineItemTypes(version *semver.Version) (string, error) {
 	if ghe220Semver.Check(version) {

--- a/internal/extsvc/github/common_test.go
+++ b/internal/extsvc/github/common_test.go
@@ -337,7 +337,7 @@ repo8: repository(owner: "sourcegraph", name: "contains.dot") { ... on Repositor
 	mock := mockHTTPResponseBody{responseBody: ""}
 	apiURL := &url.URL{Scheme: "https", Host: "example.com", Path: "/"}
 	c := NewV4Client(apiURL, nil, &mock)
-	query, err := c.buildGetReposBatchQuery(repos)
+	query, err := c.buildGetReposBatchQuery(context.Background(), repos)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
GitHub enterprise prior to version 3.0 doesn't support this field. This is causing the query to fail and currently all repo syncs to github enterprise < 3.0 are falling back to sequential mode, I _think_ this fixes it. There is also a stargazers connection on the repository, which could be queried to make it work on these older versions. I'd be happy if you could take this on, I just did the minimal effort to trace this down and have _a_ fix for it. 

Found this log in our integration test suite:

```
2021-06-07T21:38:50.841746670Z 21:38:50              repo-updater | t=2021-06-07T21:38:50+0000 lvl=warn msg="github sync: fetching in batches failed. falling back to sequential fetch" error="error in GraphQL response: Field 'stargazerCount' doesn't exist on type 'Repository'"
```