### PR TITLE
aggregate errors

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -773,7 +773,7 @@ func multierrorToAlert(me *multierror.Error) (resAlert *searchAlert, resErr erro
 	for _, err := range me.Errors {
 		alert, err := errorToAlert(err)
 		resAlert = maxAlertByPriority(resAlert, alert)
-		multierror.Append(resErr, err)
+		resErr = multierror.Append(resErr, err)
 	}
 
 	return resAlert, resErr

--- a/internal/search/run/aggregator.go
+++ b/internal/search/run/aggregator.go
@@ -59,7 +59,9 @@ func (a *Aggregator) Send(event streaming.SearchEvent) {
 }
 
 func (a *Aggregator) Error(err error) {
-	multierror.Append(a.errors, err)
+	a.mu.Lock()
+	a.errors = multierror.Append(a.errors, err)
+	a.mu.Unlock()
 }
 
 func (a *Aggregator) DoRepoSearch(ctx context.Context, args *search.TextParameters, limit int32) (err error) {


### PR DESCRIPTION
A small fix because I noticed the result of `multierror.Append` wasn't being used in these cases.
<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
