### PR TITLE
ci: fix check for the buildCandidatesNoTest path

### DIFF
--- a/enterprise/dev/ci/internal/ci/helpers.go
+++ b/enterprise/dev/ci/internal/ci/helpers.go
@@ -73,7 +73,7 @@ func ComputeConfig() Config {
 	if patchNoTest || patch {
 		version = version + "_patch"
 	}
-	buildCandidatesNoTest := strings.HasPrefix(branch, "docker-images-candidates-notest-all/")
+	buildCandidatesNoTest := branch == "docker-images-candidates-notest-all"
 
 	isBackendDryRun := strings.HasPrefix(branch, "backend-dry-run/")
 


### PR DESCRIPTION
I didn't realize that ending with a trailing slash is an invalid refspec.