### PR TITLE
Make `SearchResultsResolver` a thin wrapper around new `SearchResults`

### DIFF
--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -616,7 +616,11 @@ func pathParentsByFrequency(paths []string) []string {
 // year 1. As a workaround, wrap instantiates start with time.now().
 // TODO(rvantonder): #10801.
 func (a searchAlert) wrap(db dbutil.DB) *SearchResultsResolver {
-	return &SearchResultsResolver{db: db, alert: &a}
+	return &SearchResultsResolver{db: db, SearchResults: a.wrapResults()}
+}
+
+func (a searchAlert) wrapResults() *SearchResults {
+	return &SearchResults{Alert: &a}
 }
 
 func (a searchAlert) wrapSearchImplementer(db dbutil.DB) *alertSearchImplementer {

--- a/cmd/frontend/graphqlbackend/search_alert.go
+++ b/cmd/frontend/graphqlbackend/search_alert.go
@@ -611,14 +611,6 @@ func pathParentsByFrequency(paths []string) []string {
 	return parents
 }
 
-// Wrap an alert in a SearchResultsResolver. ElapsedMilliseconds() will
-// calculate a very large value for duration if start takes on the nil-value of
-// year 1. As a workaround, wrap instantiates start with time.now().
-// TODO(rvantonder): #10801.
-func (a searchAlert) wrap(db dbutil.DB) *SearchResultsResolver {
-	return &SearchResultsResolver{db: db, SearchResults: a.wrapResults()}
-}
-
 func (a searchAlert) wrapResults() *SearchResults {
 	return &SearchResults{Alert: &a}
 }
@@ -638,7 +630,7 @@ type alertSearchImplementer struct {
 }
 
 func (a alertSearchImplementer) Results(context.Context) (*SearchResultsResolver, error) {
-	return a.alert.wrap(a.db), nil
+	return &SearchResultsResolver{db: a.db, SearchResults: a.alert.wrapResults()}, nil
 }
 
 func (alertSearchImplementer) Suggestions(context.Context, *searchSuggestionsArgs) ([]SearchSuggestionResolver, error) {

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -66,7 +66,7 @@ func (r *SearchResultsResolver) PageInfo() *graphqlutil.PageInfo {
 //    a timeout, searcing result types in parallel) is fundamentally incompatible
 //    with the absolute ordering we do here for pagination.
 //
-func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchResultsResolver, err error) {
+func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchResults, err error) {
 	start := time.Now()
 	if r.Pagination == nil {
 		panic("never here: this method should never be called in this state")
@@ -114,7 +114,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	resolved, err := r.determineRepos(ctx, tr, start)
 	if err != nil {
 		if alert, err := errorToAlert(err); alert != nil {
-			return &SearchResultsResolver{db: r.db, SearchResults: alert.wrapResults()}, err
+			return alert.wrapResults(), err
 		}
 		return nil, err
 	}
@@ -177,14 +177,11 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 		"Finished", cursor.Finished,
 	)
 
-	return &SearchResultsResolver{
-		db: r.db,
-		SearchResults: &SearchResults{
-			Matches: results,
-			Stats:   common,
-			Cursor:  cursor,
-			Alert:   alert,
-		},
+	return &SearchResults{
+		Matches: results,
+		Stats:   common,
+		Cursor:  cursor,
+		Alert:   alert,
 	}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -49,10 +49,10 @@ func unmarshalSearchCursor(cursor *string) (*run.SearchCursor, error) {
 }
 
 func (r *SearchResultsResolver) PageInfo() *graphqlutil.PageInfo {
-	if r.cursor == nil || r.cursor.Finished {
+	if r.Cursor == nil || r.Cursor.Finished {
 		return graphqlutil.HasNextPage(false)
 	}
-	return graphqlutil.NextPageCursor(marshalSearchCursor(r.cursor))
+	return graphqlutil.NextPageCursor(marshalSearchCursor(r.Cursor))
 }
 
 // paginatedResults handles serving paginated search queries. It's logic does
@@ -178,11 +178,13 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	)
 
 	return &SearchResultsResolver{
-		db:            r.db,
-		Stats:         common,
-		SearchResults: results,
-		alert:         alert,
-		cursor:        cursor,
+		db:    r.db,
+		alert: alert,
+		SearchResults: &SearchResults{
+			Matches: results,
+			Stats:   common,
+			Cursor:  cursor,
+		},
 	}, nil
 }
 

--- a/cmd/frontend/graphqlbackend/search_pagination.go
+++ b/cmd/frontend/graphqlbackend/search_pagination.go
@@ -114,7 +114,7 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	resolved, err := r.determineRepos(ctx, tr, start)
 	if err != nil {
 		if alert, err := errorToAlert(err); alert != nil {
-			return &SearchResultsResolver{db: r.db, alert: alert}, err
+			return &SearchResultsResolver{db: r.db, SearchResults: alert.wrapResults()}, err
 		}
 		return nil, err
 	}
@@ -178,12 +178,12 @@ func (r *searchResolver) paginatedResults(ctx context.Context) (result *SearchRe
 	)
 
 	return &SearchResultsResolver{
-		db:    r.db,
-		alert: alert,
+		db: r.db,
 		SearchResults: &SearchResults{
 			Matches: results,
 			Stats:   common,
 			Cursor:  cursor,
+			Alert:   alert,
 		},
 	}, nil
 }

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -900,6 +900,9 @@ func (r *searchResolver) resultsStreaming(ctx context.Context) (*SearchResultsRe
 }
 
 func (r *searchResolver) resultsToResolver(results *SearchResults) *SearchResultsResolver {
+	if results == nil {
+		results = &SearchResults{}
+	}
 	return &SearchResultsResolver{
 		SearchResults: results,
 		limit:         r.MaxResults(),

--- a/cmd/frontend/graphqlbackend/search_results.go
+++ b/cmd/frontend/graphqlbackend/search_results.go
@@ -95,10 +95,6 @@ func (c *SearchResultsResolver) IndexUnavailable() bool {
 	return c.Stats.IsIndexUnavailable
 }
 
-func (c *SearchResultsResolver) allReposTimedout() bool {
-	return c.Stats.Status.All(search.RepoStatusTimedout) && c.Stats.Status.Len() == len(c.Stats.Repos)
-}
-
 // SearchResultsResolver is a resolver for the GraphQL type `SearchResults`
 type SearchResultsResolver struct {
 	db dbutil.DB
@@ -927,7 +923,7 @@ func DetermineStatusForLogs(srr *SearchResultsResolver, err error) string {
 		return "timeout"
 	case err != nil:
 		return "error"
-	case srr.allReposTimedout():
+	case srr.Stats.AllReposTimedOut():
 		return "timeout"
 	case srr.Stats.Status.Any(search.RepoStatusTimedout):
 		return "partial_timeout"

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -37,7 +37,12 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 
 func (srs *searchResultsStats) getResults(ctx context.Context) (*SearchResultsResolver, error) {
 	srs.once.Do(func() {
-		srs.srs, srs.srsErr = srs.sr.doResults(ctx, result.TypeEmpty)
+		results, err := srs.sr.doResults(ctx, result.TypeEmpty)
+		if err != nil {
+			srs.srsErr = err
+			return
+		}
+		srs.srs = srs.sr.resultsToResolver(results)
 	})
 	return srs.srs, srs.srsErr
 }

--- a/cmd/frontend/graphqlbackend/search_results_stats_languages.go
+++ b/cmd/frontend/graphqlbackend/search_results_stats_languages.go
@@ -23,7 +23,7 @@ func (srs *searchResultsStats) Languages(ctx context.Context) ([]*languageStatis
 		return nil, err
 	}
 
-	langs, err := searchResultsStatsLanguages(ctx, srr.SearchResults)
+	langs, err := searchResultsStatsLanguages(ctx, srr.Matches)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -671,8 +671,8 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 				SearchResults: &SearchResults{
 					Stats:   tt.fields.searchResultsCommon,
 					Matches: tt.fields.results,
+					Alert:   tt.fields.alert,
 				},
-				alert: tt.fields.alert,
 			}
 			if got := sr.ApproximateResultCount(); got != tt.want {
 				t.Errorf("searchResultsResolver.ApproximateResultCount() = %v, want %v", got, tt.want)
@@ -933,7 +933,7 @@ func TestEvaluateAnd(t *testing.T) {
 				t.Fatal("Results:", err)
 			}
 			if tt.wantAlert {
-				if results.alert == nil {
+				if results.SearchResults.Alert == nil {
 					t.Errorf("Expected results")
 				}
 			} else if int(results.MatchCount()) != len(zoektFileMatches) {

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -57,8 +57,8 @@ func TestSearchResults(t *testing.T) {
 		if err != nil {
 			t.Fatal("Results:", err)
 		}
-		resultDescriptions := make([]string, len(results.SearchResults))
-		for i, match := range results.SearchResults {
+		resultDescriptions := make([]string, len(results.Matches))
+		for i, match := range results.Matches {
 			// NOTE: Only supports one match per line. If we need to test other cases,
 			// just remove that assumption in the following line of code.
 			switch m := match.(type) {
@@ -451,7 +451,7 @@ func TestSearchResolver_DynamicFilters(t *testing.T) {
 		t.Run(test.descr, func(t *testing.T) {
 			for _, globbing := range []bool{true, false} {
 				mockDecodedViewerFinalSettings.SearchGlobbing = &globbing
-				actualDynamicFilters := (&SearchResultsResolver{db: db, SearchResults: test.searchResults}).DynamicFilters(context.Background())
+				actualDynamicFilters := (&SearchResultsResolver{db: db, SearchResults: &SearchResults{Matches: test.searchResults}}).DynamicFilters(context.Background())
 				actualDynamicFilterStrs := make(map[string]int)
 
 				for _, filter := range actualDynamicFilters {
@@ -667,10 +667,12 @@ func Test_SearchResultsResolver_ApproximateResultCount(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			sr := &SearchResultsResolver{
-				db:            db,
-				SearchResults: tt.fields.results,
-				Stats:         tt.fields.searchResultsCommon,
-				alert:         tt.fields.alert,
+				db: db,
+				SearchResults: &SearchResults{
+					Stats:   tt.fields.searchResultsCommon,
+					Matches: tt.fields.results,
+				},
+				alert: tt.fields.alert,
 			}
 			if got := sr.ApproximateResultCount(); got != tt.want {
 				t.Errorf("searchResultsResolver.ApproximateResultCount() = %v, want %v", got, tt.want)
@@ -1062,11 +1064,13 @@ func TestUnionMerge(t *testing.T) {
 		{
 			left: SearchResultsResolver{
 				db: db,
-				SearchResults: []result.Match{
-					diffResult("a", "a"),
-					commitResult("a", "a"),
-					repoResult("a"),
-					fileResult("a", nil, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						diffResult("a", "a"),
+						commitResult("a", "a"),
+						repoResult("a"),
+						fileResult("a", nil, nil),
+					},
 				},
 			},
 			right: SearchResultsResolver{db: db},
@@ -1076,87 +1080,105 @@ func TestUnionMerge(t *testing.T) {
 			left: SearchResultsResolver{db: db},
 			right: SearchResultsResolver{
 				db: db,
-				SearchResults: []result.Match{
-					diffResult("a", "a"),
-					commitResult("a", "a"),
-					repoResult("a"),
-					fileResult("a", nil, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						diffResult("a", "a"),
+						commitResult("a", "a"),
+						repoResult("a"),
+						fileResult("a", nil, nil),
+					},
 				},
 			},
 			want: autogold.Want("RightOnly", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					diffResult("a", "a"),
-					commitResult("a", "a"),
-					repoResult("a"),
-					fileResult("a", nil, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						diffResult("a", "a"),
+						commitResult("a", "a"),
+						repoResult("a"),
+						fileResult("a", nil, nil),
+					},
 				},
 			},
 			right: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					diffResult("b", "b"),
-					commitResult("b", "b"),
-					repoResult("b"),
-					fileResult("b", nil, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						diffResult("b", "b"),
+						commitResult("b", "b"),
+						repoResult("b"),
+						fileResult("b", nil, nil),
+					},
 				},
 			},
 			want: autogold.Want("MergeAllDifferent", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a, File{url:b/,symbols:[],lineMatches:[]}, Repo:/b, Commit:/b/-/commit/b, Diff:/b/-/commit/b"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					fileResult("b", []*result.LineMatch{
-						{Preview: "a"},
-						{Preview: "b"},
-					}, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						fileResult("b", []*result.LineMatch{
+							{Preview: "a"},
+							{Preview: "b"},
+						}, nil),
+					},
 				},
 			},
 			right: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					fileResult("b", []*result.LineMatch{
-						{Preview: "c"},
-						{Preview: "d"},
-					}, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						fileResult("b", []*result.LineMatch{
+							{Preview: "c"},
+							{Preview: "d"},
+						}, nil),
+					},
 				},
 			},
 			want: autogold.Want("MergeFileLineMatches", "File{url:b/,symbols:[],lineMatches:[a,b,c,d]}"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					fileResult("a", []*result.LineMatch{
-						{Preview: "a"},
-						{Preview: "b"},
-					}, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						fileResult("a", []*result.LineMatch{
+							{Preview: "a"},
+							{Preview: "b"},
+						}, nil),
+					},
 				},
 			},
 			right: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					fileResult("b", []*result.LineMatch{
-						{Preview: "c"},
-						{Preview: "d"},
-					}, nil),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						fileResult("b", []*result.LineMatch{
+							{Preview: "c"},
+							{Preview: "d"},
+						}, nil),
+					},
 				},
 			},
 			want: autogold.Want("NoMergeFileSymbols", "File{url:a/,symbols:[],lineMatches:[a,b]}, File{url:b/,symbols:[],lineMatches:[c,d]}"),
 		},
 		{
 			left: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					fileResult("a", nil, []*result.SymbolMatch{
-						{Symbol: result.Symbol{Name: "a"}},
-						{Symbol: result.Symbol{Name: "b"}},
-					}),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						fileResult("a", nil, []*result.SymbolMatch{
+							{Symbol: result.Symbol{Name: "a"}},
+							{Symbol: result.Symbol{Name: "b"}},
+						}),
+					},
 				},
 			},
 			right: SearchResultsResolver{db: db,
-				SearchResults: []result.Match{
-					fileResult("a", nil, []*result.SymbolMatch{
-						{Symbol: result.Symbol{Name: "c"}},
-						{Symbol: result.Symbol{Name: "d"}},
-					}),
+				SearchResults: &SearchResults{
+					Matches: []result.Match{
+						fileResult("a", nil, []*result.SymbolMatch{
+							{Symbol: result.Symbol{Name: "c"}},
+							{Symbol: result.Symbol{Name: "d"}},
+						}),
+					},
 				},
 			},
 			want: autogold.Want("MergeFileSymbols", "File{url:a/,symbols:[a,b,c,d],lineMatches:[]}"),
@@ -1166,8 +1188,8 @@ func TestUnionMerge(t *testing.T) {
 	for _, tc := range cases {
 		t.Run("", func(t *testing.T) {
 			got := unionMerge(&tc.left, &tc.right)
-			sort.Sort(result.Matches(got.SearchResults))
-			tc.want.Equal(t, searchResultResolversToString(got.SearchResults))
+			sort.Sort(result.Matches(got.Matches))
+			tc.want.Equal(t, searchResultResolversToString(got.Matches))
 		})
 	}
 }

--- a/cmd/frontend/graphqlbackend/search_results_test.go
+++ b/cmd/frontend/graphqlbackend/search_results_test.go
@@ -1054,131 +1054,107 @@ func fileResult(repo string, lineMatches []*result.LineMatch, symbolMatches []*r
 }
 
 func TestUnionMerge(t *testing.T) {
-	db := new(dbtesting.MockDB)
-
 	cases := []struct {
-		left  SearchResultsResolver
-		right SearchResultsResolver
+		left  SearchResults
+		right SearchResults
 		want  autogold.Value
 	}{
 		{
-			left: SearchResultsResolver{
-				db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						diffResult("a", "a"),
-						commitResult("a", "a"),
-						repoResult("a"),
-						fileResult("a", nil, nil),
-					},
+			left: SearchResults{
+				Matches: []result.Match{
+					diffResult("a", "a"),
+					commitResult("a", "a"),
+					repoResult("a"),
+					fileResult("a", nil, nil),
 				},
 			},
-			right: SearchResultsResolver{db: db},
+			right: SearchResults{},
 			want:  autogold.Want("LeftOnly", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a"),
 		},
 		{
-			left: SearchResultsResolver{db: db},
-			right: SearchResultsResolver{
-				db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						diffResult("a", "a"),
-						commitResult("a", "a"),
-						repoResult("a"),
-						fileResult("a", nil, nil),
-					},
+			left: SearchResults{},
+			right: SearchResults{
+				Matches: []result.Match{
+					diffResult("a", "a"),
+					commitResult("a", "a"),
+					repoResult("a"),
+					fileResult("a", nil, nil),
 				},
 			},
 			want: autogold.Want("RightOnly", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a"),
 		},
 		{
-			left: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						diffResult("a", "a"),
-						commitResult("a", "a"),
-						repoResult("a"),
-						fileResult("a", nil, nil),
-					},
+			left: SearchResults{
+				Matches: []result.Match{
+					diffResult("a", "a"),
+					commitResult("a", "a"),
+					repoResult("a"),
+					fileResult("a", nil, nil),
 				},
 			},
-			right: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						diffResult("b", "b"),
-						commitResult("b", "b"),
-						repoResult("b"),
-						fileResult("b", nil, nil),
-					},
+			right: SearchResults{
+				Matches: []result.Match{
+					diffResult("b", "b"),
+					commitResult("b", "b"),
+					repoResult("b"),
+					fileResult("b", nil, nil),
 				},
 			},
 			want: autogold.Want("MergeAllDifferent", "File{url:a/,symbols:[],lineMatches:[]}, Repo:/a, Commit:/a/-/commit/a, Diff:/a/-/commit/a, File{url:b/,symbols:[],lineMatches:[]}, Repo:/b, Commit:/b/-/commit/b, Diff:/b/-/commit/b"),
 		},
 		{
-			left: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						fileResult("b", []*result.LineMatch{
-							{Preview: "a"},
-							{Preview: "b"},
-						}, nil),
-					},
+			left: SearchResults{
+				Matches: []result.Match{
+					fileResult("b", []*result.LineMatch{
+						{Preview: "a"},
+						{Preview: "b"},
+					}, nil),
 				},
 			},
-			right: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						fileResult("b", []*result.LineMatch{
-							{Preview: "c"},
-							{Preview: "d"},
-						}, nil),
-					},
+			right: SearchResults{
+				Matches: []result.Match{
+					fileResult("b", []*result.LineMatch{
+						{Preview: "c"},
+						{Preview: "d"},
+					}, nil),
 				},
 			},
 			want: autogold.Want("MergeFileLineMatches", "File{url:b/,symbols:[],lineMatches:[a,b,c,d]}"),
 		},
 		{
-			left: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						fileResult("a", []*result.LineMatch{
-							{Preview: "a"},
-							{Preview: "b"},
-						}, nil),
-					},
+			left: SearchResults{
+				Matches: []result.Match{
+					fileResult("a", []*result.LineMatch{
+						{Preview: "a"},
+						{Preview: "b"},
+					}, nil),
 				},
 			},
-			right: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						fileResult("b", []*result.LineMatch{
-							{Preview: "c"},
-							{Preview: "d"},
-						}, nil),
-					},
+			right: SearchResults{
+				Matches: []result.Match{
+					fileResult("b", []*result.LineMatch{
+						{Preview: "c"},
+						{Preview: "d"},
+					}, nil),
 				},
 			},
 			want: autogold.Want("NoMergeFileSymbols", "File{url:a/,symbols:[],lineMatches:[a,b]}, File{url:b/,symbols:[],lineMatches:[c,d]}"),
 		},
 		{
-			left: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						fileResult("a", nil, []*result.SymbolMatch{
-							{Symbol: result.Symbol{Name: "a"}},
-							{Symbol: result.Symbol{Name: "b"}},
-						}),
-					},
+			left: SearchResults{
+				Matches: []result.Match{
+					fileResult("a", nil, []*result.SymbolMatch{
+						{Symbol: result.Symbol{Name: "a"}},
+						{Symbol: result.Symbol{Name: "b"}},
+					}),
 				},
 			},
-			right: SearchResultsResolver{db: db,
-				SearchResults: &SearchResults{
-					Matches: []result.Match{
-						fileResult("a", nil, []*result.SymbolMatch{
-							{Symbol: result.Symbol{Name: "c"}},
-							{Symbol: result.Symbol{Name: "d"}},
-						}),
-					},
+			right: SearchResults{
+				Matches: []result.Match{
+					fileResult("a", nil, []*result.SymbolMatch{
+						{Symbol: result.Symbol{Name: "c"}},
+						{Symbol: result.Symbol{Name: "d"}},
+					}),
 				},
 			},
 			want: autogold.Want("MergeFileSymbols", "File{url:a/,symbols:[a,b,c,d],lineMatches:[]}"),

--- a/cmd/frontend/graphqlbackend/search_suggestions.go
+++ b/cmd/frontend/graphqlbackend/search_suggestions.go
@@ -482,11 +482,11 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 			}
 			var suggestions []SearchSuggestionResolver
 			if results != nil {
-				if len(results.SearchResults) > int(*args.First) {
-					results.SearchResults = results.SearchResults[:*args.First]
+				if len(results.Matches) > int(*args.First) {
+					results.Matches = results.Matches[:*args.First]
 				}
-				suggestions = make([]SearchSuggestionResolver, 0, len(results.SearchResults))
-				for i, res := range results.SearchResults {
+				suggestions = make([]SearchSuggestionResolver, 0, len(results.Matches))
+				for i, res := range results.Matches {
 					if fm, ok := res.(*result.FileMatch); ok {
 						fmResolver := &FileMatchResolver{
 							FileMatch:    *fm,
@@ -494,7 +494,7 @@ func (r *searchResolver) Suggestions(ctx context.Context, args *searchSuggestion
 						}
 						suggestions = append(suggestions, gitTreeSuggestionResolver{
 							gitTreeEntry: fmResolver.File(),
-							score:        len(results.SearchResults) - i,
+							score:        len(results.Matches) - i,
 						})
 					}
 				}

--- a/cmd/frontend/internal/search/search_test.go
+++ b/cmd/frontend/internal/search/search_test.go
@@ -219,7 +219,8 @@ func (h *mockSearchResolver) Results(ctx context.Context) (*graphqlbackend.Searc
 		return nil, ctx.Err()
 	case <-h.done:
 		return &graphqlbackend.SearchResultsResolver{
-			UserSettings: &schema.Settings{},
+			UserSettings:  &schema.Settings{},
+			SearchResults: &graphqlbackend.SearchResults{},
 		}, nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -188,7 +188,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
-	golang.org/x/tools v0.1.2
+	golang.org/x/tools v0.1.3
 	google.golang.org/api v0.46.0
 	google.golang.org/genproto v0.0.0-20210517163617-5e0236093d7a
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -777,7 +777,6 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
-github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -983,7 +982,6 @@ github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkB
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1163,7 +1161,6 @@ github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtb
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
-github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1344,19 +1341,15 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
-github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.1.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
-github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
-github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1369,7 +1362,6 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
-github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
@@ -1393,7 +1385,6 @@ github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPr
 github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
-github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -1856,8 +1847,8 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
-golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.3 h1:L69ShwSZEyCsLKoAxDKeMvLDZkumEe8gXUZAjab0tX8=
+golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -2010,7 +2001,6 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=

--- a/go.sum
+++ b/go.sum
@@ -777,6 +777,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20170914154624-68e816d1c783/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
+github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
@@ -982,6 +983,7 @@ github.com/machinebox/graphql v0.2.2 h1:dWKpJligYKhYKO5A2gvNhkJdQMNZeChZYyBbrZkB
 github.com/machinebox/graphql v0.2.2/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
 github.com/magiconair/properties v1.7.4-0.20170902060319-8d7837e64d3c/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -1161,6 +1163,7 @@ github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtb
 github.com/pelletier/go-toml v1.0.1-0.20170904195809-1d6b12b7cb29/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+github.com/pelletier/go-toml v1.6.0 h1:aetoXYr0Tv7xRU/V4B4IZJ2QcbtMUFoNb3ORp7TzIK4=
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -1341,15 +1344,19 @@ github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0b
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.1.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
+github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v0.0.0-20170901151539-12bd96e66386/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1362,6 +1369,7 @@ github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DM
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.5.0/go.mod h1:AkYRkVJF8TkSG/xet6PzXX+l39KhhXa2pdqVSxnTcn4=
 github.com/spf13/viper v1.6.1/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
+github.com/spf13/viper v1.6.2 h1:7aKfF+e8/k68gda3LOjo5RxiUqddoFxVq4BKBPrxk5E=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
@@ -1385,6 +1393,7 @@ github.com/stripe/stripe-go v70.15.0+incompatible h1:hNML7M1zx8RgtepEMlxyu/FpVPr
 github.com/stripe/stripe-go v70.15.0+incompatible/go.mod h1:A1dQZmO/QypXmsL0T8axYZkSN/uA/T/A64pfKdBAMiY=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
+github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/temoto/robotstxt v1.1.1 h1:Gh8RCs8ouX3hRSxxK7B1mO5RFByQ4CmJZDwgom++JaA=
 github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr3ujewlOo=
@@ -2001,6 +2010,7 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
+gopkg.in/ini.v1 v1.54.0 h1:oM5ElzbIi7gwLnNbPX2M25ED1vSAK3B6dex50eS/6Fs=
 gopkg.in/ini.v1 v1.54.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mattn/go-colorable.v0 v0.1.0/go.mod h1:BVJlBXzARQxdi3nZo6f6bnl5yR20/tOL6p+V0KejgSY=
 gopkg.in/mattn/go-isatty.v0 v0.0.4/go.mod h1:wt691ab7g0X4ilKZNmMII3egK0bTxl37fEn/Fwbd8gc=

--- a/internal/search/streaming/progress.go
+++ b/internal/search/streaming/progress.go
@@ -108,3 +108,7 @@ func (c *Stats) String() string {
 func (c *Stats) Equal(other *Stats) bool {
 	return reflect.DeepEqual(c, other)
 }
+
+func (c *Stats) AllReposTimedOut() bool {
+	return c.Status.All(search.RepoStatusTimedout) && c.Status.Len() == len(c.Repos)
+}


### PR DESCRIPTION
This PR further reduces the footprint of the graphql resolvers by returning the new `SearchResults` type from `searchResolver.doResults()` and `searchResolver.evaluate*`. 

I tried to keep the footprint of this change as small as possible, focusing only on making these methods independent of `SearchResultsResolver`. 

This starts to open up the possibility of moving the `evaluate*` methods out of `graphqlbackend`, but that will require some significant further refactoring of `searchResolver` since they rely on a large amount of shared state in `searchResolver`. 


<!-- Reminder: Have you updated the changelog and relevant docs (user docs, architecture diagram, etc) ? -->
<!-- Please notify @distrubution if this PR contains changes to CI that may need to be cherry-picked on to patch release branches -->
