### PR TITLE
Fix padding of alert on API console

### DIFF
--- a/client/web/src/api/ApiConsole.tsx
+++ b/client/web/src/api/ApiConsole.tsx
@@ -175,7 +175,7 @@ export class ApiConsole extends React.PureComponent<Props, State> {
                             <Link className="btn btn-link" to="/help/api/graphql">
                                 Docs
                             </Link>
-                            <div className="alert alert-warning py-1 px-3 mb-0 ml-2 text-nowrap">
+                            <div className="alert alert-warning py-1 mb-0 ml-2 text-nowrap">
                                 <small>
                                     The API console uses <strong>real production data.</strong>
                                 </small>


### PR DESCRIPTION
Small padding fix to prevent text from being cut off.

### Before

![image](https://user-images.githubusercontent.com/19534377/121214548-81dbce80-c87f-11eb-8be1-5c4c0f4d41c0.png)

### After

![image](https://user-images.githubusercontent.com/19534377/121214473-6ffa2b80-c87f-11eb-826b-4b9765896204.png)