### PR TITLE
ci: add branch to build candidate images for all of our docker images

### DIFF
--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -31,16 +31,17 @@ type Config struct {
 	// merge-base with origin/master.
 	changedFiles []string
 
-	taggedRelease       bool
-	releaseBranch       bool
-	isBextReleaseBranch bool
-	isBextNightly       bool
-	isRenovateBranch    bool
-	patch               bool
-	patchNoTest         bool
-	isQuick             bool
-	isMainDryRun        bool
-	isBackendDryRun     bool
+	taggedRelease         bool
+	releaseBranch         bool
+	isBextReleaseBranch   bool
+	isBextNightly         bool
+	isRenovateBranch      bool
+	patch                 bool
+	patchNoTest           bool
+	buildCandidatesNoTest bool
+	isQuick               bool
+	isMainDryRun          bool
+	isBackendDryRun       bool
 
 	// profilingEnabled, if true, tells buildkite to print timing and resource utilization information
 	// for each command
@@ -72,6 +73,7 @@ func ComputeConfig() Config {
 	if patchNoTest || patch {
 		version = version + "_patch"
 	}
+	buildCandidatesNoTest := strings.HasPrefix(branch, "docker-images-candidates-notest-all/")
 
 	isBackendDryRun := strings.HasPrefix(branch, "backend-dry-run/")
 
@@ -105,17 +107,18 @@ func ComputeConfig() Config {
 		changedFiles:      changedFiles,
 		buildNumber:       buildNumber,
 
-		taggedRelease:       taggedRelease,
-		releaseBranch:       lazyregexp.New(`^[0-9]+\.[0-9]+$`).MatchString(branch),
-		isBextReleaseBranch: branch == "bext/release",
-		isRenovateBranch:    strings.HasPrefix(branch, "renovate/"),
-		patch:               patch,
-		patchNoTest:         patchNoTest,
-		isQuick:             isQuick,
-		isMainDryRun:        isMainDryRun,
-		isBackendDryRun:     isBackendDryRun,
-		profilingEnabled:    profilingEnabled,
-		isBextNightly:       os.Getenv("BEXT_NIGHTLY") == "true",
+		taggedRelease:         taggedRelease,
+		releaseBranch:         lazyregexp.New(`^[0-9]+\.[0-9]+$`).MatchString(branch),
+		isBextReleaseBranch:   branch == "bext/release",
+		isRenovateBranch:      strings.HasPrefix(branch, "renovate/"),
+		patch:                 patch,
+		patchNoTest:           patchNoTest,
+		buildCandidatesNoTest: buildCandidatesNoTest,
+		isQuick:               isQuick,
+		isMainDryRun:          isMainDryRun,
+		isBackendDryRun:       isBackendDryRun,
+		profilingEnabled:      profilingEnabled,
+		isBextNightly:         os.Getenv("BEXT_NIGHTLY") == "true",
 	}
 }
 

--- a/enterprise/dev/ci/internal/ci/pipeline.go
+++ b/enterprise/dev/ci/internal/ci/pipeline.go
@@ -79,6 +79,11 @@ func GeneratePipeline(c Config) (*bk.Pipeline, error) {
 			addDocs,
 		}
 
+	case c.buildCandidatesNoTest:
+		pipelineOperations = []func(*bk.Pipeline){
+			addDockerImages(c, false),
+		}
+
 	case c.patchNoTest:
 		// If this is a no-test branch, then run only the Docker build. No tests are run.
 		app := c.branch[27:]


### PR DESCRIPTION
Pushing to `docker-images-candidates-notest-all/` will build and push all the candidate docker images (and skip tests)