### PR TITLE
Fix default branch throwing error instead of null

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -179,6 +179,9 @@ func (r *RepositoryResolver) DefaultBranch(ctx context.Context) (*GitRefResolver
 		if err != nil {
 			return nil, err
 		}
+		if refName == "" {
+			return nil, nil
+		}
 		return &GitRefResolver{repo: r, name: refName}, nil
 	}
 	r.defaultBranchOnce.Do(func() {

--- a/cmd/frontend/graphqlbackend/repository_test.go
+++ b/cmd/frontend/graphqlbackend/repository_test.go
@@ -15,8 +15,10 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbtesting"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/search/result"
 	"github.com/sourcegraph/sourcegraph/internal/types"
+	"github.com/sourcegraph/sourcegraph/internal/vcs"
 	"github.com/sourcegraph/sourcegraph/internal/vcs/git"
 )
 
@@ -163,4 +165,80 @@ func TestRepositoryLabel(t *testing.T) {
 
 	autogold.Want("encodes spaces for URL in HTML", `<p><a href="/repo%20with%20spaces" rel="nofollow">repo with spaces</a></p>
 `).Equal(t, test("repo with spaces"))
+}
+
+func TestRepository_DefaultBranch(t *testing.T) {
+	ctx := context.Background()
+	ts := []struct {
+		name                string
+		symbolicRef         string
+		symbolicRefExitCode int
+		symbolicRefErr      error
+		resolveRevisionErr  error
+		wantBranch          *GitRefResolver
+		wantErr             error
+	}{
+		{
+			name:        "ref exists",
+			symbolicRef: "refs/heads/main",
+			wantBranch:  &GitRefResolver{name: "refs/heads/main"},
+		},
+		{
+			name:           "clone in progress",
+			symbolicRefErr: &vcs.RepoNotExistError{CloneInProgress: true},
+			// Expect it to not fail and not return a resolver.
+			wantBranch: nil,
+			wantErr:    nil,
+		},
+		{
+			name:                "symbolic ref fails",
+			symbolicRefExitCode: 1,
+			symbolicRefErr:      errors.New("bad git error"),
+			wantErr:             errors.New("bad git error"),
+		},
+		{
+			name:               "default branch doesn't exist",
+			symbolicRef:        "refs/heads/main",
+			resolveRevisionErr: &gitserver.RevisionNotFoundError{Repo: "repo", Spec: "refs/heads/main"},
+			// Expect it to not fail and not return a resolver.
+			wantBranch: nil,
+			wantErr:    nil,
+		},
+	}
+	for _, tt := range ts {
+		t.Run(tt.name, func(t *testing.T) {
+			git.Mocks.ExecSafe = func(params []string) (stdout []byte, stderr []byte, exitCode int, err error) {
+				return []byte(tt.symbolicRef), nil, tt.symbolicRefExitCode, tt.symbolicRefErr
+			}
+			t.Cleanup(func() {
+				git.Mocks.ExecSafe = nil
+			})
+
+			git.Mocks.ResolveRevision = func(spec string, opt git.ResolveRevisionOptions) (api.CommitID, error) {
+				return "", tt.resolveRevisionErr
+			}
+			t.Cleanup(func() {
+				git.Mocks.ResolveRevision = nil
+			})
+
+			res := &RepositoryResolver{RepoMatch: result.RepoMatch{Name: "repo"}}
+			branch, err := res.DefaultBranch(ctx)
+			if tt.wantErr != nil && err != nil {
+				if tt.wantErr.Error() != err.Error() {
+					t.Fatalf("incorrect error message, want=%q have=%q", tt.wantErr.Error(), err.Error())
+				}
+			} else if tt.wantErr != err {
+				t.Fatalf("incorrect error, want=%v have=%v", tt.wantErr, err)
+			}
+			if branch == nil && tt.wantBranch != nil {
+				t.Fatal("invalid nil resolver returned")
+			}
+			if branch != nil && tt.wantBranch == nil {
+				t.Fatalf("expected nil resolver but got %q", branch.name)
+			}
+			if tt.wantBranch != nil && branch.name != tt.wantBranch.name {
+				t.Fatalf("wrong resolver returned, want=%q have=%q", branch.name, tt.wantBranch.name)
+			}
+		})
+	}
 }


### PR DESCRIPTION
When getDefaultBranchForRepo discovers a repo is empty or still cloning, it returns `"", nil`. The resolver didn't properly account for that though and returned a GitRefResolver even if the refName is empty. That led to a ref resolver that tried to read the repo at `repoName@` which is an invalid refspec and causes an error to be thrown. This fixes it.
