### PR TITLE
search: Resolve repositories in star ranked order

### DIFF
--- a/client/shared/package.json
+++ b/client/shared/package.json
@@ -11,7 +11,7 @@
     "schema": "gulp schema",
     "graphql-operations": "gulp graphQlOperations",
     "watch-schema": "gulp watchSchema",
-    "download-puppeteer-browser":"TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" ts-node ./scripts/download-puppeteer-browser.ts"
+    "download-puppeteer-browser": "TS_NODE_COMPILER_OPTIONS=\"{\\\"module\\\":\\\"commonjs\\\"}\" ts-node ./scripts/download-puppeteer-browser.ts"
   },
   "sideEffects": true
 }

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -238,7 +238,9 @@ async function completeDefault(
         suggestions: [
             ...staticSuggestions,
             ...(await dynamicSuggestions.pipe(first()).toPromise())
-                .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: false, globbing }))
+                .map(suggestion => {
+                  return suggestionToCompletionItem(suggestion, { isFilterValue: false, globbing })
+                })
                 .filter(isDefined)
                 .map(completionItem => ({
                     ...completionItem,
@@ -279,7 +281,7 @@ async function completeFilter(
         staticSuggestions = resolvedFilter.definition.discreteValues(token.value, isSourcegraphDotCom).map(
             ({ label, insertText, asSnippet }, index): Monaco.languages.CompletionItem => ({
                 label,
-                sortText: index.toString().padStart(2, '0'), // suggestions sort by order in the list, not alphabetically (up to 99 values).
+                sortText: index.toString().padStart(2, '1'), // suggestions sort by order in the list, not alphabetically (up to 99 values).
                 kind: Monaco.languages.CompletionItemKind.Value,
                 insertText: `${insertText || label} `,
                 filterText: label,
@@ -302,13 +304,14 @@ async function completeFilter(
             .filter(({ __typename }) => __typename === resolvedFilter.definition.suggestions)
             .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: true, globbing }))
             .filter(isDefined)
-            .map(partialCompletionItem => ({
+            .map((partialCompletionItem, index) => ({
                 ...partialCompletionItem,
                 // Set the current value as filterText, so that all dynamic suggestions
                 // returned by the server are displayed. Otherwise, if the current filter value
                 // is a regex pattern like `repo:^` Monaco's filtering will try match `^` against the
                 // suggestions, and not display them because they don't match.
                 filterText: value?.value,
+                sortText: index.toString().padStart(2, '0'), // suggestions sort by order in the list, not alphabetically (up to 99 values).
                 range: value ? toMonacoRange(value.range) : defaultRange,
                 command: COMPLETION_ITEM_SELECTED,
             }))

--- a/client/shared/src/search/query/completion.ts
+++ b/client/shared/src/search/query/completion.ts
@@ -238,9 +238,7 @@ async function completeDefault(
         suggestions: [
             ...staticSuggestions,
             ...(await dynamicSuggestions.pipe(first()).toPromise())
-                .map(suggestion => {
-                  return suggestionToCompletionItem(suggestion, { isFilterValue: false, globbing })
-                })
+                .map(suggestion => suggestionToCompletionItem(suggestion, { isFilterValue: false, globbing }))
                 .filter(isDefined)
                 .map(completionItem => ({
                     ...completionItem,

--- a/cmd/frontend/graphqlbackend/search.go
+++ b/cmd/frontend/graphqlbackend/search.go
@@ -415,7 +415,7 @@ func (r *searchResolver) resolveRepositories(ctx context.Context, opts resolveRe
 }
 
 func (r *searchResolver) suggestFilePaths(ctx context.Context, limit int) ([]SearchSuggestionResolver, error) {
-	resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
+	resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{limit: limit})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -457,7 +457,7 @@ func (r *searchResolver) errorForOverRepoLimit(ctx context.Context) *errOverRepo
 		return buildErr(proposedQueries, description)
 	}
 
-	resolved, _ := r.resolveRepositories(ctx, nil)
+	resolved, _ := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
 	if len(resolved.RepoRevs) > 0 {
 		paths := make([]string, len(resolved.RepoRevs))
 		for i, repo := range resolved.RepoRevs {
@@ -486,7 +486,9 @@ func (r *searchResolver) errorForOverRepoLimit(ctx context.Context) *errOverRepo
 			repoFieldValues = append(repoFieldValues, repoParentPattern)
 			ctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
-			resolved, err := r.resolveRepositories(ctx, repoFieldValues)
+			resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{
+				effectiveRepoFieldValues: repoFieldValues,
+			})
 			if ctx.Err() != nil {
 				continue
 			} else if err != nil {

--- a/cmd/frontend/graphqlbackend/search_filter_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_filter_suggestions.go
@@ -27,6 +27,13 @@ func (r *schemaResolver) SearchFilterSuggestions(ctx context.Context) (*searchFi
 
 	// List at most 10 repositories as default suggestions.
 	repos, err := backend.Repos.List(ctx, database.ReposListOptions{
+		OrderBy: database.RepoListOrderBy{
+			{
+				Field:      database.RepoListStars,
+				Descending: true,
+				Nulls:      "LAST",
+			},
+		},
 		LimitOffset: &database.LimitOffset{
 			Limit: 10,
 		},

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -1304,7 +1304,7 @@ func (r *searchResolver) determineResultTypes(args search.TextParameters, forceT
 // error to see if an alert needs to be returned. Only one of the return
 // values will be non-nil.
 func (r *searchResolver) determineRepos(ctx context.Context, tr *trace.Trace, start time.Time) (*searchrepos.Resolved, error) {
-	resolved, err := r.resolveRepositories(ctx, nil)
+	resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -378,9 +378,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return mockShowSymbolMatches()
 		}
 
-		resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{
-			limit: maxSearchSuggestions,
-		})
+		resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -378,7 +378,9 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			return mockShowSymbolMatches()
 		}
 
-		resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{})
+		resolved, err := r.resolveRepositories(ctx, resolveRepositoriesOpts{
+			limit: maxSearchSuggestions,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -27,7 +27,7 @@ import (
 func TestSearchSuggestions(t *testing.T) {
 	db := new(dbtesting.MockDB)
 
-	limitOffset := &database.LimitOffset{Limit: searchrepos.SearchLimits().MaxRepos + 1}
+	limitOffset := &database.LimitOffset{Limit: maxSearchSuggestions + 1}
 
 	getSuggestions := func(t *testing.T, query, version string) []string {
 		t.Helper()

--- a/cmd/frontend/graphqlbackend/search_suggestions_test.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/inventory"
 	"github.com/sourcegraph/sourcegraph/internal/search"
-	searchrepos "github.com/sourcegraph/sourcegraph/internal/search/repos"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/search/run"
 	"github.com/sourcegraph/sourcegraph/internal/search/streaming"
@@ -26,8 +25,6 @@ import (
 
 func TestSearchSuggestions(t *testing.T) {
 	db := new(dbtesting.MockDB)
-
-	limitOffset := &database.LimitOffset{Limit: maxSearchSuggestions + 1}
 
 	getSuggestions := func(t *testing.T, query, version string) []string {
 		t.Helper()
@@ -83,11 +80,6 @@ func TestSearchSuggestions(t *testing.T) {
 		var calledReposListNamesAll, calledReposListFoo bool
 		database.Mocks.Repos.ListRepoNames = func(_ context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
 
-			// Validate that the following options are invariant
-			// when calling the DB through Repos.List, no matter how
-			// many times it is called for a single Search(...) operation.
-			assertEqual(t, op.LimitOffset, limitOffset)
-
 			if reflect.DeepEqual(op.IncludePatterns, []string{"foo"}) {
 				// when treating term as repo: field
 				calledReposListFoo = true
@@ -135,91 +127,6 @@ func TestSearchSuggestions(t *testing.T) {
 		}
 	})
 
-	t.Run("repogroup: and single term", func(t *testing.T) {
-		t.Skip("TODO(slimsag): this test is not reliable")
-		var mu sync.Mutex
-
-		mockDecodedViewerFinalSettings = &schema.Settings{}
-		defer func() { mockDecodedViewerFinalSettings = nil }()
-
-		var calledReposListRepoNamesInGroup, calledReposListFooRepo3 bool
-		database.Mocks.Repos.ListRepoNames = func(_ context.Context, op database.ReposListOptions) ([]types.RepoName, error) {
-			mu.Lock()
-			defer mu.Unlock()
-			wantReposInGroup := database.ReposListOptions{IncludePatterns: []string{`^foo-repo1$|^repo3$`}, LimitOffset: limitOffset}    // when treating term as repo: field
-			wantFooRepo3 := database.ReposListOptions{IncludePatterns: []string{"foo", `^foo-repo1$|^repo3$`}, LimitOffset: limitOffset} // when treating term as repo: field
-			if reflect.DeepEqual(op, wantReposInGroup) {
-				calledReposListRepoNamesInGroup = true
-				return []types.RepoName{
-					{Name: "foo-repo1"},
-					{Name: "repo3"},
-				}, nil
-			} else if reflect.DeepEqual(op, wantFooRepo3) {
-				calledReposListFooRepo3 = true
-				return []types.RepoName{{Name: "foo-repo1"}}, nil
-			}
-			t.Errorf("got %+v, want %+v or %+v", op, wantReposInGroup, wantFooRepo3)
-			return nil, nil
-		}
-		database.Mocks.Repos.Count = mockCount
-		defer func() { database.Mocks = database.MockStores{} }()
-		database.Mocks.Repos.MockGetByName(t, "repo", 1)
-		backend.Mocks.Repos.MockResolveRev_NoCheck(t, api.CommitID("deadbeef"))
-
-		calledSearchFilesInRepos := atomic.NewBool(false)
-		run.MockSearchFilesInRepos = func(args *search.TextParameters) ([]*result.FileMatch, *streaming.Stats, error) {
-			mu.Lock()
-			defer mu.Unlock()
-			calledSearchFilesInRepos.Store(true)
-			if args.PatternInfo.Pattern != "." && args.PatternInfo.Pattern != "foo" {
-				t.Errorf("got %q, want %q", args.PatternInfo.Pattern, `"foo" or "."`)
-			}
-			mk := func(name api.RepoName, path string) *result.FileMatch {
-				fm := mkFileMatch(types.RepoName{Name: name}, path)
-				fm.CommitID = "rev"
-				rev := "rev"
-				fm.InputRev = &rev
-				return fm
-			}
-			return []*result.FileMatch{
-				mk("repo3", "dir/foo-repo3-file-name-match"),
-				mk("repo1", "dir/foo-repo1-file-name-match"),
-				mk("repo", "dir/file-content-match"),
-			}, &streaming.Stats{}, nil
-		}
-		defer func() { run.MockSearchFilesInRepos = nil }()
-
-		calledResolveRepoGroups := false
-		searchrepos.MockResolveRepoGroups = func() (map[string][]searchrepos.RepoGroupValue, error) {
-			mu.Lock()
-			defer mu.Unlock()
-			calledResolveRepoGroups = true
-			return map[string][]searchrepos.RepoGroupValue{
-				"baz": {
-					searchrepos.RepoPath("foo-repo1"),
-					searchrepos.RepoPath("repo3"),
-				},
-			}, nil
-		}
-		defer func() { searchrepos.MockResolveRepoGroups = nil }()
-		for _, v := range searchVersions {
-			testSuggestions(t, "repogroup:baz foo", v, []string{"repo:foo-repo1", "file:dir/foo-repo3-file-name-match", "file:dir/foo-repo1-file-name-match", "file:dir/file-content-match"})
-			if !calledReposListRepoNamesInGroup {
-				t.Error("!calledReposListRepoNamesInGroup")
-			}
-			if !calledReposListFooRepo3 {
-				t.Error("!calledReposListFooRepo3")
-			}
-			if !calledSearchFilesInRepos.Load() {
-				t.Error("!calledSearchFilesInRepos")
-			}
-			if !calledResolveRepoGroups {
-				t.Error("!calledResolveRepoGroups")
-			}
-
-		}
-	})
-
 	t.Run("repo: field", func(t *testing.T) {
 		var mu sync.Mutex
 
@@ -232,10 +139,6 @@ func TestSearchSuggestions(t *testing.T) {
 			defer mu.Unlock()
 			calledReposListRepoNames = true
 
-			// Validate that the following options are invariant
-			// when calling the DB through Repos.List, no matter how
-			// many times it is called for a single Search(...) operation.
-			assertEqual(t, op.LimitOffset, limitOffset)
 			assertEqual(t, op.IncludePatterns, []string{"foo"})
 
 			return []types.RepoName{{Name: "foo-repo"}}, nil
@@ -353,10 +256,6 @@ func TestSearchSuggestions(t *testing.T) {
 			defer mu.Unlock()
 			calledReposListRepoNames = true
 
-			// Validate that the following options are invariant
-			// when calling the DB through Repos.List, no matter how
-			// many times it is called for a single Search(...) operation.
-			assertEqual(t, op.LimitOffset, limitOffset)
 			assertEqual(t, op.IncludePatterns, []string{"foo"})
 
 			return []types.RepoName{{Name: "foo-repo"}}, nil

--- a/cmd/frontend/graphqlbackend/search_test.go
+++ b/cmd/frontend/graphqlbackend/search_test.go
@@ -507,7 +507,7 @@ func TestVersionContext(t *testing.T) {
 			}
 			defer git.ResetMocks()
 
-			gotResult, err := resolver.resolveRepositories(context.Background(), nil)
+			gotResult, err := resolver.resolveRepositories(context.Background(), resolveRepositoriesOpts{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/database/repos.go
+++ b/internal/database/repos.go
@@ -505,13 +505,23 @@ func (r RepoListOrderBy) SQL() *sqlf.Query {
 type RepoListSort struct {
 	Field      RepoListColumn
 	Descending bool
+	Nulls      string
 }
 
 func (r RepoListSort) SQL() *sqlf.Query {
+	var sb strings.Builder
+
+	sb.WriteString(string(r.Field))
+
 	if r.Descending {
-		return sqlf.Sprintf(string(r.Field) + ` DESC`)
+		sb.WriteString(" DESC")
 	}
-	return sqlf.Sprintf(string(r.Field))
+
+	if r.Nulls == "FIRST" || r.Nulls == "LAST" {
+		sb.WriteString(" NULLS " + r.Nulls)
+	}
+
+	return sqlf.Sprintf(sb.String())
 }
 
 // RepoListColumn is a column by which repositories can be sorted. These correspond to columns in the database.
@@ -521,6 +531,7 @@ const (
 	RepoListCreatedAt RepoListColumn = "created_at"
 	RepoListName      RepoListColumn = "name"
 	RepoListID        RepoListColumn = "id"
+	RepoListStars     RepoListColumn = "stars"
 )
 
 // List lists repositories in the Sourcegraph repository

--- a/internal/search/run/repository.go
+++ b/internal/search/run/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"regexp"
+	"runtime"
 	"sync"
 
 	"github.com/sourcegraph/sourcegraph/internal/api"
@@ -127,58 +128,60 @@ func repoRevsToRepoMatches(ctx context.Context, repos []*search.RepositoryRevisi
 
 func matchRepos(pattern *regexp.Regexp, resolved []*search.RepositoryRevisions, results chan<- []*search.RepositoryRevisions) {
 	/*
-		Local benchmarks showed diminishing returns for higher levels of concurrency.
-		5 workers seems to be a good trade-off for now. We might want to revisit this
-		benchmark over time.
-
-		go test -cpu 1,2,3,4,5,6,7,8,9,10 -count=5 -bench=SearchRepo .
-
-		   goos: darwin
-		   goarch: amd64
-		   pkg: github.com/sourcegraph/sourcegraph/cmd/frontend/graphqlbackend
-		   BenchmarkSearchRepositories       	      13	 132088878 ns/op
-		   BenchmarkSearchRepositories-2     	      16	  69968357 ns/op
-		   BenchmarkSearchRepositories-3     	      24	  48294832 ns/op
-		   BenchmarkSearchRepositories-4     	      28	  42497674 ns/op
-		   BenchmarkSearchRepositories-5     	      27	  42851670 ns/op
-		   BenchmarkSearchRepositories-6     	      28	  39327860 ns/op
-		   BenchmarkSearchRepositories-7     	      27	  38198665 ns/op
-		   BenchmarkSearchRepositories-8     	      28	  38877182 ns/op
-		   BenchmarkSearchRepositories-9     	      26	  42457771 ns/op
-		   BenchmarkSearchRepositories-10    	      26	  40519692 ns/op
+		goos: linux
+		goarch: amd64
+		pkg: github.com/sourcegraph/sourcegraph/internal/search/run
+		cpu: Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
+		BenchmarkSearchRepositories-8   	      39	  31514267 ns/op
+		BenchmarkSearchRepositories-8   	      26	  38898255 ns/op
+		BenchmarkSearchRepositories-8   	      36	  31482727 ns/op
+		BenchmarkSearchRepositories-8   	      33	  30513691 ns/op
+		BenchmarkSearchRepositories-8   	      30	  37038388 ns/op
+		BenchmarkSearchRepositories-8   	      30	  38095363 ns/op
+		BenchmarkSearchRepositories-8   	      36	  39347784 ns/op
+		BenchmarkSearchRepositories-8   	      28	  41431416 ns/op
+		BenchmarkSearchRepositories-8   	      30	  41695426 ns/op
+		BenchmarkSearchRepositories-8   	      28	  39782412 ns/op
+		PASS
+		ok  	github.com/sourcegraph/sourcegraph/internal/search/run	18.729s
 	*/
-	step := len(resolved) / 5 // for benchmarking, replace 5 with runtime.GOMAXPROCS(0)
-	if step == 0 {
-		step = len(resolved)
-	} else {
-		step += 1
-	}
+	workers := runtime.NumCPU()
+	limit := len(resolved) / workers
+
+	last := make(chan struct{})
+	close(last)
 
 	var wg sync.WaitGroup
-	offset := 0
-	for offset < len(resolved) {
-		next := offset + step
-		if next > len(resolved) {
-			next = len(resolved)
+	wg.Add(workers)
+	defer wg.Wait()
+
+	for i := 0; i < workers; i++ {
+		page := resolved[i*limit : i*limit+limit]
+		if i == workers-1 {
+			page = resolved[i*limit:]
 		}
-		wg.Add(1)
-		go func(repos []*search.RepositoryRevisions) {
+
+		wait := last
+		done := make(chan struct{})
+		last = done
+
+		go func() {
+			defer close(done)
 			defer wg.Done()
 
 			var matched []*search.RepositoryRevisions
-			for _, r := range repos {
+			for _, r := range page {
 				if pattern.MatchString(string(r.Repo.Name)) {
 					matched = append(matched, r)
 				}
 			}
-			if len(matched) > 0 {
-				results <- matched
-			}
-		}(resolved[offset:next])
-		offset = next
-	}
 
-	wg.Wait()
+			// Wait for the previous chunk to send its matches
+			// before sending ours.
+			<-wait
+			results <- matched
+		}()
+	}
 }
 
 // reposToAdd determines which repositories should be included in the result set based on whether they fit in the subset


### PR DESCRIPTION
This change set makes our `type:repo` search results and `repo:` suggestions be sorted by descending star order.

Part of #21642
