### PR TITLE
Improve accessibility of fuzzy file finder

### DIFF
--- a/client/web/src/components/Dialog.scss
+++ b/client/web/src/components/Dialog.scss
@@ -3,6 +3,9 @@
 [data-reach-dialog-overlay] {
     background-color: rgba($gray-04, 0.5);
 }
+[data-reach-dialog-content] {
+    background-color: var(--color-bg-1);
+}
 .theme-dark {
     [data-reach-dialog-overlay] {
         background-color: rgba($gray-19, 0.5);
@@ -10,10 +13,7 @@
 }
 
 .modal-body {
-    background-color: var(--body-bg);
-    .theme-redesign & {
-        background-color: var(--color-bg-1);
-    }
+    background-color: var(--color-bg-1);
     padding: 1rem;
     width: 32rem;
     max-width: 100vw;

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -1,11 +1,8 @@
 .modal {
-    z-index: 1000;
-    position: fixed;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.5);
+    padding: 0;
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color-2);
+    background-color: transparent;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.module.scss
@@ -1,28 +1,17 @@
 .modal {
-    padding: 0;
-    border-radius: var(--border-radius);
-    border: 1px solid var(--border-color-2);
-    background-color: transparent;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    height: 80vh;
+    width: 80vw;
 }
 
 .content {
     display: flex;
     align-items: stretch;
     flex-direction: column;
-    height: 80vh;
-    width: 80vw;
-    padding: 1.5rem;
-    background-color: var(--color-bg-1);
-    border-radius: var(--border-radius);
-    border: 1px solid var(--border-color-2);
+    height: 100%;
 }
 
 .header {
     display: flex;
-    align-items: center;
     justify-content: space-between;
     padding-bottom: 0.25rem;
     margin-bottom: 0.5rem;

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -1,3 +1,4 @@
+import Dialog from '@reach/dialog'
 import classnames from 'classnames'
 import CloseIcon from 'mdi-react/CloseIcon'
 import React, { useState } from 'react'
@@ -17,6 +18,8 @@ import { HighlightedLink } from './HighlightedLink'
 // - case-insensitive search is slow but works in the torvalds/linux repo (72k files)
 // - case-insensitive search is almost unusable in the chromium/chromium repo (360k files)
 const DEFAULT_CASE_INSENSITIVE_FILE_COUNT_THRESHOLD = 80000
+
+const FUZZY_MODAL_TITLE = 'fuzzy-modal-title'
 
 // Cache for the last fuzzy query. This value is only used to avoid redoing the
 // full fuzzy search on every re-render when the user presses the down/up arrow
@@ -128,13 +131,12 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
     }
 
     return (
-        // Use 'onMouseDown' instead of 'onClick' to allow selecting the text and mouse up outside the modal
-        // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-        <div role="navigation" className={styles.modal} onMouseDown={() => props.onClose()}>
-            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
-            <div role="navigation" className={styles.content} onMouseDown={event => event.stopPropagation()}>
+        <Dialog className={styles.modal} onDismiss={() => props.onClose()} aria-labelledby={FUZZY_MODAL_TITLE}>
+            <div className={styles.content}>
                 <div className={styles.header}>
-                    <h3 className="mb-0">Find file</h3>
+                    <h3 className="mb-0" id={FUZZY_MODAL_TITLE}>
+                        Find file
+                    </h3>
                     <button type="button" className="btn btn-icon" onClick={() => props.onClose()} aria-label="Close">
                         <CloseIcon className={`icon-inline ${styles.closeIcon}`} />
                     </button>
@@ -171,7 +173,7 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
                     </button>
                 )}
             </div>
-        </div>
+        </Dialog>
     )
 }
 

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -1,5 +1,5 @@
 import Dialog from '@reach/dialog'
-import classnames from 'classnames'
+import classNames from 'classnames'
 import CloseIcon from 'mdi-react/CloseIcon'
 import React, { useState } from 'react'
 
@@ -131,7 +131,11 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
     }
 
     return (
-        <Dialog className={styles.modal} onDismiss={() => props.onClose()} aria-labelledby={FUZZY_MODAL_TITLE}>
+        <Dialog
+            className={classNames(styles.modal, 'modal-body p-4 rounded border')}
+            onDismiss={() => props.onClose()}
+            aria-labelledby={FUZZY_MODAL_TITLE}
+        >
             <div className={styles.content}>
                 <div className={styles.header}>
                     <h3 className="mb-0" id={FUZZY_MODAL_TITLE}>
@@ -149,7 +153,7 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
                     aria-controls="fuzzy-modal-results"
                     aria-expanded={props.fsm.key !== 'downloading'}
                     id="fuzzy-modal-input"
-                    className={classnames('form-control', 'px-2', 'py-1', styles.input)}
+                    className={classNames('form-control py-1', styles.input)}
                     placeholder="Enter a partial file path or name"
                     value={state.query}
                     onChange={event => {
@@ -165,7 +169,7 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
                 {fuzzyResult.element}
                 {!fuzzyResult.isComplete && (
                     <button
-                        className={classnames('btn btn-secondary', styles.showMore)}
+                        className={classNames('btn btn-secondary', styles.showMore)}
                         type="button"
                         onClick={() => state.increaseMaxResults()}
                     >
@@ -294,7 +298,7 @@ function renderFiles(
                     <li
                         id={`fuzzy-modal-result-${fileIndex}`}
                         key={file.text}
-                        className={classnames('p-1', fileIndex === state.focusIndex && styles.focused)}
+                        className={classNames('p-1', fileIndex === state.focusIndex && styles.focused)}
                     >
                         <HighlightedLink {...file} />
                     </li>

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -135,7 +135,7 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
             <div role="navigation" className={styles.content} onMouseDown={event => event.stopPropagation()}>
                 <div className={styles.header}>
                     <h3 className="mb-0">Find file</h3>
-                    <button type="button" className="btn btn-icon" onClick={() => props.onClose()}>
+                    <button type="button" className="btn btn-icon" onClick={() => props.onClose()} aria-label="Close">
                         <CloseIcon className={`icon-inline ${styles.closeIcon}`} />
                     </button>
                 </div>

--- a/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
+++ b/client/web/src/components/fuzzyFinder/FuzzyModal.tsx
@@ -142,6 +142,10 @@ export const FuzzyModal: React.FunctionComponent<FuzzyModalProps> = props => {
                 <input
                     autoComplete="off"
                     spellCheck="false"
+                    role="combobox"
+                    aria-autocomplete="list"
+                    aria-controls="fuzzy-modal-results"
+                    aria-expanded={props.fsm.key !== 'downloading'}
                     id="fuzzy-modal-input"
                     className={classnames('form-control', 'px-2', 'py-1', styles.input)}
                     placeholder="Enter a partial file path or name"
@@ -283,7 +287,7 @@ function renderFiles(
     const linksToRender = links.slice(0, state.maxResults)
     return {
         element: (
-            <ul className={styles.results}>
+            <ul id="fuzzy-modal-results" className={styles.results}>
                 {linksToRender.map((file, fileIndex) => (
                     <li
                         id={`fuzzy-modal-result-${fileIndex}`}


### PR DESCRIPTION
Following up on the suggestion in https://github.com/sourcegraph/sourcegraph/issues/21201#issuecomment-856944021 

This PR missing HTML attributes for accessibility in the fuzzy finder component. I tried to roughly use the same attribute values as the HTML structure of the Algolia search box on this page here https://scalameta.org/metals/