### PR TITLE
search: compute priority with stars column value

### DIFF
--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -208,7 +208,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 			return string(commitID), err
 		}
 
-		priority := float64(m.Stars) + repoRankFromConfig(siteConfig, repoName)
+		priority := float64(repo.Stars) + repoRankFromConfig(siteConfig, repoName)
 
 		return &searchbackend.RepoIndexOptions{
 			RepoID:     int32(repo.ID),

--- a/cmd/frontend/internal/httpapi/internal.go
+++ b/cmd/frontend/internal/httpapi/internal.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sourcegraph/sourcegraph/internal/database/dbconn"
 	"github.com/sourcegraph/sourcegraph/internal/database/dbutil"
 	"github.com/sourcegraph/sourcegraph/internal/errcode"
-	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver"
 	"github.com/sourcegraph/sourcegraph/internal/gitserver/protocol"
 	"github.com/sourcegraph/sourcegraph/internal/jsonc"
@@ -209,11 +208,7 @@ func serveSearchConfiguration(w http.ResponseWriter, r *http.Request) error {
 			return string(commitID), err
 		}
 
-		priority := repoRankFromConfig(siteConfig, repoName)
-		switch m := repo.Metadata.(type) {
-		case *github.Repository:
-			priority += float64(m.StargazerCount)
-		}
+		priority := float64(m.Stars) + repoRankFromConfig(siteConfig, repoName)
 
 		return &searchbackend.RepoIndexOptions{
 			RepoID:     int32(repo.ID),


### PR DESCRIPTION
This commit changes the Zoekt priority computation to use the stars column value instead of the same value inside metadata. This has the side effect that GitLab repos will now have priority too.
