### PR TITLE
Initial privacy docs

### DIFF
--- a/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
+++ b/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
@@ -5,7 +5,7 @@ Sourcegraph Cloud protects your private code using repository permissions from G
 ## Public repositories
 If a repository is public on GitHub.com or GitLab.com, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
 
-## Private repositories (beta)
+## Private repositories (private beta)
 If a repository is private on GitHub or GitLab, only users who have permission to access that repository on the code host **and** have added that repository to Sourcegraph Cloud can view and search that repository. The repository will not appear in search results for other users.
 
 The Sourcegraph team and administrators on Sourcegraph Cloud cannot view private repositories. Metadata related to private repositories on Sourcegraph Cloud is excluded from all analytics and plain-text data storage.

--- a/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
+++ b/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
@@ -1,12 +1,12 @@
 # Who can see your code on Sourcegraph Cloud
 
-Sourcegraph protects your private code using repository permissions from GitHub and Gitlab to determine who can see repositories you've [added to Sourcegraph Cloud](../how-to/adding_repositories_to_cloud.md).
+Sourcegraph protects your private code using repository permissions from GitHub and GitLab to determine who can see repositories you've [added to Sourcegraph Cloud](../how-to/adding_repositories_to_cloud.md).
 
 ## **Public repositories**
-If a repository is public on GitHub or Gitlab, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
+If a repository is public on GitHub or GitLab, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
 
 ## **Private repositories**
-If a repository is private on GitHub or Gitlab, only users who have permission to access that repository on the code host **and** have added that repository to Sourcegraph Cloud can view and search that repository. The repository will not appear in search results for other users.
+If a repository is private on GitHub or GitLab, only users who have permission to access that repository on the code host **and** have added that repository to Sourcegraph Cloud can view and search that repository. The repository will not appear in search results for other users.
 
 The Sourcegraph team and administrators on Sourcegraph Cloud cannot view private repositories. Metadata related to private repositories on Sourcegraph Cloud is excluded from all analytics and plain-text data storage.
 

--- a/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
+++ b/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
@@ -2,10 +2,10 @@
 
 Sourcegraph protects your private code using repository permissions from GitHub and GitLab to determine who can see repositories you've [added to Sourcegraph Cloud](../how-to/adding_repositories_to_cloud.md).
 
-## **Public repositories**
+## Public repositories
 If a repository is public on GitHub or GitLab, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
 
-## **Private repositories**
+## Private repositories
 If a repository is private on GitHub or GitLab, only users who have permission to access that repository on the code host **and** have added that repository to Sourcegraph Cloud can view and search that repository. The repository will not appear in search results for other users.
 
 The Sourcegraph team and administrators on Sourcegraph Cloud cannot view private repositories. Metadata related to private repositories on Sourcegraph Cloud is excluded from all analytics and plain-text data storage.

--- a/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
+++ b/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
@@ -5,7 +5,7 @@ Sourcegraph Cloud protects your private code using repository permissions from G
 ## Public repositories
 If a repository is public on GitHub.com or GitLab.com, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
 
-## Private repositories
+## Private repositories (beta)
 If a repository is private on GitHub or GitLab, only users who have permission to access that repository on the code host **and** have added that repository to Sourcegraph Cloud can view and search that repository. The repository will not appear in search results for other users.
 
 The Sourcegraph team and administrators on Sourcegraph Cloud cannot view private repositories. Metadata related to private repositories on Sourcegraph Cloud is excluded from all analytics and plain-text data storage.

--- a/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
+++ b/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
@@ -1,9 +1,9 @@
 # Who can see your code on Sourcegraph Cloud
 
-Sourcegraph protects your private code using repository permissions from GitHub and GitLab to determine who can see repositories you've [added to Sourcegraph Cloud](../how-to/adding_repositories_to_cloud.md).
+Sourcegraph Cloud protects your private code using repository permissions from GitHub.com and GitLab.com to determine who can see repositories you've [added to Sourcegraph Cloud](../how-to/adding_repositories_to_cloud.md).
 
 ## Public repositories
-If a repository is public on GitHub or GitLab, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
+If a repository is public on GitHub.com or GitLab.com, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
 
 ## Private repositories
 If a repository is private on GitHub or GitLab, only users who have permission to access that repository on the code host **and** have added that repository to Sourcegraph Cloud can view and search that repository. The repository will not appear in search results for other users.

--- a/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
+++ b/doc/code_search/explanations/code_visibility_on_sourcegraph_cloud.md
@@ -1,0 +1,13 @@
+# Who can see your code on Sourcegraph Cloud
+
+Sourcegraph protects your private code using repository permissions from GitHub and Gitlab to determine who can see repositories you've [added to Sourcegraph Cloud](../how-to/adding_repositories_to_cloud.md).
+
+## **Public repositories**
+If a repository is public on GitHub or Gitlab, other users on Sourcegraph Cloud can view and search across that repository. The repository will appear in the global search context.
+
+## **Private repositories**
+If a repository is private on GitHub or Gitlab, only users who have permission to access that repository on the code host **and** have added that repository to Sourcegraph Cloud can view and search that repository. The repository will not appear in search results for other users.
+
+The Sourcegraph team and administrators on Sourcegraph Cloud cannot view private repositories. Metadata related to private repositories on Sourcegraph Cloud is excluded from all analytics and plain-text data storage.
+
+> NOTE: Want to collaborate on private code with your team or organization on Sourcegraph Cloud? [Sign up for early access](https://share.hsforms.com/1copeCYh-R8uVYGCpq3s4nw1n7ku)!

--- a/doc/code_search/explanations/index.md
+++ b/doc/code_search/explanations/index.md
@@ -12,4 +12,5 @@
   - View [language statistics](features.md#statistics) for search results.
 - [Search details](search_details.md)
 - [Sourcegraph Cloud](sourcegraph_cloud.md)
+  - [Who can see your code on Sourcegraph Cloud](code_visibility_on_sourcegraph_cloud.md)
 - [Search tips](tips.md)

--- a/doc/code_search/how-to/adding_repositories_to_cloud.md
+++ b/doc/code_search/how-to/adding_repositories_to_cloud.md
@@ -31,9 +31,13 @@ To add public repositories from GitHub or Gitlab without creating a code host co
 1. Specify public repositories on GitHub and GitLab using complete URLs to the repositories. One repository per line.
 1. Press the **Save** button.
 
-### Troubleshooting
+## Who can see your code on Sourcegraph Cloud.
 
-#### Repositories from code hosts are missing or not showing up while adding repositories
+Please see [who can see your code on Sourcegraph Cloud](../explanations/code_visibility_on_sourcegraph_cloud.md).
+
+## Troubleshooting
+
+### Repositories from code hosts are missing or not showing up while adding repositories
 
 If you've connected with a code host and repositories you expect to find are not shown while adding repositories in **User menu > Settings > Repositories > Manage repositories**, you may not have permission on the remote code host to add those repositories to Sourcegraph.
 


### PR DESCRIPTION
Some initial docs to clarify privacy of code on Sourcegraph Cloud. This won't be added until private code is available for individuals. We'll update it again when organizations become available.