### PR TITLE
Add 1 click creation for search based insight creation UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to Sourcegraph are documented in this file.
 - A new bulk operation to retry many changesets at once has been added to Batch Changes. [#21173](https://github.com/sourcegraph/sourcegraph/pull/21173)
 - A `security_event_logs` database table has been added in support of upcoming security-related efforts. [#21949](https://github.com/sourcegraph/sourcegraph/pull/21949)
 - Added featured Sourcegraph extensions query to the GraphQL API, as well as a section in the extension registry to display featured extensions. [#21665](https://github.com/sourcegraph/sourcegraph/pull/21665)
+- The search page now has a `create insight` button to create search-based insight based on your search query [#21943](https://github.com/sourcegraph/sourcegraph/pull/21943)
 
 ### Changed
 

--- a/client/shared/src/search/query/validate.ts
+++ b/client/shared/src/search/query/validate.ts
@@ -1,4 +1,4 @@
-import { FilterType } from './filters'
+import { FILTERS, FilterType } from './filters'
 import { scanSearchQuery } from './scanner'
 import { Filter, Token } from './token'
 
@@ -68,3 +68,12 @@ export function filterExists(query: string, filter: FilterType): boolean {
         scannedQuery.term.some(token => token.type === 'filter' && token.field.value.toLowerCase() === filter)
     )
 }
+
+/**
+ * Type guard for repo: filter token.
+ *
+ * @param token - query parsed lexical token
+ */
+export const isRepoFilter = (token: Token): token is Filter =>
+    token.type === 'filter' &&
+    (token.field.value === FilterType.repo || token.field.value === FILTERS[FilterType.repo].alias)

--- a/client/web/src/insights/components/Icons.tsx
+++ b/client/web/src/insights/components/Icons.tsx
@@ -1,3 +1,3 @@
 import BarChartIcon from 'mdi-react/BarChartIcon'
 
-export const InsightsIcon = BarChartIcon
+export const CodeInsightsIcon = BarChartIcon

--- a/client/web/src/insights/components/InsightsNavLink/InsightsNavLink.tsx
+++ b/client/web/src/insights/components/InsightsNavLink/InsightsNavLink.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
 import { LinkWithIcon } from '../../../components/LinkWithIcon'
-import { InsightsIcon } from '../Icons'
+import { CodeInsightsIcon } from '../Icons'
 
 export const InsightsNavItem: React.FunctionComponent = () => (
     <LinkWithIcon
         to="/insights"
         text="Insights"
-        icon={InsightsIcon}
+        icon={CodeInsightsIcon}
         className="nav-link btn btn-link text-decoration-none"
         activeClassName="active"
     />

--- a/client/web/src/insights/components/index.ts
+++ b/client/web/src/insights/components/index.ts
@@ -1,4 +1,4 @@
-export { InsightsIcon } from './Icons'
+export { CodeInsightsIcon } from './Icons'
 export { InsightsNavItem } from './InsightsNavLink/InsightsNavLink'
 export { InsightsViewGrid } from './InsightsViewGrid/InsightsViewGrid'
 export type { InsightsViewGridProps } from './InsightsViewGrid/InsightsViewGrid'

--- a/client/web/src/insights/index.ts
+++ b/client/web/src/insights/index.ts
@@ -9,3 +9,6 @@ export * from './core/analytics'
 export { InsightsViewGrid } from './components'
 export { InsightsRouter } from './InsightsRouter'
 export type { InsightsViewGridProps } from './components'
+
+// Guard
+export { isCodeInsightsEnabled } from './utils/is-code-insights-enabled'

--- a/client/web/src/insights/pages/creation/CreationRoutes.tsx
+++ b/client/web/src/insights/pages/creation/CreationRoutes.tsx
@@ -46,7 +46,6 @@ export const CreationRoutes: React.FunctionComponent<CreationRoutesProps> = prop
 
             <Route
                 path={`${match.url}/search`}
-                exact={true}
                 render={() => (
                     <SearchInsightCreationLazyPage
                         telemetryService={telemetryService}

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames'
 import React, { useCallback, useContext, useEffect } from 'react'
 import { Redirect } from 'react-router'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 
 import { PlatformContextProps } from '@sourcegraph/shared/src/platform/context'
 import { SettingsCascadeProps } from '@sourcegraph/shared/src/settings/settings'
@@ -23,6 +23,7 @@ import {
 import styles from './SearchInsightCreationPage.module.scss'
 import { CreateInsightFormFields } from './types'
 import { getSanitizedSearchInsight } from './utils/insight-sanitizer'
+import { useUrlQueryInsight } from './utils/use-url-query-insight/use-url-query-insight'
 
 export interface SearchInsightCreationPageProps
     extends PlatformContextProps<'updateSettings'>,
@@ -38,13 +39,28 @@ export interface SearchInsightCreationPageProps
 /** Displays create insight page with creation form. */
 export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCreationPageProps> = props => {
     const { platformContext, authenticatedUser, settingsCascade, telemetryService } = props
-    const { updateSubjectSettings, getSubjectSettings } = useContext(InsightsApiContext)
-    const history = useHistory()
 
-    const [initialFormValues, setInitialFormValues] = useLocalStorage<CreateInsightFormFields | undefined>(
+    const history = useHistory()
+    const { search } = useLocation()
+    const { updateSubjectSettings, getSubjectSettings } = useContext(InsightsApiContext)
+
+    /**
+     * Search insight creation UI form can take value from query param in order
+     * to support 1-click insight creation from search result page.
+     */
+    const queryParameterInsight = useUrlQueryInsight(search)
+
+    /**
+     * Creation UI saves all form values in local storage to be able restore these
+     * values if page was fully refreshed or user came back from other page.
+     */
+    const [localStorageFormValues, setInitialFormValues] = useLocalStorage<CreateInsightFormFields | undefined>(
         'insights.search-insight-creation',
         undefined
     )
+
+    // Query param insight values have a higher priority that local storage values
+    const initialFormValues = queryParameterInsight ?? localStorageFormValues
 
     useEffect(() => {
         telemetryService.logViewEvent('CodeInsightsSearchBasedCreationPage')

--- a/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/SearchInsightCreationPage.tsx
@@ -23,7 +23,7 @@ import {
 import styles from './SearchInsightCreationPage.module.scss'
 import { CreateInsightFormFields } from './types'
 import { getSanitizedSearchInsight } from './utils/insight-sanitizer'
-import { useUrlQueryInsight } from './utils/use-url-query-insight/use-url-query-insight'
+import { getUrlQueryInsight } from './utils/use-url-query-insight/use-url-query-insight'
 
 export interface SearchInsightCreationPageProps
     extends PlatformContextProps<'updateSettings'>,
@@ -44,20 +44,18 @@ export const SearchInsightCreationPage: React.FunctionComponent<SearchInsightCre
     const { search } = useLocation()
     const { updateSubjectSettings, getSubjectSettings } = useContext(InsightsApiContext)
 
-    /**
-     * Search insight creation UI form can take value from query param in order
-     * to support 1-click insight creation from search result page.
-     */
-    const queryParameterInsight = useUrlQueryInsight(search)
+    // Search insight creation UI form can take value from query param in order
+    // to support 1-click insight creation from search result page.
+    const queryParameterInsight = getUrlQueryInsight(search)
 
-    /**
-     * Creation UI saves all form values in local storage to be able restore these
-     * values if page was fully refreshed or user came back from other page.
-     */
+    // Creation UI saves all form values in local storage to be able restore these
+    // values if page was fully refreshed or user came back from other page.
     const [localStorageFormValues, setInitialFormValues] = useLocalStorage<CreateInsightFormFields | undefined>(
         'insights.search-insight-creation',
         undefined
     )
+
+    console.log('render')
 
     // Query param insight values have a higher priority that local storage values
     const initialFormValues = queryParameterInsight ?? localStorageFormValues

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/SearchInsightCreationContent.tsx
@@ -15,6 +15,7 @@ import { SearchInsightLivePreview } from '../live-preview-chart/SearchInsightLiv
 import { SearchInsightCreationForm } from '../search-insight-creation-form/SearchInsightCreationForm'
 
 import { useEditableSeries, createDefaultEditSeries } from './hooks/use-editable-series'
+import { INITIAL_INSIGHT_VALUES } from './initial-insight-values'
 import styles from './SearchInsightCreationContent.module.scss'
 import {
     repositoriesExistValidator,
@@ -22,18 +23,6 @@ import {
     requiredStepValueField,
     seriesRequired,
 } from './validators'
-
-const INITIAL_VALUES: CreateInsightFormFields = {
-    visibility: 'personal',
-    // If user opens creation form to create insight
-    // we want to show the series form as soon as possible without
-    // force user to click 'add another series' button
-    series: [createDefaultEditSeries({ edit: true })],
-    step: 'months',
-    stepValue: '2',
-    title: '',
-    repositories: '',
-}
 
 export interface SearchInsightCreationContentProps {
     /** This component might be used in edit or creation insight case. */
@@ -61,7 +50,7 @@ export const SearchInsightCreationContent: React.FunctionComponent<SearchInsight
         mode = 'creation',
         organizations = [],
         settings,
-        initialValue = INITIAL_VALUES,
+        initialValue = INITIAL_INSIGHT_VALUES,
         className,
         dataTestId,
         onSubmit,

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/hooks/use-editable-series.ts
@@ -8,9 +8,9 @@ import { DEFAULT_ACTIVE_COLOR } from '../../form-color-input/FormColorInput'
 import { remove, replace } from './helpers'
 
 export const createDefaultEditSeries = (series?: Partial<EditableDataSeries>): EditableDataSeries => ({
+    id: uuid.v4(),
     ...defaultEditSeries,
     ...series,
-    id: uuid.v4(),
 })
 
 const defaultEditSeries = {

--- a/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/initial-insight-values.ts
+++ b/client/web/src/insights/pages/creation/search-insight/components/search-insight-creation-content/initial-insight-values.ts
@@ -1,0 +1,15 @@
+import { CreateInsightFormFields } from '../../types'
+
+import { createDefaultEditSeries } from './hooks/use-editable-series'
+
+export const INITIAL_INSIGHT_VALUES: CreateInsightFormFields = {
+    visibility: 'personal',
+    // If user opens the creation form to create insight
+    // we want to show the series form as soon as possible
+    // and do not force the user to click the 'add another series' button
+    series: [createDefaultEditSeries({ edit: true })],
+    step: 'months',
+    stepValue: '2',
+    title: '',
+    repositories: '',
+}

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
@@ -1,0 +1,34 @@
+import { getInsightDataFromQuery } from './use-url-query-insight'
+
+describe('getInsightDataFromQuery', () => {
+    it('should return null with empty query params', () => {
+        const result = getInsightDataFromQuery('')
+
+        expect(result).toBeNull()
+    })
+
+    describe('should return correct insight values ', () => {
+        it('with repo: and "test" pattern query', () => {
+            const queryString = 'context:global test repo:^github\\.com/sourcegraph/sourcegraph$  patterntype:literal'
+
+            const result = getInsightDataFromQuery(queryString)
+
+            expect(result).toStrictEqual({
+                repositories: 'github.com/sourcegraph/sourcegraph',
+                seriesQuery: 'context:global test patterntype:literal',
+            })
+        })
+
+        it('with multiple repo: filters and "test" pattern query', () => {
+            const queryString =
+                'context:global test repo:^github\\.com/sourcegraph/sourcegraph$ repo:^github\\.com/sourcegraph/about patterntype:literal'
+
+            const result = getInsightDataFromQuery(queryString)
+
+            expect(result).toStrictEqual({
+                repositories: 'github.com/sourcegraph/sourcegraph, github.com/sourcegraph/about',
+                seriesQuery: 'context:global test patterntype:literal',
+            })
+        })
+    })
+})

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.test.ts
@@ -30,5 +30,29 @@ describe('getInsightDataFromQuery', () => {
                 seriesQuery: 'context:global test patterntype:literal',
             })
         })
+
+        it('with multiple repo: filters regexp literals and "test" pattern query', () => {
+            const queryString =
+                'context:global test repo:^github\\.com/sourcegraph/sourcegraph$|^github\\.com/sourcegraph/about patterntype:literal'
+
+            const result = getInsightDataFromQuery(queryString)
+
+            expect(result).toStrictEqual({
+                repositories: 'github.com/sourcegraph/sourcegraph, github.com/sourcegraph/about',
+                seriesQuery: 'context:global test patterntype:literal',
+            })
+        })
+
+        it('with repo: filters and "repo: " pattern query', () => {
+            const queryString =
+                'context:global "repo: " repo:^github\\.com/sourcegraph/sourcegraph$ patterntype:literal'
+
+            const result = getInsightDataFromQuery(queryString)
+
+            expect(result).toStrictEqual({
+                repositories: 'github.com/sourcegraph/sourcegraph',
+                seriesQuery: 'context:global "repo: " patterntype:literal',
+            })
+        })
     })
 })

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
+import { dedupeWhitespace } from '@sourcegraph/shared/src/util/strings';
 
 import { DEFAULT_ACTIVE_COLOR } from '../../components/form-color-input/FormColorInput'
 import { createDefaultEditSeries } from '../../components/search-insight-creation-content/hooks/use-editable-series'
@@ -15,11 +16,6 @@ import { CreateInsightFormFields } from '../../types'
  * @param token - query parsed lexical token
  */
 const isRepoFilter = (token: Token): token is Filter => token.type === 'filter' && token.field.value === 'repo'
-
-/**
- * Generate query string without extra whitespaces.
- */
-const getSanitizedQueryString = (query: string): string => query.replace(/\s+/g, ' ').trim()
 
 /**
  * Generate repositories string value without special reg exp
@@ -83,7 +79,7 @@ export function getInsightDataFromQuery(query: string | null): InsightData | nul
     const humanReadableQueryString = stringHuman(tokensWithoutRepoFilters)
 
     return {
-        seriesQuery: getSanitizedQueryString(humanReadableQueryString),
+        seriesQuery: dedupeWhitespace(humanReadableQueryString),
         repositories: getSanitizedRepositoriesString(repositories),
     }
 }

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -46,27 +46,21 @@ export function getInsightDataFromQuery(query: string | null): InsightData | nul
     const tokens = Array.isArray(sequence.term) ? sequence.term : [sequence.term]
     const repositories = []
 
-    /** Find all repo: filters and get their values for insight repositories field */
+    // Find all repo: filters and get their values for insight repositories field
     for (const token of tokens) {
         if (isRepoFilter(token)) {
             const repoValue = token.value?.value
 
             if (repoValue) {
-                /**
-                 * Split repo value in order to support case with multiple repo values
-                 * in repo: filter.
-                 *
-                 * Example repo:^github\.com/org/repo-1$ | ^github\.com/org/repo-2$
-                 */
+                // Split repo value in order to support case with multiple repo values
+                // in repo: filter. Example repo:^github\.com/org/repo-1$ | ^github\.com/org/repo-2$
                 repositories.push(...repoValue.split('|'))
             }
         }
     }
 
-    /**
-     * Generate a string query from tokens without repo: filters for the insight
-     * query field.
-     */
+    // Generate a string query from tokens without repo: filters for the insight
+    // query field.
     const tokensWithoutRepoFilters = tokens.filter(token => !isRepoFilter(token))
     const humanReadableQueryString = stringHuman(tokensWithoutRepoFilters)
 
@@ -84,7 +78,7 @@ export function getInsightDataFromQuery(query: string | null): InsightData | nul
  */
 export function useUrlQueryInsight(queryParameters: string): CreateInsightFormFields | null {
     return useMemo(() => {
-        const queryParametersString = new URLSearchParams(queryParameters).get('insight-query')
+        const queryParametersString = new URLSearchParams(queryParameters).get('query')
 
         const insightData = getInsightDataFromQuery(queryParametersString)
 

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -5,7 +5,6 @@ import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
 import { isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'
 import { dedupeWhitespace } from '@sourcegraph/shared/src/util/strings'
 
-import { DEFAULT_ACTIVE_COLOR } from '../../components/form-color-input/FormColorInput'
 import { createDefaultEditSeries } from '../../components/search-insight-creation-content/hooks/use-editable-series'
 import { INITIAL_INSIGHT_VALUES } from '../../components/search-insight-creation-content/initial-insight-values'
 import { CreateInsightFormFields } from '../../types'
@@ -101,7 +100,6 @@ export function useUrlQueryInsight(queryParameters: string): CreateInsightFormFi
                     valid: true,
                     name: 'Search series #1',
                     query: insightData.seriesQuery,
-                    stroke: DEFAULT_ACTIVE_COLOR,
                 }),
             ],
             repositories: insightData.repositories,

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -2,20 +2,13 @@ import { useMemo } from 'react'
 
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
-import { Filter, Token } from '@sourcegraph/shared/src/search/query/token'
-import { dedupeWhitespace } from '@sourcegraph/shared/src/util/strings';
+import { isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'
+import { dedupeWhitespace } from '@sourcegraph/shared/src/util/strings'
 
 import { DEFAULT_ACTIVE_COLOR } from '../../components/form-color-input/FormColorInput'
 import { createDefaultEditSeries } from '../../components/search-insight-creation-content/hooks/use-editable-series'
 import { INITIAL_INSIGHT_VALUES } from '../../components/search-insight-creation-content/initial-insight-values'
 import { CreateInsightFormFields } from '../../types'
-
-/**
- * Type guard for repo: filter token.
- *
- * @param token - query parsed lexical token
- */
-const isRepoFilter = (token: Token): token is Filter => token.type === 'filter' && token.field.value === 'repo'
 
 /**
  * Generate repositories string value without special reg exp

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { memoize } from 'lodash'
 
 import { stringHuman } from '@sourcegraph/shared/src/search/query/printer'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
@@ -72,31 +72,26 @@ export function getInsightDataFromQuery(query: string | null): InsightData | nul
 
 /**
  * Returns initial values for the search insight from query param 'insight-query'.
- *
- * This logic is trying to find a value for the data query field in a query param
- * and extract the repo: filters for the repositories field in a creation UI.
  */
-export function useUrlQueryInsight(queryParameters: string): CreateInsightFormFields | null {
-    return useMemo(() => {
-        const queryParametersString = new URLSearchParams(queryParameters).get('query')
+export const getUrlQueryInsight = memoize((queryParameters: string): CreateInsightFormFields | null => {
+    const queryParametersString = new URLSearchParams(queryParameters).get('query')
 
-        const insightData = getInsightDataFromQuery(queryParametersString)
+    const insightData = getInsightDataFromQuery(queryParametersString)
 
-        if (insightData === null) {
-            return null
-        }
+    if (insightData === null) {
+        return null
+    }
 
-        return {
-            ...INITIAL_INSIGHT_VALUES,
-            series: [
-                createDefaultEditSeries({
-                    edit: true,
-                    valid: true,
-                    name: 'Search series #1',
-                    query: insightData.seriesQuery,
-                }),
-            ],
-            repositories: insightData.repositories,
-        }
-    }, [queryParameters])
-}
+    return {
+        ...INITIAL_INSIGHT_VALUES,
+        series: [
+            createDefaultEditSeries({
+                edit: true,
+                valid: true,
+                name: 'Search series #1',
+                query: insightData.seriesQuery,
+            }),
+        ],
+        repositories: insightData.repositories,
+    }
+})

--- a/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
+++ b/client/web/src/insights/pages/creation/search-insight/utils/use-url-query-insight/use-url-query-insight.ts
@@ -1,0 +1,74 @@
+import { useMemo } from 'react'
+
+import { DEFAULT_ACTIVE_COLOR } from '../../components/form-color-input/FormColorInput'
+import { createDefaultEditSeries } from '../../components/search-insight-creation-content/hooks/use-editable-series'
+import { INITIAL_INSIGHT_VALUES } from '../../components/search-insight-creation-content/initial-insight-values'
+import { CreateInsightFormFields } from '../../types'
+
+export interface InsightData {
+    repositories: string
+    seriesQuery: string
+}
+
+/**
+ * Return serialized value of repositories and query from the URL query params.
+ *
+ * @param query -- query param with possible value for the creation UI
+ *
+ * Exported for testing only.
+ */
+export function getInsightDataFromQuery(query: string | null): InsightData | null {
+    if (!query) {
+        return null
+    }
+
+    const queryWithoutRepo = query.replaceAll(/repo:.+?($|\s)/gi, '')
+    const repos = query.match(/repo:.+?($|\s)/gi)
+
+    return {
+        seriesQuery: queryWithoutRepo.replace(/\s+/g, ' ').trim(),
+        repositories:
+            repos !== null
+                ? repos
+                      .map(repo =>
+                          repo
+                              .replace(/(repo:)|(\^)|(\$)|(\\)/gi, '')
+                              .replace(/\s+/g, ' ')
+                              .trim()
+                      )
+                      .join(', ')
+                : '',
+    }
+}
+
+/**
+ * Returns initial values for the search insight from query param 'insight-query'.
+ *
+ * This logic is trying to find a value for the data query field in a query param
+ * and extract the repo: filters for the repositories field in a creation UI.
+ */
+export function useUrlQueryInsight(queryParameters: string): CreateInsightFormFields | null {
+    return useMemo(() => {
+        const queryParametersString = new URLSearchParams(queryParameters).get('insight-query')
+
+        const insightData = getInsightDataFromQuery(queryParametersString)
+
+        if (insightData === null) {
+            return null
+        }
+
+        return {
+            ...INITIAL_INSIGHT_VALUES,
+            series: [
+                createDefaultEditSeries({
+                    edit: true,
+                    valid: true,
+                    name: 'Search series #1',
+                    query: insightData.seriesQuery,
+                    stroke: DEFAULT_ACTIVE_COLOR,
+                }),
+            ],
+            repositories: insightData.repositories,
+        }
+    }, [queryParameters])
+}

--- a/client/web/src/insights/pages/dashboard/InsightsPage.tsx
+++ b/client/web/src/insights/pages/dashboard/InsightsPage.tsx
@@ -11,7 +11,7 @@ import { PageHeader } from '@sourcegraph/wildcard'
 
 import { FeedbackBadge } from '../../../components/FeedbackBadge'
 import { Page } from '../../../components/Page'
-import { InsightsIcon, InsightsViewGrid, InsightsViewGridProps } from '../../components'
+import { CodeInsightsIcon, InsightsViewGrid, InsightsViewGridProps } from '../../components'
 import { InsightsApiContext } from '../../core/backend/api-provider'
 
 import { useDeleteInsight } from './hooks/use-delete-insight'
@@ -52,7 +52,7 @@ export const InsightsPage: React.FunctionComponent<InsightsPageProps> = props =>
             <Page>
                 <PageHeader
                     annotation={<FeedbackBadge status="prototype" feedback={{ mailto: 'support@sourcegraph.com' }} />}
-                    path={[{ icon: InsightsIcon, text: 'Code insights' }]}
+                    path={[{ icon: CodeInsightsIcon, text: 'Code insights' }]}
                     actions={
                         <Link to="/insights/create" onClick={logAddMoreClick} className="btn btn-secondary mr-1">
                             <PlusIcon className="icon-inline" /> Create new insight

--- a/client/web/src/insights/utils/is-code-insights-enabled.ts
+++ b/client/web/src/insights/utils/is-code-insights-enabled.ts
@@ -1,0 +1,45 @@
+import { SettingsCascadeOrError } from '@sourcegraph/shared/src/settings/settings'
+import { isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { SettingsExperimentalFeatures } from '../../schema/settings.schema'
+
+/**
+ * Code insights display location setting to check setting for particular view
+ * to show code insights components.
+ */
+interface CodeInsightsDisplayLocation {
+    insightsPage: boolean
+    homepage: boolean
+    directory: boolean
+}
+
+/**
+ * Feature guard for code insights.
+ *
+ * @param settingsCascade - settings cascade object
+ * @param views - Map with display location of insights {@link CodeInsightsDisplayLocation}
+ */
+export function isCodeInsightsEnabled(
+    settingsCascade: SettingsCascadeOrError,
+    views: Partial<CodeInsightsDisplayLocation> = {}
+): boolean {
+    if (isErrorLike(settingsCascade.final)) {
+        return false
+    }
+
+    const final = settingsCascade.final
+    const viewsKeys = Object.keys(views) as (keyof CodeInsightsDisplayLocation)[]
+    const experimentalFeatures: SettingsExperimentalFeatures = final?.experimentalFeatures ?? {}
+
+    if (!experimentalFeatures.codeInsights) {
+        return false
+    }
+
+    return viewsKeys.reduce<boolean>((isEnabled, viewKey) => {
+        if (views[viewKey]) {
+            return isEnabled && final?.[`insights.displayLocation.${viewKey}`] !== false
+        }
+
+        return isEnabled
+    }, true)
+}

--- a/client/web/src/insights/utils/is-code-insights-enabled.ts
+++ b/client/web/src/insights/utils/is-code-insights-enabled.ts
@@ -35,11 +35,11 @@ export function isCodeInsightsEnabled(
         return false
     }
 
-    return viewsKeys.reduce<boolean>((isEnabled, viewKey) => {
+    return viewsKeys.every(viewKey => {
         if (views[viewKey]) {
-            return isEnabled && final?.[`insights.displayLocation.${viewKey}`] !== false
+            return final?.[`insights.displayLocation.${viewKey}`] !== false
         }
 
-        return isEnabled
-    }, true)
+        return true
+    })
 }

--- a/client/web/src/search/panels/RepositoriesPanel.tsx
+++ b/client/web/src/search/panels/RepositoriesPanel.tsx
@@ -3,8 +3,8 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Observable } from 'rxjs'
 
 import { Link } from '@sourcegraph/shared/src/components/Link'
-import { FilterType, FILTERS } from '@sourcegraph/shared/src/search/query/filters'
 import { scanSearchQuery } from '@sourcegraph/shared/src/search/query/scanner'
+import { isRepoFilter } from '@sourcegraph/shared/src/search/query/validate'
 import { TelemetryProps } from '@sourcegraph/shared/src/telemetry/telemetryService'
 import { useObservable } from '@sourcegraph/shared/src/util/useObservable'
 
@@ -132,10 +132,7 @@ function processRepositories(eventLogResult: EventLogResult): string[] | null {
         const scannedQuery = scanSearchQuery(queryFromURL || '')
         if (scannedQuery.type === 'success') {
             for (const token of scannedQuery.term) {
-                if (
-                    token.type === 'filter' &&
-                    (token.field.value === FilterType.repo || token.field.value === FILTERS[FilterType.repo].alias)
-                ) {
+                if (isRepoFilter(token)) {
                     if (token.value && !recentlySearchedRepos.includes(token.value.value)) {
                         recentlySearchedRepos.push(token.value.value)
                     }

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -22,7 +22,8 @@ import { CodeMonitoringProps } from '../../code-monitoring'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { SearchPatternType } from '../../graphql-operations'
-import { CodeInsightsIcon } from '../../insights/components'
+
+import { CreateCodeInsightButton } from './components/CreateCodeInsightButton'
 
 export interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'extHostAPI'>,
@@ -85,25 +86,6 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => {
-    const createSearchInsightButton = useMemo(() => {
-        if (!props.enableCodeInsights || !props.query || !props.authenticatedUser) {
-            return null
-        }
-
-        const searchParameters = new URLSearchParams(props.location.search)
-        searchParameters.set('insight-query', `${props.query} patterntype:${props.patternType}`)
-        const toURL = `/insights/create/search?${searchParameters.toString()}`
-
-        return (
-            <li className="nav-item">
-                <ButtonLink to={toURL} className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none">
-                    <CodeInsightsIcon className="icon-inline mr-1" />
-                    Insight
-                </ButtonLink>
-            </li>
-        )
-    }, [props.enableCodeInsights, props.query, props.authenticatedUser, props.location.search, props.patternType])
-
     const createCodeMonitorButton = useMemo(() => {
         if (!props.enableCodeMonitoring || !props.query || !props.authenticatedUser) {
             return null
@@ -203,7 +185,12 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                     {(createCodeMonitorButton || saveSearchButton) && (
                         <li className="search-results-info-bar__divider" aria-hidden="true" />
                     )}
-                    {createSearchInsightButton}
+                    <CreateCodeInsightButton
+                        query={props.query}
+                        authenticatedUser={props.authenticatedUser}
+                        patternType={props.patternType}
+                        enableCodeInsights={props.enableCodeInsights}
+                    />
                     {createCodeMonitorButton}
                     {saveSearchButton}
 

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -35,6 +35,11 @@ export interface SearchResultsInfoBarProps
     /** The currently authenticated user or null */
     authenticatedUser: Pick<AuthenticatedUser, 'id'> | null
 
+    /**
+     * Whether the code insights feature flag is enabled.
+     */
+    enableCodeInsights?: boolean
+
     /** The search query and if any results were found */
     query?: string
     resultsFound: boolean
@@ -81,18 +86,13 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => {
     const createSearchInsightButton = useMemo(() => {
-        // TODO [VK] Add enableCodeInsight check
-        if (!props.query || !props.authenticatedUser) {
+        if (!props.enableCodeInsights || !props.query || !props.authenticatedUser) {
             return null
         }
 
         const searchParameters = new URLSearchParams(props.location.search)
-
         searchParameters.set('insight-query', `${props.query} patterntype:${props.patternType}`)
-
         const toURL = `/insights/create/search?${searchParameters.toString()}`
-
-        // console.log(parseSearchQuery(props.query ?? ''
 
         return (
             <li className="nav-item">
@@ -102,7 +102,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                 </ButtonLink>
             </li>
         )
-    }, [props.query, props.authenticatedUser, props.location.search, props.patternType])
+    }, [props.enableCodeInsights, props.query, props.authenticatedUser, props.location.search, props.patternType])
 
     const createCodeMonitorButton = useMemo(() => {
         if (!props.enableCodeMonitoring || !props.query || !props.authenticatedUser) {

--- a/client/web/src/search/results/SearchResultsInfoBar.tsx
+++ b/client/web/src/search/results/SearchResultsInfoBar.tsx
@@ -22,6 +22,7 @@ import { CodeMonitoringProps } from '../../code-monitoring'
 import { CodeMonitoringLogo } from '../../code-monitoring/CodeMonitoringLogo'
 import { WebActionsNavItems as ActionsNavItems } from '../../components/shared'
 import { SearchPatternType } from '../../graphql-operations'
+import { CodeInsightsIcon } from '../../insights/components'
 
 export interface SearchResultsInfoBarProps
     extends ExtensionsControllerProps<'executeCommand' | 'extHostAPI'>,
@@ -79,6 +80,30 @@ const QuotesInterpretedLiterallyNotice: React.FunctionComponent<SearchResultsInf
  * and a few actions like expand all and save query
  */
 export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarProps> = props => {
+    const createSearchInsightButton = useMemo(() => {
+        // TODO [VK] Add enableCodeInsight check
+        if (!props.query || !props.authenticatedUser) {
+            return null
+        }
+
+        const searchParameters = new URLSearchParams(props.location.search)
+
+        searchParameters.set('insight-query', `${props.query} patterntype:${props.patternType}`)
+
+        const toURL = `/insights/create/search?${searchParameters.toString()}`
+
+        // console.log(parseSearchQuery(props.query ?? ''
+
+        return (
+            <li className="nav-item">
+                <ButtonLink to={toURL} className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none">
+                    <CodeInsightsIcon className="icon-inline mr-1" />
+                    Insight
+                </ButtonLink>
+            </li>
+        )
+    }, [props.query, props.authenticatedUser, props.location.search, props.patternType])
+
     const createCodeMonitorButton = useMemo(() => {
         if (!props.enableCodeMonitoring || !props.query || !props.authenticatedUser) {
             return null
@@ -178,6 +203,7 @@ export const SearchResultsInfoBar: React.FunctionComponent<SearchResultsInfoBarP
                     {(createCodeMonitorButton || saveSearchButton) && (
                         <li className="search-results-info-bar__divider" aria-hidden="true" />
                     )}
+                    {createSearchInsightButton}
                     {createCodeMonitorButton}
                     {saveSearchButton}
 

--- a/client/web/src/search/results/components/CreateCodeInsightButton.tsx
+++ b/client/web/src/search/results/components/CreateCodeInsightButton.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+
+import { ButtonLink } from '@sourcegraph/shared/src/components/LinkOrButton'
+
+import { PatternTypeProps } from '../..'
+import { AuthenticatedUser } from '../../../auth'
+import { CodeInsightsIcon } from '../../../insights/components'
+
+interface CreateCodeInsightButtonProps extends Pick<PatternTypeProps, 'patternType'> {
+    /** Search query string. */
+    query?: string
+
+    /** The currently authenticated user or null. */
+    authenticatedUser: Pick<AuthenticatedUser, 'id'> | null
+
+    /** Whether the code insights feature flag is enabled. */
+    enableCodeInsights?: boolean
+}
+
+/**
+ * Displays code insights creation button from search query.
+ *
+ * Basically it navigates user to search based insight creation UI with
+ * prefilled repositories and data series query field according to
+ * search page query.
+ */
+export const CreateCodeInsightButton: React.FunctionComponent<CreateCodeInsightButtonProps> = props => {
+    if (!props.enableCodeInsights || !props.query || !props.authenticatedUser) {
+        return null
+    }
+
+    const searchParameters = new URLSearchParams()
+    searchParameters.set('query', `${props.query} patterntype:${props.patternType}`)
+    const toURL = `/insights/create/search?${searchParameters.toString()}`
+
+    return (
+        <li data-tooltip="Create Insight based on this search query" data-delay={10000} className="nav-item">
+            <ButtonLink to={toURL} className="btn btn-sm btn-outline-secondary mr-2 nav-link text-decoration-none">
+                <CodeInsightsIcon className="icon-inline mr-1" />
+                Create Insight
+            </ButtonLink>
+        </li>
+    )
+}

--- a/client/web/src/search/results/streaming/StreamingSearchResults.tsx
+++ b/client/web/src/search/results/streaming/StreamingSearchResults.tsx
@@ -27,6 +27,7 @@ import {
 import { AuthenticatedUser } from '../../../auth'
 import { CodeMonitoringProps } from '../../../code-monitoring'
 import { PageTitle } from '../../../components/PageTitle'
+import { isCodeInsightsEnabled } from '../../../insights'
 import { SavedSearchModal } from '../../../savedSearches/SavedSearchModal'
 import { QueryState, submitSearch } from '../../helpers'
 import { SearchAlert } from '../SearchAlert'
@@ -224,6 +225,7 @@ export const StreamingSearchResults: React.FunctionComponent<StreamingSearchResu
             <SearchResultsInfoBar
                 {...props}
                 query={query}
+                enableCodeInsights={isCodeInsightsEnabled(props.settingsCascade)}
                 resultsFound={results ? results.results.length > 0 : false}
                 className={classNames('flex-grow-1', styles.streamingSearchResultsInfobar)}
                 allExpanded={allExpanded}


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/21323

This PR adds a button to the search page → 'Create Insight' which actually leads the user to the creation UI with prefilled query and repo values from the search query on the search page. 


### Progress checklist
- [x] Add 1 click create functionality
- [x] Write unit test for URL query params parse logic 
- [x] Add a centralized way for code insight experimental checks
- [x] Proofread the create button text

### **Search page with insight button**

<img width="792" alt="image" src="https://user-images.githubusercontent.com/18492575/121407941-8203c900-c968-11eb-9595-e8cd5b174d58.png">

### **Search based creation UI with pre-filled repo and query inputs**

<img width="510" alt="image" src="https://user-images.githubusercontent.com/18492575/121408048-9d6ed400-c968-11eb-8af1-a0e13876340d.png">

