### PR TITLE
monitoring: Do not require owner for alert-less panels

### DIFF
--- a/monitoring/monitoring/documentation.go
+++ b/monitoring/monitoring/documentation.go
@@ -148,8 +148,10 @@ func (d *documentation) renderAlertSolutionEntry(c *Container, o Observable) err
 		fmt.Fprintf(&d.alertSolutions, "> NOTE: More help interpreting this metric is available in the [dashboards reference](./%s#%s).\n\n",
 			dashboardsDocsFile, observableDocAnchor(c, o))
 	}
-	// add owner
-	fprintOwnedBy(&d.alertSolutions, o.Owner)
+	if o.Owner != "" {
+		// add owner
+		fprintOwnedBy(&d.alertSolutions, o.Owner)
+	}
 	// render break for readability
 	fmt.Fprint(&d.alertSolutions, "\n<br />\n\n")
 	return nil
@@ -168,8 +170,10 @@ func (d *documentation) renderDashboardPanelEntry(c *Container, o Observable) er
 		fmt.Fprintf(&d.dashboards, "> NOTE: Alerts related to this panel are documented in the [alert solutions reference](./%s#%s).\n\n",
 			alertSolutionsFile, observableDocAnchor(c, o))
 	}
-	// add owner
-	fprintOwnedBy(&d.dashboards, o.Owner)
+	if o.Owner != "" {
+		// add owner
+		fprintOwnedBy(&d.dashboards, o.Owner)
+	}
 	// render break for readability
 	fmt.Fprint(&d.dashboards, "\n<br />\n\n")
 	return nil

--- a/monitoring/monitoring/monitoring.go
+++ b/monitoring/monitoring/monitoring.go
@@ -566,8 +566,8 @@ func (o Observable) validate() error {
 	if v := string([]rune(o.Description)[0]); v != strings.ToLower(v) {
 		return fmt.Errorf("Description must be lowercase; found \"%s\"", o.Description)
 	}
-	if o.Owner == "" {
-		return errors.New("Owner must be defined")
+	if o.Owner == "" && !o.NoAlert {
+		return errors.New("Owner must be defined for observables with alerts")
 	}
 	if o.Panel.panelType != "graph" && o.Panel.panelType != "heatmap" {
 		return errors.New(`Panel.panelType must be "", "graph", or "heatmap"`)


### PR DESCRIPTION
This PR allows informational panels that don't belong to a single team (for counts of jobs in cross-team containers such as the new worker, for example).