### PR TITLE
add stars to repository GraphQL API

### DIFF
--- a/cmd/frontend/graphqlbackend/repository.go
+++ b/cmd/frontend/graphqlbackend/repository.go
@@ -299,6 +299,14 @@ func (r *RepositoryResolver) Type(ctx context.Context) (*types.Repo, error) {
 	return r.repo(ctx)
 }
 
+func (r *RepositoryResolver) Stars(ctx context.Context) (int32, error) {
+	repo, err := r.repo(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return int32(repo.Stars), nil
+}
+
 func (r *RepositoryResolver) hydrate(ctx context.Context) error {
 	r.hydration.Do(func() {
 		// Repositories with an empty creation date were created using RepoName.ToRepo(),

--- a/cmd/frontend/graphqlbackend/schema.graphql
+++ b/cmd/frontend/graphqlbackend/schema.graphql
@@ -2385,6 +2385,11 @@ type Repository implements Node & GenericSearchResultInterface {
     for use by code intelligence features.
     """
     codeIntelligenceCommitGraph: CodeIntelligenceCommitGraph!
+
+    """
+    The star count the repository has in the code host.
+    """
+    stars: Int!
 }
 
 """


### PR DESCRIPTION
This commit adds the star count for repositories to the GraphQL API. The
data already existed in the database thanks to recent changes, so this
just exposes it.

Related to #21636 

cc @rrhyne 
