### PR TITLE
Improve run time of GraphQL generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,7 @@
     "fancy-log": "^1.3.3",
     "get-port": "^5.1.1",
     "glob": "^7.1.6",
+    "globby": "^11.0.3",
     "googleapis": "^47.0.0",
     "gql2ts": "^1.10.1",
     "graphql": "^15.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12251,6 +12251,18 @@ globby@^11.0.1, globby@^11.0.2:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+globby@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
+  integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 globby@^6.1.0:
   version "6.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"


### PR DESCRIPTION
The graphql generator uses babel to parse the AST to very precisely find usages of graphql-tag like `gql\``. Since we always use `gql\``, we can make a simplification and not rely on the tag plucking. This reduces the generate time from 11s to 5.4s locally for me. Also, this is the same improvement that we already did for watch mode.
