### PR TITLE
frontend: Refresh webook no longer uses update queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to Sourcegraph are documented in this file.
 
 - Stricter validation of structural search queries. The `type:` parameter is not supported for structural searches and returns an appropriate alert. [#21487](https://github.com/sourcegraph/sourcegraph/pull/21487)
 - Batch changeset specs that are not attached to changesets will no longer prematurely expire before the batch specs that they are associated with. [#21678](https://github.com/sourcegraph/sourcegraph/pull/21678)
+- The [refresh webhook](https://docs.sourcegraph.com/admin/repo/webhooks#webhook-for-manually-telling-sourcegraph-to-update-a-repository) will now work even if `disableAutoGitUpdates=true` is set. [#21918](https://github.com/sourcegraph/sourcegraph/pull/21918)
 
 ### Removed
 

--- a/cmd/frontend/internal/httpapi/repo_refresh.go
+++ b/cmd/frontend/internal/httpapi/repo_refresh.go
@@ -2,11 +2,12 @@ package httpapi
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/gorilla/mux"
 
 	"github.com/sourcegraph/sourcegraph/cmd/frontend/internal/handlerutil"
-	"github.com/sourcegraph/sourcegraph/internal/repoupdater"
+	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 )
 
 func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
@@ -17,6 +18,6 @@ func serveRepoRefresh(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	_, err = repoupdater.DefaultClient.EnqueueRepoUpdate(ctx, repo.Name)
+	_, err = gitserver.DefaultClient.RequestRepoUpdate(ctx, repo.Name, 10*time.Second)
 	return err
 }

--- a/internal/gitserver/client.go
+++ b/internal/gitserver/client.go
@@ -593,13 +593,20 @@ func (c *Client) doListOne(ctx context.Context, urlSuffix, addr string) ([]strin
 	return list, err
 }
 
-// RequestRepoUpdate is the new protocol endpoint for synchronous requests
-// with more detailed responses. Do not use this if you are not repo-updater.
+// MockRequestRepoUpdate mocks (*Client).RequestRepoUpdate for tests.
+var MockRequestRepoUpdate func(context.Context, api.RepoName, time.Duration) (*protocol.RepoUpdateResponse, error)
+
+// RequestRepoUpdate is the new protocol endpoint for synchronous requests with
+// more detailed responses. This should only be called from repo-updater or via
+// the `refresh` endpoint.
 //
-// Repo updates are not guaranteed to occur. If a repo has been updated
-// recently (within the Since duration specified in the request), the
-// update won't happen.
+// Repo updates are not guaranteed to occur. If a repo has been updated recently
+// (within the Since duration specified in the request), the update won't happen.
 func (c *Client) RequestRepoUpdate(ctx context.Context, repo api.RepoName, since time.Duration) (*protocol.RepoUpdateResponse, error) {
+	if MockRequestRepoUpdate != nil {
+		return MockRequestRepoUpdate(ctx, repo, since)
+	}
+
 	req := &protocol.RepoUpdateRequest{
 		Repo:  repo,
 		Since: since,


### PR DESCRIPTION
The refresh endpoint is intended to be used as a way to manually refresh
a repo on demand, as documented [here](https://docs.sourcegraph.com/admin/repo/webhooks#webhook-for-manually-telling-sourcegraph-to-update-a-repository).


This change avoids going via our existing repo-updater queue so that
manual refreshes continue to work even when `disableAutoGitUpdates` is
set.

Fixes: https://github.com/sourcegraph/customer/issues/109
Fixes: https://github.com/sourcegraph/customer/issues/371