### PR TITLE
repo-updater: Don't alert for user added code hosts on Cloud

### DIFF
--- a/cmd/repo-updater/shared/main.go
+++ b/cmd/repo-updater/shared/main.go
@@ -144,7 +144,7 @@ func Main(enterpriseInit EnterpriseInit) {
 	// be exposing. We have a bit more to do in this method, though, and the
 	// process will be marked ready further down this function.
 
-	repos.MustRegisterMetrics(db)
+	repos.MustRegisterMetrics(db, envvar.SourcegraphDotComMode())
 
 	store := repos.NewStore(db, sql.TxOptions{Isolation: sql.LevelDefault})
 	{


### PR DESCRIPTION
We have no control over how they're configured and can't modify their
config so we shouldn't alert on them.

We do stil want to be alerted if some of our site wide code hosts are
not syncing.
