### PR TITLE
gitlab: Backoff correctly when sync is forbidden

### DIFF
--- a/internal/errcode/code.go
+++ b/internal/errcode/code.go
@@ -123,6 +123,17 @@ func IsUnauthorized(err error) bool {
 	})
 }
 
+// IsForbidden will check if err or one of its causes is a forbidden error.
+func IsForbidden(err error) bool {
+	type forbiddener interface {
+		Forbidden() bool
+	}
+	return isErrorPredicate(err, func(err error) bool {
+		e, ok := err.(forbiddener)
+		return ok && e.Forbidden()
+	})
+}
+
 // IsAccountSuspended will check if err or one of its causes was due to the
 // account being suspended
 func IsAccountSuspended(err error) bool {

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -315,7 +315,11 @@ func (err HTTPError) Error() string {
 }
 
 func (err HTTPError) Unauthorized() bool {
-	return err.code == http.StatusUnauthorized || err.code == http.StatusForbidden
+	return err.code == http.StatusUnauthorized
+}
+
+func (err HTTPError) Forbidden() bool {
+	return err.code == http.StatusForbidden
 }
 
 // HTTPErrorCode returns err's HTTP status code, if it is an HTTP error from

--- a/internal/extsvc/gitlab/client.go
+++ b/internal/extsvc/gitlab/client.go
@@ -315,7 +315,7 @@ func (err HTTPError) Error() string {
 }
 
 func (err HTTPError) Unauthorized() bool {
-	return err.code == http.StatusUnauthorized
+	return err.code == http.StatusUnauthorized || err.code == http.StatusForbidden
 }
 
 // HTTPErrorCode returns err's HTTP status code, if it is an HTTP error from

--- a/internal/repos/syncer_test.go
+++ b/internal/repos/syncer_test.go
@@ -204,8 +204,8 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 				err:  "<nil>",
 			},
 			testCase{
-				// If the source is unauthorized we should treat this as if zero repos were returned as it indicates
-				// that the source no longer has access to its repos
+				// If the source is unauthorized we should treat this as if zero repos were
+				// returned as it indicates that the source no longer has access to its repos
 				name:    string(tc.repo.Name) + "/unauthorized",
 				sourcer: repos.NewFakeSourcer(&repos.ErrUnauthorized{}),
 				store:   s,
@@ -218,6 +218,22 @@ func testSyncerSync(t *testing.T, s *repos.Store) func(*testing.T) {
 				)}},
 				svcs: []*types.ExternalService{tc.svc},
 				err:  "bad credentials",
+			},
+			testCase{
+				// If the source is forbidden we should treat this as if zero repos were returned
+				// as it indicates that the source no longer has access to its repos
+				name:    string(tc.repo.Name) + "/forbidden",
+				sourcer: repos.NewFakeSourcer(&repos.ErrForbidden{}),
+				store:   s,
+				stored: types.Repos{tc.repo.With(
+					types.Opt.RepoSources(tc.svc.URN()),
+				)},
+				now: clock.Now,
+				diff: repos.Diff{Deleted: types.Repos{tc.repo.With(
+					types.Opt.RepoSources(tc.svc.URN(), svcdup.URN()),
+				)}},
+				svcs: []*types.ExternalService{tc.svc},
+				err:  "forbidden",
 			},
 			testCase{
 				// If the source account has been suspended we should treat this as if zero repos were returned as it indicates

--- a/internal/repoupdater/errors.go
+++ b/internal/repoupdater/errors.go
@@ -12,7 +12,7 @@ type ErrNotFound struct {
 	IsNotFound bool
 }
 
-// ErrNotFound returns true if the repo does Not exist.
+// NotFound returns true if the repo does Not exist.
 func (e *ErrNotFound) NotFound() bool {
 	return e.IsNotFound
 }
@@ -43,7 +43,7 @@ type ErrTemporary struct {
 	IsTemporary bool
 }
 
-// ErrTemporary is when the repository was reported as being temporarily
+// Temporary is when the repository was reported as being temporarily
 // unavailable.
 func (e *ErrTemporary) Temporary() bool {
 	return e.IsTemporary


### PR DESCRIPTION
Currently, we're seeing quite a few user added GitLab code hosts on
Cloud that have never synced. It appears that most of the cases are
caused by GitLab returning a 403 Forbidden when attempting to list repos.
Our current code handles this as a hard failure and bails out without
writing to the last_sync column. This in turn means that the code host
sync will be attempted again in about a minute.

Instead, we handle 403 errors in the same way as Unauthorized errors and
treat it as if the code host returned a list of zero repos. This allows
us to "complete" the sync and means we'll properly back off with sync
attempts.

The forbidden case will now be handled here: 
https://github.com/sourcegraph/sourcegraph/blob/de0c449c16b7d1502aac0fe77b6f49d28f69177d/internal/repos/syncer.go#L216-L227