### PR TITLE
add coursier to gitserver, repo-updater & combined Dockerfiles (RFC 307)

### DIFF
--- a/cmd/gitserver/Dockerfile
+++ b/cmd/gitserver/Dockerfile
@@ -11,6 +11,12 @@ RUN wget http://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/p4 && \
     mv p4 /usr/local/bin/p4 && \
     chmod +x /usr/local/bin/p4
 
+FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304 AS coursier
+
+RUN wget -O coursier https://github.com/coursier/coursier/releases/download/v2.0.16/cs-x86_64-pc-linux && \
+    mv coursier /usr/local/bin/coursier && \
+    chmod +x /usr/local/bin/coursier
+
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304
 
 ARG COMMIT_SHA="unknown"
@@ -30,8 +36,9 @@ RUN apk add --no-cache \
     git-p4 \
     python2
 
-# hadolint ignore=DL3022
 COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4
+
+COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 
 # This is a trick to include libraries required by p4,
 # please refer to https://blog.tilander.org/docker-perforce/

--- a/cmd/repo-updater/Dockerfile
+++ b/cmd/repo-updater/Dockerfile
@@ -3,6 +3,12 @@
 # file, please don't be scared to make it more pleasant / remove hadolint
 # ignores.
 
+FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304 AS coursier
+
+RUN wget -O coursier https://github.com/coursier/coursier/releases/download/v2.0.16/cs-x86_64-pc-linux && \
+    mv coursier /usr/local/bin/coursier && \
+    chmod +x /usr/local/bin/coursier
+
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304
 
 ARG COMMIT_SHA="unknown"
@@ -13,6 +19,8 @@ LABEL org.opencontainers.image.revision=${COMMIT_SHA}
 LABEL org.opencontainers.image.created=${DATE}
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL com.sourcegraph.github.url=https://github.com/sourcegraph/sourcegraph/commit/${COMMIT_SHA}
+
+COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 
 USER sourcegraph
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/repo-updater"]

--- a/cmd/server/Dockerfile
+++ b/cmd/server/Dockerfile
@@ -11,6 +11,12 @@ RUN wget http://cdist2.perforce.com/perforce/r20.1/bin.linux26x86_64/p4 && \
     mv p4 /usr/local/bin/p4 && \
     chmod +x /usr/local/bin/p4
 
+FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304 AS coursier
+
+RUN wget -O coursier https://github.com/coursier/coursier/releases/download/v2.0.16/cs-x86_64-pc-linux && \
+    mv coursier /usr/local/bin/coursier && \
+    chmod +x /usr/local/bin/coursier
+
 FROM sourcegraph/alpine-3.12:99421_2021-06-16_8e20ec8@sha256:838b96d93f073aa773718e22be54362b721569e360b445675f4cab904abc9304
 # TODO(security): This container should not be running as root!
 #
@@ -92,6 +98,8 @@ COPY . /
 
 # hadolint ignore=DL3022
 COPY --from=p4cli /usr/local/bin/p4 /usr/local/bin/p4
+
+COPY --from=coursier /usr/local/bin/coursier /usr/local/bin/coursier
 
 # This is a trick to include libraries required by p4,
 # please refer to https://blog.tilander.org/docker-perforce/

--- a/third-party-licenses/ThirdPartyDistributedTools.csv
+++ b/third-party-licenses/ThirdPartyDistributedTools.csv
@@ -10,4 +10,5 @@ Zoekt,Apache License 2.0,https://github.com/sourcegraph/zoekt
 Comby,Apache License 2.0,https://github.com/comby-tools/comby/
 Alpine Linux,GNU General Public License,https://alpinelinux.org/
 Tini,MIT License,https://github.com/krallin/tini
-Minio, GNU Affero General Public License v3.0,https://min.io/
+Minio,GNU Affero General Public License v3.0,https://min.io/
+Coursier,Apache License 2.0,https://get-coursier.io/


### PR DESCRIPTION
As part of [RFC 307](https://docs.google.com/document/d/1ZcZbPLZX0vblcTI_xb5VtO_49b_9tR5lOWSLoVEBm2A/edit#), we're adding support for JVM artifact hosts as external service types to gitserver. Related PR can be found here https://github.com/sourcegraph/sourcegraph/pull/21703. 

This PR adds bundling of the [Coursier](https://get-coursier.io/) binary in the gitserver and all-in-one image, pinned to the 2.0.16 release. Coursier is used by us to communicate with Maven artifact hosts (such as Maven Central), fetch jar sources etc. All usages can be found here https://github.com/sourcegraph/sourcegraph/pull/21703/files#diff-f6650fc82f7e1706d81023230b9d12bf292463057ad9c3c2af23488482f0603c.

Closes #21881

cc @sourcegraph/security if theres anything you need to do/check with regards to adding this
cc @sourcegraph/distribution if theres any other changes that need to be made to cover all deployment cases
cc @sourcegraph/code-intel for non-review :eyes: