### PR TITLE
Implement bulk merge action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to Sourcegraph are documented in this file.
 - Added featured Sourcegraph extensions query to the GraphQL API, as well as a section in the extension registry to display featured extensions. [#21665](https://github.com/sourcegraph/sourcegraph/pull/21665)
 - The search page now has a `create insight` button to create search-based insight based on your search query [#21943](https://github.com/sourcegraph/sourcegraph/pull/21943)
 - Added support for Terraform syntax highlighting. [#22040](https://github.com/sourcegraph/sourcegraph/pull/22040)
+- A new bulk operation to merge many changesets at once has been added to Batch Changes. [#21959](https://github.com/sourcegraph/sourcegraph/pull/21959)
 
 ### Changed
 

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -41,6 +41,8 @@ import {
     ChangesetIDConnectionFields,
     ReenqueueChangesetsResult,
     ReenqueueChangesetsVariables,
+    MergeChangesetsResult,
+    MergeChangesetsVariables,
 } from '../../../graphql-operations'
 
 const changesetsStatsFragment = gql`
@@ -662,6 +664,20 @@ export async function reenqueueChangesets(batchChange: Scalars['ID'], changesets
         gql`
             mutation ReenqueueChangesets($batchChange: ID!, $changesets: [ID!]!) {
                 reenqueueChangesets(batchChange: $batchChange, changesets: $changesets) {
+                    id
+                }
+            }
+        `,
+        { batchChange, changesets }
+    ).toPromise()
+    dataOrThrowErrors(result)
+}
+
+export async function mergeChangesets(batchChange: Scalars['ID'], changesets: Scalars['ID'][]): Promise<void> {
+    const result = await requestGraphQL<MergeChangesetsResult, MergeChangesetsVariables>(
+        gql`
+            mutation MergeChangesets($batchChange: ID!, $changesets: [ID!]!) {
+                mergeChangesets(batchChange: $batchChange, changesets: $changesets) {
                     id
                 }
             }

--- a/client/web/src/enterprise/batches/detail/backend.ts
+++ b/client/web/src/enterprise/batches/detail/backend.ts
@@ -673,16 +673,20 @@ export async function reenqueueChangesets(batchChange: Scalars['ID'], changesets
     dataOrThrowErrors(result)
 }
 
-export async function mergeChangesets(batchChange: Scalars['ID'], changesets: Scalars['ID'][]): Promise<void> {
+export async function mergeChangesets(
+    batchChange: Scalars['ID'],
+    changesets: Scalars['ID'][],
+    squash: boolean
+): Promise<void> {
     const result = await requestGraphQL<MergeChangesetsResult, MergeChangesetsVariables>(
         gql`
-            mutation MergeChangesets($batchChange: ID!, $changesets: [ID!]!) {
-                mergeChangesets(batchChange: $batchChange, changesets: $changesets) {
+            mutation MergeChangesets($batchChange: ID!, $changesets: [ID!]!, $squash: Boolean!) {
+                mergeChangesets(batchChange: $batchChange, changesets: $changesets, squash: $squash) {
                     id
                 }
             }
         `,
-        { batchChange, changesets }
+        { batchChange, changesets, squash }
     ).toPromise()
     dataOrThrowErrors(result)
 }

--- a/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
+++ b/client/web/src/enterprise/batches/detail/bulk-operations/BulkOperationNode.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames'
 import CommentOutlineIcon from 'mdi-react/CommentOutlineIcon'
 import ExternalLinkIcon from 'mdi-react/ExternalLinkIcon'
 import LinkVariantRemoveIcon from 'mdi-react/LinkVariantRemoveIcon'
+import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import SyncIcon from 'mdi-react/SyncIcon'
 import React from 'react'
 
@@ -31,6 +32,11 @@ const OPERATION_TITLES: Record<BulkOperationType, JSX.Element> = {
     REENQUEUE: (
         <>
             <SyncIcon className="icon-inline text-muted" /> Retry changesets
+        </>
+    ),
+    MERGE: (
+        <>
+            <SourceBranchIcon className="icon-inline text-muted" /> Merge changesets
         </>
     ),
 }

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -12,6 +12,7 @@ import { queryAllChangesetIDs } from '../backend'
 import styles from './ChangesetSelectRow.module.scss'
 import { CreateCommentModal } from './CreateCommentModal'
 import { DetachChangesetsModal } from './DetachChangesetsModal'
+import { MergeChangesetsModal } from './MergeChangesetsModal'
 import { ReenqueueChangesetsModal } from './ReenqueueChangesetsModal'
 
 /**
@@ -84,6 +85,21 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
         isAvailable: () => true,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
             <CreateCommentModal
+                batchChangeID={batchChangeID}
+                changesetIDs={changesetIDs}
+                afterCreate={onDone}
+                onCancel={onCancel}
+            />
+        ),
+    },
+    {
+        type: 'merge',
+        buttonLabel: 'Merge changesets',
+        dropdownTitle: 'Merge changesets',
+        dropdownDescription: 'Merge all selected changesets, if constraints are met.',
+        isAvailable: () => true,
+        onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
+            <MergeChangesetsModal
                 batchChangeID={batchChangeID}
                 changesetIDs={changesetIDs}
                 afterCreate={onDone}

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -98,7 +98,7 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
         experimental: true,
         buttonLabel: 'Merge changesets',
         dropdownTitle: 'Merge changesets',
-        dropdownDescription: 'Merge all selected changesets, if constraints are met.',
+        dropdownDescription: 'Attempt to merge all selected changesets. Some changesets may be unmergeable if there are rules preventing merge, such as CI requirements.',
         isAvailable: ({ state }) => state === ChangesetState.OPEN,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
             <MergeChangesetsModal

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -39,6 +39,7 @@ interface ChangesetListAction {
         onDone: () => void,
         onCancel: () => void
     ) => void | JSX.Element
+    experimental?: boolean
 }
 
 const AVAILABLE_ACTIONS: ChangesetListAction[] = [
@@ -94,10 +95,11 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
     },
     {
         type: 'merge',
+        experimental: true,
         buttonLabel: 'Merge changesets',
         dropdownTitle: 'Merge changesets',
         dropdownDescription: 'Merge all selected changesets, if constraints are met.',
-        isAvailable: () => true,
+        isAvailable: ({ state }) => state === ChangesetState.OPEN,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
             <MergeChangesetsModal
                 batchChangeID={batchChangeID}
@@ -188,7 +190,10 @@ export const ChangesetSelectRow: React.FunctionComponent<ChangesetSelectRowProps
         }
     }, [allSelected, batchChangeID, onSubmit, queryArguments, selected, selectedAction])
 
-    const buttonLabel = selectedAction === undefined ? 'Select action' : selectedAction.buttonLabel
+    let buttonLabel = selectedAction === undefined ? 'Select action' : selectedAction.buttonLabel
+    if (selectedAction?.experimental) {
+        buttonLabel += ' (Experimental)'
+    }
 
     // If we have ALL all selected, we take the totalCount in the current connection, otherwise the count of selected changeset IDs.
     const selectedAmount = allSelected ? totalCount : selected.size
@@ -268,7 +273,15 @@ const ActionDropdownItem: React.FunctionComponent<ActionDropdownItemProps> = ({ 
     return (
         <div className="dropdown-item">
             <button type="button" className="btn text-left" onClick={onClick}>
-                <h4 className="mb-1">{action.dropdownTitle}</h4>
+                <h4 className="mb-1">
+                    {action.dropdownTitle}
+                    {action.experimental && (
+                        <>
+                            {' '}
+                            <small className="badge badge-info">Experimental</small>
+                        </>
+                    )}
+                </h4>
                 <p className="text-wrap text-muted mb-0">
                     <small>{action.dropdownDescription}</small>
                 </p>

--- a/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ChangesetSelectRow.tsx
@@ -98,7 +98,8 @@ const AVAILABLE_ACTIONS: ChangesetListAction[] = [
         experimental: true,
         buttonLabel: 'Merge changesets',
         dropdownTitle: 'Merge changesets',
-        dropdownDescription: 'Attempt to merge all selected changesets. Some changesets may be unmergeable if there are rules preventing merge, such as CI requirements.',
+        dropdownDescription:
+            'Attempt to merge all selected changesets. Some changesets may be unmergeable if there are rules preventing merge, such as CI requirements.',
         isAvailable: ({ state }) => state === ChangesetState.OPEN,
         onTrigger: (batchChangeID, changesetIDs, onDone, onCancel) => (
             <MergeChangesetsModal

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.story.tsx
@@ -1,0 +1,33 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+
+import { MergeChangesetsModal } from './MergeChangesetsModal'
+
+const { add } = storiesOf('web/batches/details/MergeChangesetsModal', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
+const mergeChangesets = () => {
+    action('MergeChangesets')
+    return Promise.resolve()
+}
+
+add('Confirmation', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <MergeChangesetsModal
+                {...props}
+                afterCreate={noop}
+                batchChangeID="test-123"
+                changesetIDs={changesetIDsFunction}
+                onCancel={noop}
+                mergeChangesets={mergeChangesets}
+            />
+        )}
+    </EnterpriseWebStory>
+))

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
@@ -40,6 +40,10 @@ export const MergeChangesetsModal: React.FunctionComponent<MergeChangesetsModalP
         }
     }, [changesetIDs, mergeChangesets, batchChangeID, squash, afterCreate])
 
+    const onToggleSquash = useCallback<React.ChangeEventHandler<HTMLInputElement>>(event => {
+        setSquash(event.target.checked)
+    }, [])
+
     return (
         <Dialog
             className="modal-body modal-body--top-third p-4 rounded border"
@@ -55,7 +59,7 @@ export const MergeChangesetsModal: React.FunctionComponent<MergeChangesetsModalP
                             id={CHECKBOX_ID}
                             type="checkbox"
                             checked={squash}
-                            onChange={event => setSquash(event.target.checked)}
+                            onChange={onToggleSquash}
                             className="form-check-input"
                             disabled={isLoading === true}
                         />

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
@@ -1,6 +1,7 @@
 import Dialog from '@reach/dialog'
 import React, { useCallback, useState } from 'react'
 
+import { Form } from '@sourcegraph/branded/src/components/Form'
 import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
 import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
 
@@ -26,45 +27,62 @@ export const MergeChangesetsModal: React.FunctionComponent<MergeChangesetsModalP
     mergeChangesets = _mergeChangesets,
 }) => {
     const [isLoading, setIsLoading] = useState<boolean | Error>(false)
+    const [squash, setSquash] = useState<boolean>(false)
 
     const onSubmit = useCallback<React.FormEventHandler>(async () => {
         setIsLoading(true)
         try {
             const ids = await changesetIDs()
-            await mergeChangesets(batchChangeID, ids)
+            await mergeChangesets(batchChangeID, ids, squash)
             afterCreate()
         } catch (error) {
             setIsLoading(asError(error))
         }
-    }, [changesetIDs, mergeChangesets, batchChangeID, afterCreate])
+    }, [changesetIDs, mergeChangesets, batchChangeID, squash, afterCreate])
 
     return (
         <Dialog
             className="modal-body modal-body--top-third p-4 rounded border"
             onDismiss={onCancel}
-            aria-labelledby={LABEL_ID}
+            aria-labelledby={MODAL_LABEL_ID}
         >
-            <div className="web-content">
-                <h3 id={LABEL_ID}>Merge changesets</h3>
-                <p className="mb-4">Are you sure you want to attempt to merge all the selected changesets?</p>
-                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
-                <div className="d-flex justify-content-end">
-                    <button
-                        type="button"
-                        disabled={isLoading === true}
-                        className="btn btn-outline-secondary mr-2"
-                        onClick={onCancel}
-                    >
-                        Cancel
-                    </button>
-                    <button type="button" onClick={onSubmit} disabled={isLoading === true} className="btn btn-primary">
-                        {isLoading === true && <LoadingSpinner className="icon-inline" />}
-                        Merge
-                    </button>
+            <h3 id={MODAL_LABEL_ID}>Merge changesets</h3>
+            <p className="mb-4">Are you sure you want to attempt to merge all the selected changesets?</p>
+            <Form>
+                <div className="form-group">
+                    <div className="form-check">
+                        <input
+                            id={CHECKBOX_ID}
+                            type="checkbox"
+                            checked={squash}
+                            onChange={event => setSquash(event.target.checked)}
+                            className="form-check-input"
+                            disabled={isLoading === true}
+                        />
+                        <label className="form-check-label" htmlFor={CHECKBOX_ID}>
+                            Squash merge all selected changesets.
+                        </label>
+                    </div>
                 </div>
+            </Form>
+            {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
+            <div className="d-flex justify-content-end">
+                <button
+                    type="button"
+                    disabled={isLoading === true}
+                    className="btn btn-outline-secondary mr-2"
+                    onClick={onCancel}
+                >
+                    Cancel
+                </button>
+                <button type="button" onClick={onSubmit} disabled={isLoading === true} className="btn btn-primary">
+                    {isLoading === true && <LoadingSpinner className="icon-inline" />}
+                    Merge
+                </button>
             </div>
         </Dialog>
     )
 }
 
-const LABEL_ID = 'merge-changesets-modal-title'
+const MODAL_LABEL_ID = 'merge-changesets-modal-title'
+const CHECKBOX_ID = 'merge-changesets-modal-squash-check'

--- a/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/MergeChangesetsModal.tsx
@@ -1,0 +1,70 @@
+import Dialog from '@reach/dialog'
+import React, { useCallback, useState } from 'react'
+
+import { LoadingSpinner } from '@sourcegraph/react-loading-spinner'
+import { asError, isErrorLike } from '@sourcegraph/shared/src/util/errors'
+
+import { ErrorAlert } from '../../../../components/alerts'
+import { Scalars } from '../../../../graphql-operations'
+import { mergeChangesets as _mergeChangesets } from '../backend'
+
+export interface MergeChangesetsModalProps {
+    onCancel: () => void
+    afterCreate: () => void
+    batchChangeID: Scalars['ID']
+    changesetIDs: () => Promise<Scalars['ID'][]>
+
+    /** For testing only. */
+    mergeChangesets?: typeof _mergeChangesets
+}
+
+export const MergeChangesetsModal: React.FunctionComponent<MergeChangesetsModalProps> = ({
+    onCancel,
+    afterCreate,
+    batchChangeID,
+    changesetIDs,
+    mergeChangesets = _mergeChangesets,
+}) => {
+    const [isLoading, setIsLoading] = useState<boolean | Error>(false)
+
+    const onSubmit = useCallback<React.FormEventHandler>(async () => {
+        setIsLoading(true)
+        try {
+            const ids = await changesetIDs()
+            await mergeChangesets(batchChangeID, ids)
+            afterCreate()
+        } catch (error) {
+            setIsLoading(asError(error))
+        }
+    }, [changesetIDs, mergeChangesets, batchChangeID, afterCreate])
+
+    return (
+        <Dialog
+            className="modal-body modal-body--top-third p-4 rounded border"
+            onDismiss={onCancel}
+            aria-labelledby={LABEL_ID}
+        >
+            <div className="web-content">
+                <h3 id={LABEL_ID}>Merge changesets</h3>
+                <p className="mb-4">Are you sure you want to attempt to merge all the selected changesets?</p>
+                {isErrorLike(isLoading) && <ErrorAlert error={isLoading} />}
+                <div className="d-flex justify-content-end">
+                    <button
+                        type="button"
+                        disabled={isLoading === true}
+                        className="btn btn-outline-secondary mr-2"
+                        onClick={onCancel}
+                    >
+                        Cancel
+                    </button>
+                    <button type="button" onClick={onSubmit} disabled={isLoading === true} className="btn btn-primary">
+                        {isLoading === true && <LoadingSpinner className="icon-inline" />}
+                        Merge
+                    </button>
+                </div>
+            </div>
+        </Dialog>
+    )
+}
+
+const LABEL_ID = 'merge-changesets-modal-title'

--- a/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
+++ b/client/web/src/enterprise/batches/detail/changesets/ReenqueueChangesetsModal.story.tsx
@@ -1,0 +1,33 @@
+import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+import { noop } from 'lodash'
+import React from 'react'
+
+import { EnterpriseWebStory } from '../../../components/EnterpriseWebStory'
+
+import { ReenqueueChangesetsModal } from './ReenqueueChangesetsModal'
+
+const { add } = storiesOf('web/batches/details/ReenqueueChangesetsModal', module).addDecorator(story => (
+    <div className="p-3 container">{story()}</div>
+))
+
+const changesetIDsFunction = () => Promise.resolve(['test-123', 'test-234'])
+const reenqueueChangesets = () => {
+    action('ReenqueueChangesets')
+    return Promise.resolve()
+}
+
+add('Confirmation', () => (
+    <EnterpriseWebStory>
+        {props => (
+            <ReenqueueChangesetsModal
+                {...props}
+                afterCreate={noop}
+                batchChangeID="test-123"
+                changesetIDs={changesetIDsFunction}
+                onCancel={noop}
+                reenqueueChangesets={reenqueueChangesets}
+            />
+        )}
+    </EnterpriseWebStory>
+))

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -225,6 +225,7 @@ type ReenqueueChangesetsArgs struct {
 
 type MergeChangesetsArgs struct {
 	BulkOperationBaseArgs
+	Squash bool
 }
 
 type BatchChangesResolver interface {

--- a/cmd/frontend/graphqlbackend/batches.go
+++ b/cmd/frontend/graphqlbackend/batches.go
@@ -223,6 +223,10 @@ type ReenqueueChangesetsArgs struct {
 	BulkOperationBaseArgs
 }
 
+type MergeChangesetsArgs struct {
+	BulkOperationBaseArgs
+}
+
 type BatchChangesResolver interface {
 	//
 	// MUTATIONS
@@ -252,6 +256,7 @@ type BatchChangesResolver interface {
 	DetachChangesets(ctx context.Context, args *DetachChangesetsArgs) (BulkOperationResolver, error)
 	CreateChangesetComments(ctx context.Context, args *CreateChangesetCommentsArgs) (BulkOperationResolver, error)
 	ReenqueueChangesets(ctx context.Context, args *ReenqueueChangesetsArgs) (BulkOperationResolver, error)
+	MergeChangesets(ctx context.Context, args *MergeChangesetsArgs) (BulkOperationResolver, error)
 
 	// Queries
 

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2091,7 +2091,7 @@ extend type Mutation {
     reenqueueChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
 
     """
-    Merge multiple changesets. When squash is true, the commits will be squashed
+    Merge multiple changesets. If squash is true, the commits will be squashed
     into a single commit.
 
     Experimental: This API is likely to change in the future.

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2091,11 +2091,12 @@ extend type Mutation {
     reenqueueChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
 
     """
-    Merge multiple changesets.
+    Merge multiple changesets. When squash is true, the commits will be squashed
+    into a single commit.
 
     Experimental: This API is likely to change in the future.
     """
-    mergeChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
+    mergeChangesets(batchChange: ID!, changesets: [ID!]!, squash: Boolean = false): BulkOperation!
 }
 
 extend type Query {

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2092,7 +2092,7 @@ extend type Mutation {
 
     """
     Merge multiple changesets. If squash is true, the commits will be squashed
-    into a single commit.
+    into a single commit on code hosts that support squash-and-merge.
 
     Experimental: This API is likely to change in the future.
     """

--- a/cmd/frontend/graphqlbackend/batches.graphql
+++ b/cmd/frontend/graphqlbackend/batches.graphql
@@ -2089,6 +2089,13 @@ extend type Mutation {
     Experimental: This API is likely to change in the future.
     """
     reenqueueChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
+
+    """
+    Merge multiple changesets.
+
+    Experimental: This API is likely to change in the future.
+    """
+    mergeChangesets(batchChange: ID!, changesets: [ID!]!): BulkOperation!
 }
 
 extend type Query {
@@ -2367,6 +2374,10 @@ enum BulkOperationType {
     Bulk reenqueue failed changesets.
     """
     REENQUEUE
+    """
+    Bulk merge changesets.
+    """
+    MERGE
 }
 
 """

--- a/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
+++ b/doc/batch_changes/how-tos/bulk_operations_on_changesets.md
@@ -23,6 +23,7 @@ Bulk operations allow a single action to be performed across many changesets in 
 - Commenting: Post a comment on all selected changesets. This can be particularly useful for pinging people, reminding them to take a look at the changeset, or posting your favorite emoji 🦡.
 - Detach: Only available in the archived tab. Detach a selection of changesets from the batch change to remove them from the archived tab.
 - Re-enqueue: Only available if filtering by state `failed`. Re-enqueues the pending changes for all selected changesets that failed.
+- Merge: Only available if filtering by state `open`. Tries to merge the selected changesets on the code hosts. Due to the nature of changesets, there are many states in which a changeset is not mergeable. This won't break the entire bulk operation, but single changesets may not be merged after the run for this reason. The bulk operations tab lists those where merging failed below the bulk operation in that case. In the confirmation modal, you can select to merge using the squash merge strategy. This is supported on both GitHub and GitLab, but not on Bitbucket Server. In this case, regular merges are always used for merging the changesets.
 
 _More types coming soon._
 

--- a/enterprise/internal/batches/background/bulk_processor.go
+++ b/enterprise/internal/batches/background/bulk_processor.go
@@ -125,11 +125,16 @@ func (b *bulkProcessor) reenqueueChangeset(ctx context.Context, job *btypes.Chan
 }
 
 func (b *bulkProcessor) mergeChangeset(ctx context.Context, job *btypes.ChangesetJob) (err error) {
+	typedPayload, ok := job.Payload.(*btypes.ChangesetJobMergePayload)
+	if !ok {
+		return fmt.Errorf("invalid payload type for changeset_job, want=%T have=%T", &btypes.ChangesetJobMergePayload{}, job.Payload)
+	}
+
 	cs := &sources.Changeset{
 		Changeset: b.ch,
 		Repo:      b.repo,
 	}
-	if err := b.css.MergeChangeset(ctx, cs, ""); err != nil {
+	if err := b.css.MergeChangeset(ctx, cs, typedPayload.Squash); err != nil {
 		return err
 	}
 

--- a/enterprise/internal/batches/background/bulk_processor.go
+++ b/enterprise/internal/batches/background/bulk_processor.go
@@ -147,8 +147,13 @@ func (b *bulkProcessor) mergeChangeset(ctx context.Context, job *btypes.Changese
 
 	if err := b.tx.UpsertChangesetEvents(ctx, events...); err != nil {
 		log15.Error("UpsertChangesetEvents", "err", err)
-		return err
+		return errcode.MakeNonRetryable(err)
 	}
 
-	return b.tx.UpdateChangeset(ctx, cs.Changeset)
+	if err := b.tx.UpdateChangeset(ctx, cs.Changeset); err != nil {
+		log15.Error("UpdateChangeset", "err", err)
+		return errcode.MakeNonRetryable(err)
+	}
+
+	return nil
 }

--- a/enterprise/internal/batches/background/bulk_processor.go
+++ b/enterprise/internal/batches/background/bulk_processor.go
@@ -33,7 +33,7 @@ func (e unknownJobTypeErr) NonRetryable() bool {
 }
 
 type bulkProcessor struct {
-	store   *store.Store
+	tx      *store.Store
 	sourcer sources.Sourcer
 
 	css  sources.ChangesetSource
@@ -42,24 +42,27 @@ type bulkProcessor struct {
 }
 
 func (b *bulkProcessor) process(ctx context.Context, job *btypes.ChangesetJob) (err error) {
+	// Use the acting user for the operation to enforce repository permissions.
+	ctx = actor.WithActor(ctx, actor.FromUser(job.UserID))
+
 	// Load changeset.
-	b.ch, err = b.store.GetChangeset(ctx, store.GetChangesetOpts{ID: job.ChangesetID})
+	b.ch, err = b.tx.GetChangeset(ctx, store.GetChangesetOpts{ID: job.ChangesetID})
 	if err != nil {
 		return errors.Wrap(err, "loading changeset")
 	}
 
 	// Load repo.
-	b.repo, err = b.store.Repos().Get(ctx, b.ch.RepoID)
+	b.repo, err = b.tx.Repos().Get(ctx, b.ch.RepoID)
 	if err != nil {
 		return errors.Wrap(err, "loading repo")
 	}
 
 	// Construct changeset source.
-	b.css, err = b.sourcer.ForRepo(ctx, b.store, b.repo)
+	b.css, err = b.sourcer.ForRepo(ctx, b.tx, b.repo)
 	if err != nil {
 		return errors.Wrap(err, "loading ChangesetSource")
 	}
-	b.css, err = sources.WithAuthenticatorForUser(ctx, b.store, b.css, job.UserID, b.repo)
+	b.css, err = sources.WithAuthenticatorForUser(ctx, b.tx, b.css, job.UserID, b.repo)
 	if err != nil {
 		return errors.Wrap(err, "authenticating ChangesetSource")
 	}
@@ -112,13 +115,11 @@ func (b *bulkProcessor) detach(ctx context.Context, job *btypes.ChangesetJob) er
 
 	// If we successfully marked the record as to-be-detached, trigger a reconciler run.
 	b.ch.ResetReconcilerState(global.DefaultReconcilerEnqueueState())
-	return b.store.UpdateChangeset(ctx, b.ch)
+	return b.tx.UpdateChangeset(ctx, b.ch)
 }
 
 func (b *bulkProcessor) reenqueueChangeset(ctx context.Context, job *btypes.ChangesetJob) error {
-	svc := service.New(b.store)
-	// Use the acting user for the operation to enforce repository permissions.
-	ctx = actor.WithActor(ctx, actor.FromUser(job.UserID))
+	svc := service.New(b.tx)
 	_, _, err := svc.ReenqueueChangeset(ctx, b.ch.ID)
 	return err
 }
@@ -132,25 +133,17 @@ func (b *bulkProcessor) mergeChangeset(ctx context.Context, job *btypes.Changese
 		return err
 	}
 
-	tx, err := b.store.Transact(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err = tx.Done(err)
-	}()
-
 	events, err := cs.Changeset.Events()
 	if err != nil {
 		log15.Error("Events", "err", err)
 		return errcode.MakeNonRetryable(err)
 	}
-	state.SetDerivedState(ctx, tx.Repos(), cs.Changeset, events)
+	state.SetDerivedState(ctx, b.tx.Repos(), cs.Changeset, events)
 
-	if err := tx.UpsertChangesetEvents(ctx, events...); err != nil {
+	if err := b.tx.UpsertChangesetEvents(ctx, events...); err != nil {
 		log15.Error("UpsertChangesetEvents", "err", err)
 		return err
 	}
 
-	return tx.UpdateChangeset(ctx, cs.Changeset)
+	return b.tx.UpdateChangeset(ctx, cs.Changeset)
 }

--- a/enterprise/internal/batches/background/bulk_processor_test.go
+++ b/enterprise/internal/batches/background/bulk_processor_test.go
@@ -29,7 +29,7 @@ func TestBulkProcessor(t *testing.T) {
 	t.Run("Unknown job type", func(t *testing.T) {
 		fake := &sources.FakeChangesetSource{}
 		bp := &bulkProcessor{
-			store:   bstore,
+			tx:      bstore,
 			sourcer: sources.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{
@@ -50,7 +50,7 @@ func TestBulkProcessor(t *testing.T) {
 	t.Run("Comment job", func(t *testing.T) {
 		fake := &sources.FakeChangesetSource{}
 		bp := &bulkProcessor{
-			store:   bstore,
+			tx:      bstore,
 			sourcer: sources.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{
@@ -73,7 +73,7 @@ func TestBulkProcessor(t *testing.T) {
 	t.Run("Detach job", func(t *testing.T) {
 		fake := &sources.FakeChangesetSource{}
 		bp := &bulkProcessor{
-			store:   bstore,
+			tx:      bstore,
 			sourcer: sources.NewFakeSourcer(nil, fake),
 		}
 		job := &types.ChangesetJob{

--- a/enterprise/internal/batches/background/bulk_processor_test.go
+++ b/enterprise/internal/batches/background/bulk_processor_test.go
@@ -103,4 +103,58 @@ func TestBulkProcessor(t *testing.T) {
 			t.Fatalf("invalid reconciler state, got=%q", ch.ReconcilerState)
 		}
 	})
+
+	t.Run("Reenqueue job", func(t *testing.T) {
+		fake := &sources.FakeChangesetSource{}
+		bp := &bulkProcessor{
+			tx:      bstore,
+			sourcer: sources.NewFakeSourcer(nil, fake),
+		}
+		job := &types.ChangesetJob{
+			JobType:     types.ChangesetJobTypeReenqueue,
+			ChangesetID: changeset.ID,
+			UserID:      user.ID,
+		}
+		changeset.ReconcilerState = btypes.ReconcilerStateFailed
+		if err := bstore.UpdateChangeset(ctx, changeset); err != nil {
+			t.Fatal(err)
+		}
+		if err := bstore.CreateChangesetJob(ctx, job); err != nil {
+			t.Fatal(err)
+		}
+		err := bp.process(ctx, job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		changeset, err = bstore.GetChangesetByID(ctx, changeset.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if have, want := changeset.ReconcilerState, btypes.ReconcilerStateQueued; have != want {
+			t.Fatalf("unexpected reconciler state, have=%q want=%q", have, want)
+		}
+	})
+
+	t.Run("Merge job", func(t *testing.T) {
+		fake := &sources.FakeChangesetSource{}
+		bp := &bulkProcessor{
+			tx:      bstore,
+			sourcer: sources.NewFakeSourcer(nil, fake),
+		}
+		job := &types.ChangesetJob{
+			JobType:     types.ChangesetJobTypeMerge,
+			ChangesetID: changeset.ID,
+			UserID:      user.ID,
+		}
+		if err := bstore.CreateChangesetJob(ctx, job); err != nil {
+			t.Fatal(err)
+		}
+		err := bp.process(ctx, job)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !fake.MergeChangesetCalled {
+			t.Fatal("expected MergeChangeset to be called but wasn't")
+		}
+	})
 }

--- a/enterprise/internal/batches/background/bulk_processor_worker.go
+++ b/enterprise/internal/batches/background/bulk_processor_worker.go
@@ -95,7 +95,7 @@ func (b *bulkProcessorWorker) HandlerFunc() dbworker.HandlerFunc {
 	return func(ctx context.Context, tx dbworkerstore.Store, record workerutil.Record) error {
 		processor := &bulkProcessor{
 			sourcer: b.sourcer,
-			store:   b.store.With(tx),
+			tx:      b.store.With(tx),
 		}
 		return processor.process(ctx, record.(*btypes.ChangesetJob))
 	}

--- a/enterprise/internal/batches/resolvers/bulk_operation.go
+++ b/enterprise/internal/batches/resolvers/bulk_operation.go
@@ -115,6 +115,8 @@ func changesetJobTypeToBulkOperationType(t btypes.ChangesetJobType) (string, err
 		return "DETACH", nil
 	case btypes.ChangesetJobTypeReenqueue:
 		return "REENQUEUE", nil
+	case btypes.ChangesetJobTypeMerge:
+		return "MERGE", nil
 	default:
 		return "", fmt.Errorf("invalid job type %q", t)
 	}

--- a/enterprise/internal/batches/resolvers/permissions_test.go
+++ b/enterprise/internal/batches/resolvers/permissions_test.go
@@ -742,6 +742,12 @@ func TestPermissionLevels(t *testing.T) {
 					return fmt.Sprintf(`mutation { reenqueueChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
 				},
 			},
+			{
+				name: "mergeChangesets",
+				mutationFunc: func(batchChangeID, changesetID, batchSpecID string) string {
+					return fmt.Sprintf(`mutation { mergeChangesets(batchChange: %q, changesets: [%q]) { id } }`, batchChangeID, changesetID)
+				},
+			},
 		}
 
 		for _, m := range mutations {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1268,6 +1268,7 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 	// 🚨 SECURITY: CreateChangesetJobs checks whether current user is authorized.
 	svc := service.New(r.store)
 	published := btypes.ChangesetPublicationStatePublished
+	openState := btypes.ChangesetExternalStateOpen
 	bulkGroupID, err := svc.CreateChangesetJobs(
 		ctx,
 		batchChangeID,
@@ -1277,6 +1278,7 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 		store.ListChangesetsOpts{
 			PublicationState: &published,
 			ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
+			ExternalState:    &openState,
 		},
 	)
 	if err != nil {

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1250,6 +1250,42 @@ func (r *Resolver) ReenqueueChangesets(ctx context.Context, args *graphqlbackend
 	return r.bulkOperationByIDString(ctx, bulkGroupID)
 }
 
+func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.MergeChangesetsArgs) (_ graphqlbackend.BulkOperationResolver, err error) {
+	tr, ctx := trace.New(ctx, "Resolver.MergeChangesets", fmt.Sprintf("BatchChange: %q, len(Changesets): %d", args.BatchChange, len(args.Changesets)))
+	defer func() {
+		tr.SetError(err)
+		tr.Finish()
+	}()
+	if err := batchChangesEnabled(ctx, r.store.DB()); err != nil {
+		return nil, err
+	}
+
+	batchChangeID, changesetIDs, err := unmarshalBulkOperationBaseArgs(args.BulkOperationBaseArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	// 🚨 SECURITY: CreateChangesetJobs checks whether current user is authorized.
+	svc := service.New(r.store)
+	published := btypes.ChangesetPublicationStatePublished
+	bulkGroupID, err := svc.CreateChangesetJobs(
+		ctx,
+		batchChangeID,
+		changesetIDs,
+		btypes.ChangesetJobTypeMerge,
+		&btypes.ChangesetJobMergePayload{},
+		store.ListChangesetsOpts{
+			PublicationState: &published,
+			ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.bulkOperationByIDString(ctx, bulkGroupID)
+}
+
 func parseBatchChangeState(s *string) (btypes.BatchChangeState, error) {
 	if s == nil {
 		return btypes.BatchChangeStateAny, nil

--- a/enterprise/internal/batches/resolvers/resolver.go
+++ b/enterprise/internal/batches/resolvers/resolver.go
@@ -1273,7 +1273,7 @@ func (r *Resolver) MergeChangesets(ctx context.Context, args *graphqlbackend.Mer
 		batchChangeID,
 		changesetIDs,
 		btypes.ChangesetJobTypeMerge,
-		&btypes.ChangesetJobMergePayload{},
+		&btypes.ChangesetJobMergePayload{Squash: args.Squash},
 		store.ListChangesetsOpts{
 			PublicationState: &published,
 			ReconcilerStates: []btypes.ReconcilerState{btypes.ReconcilerStateCompleted},

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -264,6 +264,9 @@ func (s BitbucketServerSource) MergeChangeset(ctx context.Context, c *Changeset,
 	}
 
 	if err := s.client.MergePullRequest(ctx, pr); err != nil {
+		if errors.Is(err, bitbucketserver.ErrNotMergeable) {
+			return &ChangesetNotMergeableError{ErrorMsg: err.Error()}
+		}
 		return err
 	}
 

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -252,3 +252,13 @@ func (s BitbucketServerSource) CreateComment(ctx context.Context, c *Changeset, 
 
 	return s.client.CreatePullRequestComment(ctx, pr, text)
 }
+
+// MergeChangeset merges a Changeset on the code host, if in a mergeable state.
+func (s BitbucketServerSource) MergeChangeset(ctx context.Context, c *Changeset, text string) error {
+	pr, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
+	if !ok {
+		return errors.New("Changeset is not a Bitbucket Server pull request")
+	}
+
+	return s.client.CreatePullRequestComment(ctx, pr, text)
+}

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -260,5 +260,9 @@ func (s BitbucketServerSource) MergeChangeset(ctx context.Context, c *Changeset,
 		return errors.New("Changeset is not a Bitbucket Server pull request")
 	}
 
-	return s.client.CreatePullRequestComment(ctx, pr, text)
+	if err := s.client.MergePullRequest(ctx, pr); err != nil {
+		return err
+	}
+
+	return c.Changeset.SetMetadata(pr)
 }

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -254,9 +254,8 @@ func (s BitbucketServerSource) CreateComment(ctx context.Context, c *Changeset, 
 }
 
 // MergeChangeset merges a Changeset on the code host, if in a mergeable state.
-// If squash is true, and the code host supports squash merges, the source
-// must attempt a squash merge. Otherwise, it is expected to perform a regular
-// merge.
+// The squash parameter is ignored, as Bitbucket Server does not support
+// squash merges.
 func (s BitbucketServerSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
 	pr, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
 	if !ok {

--- a/enterprise/internal/batches/sources/bitbucketserver.go
+++ b/enterprise/internal/batches/sources/bitbucketserver.go
@@ -254,7 +254,10 @@ func (s BitbucketServerSource) CreateComment(ctx context.Context, c *Changeset, 
 }
 
 // MergeChangeset merges a Changeset on the code host, if in a mergeable state.
-func (s BitbucketServerSource) MergeChangeset(ctx context.Context, c *Changeset, text string) error {
+// If squash is true, and the code host supports squash merges, the source
+// must attempt a squash merge. Otherwise, it is expected to perform a regular
+// merge.
+func (s BitbucketServerSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
 	pr, ok := c.Changeset.Metadata.(*bitbucketserver.PullRequest)
 	if !ok {
 		return errors.New("Changeset is not a Bitbucket Server pull request")

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -71,9 +71,24 @@ type ChangesetSource interface {
 	// MergeChangeset merges a Changeset on the code host, if in a mergeable state.
 	// If squash is true, and the code host supports squash merges, the source
 	// must attempt a squash merge. Otherwise, it is expected to perform a regular
-	// merge.
+	// merge. If the changeset cannot be merged, because it is in an unmergeable
+	// state, ChangesetNotMergeableError must be returned.
 	MergeChangeset(ctx context.Context, ch *Changeset, squash bool) error
 }
+
+// ChangesetNotMergeableError is returned by MergeChangeset if the changeset
+// could not be merged on the codehost, because some precondition is not met. This
+// is only returned, if the changeset is not mergeable. Other errors, such as
+// network or auth errors should NOT raise this error.
+type ChangesetNotMergeableError struct {
+	ErrorMsg string
+}
+
+func (e ChangesetNotMergeableError) Error() string {
+	return fmt.Sprintf("changeset cannot be merged:\n%s", e.ErrorMsg)
+}
+
+func (e ChangesetNotMergeableError) NonRetryable() bool { return true }
 
 // A Changeset of an existing Repo.
 type Changeset struct {

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -69,7 +69,10 @@ type ChangesetSource interface {
 	// CreateComment posts a comment on the Changeset.
 	CreateComment(context.Context, *Changeset, string) error
 	// MergeChangeset merges a Changeset on the code host, if in a mergeable state.
-	MergeChangeset(context.Context, *Changeset, string) error
+	// If squash is true, and the code host supports squash merges, the source
+	// must attempt a squash merge. Otherwise, it is expected to perform a regular
+	// merge.
+	MergeChangeset(ctx context.Context, ch *Changeset, squash bool) error
 }
 
 // A Changeset of an existing Repo.

--- a/enterprise/internal/batches/sources/common.go
+++ b/enterprise/internal/batches/sources/common.go
@@ -68,6 +68,8 @@ type ChangesetSource interface {
 	ReopenChangeset(context.Context, *Changeset) error
 	// CreateComment posts a comment on the Changeset.
 	CreateComment(context.Context, *Changeset, string) error
+	// MergeChangeset merges a Changeset on the code host, if in a mergeable state.
+	MergeChangeset(context.Context, *Changeset, string) error
 }
 
 // A Changeset of an existing Repo.

--- a/enterprise/internal/batches/sources/fake.go
+++ b/enterprise/internal/batches/sources/fake.go
@@ -51,6 +51,7 @@ type FakeChangesetSource struct {
 	CreateCommentCalled         bool
 	AuthenticatedUsernameCalled bool
 	ValidateAuthenticatorCalled bool
+	MergeChangesetCalled        bool
 
 	// The Changeset.HeadRef to be expected in CreateChangeset/UpdateChangeset calls.
 	WantHeadRef string
@@ -280,6 +281,6 @@ func (s *FakeChangesetSource) AuthenticatedUsername(ctx context.Context) (string
 }
 
 func (s *FakeChangesetSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
-	// s.CreateCommentCalled = true
+	s.MergeChangesetCalled = true
 	return s.Err
 }

--- a/enterprise/internal/batches/sources/fake.go
+++ b/enterprise/internal/batches/sources/fake.go
@@ -278,3 +278,8 @@ func (s *FakeChangesetSource) AuthenticatedUsername(ctx context.Context) (string
 	s.AuthenticatedUsernameCalled = true
 	return s.Username, nil
 }
+
+func (s *FakeChangesetSource) MergeChangeset(ctx context.Context, c *Changeset, body string) error {
+	// s.CreateCommentCalled = true
+	return s.Err
+}

--- a/enterprise/internal/batches/sources/fake.go
+++ b/enterprise/internal/batches/sources/fake.go
@@ -279,7 +279,7 @@ func (s *FakeChangesetSource) AuthenticatedUsername(ctx context.Context) (string
 	return s.Username, nil
 }
 
-func (s *FakeChangesetSource) MergeChangeset(ctx context.Context, c *Changeset, body string) error {
+func (s *FakeChangesetSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
 	// s.CreateCommentCalled = true
 	return s.Err
 }

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
-	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -254,28 +253,16 @@ func (s GithubSource) CreateComment(ctx context.Context, c *Changeset, text stri
 }
 
 // MergeChangeset merges a Changeset on the code host, if in a mergeable state.
-func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, text string) error {
-	repo, ok := c.Repo.Metadata.(*github.Repository)
-	if !ok {
-		return errors.New("Repository is not a GitHub repository")
-	}
-	var mergeMethod string
-	if repo.MergeCommitAllowed {
-		mergeMethod = "MERGE"
-	} else if repo.RebaseMergeAllowed {
-		mergeMethod = "REBASE"
-	} else if repo.SquashMergeAllowed {
-		mergeMethod = "SQUASH"
-	} else {
-		mergeMethod = "MERGE"
-		log15.Error("no merge method allowed on repo, falling back to MERGE")
-	}
+// If squash is true, and the code host supports squash merges, the source
+// must attempt a squash merge. Otherwise, it is expected to perform a regular
+// merge.
+func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
 	pr, ok := c.Changeset.Metadata.(*github.PullRequest)
 	if !ok {
 		return errors.New("Changeset is not a GitHub pull request")
 	}
 
-	if err := s.client.MergePullRequest(ctx, pr, mergeMethod, ""); err != nil {
+	if err := s.client.MergePullRequest(ctx, pr, squash); err != nil {
 		return err
 	}
 

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -253,9 +253,7 @@ func (s GithubSource) CreateComment(ctx context.Context, c *Changeset, text stri
 }
 
 // MergeChangeset merges a Changeset on the code host, if in a mergeable state.
-// If squash is true, and the code host supports squash merges, the source
-// must attempt a squash merge. Otherwise, it is expected to perform a regular
-// merge.
+// If squash is true, a squash-then-merge merge will be performed.
 func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
 	pr, ok := c.Changeset.Metadata.(*github.PullRequest)
 	if !ok {

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -263,6 +263,9 @@ func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, squash b
 	}
 
 	if err := s.client.MergePullRequest(ctx, pr, squash); err != nil {
+		if github.IsNotMergeable(err) {
+			return ChangesetNotMergeableError{ErrorMsg: err.Error()}
+		}
 		return err
 	}
 

--- a/enterprise/internal/batches/sources/github.go
+++ b/enterprise/internal/batches/sources/github.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/inconshreveable/log15"
 
 	"github.com/sourcegraph/sourcegraph/internal/database"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
@@ -266,7 +267,8 @@ func (s GithubSource) MergeChangeset(ctx context.Context, c *Changeset, text str
 	} else if repo.SquashMergeAllowed {
 		mergeMethod = "SQUASH"
 	} else {
-		return errors.New("no merge method allowed on repo")
+		mergeMethod = "MERGE"
+		log15.Error("no merge method allowed on repo, falling back to MERGE")
 	}
 	pr, ok := c.Changeset.Metadata.(*github.PullRequest)
 	if !ok {

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -423,3 +423,14 @@ func (s *GitLabSource) CreateComment(ctx context.Context, c *Changeset, text str
 
 	return s.client.CreateMergeRequestNote(ctx, project, mr, text)
 }
+
+// MergeChangeset merges a Changeset on the code host, if in a mergeable state.
+func (s *GitLabSource) MergeChangeset(ctx context.Context, c *Changeset, text string) error {
+	project := c.Repo.Metadata.(*gitlab.Project)
+	mr, ok := c.Changeset.Metadata.(*gitlab.MergeRequest)
+	if !ok {
+		return errors.New("Changeset is not a GitLab merge request")
+	}
+
+	return s.client.CreateMergeRequestNote(ctx, project, mr, text)
+}

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -425,9 +425,7 @@ func (s *GitLabSource) CreateComment(ctx context.Context, c *Changeset, text str
 }
 
 // MergeChangeset merges a Changeset on the code host, if in a mergeable state.
-// If squash is true, and the code host supports squash merges, the source
-// must attempt a squash merge. Otherwise, it is expected to perform a regular
-// merge.
+// If squash is true, a squash-then-merge merge will be performed.
 func (s *GitLabSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
 	mr, ok := c.Changeset.Metadata.(*gitlab.MergeRequest)
 	if !ok {

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -437,6 +437,9 @@ func (s *GitLabSource) MergeChangeset(ctx context.Context, c *Changeset, squash 
 
 	updated, err := s.client.MergeMergeRequest(ctx, project, mr, squash)
 	if err != nil {
+		if errors.Is(err, gitlab.ErrNotMergeable) {
+			return ChangesetNotMergeableError{ErrorMsg: err.Error()}
+		}
 		return errors.Wrap(err, "merging GitLab merge request")
 	}
 

--- a/enterprise/internal/batches/sources/gitlab.go
+++ b/enterprise/internal/batches/sources/gitlab.go
@@ -425,14 +425,17 @@ func (s *GitLabSource) CreateComment(ctx context.Context, c *Changeset, text str
 }
 
 // MergeChangeset merges a Changeset on the code host, if in a mergeable state.
-func (s *GitLabSource) MergeChangeset(ctx context.Context, c *Changeset, text string) error {
+// If squash is true, and the code host supports squash merges, the source
+// must attempt a squash merge. Otherwise, it is expected to perform a regular
+// merge.
+func (s *GitLabSource) MergeChangeset(ctx context.Context, c *Changeset, squash bool) error {
 	mr, ok := c.Changeset.Metadata.(*gitlab.MergeRequest)
 	if !ok {
 		return errors.New("Changeset is not a GitLab merge request")
 	}
 	project := c.Repo.Metadata.(*gitlab.Project)
 
-	updated, err := s.client.MergeMergeRequest(ctx, project, mr)
+	updated, err := s.client.MergeMergeRequest(ctx, project, mr, squash)
 	if err != nil {
 		return errors.Wrap(err, "merging GitLab merge request")
 	}

--- a/enterprise/internal/batches/store/changeset_jobs.go
+++ b/enterprise/internal/batches/store/changeset_jobs.go
@@ -184,6 +184,8 @@ func scanChangesetJob(c *btypes.ChangesetJob, s scanner) error {
 		c.Payload = new(btypes.ChangesetJobDetachPayload)
 	case btypes.ChangesetJobTypeReenqueue:
 		c.Payload = new(btypes.ChangesetJobReenqueuePayload)
+	case btypes.ChangesetJobTypeMerge:
+		c.Payload = new(btypes.ChangesetJobMergePayload)
 	default:
 		return fmt.Errorf("unknown job type %q", c.JobType)
 	}

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -55,7 +55,9 @@ type ChangesetJobDetachPayload struct{}
 
 type ChangesetJobReenqueuePayload struct{}
 
-type ChangesetJobMergePayload struct{}
+type ChangesetJobMergePayload struct {
+	Squash bool `json:"squash,omitempty"`
+}
 
 // ChangesetJob describes a one-time action to be taken on a changeset.
 type ChangesetJob struct {

--- a/enterprise/internal/batches/types/changeset_job.go
+++ b/enterprise/internal/batches/types/changeset_job.go
@@ -44,6 +44,7 @@ var (
 	ChangesetJobTypeComment   ChangesetJobType = "commentatore"
 	ChangesetJobTypeDetach    ChangesetJobType = "detach"
 	ChangesetJobTypeReenqueue ChangesetJobType = "reenqueue"
+	ChangesetJobTypeMerge     ChangesetJobType = "merge"
 )
 
 type ChangesetJobCommentPayload struct {
@@ -53,6 +54,8 @@ type ChangesetJobCommentPayload struct {
 type ChangesetJobDetachPayload struct{}
 
 type ChangesetJobReenqueuePayload struct{}
+
+type ChangesetJobMergePayload struct{}
 
 // ChangesetJob describes a one-time action to be taken on a changeset.
 type ChangesetJob struct {

--- a/internal/extsvc/bitbucketserver/client.go
+++ b/internal/extsvc/bitbucketserver/client.go
@@ -1507,3 +1507,25 @@ func (c *Client) CreatePullRequestComment(ctx context.Context, pr *PullRequest, 
 	_, err := c.send(ctx, "POST", path, qry, &payload, &resp)
 	return err
 }
+
+func (c *Client) MergePullRequest(ctx context.Context, pr *PullRequest) error {
+	if pr.ToRef.Repository.Slug == "" {
+		return errors.New("repository slug empty")
+	}
+
+	if pr.ToRef.Repository.Project.Key == "" {
+		return errors.New("project key empty")
+	}
+
+	path := fmt.Sprintf(
+		"rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/merge",
+		pr.ToRef.Repository.Project.Key,
+		pr.ToRef.Repository.Slug,
+		pr.ID,
+	)
+
+	qry := url.Values{"version": {strconv.Itoa(pr.Version)}}
+
+	_, err := c.send(ctx, "POST", path, qry, nil, pr)
+	return err
+}

--- a/internal/extsvc/bitbucketserver/client_test.go
+++ b/internal/extsvc/bitbucketserver/client_test.go
@@ -947,6 +947,100 @@ func TestClient_CreatePullRequestComment(t *testing.T) {
 	}
 }
 
+func TestClient_MergePullRequest(t *testing.T) {
+	instanceURL := os.Getenv("BITBUCKET_SERVER_URL")
+	if instanceURL == "" {
+		instanceURL = "https://bitbucket.sgdev.org"
+	}
+
+	timeout, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	pr := &PullRequest{}
+	pr.ToRef.Repository.Slug = "automation-testing"
+	pr.ToRef.Repository.Project.Key = "SOUR"
+
+	for _, tc := range []struct {
+		name string
+		ctx  context.Context
+		pr   func() *PullRequest
+		err  string
+	}{
+		{
+			name: "timeout",
+			pr:   func() *PullRequest { return pr },
+			ctx:  timeout,
+			err:  "context deadline exceeded",
+		},
+		{
+			name: "ToRef repo not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ToRef.Repository.Slug = ""
+				return &pr
+			},
+			err: "repository slug empty",
+		},
+		{
+			name: "ToRef project not set",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ToRef.Repository.Project.Key = ""
+				return &pr
+			},
+			err: "project key empty",
+		},
+		{
+			name: "success",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ID = 146
+				pr.Version = 0
+				return &pr
+			},
+		},
+		{
+			name: "not mergeable",
+			pr: func() *PullRequest {
+				pr := *pr
+				pr.ID = 146
+				pr.Version = 1
+				return &pr
+			},
+			err: "pull request cannot be merged",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			name := "MergePullRequest-" + strings.ReplaceAll(tc.name, " ", "-")
+
+			cli, save := NewTestClient(t, name, *update)
+			defer save()
+
+			if tc.ctx == nil {
+				tc.ctx = context.Background()
+			}
+
+			if tc.err == "" {
+				tc.err = "<nil>"
+			}
+			tc.err = strings.ReplaceAll(tc.err, "${INSTANCEURL}", instanceURL)
+
+			pr := tc.pr()
+			err := cli.MergePullRequest(tc.ctx, pr)
+			if have, want := fmt.Sprint(err), tc.err; !strings.Contains(have, want) {
+				t.Fatalf("error:\nhave: %q\nwant: %q", have, want)
+			}
+
+			if err != nil || tc.err != "<nil>" {
+				return
+			}
+
+			checkGolden(t, name, pr)
+		})
+	}
+}
+
 // NOTE: This test validates that correct repository IDs are returned from the
 // roaring bitmap permissions endpoint. Therefore, the expected results are
 // dependent on the user token supplied. The current golden files are generated

--- a/internal/extsvc/bitbucketserver/testdata/golden/MergePullRequest-success
+++ b/internal/extsvc/bitbucketserver/testdata/golden/MergePullRequest-success
@@ -1,0 +1,71 @@
+{
+  "id": 146,
+  "version": 2,
+  "title": "file3.txt edited online with Bitbucket",
+  "description": "",
+  "state": "MERGED",
+  "open": false,
+  "closed": true,
+  "createdDate": 1623421327682,
+  "updatedDate": 1623421519622,
+  "fromRef": {
+   "id": "refs/heads/erik/file3txt-1623421319662",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "toRef": {
+   "id": "refs/heads/master",
+   "repository": {
+    "id": 10070,
+    "slug": "automation-testing",
+    "project": {
+     "key": "SOUR"
+    }
+   }
+  },
+  "locked": false,
+  "author": {
+   "user": {
+    "name": "erik",
+    "emailAddress": "erik@sourcegraph.com",
+    "id": 152,
+    "displayName": "Erik Seliger",
+    "active": true,
+    "slug": "erik",
+    "type": "NORMAL"
+   },
+   "role": "AUTHOR",
+   "approved": false,
+   "status": "UNAPPROVED"
+  },
+  "reviewers": [
+   {
+    "user": {
+     "name": "thorsten",
+     "emailAddress": "thorsten@sourcegraph.com",
+     "id": 104,
+     "displayName": "thorsten",
+     "active": true,
+     "slug": "thorsten",
+     "type": "NORMAL"
+    },
+    "lastReviewedCommit": "",
+    "role": "REVIEWER",
+    "approved": false,
+    "status": "UNAPPROVED"
+   }
+  ],
+  "participants": [],
+  "links": {
+   "self": [
+    {
+     "href": "https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/146"
+    }
+   ]
+  }
+ }

--- a/internal/extsvc/bitbucketserver/testdata/vcr/MergePullRequest-not-mergeable.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/MergePullRequest-not-mergeable.yaml
@@ -1,0 +1,43 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/146/merge?version=1
+    method: POST
+  response:
+    body: '{"errors":[{"context":null,"message":"You are attempting to modify a pull
+      request based on out-of-date information.","exceptionName":"com.atlassian.bitbucket.pull.PullRequestOutOfDateException","currentVersion":2,"expectedVersion":1,"pullRequest":{"id":146,"version":2,"title":"file3.txt
+      edited online with Bitbucket","state":"MERGED","open":false,"closed":true,"createdDate":1623421327682,"updatedDate":1623421519622,"closedDate":1623421519622,"fromRef":{"id":"refs/heads/erik/file3txt-1623421319662","displayId":"erik/file3txt-1623421319662","latestCommit":"88e8840c12b7fba586f7e8aeb360d3dd638e7888","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2475733b17fc2d527bb29e5f45540e76a8c3a9b6","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/146"}]}}}]}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jun 2021 14:26:46 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TVP4VKx866x2732650x0'
+      X-Asessionid:
+      - 1isoou6
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 409 Conflict
+    code: 409
+    duration: ""

--- a/internal/extsvc/bitbucketserver/testdata/vcr/MergePullRequest-success.yaml
+++ b/internal/extsvc/bitbucketserver/testdata/vcr/MergePullRequest-success.yaml
@@ -1,0 +1,41 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://bitbucket.sgdev.org/rest/api/1.0/projects/SOUR/repos/automation-testing/pull-requests/146/merge?version=0
+    method: POST
+  response:
+    body: '{"id":146,"version":2,"title":"file3.txt edited online with Bitbucket","state":"MERGED","open":false,"closed":true,"createdDate":1623421327682,"updatedDate":1623421519622,"closedDate":1623421519622,"fromRef":{"id":"refs/heads/erik/file3txt-1623421319662","displayId":"erik/file3txt-1623421319662","latestCommit":"88e8840c12b7fba586f7e8aeb360d3dd638e7888","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"toRef":{"id":"refs/heads/master","displayId":"master","latestCommit":"2475733b17fc2d527bb29e5f45540e76a8c3a9b6","repository":{"slug":"automation-testing","id":10070,"name":"automation-testing","hierarchyId":"1c17e4711a8a022d0a9a","scmId":"git","state":"AVAILABLE","statusMessage":"Available","forkable":true,"project":{"key":"SOUR","id":1,"name":"sourcegraph","public":false,"type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR"}]}},"public":false,"links":{"clone":[{"href":"https://bitbucket.sgdev.org/scm/sour/automation-testing.git","name":"http"},{"href":"ssh://git@bitbucket.sgdev.org:7999/sour/automation-testing.git","name":"ssh"}],"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/browse"}]}}},"locked":false,"author":{"user":{"name":"erik","emailAddress":"erik@sourcegraph.com","id":152,"displayName":"Erik
+      Seliger","active":true,"slug":"erik","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/erik"}]}},"role":"AUTHOR","approved":false,"status":"UNAPPROVED"},"reviewers":[{"user":{"name":"thorsten","emailAddress":"thorsten@sourcegraph.com","id":104,"displayName":"thorsten","active":true,"slug":"thorsten","type":"NORMAL","links":{"self":[{"href":"https://bitbucket.sgdev.org/users/thorsten"}]}},"role":"REVIEWER","approved":false,"status":"UNAPPROVED"}],"participants":[],"properties":{"mergeCommit":{"displayId":"fadfd840d09","id":"fadfd840d095677bbf6457eb597255fb181050e6"}},"links":{"self":[{"href":"https://bitbucket.sgdev.org/projects/SOUR/repos/automation-testing/pull-requests/146"}]}}'
+    headers:
+      Cache-Control:
+      - private, no-cache
+      - no-cache, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Fri, 11 Jun 2021 14:25:19 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Caddy
+      Vary:
+      - accept-encoding,x-auserid,cookie,x-ausername,accept-encoding
+      X-Arequestid:
+      - '@TVP4VKx865x2732537x0'
+      X-Asessionid:
+      - 1a2pzq8
+      X-Auserid:
+      - "152"
+      X-Ausername:
+      - erik
+      X-Content-Type-Options:
+      - nosniff
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1586,6 +1586,21 @@ func IsRateLimitExceeded(err error) bool {
 	return false
 }
 
+// IsNotMergeable reports whether err is a GitHub API error reporting that a PR
+// was not in a mergeable state.
+func IsNotMergeable(err error) bool {
+	errs, ok := err.(graphqlErrors)
+	if !ok {
+		return false
+	}
+	for _, err := range errs {
+		if strings.Contains(strings.ToLower(err.Message), "pull request is not mergeable") {
+			return true
+		}
+	}
+	return false
+}
+
 var errInternalRateLimitExceeded = errors.New("internal rate limit exceeded")
 
 // ErrIncompleteResults is returned when the GitHub Search API returns an `incomplete_results: true` field in their response

--- a/internal/extsvc/github/common.go
+++ b/internal/extsvc/github/common.go
@@ -1636,10 +1636,6 @@ type Repository struct {
 	// Metadata retained for ranking
 	StargazerCount int `json:",omitempty"`
 	ForkCount      int `json:",omitempty"`
-
-	MergeCommitAllowed bool `json:"mergeCommitAllowed,omitempty"`
-	RebaseMergeAllowed bool `json:"rebaseMergeAllowed,omitempty"`
-	SquashMergeAllowed bool `json:"mergeMergeAllowed,omitempty"`
 }
 
 func ownerNameCacheKey(owner, name string) string       { return "0:" + owner + "/" + name }
@@ -1698,22 +1694,19 @@ type restRepositoryPermissions struct {
 }
 
 type restRepository struct {
-	ID               string `json:"node_id"` // GraphQL ID
-	DatabaseID       int64  `json:"id"`
-	FullName         string `json:"full_name"` // same as nameWithOwner
-	Description      string
-	HTMLURL          string                    `json:"html_url"` // web URL
-	Private          bool                      `json:"private"`
-	Fork             bool                      `json:"fork"`
-	Archived         bool                      `json:"archived"`
-	Locked           bool                      `json:"locked"`
-	Disabled         bool                      `json:"disabled"`
-	Permissions      restRepositoryPermissions `json:"permissions"`
-	Stars            int                       `json:"stargazers_count"`
-	Forks            int                       `json:"forks_count"`
-	AllowMergeCommit bool                      `json:"allow_merge_commit"`
-	AllowRebaseMerge bool                      `json:"allow_rebase_merge"`
-	AllowSquashMerge bool                      `json:"allow_squash_merge"`
+	ID          string `json:"node_id"` // GraphQL ID
+	DatabaseID  int64  `json:"id"`
+	FullName    string `json:"full_name"` // same as nameWithOwner
+	Description string
+	HTMLURL     string                    `json:"html_url"` // web URL
+	Private     bool                      `json:"private"`
+	Fork        bool                      `json:"fork"`
+	Archived    bool                      `json:"archived"`
+	Locked      bool                      `json:"locked"`
+	Disabled    bool                      `json:"disabled"`
+	Permissions restRepositoryPermissions `json:"permissions"`
+	Stars       int                       `json:"stargazers_count"`
+	Forks       int                       `json:"forks_count"`
 }
 
 // getRepositoryFromAPI attempts to fetch a repository from the GitHub API without use of the redis cache.
@@ -1736,22 +1729,19 @@ func (c *V3Client) getRepositoryFromAPI(ctx context.Context, owner, name string)
 // to a standard format.
 func convertRestRepo(restRepo restRepository) *Repository {
 	return &Repository{
-		ID:                 restRepo.ID,
-		DatabaseID:         restRepo.DatabaseID,
-		NameWithOwner:      restRepo.FullName,
-		Description:        restRepo.Description,
-		URL:                restRepo.HTMLURL,
-		IsPrivate:          restRepo.Private,
-		IsFork:             restRepo.Fork,
-		IsArchived:         restRepo.Archived,
-		IsLocked:           restRepo.Locked,
-		IsDisabled:         restRepo.Disabled,
-		ViewerPermission:   convertRestRepoPermissions(restRepo.Permissions),
-		StargazerCount:     restRepo.Stars,
-		ForkCount:          restRepo.Forks,
-		MergeCommitAllowed: restRepo.AllowMergeCommit,
-		RebaseMergeAllowed: restRepo.AllowRebaseMerge,
-		SquashMergeAllowed: restRepo.AllowSquashMerge,
+		ID:               restRepo.ID,
+		DatabaseID:       restRepo.DatabaseID,
+		NameWithOwner:    restRepo.FullName,
+		Description:      restRepo.Description,
+		URL:              restRepo.HTMLURL,
+		IsPrivate:        restRepo.Private,
+		IsFork:           restRepo.Fork,
+		IsArchived:       restRepo.Archived,
+		IsLocked:         restRepo.Locked,
+		IsDisabled:       restRepo.Disabled,
+		ViewerPermission: convertRestRepoPermissions(restRepo.Permissions),
+		StargazerCount:   restRepo.Stars,
+		ForkCount:        restRepo.Forks,
 	}
 }
 

--- a/internal/extsvc/github/testdata/golden/MergePullRequest-error
+++ b/internal/extsvc/github/testdata/golden/MergePullRequest-error
@@ -1,0 +1,15 @@
+[
+  {
+   "message": "Pull Request is not mergeable",
+   "type": "UNPROCESSABLE",
+   "path": [
+    "mergePullRequest"
+   ],
+   "locations": [
+    {
+     "line": 303,
+     "column": 3
+    }
+   ]
+  }
+ ]

--- a/internal/extsvc/github/testdata/golden/MergePullRequest-success
+++ b/internal/extsvc/github/testdata/golden/MergePullRequest-success
@@ -1,0 +1,148 @@
+{
+  "ID": "MDExOlB1bGxSZXF1ZXN0NTc3Nzc3NzEy",
+  "Title": "This is a test PR",
+  "Body": "This is the description of the test PR",
+  "State": "MERGED",
+  "URL": "https://github.com/sourcegraph/automation-testing/pull/424",
+  "HeadRefOid": "81da5d9c265d943d33a6bbed9da18da16f3ac633",
+  "BaseRefOid": "53229c4dc5ba7c0f7abf109003aa15a956be485e",
+  "HeadRefName": "test-pr-7",
+  "BaseRefName": "master",
+  "Number": 424,
+  "Author": {
+   "AvatarURL": "https://avatars.githubusercontent.com/u/229984?v=4",
+   "Login": "LawnGnome",
+   "URL": "https://github.com/LawnGnome"
+  },
+  "Participants": [
+   {
+    "AvatarURL": "https://avatars.githubusercontent.com/u/229984?v=4",
+    "Login": "LawnGnome",
+    "URL": "https://github.com/LawnGnome"
+   },
+   {
+    "AvatarURL": "https://avatars.githubusercontent.com/u/19534377?v=4",
+    "Login": "eseliger",
+    "URL": "https://github.com/eseliger"
+   },
+   {
+    "AvatarURL": "https://avatars.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+    "Login": "mrnugget",
+    "URL": "https://github.com/mrnugget"
+   }
+  ],
+  "Labels": {
+   "Nodes": []
+  },
+  "TimelineItems": [
+   {
+    "Type": "PullRequestCommit",
+    "Item": {
+     "Commit": {
+      "OID": "81da5d9c265d943d33a6bbed9da18da16f3ac633",
+      "Message": "Push a new branch",
+      "MessageHeadline": "Push a new branch",
+      "URL": "https://github.com/sourcegraph/automation-testing/commit/81da5d9c265d943d33a6bbed9da18da16f3ac633",
+      "Committer": {
+       "AvatarURL": "https://avatars.githubusercontent.com/u/1185253?v=4",
+       "Email": "mrnugget@gmail.com",
+       "Name": "Thorsten Ball",
+       "User": {
+        "AvatarURL": "https://avatars.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff\u0026v=4",
+        "Login": "mrnugget",
+        "URL": "https://github.com/mrnugget"
+       }
+      },
+      "CommittedDate": "2021-02-22T16:39:56Z",
+      "PushedDate": "2021-02-22T16:40:00Z"
+     }
+    }
+   },
+   {
+    "Type": "MergedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/19534377?v=4",
+      "Login": "eseliger",
+      "URL": "https://github.com/eseliger"
+     },
+     "MergeRefName": "master",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/424#event-4878235653",
+     "Commit": {
+      "OID": "9e89af1d640a4dfc8b03f27c7e7c228d65b9d13e",
+      "Message": "Push a new branch (#424)\n\nCo-authored-by: Thorsten Ball \u003cmrnugget@gmail.com\u003e",
+      "MessageHeadline": "Push a new branch (#424)",
+      "URL": "https://github.com/sourcegraph/automation-testing/commit/9e89af1d640a4dfc8b03f27c7e7c228d65b9d13e",
+      "Committer": {
+       "AvatarURL": "https://avatars.githubusercontent.com/u/19864447?v=4",
+       "Email": "noreply@github.com",
+       "Name": "GitHub"
+      },
+      "CommittedDate": "2021-06-11T14:08:50Z",
+      "PushedDate": "0001-01-01T00:00:00Z"
+     },
+     "CreatedAt": "2021-06-11T14:08:50Z"
+    }
+   },
+   {
+    "Type": "ClosedEvent",
+    "Item": {
+     "Actor": {
+      "AvatarURL": "https://avatars.githubusercontent.com/u/19534377?v=4",
+      "Login": "eseliger",
+      "URL": "https://github.com/eseliger"
+     },
+     "CreatedAt": "2021-06-11T14:08:50Z",
+     "URL": "https://github.com/sourcegraph/automation-testing/pull/424#event-4878235659"
+    }
+   }
+  ],
+  "Commits": {
+   "Nodes": [
+    {
+     "Commit": {
+      "OID": "81da5d9c265d943d33a6bbed9da18da16f3ac633",
+      "CheckSuites": {
+       "Nodes": [
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUyMDk2NjY1OTU4",
+         "Status": "COMPLETED",
+         "Conclusion": "STALE",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUyMDk2NjY1OTYx",
+         "Status": "COMPLETED",
+         "Conclusion": "STALE",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        },
+        {
+         "ID": "MDEwOkNoZWNrU3VpdGUyMDk2NjY1OTYy",
+         "Status": "COMPLETED",
+         "Conclusion": "STALE",
+         "ReceivedAt": "0001-01-01T00:00:00Z",
+         "CheckRuns": {
+          "Nodes": []
+         }
+        }
+       ]
+      },
+      "Status": {
+       "State": "",
+       "Contexts": null
+      },
+      "CommittedDate": "2021-02-22T16:39:56Z"
+     }
+    }
+   ]
+  },
+  "IsDraft": false,
+  "CreatedAt": "2021-02-22T16:40:45Z",
+  "UpdatedAt": "2021-06-11T14:08:50Z"
+ }

--- a/internal/extsvc/github/testdata/vcr/TestMergePullRequest.yaml
+++ b/internal/extsvc/github/testdata/vcr/TestMergePullRequest.yaml
@@ -1,0 +1,225 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"query":"\nfragment commit on Commit {\n  oid\n  message\n  messageHeadline\n  committedDate\n  pushedDate\n  url\n  committer
+      {\n    avatarUrl\n    email\n    name\n    user {\n      ...actor\n    }\n  }\n}\n\nfragment
+      review on PullRequestReview {\n  databaseId\n  author {\n    ...actor\n  }\n  authorAssociation\n  body\n  state\n  url\n  createdAt\n  updatedAt\n  commit
+      {\n    ...commit\n  }\n  includesCreatedEdit\n}\n\nfragment timelineItems on
+      PullRequestTimelineItems {\n  ... on AssignedEvent {\n    actor {\n      ...actor\n    }\n    assignee
+      {\n      ...actor\n    }\n    createdAt\n  }\n  ... on ClosedEvent {\n    actor
+      {\n      ...actor\n    }\n    createdAt\n    url\n  }\n  ... on IssueComment
+      {\n    databaseId\n    author {\n      ...actor\n    }\n    authorAssociation\n    body\n    createdAt\n    editor
+      {\n      ...actor\n    }\n    url\n    updatedAt\n    includesCreatedEdit\n    publishedAt\n  }\n  ...
+      on RenamedTitleEvent {\n    actor {\n      ...actor\n    }\n    previousTitle\n    currentTitle\n    createdAt\n  }\n  ...
+      on MergedEvent {\n    actor {\n      ...actor\n    }\n    mergeRefName\n    url\n    commit
+      {\n      ...commit\n    }\n    createdAt\n  }\n  ... on PullRequestReview {\n    ...review\n  }\n  ...
+      on PullRequestReviewThread {\n    comments(last: 100) {\n      nodes {\n        databaseId\n        author
+      {\n          ...actor\n        }\n        authorAssociation\n        editor
+      {\n          ...actor\n        }\n        commit {\n          ...commit\n        }\n        body\n        state\n        url\n        createdAt\n        updatedAt\n        includesCreatedEdit\n      }\n    }\n  }\n  ...
+      on ReopenedEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on ReviewDismissedEvent {\n    actor {\n      ...actor\n    }\n    review {\n      ...review\n    }\n    dismissalMessage\n    createdAt\n  }\n  ...
+      on ReviewRequestRemovedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer
+      {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ...
+      on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ...
+      on ReviewRequestedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer
+      {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ...
+      on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ...
+      on ReadyForReviewEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on UnassignedEvent {\n    actor {\n      ...actor\n    }\n    assignee {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on LabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ...
+      on UnlabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ...
+      on PullRequestCommit {\n    commit {\n      ...commit\n    }\n  }\n  \n  ...
+      on ConvertToDraftEvent {\n    actor {\n\t  ...actor\n\t}\n\tcreatedAt\n  }\n\n}\n\nfragment
+      actor on Actor {\n  avatarUrl\n  login\n  url\n}\n\nfragment label on Label
+      {\n  name\n  color\n  description\n  id\n}\n\nfragment commitWithChecks on Commit
+      {\n  oid\n  status {\n    state\n    contexts {\n      id\n      context\n      state\n      description\n    }\n  }\n  checkSuites(last:
+      20) {\n    nodes {\n      id\n      status\n      conclusion\n      checkRuns(last:
+      20) {\n        nodes {\n          id\n          status\n          conclusion\n        }\n      }\n    }\n  }\n  committedDate\n}\n\nfragment
+      prCommit on PullRequestCommit {\n  commit {\n    ...commitWithChecks\n  }\n}\n\nfragment
+      pr on PullRequest {\n  id\n  title\n  body\n  state\n  url\n  number\n  createdAt\n  updatedAt\n  headRefOid\n  baseRefOid\n  headRefName\n  baseRefName\n  isDraft\n  author
+      {\n    ...actor\n  }\n  participants(first: 100) {\n    nodes {\n      ...actor\n    }\n  }\n  labels(first:
+      100) {\n    nodes {\n      ...label\n    }\n  }\n  commits(last: 1) {\n    nodes
+      {\n      ...prCommit\n    }\n  }\n  timelineItems(first: 250, itemTypes: [ASSIGNED_EVENT,
+      CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW,
+      PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT,
+      REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT,
+      READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    nodes
+      {\n      __typename\n      ...timelineItems\n    }\n  }\n}\n\n\nmutation MergePullRequest($input:
+      MergePullRequestInput!) {\n  mergePullRequest(input: $input) {\n\t  pullRequest
+      {\n\t\t  ...pr\n\t  }\n  }\n}\n","variables":{"input":{"pullRequestId":"MDExOlB1bGxSZXF1ZXN0NTc3Nzc3NzEy","mergeMethod":"SQUASH"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"mergePullRequest":{"pullRequest":{"id":"MDExOlB1bGxSZXF1ZXN0NTc3Nzc3NzEy","title":"This
+      is a test PR","body":"This is the description of the test PR","state":"MERGED","url":"https://github.com/sourcegraph/automation-testing/pull/424","number":424,"createdAt":"2021-02-22T16:40:45Z","updatedAt":"2021-06-11T14:08:50Z","headRefOid":"81da5d9c265d943d33a6bbed9da18da16f3ac633","baseRefOid":"53229c4dc5ba7c0f7abf109003aa15a956be485e","headRefName":"test-pr-7","baseRefName":"master","isDraft":false,"author":{"avatarUrl":"https://avatars.githubusercontent.com/u/229984?v=4","login":"LawnGnome","url":"https://github.com/LawnGnome"},"participants":{"nodes":[{"avatarUrl":"https://avatars.githubusercontent.com/u/229984?v=4","login":"LawnGnome","url":"https://github.com/LawnGnome"},{"avatarUrl":"https://avatars.githubusercontent.com/u/19534377?v=4","login":"eseliger","url":"https://github.com/eseliger"},{"avatarUrl":"https://avatars.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"}]},"labels":{"nodes":[]},"commits":{"nodes":[{"commit":{"oid":"81da5d9c265d943d33a6bbed9da18da16f3ac633","status":null,"checkSuites":{"nodes":[{"id":"MDEwOkNoZWNrU3VpdGUyMDk2NjY1OTU4","status":"COMPLETED","conclusion":"STALE","checkRuns":{"nodes":[]}},{"id":"MDEwOkNoZWNrU3VpdGUyMDk2NjY1OTYx","status":"COMPLETED","conclusion":"STALE","checkRuns":{"nodes":[]}},{"id":"MDEwOkNoZWNrU3VpdGUyMDk2NjY1OTYy","status":"COMPLETED","conclusion":"STALE","checkRuns":{"nodes":[]}}]},"committedDate":"2021-02-22T16:39:56Z"}}]},"timelineItems":{"pageInfo":{"hasNextPage":false,"endCursor":"Y3Vyc29yOnYyOpPPAAABeftnbVABqjQ4NzgyMzU2NTk="},"nodes":[{"__typename":"PullRequestCommit","commit":{"oid":"81da5d9c265d943d33a6bbed9da18da16f3ac633","message":"Push
+      a new branch","messageHeadline":"Push a new branch","committedDate":"2021-02-22T16:39:56Z","pushedDate":"2021-02-22T16:40:00Z","url":"https://github.com/sourcegraph/automation-testing/commit/81da5d9c265d943d33a6bbed9da18da16f3ac633","committer":{"avatarUrl":"https://avatars.githubusercontent.com/u/1185253?v=4","email":"mrnugget@gmail.com","name":"Thorsten
+      Ball","user":{"avatarUrl":"https://avatars.githubusercontent.com/u/1185253?u=35f048c505007991433b46c9c0616ccbcfbd4bff&v=4","login":"mrnugget","url":"https://github.com/mrnugget"}}}},{"__typename":"MergedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/19534377?v=4","login":"eseliger","url":"https://github.com/eseliger"},"mergeRefName":"master","url":"https://github.com/sourcegraph/automation-testing/pull/424#event-4878235653","commit":{"oid":"9e89af1d640a4dfc8b03f27c7e7c228d65b9d13e","message":"Push
+      a new branch (#424)\n\nCo-authored-by: Thorsten Ball <mrnugget@gmail.com>","messageHeadline":"Push
+      a new branch (#424)","committedDate":"2021-06-11T14:08:50Z","pushedDate":null,"url":"https://github.com/sourcegraph/automation-testing/commit/9e89af1d640a4dfc8b03f27c7e7c228d65b9d13e","committer":{"avatarUrl":"https://avatars.githubusercontent.com/u/19864447?v=4","email":"noreply@github.com","name":"GitHub","user":null}},"createdAt":"2021-06-11T14:08:50Z"},{"__typename":"ClosedEvent","actor":{"avatarUrl":"https://avatars.githubusercontent.com/u/19534377?v=4","login":"eseliger","url":"https://github.com/eseliger"},"createdAt":"2021-06-11T14:08:50Z","url":"https://github.com/sourcegraph/automation-testing/pull/424#event-4878235659"}]}}}}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Jun 2021 14:08:50 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - E16A:621F:187AB1E:18FECA7:60C36E71
+      X-Oauth-Scopes:
+      - read:discussion, read:org, repo, workflow
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4994"
+      X-Ratelimit-Reset:
+      - "1623424033"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "6"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: '{"query":"\nfragment commit on Commit {\n  oid\n  message\n  messageHeadline\n  committedDate\n  pushedDate\n  url\n  committer
+      {\n    avatarUrl\n    email\n    name\n    user {\n      ...actor\n    }\n  }\n}\n\nfragment
+      review on PullRequestReview {\n  databaseId\n  author {\n    ...actor\n  }\n  authorAssociation\n  body\n  state\n  url\n  createdAt\n  updatedAt\n  commit
+      {\n    ...commit\n  }\n  includesCreatedEdit\n}\n\nfragment timelineItems on
+      PullRequestTimelineItems {\n  ... on AssignedEvent {\n    actor {\n      ...actor\n    }\n    assignee
+      {\n      ...actor\n    }\n    createdAt\n  }\n  ... on ClosedEvent {\n    actor
+      {\n      ...actor\n    }\n    createdAt\n    url\n  }\n  ... on IssueComment
+      {\n    databaseId\n    author {\n      ...actor\n    }\n    authorAssociation\n    body\n    createdAt\n    editor
+      {\n      ...actor\n    }\n    url\n    updatedAt\n    includesCreatedEdit\n    publishedAt\n  }\n  ...
+      on RenamedTitleEvent {\n    actor {\n      ...actor\n    }\n    previousTitle\n    currentTitle\n    createdAt\n  }\n  ...
+      on MergedEvent {\n    actor {\n      ...actor\n    }\n    mergeRefName\n    url\n    commit
+      {\n      ...commit\n    }\n    createdAt\n  }\n  ... on PullRequestReview {\n    ...review\n  }\n  ...
+      on PullRequestReviewThread {\n    comments(last: 100) {\n      nodes {\n        databaseId\n        author
+      {\n          ...actor\n        }\n        authorAssociation\n        editor
+      {\n          ...actor\n        }\n        commit {\n          ...commit\n        }\n        body\n        state\n        url\n        createdAt\n        updatedAt\n        includesCreatedEdit\n      }\n    }\n  }\n  ...
+      on ReopenedEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on ReviewDismissedEvent {\n    actor {\n      ...actor\n    }\n    review {\n      ...review\n    }\n    dismissalMessage\n    createdAt\n  }\n  ...
+      on ReviewRequestRemovedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer
+      {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ...
+      on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ...
+      on ReviewRequestedEvent {\n    actor {\n      ...actor\n    }\n    requestedReviewer
+      {\n      ...actor\n    }\n    requestedTeam: requestedReviewer {\n      ...
+      on Team {\n        name\n        url\n        avatarUrl\n      }\n    }\n    createdAt\n  }\n  ...
+      on ReadyForReviewEvent {\n    actor {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on UnassignedEvent {\n    actor {\n      ...actor\n    }\n    assignee {\n      ...actor\n    }\n    createdAt\n  }\n  ...
+      on LabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ...
+      on UnlabeledEvent {\n    actor {\n      ...actor\n    }\n    label {\n      ...label\n    }\n    createdAt\n  }\n  ...
+      on PullRequestCommit {\n    commit {\n      ...commit\n    }\n  }\n  \n  ...
+      on ConvertToDraftEvent {\n    actor {\n\t  ...actor\n\t}\n\tcreatedAt\n  }\n\n}\n\nfragment
+      actor on Actor {\n  avatarUrl\n  login\n  url\n}\n\nfragment label on Label
+      {\n  name\n  color\n  description\n  id\n}\n\nfragment commitWithChecks on Commit
+      {\n  oid\n  status {\n    state\n    contexts {\n      id\n      context\n      state\n      description\n    }\n  }\n  checkSuites(last:
+      20) {\n    nodes {\n      id\n      status\n      conclusion\n      checkRuns(last:
+      20) {\n        nodes {\n          id\n          status\n          conclusion\n        }\n      }\n    }\n  }\n  committedDate\n}\n\nfragment
+      prCommit on PullRequestCommit {\n  commit {\n    ...commitWithChecks\n  }\n}\n\nfragment
+      pr on PullRequest {\n  id\n  title\n  body\n  state\n  url\n  number\n  createdAt\n  updatedAt\n  headRefOid\n  baseRefOid\n  headRefName\n  baseRefName\n  isDraft\n  author
+      {\n    ...actor\n  }\n  participants(first: 100) {\n    nodes {\n      ...actor\n    }\n  }\n  labels(first:
+      100) {\n    nodes {\n      ...label\n    }\n  }\n  commits(last: 1) {\n    nodes
+      {\n      ...prCommit\n    }\n  }\n  timelineItems(first: 250, itemTypes: [ASSIGNED_EVENT,
+      CLOSED_EVENT, ISSUE_COMMENT, RENAMED_TITLE_EVENT, MERGED_EVENT, PULL_REQUEST_REVIEW,
+      PULL_REQUEST_REVIEW_THREAD, REOPENED_EVENT, REVIEW_DISMISSED_EVENT, REVIEW_REQUEST_REMOVED_EVENT,
+      REVIEW_REQUESTED_EVENT, UNASSIGNED_EVENT, LABELED_EVENT, UNLABELED_EVENT, PULL_REQUEST_COMMIT,
+      READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT]) {\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    nodes
+      {\n      __typename\n      ...timelineItems\n    }\n  }\n}\n\n\nmutation MergePullRequest($input:
+      MergePullRequestInput!) {\n  mergePullRequest(input: $input) {\n\t  pullRequest
+      {\n\t\t  ...pr\n\t  }\n  }\n}\n","variables":{"input":{"pullRequestId":"MDExOlB1bGxSZXF1ZXN0NTY1Mzk1NTc3","mergeMethod":"SQUASH"}}}'
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.antiope-preview+json
+      Content-Type:
+      - application/json; charset=utf-8
+    url: https://api.github.com/graphql
+    method: POST
+  response:
+    body: '{"data":{"mergePullRequest":null},"errors":[{"type":"UNPROCESSABLE","path":["mergePullRequest"],"locations":[{"line":303,"column":3}],"message":"Pull
+      Request is not mergeable"}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation,
+        Sunset
+      Cache-Control:
+      - no-cache
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 11 Jun 2021 14:08:51 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v4; param=antiope-preview; format=json
+      X-Github-Request-Id:
+      - E16A:621F:187AC34:18FEDCE:60C36E71
+      X-Oauth-Scopes:
+      - read:discussion, read:org, repo, workflow
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4991"
+      X-Ratelimit-Reset:
+      - "1623424033"
+      X-Ratelimit-Resource:
+      - graphql
+      X-Ratelimit-Used:
+      - "9"
+      X-Xss-Protection:
+      - "0"
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -448,9 +448,6 @@ fragment RepositoryFields on Repository {
 	viewerPermission
 	stargazerCount
 	forkCount
-	mergeCommitAllowed
-	rebaseMergeAllowed
-	squashMergeAllowed
 }
 	`
 	}
@@ -475,9 +472,6 @@ fragment RepositoryFields on Repository {
 	isLocked
 	isDisabled
 	forkCount
-	mergeCommitAllowed
-	rebaseMergeAllowed
-	squashMergeAllowed
 	%s
 }
 	`, strings.Join(ghe300Fields, "\n	"))

--- a/internal/extsvc/github/v4.go
+++ b/internal/extsvc/github/v4.go
@@ -448,6 +448,9 @@ fragment RepositoryFields on Repository {
 	viewerPermission
 	stargazerCount
 	forkCount
+	mergeCommitAllowed
+	rebaseMergeAllowed
+	squashMergeAllowed
 }
 	`
 	}
@@ -472,6 +475,9 @@ fragment RepositoryFields on Repository {
 	isLocked
 	isDisabled
 	forkCount
+	mergeCommitAllowed
+	rebaseMergeAllowed
+	squashMergeAllowed
 	%s
 }
 	`, strings.Join(ghe300Fields, "\n	"))

--- a/internal/extsvc/github/v4_test.go
+++ b/internal/extsvc/github/v4_test.go
@@ -382,6 +382,47 @@ func TestCreatePullRequestComment(t *testing.T) {
 	}
 }
 
+func TestMergePullRequest(t *testing.T) {
+	cli, save := newV4Client(t, "TestMergePullRequest")
+	defer save()
+
+	t.Run("success", func(t *testing.T) {
+		pr := &PullRequest{
+			// https://github.com/sourcegraph/automation-testing/pull/424
+			ID: "MDExOlB1bGxSZXF1ZXN0NTc3Nzc3NzEy",
+		}
+
+		err := cli.MergePullRequest(context.Background(), pr, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testutil.AssertGolden(t,
+			"testdata/golden/MergePullRequest-success",
+			update("MergePullRequest"),
+			pr,
+		)
+	})
+
+	t.Run("not mergeable", func(t *testing.T) {
+		pr := &PullRequest{
+			// https://github.com/sourcegraph/automation-testing/pull/419
+			ID: "MDExOlB1bGxSZXF1ZXN0NTY1Mzk1NTc3",
+		}
+
+		err := cli.MergePullRequest(context.Background(), pr, true)
+		if err == nil {
+			t.Fatal("invalid nil error")
+		}
+
+		testutil.AssertGolden(t,
+			"testdata/golden/MergePullRequest-error",
+			update("MergePullRequest"),
+			err,
+		)
+	})
+}
+
 func TestEstimateGraphQLCost(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -240,15 +240,19 @@ func (c *Client) UpdateMergeRequest(ctx context.Context, project *Project, mr *M
 	return resp, nil
 }
 
-func (c *Client) MergeMergeRequest(ctx context.Context, project *Project, mr *MergeRequest) (*MergeRequest, error) {
+func (c *Client) MergeMergeRequest(ctx context.Context, project *Project, mr *MergeRequest, squash bool) (*MergeRequest, error) {
 	if MockMergeMergeRequest != nil {
 		return MockMergeMergeRequest(c, ctx, project, mr)
 	}
 
 	payload := struct {
-		MergeWhenPipelineSucceeds bool `json:"merge_when_pipeline_succeeds,omitempty"`
+		Squash              bool   `json:"squash,omitempty"`
+		SquashCommitMessage string `json:"squash_commit_message,omitempty"`
 	}{
-		MergeWhenPipelineSucceeds: false,
+		Squash: squash,
+	}
+	if squash {
+		payload.SquashCommitMessage = mr.Title + "\n\n" + mr.Description
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/extsvc/gitlab/merge_requests.go
+++ b/internal/extsvc/gitlab/merge_requests.go
@@ -246,7 +246,7 @@ var ErrNotMergeable = errors.New("merge request is not in a mergeable state")
 
 func (c *Client) MergeMergeRequest(ctx context.Context, project *Project, mr *MergeRequest, squash bool) (*MergeRequest, error) {
 	if MockMergeMergeRequest != nil {
-		return MockMergeMergeRequest(c, ctx, project, mr)
+		return MockMergeMergeRequest(c, ctx, project, mr, squash)
 	}
 
 	payload := struct {

--- a/internal/extsvc/gitlab/mock.go
+++ b/internal/extsvc/gitlab/mock.go
@@ -47,7 +47,7 @@ var MockUpdateMergeRequest func(c *Client, ctx context.Context, project *Project
 
 // MockMergeMergeRequest, if non-nil, will be called instead of
 // Client.MergeMergeRequest
-var MockMergeMergeRequest func(c *Client, ctx context.Context, project *Project, mr *MergeRequest) (*MergeRequest, error)
+var MockMergeMergeRequest func(c *Client, ctx context.Context, project *Project, mr *MergeRequest, squash bool) (*MergeRequest, error)
 
 // MockCreateMergeRequestNote, if non-nil, will be called instead of
 // Client.CreateMergeRequestNote

--- a/internal/extsvc/gitlab/mock.go
+++ b/internal/extsvc/gitlab/mock.go
@@ -45,6 +45,10 @@ var MockGetOpenMergeRequestByRefs func(c *Client, ctx context.Context, project *
 // Client.UpdateMergeRequest
 var MockUpdateMergeRequest func(c *Client, ctx context.Context, project *Project, mr *MergeRequest, opts UpdateMergeRequestOpts) (*MergeRequest, error)
 
+// MockMergeMergeRequest, if non-nil, will be called instead of
+// Client.MergeMergeRequest
+var MockMergeMergeRequest func(c *Client, ctx context.Context, project *Project, mr *MergeRequest) (*MergeRequest, error)
+
 // MockCreateMergeRequestNote, if non-nil, will be called instead of
 // Client.CreateMergeRequestNote
 var MockCreateMergeRequestNote func(c *Client, ctx context.Context, project *Project, mr *MergeRequest, body string) error

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/inconshreveable/log15"
+
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -142,6 +144,11 @@ func (r *Repo) Update(n *Repo) (modified bool) {
 			// items such as maps. However, we know that copying github.Repository is safe as it only contains values.
 			clone.Metadata = &cp
 		})
+	}
+
+	log15.Warn(string(r.Name))
+	if r.Name == "ghe.sgdev.org/sourcegraph/xtaci-kcp-go" {
+		log15.Error("syncing the repo", "repo", "ghe.sgdev.org/sourcegraph/xtaci-kcp-go", "metadata", n.Metadata)
 	}
 
 	if !reflect.DeepEqual(r.Metadata, n.Metadata) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/inconshreveable/log15"
-
 	"github.com/sourcegraph/sourcegraph/internal/api"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc"
 	"github.com/sourcegraph/sourcegraph/internal/extsvc/github"
@@ -144,11 +142,6 @@ func (r *Repo) Update(n *Repo) (modified bool) {
 			// items such as maps. However, we know that copying github.Repository is safe as it only contains values.
 			clone.Metadata = &cp
 		})
-	}
-
-	log15.Warn(string(r.Name))
-	if r.Name == "ghe.sgdev.org/sourcegraph/xtaci-kcp-go" {
-		log15.Error("syncing the repo", "repo", "ghe.sgdev.org/sourcegraph/xtaci-kcp-go", "metadata", n.Metadata)
 	}
 
 	if !reflect.DeepEqual(r.Metadata, n.Metadata) {


### PR DESCRIPTION
https://user-images.githubusercontent.com/19534377/121703936-93b5af80-cad3-11eb-9666-64d3da4f9a99.mov

This PR implements a bulk merge action for changesets. It can be used to merge multiple open changesets with one operation.
This PR contains:
- A new bulk operation type
- UI for running the merge bulk operation
- Code host integrations to trigger a merge

As discussed yesterday, this PR will:
- Detect failures that are likely non mergeable state errors and bail out if it finds them (ie no retries)
- Implement two merge strategies, merge and squash. This is not supported by bitbucket server and we fall back to merge commits always in that case.


Closes https://github.com/sourcegraph/sourcegraph/issues/20865