### PR TITLE
extensibility: add URL param to show WIP extensions

### DIFF
--- a/client/web/src/extensions/ExtensionRegistry.tsx
+++ b/client/web/src/extensions/ExtensionRegistry.tsx
@@ -130,11 +130,26 @@ export const ExtensionRegistry: React.FunctionComponent<Props> = props => {
     const [changedCategory, setChangedCategory] = useState(false)
 
     // Whether to show extensions that set "wip" to true in their manifests.
-    const [showExperimentalExtensions, setShowExperimentalExtensions] = useLocalStorage(
+    const [storedShowExperimentalExtensions, setShowExperimentalExtensions] = useLocalStorage(
         SHOW_EXPERIMENTAL_EXTENSIONS_KEY,
         false
     )
-    const toggleExperimentalExtensions = (): void => setShowExperimentalExtensions(!showExperimentalExtensions)
+    // Referrers can override user's "show experimental" setting by setting URL parameter 'experimental=true'
+    const parameterShowExperimental = getExperimentalFromLocation(location)
+    const showExperimentalExtensions = parameterShowExperimental || storedShowExperimentalExtensions
+    const toggleExperimentalExtensions = (): void => {
+        if (parameterShowExperimental) {
+            // Clear search parameter when user clicks "show experimental" checkbox
+            history.replace(
+                getRegistryLocationDescriptor({
+                    query: getQueryFromLocation(location),
+                    category: getCategoryFromLocation(location),
+                    experimental: false,
+                })
+            )
+        }
+        setShowExperimentalExtensions(!showExperimentalExtensions)
+    }
 
     /**
      * Note: pass `settingsCascade` instead of making it a dependency to prevent creating
@@ -160,7 +175,13 @@ export const ExtensionRegistry: React.FunctionComponent<Props> = props => {
                         setQuery(query)
                         setSelectedCategory(getCategoryFromLocation(window.location))
 
-                        history.replace(getRegistryLocationDescriptor(query, category))
+                        history.replace(
+                            getRegistryLocationDescriptor({
+                                query,
+                                category,
+                                experimental: getExperimentalFromLocation(window.location),
+                            })
+                        )
                     }),
                     debounce(({ immediate }) => timer(immediate ? 0 : 50)),
                     distinctUntilChanged(
@@ -246,12 +267,13 @@ export const ExtensionRegistry: React.FunctionComponent<Props> = props => {
         (category: ExtensionCategoryOrAll) => {
             const query = getQueryFromLocation(window.location)
             const currentCategory = getCategoryFromLocation(window.location)
+            const experimental = getExperimentalFromLocation(window.location)
 
             if (category !== currentCategory) {
                 setChangedCategory(true)
             }
 
-            history.push(getRegistryLocationDescriptor(query, category))
+            history.push(getRegistryLocationDescriptor({ query, category, experimental }))
         },
         [history]
     )
@@ -353,22 +375,38 @@ function getCategoryFromLocation(location: Pick<H.Location, 'search'>): Extensio
     return 'All'
 }
 
+function getExperimentalFromLocation(location: Pick<H.Location, 'search'>): boolean {
+    const parameters = new URLSearchParams(location.search)
+    const experimental = parameters.get('experimental')
+
+    return experimental === 'true'
+}
+
 /**
  * Returns location descriptor object to push/replace onto the history stack
  * whenever the query or category is changed.
  */
-function getRegistryLocationDescriptor(query: string, category: ExtensionCategoryOrAll): H.LocationDescriptorObject {
+function getRegistryLocationDescriptor({
+    query,
+    category,
+    experimental,
+}: {
+    query: string
+    category: ExtensionCategoryOrAll
+    experimental: boolean
+}): H.LocationDescriptorObject {
+    const search = new URLSearchParams()
+
+    search.set(URL_CATEGORY_PARAM, category)
+    if (query) {
+        search.set(URL_QUERY_PARAM, query)
+    }
+    if (experimental) {
+        search.set('experimental', 'true')
+    }
+
     return {
-        search: new URLSearchParams(
-            query
-                ? {
-                      [URL_QUERY_PARAM]: query,
-                      [URL_CATEGORY_PARAM]: category,
-                  }
-                : {
-                      [URL_CATEGORY_PARAM]: category,
-                  }
-        ).toString(),
+        search: search.toString(),
         hash: window.location.hash,
     }
 }

--- a/client/web/src/insights/pages/creation/intro/IntroCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/intro/IntroCreationPage.tsx
@@ -109,7 +109,7 @@ export const IntroCreationPage: React.FunctionComponent<IntroCreationPageProps> 
                     </p>
 
                     <Link
-                        to="/extensions?query=category:Insights"
+                        to="/extensions?query=category:Insights&experimental=true"
                         onClick={logExploreExtensionsClick}
                         className={classnames(styles.createIntroPageInsightButton, 'btn', 'btn-secondary')}
                     >


### PR DESCRIPTION
Fix #21393 for Code Insights link to the registry.

Add `experimental` URL param to override user setting (confusingly stored in `localStorage`, not user settings).

Example: https://sourcegraph.com/extensions?query=category%3AInsights&experimental=true

We could keep URL <-> React state -> `localStorage` in sync, but that seems excessive for a quick fix. To prevent users from being frustrated at an unresponsive checkbox, I added logic to remove the URL param, after which the original React state -> `localStorage` relationship is restored.