### PR TITLE
Add patternType validation to Code Monitor search input

### DIFF
--- a/client/branded/src/global-styles/colors-redesign.scss
+++ b/client/branded/src/global-styles/colors-redesign.scss
@@ -127,6 +127,7 @@ $theme-colors-redesign: (
     --code-line-highlight-color: var(--color-bg-2);
     --diff-add-bg: #eeffec;
     --diff-remove-bg: #ffecec;
+    --triggerarea-checklist-checkbox-color: var(--gray-05);
 }
 
 .theme-dark.theme-redesign {
@@ -173,6 +174,7 @@ $theme-colors-redesign: (
     --code-line-highlight-color: var(--body-bg);
     --diff-add-bg: #224035;
     --diff-remove-bg: #3e1d1d;
+    --triggerarea-checklist-checkbox-color: var(--gray-07);
 
     // TODO: Remove from use, replace with the variables referenced here.
     // Issue: https://github.com/sourcegraph/sourcegraph/issues/19973

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -47,6 +47,14 @@
             margin-right: 0.5rem;
             color: var(--border-color);
 
+            .theme-light & {
+                color: var(--gray-05);
+            }
+
+            .theme-dark & {
+                color: var(--gray-07);
+            }
+
             &--unchecked {
                 // Make unchecked icon smaller so it doesn't look like a radio button.
                 // Scale instead of setting font size so that both checked and

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.scss
@@ -45,15 +45,7 @@
         &-checkbox {
             font-size: 0.65rem;
             margin-right: 0.5rem;
-            color: var(--border-color);
-
-            .theme-light & {
-                color: var(--gray-05);
-            }
-
-            .theme-dark & {
-                color: var(--gray-07);
-            }
+            color: var(--triggerarea-checklist-checkbox-color);
 
             &--unchecked {
                 // Make unchecked icon smaller so it doesn't look like a radio button.

--- a/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
+++ b/client/web/src/enterprise/code-monitoring/components/FormTriggerArea.test.tsx
@@ -37,13 +37,64 @@ describe('FormTriggerArea', () => {
     })
 
     const testCases = [
-        { query: '', typeChecked: false, repoChecked: false, validChecked: false },
-        { query: 'test', typeChecked: false, repoChecked: false, validChecked: true },
-        { query: 'test type:repo', typeChecked: false, repoChecked: false, validChecked: true },
-        { query: 'test type:diff', typeChecked: true, repoChecked: false, validChecked: true },
-        { query: 'test type:commit', typeChecked: true, repoChecked: false, validChecked: true },
-        { query: 'test repo:test', typeChecked: false, repoChecked: true, validChecked: true },
-        { query: 'test repo:test type:diff', typeChecked: true, repoChecked: true, validChecked: true },
+        { query: '', patternTypeChecked: true, typeChecked: false, repoChecked: false, validChecked: false },
+        { query: 'test', patternTypeChecked: true, typeChecked: false, repoChecked: false, validChecked: true },
+        {
+            query: 'test patternType:literal',
+            patternTypeChecked: true,
+            typeChecked: false,
+            repoChecked: false,
+            validChecked: true,
+        },
+        {
+            query: 'test patternType:regexp',
+            patternTypeChecked: true,
+            typeChecked: false,
+            repoChecked: false,
+            validChecked: true,
+        },
+        {
+            query: 'test patternType:structural',
+            patternTypeChecked: false,
+            typeChecked: false,
+            repoChecked: false,
+            validChecked: true,
+        },
+        {
+            query: 'test type:repo',
+            patternTypeChecked: true,
+            typeChecked: false,
+            repoChecked: false,
+            validChecked: true,
+        },
+        {
+            query: 'test type:diff',
+            patternTypeChecked: true,
+            typeChecked: true,
+            repoChecked: false,
+            validChecked: true,
+        },
+        {
+            query: 'test type:commit',
+            patternTypeChecked: true,
+            typeChecked: true,
+            repoChecked: false,
+            validChecked: true,
+        },
+        {
+            query: 'test repo:test',
+            patternTypeChecked: true,
+            typeChecked: false,
+            repoChecked: true,
+            validChecked: true,
+        },
+        {
+            query: 'test repo:test type:diff',
+            patternTypeChecked: true,
+            typeChecked: true,
+            repoChecked: true,
+            validChecked: true,
+        },
     ]
 
     for (const testCase of testCases) {
@@ -63,6 +114,9 @@ describe('FormTriggerArea', () => {
                 clock.tick(600)
             })
             component = component.update()
+
+            const patternTypeCheckbox = component.find('.test-patterntype-checkbox input[type="checkbox"]')
+            expect(patternTypeCheckbox.get(0).props?.checked).toBe(testCase.patternTypeChecked)
 
             const typeCheckbox = component.find('.test-type-checkbox input[type="checkbox"]')
             expect(typeCheckbox.get(0).props?.checked).toBe(testCase.typeChecked)
@@ -101,7 +155,7 @@ describe('FormTriggerArea', () => {
         sinon.assert.calledOnceWithExactly(onQueryChange, 'test type:diff repo:test patternType:literal')
     })
 
-    test('Do not append patternType:literal if no patternType is present', () => {
+    test('Do not append patternType:literal if patternType is present', () => {
         const onQueryChange = sinon.spy()
         let component = mount(
             <FormTriggerArea

--- a/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
+++ b/client/web/src/enterprise/code-monitoring/components/__snapshots__/FormTriggerArea.test.tsx.snap
@@ -50,6 +50,126 @@ exports[`FormTriggerArea Correct checkboxes shown when query does not fulfill re
           >
             <li>
               <ValidQueryChecklistItem
+                checked={true}
+                className="test-patterntype-checkbox"
+                hint="Code monitors support literal and regex search. Searches are literal by default."
+              >
+                <label
+                  className="d-flex align-items-center mb-1 text-muted test-patterntype-checkbox"
+                  onBlur={[Function]}
+                  onFocus={[Function]}
+                  onMouseOut={[Function]}
+                  onMouseOver={[Function]}
+                >
+                  <input
+                    checked={true}
+                    className="sr-only"
+                    disabled={true}
+                    type="checkbox"
+                  />
+                  <Memo(CheckIcon)
+                    aria-hidden={true}
+                    className="trigger-area__checklist-checkbox icon-inline text-success"
+                  />
+                  <small
+                    className="trigger-area__checklist-children--faded"
+                  >
+                    Is 
+                    <code>
+                      patternType:literal
+                    </code>
+                     or 
+                    <code>
+                      patternType:regexp
+                    </code>
+                  </small>
+                  <span
+                    className="sr-only"
+                  >
+                     
+                    Code monitors support literal and regex search. Searches are literal by default.
+                  </span>
+                  <span
+                    className="d-flex"
+                  >
+                    <Memo(HelpCircleIcon)
+                      aria-hidden={true}
+                      className="trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                    />
+                  </span>
+                  <Tooltip
+                    autohide={true}
+                    innerClassName="trigger-area__checklist-tooltip"
+                    isOpen={false}
+                    placement="bottom"
+                    placementPrefix="bs-tooltip"
+                    target={
+                      Object {
+                        "current": <span
+                          class="d-flex"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="mdi-icon trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                            fill="currentColor"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            width="24"
+                          >
+                            <path
+                              d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                            />
+                          </svg>
+                        </span>,
+                      }
+                    }
+                    toggle={[Function]}
+                    trigger="hover focus"
+                  >
+                    <TooltipPopoverWrapper
+                      autohide={true}
+                      delay={
+                        Object {
+                          "hide": 50,
+                          "show": 0,
+                        }
+                      }
+                      fade={true}
+                      hideArrow={false}
+                      innerClassName="tooltip-inner trigger-area__checklist-tooltip"
+                      isOpen={false}
+                      placement="bottom"
+                      placementPrefix="bs-tooltip"
+                      popperClassName="tooltip show"
+                      target={
+                        Object {
+                          "current": <span
+                            class="d-flex"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              class="mdi-icon trigger-area__checklist-hint icon-inline trigger-area__checklist-hint--faded"
+                              fill="currentColor"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              width="24"
+                            >
+                              <path
+                                d="M15.07,11.25L14.17,12.17C13.45,12.89 13,13.5 13,15H11V14.5C11,13.39 11.45,12.39 12.17,11.67L13.41,10.41C13.78,10.05 14,9.55 14,9C14,7.89 13.1,7 12,7A2,2 0 0,0 10,9H8A4,4 0 0,1 12,5A4,4 0 0,1 16,9C16,9.88 15.64,10.67 15.07,11.25M13,19H11V17H13M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12C22,6.47 17.5,2 12,2Z"
+                              />
+                            </svg>
+                          </span>,
+                        }
+                      }
+                      toggle={[Function]}
+                      trigger="hover focus"
+                    />
+                  </Tooltip>
+                </label>
+              </ValidQueryChecklistItem>
+            </li>
+            <li>
+              <ValidQueryChecklistItem
                 checked={false}
                 className="test-type-checkbox"
                 hint="type:diff targets code present in new commits, while type:commit targets commit messages"


### PR DESCRIPTION
Only literal and regex searches are supported. I added the new item as the first one since it will be checked by default and I thought it might look better that way.

![2021-06-08_12-00](https://user-images.githubusercontent.com/179026/121185333-3ec13180-c866-11eb-9f6e-6121ab805ac7.png)
![2021-06-08_12-01](https://user-images.githubusercontent.com/179026/121185335-3f59c800-c866-11eb-8ded-7b18e1b443b8.png)
![2021-06-08_12-02](https://user-images.githubusercontent.com/179026/121185339-3ff25e80-c866-11eb-954d-df7770d8c779.png)

I also updated the colors of the "unchecked" circle per @quinnkeast's request.