### PR TITLE
extensibility: update registry extension sorting parameters

### DIFF
--- a/client/web/src/integration/extension-registry.test.ts
+++ b/client/web/src/integration/extension-registry.test.ts
@@ -278,7 +278,7 @@ describe('Extension Registry', () => {
             assert.deepStrictEqual(request, {
                 getFeatured: false,
                 query: 'sqs',
-                prioritizeExtensionIDs: ['sqs/word-count'],
+                prioritizeExtensionIDs: [],
             })
         })
     })

--- a/cmd/frontend/registry/api/extension_connection_graphql.go
+++ b/cmd/frontend/registry/api/extension_connection_graphql.go
@@ -91,6 +91,10 @@ func (r *registryExtensionConnectionResolver) compute(ctx context.Context) ([]gr
 			r.registryExtensions[len(local)+i] = &registryExtensionRemoteResolver{v: x}
 		}
 
+		sort.SliceStable(r.registryExtensions, func(i, j int) bool {
+			return r.registryExtensions[i].Name() < r.registryExtensions[j].Name()
+		})
+
 		// Sort WIP extensions last. (The local extensions list is already sorted in that way, but
 		// the remote extensions list isn't, so therefore the combined list isn't.)
 		sort.SliceStable(r.registryExtensions, func(i, j int) bool {


### PR DESCRIPTION
Fix #21572.

Registry extensions now sorted first sorted by name first.

Sort order:
- By name (`{host}/{publisher}/{name}` ID format)
- non-WIP extensions before WIP extensions
- "Prioritized" extensions first (this used to be all extensions included in user settings, but now it only includes enabled extensions)

Example:
![Screenshot from 2021-06-08 13-56-24](https://user-images.githubusercontent.com/37420160/121234105-59dd7280-c861-11eb-914b-45559bc4fb25.png)